### PR TITLE
Warnint util 4516 v12.3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -781,7 +781,7 @@ jobs:
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
-      - run: LIB_FUZZING_ENGINE="fail_to_onefile_driver" CC=clang-10 CXX=clang++-10 CFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1" CXXFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++" ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --with-gnu-ld --enable-fuzztargets --disable-shared --enable-gccprotect
+      - run: LIB_FUZZING_ENGINE="fail_to_onefile_driver" CC=clang-10 CXX=clang++-10 CFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1" CXXFLAGS="-fprofile-arcs -ftest-coverage -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion -Wimplicit-int-conversion" ac_cv_func_malloc_0_nonnull=yes ac_cv_func_realloc_0_nonnull=yes ./configure --with-gnu-ld --enable-fuzztargets --disable-shared --enable-gccprotect
       - run: make -j2
       - run: ./qa/run-ossfuzz-corpus.sh
       - name: Gcov

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -625,7 +625,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
 
     FtpInput ftpi = { .input = input, .input_len = input_len };
 
-    int direction = STREAM_TOSERVER;
+    uint8_t direction = STREAM_TOSERVER;
     while (FTPGetLine(state, STREAM_TOSERVER, &ftpi) >= 0) {
         const FtpCommand *cmd_descriptor;
 

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -187,7 +187,7 @@ typedef struct ICMPV4Vars_
     uint16_t  seq;
 
     /** Actual header length **/
-    uint32_t hlen;
+    uint16_t hlen;
 
     /** Pointers to the embedded packet headers */
     IPV4Hdr *emb_ipv4h;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -839,8 +839,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
         goto done;
     }
     memcpy(new->pkt, GET_PKT_DATA(p) + ltrim, GET_PKT_LEN(p) - ltrim);
-    DEBUG_VALIDATE_BUG_ON(GET_PKT_LEN(p) - ltrim > UINT16_MAX);
-    new->len = (uint16_t)(GET_PKT_LEN(p) - ltrim);
+    new->len = (GET_PKT_LEN(p) - ltrim);
     /* in case of unfragmentable exthdrs, update the 'next hdr' field
      * in the raw buffer so the reassembled packet will point to the
      * correct next header after stripping the frag header */

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -55,7 +55,7 @@ static int DetectAppLayerEventSetupP1(DetectEngineCtx *, Signature *, const char
 static void DetectAppLayerEventRegisterTests(void);
 #endif
 static void DetectAppLayerEventFree(DetectEngineCtx *, void *);
-static int DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *tx, uint64_t tx_id);
 static int g_applayer_events_list_id = 0;
@@ -85,7 +85,7 @@ void DetectAppLayerEventRegister(void)
     g_applayer_events_list_id = DetectBufferTypeGetByName("app-layer-events");
 }
 
-static int DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineAptEventInspect(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *tx, uint64_t tx_id)
 {

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -145,7 +145,7 @@ static DetectAppLayerEventData *DetectAppLayerEventParsePkt(const char *arg,
 {
     int event_id = 0;
     int r = AppLayerGetPktEventInfo(arg, &event_id);
-    if (r < 0) {
+    if (r < 0 || r > UINT8_MAX) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "app-layer-event keyword "
                    "supplied with packet based event - \"%s\" that isn't "
                    "supported yet.", arg);
@@ -155,7 +155,7 @@ static DetectAppLayerEventData *DetectAppLayerEventParsePkt(const char *arg,
     DetectAppLayerEventData *aled = SCCalloc(1, sizeof(DetectAppLayerEventData));
     if (unlikely(aled == NULL))
         return NULL;
-    aled->event_id = event_id;
+    aled->event_id = (uint8_t)event_id;
     *event_type = APP_LAYER_EVENT_TYPE_PACKET;
 
     return aled;
@@ -231,7 +231,11 @@ static int DetectAppLayerEventParseAppP2(DetectAppLayerEventData *data,
             return -3;
         }
     }
-    data->event_id = event_id;
+    if (event_id > UINT8_MAX) {
+        SCLogWarning(SC_ERR_INVALID_SIGNATURE, "app-layer-event keyword's id has invalid value");
+        return -4;
+    }
+    data->event_id = (uint8_t)event_id;
 
     return 0;
 }

--- a/src/detect-app-layer-event.h
+++ b/src/detect-app-layer-event.h
@@ -26,7 +26,7 @@
 
 typedef struct DetectAppLayerEventData_ {
     AppProto alproto;
-    int event_id;
+    uint8_t event_id;
 
     /* it's used to check if there are event set into the detect engine */
     bool needs_detctx;

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -112,9 +112,8 @@ void DetectByteExtractRegister(void)
 }
 
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *smd,
-                             const Signature *s, const uint8_t *payload,
-                             uint16_t payload_len, uint64_t *value,
-                             uint8_t endian)
+        const Signature *s, const uint8_t *payload, uint32_t payload_len, uint64_t *value,
+        uint8_t endian)
 {
     DetectByteExtractData *data = (DetectByteExtractData *)smd->ctx;
     const uint8_t *ptr = NULL;
@@ -320,11 +319,10 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
                         i);
                 goto error;
             }
-            int32_t multiplier;
-            if (StringParseI32RangeCheck(&multiplier, 10, 0,
-                                 (const char *)multiplier_str,
-                                 DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
-                                 DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) < 0) {
+            uint16_t multiplier;
+            if (StringParseU16RangeCheck(&multiplier, 10, 0, (const char *)multiplier_str,
+                        DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
+                        DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) < 0) {
                 SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid value for"
                         "multiplier: \"%s\".", multiplier_str);
                 goto error;

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -63,6 +63,6 @@ void DetectByteExtractRegister(void);
 
 SigMatch *DetectByteExtractRetrieveSMVar(const char *, const Signature *);
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *, const SigMatchData *, const Signature *,
-                             const uint8_t *, uint16_t, uint64_t *, uint8_t);
+        const uint8_t *, uint32_t, uint64_t *, uint8_t);
 
 #endif /* __DETECT_BYTEEXTRACT_H__ */

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -104,9 +104,9 @@ static DetectCipServiceData *DetectCipServiceParse(const char *rulestrc)
 
     char* token;
     char *save;
-    int var;
-    int input[3] = { 0, 0, 0 };
-    int i = 0;
+    uint8_t var;
+    uint8_t input[3] = { 0, 0, 0 };
+    uint8_t i = 0;
 
     token = strtok_r(rulestr, delims, &save);
     while (token != NULL)
@@ -156,7 +156,7 @@ static DetectCipServiceData *DetectCipServiceParse(const char *rulestrc)
             goto error;
         }
 
-        sscanf(token, "%d", &var);
+        sscanf(token, "%2" SCNu8, &var);
         input[i++] = var;
 
         token = strtok_r(NULL, delims, &save);

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -506,7 +506,7 @@ void DetectContentPropagateLimits(Signature *s)
 
                     if (cd->flags & DETECT_CONTENT_DISTANCE && cd->distance >= 0) {
                         if ((uint32_t)offset_plus_pat + cd->distance <= UINT16_MAX) {
-                            offset = cd->offset = offset_plus_pat + cd->distance;
+                            offset = cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
                         } else {
                             SCLogDebug("not updated content offset as it would overflow : %u + %d", offset_plus_pat, cd->distance);
                         }
@@ -514,16 +514,29 @@ void DetectContentPropagateLimits(Signature *s)
                     }
                     if (have_anchor && !last_reset && offset_plus_pat && cd->flags & DETECT_CONTENT_WITHIN && cd->within >= 0) {
                         if (depth && depth > offset_plus_pat) {
-                            uint16_t dist = 0;
+                            int32_t dist = 0;
                             if (cd->flags & DETECT_CONTENT_DISTANCE && cd->distance > 0) {
                                 dist = cd->distance;
                                 SCLogDebug("distance to add: %u. depth + dist %u", dist, depth + dist);
                             }
                             SCLogDebug("depth %u + cd->within %u", depth, cd->within);
-                            depth = cd->depth = depth + cd->within + dist;
+                            if (depth + cd->within + dist < 0 ||
+                                    depth + cd->within + dist > UINT16_MAX) {
+                                SCLogDebug("not updated content depth as it would overflow : %u + "
+                                           "%d + %u",
+                                        depth, cd->within, dist);
+                            } else {
+                                depth = cd->depth = (uint16_t)(depth + cd->within + dist);
+                            }
                         } else {
                             SCLogDebug("offset %u + cd->within %u", offset, cd->within);
-                            depth = cd->depth = offset + cd->within;
+                            if (depth + cd->within < 0 || depth + cd->within > UINT16_MAX) {
+                                SCLogDebug(
+                                        "not updated content depth as it would overflow : %u + %d",
+                                        offset, cd->within);
+                            } else {
+                                depth = cd->depth = (uint16_t)(offset + cd->within);
+                            }
                         }
                         SCLogDebug("updated content to have depth %u", cd->depth);
                     } else {
@@ -531,11 +544,24 @@ void DetectContentPropagateLimits(Signature *s)
                             if (cd->within > 0) {
                                 SCLogDebug("within %d distance %d", cd->within, cd->distance);
                                 if (cd->flags & DETECT_CONTENT_DISTANCE && cd->distance >= 0) {
-                                    cd->offset = offset_plus_pat + cd->distance;
+                                    if (offset_plus_pat + cd->distance < 0 ||
+                                            offset_plus_pat + cd->distance > UINT16_MAX) {
+                                        SCLogDebug("not updated content offset as it would "
+                                                   "overflow : %u + %d",
+                                                offset_plus_pat, cd->distance);
+                                    } else {
+                                        cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
+                                    }
                                     SCLogDebug("updated content to have offset %u", cd->offset);
                                 }
 
-                                cd->depth = cd->within + depth;
+                                if (depth + cd->within < 0 || depth + cd->within > UINT16_MAX) {
+                                    SCLogDebug("not updated content depth as it would overflow : "
+                                               "%u + %d",
+                                            offset, cd->within);
+                                } else {
+                                    cd->depth = (uint16_t)(cd->within + depth);
+                                }
                                 depth = cd->depth;
                                 SCLogDebug("updated content to have depth %u", cd->depth);
 
@@ -560,7 +586,7 @@ void DetectContentPropagateLimits(Signature *s)
                         if (cd->distance >= 0) {
                             // only distance
                             if ((uint32_t)offset_plus_pat + cd->distance <= UINT16_MAX) {
-                                offset = cd->offset = offset_plus_pat + cd->distance;
+                                offset = cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
                             } else {
                                 SCLogDebug("not updated content offset as it would overflow : %u + %d", offset_plus_pat, cd->distance);
                             }

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -819,7 +819,7 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 
     if (p->level4_comp_csum == -1) {
         uint16_t len = IPV6_GET_RAW_PLEN(p->ip6h) -
-            ((uint8_t *)p->icmpv6h - (uint8_t *)p->ip6h - IPV6_HEADER_LEN);
+                       (uint16_t)((uint8_t *)p->icmpv6h - (uint8_t *)p->ip6h - IPV6_HEADER_LEN);
         p->level4_comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
                                                       (uint16_t *)p->icmpv6h,
                                                       len);

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -62,7 +62,7 @@ static void DetectDceIfaceRegisterTests(void);
 #endif
 static int g_dce_generic_list_id = 0;
 
-static int InspectDceGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectDceGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -94,7 +94,7 @@ void DetectDceIfaceRegister(void)
             "dce_generic", ALPROTO_SMB, SIG_FLAG_TOCLIENT, 0, InspectDceGeneric, NULL);
 }
 
-static int InspectDceGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectDceGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -175,7 +175,7 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static int DetectEngineInspectDNP3(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineInspectDNP3(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -196,7 +196,7 @@ static int DetectEngineInspectDNP3(DetectEngineCtx *de_ctx, DetectEngineThreadCt
  */
 static int DetectDNP3FuncParseFunctionCode(const char *str, uint8_t *fc)
 {
-    if (StringParseUint8(fc, 10, strlen(str), str) >= 0) {
+    if (StringParseUint8(fc, 10, (uint16_t)strlen(str), str) >= 0) {
         return 1;
     }
 
@@ -204,7 +204,7 @@ static int DetectDNP3FuncParseFunctionCode(const char *str, uint8_t *fc)
     for (size_t i = 0;
             i < sizeof(DNP3FunctionNameMap) / sizeof(DNP3Mapping); i++) {
         if (strcasecmp(str, DNP3FunctionNameMap[i].name) == 0) {
-            *fc = DNP3FunctionNameMap[i].value;
+            *fc = (uint8_t)(DNP3FunctionNameMap[i].value);
             return 1;
         }
     }
@@ -288,7 +288,7 @@ static int DetectDNP3IndParse(const char *str, uint16_t *flags)
 {
     *flags = 0;
 
-    if (StringParseUint16(flags, 0, strlen(str), str) > 0) {
+    if (StringParseUint16(flags, 0, (uint16_t)strlen(str), str) > 0) {
         return 1;
     }
 
@@ -363,11 +363,11 @@ static int DetectDNP3ObjParse(const char *str, uint8_t *group, uint8_t *var)
     *sep = '\0';
     varstr = sep + 1;
 
-    if (StringParseUint8(group, 0, strlen(groupstr), groupstr) < 0) {
+    if (StringParseUint8(group, 0, (uint16_t)strlen(groupstr), groupstr) < 0) {
         return 0;
     }
 
-    if (StringParseUint8(var, 0, strlen(varstr), varstr) < 0) {
+    if (StringParseUint8(var, 0, (uint16_t)strlen(varstr), varstr) < 0) {
         return 0;
     }
 

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -74,7 +74,7 @@ static int DetectDnsOpcodeMatch(DetectEngineThreadCtx *det_ctx,
     return rs_dns_opcode_match(txv, (void *)ctx, flags);
 }
 
-static int DetectEngineInspectRequestGenericDnsOpcode(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectRequestGenericDnsOpcode(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -94,11 +94,9 @@ static InspectionBuffer *DnsQueryGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectDnsQuery(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectDnsQuery(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 
@@ -199,17 +197,17 @@ static int PrefilterMpmDnsQueryRegister(DetectEngineCtx *de_ctx,
 }
 
 #ifdef HAVE_LUA
-static int DetectEngineInspectDnsRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectDnsRequest(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     return DetectEngineInspectGenericList(
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);
 }
 
-static int DetectEngineInspectDnsResponse(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectDnsResponse(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     return DetectEngineInspectGenericList(
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1330,8 +1330,7 @@ static char DetectAddressMapCompareFunc(void *data1, uint16_t len1, void *data2,
     DetectAddressMap *map1 = (DetectAddressMap *)data1;
     DetectAddressMap *map2 = (DetectAddressMap *)data2;
 
-
-    int r = (strcmp(map1->string, map2->string) == 0);
+    char r = (strcmp(map1->string, map2->string) == 0);
     return r;
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -336,12 +336,12 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
     qsort(det_ctx->alert_queue, det_ctx->alert_queue_size, sizeof(PacketAlert),
             AlertQueueSortHelper);
 
-    int i = 0;
+    uint16_t i = 0;
     uint16_t max_pos = det_ctx->alert_queue_size;
 
     while (i < max_pos) {
         const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
-        uint8_t res = PacketAlertHandle(de_ctx, det_ctx, s, p, &det_ctx->alert_queue[i]);
+        int res = PacketAlertHandle(de_ctx, det_ctx, s, p, &det_ctx->alert_queue[i]);
 
         if (res > 0) {
             /* Now, if we have an alert, we have to check if we want

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -38,6 +38,7 @@
 #include "detect-tcp-flags.h"
 #include "feature.h"
 #include "util-print.h"
+#include "util-validate.h"
 
 static int rule_warnings_only = 0;
 static FILE *rule_engine_analysis_FD = NULL;
@@ -457,7 +458,7 @@ int PerCentEncodingSetup ()
  * \retval 0 if it doesn't have % encoding
  * \retval -1 on error
  */
-int PerCentEncodingMatch (uint8_t *content, uint8_t content_len)
+static int PerCentEncodingMatch(uint8_t *content, uint16_t content_len)
 {
     int ret = 0;
 
@@ -1073,7 +1074,9 @@ static void EngineAnalysisItemsInit(void)
     for (size_t i = 0; i < ARRAY_SIZE(analyzer_items); i++) {
         DetectEngineAnalyzerItems *analyzer_item = &analyzer_items[i];
 
-        analyzer_item->item_id = DetectBufferTypeGetByName(analyzer_item->item_name);
+        int item_id = DetectBufferTypeGetByName(analyzer_item->item_name);
+        DEBUG_VALIDATE_BUG_ON(item_id < 0 || item_id > UINT16_MAX);
+        analyzer_item->item_id = (uint16_t)item_id;
         if (analyzer_item->item_id == -1) {
             /* Mismatch between the analyzer_items array and what's supported */
             FatalError(SC_ERR_INITIALIZATION,

--- a/src/detect-engine-analyzer.h
+++ b/src/detect-engine-analyzer.h
@@ -33,7 +33,6 @@ int SetupRuleAnalyzer(void);
 void CleanupRuleAnalyzer (void);
 
 int PerCentEncodingSetup (void);
-int PerCentEncodingMatch (uint8_t *content, uint8_t content_len);
 
 void EngineAnalysisFP(const DetectEngineCtx *de_ctx,
         const Signature *s, char *line);

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -830,7 +830,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_object_set_new(types, "any5", json_integer(any5_cnt));
     json_object_set_new(stats, "types", types);
 
-    for (int i = 0; i < ALPROTO_MAX; i++) {
+    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
         if (alstats[i] > 0) {
             json_t *app = json_object();
             json_object_set_new(app, "total", json_integer(alstats[i]));
@@ -1178,7 +1178,8 @@ static int RuleSetWhitelist(Signature *s)
 int CreateGroupedPortList(DetectEngineCtx *de_ctx, DetectPort *port_list, DetectPort **newhead, uint32_t unique_groups, int (*CompareFunc)(DetectPort *, DetectPort *), uint32_t max_idx);
 int CreateGroupedPortListCmpCnt(DetectPort *a, DetectPort *b);
 
-static DetectPort *RulesGroupByPorts(DetectEngineCtx *de_ctx, int ipproto, uint32_t direction) {
+static DetectPort *RulesGroupByPorts(DetectEngineCtx *de_ctx, uint8_t ipproto, uint32_t direction)
+{
     /* step 1: create a hash of 'DetectPort' objects based on all the
      *         rules. Each object will have a SGH with the sigs added
      *         that belong to the SGH. */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -52,6 +52,7 @@
 #include "util-spm.h"
 #include "util-debug.h"
 #include "util-print.h"
+#include "util-validate.h"
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -527,10 +528,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                        DETECT_BYTE_EXTRACT_ENDIAN_LITTLE : DETECT_BYTE_EXTRACT_ENDIAN_BIG);
         }
 
-        if (DetectByteExtractDoMatch(det_ctx, smd, s, buffer,
-                                     buffer_len,
-                                     &det_ctx->byte_values[bed->local_id],
-                                     endian) != 1) {
+        if (DetectByteExtractDoMatch(det_ctx, smd, s, buffer, buffer_len,
+                    &det_ctx->byte_values[bed->local_id], endian) != 1) {
             goto no_match;
         }
 
@@ -561,12 +560,9 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
              rvalue = bmd->rvalue;
         }
 
-
-        if (DetectByteMathDoMatch(det_ctx, smd, s, buffer,
-                                     buffer_len,
-                                     rvalue,
-                                     &det_ctx->byte_values[bmd->local_id],
-                                     endian) != 1) {
+        DEBUG_VALIDATE_BUG_ON(buffer_len > UINT16_MAX);
+        if (DetectByteMathDoMatch(det_ctx, smd, s, buffer, (uint16_t)buffer_len, rvalue,
+                    &det_ctx->byte_values[bmd->local_id], endian) != 1) {
             goto no_match;
         }
 

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -100,12 +100,9 @@
  *  \retval 0 no match
  *  \retval 1 match
  */
-int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-                                  const Signature *s, const SigMatchData *smd,
-                                  Packet *p, Flow *f,
-                                  const uint8_t *buffer, uint32_t buffer_len,
-                                  uint32_t stream_start_offset, uint8_t flags,
-                                  uint8_t inspection_mode)
+uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const Signature *s, const SigMatchData *smd, Packet *p, Flow *f, const uint8_t *buffer,
+        uint32_t buffer_len, uint32_t stream_start_offset, uint8_t flags, uint8_t inspection_mode)
 {
     SCEnter();
     KEYWORD_PROFILING_START;
@@ -343,9 +340,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                     /* see if the next buffer keywords match. If not, we will
                      * search for another occurrence of this content and see
                      * if the others match then until we run out of matches */
-                    int r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd+1,
-                            p, f, buffer, buffer_len, stream_start_offset, flags,
-                            inspection_mode);
+                    uint8_t r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd + 1, p, f,
+                            buffer, buffer_len, stream_start_offset, flags, inspection_mode);
                     if (r == 1) {
                         SCReturnInt(1);
                     }
@@ -609,7 +605,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
     } else if (smd->type == DETECT_AL_URILEN) {
         SCLogDebug("inspecting uri len");
 
-        int r = 0;
+        uint8_t r = 0;
         DetectUrilenData *urilend = (DetectUrilenData *) smd->ctx;
 
         switch (urilend->mode) {
@@ -680,9 +676,8 @@ match:
      * the buffer portion of the signature matched. */
     if (!smd->is_last) {
         KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
-        int r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd+1,
-                p, f, buffer, buffer_len, stream_start_offset, flags,
-                inspection_mode);
+        uint8_t r = DetectEngineContentInspection(de_ctx, det_ctx, s, smd + 1, p, f, buffer,
+                buffer_len, stream_start_offset, flags, inspection_mode);
         SCReturnInt(r);
     }
 final_match:

--- a/src/detect-engine-content-inspection.h
+++ b/src/detect-engine-content-inspection.h
@@ -46,12 +46,9 @@ enum {
  *  inspection function contains both start and end of the data. */
 #define DETECT_CI_FLAGS_SINGLE  (DETECT_CI_FLAGS_START|DETECT_CI_FLAGS_END)
 
-int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-                                  const Signature *s, const SigMatchData *smd,
-                                  Packet *p, Flow *f,
-                                  const uint8_t *buffer, uint32_t buffer_len,
-                                  uint32_t stream_start_offset, uint8_t flags,
-                                  uint8_t inspection_mode);
+uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const Signature *s, const SigMatchData *smd, Packet *p, Flow *f, const uint8_t *buffer,
+        uint32_t buffer_len, uint32_t stream_start_offset, uint8_t flags, uint8_t inspection_mode);
 
 void DetectEngineContentInspectionRegisterTests(void);
 

--- a/src/detect-engine-dcepayload.h
+++ b/src/detect-engine-dcepayload.h
@@ -24,7 +24,7 @@
 #ifndef __DETECT_ENGINE_DCEPAYLOAD_H__
 #define __DETECT_ENGINE_DCEPAYLOAD_H__
 
-//int DetectEngineInspectDcePayload(DetectEngineCtx *, DetectEngineThreadCtx *,
+// uint8_t DetectEngineInspectDcePayload(DetectEngineCtx *, DetectEngineThreadCtx *,
 //        const Signature *, Flow *, uint8_t, void *);
 
 void DcePayloadRegisterTests(void);

--- a/src/detect-engine-enip.c
+++ b/src/detect-engine-enip.c
@@ -217,7 +217,7 @@ static int CIPServiceMatch(ENIPTransaction *enip_data,
  *
  *  \retval 0 no match or 1 match
  */
-int DetectEngineInspectCIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectEngineInspectCIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
@@ -256,7 +256,7 @@ int DetectEngineInspectCIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_c
  *  \retval 0 no match or 1 match
  */
 
-int DetectEngineInspectENIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectEngineInspectENIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-engine-enip.h
+++ b/src/detect-engine-enip.h
@@ -23,11 +23,11 @@
 #ifndef __DETECT_ENGINE_ENIP_H__
 #define __DETECT_ENGINE_ENIP_H__
 
-int DetectEngineInspectCIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *,
+uint8_t DetectEngineInspectCIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *,
         const struct DetectEngineAppInspectionEngine_ *, const Signature *, Flow *, uint8_t, void *,
         void *, uint64_t);
 
-int DetectEngineInspectENIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *,
+uint8_t DetectEngineInspectENIP(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *,
         const struct DetectEngineAppInspectionEngine_ *, const Signature *, Flow *, uint8_t, void *,
         void *, uint64_t);
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -181,8 +181,8 @@ error:
  * \retval 0 on Success
  * \retval -1 on Failure
  */
-static int DetectEngineEventSetupDo (DetectEngineCtx *de_ctx, Signature *s,
-        const char *rawstr, int smtype)
+static int DetectEngineEventSetupDo(
+        DetectEngineCtx *de_ctx, Signature *s, const char *rawstr, uint16_t smtype)
 {
     DetectEngineEventData *de = DetectEngineEventParse(rawstr);
     if (de == NULL)

--- a/src/detect-engine-file.c
+++ b/src/detect-engine-file.c
@@ -64,10 +64,10 @@
  *  \retval 2 can't match
  *  \retval 3 can't match filestore signature
  */
-static int DetectFileInspect(DetectEngineThreadCtx *det_ctx, Flow *f, const Signature *s,
+static uint8_t DetectFileInspect(DetectEngineThreadCtx *det_ctx, Flow *f, const Signature *s,
         const SigMatchData *smd, uint8_t flags, FileContainer *ffc)
 {
-    int r = 0;
+    uint8_t r = 0;
     int match = 0;
     int store_r = 0;
 
@@ -213,7 +213,7 @@ static int DetectFileInspect(DetectEngineThreadCtx *det_ctx, Flow *f, const Sign
  *
  *  \note flow is not locked at this time
  */
-int DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *_alstate, void *tx, uint64_t tx_id)
 {
@@ -226,8 +226,8 @@ int DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
         SCReturnInt(DETECT_ENGINE_INSPECT_SIG_NO_MATCH);
     }
 
-    int r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
-    int match = DetectFileInspect(det_ctx, f, s, engine->smd, flags, ffc);
+    uint8_t r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+    uint8_t match = DetectFileInspect(det_ctx, f, s, engine->smd, flags, ffc);
     if (match == DETECT_ENGINE_INSPECT_SIG_MATCH) {
         r = DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else if (match == DETECT_ENGINE_INSPECT_SIG_CANT_MATCH) {

--- a/src/detect-engine-file.h
+++ b/src/detect-engine-file.h
@@ -24,7 +24,7 @@
 #ifndef __DETECT_ENGINE_FILE_H__
 #define __DETECT_ENGINE_FILE_H__
 
-int DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *_alstate, void *tx, uint64_t tx_id);
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -216,8 +216,8 @@ static int IPOnlyCIDRItemParseSingle(IPOnlyCIDRItem **pdd, const char *str)
                         goto error;
                 }
 
-                int cidr;
-                if (StringParseI32RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
+                uint8_t cidr;
+                if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask, 0, 32) < 0)
                     goto error;
 
                 dd->netmask = cidr;
@@ -1170,7 +1170,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     SigNumArray *sna = SigNumArrayNew(de_ctx, &de_ctx->io_ctx);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (src->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
 
                     if (src->negated > 0)
                         /* Unset it */
@@ -1198,7 +1198,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     sna = SigNumArrayCopy((SigNumArray *) user_data);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (src->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
 
                     if (src->negated > 0)
                         /* Unset it */
@@ -1231,7 +1231,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                 SigNumArray *sna = (SigNumArray *)user_data;
 
                 /* Update the sig */
-                uint8_t tmp = 1 << (src->signum % 8);
+                uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
 
                 if (src->negated > 0)
                     /* Unset it */
@@ -1264,7 +1264,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     SigNumArray *sna = SigNumArrayNew(de_ctx, &de_ctx->io_ctx);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (src->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
 
                     if (src->negated > 0)
                         /* Unset it */
@@ -1289,7 +1289,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     sna = SigNumArrayCopy((SigNumArray *)user_data);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (src->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
                     if (src->negated > 0)
                         /* Unset it */
                         sna->array[src->signum / 8] &= ~tmp;
@@ -1313,7 +1313,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                 SigNumArray *sna = (SigNumArray *)user_data;
 
                 /* Update the sig */
-                uint8_t tmp = 1 << (src->signum % 8);
+                uint8_t tmp = (uint8_t)(1 << (src->signum % 8));
                 if (src->negated > 0)
                     /* Unset it */
                     sna->array[src->signum / 8] &= ~tmp;
@@ -1366,7 +1366,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     SigNumArray *sna = SigNumArrayNew(de_ctx, &de_ctx->io_ctx);
 
                     /** Update the sig */
-                    uint8_t tmp = 1 << (dst->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                     if (dst->negated > 0)
                         /** Unset it */
                         sna->array[dst->signum / 8] &= ~tmp;
@@ -1393,7 +1393,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     sna = SigNumArrayCopy((SigNumArray *) user_data);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (dst->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                     if (dst->negated > 0)
                         /* Unset it */
                         sna->array[dst->signum / 8] &= ~tmp;
@@ -1420,7 +1420,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                 SigNumArray *sna = (SigNumArray *)user_data;
 
                 /* Update the sig */
-                uint8_t tmp = 1 << (dst->signum % 8);
+                uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                 if (dst->negated > 0)
                     /* Unset it */
                     sna->array[dst->signum / 8] &= ~tmp;
@@ -1454,7 +1454,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     SigNumArray *sna = SigNumArrayNew(de_ctx, &de_ctx->io_ctx);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (dst->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                     if (dst->negated > 0)
                         /* Unset it */
                         sna->array[dst->signum / 8] &= ~tmp;
@@ -1479,7 +1479,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                     sna = SigNumArrayCopy((SigNumArray *)user_data);
 
                     /* Update the sig */
-                    uint8_t tmp = 1 << (dst->signum % 8);
+                    uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                     if (dst->negated > 0)
                         /* Unset it */
                         sna->array[dst->signum / 8] &= ~tmp;
@@ -1504,7 +1504,7 @@ void IPOnlyPrepare(DetectEngineCtx *de_ctx)
                 SigNumArray *sna = (SigNumArray *)user_data;
 
                 /* Update the sig */
-                uint8_t tmp = 1 << (dst->signum % 8);
+                uint8_t tmp = (uint8_t)(1 << (dst->signum % 8));
                 if (dst->negated > 0)
                     /* Unset it */
                     sna->array[dst->signum / 8] &= ~tmp;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -118,8 +118,8 @@ void DetectAppLayerMpmRegister2(const char *name,
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
     am->direction = direction;
     DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > INT16_MAX);
-    am->sm_list = sm_list;
-    am->sm_list_base = sm_list;
+    am->sm_list = (int16_t)sm_list;
+    am->sm_list_base = (int16_t)sm_list;
     am->priority = priority;
     am->type = DETECT_BUFFER_MPM_TYPE_APP;
 
@@ -159,7 +159,7 @@ void DetectAppLayerMpmRegisterByParentId(DetectEngineCtx *de_ctx,
             am->name = t->name;
             am->direction = t->direction;
             DEBUG_VALIDATE_BUG_ON(id < 0 || id > INT16_MAX);
-            am->sm_list = id; // use new id
+            am->sm_list = (uint16_t)id; // use new id
             am->sm_list_base = t->sm_list;
             am->type = DETECT_BUFFER_MPM_TYPE_APP;
             am->PrefilterRegisterWithListId = t->PrefilterRegisterWithListId;
@@ -302,7 +302,7 @@ void DetectFrameMpmRegister(const char *name, int direction, int priority,
     DetectBufferTypeSupportsFrames(name);
     DetectBufferTypeSupportsTransformations(name);
     int sm_list = DetectBufferTypeGetByName(name);
-    if (sm_list == -1) {
+    if (sm_list < 0 || sm_list > UINT16_MAX) {
         FatalError(SC_ERR_INITIALIZATION, "MPM engine registration for %s failed", name);
     }
 
@@ -310,7 +310,7 @@ void DetectFrameMpmRegister(const char *name, int direction, int priority,
     BUG_ON(am == NULL);
     am->name = name;
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
-    am->sm_list = sm_list;
+    am->sm_list = (uint16_t)sm_list;
     am->direction = direction;
     am->priority = priority;
     am->type = DETECT_BUFFER_MPM_TYPE_FRAME;
@@ -350,7 +350,8 @@ void DetectFrameMpmRegisterByParentId(DetectEngineCtx *de_ctx, const int id, con
             BUG_ON(am == NULL);
             am->name = t->name;
             snprintf(am->pname, sizeof(am->pname), "%s#%d", am->name, id);
-            am->sm_list = id; // use new id
+            DEBUG_VALIDATE_BUG_ON(id < 0 || id > UINT16_MAX);
+            am->sm_list = (uint16_t)id; // use new id
             am->sm_list_base = t->sm_list;
             am->type = DETECT_BUFFER_MPM_TYPE_FRAME;
             am->PrefilterRegisterWithListId = t->PrefilterRegisterWithListId;
@@ -386,7 +387,7 @@ void DetectEngineFrameMpmRegister(DetectEngineCtx *de_ctx, const char *name, int
             AppProtoToString(alproto), type);
 
     const int sm_list = DetectEngineBufferTypeRegister(de_ctx, name);
-    if (sm_list < 0) {
+    if (sm_list < 0 || sm_list > UINT16_MAX) {
         FatalError(SC_ERR_INITIALIZATION, "MPM engine registration for %s failed", name);
     }
 
@@ -398,7 +399,7 @@ void DetectEngineFrameMpmRegister(DetectEngineCtx *de_ctx, const char *name, int
     BUG_ON(am == NULL);
     am->name = name;
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
-    am->sm_list = sm_list;
+    am->sm_list = (uint16_t)sm_list;
     am->direction = direction;
     am->priority = priority;
     am->type = DETECT_BUFFER_MPM_TYPE_FRAME;
@@ -549,7 +550,7 @@ void DetectPktMpmRegister(const char *name,
     am->name = name;
     snprintf(am->pname, sizeof(am->pname), "%s", am->name);
     DEBUG_VALIDATE_BUG_ON(sm_list < 0 || sm_list > INT16_MAX);
-    am->sm_list = sm_list;
+    am->sm_list = (uint16_t)sm_list;
     am->priority = priority;
     am->type = DETECT_BUFFER_MPM_TYPE_PKT;
 
@@ -587,7 +588,7 @@ void DetectPktMpmRegisterByParentId(DetectEngineCtx *de_ctx,
             am->name = t->name;
             snprintf(am->pname, sizeof(am->pname), "%s#%d", am->name, id);
             DEBUG_VALIDATE_BUG_ON(id < 0 || id > INT16_MAX);
-            am->sm_list = id; // use new id
+            am->sm_list = (uint16_t)id; // use new id
             am->sm_list_base = t->sm_list;
             am->type = DETECT_BUFFER_MPM_TYPE_PKT;
             am->PrefilterRegisterWithListId = t->PrefilterRegisterWithListId;
@@ -869,7 +870,7 @@ uint8_t PatternMatchDefaultMatcher(void)
             if (strcmp("auto", mpm_algo) == 0) {
                 goto done;
             }
-            for (uint16_t u = 0; u < MPM_TABLE_SIZE; u++) {
+            for (uint8_t u = 0; u < MPM_TABLE_SIZE; u++) {
                 if (mpm_table[u].name == NULL)
                     continue;
 

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -145,8 +145,8 @@ int PrefilterPktPayloadRegister(DetectEngineCtx *de_ctx,
  *  \retval 0 no match
  *  \retval 1 match
  */
-int DetectEngineInspectPacketPayload(DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx, const Signature *s, Flow *f, Packet *p)
+uint8_t DetectEngineInspectPacketPayload(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const Signature *s, Flow *f, Packet *p)
 {
     SCEnter();
     int r = 0;
@@ -186,10 +186,9 @@ int DetectEngineInspectPacketPayload(DetectEngineCtx *de_ctx,
  *  \retval 0 no match
  *  \retval 1 match
  */
-static int DetectEngineInspectStreamUDPPayload(DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx,
-        const Signature *s, const SigMatchData *smd,
-        Flow *f, Packet *p)
+static uint8_t DetectEngineInspectStreamUDPPayload(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const Signature *s, const SigMatchData *smd, Flow *f,
+        Packet *p)
 {
     SCEnter();
     int r = 0;
@@ -314,7 +313,7 @@ static int StreamContentInspectEngineFunc(
  *
  *  Returns "can't match" if depth is reached.
  */
-int DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-engine-payload.h
+++ b/src/detect-engine-payload.h
@@ -29,12 +29,12 @@ int PrefilterPktPayloadRegister(DetectEngineCtx *de_ctx,
 int PrefilterPktStreamRegister(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, MpmCtx *mpm_ctx);
 
-int DetectEngineInspectPacketPayload(DetectEngineCtx *,
-        DetectEngineThreadCtx *, const Signature *, Flow *, Packet *);
+uint8_t DetectEngineInspectPacketPayload(
+        DetectEngineCtx *, DetectEngineThreadCtx *, const Signature *, Flow *, Packet *);
 int DetectEngineInspectStreamPayload(DetectEngineCtx *,
         DetectEngineThreadCtx *, const Signature *, Flow *,
         Packet *);
-int DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -260,10 +260,10 @@ error:
 static int DetectPortCut(DetectEngineCtx *de_ctx, DetectPort *a,
                          DetectPort *b, DetectPort **c)
 {
-    uint32_t a_port1 = a->port;
-    uint32_t a_port2 = a->port2;
-    uint32_t b_port1 = b->port;
-    uint32_t b_port2 = b->port2;
+    uint16_t a_port1 = a->port;
+    uint16_t a_port2 = a->port2;
+    uint16_t b_port1 = b->port;
+    uint16_t b_port2 = b->port2;
 
     /* default to NULL */
     *c = NULL;

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -286,7 +286,9 @@ int PrefilterAppendTxEngine(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
     e->PrefilterTx = PrefilterTxFunc;
     e->pectx = pectx;
     e->alproto = alproto;
-    e->tx_min_progress = tx_min_progress;
+    // TODO change function prototype ?
+    DEBUG_VALIDATE_BUG_ON(tx_min_progress > UINT8_MAX);
+    e->tx_min_progress = (uint8_t)tx_min_progress;
     e->Free = FreeFunc;
 
     if (sgh->init->tx_engines == NULL) {
@@ -498,7 +500,7 @@ void PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         }
         memset(sgh->tx_engines, 0x00, (cnt * sizeof(PrefilterEngine)));
 
-        uint32_t local_id = 0;
+        uint16_t local_id = 0;
         PrefilterEngine *e = sgh->tx_engines;
         for (el = sgh->init->tx_engines ; el != NULL; el = el->next) {
             e->local_id = local_id++;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1946,9 +1946,9 @@ int DetectEngineReloadIsIdle(void)
  *  \retval 0 no match
  *  \retval 1 match
  */
-int DetectEngineInspectGenericList(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const Signature *s, const SigMatchData *smd, Flow *f, const uint8_t flags, void *alstate,
-        void *txv, uint64_t tx_id)
+uint8_t DetectEngineInspectGenericList(const DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const Signature *s, const SigMatchData *smd, Flow *f,
+        const uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     SCLogDebug("running match functions, sm %p", smd);
     if (smd != NULL) {
@@ -1988,11 +1988,9 @@ int DetectEngineInspectGenericList(const DetectEngineCtx *de_ctx, DetectEngineTh
  * \retval 1 match.
  * \retval 2 Sig can't match.
  */
-int DetectEngineInspectBufferGeneric(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     const int list_id = engine->sm_list;
     SCLogDebug("running inspect on %d", list_id);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -134,14 +134,12 @@ int DetectEngineTentantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTentantRegisterPcapFile(uint32_t tenant_id);
 int DetectEngineTentantUnregisterPcapFile(uint32_t tenant_id);
 
-int DetectEngineInspectGenericList(const DetectEngineCtx *, DetectEngineThreadCtx *,
+uint8_t DetectEngineInspectGenericList(const DetectEngineCtx *, DetectEngineThreadCtx *,
         const Signature *, const SigMatchData *, Flow *, const uint8_t, void *, void *, uint64_t);
 
-int DetectEngineInspectBufferGeneric(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
 
 int DetectEngineInspectPktBufferGeneric(
         DetectEngineThreadCtx *det_ctx,

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -66,16 +66,14 @@ static int PrefilterMpmHTTPFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHea
         MpmCtx *mpm_ctx, const DetectBufferMpmRegistery *mpm_reg, int list_id);
 
 /* file API */
-static int DetectEngineInspectFiledata(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
 int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistery *mpm_reg, int list_id);
 
-static int DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -401,7 +399,7 @@ static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *de
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
@@ -596,11 +594,9 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
     }
 }
 
-static int DetectEngineInspectFiledata(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     int r = 0;
     int match = 0;

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -320,8 +320,8 @@ error:
  * \retval 0 on Success
  * \retval -1 on Failure
  */
-int DetectFileHashSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str,
-        uint32_t type, int list)
+int DetectFileHashSetup(
+        DetectEngineCtx *de_ctx, Signature *s, const char *str, uint16_t type, int list)
 {
     DetectFileHashData *filehash = NULL;
     SigMatch *sm = NULL;

--- a/src/detect-file-hash-common.h
+++ b/src/detect-file-hash-common.h
@@ -39,7 +39,7 @@ int LoadHashTable(ROHashTable *, const char *, const char *, int, uint32_t);
 
 int DetectFileHashMatch(DetectEngineThreadCtx *, Flow *, uint8_t,
         File *, const Signature *, const SigMatchCtx *);
-int DetectFileHashSetup(DetectEngineCtx *, Signature *, const char *, uint32_t, int);
+int DetectFileHashSetup(DetectEngineCtx *, Signature *, const char *, uint16_t, int);
 void DetectFileHashFree(DetectEngineCtx *, void *);
 
 #endif /* __UTIL_DETECT_FILE_HASH_H__ */

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -93,11 +93,9 @@ static int g_file_magic_buffer_id = 0;
 static int PrefilterMpmFilemagicRegister(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistery *mpm_reg, int list_id);
-static int DetectEngineInspectFilemagic(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
 
 static int g_magic_thread_ctx_id = -1;
 
@@ -465,11 +463,9 @@ static InspectionBuffer *FilemagicGetDataCallback(DetectEngineThreadCtx *det_ctx
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectFilemagic(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     const DetectEngineTransforms *transforms = NULL;
     if (!engine->mpm) {
@@ -481,7 +477,7 @@ static int DetectEngineInspectFilemagic(
         return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     }
 
-    int r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+    uint8_t r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     int local_file_id = 0;
     for (File *file = ffc->head; file != NULL; file = file->next) {
         if (file->txid != tx_id)

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -68,11 +68,9 @@ static int g_file_name_buffer_id = 0;
 static int PrefilterMpmFilenameRegister(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistery *mpm_reg, int list_id);
-static int DetectEngineInspectFilename(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
 
 /**
  * \brief Registration function for keyword: filename
@@ -371,11 +369,9 @@ static InspectionBuffer *FilenameGetDataCallback(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectFilename(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     const DetectEngineTransforms *transforms = NULL;
     if (!engine->mpm) {
@@ -387,7 +383,7 @@ static int DetectEngineInspectFilename(
         return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     }
 
-    int r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+    uint8_t r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     int local_file_id = 0;
     for (File *file = ffc->head; file != NULL; file = file->next) {
         if (file->txid != tx_id)

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -86,8 +86,8 @@ void DetectFlowRegister (void)
  * \param dflags detect flow flags
  * \param match_cnt number of matches to trigger
  */
-static inline int FlowMatch(const uint32_t pflags, const uint8_t pflowflags,
-    const uint16_t tflags, const uint16_t dflags, const uint8_t match_cnt)
+static inline int FlowMatch(const uint32_t pflags, const uint8_t pflowflags, const uint16_t tflags,
+        const uint16_t dflags, const uint16_t match_cnt)
 {
     uint8_t cnt = 0;
 
@@ -439,8 +439,7 @@ PrefilterPacketFlowMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if (FlowMatch(p->flags, p->flowflags, det_ctx->flags, ctx->v1.u8[0], ctx->v1.u8[1]))
-    {
+    if (FlowMatch(p->flags, p->flowflags, det_ctx->flags, ctx->v1.u16[0], ctx->v1.u16[1])) {
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
 }
@@ -449,17 +448,15 @@ static void
 PrefilterPacketFlowSet(PrefilterPacketHeaderValue *v, void *smctx)
 {
     const DetectFlowData *fb = smctx;
-    v->u8[0] = fb->flags;
-    v->u8[1] = fb->match_cnt;
+    v->u16[0] = fb->flags;
+    v->u16[1] = fb->match_cnt;
 }
 
 static bool
 PrefilterPacketFlowCompare(PrefilterPacketHeaderValue v, void *smctx)
 {
     const DetectFlowData *fb = smctx;
-    if (v.u8[0] == fb->flags &&
-        v.u8[1] == fb->match_cnt)
-    {
+    if (v.u16[0] == fb->flags && v.u16[1] == fb->match_cnt) {
         return true;
     }
     return false;

--- a/src/detect-flowvar.h
+++ b/src/detect-flowvar.h
@@ -28,8 +28,8 @@ typedef struct DetectFlowvarData_ {
     char *name;
     uint32_t idx;
     uint8_t *content;
-    uint8_t content_len;
-    uint8_t flags;
+    uint16_t content_len;
+    uint32_t flags;
 } DetectFlowvarData;
 
 /* prototypes */

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -57,7 +57,7 @@ static void DetectFtpbounceRegisterTests(void);
 #endif
 static int g_ftp_request_list_id = 0;
 
-static int InspectFtpRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectFtpRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -83,7 +83,7 @@ void DetectFtpbounceRegister(void)
             "ftp_request", ALPROTO_FTP, SIG_FLAG_TOSERVER, 0, InspectFtpRequest, NULL);
 }
 
-static int InspectFtpRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectFtpRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -101,13 +101,13 @@ static int InspectFtpRequest(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
  *
  * \retval 1 if ftpbounce detected, 0 if not
  */
-static int DetectFtpbounceMatchArgs(uint8_t *payload, uint16_t payload_len,
-                             uint32_t ip_orig, uint16_t offset)
+static int DetectFtpbounceMatchArgs(
+        uint8_t *payload, uint32_t payload_len, uint32_t ip_orig, uint32_t offset)
 {
     SCEnter();
     SCLogDebug("Checking ftpbounce condition");
     char *c = NULL;
-    uint16_t i = 0;
+    uint32_t i = 0;
     int octet = 0;
     int octet_ascii_len = 0;
     int noctet = 0;

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -49,7 +49,7 @@ static void DetectFtpdataFree (DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectFtpdataRegisterTests (void);
 #endif
-static int DetectEngineInspectFtpdataGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectFtpdataGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 static int g_ftpdata_buffer_id = 0;
@@ -87,7 +87,7 @@ void DetectFtpdataRegister(void) {
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
-static int DetectEngineInspectFtpdataGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectFtpdataGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -68,7 +68,7 @@ static void DetectHttpClientBodySetupCallback(const DetectEngineCtx *de_ctx,
                                               Signature *s);
 static int g_http_client_body_buffer_id = 0;
 
-static int DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -295,7 +295,7 @@ static InspectionBuffer *HttpRequestBodyGetDataCallback(DetectEngineThreadCtx *d
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -166,11 +166,9 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
 /** \internal
  *  \brief custom inspect function to utilize the cached headers
  */
-static int DetectEngineInspectBufferHttpHeader(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectBufferHttpHeader(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -86,21 +86,17 @@ static int DetectHTTP2headerNameSetup(DetectEngineCtx *de_ctx, Signature *s, con
 static int PrefilterMpmHttp2HeaderNameRegister(DetectEngineCtx *de_ctx,
                                                SigGroupHead *sgh, MpmCtx *mpm_ctx,
                                                const DetectBufferMpmRegistery *mpm_reg, int list_id);
-static int DetectEngineInspectHttp2HeaderName(
-                                              DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-                                              const DetectEngineAppInspectionEngine *engine,
-                                              const Signature *s,
-                                              Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectHttp2HeaderName(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 static int DetectHTTP2headerSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg);
 static int PrefilterMpmHttp2HeaderRegister(DetectEngineCtx *de_ctx,
                                                SigGroupHead *sgh, MpmCtx *mpm_ctx,
                                                const DetectBufferMpmRegistery *mpm_reg, int list_id);
-static int DetectEngineInspectHttp2Header(
-                                          DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-                                          const DetectEngineAppInspectionEngine *engine,
-                                          const Signature *s,
-                                          Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectHttp2Header(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 static bool DetectHttp2HeaderValidateCallback(const Signature *s, const char **sigerror);
 
 #ifdef UNITTESTS
@@ -111,7 +107,7 @@ static int g_http2_match_buffer_id = 0;
 static int g_http2_header_name_buffer_id = 0;
 static int g_http2_header_buffer_id = 0;
 
-static int DetectEngineInspectHTTP2(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineInspectHTTP2(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
@@ -759,11 +755,9 @@ static int PrefilterMpmHttp2HeaderNameRegister(DetectEngineCtx *de_ctx,
             pectx, PrefilterMpmHttp2HNameFree, mpm_reg->name);
 }
 
-static int DetectEngineInspectHttp2HeaderName(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectHttp2HeaderName(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 
@@ -891,11 +885,9 @@ static int PrefilterMpmHttp2HeaderRegister(DetectEngineCtx *de_ctx,
             pectx, PrefilterMpmHttp2HeaderFree, mpm_reg->name);
 }
 
-static int DetectEngineInspectHttp2Header(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectHttp2Header(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -266,14 +266,14 @@ static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
 {
     // first parse numeric value
-    if (ByteExtractStringUint8(ft, 10, strlen(str), str) >= 0) {
+    if (ByteExtractStringUint8(ft, 10, (uint16_t)strlen(str), str) >= 0) {
         return 1;
     }
 
     // it it failed so far, parse string value from enumeration
     int r = rs_http2_parse_frametype(str);
-    if (r >= 0) {
-        *ft = r;
+    if (r >= 0 && r <= UINT8_MAX) {
+        *ft = (uint8_t)r;
         return 1;
     }
 
@@ -352,7 +352,7 @@ static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
 {
     // first parse numeric value
-    if (ByteExtractStringUint32(ec, 10, strlen(str), str) >= 0) {
+    if (ByteExtractStringUint32(ec, 10, (uint16_t)strlen(str), str) >= 0) {
         return 1;
     }
 
@@ -433,7 +433,7 @@ static int DetectHTTP2priorityMatch(DetectEngineThreadCtx *det_ctx,
     int value = rs_http2_tx_get_next_priority(txv, flags, nb);
     const DetectU8Data *du8 = (const DetectU8Data *)ctx;
     while (value >= 0) {
-        if (DetectU8Match(value, du8)) {
+        if (DetectU8Match((uint8_t)value, du8)) {
             return 1;
         }
         nb++;

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -122,7 +122,7 @@ static int DetectIdMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
  */
 static DetectIdData *DetectIdParse (const char *idstr)
 {
-    uint32_t temp;
+    uint16_t temp;
     DetectIdData *id_d = NULL;
     int ret = 0, res = 0;
     size_t pcre2len;
@@ -154,8 +154,7 @@ static DetectIdData *DetectIdParse (const char *idstr)
     }
 
     /* ok, fill the id data */
-    if (StringParseU32RangeCheck(&temp, 10, 0, (const char *)tmp_str,
-                                 DETECT_IPID_MIN, DETECT_IPID_MAX) < 0) {
+    if (StringParseUint16(&temp, 10, 0, (const char *)tmp_str) < 0) {
         SCLogError(SC_ERR_INVALID_VALUE, "invalid id option '%s'", tmp_str);
         return NULL;
     }

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -56,7 +56,7 @@ static int DetectIkeChosenSaSetup(DetectEngineCtx *, Signature *s, const char *s
 static void DetectIkeChosenSaFree(DetectEngineCtx *, void *);
 static int g_ike_chosen_sa_buffer_id = 0;
 
-static int DetectEngineInspectIkeChosenSaGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeChosenSaGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -87,7 +87,7 @@ void DetectIkeChosenSaRegister(void)
     g_ike_chosen_sa_buffer_id = DetectBufferTypeGetByName("ike.chosen_sa_attribute");
 }
 
-static int DetectEngineInspectIkeChosenSaGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeChosenSaGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ike-exch-type.c
+++ b/src/detect-ike-exch-type.c
@@ -41,7 +41,7 @@ static int DetectIkeExchTypeSetup(DetectEngineCtx *, Signature *s, const char *s
 static void DetectIkeExchTypeFree(DetectEngineCtx *, void *);
 static int g_ike_exch_type_buffer_id = 0;
 
-static int DetectEngineInspectIkeExchTypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeExchTypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -70,7 +70,7 @@ void DetectIkeExchTypeRegister(void)
     g_ike_exch_type_buffer_id = DetectBufferTypeGetByName("ike.exchtype");
 }
 
-static int DetectEngineInspectIkeExchTypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeExchTypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ike-key-exchange-payload-length.c
+++ b/src/detect-ike-key-exchange-payload-length.c
@@ -40,7 +40,7 @@ static int DetectIkeKeyExchangePayloadLengthSetup(DetectEngineCtx *, Signature *
 static void DetectIkeKeyExchangePayloadLengthFree(DetectEngineCtx *, void *);
 static int g_ike_key_exch_payload_length_buffer_id = 0;
 
-static int DetectEngineInspectIkeKeyExchangePayloadLengthGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeKeyExchangePayloadLengthGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -75,7 +75,7 @@ void DetectIkeKeyExchangePayloadLengthRegister(void)
             DetectBufferTypeGetByName("ike.key_exchange_payload_length");
 }
 
-static int DetectEngineInspectIkeKeyExchangePayloadLengthGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeKeyExchangePayloadLengthGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ike-nonce-payload-length.c
+++ b/src/detect-ike-nonce-payload-length.c
@@ -40,7 +40,7 @@ static int DetectIkeNoncePayloadLengthSetup(DetectEngineCtx *, Signature *s, con
 static void DetectIkeNoncePayloadLengthFree(DetectEngineCtx *, void *);
 static int g_ike_nonce_payload_length_buffer_id = 0;
 
-static int DetectEngineInspectIkeNoncePayloadLengthGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeNoncePayloadLengthGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -70,7 +70,7 @@ void DetectIkeNoncePayloadLengthRegister(void)
     g_ike_nonce_payload_length_buffer_id = DetectBufferTypeGetByName("ike.nonce_payload_length");
 }
 
-static int DetectEngineInspectIkeNoncePayloadLengthGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectIkeNoncePayloadLengthGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -132,7 +132,7 @@ static int PrefilterMpmIkeVendorRegister(DetectEngineCtx *de_ctx, SigGroupHead *
             mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmIkeVendorFree, mpm_reg->pname);
 }
 
-static int DetectEngineInspectIkeVendor(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineInspectIkeVendor(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -241,7 +241,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
                 goto error;
             }
             if (!lt_set && !not_set) {
-                s->proto.proto[data->proto / 8] = 0xfe << (data->proto % 8);
+                s->proto.proto[data->proto / 8] = (uint8_t)(0xfe << (data->proto % 8));
                 for (i = (data->proto / 8) + 1; i < (256 / 8); i++) {
                     s->proto.proto[i] = 0xff;
                 }
@@ -319,7 +319,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
                 for (i = 0; i < (data->proto / 8); i++) {
                     s->proto.proto[i] = 0xff;
                 }
-                s->proto.proto[data->proto / 8] = ~(0xff << (data->proto % 8));
+                s->proto.proto[data->proto / 8] = (uint8_t)(~(0xff << (data->proto % 8)));
             } else if (gt_set && !not_set) {
                 SigMatch *temp_sm = s->init_data->smlists[DETECT_SM_LIST_MATCH];
                 while (temp_sm != NULL) {
@@ -394,7 +394,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
                 for (i = 0; i < (data->proto / 8); i++) {
                     s->proto.proto[i] = 0xff;
                 }
-                s->proto.proto[data->proto / 8] = ~(1 << (data->proto % 8));
+                s->proto.proto[data->proto / 8] = (uint8_t)(~(1 << (data->proto % 8)));
                 for (i = (data->proto / 8) + 1; i < (256 / 8); i++) {
                     s->proto.proto[i] = 0xff;
                 }

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -81,11 +81,9 @@ static InspectionBuffer *GetKrb5CNameData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectKrb5CName(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectKrb5CName(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -49,9 +49,9 @@ static void DetectKrb5ErrCodeFree (DetectEngineCtx *, void *);
 static void DetectKrb5ErrCodeRegisterTests (void);
 #endif
 
-static int DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 static int g_krb5_err_code_list_id = 0;
 
@@ -86,9 +86,9 @@ void DetectKrb5ErrCodeRegister(void)
     SCLogDebug("g_krb5_err_code_list_id %d", g_krb5_err_code_list_id);
 }
 
-static int DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     return DetectEngineInspectGenericList(
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -49,9 +49,9 @@ static void DetectKrb5MsgTypeFree (DetectEngineCtx *, void *);
 static void DetectKrb5MsgTypeRegisterTests (void);
 #endif
 
-static int DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
-        void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 static int g_krb5_msg_type_list_id = 0;
 
@@ -86,9 +86,9 @@ void DetectKrb5MsgTypeRegister(void)
     SCLogDebug("g_krb5_msg_type_list_id %d", g_krb5_msg_type_list_id);
 }
 
-static int DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
-        void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectKRB5Generic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     return DetectEngineInspectGenericList(
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -81,11 +81,9 @@ static InspectionBuffer *GetKrb5SNameData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectKrb5SName(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectKrb5SName(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -103,7 +103,7 @@ static void DetectLuaRegisterTests(void);
 static void DetectLuaFree(DetectEngineCtx *, void *);
 static int g_smtp_generic_list_id = 0;
 
-static int InspectSmtpGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectSmtpGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -134,7 +134,7 @@ void DetectLuaRegister(void)
     return;
 }
 
-static int InspectSmtpGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectSmtpGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-metadata.c
+++ b/src/detect-metadata.c
@@ -85,7 +85,8 @@ void DetectMetadataHashFree(DetectEngineCtx *de_ctx)
 
 static const char *DetectMedatataHashAdd(DetectEngineCtx *de_ctx, const char *string)
 {
-    const char * hstring = (char *)HashTableLookup(de_ctx->metadata_table, (void *)string, strlen(string));
+    const char *hstring = (char *)HashTableLookup(
+            de_ctx->metadata_table, (void *)string, (uint16_t)strlen(string));
     if (hstring) {
         return hstring;
     }
@@ -95,8 +96,9 @@ static const char *DetectMedatataHashAdd(DetectEngineCtx *de_ctx, const char *st
         return NULL;
     }
 
-    if (HashTableAdd(de_ctx->metadata_table, (void *)astring, strlen(astring)) == 0) {
-        return (char *)HashTableLookup(de_ctx->metadata_table, (void *)astring, strlen(astring));
+    if (HashTableAdd(de_ctx->metadata_table, (void *)astring, (uint16_t)strlen(astring)) == 0) {
+        return (char *)HashTableLookup(
+                de_ctx->metadata_table, (void *)astring, (uint16_t)strlen(astring));
     } else {
         SCFree((void *)astring);
     }

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -133,7 +133,7 @@ static int DetectModbusMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t fl
  *
  *  \retval 0 no match or 1 match
  */
-static int DetectEngineInspectModbus(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineInspectModbus(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-connack-sessionpresent.c
+++ b/src/detect-mqtt-connack-sessionpresent.c
@@ -45,7 +45,7 @@ static int DetectMQTTConnackSessionPresentSetup (DetectEngineCtx *, Signature *,
 void MQTTConnackSessionPresentRegisterTests(void);
 void DetectMQTTConnackSessionPresentFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTConnackSessionPresentGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTConnackSessionPresentGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -72,7 +72,7 @@ void DetectMQTTConnackSessionPresentRegister (void)
     mqtt_connack_session_present_id = DetectBufferTypeGetByName("mqtt.connack.session_present");
 }
 
-static int DetectEngineInspectMQTTConnackSessionPresentGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTConnackSessionPresentGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -45,7 +45,7 @@ static int DetectMQTTConnectFlagsSetup (DetectEngineCtx *, Signature *, const ch
 void MQTTConnectFlagsRegisterTests(void);
 void DetectMQTTConnectFlagsFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTConnectFlagsGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTConnectFlagsGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -80,7 +80,7 @@ void DetectMQTTConnectFlagsRegister (void)
     mqtt_connect_flags_id = DetectBufferTypeGetByName("mqtt.connect.flags");
 }
 
-static int DetectEngineInspectMQTTConnectFlagsGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTConnectFlagsGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -45,7 +45,7 @@ static int DetectMQTTFlagsSetup (DetectEngineCtx *, Signature *, const char *);
 void MQTTFlagsRegisterTests(void);
 void DetectMQTTFlagsFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTFlagsGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTFlagsGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -76,7 +76,7 @@ void DetectMQTTFlagsRegister (void)
     mqtt_flags_id = DetectBufferTypeGetByName("mqtt.flags");
 }
 
-static int DetectEngineInspectMQTTFlagsGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTFlagsGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-protocol-version.c
+++ b/src/detect-mqtt-protocol-version.c
@@ -44,7 +44,7 @@ static int DetectMQTTProtocolVersionSetup (DetectEngineCtx *, Signature *, const
 void MQTTProtocolVersionRegisterTests(void);
 void DetectMQTTProtocolVersionFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTProtocolVersionGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTProtocolVersionGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -69,7 +69,7 @@ void DetectMQTTProtocolVersionRegister (void)
     mqtt_protocol_version_id = DetectBufferTypeGetByName("mqtt.protocol_version");
 }
 
-static int DetectEngineInspectMQTTProtocolVersionGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTProtocolVersionGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-qos.c
+++ b/src/detect-mqtt-qos.c
@@ -43,7 +43,7 @@ static int DetectMQTTQosSetup (DetectEngineCtx *, Signature *, const char *);
 void MQTTQosRegisterTests(void);
 void DetectMQTTQosFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTQosGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTQosGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -68,7 +68,7 @@ void DetectMQTTQosRegister (void)
     mqtt_qos_id = DetectBufferTypeGetByName("mqtt.qos");
 }
 
-static int DetectEngineInspectMQTTQosGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTQosGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-reason-code.c
+++ b/src/detect-mqtt-reason-code.c
@@ -46,7 +46,7 @@ static int DetectMQTTReasonCodeSetup (DetectEngineCtx *, Signature *, const char
 void MQTTReasonCodeRegisterTests(void);
 void DetectMQTTReasonCodeFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTReasonCodeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTReasonCodeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -74,7 +74,7 @@ void DetectMQTTReasonCodeRegister (void)
     mqtt_reason_code_id = DetectBufferTypeGetByName("mqtt.reason_code");
 }
 
-static int DetectEngineInspectMQTTReasonCodeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTReasonCodeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -89,11 +89,9 @@ static InspectionBuffer *MQTTSubscribeTopicGetData(DetectEngineThreadCtx *det_ct
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectMQTTSubscribeTopic(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectMQTTSubscribeTopic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-mqtt-type.c
+++ b/src/detect-mqtt-type.c
@@ -42,7 +42,7 @@ static int DetectMQTTTypeSetup (DetectEngineCtx *, Signature *, const char *);
 void MQTTTypeRegisterTests(void);
 void DetectMQTTTypeFree(DetectEngineCtx *de_ctx, void *);
 
-static int DetectEngineInspectMQTTTypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTTypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -67,7 +67,7 @@ void DetectMQTTTypeRegister (void)
     mqtt_type_id = DetectBufferTypeGetByName("mqtt.type");
 }
 
-static int DetectEngineInspectMQTTTypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectMQTTTypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -89,11 +89,9 @@ static InspectionBuffer *MQTTUnsubscribeTopicGetData(DetectEngineThreadCtx *det_
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectMQTTUnsubscribeTopic(
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine,
-        const Signature *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectMQTTUnsubscribeTopic(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -76,7 +76,7 @@ static void DetectNfsProcedureRegisterTests(void);
 #endif
 static int g_nfs_request_buffer_id = 0;
 
-static int DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -110,7 +110,7 @@ void DetectNfsProcedureRegister (void)
     SCLogDebug("g_nfs_request_buffer_id %d", g_nfs_request_buffer_id);
 }
 
-static int DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -76,7 +76,7 @@ static void DetectNfsVersionRegisterTests(void);
 #endif
 static int g_nfs_request_buffer_id = 0;
 
-static int DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -109,7 +109,7 @@ void DetectNfsVersionRegister (void)
     SCLogDebug("g_nfs_request_buffer_id %d", g_nfs_request_buffer_id);
 }
 
-static int DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectNfsRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -181,7 +181,7 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     SCEnter();
     int ret = 0;
     const uint8_t *ptr = NULL;
-    uint16_t len = 0;
+    uint32_t len = 0;
     PCRE2_SIZE capture_len = 0;
 
     DetectPcreData *pe = (DetectPcreData *)smd->ctx;
@@ -273,20 +273,17 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
                         memcpy(str_ptr2, pcre2_str_ptr2, capture_len);
                         pcre2_substring_free((PCRE2_UCHAR8 *)pcre2_str_ptr2);
 
-                        (void)DetectVarStoreMatchKeyValue(det_ctx,
-                                (uint8_t *)str_ptr, key_len,
-                                (uint8_t *)str_ptr2, capture_len,
+                        (void)DetectVarStoreMatchKeyValue(det_ctx, (uint8_t *)str_ptr, key_len,
+                                (uint8_t *)str_ptr2, (uint16_t)capture_len,
                                 DETECT_VAR_TYPE_PKT_POSTMATCH);
 
                     } else if (pe->captypes[x] == VAR_TYPE_PKT_VAR) {
-                        (void)DetectVarStoreMatch(det_ctx, pe->capids[x],
-                                (uint8_t *)str_ptr, capture_len,
-                                DETECT_VAR_TYPE_PKT_POSTMATCH);
+                        (void)DetectVarStoreMatch(det_ctx, pe->capids[x], (uint8_t *)str_ptr,
+                                (uint16_t)capture_len, DETECT_VAR_TYPE_PKT_POSTMATCH);
 
                     } else if (pe->captypes[x] == VAR_TYPE_FLOW_VAR && f != NULL) {
-                        (void)DetectVarStoreMatch(det_ctx, pe->capids[x],
-                                (uint8_t *)str_ptr, capture_len,
-                                DETECT_VAR_TYPE_FLOW_POSTMATCH);
+                        (void)DetectVarStoreMatch(det_ctx, pe->capids[x], (uint8_t *)str_ptr,
+                                (uint16_t)capture_len, DETECT_VAR_TYPE_FLOW_POSTMATCH);
                     } else {
                         BUG_ON(1); // Impossible captype
                         SCFree(str_ptr);

--- a/src/detect-pktvar.h
+++ b/src/detect-pktvar.h
@@ -26,7 +26,7 @@
 
 typedef struct DetectPktvarData_ {
     uint32_t id;
-    uint8_t content_len;
+    uint16_t content_len;
     uint8_t flags;
     uint8_t *content;
 } DetectPktvarData;

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -80,7 +80,7 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectQuicHash(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t DetectEngineInspectQuicHash(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -80,9 +80,9 @@ static InspectionBuffer *QuicStringGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectQuicString(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
-        void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectQuicString(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     uint32_t local_id = 0;
 

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -47,7 +47,7 @@ static void RfbSecresultRegisterTests(void);
 #endif
 void DetectRfbSecresultFree(DetectEngineCtx *, void *);
 
-static int DetectEngineInspectRfbSecresultGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectRfbSecresultGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -77,7 +77,7 @@ void DetectRfbSecresultRegister (void)
     rfb_secresult_id = DetectBufferTypeGetByName("rfb.secresult");
 }
 
-static int DetectEngineInspectRfbSecresultGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectRfbSecresultGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -56,7 +56,7 @@ static int DetectRfbSectypeSetup (DetectEngineCtx *, Signature *s, const char *s
 static void DetectRfbSectypeFree(DetectEngineCtx *, void *);
 static int g_rfb_sectype_buffer_id = 0;
 
-static int DetectEngineInspectRfbSectypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectRfbSectypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -84,7 +84,7 @@ void DetectRfbSectypeRegister (void)
     g_rfb_sectype_buffer_id = DetectBufferTypeGetByName("rfb.sectype");
 }
 
-static int DetectEngineInspectRfbSectypeGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectRfbSectypeGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -49,7 +49,7 @@ static void DetectSNMPPduTypeRegisterTests(void);
 #endif
 static int g_snmp_pdu_type_buffer_id = 0;
 
-static int DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -81,7 +81,7 @@ void DetectSNMPPduTypeRegister(void)
     g_snmp_pdu_type_buffer_id = DetectBufferTypeGetByName("snmp.pdu_type");
 }
 
-static int DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -58,7 +58,7 @@ static void DetectSNMPVersionRegisterTests(void);
 #endif
 static int g_snmp_version_buffer_id = 0;
 
-static int DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -93,7 +93,7 @@ void DetectSNMPVersionRegister (void)
     g_snmp_version_buffer_id = DetectBufferTypeGetByName("snmp.version");
 }
 
-static int DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -200,7 +200,7 @@ static DetectSshVersionData *DetectSshVersionParse (DetectEngineCtx *de_ctx, con
             pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
             goto error;
         }
-        ssh->len = strlen((char *) ssh->ver);
+        ssh->len = (uint16_t)strlen((char *)ssh->ver);
         pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
 
         SCLogDebug("will look for ssh %s", ssh->ver);

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -76,7 +76,7 @@ static void DetectSshSoftwareVersionRegisterTests(void);
 static void DetectSshSoftwareVersionFree(DetectEngineCtx *de_ctx, void *);
 static int g_ssh_banner_list_id = 0;
 
-static int InspectSshBanner(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectSshBanner(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -193,7 +193,7 @@ static DetectSshSoftwareVersionData *DetectSshSoftwareVersionParse (DetectEngine
         }
         pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
 
-        ssh->len = strlen((char *)ssh->software_ver);
+        ssh->len = (uint16_t)strlen((char *)ssh->software_ver);
 
         SCLogDebug("will look for ssh %s", ssh->software_ver);
     }

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -66,7 +66,7 @@ static void DetectSslStateRegisterTests(void);
 #endif
 static void DetectSslStateFree(DetectEngineCtx *, void *);
 
-static int InspectTlsGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectTlsGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
@@ -100,7 +100,7 @@ void DetectSslStateRegister(void)
             "tls_generic", ALPROTO_TLS, SIG_FLAG_TOCLIENT, 0, InspectTlsGeneric, NULL);
 }
 
-static int InspectTlsGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectTlsGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -177,7 +177,7 @@ static int DetectSslVersionMatch(DetectEngineThreadCtx *det_ctx,
 struct SSLVersionKeywords {
     const char *word;
     int index;
-    int value;
+    uint16_t value;
 };
 
 struct SSLVersionKeywords ssl_version_keywords[TLS_SIZE] = {

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -66,7 +66,7 @@ typedef struct DetectTagData_ {
     uint8_t type;          /**< tag type */
     uint8_t direction;     /**< host direction */
     uint32_t count;        /**< count */
-    uint32_t metric;       /**< metric */
+    uint8_t metric;        /**< metric */
 } DetectTagData;
 
 /** This is the installed data at the session/global or host table */

--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -43,7 +43,7 @@
 
 static int DetectTemplateRustBufferSetup(DetectEngineCtx *, Signature *,
     const char *);
-static int DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 #ifdef UNITTESTS
@@ -92,11 +92,11 @@ static int DetectTemplateRustBufferSetup(DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 }
 
-static int DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
+static uint8_t DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
-    int ret = 0;
+    uint8_t ret = 0;
     const uint8_t *data = NULL;
     uint32_t data_len = 0;
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -75,9 +75,9 @@ static void TlsValidRegisterTests(void);
 static void DetectTlsValidityFree(DetectEngineCtx *, void *);
 static int g_tls_validity_buffer_id = 0;
 
-static int DetectEngineInspectTlsValidity(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+static uint8_t DetectEngineInspectTlsValidity(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 /**
  * \brief Registration function for tls validity keywords.
@@ -134,9 +134,9 @@ void DetectTlsValidityRegister (void)
     g_tls_validity_buffer_id = DetectBufferTypeGetByName("tls_validity");
 }
 
-static int DetectEngineInspectTlsValidity(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+static uint8_t DetectEngineInspectTlsValidity(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const struct DetectEngineAppInspectionEngine_ *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {
     return DetectEngineInspectGenericList(
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -59,11 +59,9 @@ static int DetectTlsCertsSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectTlsCertsRegisterTests(void);
 #endif
-static int DetectEngineInspectTlsCerts(DetectEngineCtx *de_ctx,
-	DetectEngineThreadCtx *det_ctx,
-	const DetectEngineAppInspectionEngine *engine,
-        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv,
-	uint64_t tx_id);
+static uint8_t DetectEngineInspectTlsCerts(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
 static int PrefilterMpmTlsCertsRegister(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistery *mpm_reg, int list_id);
@@ -162,11 +160,9 @@ static InspectionBuffer *TlsCertsGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static int DetectEngineInspectTlsCerts(DetectEngineCtx *de_ctx,
-	DetectEngineThreadCtx *det_ctx,
-	const DetectEngineAppInspectionEngine *engine,
-        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv,
-	uint64_t tx_id)
+static uint8_t DetectEngineInspectTlsCerts(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id)
 {
     const DetectEngineTransforms *transforms = NULL;
     if (!engine->mpm) {

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -95,7 +95,7 @@ static int DetectTlsStorePostMatch (DetectEngineThreadCtx *det_ctx,
 
 static int g_tls_cert_list_id = 0;
 
-static int InspectTlsCert(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+static uint8_t InspectTlsCert(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-transform-urldecode.c
+++ b/src/detect-transform-urldecode.c
@@ -86,7 +86,9 @@ static bool BufferUrlDecode(const uint8_t *input, const uint32_t input_len, uint
             if (i + 2 < input_len) {
                 if ((isxdigit(input[i+1])) && (isxdigit(input[i+2]))) {
                     // Decode %HH encoding.
-                    *oi = (input[i+1] >= 'A' ? ((input[i+1] & 0xdf) - 'A') + 10 : (input[i+1] - '0')) << 4;
+                    *oi = (uint8_t)((input[i + 1] >= 'A' ? ((input[i + 1] & 0xdf) - 'A') + 10
+                                                         : (input[i + 1] - '0'))
+                                    << 4);
                     *oi |= (input[i+2] >= 'A' ? ((input[i+2] & 0xdf) - 'A') + 10 : (input[i+2] - '0'));
                     oi++;
                     // one more increment before looping

--- a/src/detect-transform-xor.c
+++ b/src/detect-transform-xor.c
@@ -96,7 +96,7 @@ static int DetectTransformXorSetup(DetectEngineCtx *de_ctx, Signature *s, const 
         DetectTransformXorFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
-    pxd->length = keylen / 2;
+    pxd->length = (uint8_t)(keylen / 2);
     pxd->key = SCMalloc(keylen / 2);
     if (pxd->key == NULL) {
         SCLogError(SC_ERR_MEM_ALLOC, "memory allocation failed");
@@ -105,9 +105,9 @@ static int DetectTransformXorSetup(DetectEngineCtx *de_ctx, Signature *s, const 
     }
     for (size_t i = 0; i < keylen / 2; i++) {
         if ((isxdigit(optstr[2 * i])) && (isxdigit(optstr[2 * i + 1]))) {
-            pxd->key[i] = (optstr[2 * i] >= 'A' ? ((optstr[2 * i] & 0xdf) - 'A') + 10
-                                                : (optstr[2 * i] - '0'))
-                          << 4;
+            pxd->key[i] = (uint8_t)((optstr[2 * i] >= 'A' ? ((optstr[2 * i] & 0xdf) - 'A') + 10
+                                                          : (optstr[2 * i] - '0'))
+                                    << 4);
             pxd->key[i] |= (optstr[2 * i + 1] >= 'A' ? ((optstr[2 * i + 1] & 0xdf) - 'A') + 10
                                                      : (optstr[2 * i + 1] - '0'));
         } else {

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -175,7 +175,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
     }
 
     /** set the first urilen value */
-    if (StringParseUint16(&urilend->urilen1,10,strlen(arg2),arg2) <= 0){
+    if (StringParseUint16(&urilend->urilen1, 10, (uint16_t)strlen(arg2), arg2) <= 0) {
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg2);
         goto error;
     }
@@ -188,8 +188,7 @@ static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
             goto error;
         }
 
-        if(StringParseUint16(&urilend->urilen2,10,strlen(arg4),arg4) <= 0)
-        {
+        if (StringParseUint16(&urilend->urilen2, 10, (uint16_t)strlen(arg4), arg4) <= 0) {
             SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg4);
             goto error;
         }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1137,7 +1137,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             }
 
             /* run callback: but bypass stream callback if we can */
-            int match;
+            uint8_t match;
             if (unlikely(engine->stream && can->stream_stored)) {
                 match = can->stream_result;
                 TRACE_SID_TXS(s->id, tx, "stream skipped, stored result %d used instead", match);
@@ -1149,8 +1149,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 TRACE_SID_TXS(s->id, tx, "engine %p match %d", engine, match);
                 if (engine->stream) {
                     can->stream_stored = true;
-                    // TODO change Callback prototype ?
-                    can->stream_result = (uint8_t)match;
+                    can->stream_result = match;
                     TRACE_SID_TXS(s->id, tx, "stream ran, store result %d for next tx (if any)", match);
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -369,15 +369,14 @@ static inline void DetectPrefilterMergeSort(DetectEngineCtx *de_ctx,
 /** \internal
  *  \brief build non-prefilter list based on the rule group list we've set.
  */
-static inline void
-DetectPrefilterBuildNonPrefilterList(DetectEngineThreadCtx *det_ctx,
-        const SignatureMask mask, const uint8_t alproto)
+static inline void DetectPrefilterBuildNonPrefilterList(
+        DetectEngineThreadCtx *det_ctx, const SignatureMask mask, const AppProto alproto)
 {
     for (uint32_t x = 0; x < det_ctx->non_pf_store_cnt; x++) {
         /* only if the mask matches this rule can possibly match,
          * so build the non_mpm array only for match candidates */
         const SignatureMask rule_mask = det_ctx->non_pf_store_ptr[x].mask;
-        const uint8_t rule_alproto = det_ctx->non_pf_store_ptr[x].alproto;
+        const AppProto rule_alproto = det_ctx->non_pf_store_ptr[x].alproto;
         if ((rule_mask & mask) == rule_mask &&
                 (rule_alproto == 0 || AppProtoEquals(rule_alproto, alproto))) {
             det_ctx->non_pf_id_array[det_ctx->non_pf_id_cnt++] = det_ctx->non_pf_store_ptr[x].id;
@@ -1070,7 +1069,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     const int direction = (flow_flags & STREAM_TOSERVER) ? 0 : 1;
     uint32_t inspect_flags = stored_flags ? *stored_flags : 0;
     int total_matches = 0;
-    int file_no_match = 0;
+    uint16_t file_no_match = 0;
     bool retval = false;
     bool mpm_before_progress = false;   // is mpm engine before progress?
     bool mpm_in_progress = false;       // is mpm engine in a buffer we will revisit?
@@ -1150,7 +1149,8 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 TRACE_SID_TXS(s->id, tx, "engine %p match %d", engine, match);
                 if (engine->stream) {
                     can->stream_stored = true;
-                    can->stream_result = match;
+                    // TODO change Callback prototype ?
+                    can->stream_result = (uint8_t)match;
                     TRACE_SID_TXS(s->id, tx, "stream ran, store result %d for next tx (if any)", match);
                 }
             }

--- a/src/detect.h
+++ b/src/detect.h
@@ -843,7 +843,7 @@ typedef struct DetectEngineCtx_ {
     DetectEngineIPOnlyCtx io_ctx;
     ThresholdCtx ths_ctx;
 
-    uint16_t mpm_matcher; /**< mpm matcher this ctx uses */
+    uint8_t mpm_matcher;  /**< mpm matcher this ctx uses */
     uint16_t spm_matcher; /**< spm matcher this ctx uses */
 
     /* spm thread context prototype, built as spm matchers are constructed and
@@ -1021,7 +1021,7 @@ typedef struct HttpReassembledBody_ {
 typedef struct SignatureNonPrefilterStore_ {
     SigIntId id;
     SignatureMask mask;
-    uint8_t alproto;
+    AppProto alproto;
 } SignatureNonPrefilterStore;
 
 /** array of TX inspect rule candidates */

--- a/src/detect.h
+++ b/src/detect.h
@@ -392,11 +392,10 @@ typedef InspectionBuffer *(*InspectionBufferGetDataPtr)(
         void *txv, const int list_id);
 struct DetectEngineAppInspectionEngine_;
 
-typedef int (*InspectEngineFuncPtr2)(
-        struct DetectEngineCtx_ *de_ctx, struct DetectEngineThreadCtx_ *det_ctx,
-        const struct DetectEngineAppInspectionEngine_ *engine,
-        const struct Signature_ *s,
-        Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+typedef uint8_t (*InspectEngineFuncPtr2)(struct DetectEngineCtx_ *de_ctx,
+        struct DetectEngineThreadCtx_ *det_ctx,
+        const struct DetectEngineAppInspectionEngine_ *engine, const struct Signature_ *s, Flow *f,
+        uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 typedef struct DetectEngineAppInspectionEngine_ {
     AppProto alproto;

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1224,7 +1224,7 @@ static uint8_t ProcessBase64Remainder(
         const uint8_t *buf, const uint32_t len, MimeDecParseState *state, int force)
 {
     uint8_t buf_consumed = 0; /* consumed bytes from 'buf' */
-    uint32_t cnt = 0;
+    uint8_t cnt = 0;
     uint8_t block[B64_BLOCK];
 
     /* should be impossible, but lets be defensive */
@@ -1345,7 +1345,7 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
         uint32_t left = len - consumed;
         if (left < B64_BLOCK) {
             memcpy(state->bvremain, buf + consumed, left);
-            state->bvr_len = left;
+            state->bvr_len = (uint8_t)left;
             return MIME_DEC_OK;
         }
         remaining -= consumed;
@@ -1408,7 +1408,7 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
             /* If remaining is 4 by this time, we encountered spaces during processing */
             DEBUG_VALIDATE_BUG_ON(state->bvr_len != 0);
             memcpy(state->bvremain, buf + offset + consumed_bytes, leftover_bytes);
-            state->bvr_len = leftover_bytes;
+            state->bvr_len = (uint8_t)leftover_bytes;
             return MIME_DEC_OK;
         }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4516

Describe changes:
- Fix integer warnings `-Wimplicit-int-conversion` for detect*
- Adds ci check for this warning

Follows #7490 with 
- fixing warnings with Lua enabled
- fixing https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47872 (defrag has u32, no need to cast it to u16)

