### PR TITLE
Notification of fully initialised Suricata v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -636,6 +636,35 @@
         AC_MSG_RESULT(no)
     fi
 
+  #systemd
+    AC_ARG_WITH(systemd_includes,
+            [  --with-systemd-includes=DIR  systemd include directory],
+            [with_systemd_includes="$withval"],[with_systemd_includes=no])
+    AC_ARG_WITH(systemd_libraries,
+            [  --with-systemd-libraries=DIR    systemd library directory],
+            [with_systemd_libraries="$withval"],[with_systemd_libraries="no"])
+
+    if test "$with_systemd_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_systemd_includes}"
+    fi
+
+    AC_CHECK_HEADER(systemd/sd-daemon.h, SYSTEMD="yes",SYSTEMD="no")
+    if test "$SYSTEMD" = "yes"; then
+        if test "$with_systemd_libraries" != "no"; then
+            LDFLAGS="${LDFLAGS}  -L${with_systemd_libraries}"
+        fi
+
+        # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+        # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+        SYSTEMD=""
+        TMPLIBS="${LIBS}"
+        AC_CHECK_LIB(systemd,sd_notify,,SYSTEMD="no")
+
+        if test "$SYSTEMD" != "no"; then
+            LIBS="${TMPLIBS} -lsystemd"
+        fi
+    fi
+  
   # libhs
     enable_hyperscan="no"
 

--- a/doc/userguide/configuration/systemd-notify.rst
+++ b/doc/userguide/configuration/systemd-notify.rst
@@ -1,0 +1,47 @@
+systemd notification
+====================
+
+Introduction
+------------
+Suricata supports systemd notification with the aim of notifying the service manager of successful
+initialisation. The purpose is to enable services/test frameworks that depend on a fully initialised
+Suricata the ability to start upon/await successful start-up.
+
+During the initialisation phase Suricata synchronises the initialisation thread with all active
+threads to ensure they are in a running state. Once synchronisation has been completed a ``READY=1``
+status notification is sent to the service manager using ``sd_notify()``.
+
+Example
+*******
+A test framework requires Suricata to be capturing before the tests can be carried out.
+Writing a ``test.service`` and ensuring the correct execution order with ``After=suricata.service``
+forces the unit to be started after ``suricata.service``. This does not enforce Suricata has fully
+initialised. By configuring ``suricata.service`` as ``Type=notify`` instructs the service manager
+to wait for the notification before starting ``test.service``.
+
+Requirements
+------------
+This feature is only supported for distributions under the following conditions:
+
+1. Distribution contains ``libsystemd``
+2. Any distribution that runs under **systemd**
+3. Unit file configuration: ``Type=notify``
+
+This package shall be compile-time configured and therefore only built with distributions fulfilling
+requirements [1, 2]. For notification to the service manager the unit file must be configured as 
+shown in requirement [3]. Upon all requirements being met the service manager will start and await
+``READY=1`` status from Suricata. Otherwise the service manager will treat the service unit as
+``Type=simple`` and consider it started immediately after the main process ``ExecStart=`` has been
+forked.
+
+Additional Information
+----------------------
+To confirm the system is running under systemd:
+
+``ps --no-headers -o comm 1``
+
+See: https://man7.org/linux/man-pages/man3/sd_notify.3.html for a detailed description on
+``sd_notify``.
+
+See https://www.freedesktop.org/software/systemd/man/systemd.service.html for help
+writing systemd unit files.

--- a/src/counters.c
+++ b/src/counters.c
@@ -393,7 +393,7 @@ static void *StatsMgmtThread(void *arg)
     }
     SCLogDebug("stats_thread_data %p", &stats_thread_data);
 
-    TmThreadsSetFlag(tv_local, THV_INIT_DONE);
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
             TmThreadsSetFlag(tv_local, THV_PAUSED);
@@ -462,7 +462,8 @@ static void *StatsWakeupThread(void *arg)
         return NULL;
     }
 
-    TmThreadsSetFlag(tv_local, THV_INIT_DONE);
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
+
     while (1) {
         if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
             TmThreadsSetFlag(tv_local, THV_PAUSED);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -770,6 +770,8 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     uint32_t emerg_over_cnt = 0;
     uint64_t next_run_ms = 0;
 
+    TmThreadsSetFlag(th_v, THV_RUNNING);
+
     while (1)
     {
         if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
@@ -1089,6 +1091,8 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
     struct timeval startts;
     memset(&startts, 0, sizeof(startts));
     gettimeofday(&startts, NULL);
+
+    TmThreadsSetFlag(th_v, THV_RUNNING);
 
     while (1)
     {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1338,6 +1338,10 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     fds.fd = ptv->socket;
     fds.events = POLLIN;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         /* Start by checking the state of our interface */
         if (unlikely(ptv->afp_state == AFP_STATE_DOWN)) {

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -338,6 +338,10 @@ ReceiveErfDagLoop(ThreadVars *tv, void *data, void *slot)
 
     dtv->slot = s->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -116,6 +116,10 @@ TmEcode ReceiveErfFileLoop(ThreadVars *tv, void *data, void *slot)
 
     etv->slot = ((TmSlot *)slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -240,6 +240,11 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
     SCLogInfo("Thread '%s' will run on port %d (item %d)",
               tv->name, nq->port_num, ptv->ipfw_index);
+
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (unlikely(suricata_ctl_flags != 0)) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -909,6 +909,10 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     TmSlot *s = (TmSlot *) slot;
     ntv->slot = s->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (!(suricata_ctl_flags & SURICATA_STOP)) {
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -785,7 +785,13 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
     fds.fd = ntv->ifsrc->nmd->fd;
     fds.events = POLLIN;
 
+
     SCLogDebug("thread %s polling on %d", tv->name, fds.fd);
+
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     for(;;) {
         if (unlikely(suricata_ctl_flags != 0)) {
             break;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -430,6 +430,10 @@ TmEcode ReceiveNFLOGLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags != 0)
             break;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1008,6 +1008,10 @@ TmEcode ReceiveNFQLoop(ThreadVars *tv, void *data, void *slot)
 
     ntv->slot = ((TmSlot *) slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while(1) {
         if (unlikely(suricata_ctl_flags != 0)) {
             NFQDestroyQueue(nq);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -169,6 +169,10 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     ptv->shared.slot = s->slot_next;
     ptv->shared.cb_result = TM_ECODE_OK;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     if(ptv->is_directory == 0) {
         SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
         status = PcapFileDispatch(ptv->behavior.file);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -311,6 +311,10 @@ static TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot)
     ptv->slot = s->slot_next;
     ptv->cb_result = TM_ECODE_OK;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -361,6 +361,10 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while(1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-windivert.c
+++ b/src/source-windivert.c
@@ -410,6 +410,10 @@ TmEcode ReceiveWinDivertLoop(ThreadVars *tv, void *data, void *slot)
     WinDivertThreadVars *wd_tv = (WinDivertThreadVars *)data;
     wd_tv->slot = ((TmSlot *)slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (true) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -442,6 +442,18 @@ static void GlobalsDestroy(SCInstance *suri)
     suri->pid_filename = NULL;
 }
 
+/**
+ * \brief Used to send OS specific notification of running threads
+ *
+ * \retval TmEcode TM_ECODE_OK on success; TM_ECODE_FAILED on failure.
+ */
+static TmEcode SendOSSpecificNotification(void)
+{
+    SCLogNotice("All threads in running state.");
+
+    return TM_ECODE_OK;
+}
+
 /** \brief make sure threads can stop the engine by calling this
  *  function. Purpose: pcap file mode needs to be able to tell the
  *  engine the file eof is reached. */
@@ -2920,6 +2932,14 @@ int SuricataMain(int argc, char **argv)
 
     /* Un-pause all the paused threads */
     TmThreadContinueThreads();
+
+    /* Must ensure all threads are fully operational before contunuing with init process */
+    if(TmThreadWaitOnThreadRunning() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Print notice and send OS specifc notication of threads in running state */
+    SendOSSpecificNotification();
 
     PostRunStartedDetectSetup(&suricata);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -31,6 +31,10 @@
 #include <signal.h>
 #endif
 
+#if HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include "suricata.h"
 #include "decode.h"
 #include "feature.h"
@@ -450,6 +454,13 @@ static void GlobalsDestroy(SCInstance *suri)
 static TmEcode SendOSSpecificNotification(void)
 {
     SCLogNotice("All threads in running state.");
+
+#if HAVE_LIBSYSTEMD
+    if(sd_notify(0, "READY=1") < 0) {
+        SCLogWarning(SC_ERR_SYSCALL, "failed to send sd_notify()");
+        return TM_ECODE_FAILED;
+    }
+#endif
 
     return TM_ECODE_OK;
 }

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -54,6 +54,7 @@ struct TmSlot_;
  *  rule reloads even if no packets are read by the capture method. */
 #define THV_CAPTURE_INJECT_PKT  BIT_U32(11)
 #define THV_DEAD                BIT_U32(12) /**< thread has been joined with pthread_join() */
+#define THV_RUNNING             BIT_U32(13) /**< thread is running */
 
 /** \brief Per thread variable structure */
 typedef struct ThreadVars_ {

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -427,7 +427,11 @@ static void *TmThreadsSlotVar(void *td)
 
     StatsSetupPrivate(tv);
 
-    TmThreadsSetFlag(tv, THV_INIT_DONE);
+    // Each 'worker' thread uses this func to process/decode the packet read.
+    // Each decode method is different to receive methods in that they do not
+    // enter infinite loops. They use this as the core loop. As a result, at this
+    // point the worker threads can be considered both initialized and running.
+    TmThreadsSetFlag(tv, THV_INIT_DONE | THV_RUNNING);
 
     s = (TmSlot *)tv->tm_slots;
 
@@ -1031,7 +1035,6 @@ ThreadVars *TmThreadCreatePacketHandler(const char *name, const char *inq_name,
         tv->type = TVT_PPT;
         tv->id = TmThreadsRegisterThread(tv, tv->type);
     }
-
 
     return tv;
 }
@@ -1772,8 +1775,55 @@ void TmThreadWaitForFlag(ThreadVars *tv, uint32_t flags)
 void TmThreadContinue(ThreadVars *tv)
 {
     TmThreadsUnsetFlag(tv, THV_PAUSE);
-
     return;
+}
+
+/**
+ * \brief Waits for all threads to be in a running state
+ *
+ * \retval TM_ECODE_OK if all are running or error if a thread failed
+ */
+TmEcode TmThreadWaitOnThreadRunning(void)
+{
+    struct timeval start_ts;
+    struct timeval cur_ts;
+    gettimeofday(&start_ts, NULL);
+
+again:
+    SCMutexLock(&tv_root_lock);
+    for (int i = 0; i < TVT_MAX; i++) {
+        ThreadVars *tv = tv_root[i];
+        while (tv != NULL) {
+            if (TmThreadsCheckFlag(tv,(THV_FAILED|THV_CLOSED|THV_DEAD))) {
+                SCMutexUnlock(&tv_root_lock);
+
+                SCLogError(SC_ERR_THREAD_INIT, "thread \"%s\" failed to "
+                        "start: flags %04x", tv->name,
+                        SC_ATOMIC_GET(tv->flags));
+                return TM_ECODE_FAILED;
+            }
+
+            if (!(TmThreadsCheckFlag(tv, THV_RUNNING))) {
+                SCMutexUnlock(&tv_root_lock);
+
+                gettimeofday(&cur_ts, NULL);
+                if ((cur_ts.tv_sec - start_ts.tv_sec) > 60) {
+                    SCLogError(SC_ERR_THREAD_INIT, "thread \"%s\" failed to "
+                            "start in time: flags %04x", tv->name,
+                            SC_ATOMIC_GET(tv->flags));
+                    return TM_ECODE_FAILED;
+                }
+
+                /* sleep a little to give the thread some
+                 * time to start running */
+                SleepUsec(100);
+                goto again;
+            }
+            tv = tv->next;
+        }
+    }
+    SCMutexUnlock(&tv_root_lock);
+    return TM_ECODE_OK;
 }
 
 /**
@@ -2148,6 +2198,7 @@ void TmThreadsInitThreadsTimestamp(const struct timeval *ts)
     struct timeval systs;
     gettimeofday(&systs, NULL);
     SCMutexLock(&thread_store_lock);
+
     for (size_t s = 0; s < thread_store.threads_size; s++) {
         Thread *t = &thread_store.threads[s];
         if (!t->in_use)

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -122,6 +122,8 @@ void TmThreadDisableReceiveThreads(void);
 
 uint32_t TmThreadCountThreadsByTmmFlags(uint8_t flags);
 
+TmEcode TmThreadWaitOnThreadRunning(void);
+
 static inline void TmThreadsCleanDecodePQ(PacketQueueNoLock *pq)
 {
     while (1) {

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1120,7 +1120,8 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
     th_v->cap_flags = 0;
     SCDropCaps(th_v);
 
-    TmThreadsSetFlag(th_v, THV_INIT_DONE);
+    TmThreadsSetFlag(th_v, THV_INIT_DONE | THV_RUNNING);
+
     while (1) {
         ret = UnixMain(&command);
         if (ret == 0) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5384

Describe changes:
- THV_RUNNING status flag added to indicate threads are in a running state - each module reports this
- TmThreadWaitOnThreadRunning function added to await running state of all modules - during initialisation 
- Prints a notification stating: "All threads in running state" - can be used by test frameworks
- Compile-time configured systemd notification - inform service manager Suricata is initialised 
-  systemd-notify.rst document added to describe feature

Inspiration for the THV_RUNNING state indicator was taken from https://github.com/OISF/suricata/pull/5927, so thanks to @rtkjweeks.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
