### PR TITLE
detect/dcerpc: apply dcerpc to smb as well

### DIFF
--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -91,6 +91,8 @@ static inline bool AppProtoEquals(AppProto sigproto, AppProto alproto)
         case ALPROTO_HTTP:
             return (alproto == ALPROTO_HTTP1) || (alproto == ALPROTO_HTTP2) ||
                    (alproto == ALPROTO_HTTP);
+        case ALPROTO_DCERPC:
+            return (alproto == ALPROTO_DCERPC || alproto == ALPROTO_SMB);
     }
     return (sigproto == alproto);
 }


### PR DESCRIPTION
So 'alert dcerpc' also matches if the DCERPC is over SMB.

Bug: #5208.

suricata-verify-pr: 816