### PR TITLE
detect/config: Raise errors if test mode discovers invalid classification.config

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2365,14 +2365,17 @@ static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, cons
     /* init iprep... ignore errors for now */
     (void)SRepInit(de_ctx);
 
-    SCClassConfLoadClassficationConfigFile(de_ctx, NULL);
-    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0) {
+    if (!SCClassConfLoadClassficationConfigFile(de_ctx, NULL)) {
         if (RunmodeGetCurrent() == RUNMODE_CONF_TEST)
             goto error;
     }
 
     if (ActionInitConfig() < 0) {
         goto error;
+    }
+    if (SCRConfLoadReferenceConfigFile(de_ctx, NULL) < 0) {
+        if (RunmodeGetCurrent() == RUNMODE_CONF_TEST)
+            goto error;
     }
 
     de_ctx->version = DetectEngineGetVersion();
@@ -2773,8 +2776,10 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
 
     }
     if (DetectPortParse(de_ctx, &de_ctx->udp_whitelist, ports) != 0) {
-        SCLogWarning(SC_ERR_INVALID_YAML_CONF_ENTRY, "'%s' is not a valid value "
-                "forr detect.grouping.udp-whitelist", ports);
+        SCLogWarning(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                "'%s' is not a valid value "
+                "for detect.grouping.udp-whitelist",
+                ports);
     }
     for (x = de_ctx->udp_whitelist; x != NULL;  x = x->next) {
         if (x->port != x->port2) {

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -252,8 +252,10 @@ int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t inde
 
     ret = pcre2_match(regex, (PCRE2_SPTR8)rawstr, strlen(rawstr), 0, 0, regex_match, NULL);
     if (ret < 0) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid Classtype in "
-                   "classification.config file");
+        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                "Invalid Classtype in "
+                "classification.config file %s: \"%s\"",
+                SCClassConfGetConfFilename(de_ctx), rawstr);
         goto error;
     }
 
@@ -344,7 +346,7 @@ static int SCClassConfIsLineBlankOrComment(char *line)
  *
  * \param de_ctx Pointer to the Detection Engine Context.
  */
-static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
+static bool SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
     uint16_t i = 1;
@@ -353,7 +355,9 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
         if (SCClassConfIsLineBlankOrComment(line))
             continue;
 
-        SCClassConfAddClasstype(de_ctx, line, i);
+        if (SCClassConfAddClasstype(de_ctx, line, i) == -1) {
+            return false;
+        }
         i++;
     }
 
@@ -362,7 +366,7 @@ static void SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
               de_ctx->class_conf_ht->count);
 #endif
 
-    return;
+    return true;
 }
 
 /**
@@ -522,24 +526,31 @@ void SCClassConfClasstypeHashFree(void *ch)
  * \param de_ctx Pointer to the Detection Engine Context that should be updated
  *               with Classtype information.
  */
-void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
+bool SCClassConfLoadClassficationConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     fd = SCClassConfInitContextAndLocalResources(de_ctx, fd);
     if (fd == NULL) {
 #ifdef UNITTESTS
-        if (RunmodeIsUnittests() && fd == NULL) {
-            return;
+        if (RunmodeIsUnittests()) {
+            return false;
         }
 #endif
         SCLogError(SC_ERR_OPENING_FILE, "please check the \"classification-file\" "
                 "option in your suricata.yaml file");
-        return;
+        return false;
     }
 
-    SCClassConfParseFile(de_ctx, fd);
+    bool ret = true;
+    if (!SCClassConfParseFile(de_ctx, fd)) {
+        SCLogWarning(SC_WARN_CLASSIFICATION_CONFIG,
+                "Error loading classification configuration from %s",
+                SCClassConfGetConfFilename(de_ctx));
+        ret = false;
+    }
+
     SCClassConfDeInitLocalResources(de_ctx, fd);
 
-    return;
+    return ret;
 }
 
 /**
@@ -696,22 +707,15 @@ static int SCClassConfTest02(void)
 static int SCClassConfTest03(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    int result = 0;
 
-    if (de_ctx == NULL)
-        return result;
+    FAIL_IF_NULL(de_ctx);
 
     FILE *fd = SCClassConfGenerateInValidDummyClassConfigFD02();
-    SCClassConfLoadClassficationConfigFile(de_ctx, fd);
-
-    if (de_ctx->class_conf_ht == NULL)
-        return result;
-
-    result = (de_ctx->class_conf_ht->count == 3);
+    FAIL_IF(SCClassConfLoadClassficationConfigFile(de_ctx, fd));
 
     DetectEngineCtxFree(de_ctx);
 
-    return result;
+    PASS;
 }
 
 /**
@@ -780,38 +784,6 @@ static int SCClassConfTest05(void)
 }
 
 /**
- * \test Check if the classtype info from the classification.config file have
- *       been loaded into the hash table.
- */
-static int SCClassConfTest06(void)
-{
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    int result = 1;
-
-    if (de_ctx == NULL)
-        return 0;
-
-    FILE *fd = SCClassConfGenerateInValidDummyClassConfigFD02();
-    SCClassConfLoadClassficationConfigFile(de_ctx, fd);
-
-    if (de_ctx->class_conf_ht == NULL)
-        return 0;
-
-    result = (de_ctx->class_conf_ht->count == 3);
-
-    result &= (SCClassConfGetClasstype("unknown", de_ctx) == NULL);
-    result &= (SCClassConfGetClasstype("not-suspicious", de_ctx) != NULL);
-    result &= (SCClassConfGetClasstype("bamboola1", de_ctx) != NULL);
-    result &= (SCClassConfGetClasstype("bamboola1", de_ctx) != NULL);
-    result &= (SCClassConfGetClasstype("BAMBOolA1", de_ctx) != NULL);
-    result &= (SCClassConfGetClasstype("unkNOwn", de_ctx) == NULL);
-
-    DetectEngineCtxFree(de_ctx);
-
-    return result;
-}
-
-/**
  * \brief This function registers unit tests for Classification Config API.
  */
 void SCClassConfRegisterTests(void)
@@ -821,6 +793,5 @@ void SCClassConfRegisterTests(void)
     UtRegisterTest("SCClassConfTest03", SCClassConfTest03);
     UtRegisterTest("SCClassConfTest04", SCClassConfTest04);
     UtRegisterTest("SCClassConfTest05", SCClassConfTest05);
-    UtRegisterTest("SCClassConfTest06", SCClassConfTest06);
 }
 #endif /* UNITTESTS */

--- a/src/util-classification-config.h
+++ b/src/util-classification-config.h
@@ -45,7 +45,7 @@ typedef struct SCClassConfClasstype_ {
     char *classtype_desc;
 } SCClassConfClasstype;
 
-void SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);
+bool SCClassConfLoadClassficationConfigFile(DetectEngineCtx *, FILE *fd);
 int SCClassConfAddClasstype(DetectEngineCtx *de_ctx, char *rawstr, uint16_t index);
 SCClassConfClasstype *SCClassConfGetClasstype(const char *,
                                               DetectEngineCtx *);

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -388,6 +388,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_ERR_SIGNAL);
         CASE_CODE(SC_WARN_CHOWN);
         CASE_CODE(SC_ERR_HASH_ADD);
+        CASE_CODE(SC_WARN_CLASSIFICATION_CONFIG);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -378,6 +378,7 @@ typedef enum {
     SC_ERR_SIGNAL,
     SC_WARN_CHOWN,
     SC_ERR_HASH_ADD,
+    SC_WARN_CLASSIFICATION_CONFIG,
 
     SC_ERR_MAX
 } SCError;


### PR DESCRIPTION
Continuation of #7114

This PR adds logic to raise an error in test mode (only) if classification.config won't parse properly.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4554](https://redmine.openinfosecfoundation.org/issues/4554)

Describe changes:
- Propagate classification.config parse errors
- Raise error if in test mode and classification.config won't load

Updates:
- Reword commit
- Rebase

suricata-verify-pr: 712
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
