### PR TITLE
Detect generic uint 4112 v10

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -109,6 +109,7 @@ exclude = [
     "free",
     "IPPROTO_TCP",
     "IPPROTO_UDP",
+    "SRepCatGetByShortname",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -23,7 +23,7 @@ use nom7::error::{make_error, ErrorKind};
 use nom7::Err;
 use nom7::IResult;
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::str::FromStr;
 
 #[derive(PartialEq, Clone, Debug)]
@@ -441,6 +441,106 @@ pub unsafe extern "C" fn rs_detect_urilen_parse(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_detect_urilen_free(ctx: &mut DetectUrilenData) {
+    // Just unbox...
+    std::mem::drop(Box::from_raw(ctx));
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, FromPrimitive, Debug)]
+pub enum DetectIPRepDataCmd {
+    IPRepCmdAny = 0,
+    IPRepCmdBoth = 1,
+    IPRepCmdSrc = 2,
+    IPRepCmdDst = 3,
+}
+
+impl std::str::FromStr for DetectIPRepDataCmd {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "any" => Ok(DetectIPRepDataCmd::IPRepCmdAny),
+            "both" => Ok(DetectIPRepDataCmd::IPRepCmdBoth),
+            "src" => Ok(DetectIPRepDataCmd::IPRepCmdSrc),
+            "dst" => Ok(DetectIPRepDataCmd::IPRepCmdDst),
+            _ => Err(format!(
+                "'{}' is not a valid value for DetectIPRepDataCmd",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DetectIPRepData {
+    pub du8: DetectUintData<u8>,
+    pub cat: u8,
+    pub cmd: DetectIPRepDataCmd,
+}
+
+pub fn is_alphanumeric_or_slash(chr: char) -> bool {
+    if chr.is_ascii_alphanumeric() {
+        return true;
+    }
+    if chr == '_' || chr == '-' {
+        return true;
+    }
+    return false;
+}
+
+extern "C" {
+    pub fn SRepCatGetByShortname(name: *const i8) -> u8;
+}
+
+pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, cmd) = map_res(alpha0, |s: &str| DetectIPRepDataCmd::from_str(s))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+
+    let (i, name) = take_while(is_alphanumeric_or_slash)(i)?;
+    // copy as to have final zero
+    let namez = CString::new(name).unwrap();
+    let cat = unsafe { SRepCatGetByShortname(namez.as_ptr() as *const i8) };
+    if cat == 0 {
+        return Err(Err::Error(make_error(i, ErrorKind::MapOpt)));
+    }
+
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, mode) = detect_parse_uint_mode(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<u8>().ok())(i)?;
+    let (i, _) = all_consuming(take_while(|c| c == ' '))(i)?;
+    let du8 = DetectUintData::<u8> {
+        arg1: arg1,
+        arg2: 0,
+        mode: mode,
+    };
+    return Ok((i, DetectIPRepData { du8, cat, cmd }));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_iprep_parse(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectIPRepData {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Ok((_, ctx)) = detect_parse_iprep(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_iprep_free(ctx: &mut DetectIPRepData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -42,6 +42,7 @@
 #include "detect-engine-content-inspection.h"
 #include "detect-uricontent.h"
 #include "detect-urilen.h"
+#include "detect-engine-uint.h"
 #include "detect-bsize.h"
 #include "detect-lua.h"
 #include "detect-base64-decode.h"
@@ -605,28 +606,12 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
     } else if (smd->type == DETECT_AL_URILEN) {
         SCLogDebug("inspecting uri len");
 
-        uint8_t r = 0;
+        int r = 0;
         DetectUrilenData *urilend = (DetectUrilenData *) smd->ctx;
-
-        switch (urilend->mode) {
-            case DETECT_URILEN_EQ:
-                if (buffer_len == urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_LT:
-                if (buffer_len < urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_GT:
-                if (buffer_len > urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_RA:
-                if (buffer_len > urilend->urilen1 &&
-                    buffer_len < urilend->urilen2) {
-                    r = 1;
-                }
-                break;
+        if (buffer_len > UINT16_MAX) {
+            r = DetectU16Match(UINT16_MAX, &urilend->du16);
+        } else {
+            r = DetectU16Match((uint16_t)buffer_len, &urilend->du16);
         }
 
         if (r == 1) {

--- a/src/detect-iprep.h
+++ b/src/detect-iprep.h
@@ -24,22 +24,6 @@
 #ifndef __DETECT_IPREP_H__
 #define __DETECT_IPREP_H__
 
-#define DETECT_IPREP_CMD_ANY      0
-#define DETECT_IPREP_CMD_BOTH     1
-#define DETECT_IPREP_CMD_SRC      2
-#define DETECT_IPREP_CMD_DST      3
-
-#define DETECT_IPREP_OP_LT        0
-#define DETECT_IPREP_OP_GT        1
-#define DETECT_IPREP_OP_EQ        2
-
-typedef struct DetectIPRepData_ {
-    uint8_t cmd;
-    int8_t cat;
-    int8_t op;
-    uint8_t val;
-} DetectIPRepData;
-
 /* prototypes */
 void DetectIPRepRegister (void);
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -478,7 +478,9 @@ static int DetectUrilenSetpTest01(void)
     }
 
 cleanup:
-    if (urilend) DetectUrilenFree(NULL, urilend);;
+    if (urilend)
+        DetectUrilenFree(NULL, urilend);
+    ;
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -35,6 +35,7 @@
 #include "detect-engine.h"
 #include "detect-engine-state.h"
 #include "detect-content.h"
+#include "detect-engine-uint.h"
 
 #include "detect-urilen.h"
 #include "util-debug.h"
@@ -42,12 +43,6 @@
 #include "flow-util.h"
 #include "stream-tcp.h"
 
-/**
- * \brief Regex for parsing our urilen
- */
-#define PARSE_REGEX  "^(?:\\s*)(<|>)?(?:\\s*)([0-9]{1,5})(?:\\s*)(?:(<>)(?:\\s*)([0-9]{1,5}))?\\s*(?:,\\s*(norm|raw))?\\s*$"
-
-static DetectParseRegex parse_regex;
 
 /*prototypes*/
 static int DetectUrilenSetup (DetectEngineCtx *, Signature *, const char *);
@@ -73,7 +68,6 @@ void DetectUrilenRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_AL_URILEN].RegisterTests = DetectUrilenRegisterTests;
 #endif
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 
     g_http_uri_buffer_id = DetectBufferTypeRegister("http_uri");
     g_http_raw_uri_buffer_id = DetectBufferTypeRegister("http_raw_uri");
@@ -90,147 +84,7 @@ void DetectUrilenRegister(void)
 
 static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 {
-    DetectUrilenData *urilend = NULL;
-    char *arg1 = NULL;
-    char *arg2 = NULL;
-    char *arg3 = NULL;
-    char *arg4 = NULL;
-    char *arg5 = NULL;
-    int ret = 0, res = 0;
-    size_t pcre2_len;
-
-    ret = DetectParsePcreExec(&parse_regex, urilenstr, 0, 0);
-    if (ret < 3 || ret > 6) {
-        SCLogError(SC_ERR_PCRE_PARSE, "urilen option pcre parse error: \"%s\"", urilenstr);
-        goto error;
-    }
-    const char *str_ptr;
-
-    SCLogDebug("ret %d", ret);
-
-    res = SC_Pcre2SubstringGet(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-        goto error;
-    }
-    arg1 = (char *) str_ptr;
-    SCLogDebug("Arg1 \"%s\"", arg1);
-
-    res = pcre2_substring_get_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-        goto error;
-    }
-    arg2 = (char *) str_ptr;
-    SCLogDebug("Arg2 \"%s\"", arg2);
-
-    if (ret > 3) {
-        res = SC_Pcre2SubstringGet(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-        if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-            goto error;
-        }
-        arg3 = (char *) str_ptr;
-        SCLogDebug("Arg3 \"%s\"", arg3);
-
-        if (ret > 4) {
-            res = SC_Pcre2SubstringGet(parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-            if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-                goto error;
-            }
-            arg4 = (char *) str_ptr;
-            SCLogDebug("Arg4 \"%s\"", arg4);
-        }
-        if (ret > 5) {
-            res = pcre2_substring_get_bynumber(
-                    parse_regex.match, 5, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-            if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-                goto error;
-            }
-            arg5 = (char *) str_ptr;
-            SCLogDebug("Arg5 \"%s\"", arg5);
-        }
-    }
-
-    urilend = SCMalloc(sizeof (DetectUrilenData));
-    if (unlikely(urilend == NULL))
-        goto error;
-    memset(urilend, 0, sizeof(DetectUrilenData));
-
-    if (arg1 != NULL && arg1[0] == '<')
-        urilend->mode = DETECT_URILEN_LT;
-    else if (arg1 != NULL && arg1[0] == '>')
-        urilend->mode = DETECT_URILEN_GT;
-    else
-        urilend->mode = DETECT_URILEN_EQ;
-
-    if (arg3 != NULL && strcmp("<>", arg3) == 0) {
-        if (arg1 != NULL && strlen(arg1) != 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Range specified but mode also set");
-            goto error;
-        }
-        urilend->mode = DETECT_URILEN_RA;
-    }
-
-    /** set the first urilen value */
-    if (StringParseUint16(&urilend->urilen1, 10, (uint16_t)strlen(arg2), arg2) <= 0) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg2);
-        goto error;
-    }
-
-    /** set the second urilen value if specified */
-    if (arg4 != NULL && strlen(arg4) > 0) {
-        if (urilend->mode != DETECT_URILEN_RA) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Multiple urilen values specified"
-                                           " but mode is not range");
-            goto error;
-        }
-
-        if (StringParseUint16(&urilend->urilen2, 10, (uint16_t)strlen(arg4), arg4) <= 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg4);
-            goto error;
-        }
-
-        if (urilend->urilen2 <= urilend->urilen1){
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"urilen2:%"PRIu16" <= urilen:"
-                        "%"PRIu16"",urilend->urilen2,urilend->urilen1);
-            goto error;
-        }
-    }
-
-    if (arg5 != NULL) {
-        if (strcasecmp("raw", arg5) == 0) {
-            urilend->raw_buffer = 1;
-        }
-    }
-
-    if (arg1 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg1);
-    pcre2_substring_free((PCRE2_UCHAR *)arg2);
-    if (arg3 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg3);
-    if (arg4 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg4);
-    if (arg5 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg5);
-    return urilend;
-
-error:
-    if (urilend)
-        SCFree(urilend);
-    if (arg1 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg1);
-    if (arg2 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg2);
-    if (arg3 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg3);
-    if (arg4 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg4);
-    if (arg5 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg5);
-    return NULL;
+    return rs_detect_urilen_parse(urilenstr);
 }
 
 /**
@@ -284,7 +138,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectUrilenData *urilend = (DetectUrilenData *)ptr;
-    SCFree(urilend);
+    rs_detect_urilen_free(urilend);
 }
 
 /** \brief set prefilter dsize pair
@@ -292,7 +146,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
  */
 void DetectUrilenApplyToContent(Signature *s, int list)
 {
-    uint16_t high = 65535;
+    uint16_t high = UINT16_MAX;
     bool found = false;
 
     SigMatch *sm = s->init_data->smlists[list];
@@ -302,25 +156,35 @@ void DetectUrilenApplyToContent(Signature *s, int list)
 
         DetectUrilenData *dd = (DetectUrilenData *)sm->ctx;
 
-        switch (dd->mode) {
-            case DETECT_URILEN_LT:
-                high = dd->urilen1 + 1;
+        switch (dd->du16.mode) {
+            case DETECT_UINT_LT:
+                if (dd->du16.arg1 < UINT16_MAX) {
+                    high = dd->du16.arg1 + 1;
+                }
                 break;
-            case DETECT_URILEN_EQ:
-                high = dd->urilen1;
+            case DETECT_UINT_LTE:
+                // fallthrough
+            case DETECT_UINT_EQ:
+                high = dd->du16.arg1;
                 break;
-            case DETECT_URILEN_RA:
-                high = dd->urilen2 + 1;
+            case DETECT_UINT_RA:
+                if (dd->du16.arg2 < UINT16_MAX) {
+                    high = dd->du16.arg2 + 1;
+                }
                 break;
-            case DETECT_URILEN_GT:
-                high = 65535;
+            case DETECT_UINT_NE:
+                // fallthrough
+            case DETECT_UINT_GTE:
+                // fallthrough
+            case DETECT_UINT_GT:
+                high = UINT16_MAX;
                 break;
         }
         found = true;
     }
 
     // skip 65535 to avoid mismatch on uri > 64k
-    if (!found || high == 65535)
+    if (!found || high == UINT16_MAX)
         return;
 
     SCLogDebug("high %u", high);
@@ -336,7 +200,7 @@ void DetectUrilenApplyToContent(Signature *s, int list)
         }
 
         if (cd->depth == 0 || cd->depth > high) {
-            cd->depth = (uint16_t)high;
+            cd->depth = high;
             SCLogDebug("updated %u, content %u to have depth %u "
                     "because of urilen.", s->id, cd->id, cd->depth);
         }
@@ -382,8 +246,8 @@ static int DetectUrilenParseTest01(void)
 
     urilend = DetectUrilenParse("10");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_EQ &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_EQ &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -399,8 +263,8 @@ static int DetectUrilenParseTest02(void)
 
     urilend = DetectUrilenParse(" < 10  ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -416,8 +280,8 @@ static int DetectUrilenParseTest03(void)
 
     urilend = DetectUrilenParse(" > 10 ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -433,9 +297,8 @@ static int DetectUrilenParseTest04(void)
 
     urilend = DetectUrilenParse(" 5 <> 10 ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -451,9 +314,8 @@ static int DetectUrilenParseTest05(void)
 
     urilend = DetectUrilenParse("5<>10,norm");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -469,9 +331,8 @@ static int DetectUrilenParseTest06(void)
 
     urilend = DetectUrilenParse("5<>10,raw");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -487,8 +348,8 @@ static int DetectUrilenParseTest07(void)
 
     urilend = DetectUrilenParse(">10, norm ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -504,8 +365,8 @@ static int DetectUrilenParseTest08(void)
 
     urilend = DetectUrilenParse("<10, norm ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -521,8 +382,7 @@ static int DetectUrilenParseTest09(void)
 
     urilend = DetectUrilenParse(">10, raw ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -538,8 +398,7 @@ static int DetectUrilenParseTest10(void)
 
     urilend = DetectUrilenParse("<10, raw ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -613,13 +472,13 @@ static int DetectUrilenSetpTest01(void)
         goto cleanup;
 
     if (urilend != NULL) {
-        if (urilend->urilen1 == 1 && urilend->urilen2 == 2 &&
-                urilend->mode == DETECT_URILEN_RA)
+        if (urilend->du16.arg1 == 1 && urilend->du16.arg2 == 2 &&
+                urilend->du16.mode == DETECT_UINT_RA)
             res = 1;
     }
 
 cleanup:
-    if (urilend) SCFree(urilend);
+    if (urilend) DetectUrilenFree(NULL, urilend);;
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);

--- a/src/detect-urilen.h
+++ b/src/detect-urilen.h
@@ -24,18 +24,6 @@
 #ifndef _DETECT_URILEN_H
 #define	_DETECT_URILEN_H
 
-#define DETECT_URILEN_LT   0   /**< "less than" operator */
-#define DETECT_URILEN_GT   1   /**< "greater than" operator */
-#define DETECT_URILEN_RA   2   /**< range operator */
-#define DETECT_URILEN_EQ   3   /**< equal operator */
-
-typedef struct DetectUrilenData_ {
-    uint16_t urilen1;   /**< 1st Uri Length value in the signature*/
-    uint16_t urilen2;   /**< 2nd Uri Length value in the signature*/
-    uint8_t mode;   /**< operator used in the signature */
-    uint8_t raw_buffer;
-}DetectUrilenData;
-
 bool DetectUrilenValidateContent(const Signature *s, int list, const char **);
 void DetectUrilenApplyToContent(Signature *s, int list);
 int DetectUrilenMatch (ThreadVars *, DetectEngineThreadCtx *, Flow *,

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -17,45 +17,48 @@
 
 #include "../util-unittest.h"
 
-#define TEST_OK(str, m, lo, hi) {                       \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NULL(bsz);                                  \
-    FAIL_IF_NOT(bsz->mode == (m));                      \
-    DetectBsizeFree(NULL, bsz);                         \
-    SCLogDebug("str %s OK", (str));                     \
-}
-#define TEST_FAIL(str) {                                \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NOT_NULL(bsz);                              \
-}
+#define TEST_OK(str, m, lo, hi)                                                                    \
+    {                                                                                              \
+        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        FAIL_IF_NULL(bsz);                                                                         \
+        FAIL_IF_NOT(bsz->mode == (m));                                                             \
+        DetectBsizeFree(NULL, bsz);                                                                \
+        SCLogDebug("str %s OK", (str));                                                            \
+    }
+#define TEST_FAIL(str)                                                                             \
+    {                                                                                              \
+        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        FAIL_IF_NOT_NULL(bsz);                                                                     \
+    }
 
 static int DetectBsizeTest01(void)
 {
-    TEST_OK("50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK(" 50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50 ", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50  ", DETECT_BSIZE_EQ, 50, 0);
+    TEST_OK("50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK(" 50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50 ", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50  ", DETECT_UINT_EQ, 50, 0);
 
     TEST_FAIL("AA");
     TEST_FAIL("5A");
     TEST_FAIL("A5");
-    TEST_FAIL("10000000001");
-    TEST_OK("  1000000001  ", DETECT_BSIZE_EQ, 1000000001, 0);
+    // bigger than UINT64_MAX
+    TEST_FAIL("100000000000000000001");
+    TEST_OK("  1000000001  ", DETECT_UINT_EQ, 1000000001, 0);
     PASS;
 }
 
 static int DetectBsizeTest02(void)
 {
-    TEST_OK(">50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK("> 50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(">  50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" > 50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >  50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >50 ", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" > 50  ", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >  50   ", DETECT_BSIZE_GT, 50, 0);
+    TEST_OK(">50", DETECT_UINT_GT, 50, 0);
+    TEST_OK("> 50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(">  50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" > 50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >  50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >50 ", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" > 50  ", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >  50   ", DETECT_UINT_GT, 50, 0);
 
     TEST_FAIL(">>50");
     TEST_FAIL("<>50");
@@ -65,15 +68,15 @@ static int DetectBsizeTest02(void)
 
 static int DetectBsizeTest03(void)
 {
-    TEST_OK("<50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK("< 50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK("<  50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" < 50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <  50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <50 ", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" < 50  ", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <  50   ", DETECT_BSIZE_LT, 50, 0);
+    TEST_OK("<50", DETECT_UINT_LT, 50, 0);
+    TEST_OK("< 50", DETECT_UINT_LT, 50, 0);
+    TEST_OK("<  50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" < 50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <  50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <50 ", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" < 50  ", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <  50   ", DETECT_UINT_LT, 50, 0);
 
     TEST_FAIL(">>50");
     TEST_FAIL(" < 50A");
@@ -82,7 +85,7 @@ static int DetectBsizeTest03(void)
 
 static int DetectBsizeTest04(void)
 {
-    TEST_OK("50<>100", DETECT_BSIZE_RA, 50, 100);
+    TEST_OK("50<>100", DETECT_UINT_RA, 50, 100);
 
     TEST_FAIL("50<$50");
     TEST_FAIL("100<>50");


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4112

Describe changes:
- Use generic integer functions for more keywords

Continues https://github.com/OISF/suricata/pull/7461

What may remain
```
> git grep -Eow "[A-Z_]*_LT" | cut -d: -f2 | sort | uniq
ADDRESS_LT
DATAREP_OP_LT
DETECT_BYTETEST_OP_LT
DETECT_IPPROTO_OP_LT
DETECT_ITYPE_LT
DETECT_TLS_VALIDITY_LT
DETECT_UINT_LT
FLOWINT_MODIFIER_LT
PORT_LT
PROCEDURE_LT
SEQ_LT
```