### PR TITLE
Detect generic uint 4112 v11

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -109,6 +109,7 @@ exclude = [
     "free",
     "IPPROTO_TCP",
     "IPPROTO_UDP",
+    "SRepCatGetByShortname",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/src/detect.rs
+++ b/rust/src/detect.rs
@@ -23,7 +23,7 @@ use nom7::error::{make_error, ErrorKind};
 use nom7::Err;
 use nom7::IResult;
 
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::str::FromStr;
 
 #[derive(PartialEq, Clone, Debug)]
@@ -441,6 +441,106 @@ pub unsafe extern "C" fn rs_detect_urilen_parse(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_detect_urilen_free(ctx: &mut DetectUrilenData) {
+    // Just unbox...
+    std::mem::drop(Box::from_raw(ctx));
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, FromPrimitive, Debug)]
+pub enum DetectIPRepDataCmd {
+    IPRepCmdAny = 0,
+    IPRepCmdBoth = 1,
+    IPRepCmdSrc = 2,
+    IPRepCmdDst = 3,
+}
+
+impl std::str::FromStr for DetectIPRepDataCmd {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "any" => Ok(DetectIPRepDataCmd::IPRepCmdAny),
+            "both" => Ok(DetectIPRepDataCmd::IPRepCmdBoth),
+            "src" => Ok(DetectIPRepDataCmd::IPRepCmdSrc),
+            "dst" => Ok(DetectIPRepDataCmd::IPRepCmdDst),
+            _ => Err(format!(
+                "'{}' is not a valid value for DetectIPRepDataCmd",
+                s
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct DetectIPRepData {
+    pub du8: DetectUintData<u8>,
+    pub cat: u8,
+    pub cmd: DetectIPRepDataCmd,
+}
+
+pub fn is_alphanumeric_or_slash(chr: char) -> bool {
+    if chr.is_ascii_alphanumeric() {
+        return true;
+    }
+    if chr == '_' || chr == '-' {
+        return true;
+    }
+    return false;
+}
+
+extern "C" {
+    pub fn SRepCatGetByShortname(name: *const i8) -> u8;
+}
+
+pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, cmd) = map_res(alpha0, |s: &str| DetectIPRepDataCmd::from_str(s))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+
+    let (i, name) = take_while(is_alphanumeric_or_slash)(i)?;
+    // copy as to have final zero
+    let namez = CString::new(name).unwrap();
+    let cat = unsafe { SRepCatGetByShortname(namez.as_ptr() as *const i8) };
+    if cat == 0 {
+        return Err(Err::Error(make_error(i, ErrorKind::MapOpt)));
+    }
+
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, mode) = detect_parse_uint_mode(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = char(',')(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<u8>().ok())(i)?;
+    let (i, _) = all_consuming(take_while(|c| c == ' '))(i)?;
+    let du8 = DetectUintData::<u8> {
+        arg1: arg1,
+        arg2: 0,
+        mode: mode,
+    };
+    return Ok((i, DetectIPRepData { du8, cat, cmd }));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_iprep_parse(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectIPRepData {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Ok((_, ctx)) = detect_parse_iprep(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_iprep_free(ctx: &mut DetectIPRepData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -42,6 +42,7 @@
 #include "detect-engine-content-inspection.h"
 #include "detect-uricontent.h"
 #include "detect-urilen.h"
+#include "detect-engine-uint.h"
 #include "detect-bsize.h"
 #include "detect-lua.h"
 #include "detect-base64-decode.h"
@@ -605,28 +606,12 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
     } else if (smd->type == DETECT_AL_URILEN) {
         SCLogDebug("inspecting uri len");
 
-        uint8_t r = 0;
+        int r = 0;
         DetectUrilenData *urilend = (DetectUrilenData *) smd->ctx;
-
-        switch (urilend->mode) {
-            case DETECT_URILEN_EQ:
-                if (buffer_len == urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_LT:
-                if (buffer_len < urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_GT:
-                if (buffer_len > urilend->urilen1)
-                    r = 1;
-                break;
-            case DETECT_URILEN_RA:
-                if (buffer_len > urilend->urilen1 &&
-                    buffer_len < urilend->urilen2) {
-                    r = 1;
-                }
-                break;
+        if (buffer_len > UINT16_MAX) {
+            r = DetectU16Match(UINT16_MAX, &urilend->du16);
+        } else {
+            r = DetectU16Match((uint16_t)buffer_len, &urilend->du16);
         }
 
         if (r == 1) {

--- a/src/detect-iprep.h
+++ b/src/detect-iprep.h
@@ -24,22 +24,6 @@
 #ifndef __DETECT_IPREP_H__
 #define __DETECT_IPREP_H__
 
-#define DETECT_IPREP_CMD_ANY      0
-#define DETECT_IPREP_CMD_BOTH     1
-#define DETECT_IPREP_CMD_SRC      2
-#define DETECT_IPREP_CMD_DST      3
-
-#define DETECT_IPREP_OP_LT        0
-#define DETECT_IPREP_OP_GT        1
-#define DETECT_IPREP_OP_EQ        2
-
-typedef struct DetectIPRepData_ {
-    uint8_t cmd;
-    int8_t cat;
-    int8_t op;
-    uint8_t val;
-} DetectIPRepData;
-
 /* prototypes */
 void DetectIPRepRegister (void);
 

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -146,7 +146,7 @@ static int DetectNfsProcedureMatch (DetectEngineThreadCtx *det_ctx,
  */
 static DetectU32Data *DetectNfsProcedureParse(const char *rawstr)
 {
-    return DetectU32Parse(rawstr);
+    return rs_detect_u32_parse_inclusive(rawstr);
 }
 
 
@@ -267,9 +267,9 @@ static int ValidityTestParse03 (void)
 static int ValidityTestParse04 (void)
 {
     DetectU32Data *dd = NULL;
-    dd = DetectNfsProcedureParse("1430000000<>1470000000");
+    dd = DetectNfsProcedureParse("1430000001<>1470000000");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->arg1 == 1430000000 && dd->arg2 == 1470000000 && dd->mode == DETECT_UINT_RA);
+    FAIL_IF_NOT(dd->arg1 == 1430000000 && dd->arg2 == 1470000001 && dd->mode == DETECT_UINT_RA);
     DetectNfsProcedureFree(NULL, dd);
     PASS;
 }
@@ -381,9 +381,9 @@ static int ValidityTestParse11 (void)
 static int ValidityTestParse12 (void)
 {
     DetectU32Data *dd = NULL;
-    dd = DetectNfsProcedureParse("1430000000 <> 1490000000");
+    dd = DetectNfsProcedureParse("1430000001 <> 1490000000");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->arg1 == 1430000000 && dd->arg2 == 1490000000 && dd->mode == DETECT_UINT_RA);
+    FAIL_IF_NOT(dd->arg1 == 1430000000 && dd->arg2 == 1490000001 && dd->mode == DETECT_UINT_RA);
     DetectNfsProcedureFree(NULL, dd);
     PASS;
 }

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -133,7 +133,7 @@ static int DetectNfsVersionMatch (DetectEngineThreadCtx *det_ctx,
  */
 static DetectU32Data *DetectNfsVersionParse(const char *rawstr)
 {
-    return DetectU32Parse(rawstr);
+    return rs_detect_u32_parse_inclusive(rawstr);
 }
 
 

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -28,29 +28,11 @@
 #include "detect-engine.h"
 #include "detect-engine-content-inspection.h"
 #include "detect-snmp-version.h"
+#include "detect-engine-uint.h"
 #include "app-layer-parser.h"
 #include "rust.h"
 
-/**
- *   [snmp.version]:[<|>|<=|>=]<version>;
- */
-#define PARSE_REGEX "^\\s*(<=|>=|<|>)?\\s*([0-9]+)\\s*$"
-static DetectParseRegex parse_regex;
 
-enum DetectSNMPVersionMode {
-    PROCEDURE_EQ = 1, /* equal */
-    PROCEDURE_LT, /* less than */
-    PROCEDURE_LE, /* less than or equal */
-    PROCEDURE_GT, /* greater than */
-    PROCEDURE_GE, /* greater than or equal */
-};
-
-typedef struct DetectSNMPVersionData_ {
-    uint32_t version;
-    enum DetectSNMPVersionMode mode;
-} DetectSNMPVersionData;
-
-static DetectSNMPVersionData *DetectSNMPVersionParse (const char *);
 static int DetectSNMPVersionSetup (DetectEngineCtx *, Signature *s, const char *str);
 static void DetectSNMPVersionFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
@@ -82,8 +64,6 @@ void DetectSNMPVersionRegister (void)
     sigmatch_table[DETECT_AL_SNMP_VERSION].RegisterTests = DetectSNMPVersionRegisterTests;
 #endif
 
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
-
     DetectAppLayerInspectEngineRegister2("snmp.version", ALPROTO_SNMP, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectSNMPRequestGeneric, NULL);
 
@@ -101,35 +81,6 @@ static uint8_t DetectEngineInspectSNMPRequestGeneric(DetectEngineCtx *de_ctx,
             de_ctx, det_ctx, s, engine->smd, f, flags, alstate, txv, tx_id);
 }
 
-static inline int
-VersionMatch(const uint32_t version,
-        enum DetectSNMPVersionMode mode, uint32_t ref_version)
-{
-    switch (mode) {
-        case PROCEDURE_EQ:
-            if (version == ref_version)
-                SCReturnInt(1);
-            break;
-        case PROCEDURE_LT:
-            if (version < ref_version)
-                SCReturnInt(1);
-            break;
-        case PROCEDURE_LE:
-            if (version <= ref_version)
-                SCReturnInt(1);
-            break;
-        case PROCEDURE_GT:
-            if (version > ref_version)
-                SCReturnInt(1);
-            break;
-        case PROCEDURE_GE:
-            if (version >= ref_version)
-                SCReturnInt(1);
-            break;
-    }
-    SCReturnInt(0);
-}
-
 /**
  * \internal
  * \brief Function to match version of a TX
@@ -141,7 +92,7 @@ VersionMatch(const uint32_t version,
  * \param state   App layer state.
  * \param s       Pointer to the Signature.
  * \param m       Pointer to the sigmatch that we will cast into
- *                DetectSNMPVersionData.
+ *                DetectU32Data.
  *
  * \retval 0 no match.
  * \retval 1 match.
@@ -153,12 +104,11 @@ static int DetectSNMPVersionMatch (DetectEngineThreadCtx *det_ctx,
 {
     SCEnter();
 
-    const DetectSNMPVersionData *dd = (const DetectSNMPVersionData *)ctx;
+    const DetectU32Data *dd = (const DetectU32Data *)ctx;
     uint32_t version;
     rs_snmp_tx_get_version(txv, &version);
-    SCLogDebug("version %u mode %u ref_version %d",
-            version, dd->mode, dd->version);
-    if (VersionMatch(version, dd->mode, dd->version))
+    SCLogDebug("version %u mode %u ref_version %d", version, dd->mode, dd->arg1);
+    if (DetectU32Match(version, dd))
         SCReturnInt(1);
     SCReturnInt(0);
 }
@@ -169,72 +119,12 @@ static int DetectSNMPVersionMatch (DetectEngineThreadCtx *det_ctx,
  *
  * \param rawstr Pointer to the user provided options.
  *
- * \retval dd pointer to DetectSNMPVersionData on success.
+ * \retval dd pointer to DetectU32Data on success.
  * \retval NULL on failure.
  */
-static DetectSNMPVersionData *DetectSNMPVersionParse (const char *rawstr)
+static DetectU32Data *DetectSNMPVersionParse(const char *rawstr)
 {
-    DetectSNMPVersionData *dd = NULL;
-    int ret = 0, res = 0;
-    size_t pcre2len;
-    char mode[2] = "";
-    char value1[20] = "";
-    char *endptr = NULL;
-
-    ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
-    if (ret < 3 || ret > 5) {
-        SCLogError(SC_ERR_PCRE_MATCH, "Parse error %s", rawstr);
-        goto error;
-    }
-
-    pcre2len = sizeof(mode);
-    res = SC_Pcre2SubstringCopy(parse_regex.match, 1, (PCRE2_UCHAR8 *)mode, &pcre2len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
-        goto error;
-    }
-
-    pcre2len = sizeof(value1);
-    res = pcre2_substring_copy_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 *)value1, &pcre2len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_copy_bynumber failed");
-        goto error;
-    }
-
-    dd = SCCalloc(1, sizeof(DetectSNMPVersionData));
-    if (unlikely(dd == NULL))
-        goto error;
-
-    if (strlen(mode) == 1) {
-        if (mode[0] == '<')
-            dd->mode = PROCEDURE_LT;
-        else if (mode[0] == '>')
-            dd->mode = PROCEDURE_GT;
-    } else if (strlen(mode) == 2) {
-        if (strcmp(mode, "<=") == 0)
-            dd->mode = PROCEDURE_LE;
-        if (strcmp(mode, ">=") == 0)
-            dd->mode = PROCEDURE_GE;
-    }
-
-    if (dd->mode == 0) {
-        dd->mode = PROCEDURE_EQ;
-    }
-
-    /* set the first value */
-    dd->version = strtoul(value1, &endptr, 10);
-    if (endptr == NULL || *endptr != '\0') {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "invalid character as arg "
-                   "to snmp.version keyword");
-        goto error;
-    }
-
-    return dd;
-
-error:
-    if (dd)
-        SCFree(dd);
-    return NULL;
+    return DetectU32Parse(rawstr);
 }
 
 
@@ -253,7 +143,7 @@ error:
 static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
                                    const char *rawstr)
 {
-    DetectSNMPVersionData *dd = NULL;
+    DetectU32Data *dd = NULL;
     SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0)
@@ -274,7 +164,7 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_AL_SNMP_VERSION;
     sm->ctx = (void *)dd;
 
-    SCLogDebug("snmp.version %d", dd->version);
+    SCLogDebug("snmp.version %d", dd->arg1);
     SigMatchAppendSMToList(s, sm, g_snmp_version_buffer_id);
     return 0;
 
@@ -285,13 +175,13 @@ error:
 
 /**
  * \internal
- * \brief Function to free memory associated with DetectSNMPVersionData.
+ * \brief Function to free memory associated with DetectU32Data.
  *
- * \param de_ptr Pointer to DetectSNMPVersionData.
+ * \param de_ptr Pointer to DetectU32Data.
  */
 static void DetectSNMPVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCFree(ptr);
+    rs_detect_u32_free(ptr);
 }
 
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -35,6 +35,7 @@
 #include "detect-engine.h"
 #include "detect-engine-state.h"
 #include "detect-content.h"
+#include "detect-engine-uint.h"
 
 #include "detect-urilen.h"
 #include "util-debug.h"
@@ -42,12 +43,6 @@
 #include "flow-util.h"
 #include "stream-tcp.h"
 
-/**
- * \brief Regex for parsing our urilen
- */
-#define PARSE_REGEX  "^(?:\\s*)(<|>)?(?:\\s*)([0-9]{1,5})(?:\\s*)(?:(<>)(?:\\s*)([0-9]{1,5}))?\\s*(?:,\\s*(norm|raw))?\\s*$"
-
-static DetectParseRegex parse_regex;
 
 /*prototypes*/
 static int DetectUrilenSetup (DetectEngineCtx *, Signature *, const char *);
@@ -73,7 +68,6 @@ void DetectUrilenRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_AL_URILEN].RegisterTests = DetectUrilenRegisterTests;
 #endif
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 
     g_http_uri_buffer_id = DetectBufferTypeRegister("http_uri");
     g_http_raw_uri_buffer_id = DetectBufferTypeRegister("http_raw_uri");
@@ -90,147 +84,7 @@ void DetectUrilenRegister(void)
 
 static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 {
-    DetectUrilenData *urilend = NULL;
-    char *arg1 = NULL;
-    char *arg2 = NULL;
-    char *arg3 = NULL;
-    char *arg4 = NULL;
-    char *arg5 = NULL;
-    int ret = 0, res = 0;
-    size_t pcre2_len;
-
-    ret = DetectParsePcreExec(&parse_regex, urilenstr, 0, 0);
-    if (ret < 3 || ret > 6) {
-        SCLogError(SC_ERR_PCRE_PARSE, "urilen option pcre parse error: \"%s\"", urilenstr);
-        goto error;
-    }
-    const char *str_ptr;
-
-    SCLogDebug("ret %d", ret);
-
-    res = SC_Pcre2SubstringGet(parse_regex.match, 1, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-        goto error;
-    }
-    arg1 = (char *) str_ptr;
-    SCLogDebug("Arg1 \"%s\"", arg1);
-
-    res = pcre2_substring_get_bynumber(parse_regex.match, 2, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-        goto error;
-    }
-    arg2 = (char *) str_ptr;
-    SCLogDebug("Arg2 \"%s\"", arg2);
-
-    if (ret > 3) {
-        res = SC_Pcre2SubstringGet(parse_regex.match, 3, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-        if (res < 0) {
-            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-            goto error;
-        }
-        arg3 = (char *) str_ptr;
-        SCLogDebug("Arg3 \"%s\"", arg3);
-
-        if (ret > 4) {
-            res = SC_Pcre2SubstringGet(parse_regex.match, 4, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-            if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-                goto error;
-            }
-            arg4 = (char *) str_ptr;
-            SCLogDebug("Arg4 \"%s\"", arg4);
-        }
-        if (ret > 5) {
-            res = pcre2_substring_get_bynumber(
-                    parse_regex.match, 5, (PCRE2_UCHAR8 **)&str_ptr, &pcre2_len);
-            if (res < 0) {
-                SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre2_substring_get_bynumber failed");
-                goto error;
-            }
-            arg5 = (char *) str_ptr;
-            SCLogDebug("Arg5 \"%s\"", arg5);
-        }
-    }
-
-    urilend = SCMalloc(sizeof (DetectUrilenData));
-    if (unlikely(urilend == NULL))
-        goto error;
-    memset(urilend, 0, sizeof(DetectUrilenData));
-
-    if (arg1 != NULL && arg1[0] == '<')
-        urilend->mode = DETECT_URILEN_LT;
-    else if (arg1 != NULL && arg1[0] == '>')
-        urilend->mode = DETECT_URILEN_GT;
-    else
-        urilend->mode = DETECT_URILEN_EQ;
-
-    if (arg3 != NULL && strcmp("<>", arg3) == 0) {
-        if (arg1 != NULL && strlen(arg1) != 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Range specified but mode also set");
-            goto error;
-        }
-        urilend->mode = DETECT_URILEN_RA;
-    }
-
-    /** set the first urilen value */
-    if (StringParseUint16(&urilend->urilen1, 10, (uint16_t)strlen(arg2), arg2) <= 0) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg2);
-        goto error;
-    }
-
-    /** set the second urilen value if specified */
-    if (arg4 != NULL && strlen(arg4) > 0) {
-        if (urilend->mode != DETECT_URILEN_RA) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Multiple urilen values specified"
-                                           " but mode is not range");
-            goto error;
-        }
-
-        if (StringParseUint16(&urilend->urilen2, 10, (uint16_t)strlen(arg4), arg4) <= 0) {
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"Invalid size :\"%s\"",arg4);
-            goto error;
-        }
-
-        if (urilend->urilen2 <= urilend->urilen1){
-            SCLogError(SC_ERR_INVALID_ARGUMENT,"urilen2:%"PRIu16" <= urilen:"
-                        "%"PRIu16"",urilend->urilen2,urilend->urilen1);
-            goto error;
-        }
-    }
-
-    if (arg5 != NULL) {
-        if (strcasecmp("raw", arg5) == 0) {
-            urilend->raw_buffer = 1;
-        }
-    }
-
-    if (arg1 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg1);
-    pcre2_substring_free((PCRE2_UCHAR *)arg2);
-    if (arg3 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg3);
-    if (arg4 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg4);
-    if (arg5 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg5);
-    return urilend;
-
-error:
-    if (urilend)
-        SCFree(urilend);
-    if (arg1 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg1);
-    if (arg2 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg2);
-    if (arg3 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg3);
-    if (arg4 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg4);
-    if (arg5 != NULL)
-        pcre2_substring_free((PCRE2_UCHAR *)arg5);
-    return NULL;
+    return rs_detect_urilen_parse(urilenstr);
 }
 
 /**
@@ -284,7 +138,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectUrilenData *urilend = (DetectUrilenData *)ptr;
-    SCFree(urilend);
+    rs_detect_urilen_free(urilend);
 }
 
 /** \brief set prefilter dsize pair
@@ -292,7 +146,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
  */
 void DetectUrilenApplyToContent(Signature *s, int list)
 {
-    uint16_t high = 65535;
+    uint16_t high = UINT16_MAX;
     bool found = false;
 
     SigMatch *sm = s->init_data->smlists[list];
@@ -302,25 +156,35 @@ void DetectUrilenApplyToContent(Signature *s, int list)
 
         DetectUrilenData *dd = (DetectUrilenData *)sm->ctx;
 
-        switch (dd->mode) {
-            case DETECT_URILEN_LT:
-                high = dd->urilen1 + 1;
+        switch (dd->du16.mode) {
+            case DETECT_UINT_LT:
+                if (dd->du16.arg1 < UINT16_MAX) {
+                    high = dd->du16.arg1 + 1;
+                }
                 break;
-            case DETECT_URILEN_EQ:
-                high = dd->urilen1;
+            case DETECT_UINT_LTE:
+                // fallthrough
+            case DETECT_UINT_EQ:
+                high = dd->du16.arg1;
                 break;
-            case DETECT_URILEN_RA:
-                high = dd->urilen2 + 1;
+            case DETECT_UINT_RA:
+                if (dd->du16.arg2 < UINT16_MAX) {
+                    high = dd->du16.arg2 + 1;
+                }
                 break;
-            case DETECT_URILEN_GT:
-                high = 65535;
+            case DETECT_UINT_NE:
+                // fallthrough
+            case DETECT_UINT_GTE:
+                // fallthrough
+            case DETECT_UINT_GT:
+                high = UINT16_MAX;
                 break;
         }
         found = true;
     }
 
     // skip 65535 to avoid mismatch on uri > 64k
-    if (!found || high == 65535)
+    if (!found || high == UINT16_MAX)
         return;
 
     SCLogDebug("high %u", high);
@@ -336,7 +200,7 @@ void DetectUrilenApplyToContent(Signature *s, int list)
         }
 
         if (cd->depth == 0 || cd->depth > high) {
-            cd->depth = (uint16_t)high;
+            cd->depth = high;
             SCLogDebug("updated %u, content %u to have depth %u "
                     "because of urilen.", s->id, cd->id, cd->depth);
         }
@@ -382,8 +246,8 @@ static int DetectUrilenParseTest01(void)
 
     urilend = DetectUrilenParse("10");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_EQ &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_EQ &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -399,8 +263,8 @@ static int DetectUrilenParseTest02(void)
 
     urilend = DetectUrilenParse(" < 10  ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -416,8 +280,8 @@ static int DetectUrilenParseTest03(void)
 
     urilend = DetectUrilenParse(" > 10 ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -433,9 +297,8 @@ static int DetectUrilenParseTest04(void)
 
     urilend = DetectUrilenParse(" 5 <> 10 ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -451,9 +314,8 @@ static int DetectUrilenParseTest05(void)
 
     urilend = DetectUrilenParse("5<>10,norm");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -469,9 +331,8 @@ static int DetectUrilenParseTest06(void)
 
     urilend = DetectUrilenParse("5<>10,raw");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 5 && urilend->urilen2 == 10 &&
-            urilend->mode == DETECT_URILEN_RA &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 5 && urilend->du16.arg2 == 10 &&
+                urilend->du16.mode == DETECT_UINT_RA && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -487,8 +348,8 @@ static int DetectUrilenParseTest07(void)
 
     urilend = DetectUrilenParse(">10, norm ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -504,8 +365,8 @@ static int DetectUrilenParseTest08(void)
 
     urilend = DetectUrilenParse("<10, norm ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            !urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT &&
+                !urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -521,8 +382,7 @@ static int DetectUrilenParseTest09(void)
 
     urilend = DetectUrilenParse(">10, raw ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_GT &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_GT && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -538,8 +398,7 @@ static int DetectUrilenParseTest10(void)
 
     urilend = DetectUrilenParse("<10, raw ");
     if (urilend != NULL) {
-        if (urilend->urilen1 == 10 && urilend->mode == DETECT_URILEN_LT &&
-            urilend->raw_buffer)
+        if (urilend->du16.arg1 == 10 && urilend->du16.mode == DETECT_UINT_LT && urilend->raw_buffer)
             ret = 1;
 
         DetectUrilenFree(NULL, urilend);
@@ -613,13 +472,14 @@ static int DetectUrilenSetpTest01(void)
         goto cleanup;
 
     if (urilend != NULL) {
-        if (urilend->urilen1 == 1 && urilend->urilen2 == 2 &&
-                urilend->mode == DETECT_URILEN_RA)
+        if (urilend->du16.arg1 == 1 && urilend->du16.arg2 == 2 &&
+                urilend->du16.mode == DETECT_UINT_RA)
             res = 1;
     }
 
 cleanup:
-    if (urilend) SCFree(urilend);
+    if (urilend)
+        DetectUrilenFree(NULL, urilend);
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);

--- a/src/detect-urilen.h
+++ b/src/detect-urilen.h
@@ -24,18 +24,6 @@
 #ifndef _DETECT_URILEN_H
 #define	_DETECT_URILEN_H
 
-#define DETECT_URILEN_LT   0   /**< "less than" operator */
-#define DETECT_URILEN_GT   1   /**< "greater than" operator */
-#define DETECT_URILEN_RA   2   /**< range operator */
-#define DETECT_URILEN_EQ   3   /**< equal operator */
-
-typedef struct DetectUrilenData_ {
-    uint16_t urilen1;   /**< 1st Uri Length value in the signature*/
-    uint16_t urilen2;   /**< 2nd Uri Length value in the signature*/
-    uint8_t mode;   /**< operator used in the signature */
-    uint8_t raw_buffer;
-}DetectUrilenData;
-
 bool DetectUrilenValidateContent(const Signature *s, int list, const char **);
 void DetectUrilenApplyToContent(Signature *s, int list);
 int DetectUrilenMatch (ThreadVars *, DetectEngineThreadCtx *, Flow *,

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -17,45 +17,48 @@
 
 #include "../util-unittest.h"
 
-#define TEST_OK(str, m, lo, hi) {                       \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NULL(bsz);                                  \
-    FAIL_IF_NOT(bsz->mode == (m));                      \
-    DetectBsizeFree(NULL, bsz);                         \
-    SCLogDebug("str %s OK", (str));                     \
-}
-#define TEST_FAIL(str) {                                \
-    DetectBsizeData *bsz = DetectBsizeParse((str));     \
-    FAIL_IF_NOT_NULL(bsz);                              \
-}
+#define TEST_OK(str, m, lo, hi)                                                                    \
+    {                                                                                              \
+        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        FAIL_IF_NULL(bsz);                                                                         \
+        FAIL_IF_NOT(bsz->mode == (m));                                                             \
+        DetectBsizeFree(NULL, bsz);                                                                \
+        SCLogDebug("str %s OK", (str));                                                            \
+    }
+#define TEST_FAIL(str)                                                                             \
+    {                                                                                              \
+        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        FAIL_IF_NOT_NULL(bsz);                                                                     \
+    }
 
 static int DetectBsizeTest01(void)
 {
-    TEST_OK("50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK(" 50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50 ", DETECT_BSIZE_EQ, 50, 0);
-    TEST_OK("  50  ", DETECT_BSIZE_EQ, 50, 0);
+    TEST_OK("50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK(" 50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50 ", DETECT_UINT_EQ, 50, 0);
+    TEST_OK("  50  ", DETECT_UINT_EQ, 50, 0);
 
     TEST_FAIL("AA");
     TEST_FAIL("5A");
     TEST_FAIL("A5");
-    TEST_FAIL("10000000001");
-    TEST_OK("  1000000001  ", DETECT_BSIZE_EQ, 1000000001, 0);
+    // bigger than UINT64_MAX
+    TEST_FAIL("100000000000000000001");
+    TEST_OK("  1000000001  ", DETECT_UINT_EQ, 1000000001, 0);
     PASS;
 }
 
 static int DetectBsizeTest02(void)
 {
-    TEST_OK(">50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK("> 50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(">  50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" > 50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >  50", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >50 ", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" > 50  ", DETECT_BSIZE_GT, 50, 0);
-    TEST_OK(" >  50   ", DETECT_BSIZE_GT, 50, 0);
+    TEST_OK(">50", DETECT_UINT_GT, 50, 0);
+    TEST_OK("> 50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(">  50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" > 50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >  50", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >50 ", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" > 50  ", DETECT_UINT_GT, 50, 0);
+    TEST_OK(" >  50   ", DETECT_UINT_GT, 50, 0);
 
     TEST_FAIL(">>50");
     TEST_FAIL("<>50");
@@ -65,15 +68,15 @@ static int DetectBsizeTest02(void)
 
 static int DetectBsizeTest03(void)
 {
-    TEST_OK("<50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK("< 50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK("<  50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" < 50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <  50", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <50 ", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" < 50  ", DETECT_BSIZE_LT, 50, 0);
-    TEST_OK(" <  50   ", DETECT_BSIZE_LT, 50, 0);
+    TEST_OK("<50", DETECT_UINT_LT, 50, 0);
+    TEST_OK("< 50", DETECT_UINT_LT, 50, 0);
+    TEST_OK("<  50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" < 50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <  50", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <50 ", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" < 50  ", DETECT_UINT_LT, 50, 0);
+    TEST_OK(" <  50   ", DETECT_UINT_LT, 50, 0);
 
     TEST_FAIL(">>50");
     TEST_FAIL(" < 50A");
@@ -82,7 +85,7 @@ static int DetectBsizeTest03(void)
 
 static int DetectBsizeTest04(void)
 {
-    TEST_OK("50<>100", DETECT_BSIZE_RA, 50, 100);
+    TEST_OK("50<>100", DETECT_UINT_RA, 50, 100);
 
     TEST_FAIL("50<$50");
     TEST_FAIL("100<>50");

--- a/src/tests/detect-snmp-version.c
+++ b/src/tests/detect-snmp-version.c
@@ -26,10 +26,10 @@
  */
 static int SNMPValidityTestParse01 (void)
 {
-    DetectSNMPVersionData *dd = NULL;
+    DetectU32Data *dd = NULL;
     dd = DetectSNMPVersionParse("2");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->version == 2 && dd->mode == PROCEDURE_EQ);
+    FAIL_IF_NOT(dd->arg1 == 2 && dd->mode == DETECT_UINT_EQ);
     DetectSNMPVersionFree(NULL, dd);
     PASS;
 }
@@ -42,10 +42,10 @@ static int SNMPValidityTestParse01 (void)
  */
 static int SNMPValidityTestParse02 (void)
 {
-    DetectSNMPVersionData *dd = NULL;
+    DetectU32Data *dd = NULL;
     dd = DetectSNMPVersionParse(">2");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->version == 2 && dd->mode == PROCEDURE_GT);
+    FAIL_IF_NOT(dd->arg1 == 2 && dd->mode == DETECT_UINT_GT);
     DetectSNMPVersionFree(NULL, dd);
     PASS;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4112

Describe changes:
- Use generic integer functions for more keywords

Continues https://github.com/OISF/suricata/pull/7519 with more keywords

What may remain cf ` git grep -Eow "[A-Z_]*_LT" | cut -d: -f2 | sort | uniq`

Ok now:
- DETECT_UINT_LT : this is the standard to use
- ADDRESS_LT, PORT_LT : can be ruled out because logic seems specific
- SEQ_LT : can be ruled out (not detection, but stream-engine)
- DETECT_BYTETEST_OP_LT: can be ruled out, byte test does other things such as bitwise operations
- DETECT_TLS_VALIDITY_LT: uses time_t instead of unsigned integer...

I do not know:
- FLOWINT_MODIFIER_LT: not sure as there are other modifiers such as FLOWINT_MODIFIER_ISSET in the same enum
- DETECT_IPPROTO_OP_LT : not sure as there is a special handling to create a 256-sized array with all matching protocols... Nice feature by the way
- DATAREP_OP_LT: not sure id there is much to gain here

And look for uses of set_uint in loggers to see if we can easily add new keywords