### PR TITLE
detect: update text for nocase used with http.host

### DIFF
--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -184,10 +184,10 @@ static bool DetectHttpHostValidateCallback(const Signature *s, const char **sige
         if (sm->type == DETECT_CONTENT) {
             DetectContentData *cd = (DetectContentData *)sm->ctx;
             if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "http_host keyword "
+                *sigerror = "http.host keyword "
                         "specified along with \"nocase\". "
-                        "Since the hostname buffer we match against "
-                        "is actually lowercase.  So having a "
+                        "Since the hostname buffer is normalized "
+                        "to lowercase. So specifying "
                         "nocase is redundant.";
                 SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
                 return false;
@@ -199,9 +199,9 @@ static bool DetectHttpHostValidateCallback(const Signature *s, const char **sige
                 }
                 if (u != cd->content_len) {
                     *sigerror = "A pattern with "
-                            "uppercase chars detected for http_host.  "
+                            "uppercase chars detected for http.host.  "
                             "Since the hostname buffer we match against "
-                            "is lowercase only, please specify a "
+                            "is normalized to lowercase, please specify a "
                             "lowercase pattern.";
                     SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
                     return false;


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- remove extra space in text
- update http host keyword to sticky version
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
