### PR TITLE
fuzz: remove check about max transactions

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -169,31 +169,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
 
             AppLayerParserTransactionsCleanup(f);
-
-            if (f->alstate && f->alparser) {
-                // check if we have too many open transactions
-                const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
-                uint64_t min = 0;
-                AppLayerGetTxIterState state;
-                memset(&state, 0, sizeof(state));
-                uint64_t nbtx = 0;
-                AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
-                while (1) {
-                    AppLayerGetTxIterTuple ires =
-                            IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
-                    if (ires.tx_ptr == NULL)
-                        break;
-                    min = ires.tx_id + 1;
-                    nbtx++;
-                    if (nbtx > ALPROTO_MAXTX) {
-                        printf("Too many open transactions for protocol %s\n",
-                                AppProtoToString(f->alproto));
-                        printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
-                        fflush(stdout);
-                        abort();
-                    }
-                }
-            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -66,7 +66,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     }
     alproto = AppLayerProtoDetectGetProto(
             alpd_tctx, f, data + HEADER_LEN, size - HEADER_LEN, f->proto, flags, &reverse);
-    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && f->proto == IPPROTO_TCP) {
+    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && alproto != ALPROTO_ENIP &&
+            f->proto == IPPROTO_TCP) {
         /* If we find a valid protocol at the start of a stream :
          * check that with smaller input
          * we find the same protocol or ALPROTO_UNKNOWN.
@@ -77,7 +78,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             AppLayerProtoDetectReset(f);
             alproto2 = AppLayerProtoDetectGetProto(
                     alpd_tctx, f, data + HEADER_LEN, i, f->proto, flags, &reverse);
-            if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto) {
+            // exception for ENIP which is too likely to be found
+            if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto && alproto2 != ALPROTO_ENIP) {
                 printf("Failed with input length %" PRIuMAX " versus %" PRIuMAX
                        ", found %s instead of %s\n",
                         (uintmax_t)i, (uintmax_t)size - HEADER_LEN, AppProtoToString(alproto2),


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44798 and other

Describe changes:
- removes fuzzer's check about too many transactions

HTTP1 and other can indeed pipeline many transactions.
The protocols for which it caused a timeout now have their limit.
I do not think this check is relevant...
Ideas ?