### PR TITLE
nfs4: fix write record handling

### DIFF
--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -52,6 +52,11 @@ impl NFSState {
             fill_bytes = 4 - pad;
         }
 
+        // linux defines a max of 1mb. Allow several multiples.
+        if w.write_len == 0 || w.write_len > 16777216 {
+            return;
+        }
+
         let file_handle = fh.to_vec();
         let file_name = if let Some(name) = self.namemap.get(fh) {
             SCLogDebug!("WRITE name {:?}", name);
@@ -115,8 +120,8 @@ impl NFSState {
             }
         }
         self.ts_chunk_xid = r.hdr.xid;
-        let file_data_len = w.data.len() as u32 - fill_bytes as u32;
-        self.ts_chunk_left = w.write_len as u32 - file_data_len as u32;
+        debug_validate_bug_on!(w.data.len() as u32 > w.write_len);
+        self.ts_chunk_left = w.write_len as u32 - w.data.len()  as u32;
     }
 
     fn close_v4<'b>(&mut self, r: &RpcPacket<'b>, fh: &'b [u8]) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5280#change-23168

Describe changes:
- nfs4: fix write record handling

See also commit 4418fc1b02f47533439fe00789d9c850a24271b2

For what I understand, with NFS4 (instead of NFS3), we always have complete data with these compound records PDU...

And I also understand that with a `WRITEv4` we cannot know if there are more data to be written afterwards...

Thoughts ?