### PR TITLE
defrag: use util function for timeout

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -628,8 +628,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     }
 
     /* Update timeout. */
-    tracker->timeout.tv_sec = p->ts.tv_sec + tracker->host_timeout;
-    tracker->timeout.tv_usec = p->ts.tv_usec;
+    tracker->timeout = TimevalWithSeconds(&p->ts, tracker->host_timeout);
 
     Frag *prev = NULL, *next = NULL;
     bool overlap = false;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44608

Describe changes:
- use util function to avoid timestamp overflow

A few other places may need this  cf `git grep "tv_sec + "`

Replaces #7345 with using the util function merged in #7511