### PR TITLE
Backports/60x/exceptions/v9

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -483,6 +483,7 @@ util-device.c util-device.h \
 util-ebpf.c util-ebpf.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \
+util-exception-policy.c util-exception-policy.h \
 util-file.c util-file.h \
 util-file-decompression.c util-file-decompression.h \
 util-file-swf-decompression.c util-file-swf-decompression.h \

--- a/src/decode.c
+++ b/src/decode.c
@@ -766,6 +766,38 @@ const char *PktSrcToString(enum PktSrcEnum pkt_src)
     return pkt_src_str;
 }
 
+const char *PacketDropReasonToString(enum PacketDropReason r)
+{
+    switch (r) {
+        case PKT_DROP_REASON_DECODE_ERROR:
+            return "decode error";
+        case PKT_DROP_REASON_DEFRAG_ERROR:
+            return "defrag error";
+        case PKT_DROP_REASON_DEFRAG_MEMCAP:
+            return "defrag memcap";
+        case PKT_DROP_REASON_FLOW_MEMCAP:
+            return "flow memcap";
+        case PKT_DROP_REASON_FLOW_DROP:
+            return "flow drop";
+        case PKT_DROP_REASON_STREAM_ERROR:
+            return "stream error";
+        case PKT_DROP_REASON_STREAM_MEMCAP:
+            return "stream memcap";
+        case PKT_DROP_REASON_APPLAYER_ERROR:
+            return "applayer error";
+        case PKT_DROP_REASON_APPLAYER_MEMCAP:
+            return "applayer memcap";
+        case PKT_DROP_REASON_RULES:
+            return "rules";
+        case PKT_DROP_REASON_RULES_THRESHOLD:
+            return "threshold detection_filter";
+        case PKT_DROP_REASON_NOT_SET:
+        default:
+            return NULL;
+    }
+}
+
+/* TODO drop reason stats! */
 void CaptureStatsUpdate(ThreadVars *tv, CaptureStats *s, const Packet *p)
 {
     if (unlikely(PACKET_TEST_ACTION(p, (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)))) {

--- a/src/decode.h
+++ b/src/decode.h
@@ -397,6 +397,21 @@ typedef struct PktProfiling_ {
 
 #endif /* PROFILING */
 
+enum PacketDropReason {
+    PKT_DROP_REASON_NOT_SET = 0,
+    PKT_DROP_REASON_DECODE_ERROR,
+    PKT_DROP_REASON_DEFRAG_ERROR,
+    PKT_DROP_REASON_DEFRAG_MEMCAP,
+    PKT_DROP_REASON_FLOW_MEMCAP,
+    PKT_DROP_REASON_FLOW_DROP,
+    PKT_DROP_REASON_STREAM_ERROR,
+    PKT_DROP_REASON_STREAM_MEMCAP,
+    PKT_DROP_REASON_APPLAYER_ERROR,
+    PKT_DROP_REASON_APPLAYER_MEMCAP,
+    PKT_DROP_REASON_RULES,
+    PKT_DROP_REASON_RULES_THRESHOLD, /**< detection_filter in action */
+};
+
 /* forward declaration since Packet struct definition requires this */
 struct PacketQueue_;
 
@@ -588,6 +603,14 @@ typedef struct Packet_
     /** data linktype in host order */
     int datalink;
 
+    /* count decoded layers of packet : too many layers
+     * cause issues with performance and stability (stack exhaustion)
+     */
+    uint8_t nb_decoded_layers;
+
+    /* enum PacketDropReason::PKT_DROP_REASON_* as uint8_t for compactness */
+    uint8_t drop_reason;
+
     /* tunnel/encapsulation handling */
     struct Packet_ *root; /* in case of tunnel this is a ptr
                            * to the 'real' packet, the one we
@@ -612,11 +635,6 @@ typedef struct Packet_
      * the packet to its owner's stack. If NULL, then allocated with malloc.
      */
     struct PktPool_ *pool;
-
-    /* count decoded layers of packet : too many layers
-     * cause issues with performance and stability (stack exhaustion)
-     */
-    uint8_t nb_decoded_layers;
 
 #ifdef PROFILING
     PktProfiling *profile;
@@ -788,6 +806,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->ts.tv_sec = 0;                                                                        \
         (p)->ts.tv_usec = 0;                                                                       \
         (p)->datalink = 0;                                                                         \
+        (p)->drop_reason = 0;                                                                      \
         (p)->action = 0;                                                                           \
         if ((p)->pktvar != NULL) {                                                                 \
             PktVarFree((p)->pktvar);                                                               \
@@ -877,8 +896,6 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
 
 #define PACKET_ACCEPT(p) PACKET_SET_ACTION(p, ACTION_ACCEPT)
 
-#define PACKET_DROP(p) PACKET_SET_ACTION(p, ACTION_DROP)
-
 #define PACKET_REJECT(p) PACKET_SET_ACTION(p, (ACTION_REJECT|ACTION_DROP))
 
 #define PACKET_REJECT_DST(p) PACKET_SET_ACTION(p, (ACTION_REJECT_DST|ACTION_DROP))
@@ -887,10 +904,26 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
 
 #define PACKET_PASS(p) PACKET_SET_ACTION(p, ACTION_PASS)
 
-#define PACKET_TEST_ACTION(p, a) \
-    ((p)->root ? \
-     ((p)->root->action & a) : \
-     ((p)->action & a))
+#define PACKET_TEST_ACTION_DO(p, a) (p)->action &(a)
+
+static inline void PacketDrop(Packet *p, enum PacketDropReason r)
+{
+    if (p->drop_reason == PKT_DROP_REASON_NOT_SET)
+        p->drop_reason = (uint8_t)r;
+
+    PACKET_SET_ACTION(p, ACTION_DROP);
+}
+#define PACKET_DROP(p) PacketDrop((p), PKT_DROP_REASON_NOT_SET)
+
+static inline uint8_t PacketTestAction(const Packet *p, const uint8_t a)
+{
+    if (likely(p->root == NULL)) {
+        return PACKET_TEST_ACTION_DO(p, a);
+    } else {
+        return PACKET_TEST_ACTION_DO(p->root, a);
+    }
+}
+#define PACKET_TEST_ACTION(p, a) PacketTestAction((p), (a))
 
 #define PACKET_UPDATE_ACTION(p, a) do { \
     ((p)->root ? \
@@ -955,6 +988,7 @@ DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *);
 void DecodeThreadVarsFree(ThreadVars *, DecodeThreadVars *);
 void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p);
+const char *PacketDropReasonToString(enum PacketDropReason r);
 
 /* decoder functions */
 int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -181,6 +181,7 @@ void DefragInitConfig(char quiet)
     defrag_config.hash_size   = DEFRAG_DEFAULT_HASHSIZE;
     defrag_config.prealloc    = DEFRAG_DEFAULT_PREALLOC;
     SC_ATOMIC_SET(defrag_config.memcap, DEFRAG_DEFAULT_MEMCAP);
+    defrag_config.memcap_policy = ExceptionPolicyParse("defrag.memcap-policy", false);
 
     /* Check if we have memcap and hash_size defined at config */
     const char *conf_val;
@@ -472,6 +473,14 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  */
 static DefragTracker *DefragTrackerGetNew(Packet *p)
 {
+#ifdef DEBUG
+    if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
+        SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
+        ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+        return NULL;
+    }
+#endif
+
     DefragTracker *dt = NULL;
 
     /* get a tracker from the spare queue */
@@ -491,6 +500,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
 
             dt = DefragTrackerGetUsedDefragTracker();
             if (dt == NULL) {
+                ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
                 return NULL;
             }
 
@@ -499,6 +509,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             /* now see if we can alloc a new tracker */
             dt = DefragTrackerAlloc();
             if (dt == NULL) {
+                ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
                 return NULL;
             }
 

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -72,6 +72,7 @@ typedef struct DefragConfig_ {
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
+    enum ExceptionPolicy memcap_policy;
 } DefragConfig;
 
 /** \brief check if a memory alloc would fit in the memcap

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -62,6 +62,8 @@
 #include "util-unittest.h"
 #endif
 
+#include "util-validate.h"
+
 #define DEFAULT_DEFRAG_HASH_SIZE 0xffff
 #define DEFAULT_DEFRAG_POOL_SIZE 0xffff
 
@@ -620,8 +622,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
         }
     }
     else {
-        /* Abort - should not happen. */
-        SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid address family, aborting.");
+        DEBUG_VALIDATE_BUG_ON(1);
         return NULL;
     }
 

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -300,7 +300,7 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_DROP:
-            PACKET_DROP(p);
+            PacketDrop(p, PKT_DROP_REASON_RULES_THRESHOLD);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_REJECT:

--- a/src/detect.c
+++ b/src/detect.c
@@ -547,12 +547,6 @@ static void DetectRunInspectIPOnly(ThreadVars *tv, const DetectEngineCtx *de_ctx
             /* save in the flow that we scanned this direction... */
             FlowSetIPOnlyFlag(pflow, p->flowflags & FLOW_PKT_TOSERVER ? 1 : 0);
         }
-        /* If we have a drop from IP only module,
-         * we will drop the rest of the flow packets
-         * This will apply only to inline/IPS */
-        if (pflow->flags & FLOW_ACTION_DROP) {
-            PACKET_DROP(p);
-        }
     } else { /* p->flags & PKT_HAS_FLOW */
         /* no flow */
 
@@ -1562,6 +1556,12 @@ static void DetectFlow(ThreadVars *tv,
         SCLogDebug("p->pcap %"PRIu64": no detection on packet, "
                 "PKT_NOPACKET_INSPECTION is set", p->pcap_cnt);
         return;
+    }
+
+    /* if flow is set to drop, we enforce that here */
+    if (p->flow->flags & FLOW_ACTION_DROP) {
+        PACKET_DROP(p);
+        SCReturn;
     }
 
     /* see if the packet matches one or more of the sigs */

--- a/src/detect.c
+++ b/src/detect.c
@@ -1661,11 +1661,14 @@ void DisableDetectFlowFileFlags(Flow *f)
 /**
  *  \brief wrapper for old tests
  */
-void SigMatchSignatures(ThreadVars *th_v,
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        Packet *p)
+void SigMatchSignatures(
+        ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
-    DetectRun(th_v, de_ctx, det_ctx, p);
+    if (p->flow) {
+        DetectFlow(tv, de_ctx, det_ctx, p);
+    } else {
+        DetectNoFlow(tv, de_ctx, det_ctx, p);
+    }
 }
 #endif
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1560,7 +1560,7 @@ static void DetectFlow(ThreadVars *tv,
 
     /* if flow is set to drop, we enforce that here */
     if (p->flow->flags & FLOW_ACTION_DROP) {
-        PACKET_DROP(p);
+        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
         SCReturn;
     }
 

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -77,8 +77,7 @@ typedef struct FlowBucket_ {
 
 /* prototypes */
 
-Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx,
-        const Packet *, Flow **);
+Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
 
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
 Flow *FlowGetExistingFlowFromHash(FlowKey * key, uint32_t hash);

--- a/src/flow.c
+++ b/src/flow.c
@@ -589,6 +589,9 @@ void FlowInitConfig(char quiet)
             flow_config.prealloc = configval;
         }
     }
+
+    flow_config.memcap_policy = ExceptionPolicyParse("flow.memcap-policy", false);
+
     SCLogDebug("Flow config from suricata.yaml: memcap: %"PRIu64", hash-size: "
                "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(flow_config.memcap),
                flow_config.hash_size, flow_config.prealloc);

--- a/src/flow.h
+++ b/src/flow.h
@@ -28,6 +28,7 @@
 typedef struct FlowStorageId FlowStorageId;
 
 #include "decode.h"
+#include "util-exception-policy.h"
 #include "util-var.h"
 #include "util-atomic.h"
 #include "util-device.h"
@@ -298,6 +299,8 @@ typedef struct FlowCnf_
     uint32_t emerg_timeout_new;
     uint32_t emerg_timeout_est;
     uint32_t emergency_recovery;
+
+    enum ExceptionPolicy memcap_policy;
 
     SC_ATOMIC_DECLARE(uint64_t, memcap);
 } FlowConfig;

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -147,6 +147,10 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             }
             break;
     }
+    if (p->drop_reason != 0) {
+        const char *str = PacketDropReasonToString(p->drop_reason);
+        jb_set_string(js, "reason", str);
+    }
 
     /* Close drop. */
     jb_close(js);

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -285,6 +285,12 @@ static void EveFlowLogJSON(JsonFlowLogThread *aft, JsonBuilder *jb, Flow *f)
     if (f->flags & FLOW_WRONG_THREAD)
         JB_SET_TRUE(jb, "wrong_thread");
 
+    if (f->flags & FLOW_ACTION_DROP) {
+        JB_SET_STRING(jb, "action", "drop");
+    } else if (f->flags & FLOW_ACTION_PASS) {
+        JB_SET_STRING(jb, "action", "pass");
+    }
+
     /* Close flow. */
     jb_close(jb);
 

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -27,6 +27,7 @@
 #include "util-checksum.h"
 #include "util-profiling.h"
 #include "source-pcap-file.h"
+#include "util-exception-policy.h"
 
 extern int max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
@@ -59,7 +60,13 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
 void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 {
     SCEnter();
-
+#ifdef DEBUG
+    if (unlikely((pcap_g.cnt + 1ULL) == g_eps_pcap_packet_loss)) {
+        SCLogNotice("skipping packet %" PRIu64, g_eps_pcap_packet_loss);
+        pcap_g.cnt++;
+        SCReturn;
+    }
+#endif
     PcapFileFileVars *ptv = (PcapFileFileVars *)user;
     Packet *p = PacketGetFromQueueOrAlloc();
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4859,7 +4859,7 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         FlowSetNoPacketInspectionFlag(p->flow);
         DecodeSetNoPacketInspectionFlag(p);
         StreamTcpDisableAppLayer(p->flow);
-        PACKET_DROP(p);
+        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
         /* return the segments to the pool */
         StreamTcpSessionPktFree(p);
         SCReturnInt(0);
@@ -5018,7 +5018,7 @@ error:
          * anyway. Doesn't disable all detection, so we can still
          * match on the stream event that was set. */
         DecodeSetNoPayloadInspectionFlag(p);
-        PACKET_DROP(p);
+        PacketDrop(p, PKT_DROP_REASON_STREAM_ERROR);
     }
     SCReturnInt(-1);
 }

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -63,6 +63,9 @@ typedef struct TcpStreamCnf_ {
     uint16_t reassembly_toclient_chunk_size;
 
     bool streaming_log_api;
+
+    enum ExceptionPolicy ssn_memcap_policy;
+    enum ExceptionPolicy reassembly_memcap_policy;
 
     StreamingBufferConfig sbcnf;
 } TcpStreamCnf;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1233,7 +1233,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     g_ut_modules = 0;
     g_ut_covered = 0;
 #endif
-
+    // clang-format off
     struct option long_opts[] = {
         {"dump-config", 0, &dump_config, 1},
         {"dump-features", 0, &dump_features, 1},
@@ -1295,6 +1295,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif
         {NULL, 0, NULL, 0}
     };
+    // clang-format on
 
     /* getopt_long stores the option index here. */
     int option_index = 0;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -86,6 +86,7 @@
 
 #include "source-pcap.h"
 #include "source-pcap-file.h"
+#include "source-pcap-file-helper.h"
 
 #include "source-pfring.h"
 
@@ -175,6 +176,8 @@
 #include "util-lua.h"
 
 #include "util-plugin.h"
+
+#include "util-exception-policy.h"
 
 #include "rust.h"
 
@@ -1293,6 +1296,14 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #ifdef HAVE_NFLOG
         {"nflog", optional_argument, 0, 0},
 #endif
+        {"simulate-packet-flow-memcap", required_argument, 0, 0},
+        {"simulate-applayer-error-at-offset-ts", required_argument, 0, 0},
+        {"simulate-applayer-error-at-offset-tc", required_argument, 0, 0},
+        {"simulate-packet-loss", required_argument, 0, 0},
+        {"simulate-packet-tcp-reassembly-memcap", required_argument, 0, 0},
+        {"simulate-packet-tcp-ssn-memcap", required_argument, 0, 0},
+        {"simulate-packet-defrag-memcap", required_argument, 0, 0},
+
         {NULL, 0, NULL, 0}
     };
     // clang-format on
@@ -1662,6 +1673,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->strict_rule_parsing_string == NULL) {
                     FatalError(SC_ERR_MEM_ALLOC, "failed to duplicate 'strict' string");
                 }
+            } else {
+                int r = ExceptionSimulationCommandlineParser(
+                        (long_opts[option_index]).name, optarg);
+                if (r < 0)
+                    return TM_ECODE_FAILED;
             }
             break;
         case 'c':

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -4799,7 +4799,6 @@ end:
  *        as usual (instead of on IPS mode) */
 static int SigTestDropFlow04(void)
 {
-    int result = 0;
     Flow f;
     HtpState *http_state = NULL;
     uint8_t http_buf1[] = "POST /one HTTP/1.0\r\n"
@@ -4846,127 +4845,56 @@ static int SigTestDropFlow04(void)
     StreamTcpInitConfig(TRUE);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"one\";"
-                                   "sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 "
+                                      "(msg:\"Test proto match\"; uricontent:\"one\";"
+                                      "sid:1;)");
+    FAIL_IF_NULL(s);
 
     /* the no inspection flag should be set after the first sig gets triggered,
      * so the second packet should not match the next sig (because of no inspection) */
-    s = de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"two\";"
-                                   "sid:2;)");
-    if (s == NULL) {
-        goto end;
-    }
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any 80 "
+                                      "(msg:\"Test proto match\"; uricontent:\"two\";"
+                                      "sid:2;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
 
-    FLOWLOCK_WRLOCK(&f);
-    int r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                                STREAM_TOSERVER, http_buf1, http_buf1_len);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        FLOWLOCK_UNLOCK(&f);
-        goto end;
-    }
-    FLOWLOCK_UNLOCK(&f);
+    int r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_buf1_len);
+    FAIL_IF_NOT(r == 0);
 
     http_state = f.alstate;
-    if (http_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
+    FAIL_IF_NULL(http_state);
 
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p1);
 
-    if (!PacketAlertCheck(p1, 1)) {
-        printf("sig 1 didn't alert on p1, but it should: ");
-        goto end;
-    }
+    FAIL_IF_NOT(PacketAlertCheck(p1, 1));
+    FAIL_IF(PacketAlertCheck(p1, 2));
 
-    if (PacketAlertCheck(p1, 2)) {
-        printf("sig 2 alerted on p1, but it should not: ");
-        goto end;
-    }
+    FAIL_IF_NOT(p1->flow->flags & FLOW_ACTION_DROP);
+    FAIL_IF_NOT(PacketTestAction(p1, ACTION_DROP));
 
-    if ( !(p1->flow->flags & FLOW_ACTION_DROP)) {
-        printf("sig 1 alerted but flow was not flagged correctly: ");
-        goto end;
-    }
+    FAIL_IF(p2->flags & PKT_NOPACKET_INSPECTION);
 
-    if (!(PACKET_TEST_ACTION(p1, ACTION_DROP))) {
-        printf("A \"drop\" action was set from the flow to the packet "
-               "which is right, but setting the flag shouldn't disable "
-               "inspection on the packet in IDS mode");
-        goto end;
-    }
-
-    /* Second part.. Let's feed with another packet */
-    if (StreamTcpCheckFlowDrops(p2) == 1) {
-        FlowSetNoPacketInspectionFlag(p2->flow);
-        DecodeSetNoPacketInspectionFlag(p2);
-        StreamTcpDisableAppLayer(p2->flow);
-        p2->action |= ACTION_DROP;
-        /* return the segments to the pool */
-        StreamTcpSessionPktFree(p2);
-    }
-
-    if ( (p2->flags & PKT_NOPACKET_INSPECTION)) {
-        printf("The packet was flagged with no-inspection but we are not on IPS mode: ");
-        goto end;
-    }
-
-    FLOWLOCK_WRLOCK(&f);
-    r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_HTTP,
-                            STREAM_TOSERVER, http_buf2, http_buf2_len);
-    if (r != 0) {
-        printf("toserver chunk 2 returned %" PRId32 ", expected 0: ", r);
-        FLOWLOCK_UNLOCK(&f);
-        goto end;
-    }
-    FLOWLOCK_UNLOCK(&f);
+    r = AppLayerParserParse(
+            NULL, alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf2, http_buf2_len);
+    FAIL_IF_NOT(r == 0);
 
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p2);
 
-    if (PacketAlertCheck(p2, 1)) {
-        printf("sig 1 alerted, but it should not: ");
-        goto end;
-    }
+    FAIL_IF(PacketAlertCheck(p2, 1));
+    FAIL_IF(PacketAlertCheck(p2, 2));
+    FAIL_IF_NOT(PacketTestAction(p2, ACTION_DROP));
 
-    if (!PacketAlertCheck(p2, 2)) {
-        printf("sig 2 didn't alert, but it should, since we are not on IPS mode: ");
-        goto end;
-    }
-
-    if (!(PACKET_TEST_ACTION(p2, ACTION_DROP))) {
-        printf("A \"drop\" action was set from the flow to the packet "
-               "which is right, but setting the flag shouldn't disable "
-               "inspection on the packet in IDS mode");
-        goto end;
-    }
-
-    result = 1;
-
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
-    if (det_ctx != NULL)
-        DetectEngineThreadCtxDeinit(&tv, det_ctx);
-    if (de_ctx != NULL)
-        SigGroupCleanup(de_ctx);
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
+    AppLayerParserThreadCtxFree(alp_tctx);
+    DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    DetectEngineCtxFree(de_ctx);
 
     StreamTcpFreeConfig(TRUE);
     FLOW_DESTROY(&f);
@@ -4974,7 +4902,7 @@ end:
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
 
-    return result;
+    PASS;
 }
 
 /** \test ICMP packet shouldn't be matching port based sig

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -1,0 +1,185 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */
+
+#include "suricata-common.h"
+#include "util-exception-policy.h"
+#include "util-misc.h"
+
+void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason)
+{
+    SCLogDebug("start: pcap_cnt %" PRIu64 ", policy %u", p->pcap_cnt, policy);
+    if (EngineModeIsIPS()) {
+        switch (policy) {
+            case EXCEPTION_POLICY_IGNORE:
+                break;
+            case EXCEPTION_POLICY_DROP_FLOW:
+                SCLogDebug("EXCEPTION_POLICY_DROP_FLOW");
+                if (p->flow) {
+                    p->flow->flags |= FLOW_ACTION_DROP;
+                }
+                /* fall through */
+            case EXCEPTION_POLICY_DROP_PACKET:
+                SCLogDebug("EXCEPTION_POLICY_DROP_PACKET");
+                DecodeSetNoPayloadInspectionFlag(p);
+                DecodeSetNoPacketInspectionFlag(p);
+                PacketDrop(p, drop_reason);
+                break;
+            case EXCEPTION_POLICY_BYPASS_FLOW:
+                PacketBypassCallback(p);
+                /* fall through */
+            case EXCEPTION_POLICY_PASS_FLOW:
+                SCLogDebug("EXCEPTION_POLICY_PASS_FLOW");
+                if (p->flow) {
+                    p->flow->flags |= FLOW_ACTION_PASS;
+                    FlowSetNoPacketInspectionFlag(p->flow); // TODO util func
+                }
+                /* fall through */
+            case EXCEPTION_POLICY_PASS_PACKET:
+                SCLogDebug("EXCEPTION_POLICY_PASS_PACKET");
+                DecodeSetNoPayloadInspectionFlag(p);
+                DecodeSetNoPacketInspectionFlag(p);
+                PACKET_PASS(p);
+                break;
+        }
+    }
+    SCLogDebug("end");
+}
+
+enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow)
+{
+    enum ExceptionPolicy policy = EXCEPTION_POLICY_IGNORE;
+    const char *value_str = NULL;
+    if ((ConfGet(option, &value_str)) == 1 && value_str != NULL) {
+        if (strcmp(value_str, "drop-flow") == 0) {
+            policy = EXCEPTION_POLICY_DROP_FLOW;
+            SCLogConfig("%s: %s", option, value_str);
+        } else if (strcmp(value_str, "pass-flow") == 0) {
+            policy = EXCEPTION_POLICY_PASS_FLOW;
+            SCLogConfig("%s: %s", option, value_str);
+        } else if (strcmp(value_str, "bypass") == 0) {
+            policy = EXCEPTION_POLICY_BYPASS_FLOW;
+            SCLogConfig("%s: %s", option, value_str);
+        } else if (strcmp(value_str, "drop-packet") == 0) {
+            policy = EXCEPTION_POLICY_DROP_PACKET;
+            SCLogConfig("%s: %s", option, value_str);
+        } else if (strcmp(value_str, "pass-packet") == 0) {
+            policy = EXCEPTION_POLICY_PASS_PACKET;
+            SCLogConfig("%s: %s", option, value_str);
+        } else if (strcmp(value_str, "ignore") == 0) { // TODO name?
+            policy = EXCEPTION_POLICY_IGNORE;
+            SCLogConfig("%s: %s", option, value_str);
+        } else {
+            SCLogConfig("%s: ignore", option);
+        }
+
+        if (!support_flow) {
+            if (policy == EXCEPTION_POLICY_DROP_FLOW || policy == EXCEPTION_POLICY_PASS_FLOW ||
+                    policy == EXCEPTION_POLICY_BYPASS_FLOW) {
+                SCLogWarning(SC_WARN_COMPATIBILITY,
+                        "flow actions not supported for %s, defaulting to \"ignore\"", option);
+                policy = EXCEPTION_POLICY_IGNORE;
+            }
+        }
+
+    } else {
+        SCLogConfig("%s: ignore", option);
+    }
+    return policy;
+}
+
+#ifndef DEBUG
+
+int ExceptionSimulationCommandlineParser(const char *name, const char *arg)
+{
+    return 0;
+}
+
+#else
+
+/* exception policy simulation (eps) handling */
+
+uint64_t g_eps_applayer_error_offset_ts = UINT64_MAX;
+uint64_t g_eps_applayer_error_offset_tc = UINT64_MAX;
+uint64_t g_eps_pcap_packet_loss = UINT64_MAX;
+uint64_t g_eps_stream_ssn_memcap = UINT64_MAX;
+uint64_t g_eps_stream_reassembly_memcap = UINT64_MAX;
+uint64_t g_eps_flow_memcap = UINT64_MAX;
+uint64_t g_eps_defrag_memcap = UINT64_MAX;
+
+/* 1: parsed, 0: not for us, -1: error */
+int ExceptionSimulationCommandlineParser(const char *name, const char *arg)
+{
+    if (strcmp(name, "simulate-applayer-error-at-offset-ts") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t offset = 0;
+        if (ParseSizeStringU64(arg, &offset) < 0) {
+            return -1;
+        }
+        g_eps_applayer_error_offset_ts = offset;
+    } else if (strcmp(name, "simulate-applayer-error-at-offset-tc") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t offset = 0;
+        if (ParseSizeStringU64(arg, &offset) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_applayer_error_offset_tc = offset;
+    } else if (strcmp(name, "simulate-packet-loss") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t pkt_num = 0;
+        if (ParseSizeStringU64(arg, &pkt_num) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_pcap_packet_loss = pkt_num;
+    } else if (strcmp(name, "simulate-packet-tcp-reassembly-memcap") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t pkt_num = 0;
+        if (ParseSizeStringU64(arg, &pkt_num) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_stream_reassembly_memcap = pkt_num;
+    } else if (strcmp(name, "simulate-packet-tcp-ssn-memcap") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t pkt_num = 0;
+        if (ParseSizeStringU64(arg, &pkt_num) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_stream_ssn_memcap = pkt_num;
+    } else if (strcmp(name, "simulate-packet-flow-memcap") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t pkt_num = 0;
+        if (ParseSizeStringU64(arg, &pkt_num) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_flow_memcap = pkt_num;
+    } else if (strcmp(name, "simulate-packet-defrag-memcap") == 0) {
+        BUG_ON(arg == NULL);
+        uint64_t pkt_num = 0;
+        if (ParseSizeStringU64(arg, &pkt_num) < 0) {
+            return TM_ECODE_FAILED;
+        }
+        g_eps_defrag_memcap = pkt_num;
+    } else {
+        // not for us
+        return 0;
+    }
+    return 1;
+}
+#endif

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */
+
+#ifndef __UTIL_EXCEPTION_POLICY_H__
+#define __UTIL_EXCEPTION_POLICY_H__
+
+enum ExceptionPolicy {
+    EXCEPTION_POLICY_IGNORE = 0,
+    EXCEPTION_POLICY_PASS_PACKET,
+    EXCEPTION_POLICY_PASS_FLOW,
+    EXCEPTION_POLICY_BYPASS_FLOW,
+    EXCEPTION_POLICY_DROP_PACKET,
+    EXCEPTION_POLICY_DROP_FLOW,
+};
+
+void ExceptionPolicyApply(
+        Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
+enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);
+
+#ifdef DEBUG
+extern uint64_t g_eps_applayer_error_offset_ts;
+extern uint64_t g_eps_applayer_error_offset_tc;
+extern uint64_t g_eps_pcap_packet_loss;
+extern uint64_t g_eps_stream_ssn_memcap;
+extern uint64_t g_eps_stream_reassembly_memcap;
+extern uint64_t g_eps_flow_memcap;
+extern uint64_t g_eps_defrag_memcap;
+#endif
+
+int ExceptionSimulationCommandlineParser(const char *name, const char *arg);
+
+#endif


### PR DESCRIPTION
#7544, with an additional backport for improved `drop.reason` logging.

https://redmine.openinfosecfoundation.org/issues/5403