### PR TITLE
detect: impose limits on pcrexform

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -64,9 +64,6 @@
 #define PARSE_CAPTURE_REGEX "\\(\\?P\\<([A-z]+)\\_([A-z0-9_]+)\\>"
 #define PARSE_REGEX         "(?<!\\\\)/(.*(?<!(?<!\\\\)\\\\))/([^\"]*)"
 
-#define SC_MATCH_LIMIT_DEFAULT 3500
-#define SC_MATCH_LIMIT_RECURSION_DEFAULT 1500
-
 static int pcre_match_limit = 0;
 static int pcre_match_limit_recursion = 0;
 

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -36,6 +36,9 @@
 
 #define DETECT_PCRE_CAPTURE_MAX         8
 
+#define SC_MATCH_LIMIT_DEFAULT           3500
+#define SC_MATCH_LIMIT_RECURSION_DEFAULT 1500
+
 typedef struct DetectPcreData_ {
     /* pcre options */
     DetectParseRegex parse_regex;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5409

Describe changes:
- impose limits on `pcrexform` keyword (as is done for pcre)

cc @jlucovsky as you wrote pcrexform in the first place if I remember correctly