### PR TITLE
source/pcap: fix infinite loop if interface goes down - v1

### DIFF
--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -208,7 +208,7 @@ static int PcapTryReopen(PcapThreadVars *ptv)
     ptv->pcap_state = PCAP_STATE_DOWN;
 
     int pcap_activate_r = pcap_activate(ptv->pcap_handle);
-    if (pcap_activate_r != 0) {
+    if (pcap_activate_r != 0 && pcap_activate_r != PCAP_ERROR_ACTIVATED) {
         return pcap_activate_r;
     }
 


### PR DESCRIPTION
When in live-pcap mode, if the sniffed interface went down and up again,
Suri would enter an infinite and keep running, while not registering new
events. This fixes that behavior by allowing Suri to retry to open the
pcap in case of a retry on an already activated capture
('PCAP_ERROR_ACTIVATED').

Bug #3846

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3846

Implementing change proposed by: https://github.com/OISF/suricata/pull/6274 as that PR seems to have gone stale (we don't have a CLA signed by the author)