### PR TITLE
Detect filestore 5408 v1

### DIFF
--- a/src/output-file.c
+++ b/src/output-file.c
@@ -97,9 +97,9 @@ int OutputRegisterFileLogger(LoggerId id, const char *name, FileLogger LogFunc,
 static void CloseFile(const Packet *p, Flow *f, File *file)
 {
     DEBUG_VALIDATE_BUG_ON((file->flags & FILE_LOGGED) != 0);
-    void *txv = AppLayerParserGetTx(p->proto, f->alproto, f->alstate, file->txid);
+    void *txv = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, file->txid);
     if (txv) {
-        AppLayerTxData *txd = AppLayerParserGetTxData(p->proto, f->alproto, txv);
+        AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
         if (txd) {
             txd->files_logged++;
             DEBUG_VALIDATE_BUG_ON(txd->files_logged > txd->files_opened);

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -125,9 +125,9 @@ static int CallLoggers(ThreadVars *tv, OutputLoggerThreadStore *store_list,
 
 static void CloseFile(const Packet *p, Flow *f, File *file)
 {
-    void *txv = AppLayerParserGetTx(p->proto, f->alproto, f->alstate, file->txid);
+    void *txv = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, file->txid);
     if (txv) {
-        AppLayerTxData *txd = AppLayerParserGetTxData(p->proto, f->alproto, txv);
+        AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
         if (txd)
             txd->files_stored++;
     }

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -75,6 +75,10 @@ outputs:\n\
       enabled: yes\n\
       filename: /dev/null\n\
       extended: yes\n\
+  - file-store:\n\
+      version: 2\n\
+      enabled: yes\n\
+      force-filestore: yes\n\
 app-layer:\n\
   protocols:\n\
     rdp:\n\


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5408

Describe changes:
- Prevents segfault with forced filestore by using the flow's proto instead of the packet's one
- adds forced filestore to the fuzzing configuration

suricata-verify-pr: 867
https://github.com/OISF/suricata-verify/pull/867