### PR TITLE
output: do not log empty arrays for sid

### DIFF
--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -233,11 +233,13 @@ fn log_mqtt(tx: &MQTTTransaction, flags: u32, js: &mut JsonBuilder) -> Result<()
                 log_mqtt_header(js, &msg.header)?;
                 js.set_uint("message_id", unsuback.message_id as u64)?;
                 if let Some(codes) = &unsuback.reason_codes {
-                    js.open_array("reason_codes")?;
-                    for t in codes {
-                        js.append_uint(*t as u64)?;
+                    if codes.len() > 0 {
+                        js.open_array("reason_codes")?;
+                        for t in codes {
+                            js.append_uint(*t as u64)?;
+                        }
+                        js.close()?; // reason_codes
                     }
-                    js.close()?; // reason_codes
                 }
                 js.close()?; // unsuback
             }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -128,11 +128,13 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
 {
     jb_set_string_from_bytes(jb, "filename", ff->name, ff->name_len);
 
-    jb_open_array(jb, "sid");
-    for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
-        jb_append_uint(jb, ff->sid[i]);
+    if (ff->sid_cnt > 0) {
+        jb_open_array(jb, "sid");
+        for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
+            jb_append_uint(jb, ff->sid[i]);
+        }
+        jb_close(jb);
     }
-    jb_close(jb);
 
 #ifdef HAVE_MAGIC
     if (ff->magic)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5167

Describe changes:
- output: do not log empty arrays for `fileinfo.sid` 

@jasonish thoughts on this ?