### PR TITLE
Output emptyarrays 5167 v3

### DIFF
--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -214,11 +214,13 @@ fn log_ikev2(tx: &IKETransaction, jb: &mut JsonBuilder) -> Result<(), JsonError>
     jb.open_object("ikev2")?;
 
     jb.set_uint("errors", tx.errors as u64)?;
-    jb.open_array("notify")?;
-    for notify in tx.notify_types.iter() {
-        jb.append_string(&format!("{:?}", notify))?;
+    if tx.notify_types.len() > 0 {
+        jb.open_array("notify")?;
+        for notify in tx.notify_types.iter() {
+            jb.append_string(&format!("{:?}", notify))?;
+        }
+        jb.close()?;
     }
-    jb.close()?;
     jb.close()?;
     Ok(())
 }

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -233,11 +233,13 @@ fn log_mqtt(tx: &MQTTTransaction, flags: u32, js: &mut JsonBuilder) -> Result<()
                 log_mqtt_header(js, &msg.header)?;
                 js.set_uint("message_id", unsuback.message_id as u64)?;
                 if let Some(codes) = &unsuback.reason_codes {
-                    js.open_array("reason_codes")?;
-                    for t in codes {
-                        js.append_uint(*t as u64)?;
+                    if codes.len() > 0 {
+                        js.open_array("reason_codes")?;
+                        for t in codes {
+                            js.append_uint(*t as u64)?;
+                        }
+                        js.close()?; // reason_codes
                     }
-                    js.close()?; // reason_codes
                 }
                 js.close()?; // unsuback
             }

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -30,14 +30,16 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
             js.set_string("ua", &String::from_utf8_lossy(&ua))?;
         }
     }
-    js.open_array("cyu")?;
-    for cyu in &tx.cyu {
-        js.start_object()?;
-        js.set_string("hash", &cyu.hash)?;
-        js.set_string("string", &cyu.string)?;
+    if tx.cyu.len() > 0 {
+        js.open_array("cyu")?;
+        for cyu in &tx.cyu {
+            js.start_object()?;
+            js.set_string("hash", &cyu.hash)?;
+            js.set_string("string", &cyu.string)?;
+            js.close()?;
+        }
         js.close()?;
     }
-    js.close()?;
 
     js.close()?;
     Ok(())

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -64,9 +64,9 @@ static void JsonDNP3LogLinkControl(JsonBuilder *js, uint8_t lc)
 
 static void JsonDNP3LogIin(JsonBuilder *js, uint16_t iin)
 {
-    jb_open_array(js, "indicators");
-
     if (iin) {
+        jb_open_array(js, "indicators");
+
         int mapping = 0;
         do {
             if (iin & DNP3IndicatorsMap[mapping].value) {
@@ -74,8 +74,8 @@ static void JsonDNP3LogIin(JsonBuilder *js, uint16_t iin)
             }
             mapping++;
         } while (DNP3IndicatorsMap[mapping].name != NULL);
+        jb_close(js);
     }
-    jb_close(js);
 }
 
 static void JsonDNP3LogApplicationControl(JsonBuilder *js, uint8_t ac)
@@ -160,9 +160,11 @@ void JsonDNP3LogRequest(JsonBuilder *js, DNP3Transaction *dnp3tx)
 
     jb_set_uint(js, "function_code", dnp3tx->request_ah.function_code);
 
-    jb_open_array(js, "objects");
-    JsonDNP3LogObjects(js, &dnp3tx->request_objects);
-    jb_close(js);
+    if (!TAILQ_EMPTY(&dnp3tx->request_objects)) {
+        jb_open_array(js, "objects");
+        JsonDNP3LogObjects(js, &dnp3tx->request_objects);
+        jb_close(js);
+    }
 
     jb_set_bool(js, "complete", dnp3tx->request_complete);
 
@@ -194,9 +196,11 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
 
     jb_set_uint(js, "function_code", dnp3tx->response_ah.function_code);
 
-    jb_open_array(js, "objects");
-    JsonDNP3LogObjects(js, &dnp3tx->response_objects);
-    jb_close(js);
+    if (!TAILQ_EMPTY(&dnp3tx->response_objects)) {
+        jb_open_array(js, "objects");
+        JsonDNP3LogObjects(js, &dnp3tx->response_objects);
+        jb_close(js);
+    }
 
     jb_set_bool(js, "complete", dnp3tx->response_complete);
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -128,11 +128,13 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
 {
     jb_set_string_from_bytes(jb, "filename", ff->name, ff->name_len);
 
-    jb_open_array(jb, "sid");
-    for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
-        jb_append_uint(jb, ff->sid[i]);
+    if (ff->sid_cnt > 0) {
+        jb_open_array(jb, "sid");
+        for (uint32_t i = 0; ff->sid != NULL && i < ff->sid_cnt; i++) {
+            jb_append_uint(jb, ff->sid[i]);
+        }
+        jb_close(jb);
     }
-    jb_close(jb);
 
 #ifdef HAVE_MAGIC
     if (ff->magic)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5167

Describe changes:
- output: do not log empty arrays

Most likely a draft to catch more empty arrays

suricata-verify-pr: 872
https://github.com/OISF/suricata-verify/pull/872

Updates #7604 with more empty arrays removed
