### PR TITLE
stream/event: Add event when stream reassembly depth has been reached

### DIFF
--- a/rules/stream-events.rules
+++ b/rules/stream-events.rules
@@ -98,5 +98,6 @@ alert tcp any any -> any any (msg:"SURICATA STREAM FIN SYN reuse"; stream-event:
 # Disabled by default as this quite common and not malicious.
 #alert tcp any any -> any any (msg:"SURICATA STREAM spurious retransmission"; stream-event:pkt_spurious_retransmission; classtype:protocol-command-decode; sid:2210061; rev:1;)
 
-# next sid 2210062
+alert tcp any any -> any any (msg:"SURICATA STREAM reassembly depth reached"; stream-event:reassembly_depth_reached; classtype:protocol-command-decode; sid:2210062; rev:1;)
+# next sid 2210063
 

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -835,6 +835,10 @@ const struct DecodeEvents_ DEvents[] = {
     {
             "stream.reassembly_overlap_different_data",
             STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA,
+    },
+    {
+            "stream.reassembly_depth_reached",
+            STREAM_REASSEMBLY_DEPTH_REACHED,
     },
 
     { NULL, 0 },

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -58,8 +58,8 @@ enum {
     ICMPV6_IPV6_UNKNOWN_VER,            /**< unknown version in icmpv6 packet */
     ICMPV6_IPV6_TRUNC_PKT,              /**< truncated icmpv6 packet */
     ICMPV6_MLD_MESSAGE_WITH_INVALID_HL, /**< invalid MLD that doesn't have HL 1 */
-    ICMPV6_UNASSIGNED_TYPE,             /**< unsassigned ICMPv6 type */
-    ICMPV6_EXPERIMENTATION_TYPE,        /**< uprivate experimentation ICMPv6 type */
+    ICMPV6_UNASSIGNED_TYPE,             /**< unassigned ICMPv6 type */
+    ICMPV6_EXPERIMENTATION_TYPE,        /**< private experimentation ICMPv6 type */
 
     /* IPV6 EVENTS */
     IPV6_PKT_TOO_SMALL,     /**< ipv6 packet smaller than minimum size */
@@ -164,7 +164,7 @@ enum {
     /* ESP EVENTS */
     ESP_PKT_TOO_SMALL, /**< esp packet smaller than minimum size */
 
-    /* Fragmentation reasembly events. */
+    /* Fragmentation reassembly events. */
     IPV4_FRAG_PKT_TOO_LARGE,
     IPV6_FRAG_PKT_TOO_LARGE,
     IPV4_FRAG_OVERLAP,

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -287,6 +287,7 @@ enum {
     STREAM_REASSEMBLY_NO_SEGMENT,
     STREAM_REASSEMBLY_SEQ_GAP,
     STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA,
+    STREAM_REASSEMBLY_DEPTH_REACHED,
 
     /* should always be last! */
     DECODE_EVENT_MAX,

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -728,10 +728,14 @@ int StreamTcpReassembleHandleSegmentHandleData(ThreadVars *tv, TcpReassemblyThre
 
     /* If we have reached the defined depth for either of the stream, then stop
        reassembling the TCP session */
+    bool depth_reached = (stream->flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED);
     uint32_t size = StreamTcpReassembleCheckDepth(ssn, stream, TCP_GET_SEQ(p), p->payload_len);
     SCLogDebug("ssn %p: check depth returned %"PRIu32, ssn, size);
 
     if (stream->flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) {
+        if (!depth_reached)
+            /* Only event when the depth is first reached */
+            StreamTcpSetEvent(p, STREAM_REASSEMBLY_DEPTH_REACHED);
         /* increment stream depth counter */
         StatsIncr(tv, ra_ctx->counter_tcp_stream_depth);
     }


### PR DESCRIPTION
This PR adds a new stream event triggered when the stream reassembly depth has been reached.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3512](https://redmine.openinfosecfoundation.org/issues/3512)

Describe changes:
- Define event
- Add sample rule utilizing event
- Raise event when the stream reassembly depth is first reached on a stream.

suricata-verify-pr: 879
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
