### PR TITLE
stream: fix StreamTcpSegmentForSession missing segments

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6451,8 +6451,8 @@ int StreamTcpSegmentForSession(
     TcpStream *server_stream = &(ssn->server);
     TcpStream *client_stream = &(ssn->client);
 
-    TcpSegment *server_node = RB_ROOT(&(server_stream->seg_tree));
-    TcpSegment *client_node = RB_ROOT(&(client_stream->seg_tree));
+    TcpSegment *server_node = RB_MIN(TCPSEG, &server_stream->seg_tree);
+    TcpSegment *client_node = RB_MIN(TCPSEG, &client_stream->seg_tree);
     if (server_node == NULL && client_node == NULL) {
         return cnt;
     }


### PR DESCRIPTION
Bugfix, segment traversal was being initialized at root node, but
should have been started at the min node. Bug resulted in captures
missing segments left of root node.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- I noticed this while messing around with the pcap conditional feature. TCP segment dumping was starting from the root node of RB tree when it should have been starting at the min node.