### PR TITLE
6.0.x: Fix read the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.rules
 *.pcap
 *.pcapng
-/*.yaml
+/suricata.yaml
 Makefile
 .deps/
 .libs/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+# Required by Read The Docs
+version: 2
+
+python:
+  version: "3.8"
+
+  # Use an empty install section to avoid RTD from picking up a non-python
+  # requirements.txt file.
+  install: []

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-    AC_INIT([suricata],[6.0.6])
+    AC_INIT([suricata],[6.0.7-dev])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([src/autoconf.h])
     AC_CONFIG_SRCDIR([src/suricata.c])


### PR DESCRIPTION
6.0.6 was tagged and push with the addition of our requirements.txt file for handling Suricata requirements which is not compatible with Python requirements.txt, and Readthedocs tries to use this by default.  We addressed this in master with a `.readthedocs.yml` file, but that never made it into `master-6.0.x`, resulting in the documentation for `suricata-6.0.6` failing to build.

Current readthedocs is pinned to 6.0.5.

We could leave it pinned at 6.0.5 until 6.0.7.  Or make a new tag, `suricata-6.0.6-rtd` which would be this PR minus to version change commit to have it more up to date.  I don't think anything can be done at the RTD site, but will take another look.