### PR TITLE
detect/alert: ensure reject action is applied to packet/flow - v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -179,7 +179,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
             s->action, alert_flags);
 
-    if (s->action & ACTION_DROP) {
+    if (s->action & (ACTION_DROP | ACTION_REJECT_ANY)) {
         PacketDrop(p, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {


### PR DESCRIPTION
Bug 5458 states that the reject action is no longer working. While SV
tests that use the reject action still pass, it indeed seems that a
regression has happened with commit aa93984b7e58d3d8c, because while the
function that applies rule actions to the flow (RuleActionToFlow) does
check for the reject action, the newly added function PacketApply
SignatureActions only checks for ACTION_DROP or ACTION_PASS when
deciding to call RuleActionToFlow.

Bug #5458

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5458


Describe changes:
- also check for `ACTION_REJECT_ANY` when checking for `ACTION_DROP` when applying signature actions to the packet.

suricata-verify-pr: 888
https://github.com/OISF/suricata-verify/pull/888