### PR TITLE
detect/engine: init alert queue counters on reload (6.0.x backport) - v1

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2934,6 +2934,8 @@ static DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
 
     /** alert counter setup */
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
+    det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
+    det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
 #ifdef PROFILING
     uint16_t counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     uint16_t counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);


### PR DESCRIPTION
6.0.x backport for Bug #5457

(cherry picked from commit 93c2c9743d4ebe35017317a2668c6f8a54498d34)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5459