### PR TITLE
detect/filename: fix buffer description

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -155,7 +155,7 @@ void DetectFiledataRegister(void)
             "file_data", ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectFiledata, NULL);
 
     DetectBufferTypeSetDescriptionByName("file_data",
-            "http response body, smb files or smtp attachments data");
+            "data of file transferred over protocols");
 
     g_file_data_buffer_id = DetectBufferTypeGetByName("file_data");
 }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -151,7 +151,7 @@ void DetectFilenameRegister(void)
     }
 
     DetectBufferTypeSetDescriptionByName("file.name",
-            "http user agent");
+            "file name");
 
     g_file_name_buffer_id = DetectBufferTypeGetByName("file.name");
 	SCLogDebug("registering filename rule option");


### PR DESCRIPTION
Fix some buffer descriptions

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Fix string in detect filename
- Improve string in file data