### PR TITLE
lua: Expose byte_extract to lua match scripts

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -1083,3 +1083,26 @@ Expose the log path.
       filename = SCLogPath() .. "/" .. name
       file = assert(io.open(filename, "a"))
   end
+
+SCByteVarGet
+~~~~~~~~~~~~
+
+Get the ByteVar at index given by the parameter. These variables are defined by 
+`byte_extract` or `byte_math` in Suricata rules. Only callable from match scripts.
+
+::
+
+ function init(args)
+     local needs = {}
+     needs["bytevar"] = {"var1", "var2"}
+     return needs
+ end
+
+Here we define a register that we will be using variables `var1` and `var2`.
+The access to the Byte variables is done by index.
+
+::
+
+ function match(args)
+     var1 = SCByteVarGet(0)
+     var2 = SCByteVarGet(1)

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -36,6 +36,7 @@ typedef struct DetectLuaThreadData {
 
 #define DETECT_LUAJIT_MAX_FLOWVARS  15
 #define DETECT_LUAJIT_MAX_FLOWINTS  15
+#define DETECT_LUAJIT_MAX_BYTEVARS  15
 
 typedef struct DetectLuaData {
     int thread_ctx_id;
@@ -48,6 +49,8 @@ typedef struct DetectLuaData {
     uint16_t flowints;
     uint16_t flowvars;
     uint32_t flowvar[DETECT_LUAJIT_MAX_FLOWVARS];
+    uint16_t bytevars;
+    uint32_t bytevar[DETECT_LUAJIT_MAX_BYTEVARS];
     uint32_t sid;
     uint32_t rev;
     uint32_t gid;

--- a/src/util-lua.c
+++ b/src/util-lua.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -102,6 +102,8 @@ const char lua_ext_key_pa[] = "suricata:lua:pkt:alert:ptr";
 const char lua_ext_key_s[] = "suricata:lua:signature:ptr";
 /* key for file pointer */
 const char lua_ext_key_file[] = "suricata:lua:file:ptr";
+/* key for DetectEngineThreadCtx pointer */
+const char lua_ext_key_det_ctx[] = "suricata:lua:det_ctx:ptr";
 /* key for streaming buffer pointer */
 const char lua_ext_key_streaming_buffer[] = "suricata:lua:streaming_buffer:ptr";
 
@@ -227,6 +229,22 @@ void LuaStateSetFile(lua_State *luastate, File *file)
 {
     lua_pushlightuserdata(luastate, (void *)&lua_ext_key_file);
     lua_pushlightuserdata(luastate, (void *)file);
+    lua_settable(luastate, LUA_REGISTRYINDEX);
+}
+
+/** \brief get DetectEngineThreadCtx pointer from the lua state */
+DetectEngineThreadCtx *LuaStateGetDetCtx(lua_State *luastate)
+{
+    lua_pushlightuserdata(luastate, (void *)&lua_ext_key_det_ctx);
+    lua_gettable(luastate, LUA_REGISTRYINDEX);
+    void *det_ctx = lua_touserdata(luastate, -1);
+    return (DetectEngineThreadCtx *)det_ctx;
+}
+
+void LuaStateSetDetCtx(lua_State *luastate, DetectEngineThreadCtx *det_ctx)
+{
+    lua_pushlightuserdata(luastate, (void *)&lua_ext_key_det_ctx);
+    lua_pushlightuserdata(luastate, (void *)det_ctx);
     lua_settable(luastate, LUA_REGISTRYINDEX);
 }
 

--- a/src/util-lua.h
+++ b/src/util-lua.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -67,6 +67,9 @@ Signature *LuaStateGetSignature(lua_State *luastate);
 /** \brief get file pointer from the lua state */
 File *LuaStateGetFile(lua_State *luastate);
 
+/** \brief get detect engine thread context pointer from the lua state */
+DetectEngineThreadCtx *LuaStateGetDetCtx(lua_State *luastate);
+
 LuaStreamingBuffer *LuaStateGetStreamingBuffer(lua_State *luastate);
 
 int LuaStateGetDirection(lua_State *luastate);
@@ -87,6 +90,8 @@ void LuaStateSetPacketAlert(lua_State *luastate, PacketAlert *pa);
 void LuaStateSetSignature(lua_State *luastate, const Signature *s);
 
 void LuaStateSetFile(lua_State *luastate, File *file);
+
+void LuaStateSetDetCtx(lua_State *luastate, DetectEngineThreadCtx *det_ctx);
 
 void LuaStateSetThreadVars(lua_State *luastate, ThreadVars *tv);
 


### PR DESCRIPTION
Continuation of #6659 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2871](https://redmine.openinfosecfoundation.org/issues/2871)

Describe changes:
- Allow lua match scripts to access variables defined in rule by byte_extract or byte_math

suricata-verify-pr: 899
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
