### PR TITLE
Smtp server detection 1125 v5

### DIFF
--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -18,7 +18,103 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+use nom7::bytes::complete::take_while1;
+use nom7::character::complete::char;
+use nom7::character::{is_alphabetic, is_alphanumeric};
+use nom7::combinator::verify;
+use nom7::multi::many1_count;
+use nom7::IResult;
+
 #[no_mangle]
 pub unsafe extern "C" fn rs_check_utf8(val: *const c_char) -> bool {
     CStr::from_ptr(val).to_str().is_ok()
+}
+
+fn is_alphanumeric_or_hyphen(chr: u8) -> bool {
+    return is_alphanumeric(chr) || chr == b'-';
+}
+
+fn parse_domain_label(i: &[u8]) -> IResult<&[u8], ()> {
+    let (i, _) = verify(take_while1(is_alphanumeric_or_hyphen), |x: &[u8]| {
+        is_alphabetic(x[0]) && x[x.len() - 1] != b'-'
+    })(i)?;
+    return Ok((i, ()));
+}
+
+fn parse_subdomain(input: &[u8]) -> IResult<&[u8], ()> {
+    let (input, _) = parse_domain_label(input)?;
+    let (input, _) = char('.')(input)?;
+    return Ok((input, ()));
+}
+
+fn parse_domain(input: &[u8]) -> IResult<&[u8], ()> {
+    let (input, _) = many1_count(parse_subdomain)(input)?;
+    let (input, _) = parse_domain_label(input)?;
+    return Ok((input, ()));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_validate_domain(input: *const u8, in_len: u32) -> u32 {
+    let islice = build_slice!(input, in_len as usize);
+    match parse_domain(islice) {
+        Ok((rem, _)) => {
+            return (islice.len() - rem.len()) as u32;
+        }
+        _ => {
+            return 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse_domain() {
+        let buf0: &[u8] = "a-1.oisf.net more".as_bytes();
+        let r0 = parse_domain(buf0);
+        match r0 {
+            Ok((rem, _)) => {
+                // And we should have 5 bytes left.
+                assert_eq!(rem.len(), 5);
+            }
+            _ => {
+                panic!("Result should have been ok.");
+            }
+        }
+        let buf1: &[u8] = "justatext".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "1.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "a-.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "a(x)y.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+    }
 }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1045,6 +1045,34 @@ static int FTPGetAlstateProgress(void *vtx, uint8_t direction)
     return FTP_STATE_FINISHED;
 }
 
+static AppProto FTPServerProbingParser(
+        Flow *f, uint8_t direction, const uint8_t *input, uint32_t len, uint8_t *rdir)
+{
+    // another check for minimum length
+    if (len < 5) {
+        return ALPROTO_UNKNOWN;
+    }
+    // begins by 220
+    if (input[0] != '2' || input[1] != '2' || input[2] != '0') {
+        return ALPROTO_FAILED;
+    }
+    // followed by space or hypen
+    if (input[3] != ' ' && input[3] != '-') {
+        return ALPROTO_FAILED;
+    }
+    AppProto r = ALPROTO_UNKNOWN;
+    if (f->alproto_ts == ALPROTO_FTP || (f->todstbytecnt > 4 && f->alproto_ts == ALPROTO_UNKNOWN)) {
+        // only validates FTP if client side was FTP
+        // or if client side is unknown despite having received bytes
+        r = ALPROTO_FTP;
+    }
+    for (uint32_t i = 4; i < len; i++) {
+        if (input[i] == '\n') {
+            return r;
+        }
+    }
+    return ALPROTO_UNKNOWN;
+}
 
 static int FTPRegisterPatternsForProtocolDetection(void)
 {
@@ -1073,7 +1101,13 @@ static int FTPRegisterPatternsForProtocolDetection(void)
     {
         return -1;
     }
-
+    // Only check FTP on known ports as the banner has nothing special beyond
+    // the response code shared with SMTP.
+    if (!AppLayerProtoDetectPPParseConfPorts(
+                "tcp", IPPROTO_TCP, "ftp", ALPROTO_FTP, 0, 5, NULL, FTPServerProbingParser)) {
+        AppLayerProtoDetectPPRegister(IPPROTO_TCP, "21", ALPROTO_FTP, 0, 5, STREAM_TOSERVER, NULL,
+                FTPServerProbingParser);
+    }
     return 0;
 }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1648,23 +1648,13 @@ static AppProto SMTPServerProbingParser(
         // or if client side is unknown despite having received bytes
         r = ALPROTO_SMTP;
     }
-    uint8_t state = 0; // domain
-    for (uint32_t i = 4; i < len; i++) {
-        switch (state) {
-            case 0:
-                if (isalpha(input[i]) || isdigit(input[i]) || input[i] == '.' || input[i] == '-') {
-                    // basic domain validation : continue
-                } else if (input[i] == ' ') {
-                    state = 1; // next state is textstring
-                } else {
-                    return ALPROTO_FAILED;
-                }
-                break;
-            case 1:
-                if (input[i] == '\n') {
-                    return r; // state = 2;
-                }
-                break;
+    uint32_t offset = rs_validate_domain(input + 4, len - 4);
+    if (offset == 0) {
+        return ALPROTO_FAILED;
+    }
+    for (uint32_t i = offset + 4; i < len; i++) {
+        if (input[i] == '\n') {
+            return r;
         }
     }
     return ALPROTO_UNKNOWN;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1626,6 +1626,50 @@ static int SMTPStateGetEventInfoById(int event_id, const char **event_name,
     return 0;
 }
 
+static AppProto SMTPServerProbingParser(
+        Flow *f, uint8_t direction, const uint8_t *input, uint32_t len, uint8_t *rdir)
+{
+    // another check for minimum length
+    if (len < 5) {
+        return ALPROTO_UNKNOWN;
+    }
+    // begins by 220
+    if (input[0] != '2' || input[1] != '2' || input[2] != '0') {
+        return ALPROTO_FAILED;
+    }
+    // followed by space or hypen
+    if (input[3] != ' ' && input[3] != '-') {
+        return ALPROTO_FAILED;
+    }
+    AppProto r = ALPROTO_UNKNOWN;
+    if (f->alproto_ts == ALPROTO_SMTP ||
+            (f->todstbytecnt > 4 && f->alproto_ts == ALPROTO_UNKNOWN)) {
+        // only validates SMTP if client side was SMTP
+        // or if client side is unknown despite having received bytes
+        r = ALPROTO_SMTP;
+    }
+    uint8_t state = 0; // domain
+    for (uint32_t i = 4; i < len; i++) {
+        switch (state) {
+            case 0:
+                if (isalpha(input[i]) || isdigit(input[i]) || input[i] == '.' || input[i] == '-') {
+                    // basic domain validation : continue
+                } else if (input[i] == ' ') {
+                    state = 1; // next state is textstring
+                } else {
+                    return ALPROTO_FAILED;
+                }
+                break;
+            case 1:
+                if (input[i] == '\n') {
+                    return r; // state = 2;
+                }
+                break;
+        }
+    }
+    return ALPROTO_UNKNOWN;
+}
+
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
@@ -1641,6 +1685,19 @@ static int SMTPRegisterPatternsForProtocolDetection(void)
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "QUIT", 4, 0, STREAM_TOSERVER) < 0)
     {
+        return -1;
+    }
+    if (!AppLayerProtoDetectPPParseConfPorts(
+                "tcp", IPPROTO_TCP, "smtp", ALPROTO_SMTP, 0, 5, NULL, SMTPServerProbingParser)) {
+        AppLayerProtoDetectPPRegister(IPPROTO_TCP, "25", ALPROTO_SMTP, 0, 5, STREAM_TOSERVER, NULL,
+                SMTPServerProbingParser);
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP, "220 ", 4, 0,
+                STREAM_TOCLIENT, SMTPServerProbingParser, 5, 5) < 0) {
+        return -1;
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP, "220-", 4, 0,
+                STREAM_TOCLIENT, SMTPServerProbingParser, 5, 5) < 0) {
         return -1;
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1125

Describe changes:
- smtp : adds server side detection
- ftp : adds server side detection

The most special trick is that the (server) probing parser waits for the client side to have seen some data to take a definitive positive decision.
So that If it looks like a SMTP server (it could be a FTP server), let's see if the client looks like SMTP or FTP or something unknown...

suricata-verify-pr: 866

Modifies #7599 by rebase and removing one unneeded `many1` as it was always one and only one