### PR TITLE
Ike v1 logging tx transforms 5455 v2

### DIFF
--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -142,11 +142,9 @@ pub extern "C" fn rs_ike_state_get_sa_attribute(
     debug_validate_bug_on!(value == std::ptr::null_mut());
     let mut ret_val = 0;
     let mut ret_code = 0;
-    let sa_type_s: Result<_,_>;
+    let sa_type_s: Result<_, _>;
 
-    unsafe {
-        sa_type_s = CStr::from_ptr(sa_type).to_str()
-    }
+    unsafe { sa_type_s = CStr::from_ptr(sa_type).to_str() }
     SCLogInfo!("{:#?}", sa_type_s);
 
     if let Ok(sa) = sa_type_s {
@@ -159,7 +157,7 @@ pub extern "C" fn rs_ike_state_get_sa_attribute(
                             if let Some(numeric_value) = attr.numeric_value {
                                 ret_val = numeric_value;
                                 ret_code = 1;
-                                break
+                                break;
                             }
                         }
                     }

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -97,6 +97,7 @@ pub struct IKETransaction {
     tx_id: u64,
 
     pub ike_version: u8,
+    pub direction: Direction,
     pub hdr: IkeHeaderWrapper,
     pub payload_types: IkePayloadWrapper,
     pub notify_types: Vec<NotifyType>,
@@ -119,6 +120,7 @@ impl IKETransaction {
         IKETransaction {
             tx_id: 0,
             ike_version: 0,
+            direction: Direction::ToServer,
             hdr: IkeHeaderWrapper::new(),
             payload_types: Default::default(),
             notify_types: vec![],

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -320,8 +320,7 @@ pub unsafe extern "C" fn rs_ike_state_tx_free(state: *mut std::os::raw::c_void, 
 #[no_mangle]
 pub unsafe extern "C" fn rs_ike_parse_request(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
-    stream_slice: StreamSlice,
-    _data: *const std::os::raw::c_void,
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, IKEState);
     return state.handle_input(stream_slice.as_slice(), Direction::ToServer);
@@ -330,8 +329,7 @@ pub unsafe extern "C" fn rs_ike_parse_request(
 #[no_mangle]
 pub unsafe extern "C" fn rs_ike_parse_response(
     _flow: *const Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
-    stream_slice: StreamSlice,
-    _data: *const std::os::raw::c_void,
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
     let state = cast_pointer!(state, IKEState);
     return state.handle_input(stream_slice.as_slice(), Direction::ToClient);
@@ -387,7 +385,7 @@ pub unsafe extern "C" fn rs_ike_tx_set_logged(
     tx.logged.set(logged);
 }
 
-static mut ALPROTO_IKE : AppProto = ALPROTO_UNKNOWN;
+static mut ALPROTO_IKE: AppProto = ALPROTO_UNKNOWN;
 
 // Parser name as a C style string.
 const PARSER_NAME: &'static [u8] = b"ike\0";
@@ -399,33 +397,33 @@ export_tx_data_get!(rs_ike_get_tx_data, IKETransaction);
 pub unsafe extern "C" fn rs_ike_register_parser() {
     let default_port = CString::new("500").unwrap();
     let parser = RustParser {
-        name               : PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
-        default_port       : default_port.as_ptr(),
-        ipproto            : core::IPPROTO_UDP,
-        probe_ts           : Some(rs_ike_probing_parser),
-        probe_tc           : Some(rs_ike_probing_parser),
-        min_depth          : 0,
-        max_depth          : 16,
-        state_new          : rs_ike_state_new,
-        state_free         : rs_ike_state_free,
-        tx_free            : rs_ike_state_tx_free,
-        parse_ts           : rs_ike_parse_request,
-        parse_tc           : rs_ike_parse_response,
-        get_tx_count       : rs_ike_state_get_tx_count,
-        get_tx             : rs_ike_state_get_tx,
-        tx_comp_st_ts      : 1,
-        tx_comp_st_tc      : 1,
-        tx_get_progress    : rs_ike_tx_get_alstate_progress,
-        get_eventinfo      : Some(IkeEvent::get_event_info),
-        get_eventinfo_byid : Some(IkeEvent::get_event_info_by_id),
-        localstorage_new   : None,
-        localstorage_free  : None,
-        get_files          : None,
-        get_tx_iterator    : Some(applayer::state_get_tx_iterator::<IKEState, IKETransaction>),
-        get_tx_data        : rs_ike_get_tx_data,
-        apply_tx_config    : None,
-        flags              : APP_LAYER_PARSER_OPT_UNIDIR_TXS,
-        truncate           : None,
+        name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: core::IPPROTO_UDP,
+        probe_ts: Some(rs_ike_probing_parser),
+        probe_tc: Some(rs_ike_probing_parser),
+        min_depth: 0,
+        max_depth: 16,
+        state_new: rs_ike_state_new,
+        state_free: rs_ike_state_free,
+        tx_free: rs_ike_state_tx_free,
+        parse_ts: rs_ike_parse_request,
+        parse_tc: rs_ike_parse_response,
+        get_tx_count: rs_ike_state_get_tx_count,
+        get_tx: rs_ike_state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: rs_ike_tx_get_alstate_progress,
+        get_eventinfo: Some(IkeEvent::get_event_info),
+        get_eventinfo_byid: Some(IkeEvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_files: None,
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<IKEState, IKETransaction>),
+        get_tx_data: rs_ike_get_tx_data,
+        apply_tx_config: None,
+        flags: APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        truncate: None,
         get_frame_id_by_name: None,
         get_frame_name_by_id: None,
     };

--- a/rust/src/ike/ikev1.rs
+++ b/rust/src/ike/ikev1.rs
@@ -40,27 +40,27 @@ pub struct IkeV1Header {
 pub struct Ikev1ParticipantData {
     pub key_exchange: String,
     pub nonce: String,
-    pub vendor_ids: HashSet<String>,
-    /// nested Vec, outer Vec per Proposal/Transform, inner Vec has the list of attributes.
-    pub transforms: Vec<Vec<SaAttribute>>,
+    pub nb_transforms: usize,
+    pub transform: Vec<SaAttribute>,
 }
 
 impl Ikev1ParticipantData {
     pub fn reset(&mut self) {
         self.key_exchange.clear();
         self.nonce.clear();
-        self.vendor_ids.clear();
-        self.transforms.clear();
+        self.nb_transforms = 0;
+        self.transform.clear();
     }
 
     pub fn update(
-        &mut self, key_exchange: &String, nonce: &String, vendor_ids: &Vec<String>,
-        transforms: &Vec<Vec<SaAttribute>>,
+        &mut self, key_exchange: &String, nonce: &String, transforms: &Vec<Vec<SaAttribute>>,
     ) {
         self.key_exchange = key_exchange.clone();
         self.nonce = nonce.clone();
-        self.vendor_ids.extend(vendor_ids.iter().cloned());
-        self.transforms.extend(transforms.iter().cloned());
+        if self.nb_transforms == 0 && transforms.len() > 0 {
+            self.transform.extend(transforms[0].iter().cloned());
+        }
+        self.nb_transforms += transforms.len();
     }
 }
 
@@ -77,6 +77,7 @@ pub fn handle_ikev1(
     let mut tx = state.new_tx();
 
     tx.ike_version = 1;
+    tx.direction = direction;
     tx.hdr.spi_initiator = format!("{:016x}", isakmp_header.init_spi);
     tx.hdr.spi_responder = format!("{:016x}", isakmp_header.resp_spi);
     tx.hdr.maj_ver = isakmp_header.maj_ver;
@@ -126,12 +127,11 @@ pub fn handle_ikev1(
                     state.ikev1_container.client.update(
                         &to_hex(tx.hdr.ikev1_header.key_exchange.as_ref()),
                         &to_hex(tx.hdr.ikev1_header.nonce.as_ref()),
-                        &tx.hdr.ikev1_header.vendor_ids,
                         &tx.hdr.ikev1_transforms,
                     );
                 } else {
-                    if state.ikev1_container.server.transforms.len() <= 1
-                        && state.ikev1_container.server.transforms.len()
+                    if state.ikev1_container.server.nb_transforms <= 1
+                        && state.ikev1_container.server.nb_transforms
                             + tx.hdr.ikev1_transforms.len()
                             > 1
                     {
@@ -142,7 +142,6 @@ pub fn handle_ikev1(
                     state.ikev1_container.server.update(
                         &to_hex(tx.hdr.ikev1_header.key_exchange.as_ref()),
                         &to_hex(tx.hdr.ikev1_header.nonce.as_ref()),
-                        &tx.hdr.ikev1_header.vendor_ids,
                         &tx.hdr.ikev1_transforms,
                     );
                 }

--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -19,9 +19,9 @@ use super::ike::{IKEState, IKETransaction};
 use super::ipsec_parser::IKEV2_FLAG_INITIATOR;
 use crate::ike::parser::{ExchangeType, IsakmpPayloadType, SaAttribute};
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use num_traits::FromPrimitive;
 use std;
 use std::convert::TryFrom;
-use num_traits::FromPrimitive;
 
 const LOG_EXTENDED: u32 = 0x01;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5455

Describe changes:
- ikev1 : log fields from transaction instead of fields from state

ping @satta @fhonza as you have worked on ikev1

Replaces #7667 with S-V passing by keeping in the state the one transform chosen by the server