### PR TITLE
source/pcap: fix infinite loop if interface goes down (6.0.x backport) - v1

### DIFF
--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -207,7 +207,7 @@ static int PcapTryReopen(PcapThreadVars *ptv)
     ptv->pcap_state = PCAP_STATE_DOWN;
 
     int pcap_activate_r = pcap_activate(ptv->pcap_handle);
-    if (pcap_activate_r != 0) {
+    if (pcap_activate_r != 0 && pcap_activate_r != PCAP_ERROR_ACTIVATED) {
         return pcap_activate_r;
     }
 


### PR DESCRIPTION
When in live-pcap mode, if the sniffed interface went down and up again,
Suri would enter an infinite and keep running, while not registering new
events. This fixes that behavior by allowing Suri to retry to open the
pcap in case of a retry on an already activated capture
('PCAP_ERROR_ACTIVATED').

This change is based on Zhiyuan Liao's work.

Bug #3846

(cherry picked from commit 2544be4672215d8c86c68f0d03c8fd88f498f1d2)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5436

Describe changes:
- as per Zhiyuan Liao's contribution suggested for `master`, allow Suri to retry to open the pcap in case of a retry on an already activated capture