### PR TITLE
Add command-line option to simulate alert-queue-expansion-failure (60x backport) - v1

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -27,6 +27,10 @@
 #include "flow.h"
 #include "flow-private.h"
 
+#ifdef DEBUG
+#include "util-exception-policy.h"
+#endif
+
 #include "util-profiling.h"
 
 /** tag signature we use for tag alerts */
@@ -224,6 +228,10 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx)
  */
 static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
 {
+#ifdef DEBUG
+    if (unlikely(g_eps_is_alert_queue_fail_mode))
+        return det_ctx->alert_queue_capacity;
+#endif
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
     void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
     if (unlikely(tmp_queue == NULL)) {

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1769,7 +1769,7 @@ typedef struct DetectFPAndItsId_ {
 } DetectFPAndItsId;
 
 /**
- * \brief Figured out the FP and their respective content ids for all the
+ * \brief Figure out the FP and their respective content ids for all the
  *        sigs in the engine.
  *
  * \param de_ctx Detection engine context.

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -68,7 +68,7 @@ void MpmStoreReportStats(const DetectEngineCtx *de_ctx);
 MpmStore *MpmStorePrepareBuffer(DetectEngineCtx *de_ctx, SigGroupHead *sgh, enum MpmBuiltinBuffers buf);
 
 /**
- * \brief Figured out the FP and their respective content ids for all the
+ * \brief Figure out the FP and their respective content ids for all the
  *        sigs in the engine.
  *
  * \param de_ctx Detection engine context.

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -776,7 +776,7 @@ void SCSigOrderSignatures(DetectEngineCtx *de_ctx)
 
 /**
  * \brief Lets you register the Signature ordering functions.  The order in
- *        which the functions are registered, show the priority.  The first
+ *        which the functions are registered shows the priority.  The first
  *        function registered provides more priority than the function
  *        registered after it.  To add a new registration function, register
  *        it by listing it in the correct position in the below sequence,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1303,6 +1303,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"simulate-packet-tcp-reassembly-memcap", required_argument, 0, 0},
         {"simulate-packet-tcp-ssn-memcap", required_argument, 0, 0},
         {"simulate-packet-defrag-memcap", required_argument, 0, 0},
+        {"simulate-alert-queue-realloc-failure", 0, 0, 0},
 
         {NULL, 0, NULL, 0}
     };

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -123,6 +123,7 @@ uint64_t g_eps_stream_ssn_memcap = UINT64_MAX;
 uint64_t g_eps_stream_reassembly_memcap = UINT64_MAX;
 uint64_t g_eps_flow_memcap = UINT64_MAX;
 uint64_t g_eps_defrag_memcap = UINT64_MAX;
+bool g_eps_is_alert_queue_fail_mode = false;
 
 /* 1: parsed, 0: not for us, -1: error */
 int ExceptionSimulationCommandlineParser(const char *name, const char *arg)
@@ -176,6 +177,8 @@ int ExceptionSimulationCommandlineParser(const char *name, const char *arg)
             return TM_ECODE_FAILED;
         }
         g_eps_defrag_memcap = pkt_num;
+    } else if (strcmp(name, "simulate-alert-queue-realloc-failure") == 0) {
+        g_eps_is_alert_queue_fail_mode = true;
     } else {
         // not for us
         return 0;

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -43,6 +43,7 @@ extern uint64_t g_eps_stream_ssn_memcap;
 extern uint64_t g_eps_stream_reassembly_memcap;
 extern uint64_t g_eps_flow_memcap;
 extern uint64_t g_eps_defrag_memcap;
+extern bool g_eps_is_alert_queue_fail_mode;
 #endif
 
 int ExceptionSimulationCommandlineParser(const char *name, const char *arg);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5381

Describe changes:
- bring commandline option for simulation of the alert queue reallocation failure to 6.0.x
- typo fixes
