### PR TITLE
detect/alert: ensure reject action is applied to packet/flow - v2

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -922,12 +922,22 @@ static inline void PacketSetAction(Packet *p, const uint8_t a)
 
 #define PACKET_TEST_ACTION(p, a) (p)->action &(a)
 
-static inline void PacketDrop(Packet *p, enum PacketDropReason r)
+#define PACKET_UPDATE_ACTION(p, a) (p)->action |= (a)
+static inline void PacketUpdateAction(Packet *p, const uint8_t a)
+{
+    if (likely(p->root == NULL)) {
+        PACKET_UPDATE_ACTION(p, a);
+    } else {
+        PACKET_UPDATE_ACTION(p->root, a);
+    }
+}
+
+static inline void PacketDrop(Packet *p, const uint8_t action, enum PacketDropReason r)
 {
     if (p->drop_reason == PKT_DROP_REASON_NOT_SET)
         p->drop_reason = (uint8_t)r;
 
-    PACKET_SET_ACTION(p, ACTION_DROP);
+    PACKET_UPDATE_ACTION(p, action);
 }
 
 static inline void PacketPass(Packet *p)
@@ -941,16 +951,6 @@ static inline uint8_t PacketTestAction(const Packet *p, const uint8_t a)
         return PACKET_TEST_ACTION(p, a);
     } else {
         return PACKET_TEST_ACTION(p->root, a);
-    }
-}
-
-#define PACKET_UPDATE_ACTION(p, a) (p)->action |= (a)
-static inline void PacketUpdateAction(Packet *p, const uint8_t a)
-{
-    if (likely(p->root == NULL)) {
-        PACKET_UPDATE_ACTION(p, a);
-    } else {
-        PACKET_UPDATE_ACTION(p->root, a);
     }
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -184,7 +184,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
             s->action, alert_flags);
 
     if (s->action & ACTION_DROP) {
-        PacketDrop(p, PKT_DROP_REASON_RULES);
+        PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {
             p->alerts.drop.num = s->num;

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -183,7 +183,8 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
             s->action, alert_flags);
 
-    if (s->action & ACTION_DROP) {
+    if (s->action & (ACTION_DROP | ACTION_REJECT_ANY)) {
+        /* PacketDrop will update the packet action, too */
         PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {
@@ -192,6 +193,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
             p->alerts.drop.s = (Signature *)s;
         }
         if ((p->flow != NULL) && (alert_flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)) {
+
             RuleActionToFlow(s->action, p->flow);
         }
     } else {

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -36,5 +36,6 @@ void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
+void DetectEngineAlertRegisterTests(void);
 
 #endif /* __DETECT_ENGINE_ALERT_H__ */

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -300,7 +300,7 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_DROP:
-            PacketDrop(p, PKT_DROP_REASON_RULES_THRESHOLD);
+            PacketDrop(p, new_action, PKT_DROP_REASON_RULES_THRESHOLD);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_REJECT:

--- a/src/detect.c
+++ b/src/detect.c
@@ -1684,7 +1684,7 @@ static void DetectFlow(ThreadVars *tv,
 
     /* if flow is set to drop, we enforce that here */
     if (p->flow->flags & FLOW_ACTION_DROP) {
-        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
         SCReturn;
     }
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -29,6 +29,7 @@
 #include "detect-parse.h"
 #include "detect-engine.h"
 #include "detect-engine-address.h"
+#include "detect-engine-alert.h"
 #include "detect-engine-proto.h"
 #include "detect-engine-port.h"
 #include "detect-engine-mpm.h"
@@ -198,6 +199,7 @@ static void RegisterUnittests(void)
     DetectAddressTests();
     DetectProtoTests();
     DetectPortTests();
+    DetectEngineAlertRegisterTests();
     SCAtomicRegisterTests();
     MemrchrRegisterTests();
     AppLayerUnittestsRegister();

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4963,7 +4963,7 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         FlowSetNoPacketInspectionFlag(p->flow);
         DecodeSetNoPacketInspectionFlag(p);
         StreamTcpDisableAppLayer(p->flow);
-        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
         /* return the segments to the pool */
         StreamTcpSessionPktFree(p);
         SCReturnInt(0);
@@ -5131,7 +5131,7 @@ error:
          * anyway. Doesn't disable all detection, so we can still
          * match on the stream event that was set. */
         DecodeSetNoPayloadInspectionFlag(p);
-        PacketDrop(p, PKT_DROP_REASON_STREAM_ERROR);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_STREAM_ERROR);
     }
     SCReturnInt(-1);
 }

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -41,7 +41,7 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
                 SCLogDebug("EXCEPTION_POLICY_DROP_PACKET");
                 DecodeSetNoPayloadInspectionFlag(p);
                 DecodeSetNoPacketInspectionFlag(p);
-                PacketDrop(p, drop_reason);
+                PacketDrop(p, ACTION_DROP, drop_reason);
                 break;
             case EXCEPTION_POLICY_BYPASS_FLOW:
                 PacketBypassCallback(p);


### PR DESCRIPTION
Previous PR: #7661 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5458

Changes from last PR:
- Added two unittests to check for correct packet-action flags after signature matching

Thoughts:
- should more unittests be added?
- Many places call PacketDrop in contexts where we don't have a rule nor is it clear what action resulted in the drop. I passed ACTION_DROP in all those cases. Wondering if we should have something more specific/descriptive?