### PR TITLE
Fix dns in tcp flow not detected

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -778,8 +778,11 @@ pub extern "C" fn rs_dns_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
                                                  -> std::os::raw::c_int
 {
     // This is a stateless parser, just the existence of a transaction
-    // means its complete.
+    // means its complete. However this is only true for UDP and not TCP
     SCLogDebug!("rs_dns_tx_get_alstate_progress");
+    if _direction & core::STREAM_TOCLIENT != 0 {
+        return 0;
+    }
     return 1;
 }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/4759

Describe changes:
This fixes issue 4759. The problem is, that when tcp rules are active
a tcp dns connection first the server to client is inspected
and nothing found.
Afterwards the full flow is marked as processed and therefore the dns
query in TCP is not found.
This patch does not mark the flow as processed in case of a server to client connection
