### PR TITLE
Http2 noalloc header compare 5454 v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1302,8 +1302,7 @@ jobs:
 
   macos-latest:
     name: MacOS Latest
-    # use 10.15 for now. Build fails on macos-11 (aka macos-latest)
-    runs-on: macos-10.15
+    runs-on: macos-latest
     needs: [prepare-deps]
     steps:
       # Cache Rust stuff.
@@ -1343,7 +1342,8 @@ jobs:
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests
       - run: make -j2
-      - run: make check
+      # somehow it gets included by some C++ stdlib header (case unsensitive)
+      - run: rm libhtp/VERSION && make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
         run: python3 ./suricata-verify/run.py -q

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -165,7 +165,7 @@ impl HTTP2DecoderHalf {
         }
     }
 
-    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>) {
+    pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
         if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
             if *input == "gzip".as_bytes().to_vec() {
@@ -240,7 +240,7 @@ impl HTTP2Decoder {
         }
     }
 
-    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>, dir: Direction) {
+    pub fn http2_encoding_fromvec(&mut self, input: &[u8], dir: Direction) {
         if dir == Direction::ToClient {
             self.decoder_tc.http2_encoding_fromvec(input);
         } else {

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -168,13 +168,13 @@ impl HTTP2DecoderHalf {
     pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
         if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
-            if *input == "gzip".as_bytes().to_vec() {
+            if input == b"gzip" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingGzip;
                 self.decoder = HTTP2Decompresser::GZIP(GzDecoder::new(HTTP2cursor::new()));
-            } else if *input == "deflate".as_bytes().to_vec() {
+            } else if input == b"deflate" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingDeflate;
                 self.decoder = HTTP2Decompresser::DEFLATE(DeflateDecoder::new(HTTP2cursor::new()));
-            } else if *input == "br".as_bytes().to_vec() {
+            } else if input == b"br" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingBr;
                 self.decoder = HTTP2Decompresser::BROTLI(brotli::Decompressor::new(
                     HTTP2cursor::new(),

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -416,7 +416,7 @@ fn http2_frames_get_header_firstvalue<'a>(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if block.name == name.as_bytes().to_vec() {
+                if block.name == name.as_bytes() {
                     return Ok(&block.value);
                 }
             }
@@ -440,7 +440,7 @@ pub fn http2_frames_get_header_value_vec(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if block.name == name.as_bytes().to_vec() {
+                if block.name == name.as_bytes() {
                     if found == 0 {
                         vec.extend_from_slice(&block.value);
                         found = 1;
@@ -477,7 +477,7 @@ fn http2_frames_get_header_value<'a>(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if block.name == name.as_bytes().to_vec() {
+                if block.name == name.as_bytes() {
                     if found == 0 {
                         single = Ok(&block.value);
                         found = 1;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -194,7 +194,7 @@ impl HTTP2Transaction {
 
     fn handle_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: Direction) {
         for i in 0..blocks.len() {
-            if blocks[i].name == "content-encoding".as_bytes().to_vec() {
+            if blocks[i].name == b"content-encoding" {
                 self.decoder.http2_encoding_fromvec(&blocks[i].value, dir);
             }
         }

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -169,12 +169,12 @@ pub fn http2_range_close(
 ) {
     let added = if let Some(c) = unsafe { SC } {
         let added = (c.HTPFileCloseHandleRange)(
-                files,
-                flags,
-                tx.file_range,
-                data.as_ptr(),
-                data.len() as u32,
-                );
+            files,
+            flags,
+            tx.file_range,
+            data.as_ptr(),
+            data.len() as u32,
+        );
         (c.HttpRangeFreeBlock)(tx.file_range);
         added
     } else {

--- a/src/util-daemon.c
+++ b/src/util-daemon.c
@@ -110,7 +110,14 @@ void Daemonize (void)
               through conf file */
 
     /* Creates a new process */
+#if defined(OS_DARWIN) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
     pid = fork();
+#if defined(OS_DARWIN) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
     if (pid < 0) {
         /* Fork error */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5454

Describe changes:
- http2: remove `to_vec` in comparisons (no need to alloc)

Replaces #7685 with better style from Jason
