### PR TITLE
detect/tls: fix descriptions

### DIFF
--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -75,7 +75,7 @@ void DetectTlsFingerprintRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].name = "tls.cert_fingerprint";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].alias = "tls_cert_fingerprint";
-    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].desc = "match on the TLS cert fingerprint buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].desc = "sticky byffer to match the TLS cert fingerprint buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].url = "/rules/tls-keywords.html#tls-cert-fingerprint";
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].Setup = DetectTlsFingerprintSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -71,7 +71,7 @@ void DetectTlsIssuerRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].name = "tls.cert_issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].alias = "tls_cert_issuer";
-    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].desc = "content modifier to match specifically and only on the TLS cert issuer buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].desc = "sticky buffer to match specifically and only on the TLS cert issuer buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].url = "/rules/tls-keywords.html#tls-cert-issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].Setup = DetectTlsIssuerSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -75,7 +75,7 @@ void DetectTlsSerialRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].name = "tls.cert_serial";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].alias = "tls_cert_serial";
-    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].desc = "content modifier to match the TLS cert serial buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].desc = "sticky buffer to match the TLS cert serial buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].url = "/rules/tls-keywords.html#tls-cert-serial";
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].Setup = DetectTlsSerialSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -71,7 +71,7 @@ void DetectTlsSubjectRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].name = "tls.cert_subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].alias = "tls_cert_subject";
-    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].desc = "content modifier to match specifically and only on the TLS cert subject buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].desc = "sticky buffer to match specifically and only on the TLS cert subject buffer";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].url = "/rules/tls-keywords.html#tls-cert-subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].Setup = DetectTlsSubjectSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -85,7 +85,7 @@ typedef struct PrefilterMpmTlsCerts {
 void DetectTlsCertsRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERTS].name = "tls.certs";
-    sigmatch_table[DETECT_AL_TLS_CERTS].desc = "content modifier to match the TLS certificate sticky buffer";
+    sigmatch_table[DETECT_AL_TLS_CERTS].desc = "sticky buffer to match the TLS certificate buffer";
     sigmatch_table[DETECT_AL_TLS_CERTS].url = "/rules/tls-keywords.html#tls-certs";
     sigmatch_table[DETECT_AL_TLS_CERTS].Setup = DetectTlsCertsSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -79,7 +79,7 @@ void DetectTlsJa3HashRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].name = "ja3.hash";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].alias = "ja3_hash";
-    sigmatch_table[DETECT_AL_TLS_JA3_HASH].desc = "content modifier to match the JA3 hash buffer";
+    sigmatch_table[DETECT_AL_TLS_JA3_HASH].desc = "sticky buffer to match the JA3 hash buffer";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].url = "/rules/ja3-keywords.html#ja3-hash";
     sigmatch_table[DETECT_AL_TLS_JA3_HASH].Setup = DetectTlsJa3HashSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -95,7 +95,7 @@ void DetectTlsJa3StringRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].name = "ja3.string";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].alias = "ja3_string";
-    sigmatch_table[DETECT_AL_TLS_JA3_STRING].desc = "content modifier to match the JA3 string buffer";
+    sigmatch_table[DETECT_AL_TLS_JA3_STRING].desc = "sticky buffer to match the JA3 string buffer";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].url = "/rules/ja3-keywords.html#ja3-string";
     sigmatch_table[DETECT_AL_TLS_JA3_STRING].Setup = DetectTlsJa3StringSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -78,7 +78,7 @@ static int g_tls_ja3s_hash_buffer_id = 0;
 void DetectTlsJa3SHashRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_JA3S_HASH].name = "ja3s.hash";
-    sigmatch_table[DETECT_AL_TLS_JA3S_HASH].desc = "content modifier to match the JA3S hash sticky buffer";
+    sigmatch_table[DETECT_AL_TLS_JA3S_HASH].desc = "sticky buffer to match the JA3S hash buffer";
     sigmatch_table[DETECT_AL_TLS_JA3S_HASH].url = "/rules/ja3-keywords.html#ja3s-hash";
     sigmatch_table[DETECT_AL_TLS_JA3S_HASH].Setup = DetectTlsJa3SHashSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -94,7 +94,7 @@ static InspectionBuffer *GetJa3Data(DetectEngineThreadCtx *det_ctx,
 void DetectTlsJa3SStringRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_JA3S_STRING].name = "ja3s.string";
-    sigmatch_table[DETECT_AL_TLS_JA3S_STRING].desc = "content modifier to match the JA3S string sticky buffer";
+    sigmatch_table[DETECT_AL_TLS_JA3S_STRING].desc = "sticky buffer to match the JA3S string buffer";
     sigmatch_table[DETECT_AL_TLS_JA3S_STRING].url = "/rules/ja3-keywords.html#ja3s-string";
     sigmatch_table[DETECT_AL_TLS_JA3S_STRING].Setup = DetectTlsJa3SStringSetup;
 #ifdef UNITTESTS

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -71,7 +71,7 @@ void DetectTlsSniRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_SNI].name = "tls.sni";
     sigmatch_table[DETECT_AL_TLS_SNI].alias = "tls_sni";
-    sigmatch_table[DETECT_AL_TLS_SNI].desc = "content modifier to match specifically and only on the TLS SNI buffer";
+    sigmatch_table[DETECT_AL_TLS_SNI].desc = "sticky buffer to match specifically and only on the TLS SNI buffer";
     sigmatch_table[DETECT_AL_TLS_SNI].url = "/rules/tls-keywords.html#tls-sni";
     sigmatch_table[DETECT_AL_TLS_SNI].Setup = DetectTlsSniSetup;
 #ifdef UNITTESTS


### PR DESCRIPTION
Most keywords were presented as content modifiers when they
were in fact sticky buffers.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)