### PR TITLE
app-layer: don't wrap around on port 65535

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1708,7 +1708,7 @@ void AppLayerProtoDetectPPRegister(uint8_t ipproto,
         uint16_t port = temp_dp->port;
         if (port == 0 && temp_dp->port2 != 0)
             port++;
-        for ( ; port <= temp_dp->port2; port++) {
+        for (;;) {
             AppLayerProtoDetectInsertNewProbingParser(&alpd_ctx.ctx_pp,
                                                       ipproto,
                                                       port,
@@ -1717,6 +1717,11 @@ void AppLayerProtoDetectPPRegister(uint8_t ipproto,
                                                       direction,
                                                       ProbingParser1,
                                                       ProbingParser2);
+            if (port == temp_dp->port2) {
+                break;
+            } else {
+                port++;
+            }
         }
         temp_dp = temp_dp->next;
     }


### PR DESCRIPTION
A port value of 65535 caused the port value to wrap-around to 0
resulting in an infinite loop.

Introduced with commit 53fc70a9a73cd157ed8235f6a73a8752f8f1396a.
