### PR TITLE
doc/conf: fix sphinx language setting

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -80,7 +80,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
`sphinx-build 5.1.1` and above throws a warning which is treated as an
error while building.

```
Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
```