### PR TITLE
rust/filecontainer: fix double implementation

### DIFF
--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -69,9 +69,6 @@ impl Default for FileContainer {
 }
 
 impl FileContainer {
-    pub fn default() -> FileContainer {
-        FileContainer { head:ptr::null_mut(), tail:ptr::null_mut() }
-    }
     pub fn free(&mut self) {
         SCLogDebug!("freeing self");
         match unsafe {SC} {


### PR DESCRIPTION
Default was implemented twice on the FileContainer struct

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
