### PR TITLE
stream: add exception policy for midstream flows - v1

### DIFF
--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -67,6 +67,7 @@ typedef struct TcpStreamCnf_ {
 
     enum ExceptionPolicy ssn_memcap_policy;
     enum ExceptionPolicy reassembly_memcap_policy;
+    enum ExceptionPolicy midstream_policy;
 
     StreamingBufferConfig sbcnf;
 } TcpStreamCnf;


### PR DESCRIPTION
This allows to set a midstream-policy that can:
- fail closed (stream.midstream-policy=drop-flow)
- fail open (stream.midstream-policy=bypass)
- do nothing (default behavior)

Usage and behavior:

If Suricata is configured to inspect midstream traffic
(stream.midstream=true), then it is possible to define a midstream
policy to fully DROP or PASS a midstream flow, when Suricata identifies
one, or just ignore it and keep the default behavior (that is, inspect
it).

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5468

Describe changes:
- add a `stream.midstream-policy` option that allows for controlling if a flow should be fully dropped or bypassed. It is also possible to just ignore the policy (keeps normal behavior) if it is a midstream flow (in IPS mode)
- This change assumes that this policy should only be applied if Suricata is configured with `stream.midstream=true`

Missing: documentation (will start working on it following this PR)

suricata-verify-pr: 907
https://github.com/OISF/suricata-verify/pull/907