### PR TITLE
detect/parse: test sig parsing for more actions (60x backport) - v1

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -4151,6 +4151,38 @@ static int SigParseBidirWithSameSrcAndDest02(void)
     PASS;
 }
 
+static int SigParseTestActionReject(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    Signature *sig = DetectEngineAppendSig(
+            de_ctx, "reject tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1;)");
+#ifdef HAVE_LIBNET11
+    FAIL_IF_NULL(sig);
+    FAIL_IF_NOT((sig->action & (ACTION_DROP | ACTION_REJECT)) == (ACTION_DROP | ACTION_REJECT));
+#else
+    FAIL_IF_NOT_NULL(sig);
+#endif
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+static int SigParseTestActionDrop(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    Signature *sig = DetectEngineAppendSig(
+            de_ctx, "drop tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1;)");
+    FAIL_IF_NULL(sig);
+    FAIL_IF_NOT(sig->action & ACTION_DROP);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 #ifdef UNITTESTS
@@ -4225,5 +4257,7 @@ void SigParseRegisterTests(void)
             SigParseBidirWithSameSrcAndDest01);
     UtRegisterTest("SigParseBidirWithSameSrcAndDest02",
             SigParseBidirWithSameSrcAndDest02);
+    UtRegisterTest("SigParseTestActionReject", SigParseTestActionReject);
+    UtRegisterTest("SigParseTestActionDrop", SigParseTestActionDrop);
 #endif /* UNITTESTS */
 }


### PR DESCRIPTION
Our unittests were only covering sig parsing for alert actions. As in
environments without LibNet the reject action will not work, we must
ensure that our parser properly fails in such cases, instead of silently
accepting an unsupported action.

Added tests for the reject and drop action.

Task #5496

(cherry picked from commit c81b78fd1c9a6e86d6be14b7567c5b8d8c89d6af)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- haven't created one as I don't know if we really want this backport or not.

Describe changes:
- add unittests to check that the signature parser properly errors out for sigs with reject in environments without libnet