### PR TITLE
detect/alert: ensure reject action is applied to packet/flow - v4

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1219,6 +1219,7 @@ EXTRA_DIST = \
 	tests/detect-ttl.c \
 	tests/source-pcap.c \
 	tests/app-layer-htp-file.c \
+	tests/detect-engine-alert.c \
 	tests/detect-engine-content-inspection.c \
 	tests/detect-icmpv4hdr.c \
 	tests/detect-parse.c \

--- a/src/decode.h
+++ b/src/decode.h
@@ -912,14 +912,6 @@ static inline void PacketSetAction(Packet *p, const uint8_t a)
 
 #define PACKET_ACCEPT(p) PACKET_SET_ACTION(p, ACTION_ACCEPT)
 
-#define PACKET_REJECT(p) PACKET_SET_ACTION(p, (ACTION_REJECT|ACTION_DROP))
-
-#define PACKET_REJECT_DST(p) PACKET_SET_ACTION(p, (ACTION_REJECT_DST|ACTION_DROP))
-
-#define PACKET_REJECT_BOTH(p) PACKET_SET_ACTION(p, (ACTION_REJECT_BOTH|ACTION_DROP))
-
-#define PACKET_PASS(p) PACKET_SET_ACTION(p, ACTION_PASS)
-
 #define PACKET_TEST_ACTION(p, a) (p)->action &(a)
 
 #define PACKET_UPDATE_ACTION(p, a) (p)->action |= (a)

--- a/src/decode.h
+++ b/src/decode.h
@@ -922,12 +922,22 @@ static inline void PacketSetAction(Packet *p, const uint8_t a)
 
 #define PACKET_TEST_ACTION(p, a) (p)->action &(a)
 
-static inline void PacketDrop(Packet *p, enum PacketDropReason r)
+#define PACKET_UPDATE_ACTION(p, a) (p)->action |= (a)
+static inline void PacketUpdateAction(Packet *p, const uint8_t a)
+{
+    if (likely(p->root == NULL)) {
+        PACKET_UPDATE_ACTION(p, a);
+    } else {
+        PACKET_UPDATE_ACTION(p->root, a);
+    }
+}
+
+static inline void PacketDrop(Packet *p, const uint8_t action, enum PacketDropReason r)
 {
     if (p->drop_reason == PKT_DROP_REASON_NOT_SET)
         p->drop_reason = (uint8_t)r;
 
-    PACKET_SET_ACTION(p, ACTION_DROP);
+    PACKET_UPDATE_ACTION(p, action);
 }
 
 static inline void PacketPass(Packet *p)
@@ -941,16 +951,6 @@ static inline uint8_t PacketTestAction(const Packet *p, const uint8_t a)
         return PACKET_TEST_ACTION(p, a);
     } else {
         return PACKET_TEST_ACTION(p->root, a);
-    }
-}
-
-#define PACKET_UPDATE_ACTION(p, a) (p)->action |= (a)
-static inline void PacketUpdateAction(Packet *p, const uint8_t a)
-{
-    if (likely(p->root == NULL)) {
-        PACKET_UPDATE_ACTION(p, a);
-    } else {
-        PACKET_UPDATE_ACTION(p->root, a);
     }
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -184,7 +184,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
             s->action, alert_flags);
 
     if (s->action & ACTION_DROP) {
-        PacketDrop(p, PKT_DROP_REASON_RULES);
+        PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {
             p->alerts.drop.num = s->num;

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -417,6 +417,8 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
             p->flags |= PKT_FIRST_ALERTS;
         }
     }
-
 }
 
+#ifdef UNITTESTS
+#include "tests/detect-engine-alert.c"
+#endif

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -36,5 +36,6 @@ void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);
+void DetectEngineAlertRegisterTests(void);
 
 #endif /* __DETECT_ENGINE_ALERT_H__ */

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -300,7 +300,7 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_DROP:
-            PacketDrop(p, PKT_DROP_REASON_RULES_THRESHOLD);
+            PacketDrop(p, new_action, PKT_DROP_REASON_RULES_THRESHOLD);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_REJECT:

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -308,7 +308,7 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_PASS:
-            PACKET_PASS(p);
+            PacketPass(p);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         default:

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -300,11 +300,11 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_DROP:
-            PacketDrop(p, new_action, PKT_DROP_REASON_RULES_THRESHOLD);
+            PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_RULES_THRESHOLD);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_REJECT:
-            PACKET_REJECT(p);
+            PacketDrop(p, (ACTION_REJECT | ACTION_DROP), PKT_DROP_REASON_RULES_THRESHOLD);
             pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
             break;
         case TH_ACTION_PASS:

--- a/src/detect.c
+++ b/src/detect.c
@@ -1684,7 +1684,7 @@ static void DetectFlow(ThreadVars *tv,
 
     /* if flow is set to drop, we enforce that here */
     if (p->flow->flags & FLOW_ACTION_DROP) {
-        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
         SCReturn;
     }
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -198,6 +198,7 @@ static void RegisterUnittests(void)
     DetectAddressTests();
     DetectProtoTests();
     DetectPortTests();
+    DetectEngineAlertRegisterTests();
     SCAtomicRegisterTests();
     MemrchrRegisterTests();
     AppLayerUnittestsRegister();

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4963,7 +4963,7 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         FlowSetNoPacketInspectionFlag(p->flow);
         DecodeSetNoPacketInspectionFlag(p);
         StreamTcpDisableAppLayer(p->flow);
-        PacketDrop(p, PKT_DROP_REASON_FLOW_DROP);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
         /* return the segments to the pool */
         StreamTcpSessionPktFree(p);
         SCReturnInt(0);
@@ -5131,7 +5131,7 @@ error:
          * anyway. Doesn't disable all detection, so we can still
          * match on the stream event that was set. */
         DecodeSetNoPayloadInspectionFlag(p);
-        PacketDrop(p, PKT_DROP_REASON_STREAM_ERROR);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_STREAM_ERROR);
     }
     SCReturnInt(-1);
 }

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -188,7 +188,6 @@ TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueueNoLock *);
 uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
-void StreamTcpRegisterTests (void);
 
 int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
                      PacketQueueNoLock *pq);

--- a/src/tests/detect-engine-alert.c
+++ b/src/tests/detect-engine-alert.c
@@ -1,0 +1,77 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../suricata-common.h"
+
+#include "../detect.h"
+#include "../detect-engine.h"
+#include "../detect-engine-alert.h"
+#include "../detect-parse.h"
+
+#include "../util-unittest.h"
+#include "../util-unittest-helper.h"
+
+/**
+ * \brief Tests that the reject action is correctly set in Packet->action
+ */
+static int TestDetectAlertPacketApplySignatureActions01(void)
+{
+#ifdef HAVE_LIBNET11
+    uint8_t payload[] = "Hi all!";
+    uint16_t length = sizeof(payload) - 1;
+    Packet *p = UTHBuildPacketReal(
+            (uint8_t *)payload, length, IPPROTO_TCP, "192.168.1.5", "192.168.1.1", 41424, 80);
+    FAIL_IF_NULL(p);
+
+    const char sig[] = "reject tcp any any -> any 80 (content:\"Hi all\"; sid:1; rev:1;)";
+    FAIL_IF(UTHPacketMatchSig(p, sig) == 0);
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_REJECT_ANY));
+
+    UTHFreePackets(&p, 1);
+#endif /* HAVE_LIBNET11 */
+    PASS;
+}
+
+/**
+ * \brief Tests that the packet has the drop action correctly updated in Packet->action
+ */
+static int TestDetectAlertPacketApplySignatureActions02(void)
+{
+    uint8_t payload[] = "Hi all!";
+    uint16_t length = sizeof(payload) - 1;
+    Packet *p = UTHBuildPacketReal(
+            (uint8_t *)payload, length, IPPROTO_TCP, "192.168.1.5", "192.168.1.1", 41424, 80);
+    FAIL_IF_NULL(p);
+
+    const char sig[] = "drop tcp any any -> any any (msg:\"sig 1\"; content:\"Hi all\"; sid:1;)";
+    FAIL_IF(UTHPacketMatchSig(p, sig) == 0);
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
+
+    UTHFreePackets(&p, 1);
+    PASS;
+}
+
+/**
+ * \brief Registers Detect Engine Alert unit tests
+ */
+void DetectEngineAlertRegisterTests(void)
+{
+    UtRegisterTest("TestDetectAlertPacketApplySignatureActions01",
+            TestDetectAlertPacketApplySignatureActions01);
+    UtRegisterTest("TestDetectAlertPacketApplySignatureActions02",
+            TestDetectAlertPacketApplySignatureActions02);
+}

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -49,6 +49,7 @@
 #include "util-error.h"
 #include "util-profiling.h"
 #include "util-device.h"
+#include "util-validate.h"
 
 /* Number of freed packet to save for one pool before freeing them. */
 #define MAX_PENDING_RETURN_PACKETS 32
@@ -448,6 +449,11 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
         SCMutexUnlock(m);
 
         SCLogDebug("tunnel stuff done, move on (proot %d)", proot);
+    }
+
+    /* Check that the drop reason has been set, if we have a drop */
+    if (PacketTestAction(p, ACTION_DROP)) {
+        DEBUG_VALIDATE_BUG_ON((p)->drop_reason == PKT_DROP_REASON_NOT_SET);
     }
 
     /* we're done with the tunnel root now as well */

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -41,7 +41,7 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
                 SCLogDebug("EXCEPTION_POLICY_DROP_PACKET");
                 DecodeSetNoPayloadInspectionFlag(p);
                 DecodeSetNoPacketInspectionFlag(p);
-                PacketDrop(p, drop_reason);
+                PacketDrop(p, ACTION_DROP, drop_reason);
                 break;
             case EXCEPTION_POLICY_BYPASS_FLOW:
                 PacketBypassCallback(p);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/7723

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5458

Changes from last PR:
- Remove macros `PACKET_REJECT`, `PACKET_REJECT_BOTH` and `PACKET_REJECT_DST`
- Replace (single) usage of macro `PACKET_PASS` for function `PacketPass()`

**Note:** I didn't implement the request for removing the function `PacketSetAcion()` as it seems to me that it is slightly different from the macro `PACKET_SET_ACTION` and I think that we should replace the macro for the function - but this would lead to more changes.
 