### PR TITLE
Fuzzing targets fixes

### DIFF
--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -99,7 +99,6 @@ app-layer:\n\
       enabled: yes\n\
       detection-ports:\n\
         dp: 44818\n\
-        sp: 44818\n\
     sip:\n\
       enabled: yes\n\
     ssh:\n\

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -170,31 +170,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
 
             AppLayerParserTransactionsCleanup(f);
-
-            if (f->alstate && f->alparser) {
-                // check if we have too many open transactions
-                const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
-                uint64_t min = 0;
-                AppLayerGetTxIterState state;
-                memset(&state, 0, sizeof(state));
-                uint64_t nbtx = 0;
-                AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(f->proto, f->alproto);
-                while (1) {
-                    AppLayerGetTxIterTuple ires =
-                            IterFunc(f->proto, f->alproto, f->alstate, min, total_txs, &state);
-                    if (ires.tx_ptr == NULL)
-                        break;
-                    min = ires.tx_id + 1;
-                    nbtx++;
-                    if (nbtx > ALPROTO_MAXTX) {
-                        printf("Too many open transactions for protocol %s\n",
-                                AppProtoToString(f->alproto));
-                        printf("Assertion failure: %s\n", AppProtoToString(f->alproto));
-                        fflush(stdout);
-                        abort();
-                    }
-                }
-            }
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44798 and other

Describe changes:
- removes fuzzer's check about too many transactions
- removes fuzzing detecting enip based on source port

HTTP1 and other can indeed pipeline many transactions.
Do we want to do something else about it ?