### PR TITLE
userguide: update dsize documentation/examples

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -295,29 +295,42 @@ Examples of bsize values:
 
    alert dns any any -> any any (msg:"bsize buffer range value"; dns.query; content:"google.com"; bsize:8<>20; sid:6; rev:1;)
 
-
 dsize
 -----
 
 With the dsize keyword, you can match on the size of the packet
-payload. You can use the keyword for example to look for abnormal
+payload/data. You can use the keyword for example to look for abnormal
 sizes of payloads which are equal to some n i.e. 'dsize:n'
 not equal 'dsize:!n' less than 'dsize:<n' or greater than 'dsize:>n'
 This may be convenient in detecting buffer overflows.
+
+dsize cannot be used when using app/streamlayer protocol keywords (i.e. http.uri)
 
 Format::
 
   dsize:[<>!]number; || dsize:min<>max;
 
-Example of dsize in a rule:
+Examples of dsize values:
 
 .. container:: example-rule
 
-    alert udp $EXTERNAL_NET any -> $HOME_NET 65535 (msg:"GPL DELETED EXPLOIT LANDesk Management Suite Alerting Service buffer overflow"; :example-rule-emphasis:`dsize:>268;` reference: bugtraq,23483; reference: cve,2007-1674; classtype: attempted-admin; sid:100000928; rev:1;)
-    alert tcp $EXTERNAL_NET any -> $HOME_NET 8081 (msg:"Example Negation"; :example-rule-emphasis:`dsize:!10;` sid:123; rev:1;)
+   alert tcp any any -> any any (msg:"dsize exact size"; dsize:10; sid:1; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize less than value"; dsize:<10; sid:2; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize less than or equal value"; dsize:<=10; sid:3; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize greater than value"; dsize:>8; sid:4; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize greater than or equal value"; dsize:>=10; sid:5; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize range value"; dsize:8<>20; sid:6; rev:1;)
+
+   alert tcp any any -> any any (msg:"dsize not equal value"; dsize:!9; sid:7; rev:1;)
 
 byte_test
 ---------
+
 The ``byte_test`` keyword extracts ``<num of bytes>`` and performs an operation selected
 with ``<operator>`` against the value in ``<test value>`` at a particular ``<offset>``.
 The ``<bitmask value>`` is applied to the extracted bytes (before the operator is applied),


### PR DESCRIPTION
Signed-off-by: jason taylor <jtfas90@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Generally related to https://redmine.openinfosecfoundation.org/issues/5182 If this needs a separate ticket I can create one.

Describe changes:
- Add dsize keyword examples
- Minor formatting changes
-

#suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/917
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
