### PR TITLE
exceptions: error out when invalid policy is used - v1

### DIFF
--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -88,7 +88,10 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support
             policy = EXCEPTION_POLICY_IGNORE;
             SCLogConfig("%s: %s", option, value_str);
         } else {
-            SCLogConfig("%s: ignore", option);
+            FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                    "\"%s\" is not a valid exception policy value,  please check Suricata "
+                    "documentation for available options.",
+                    value_str);
         }
 
         if (!support_flow) {


### PR DESCRIPTION
Before, if an invalid value was passed as exception policy, Suricata
would log a warning and set the exception policy to "ignore". This is a
very different result, than, say, dropping or bypassing a midstream flow.

Task #5504

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5504

Describe changes:
- instead of a config log informing that the exception policy will be set to `ignore`, fail at init, indicating the error, so it can be fixed asap
<Error> (ExceptionPolicyParse) -- [ERRCODE: SC_ERR_INVALID_ARGUMENT(13)] - "flow-drop" is not a valid exception policy value,  please check Suricata documentation for available options.