### PR TITLE
luajit: fix unittests build

### DIFF
--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -103,6 +103,7 @@
 
 #include "util-streaming-buffer.h"
 #include "util-lua.h"
+#include "util-luajit.h"
 #include "tm-modules.h"
 #include "tmqh-packetpool.h"
 #include "decode-chdlc.h"


### PR DESCRIPTION
When building latest master with the following options:
```
 ./configure CC=clang --enable-luajit --enable-geoip --enable-unittests
```
There is a build failure:
```
runmode-unittests.c:234:9: error: implicit declaration of function 'LuajitSetupStatesPool' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (LuajitSetupStatesPool() != 0) {
```
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fix build
