### PR TITLE
exceptions: error out when invalid policy is used - v2

### DIFF
--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -88,7 +88,11 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support
             policy = EXCEPTION_POLICY_IGNORE;
             SCLogConfig("%s: %s", option, value_str);
         } else {
-            SCLogConfig("%s: ignore", option);
+            FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                    "\"%s\" is not a valid exception policy value. Valid options are drop-flow, "
+                    "pass-flow, bypass, drop-packet or pass-packet. For more infomation, please "
+                    "check the Suricata documentation.",
+                    value_str);
         }
 
         if (!support_flow) {


### PR DESCRIPTION
Before, if an invalid value was passed as exception policy, Suricata
would log a warning and set the exception policy to "ignore". This is a
very different result, than, say, dropping or bypassing a midstream flow.

Task #5504

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5504

Previous PR: #7760

Changes from previous PR: 
- Make the error message more informative and user friendly:
`<Error> (ExceptionPolicyParse) -- [ERRCODE: SC_ERR_INVALID_ARGUMENT(13)] - "flow-drop" is not a valid exception policy value. Valid options are drop-flow, pass-flow, bypass, drop-packet or pass-packet. For more infomation, please check the Suricata documentation.`