### PR TITLE
detect: transforms check for 0-sized buffer

### DIFF
--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -107,6 +107,10 @@ static void TransformCompressWhitespace(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
+    if (input_len == 0) {
+        return;
+    }
+
     uint8_t output[input_len]; // we can only shrink
     uint8_t *oi = output, *os = output;
 

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -103,6 +103,9 @@ static void TransformStripWhitespace(InspectionBuffer *buffer, void *options)
 {
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
+    if (input_len == 0) {
+        return;
+    }
     uint8_t output[input_len]; // we can only shrink
     uint8_t *oi = output, *os = output;
 

--- a/src/detect-transform-urldecode.c
+++ b/src/detect-transform-urldecode.c
@@ -122,6 +122,9 @@ static void TransformUrlDecode(InspectionBuffer *buffer, void *options)
 
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
+    if (input_len == 0) {
+        return;
+    }
     uint8_t output[input_len]; // we can only shrink
 
     changed = BufferUrlDecode(input, input_len, output, &output_size);

--- a/src/detect-transform-xor.c
+++ b/src/detect-transform-xor.c
@@ -131,6 +131,9 @@ static void DetectTransformXor(InspectionBuffer *buffer, void *options)
     const uint8_t *input = buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;
     DetectTransformXorData *pxd = options;
+    if (input_len == 0) {
+        return;
+    }
     uint8_t output[input_len];
 
     for (uint32_t i = 0; i < input_len; i++) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5521

Describe changes:
- transforms check for 0-sized buffer to avoid undefined behavior  with a 0-sized variable length array