### PR TITLE
detect: support file.data for HTTP1 to server

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -97,6 +97,8 @@ void DetectFiledataRegister(void)
             ALPROTO_SMTP, 0);
     DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2, PrefilterMpmHTTPFiledataRegister,
             NULL, ALPROTO_HTTP1, HTP_RESPONSE_BODY);
+    DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2, PrefilterMpmFiledataRegister,
+            NULL, ALPROTO_HTTP1, HTP_REQUEST_BODY);
     DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2,
             PrefilterMpmFiledataRegister, NULL,
             ALPROTO_SMB, 0);
@@ -124,6 +126,8 @@ void DetectFiledataRegister(void)
 
     DetectAppLayerInspectEngineRegister2("file_data", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_BODY, DetectEngineInspectBufferHttpBody, NULL);
+    DetectAppLayerInspectEngineRegister2("file_data", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
+            HTP_REQUEST_BODY, DetectEngineInspectFiledata, NULL);
     DetectAppLayerInspectEngineRegister2("file_data",
             ALPROTO_SMTP, SIG_FLAG_TOSERVER, 0,
             DetectEngineInspectFiledata, NULL);
@@ -207,14 +211,6 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
                     s->alproto != ALPROTO_FTPDATA && s->alproto != ALPROTO_HTTP &&
                     s->alproto != ALPROTO_NFS)) {
         SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting keywords.");
-        return -1;
-    }
-
-    if ((s->alproto == ALPROTO_HTTP1 || s->alproto == ALPROTO_HTTP) &&
-            (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) && (s->flags & SIG_FLAG_TOSERVER) &&
-            !(s->flags & SIG_FLAG_TOCLIENT)) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with "
-                "flow:to_server or flow:from_client with http.");
         return -1;
     }
 

--- a/src/tests/detect-file-data.c
+++ b/src/tests/detect-file-data.c
@@ -106,22 +106,6 @@ static int DetectFiledataParseTest04(void)
     PASS;
 }
 
-/**
- * \test Test the file_data fails with flow:to_server.
- */
-static int DetectFiledataParseTest05(void)
-{
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    FAIL_IF_NULL(de_ctx);
-    de_ctx->flags |= DE_QUIET;
-    Signature *s = DetectEngineAppendSig(de_ctx,
-            "alert http any any -> any any "
-            "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)");
-    FAIL_IF_NOT_NULL(s);
-    DetectEngineCtxFree(de_ctx);
-    PASS;
-}
-
 static int DetectFiledataIsdataatParseTest1(void)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -184,7 +168,6 @@ void DetectFiledataRegisterTests(void)
     UtRegisterTest("DetectFiledataParseTest02", DetectFiledataParseTest02);
     UtRegisterTest("DetectFiledataParseTest03", DetectFiledataParseTest03);
     UtRegisterTest("DetectFiledataParseTest04", DetectFiledataParseTest04);
-    UtRegisterTest("DetectFiledataParseTest05", DetectFiledataParseTest05);
 
     UtRegisterTest("DetectFiledataIsdataatParseTest1",
             DetectFiledataIsdataatParseTest1);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4144

cc @jlucovsky as you were assigned that one

Describe changes:
- support `file.data` keyword for HTTP1 POST or such

Replaces https://github.com/OISF/suricata/pull/7759 with commit reworded to include ticket

suricata-verify-pr: 920
https://github.com/OISF/suricata-verify/pull/920