### PR TITLE
exceptions: error out when invalid policy is used (6.0.x backport) - v1

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -80,7 +80,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -87,7 +87,10 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support
             policy = EXCEPTION_POLICY_IGNORE;
             SCLogConfig("%s: %s", option, value_str);
         } else {
-            SCLogConfig("%s: ignore", option);
+            FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                    "\"%s\" is not a valid exception policy value. Valid options are drop-flow, "
+                    "pass-flow, bypass, drop-packet, pass-packet or ignore.",
+                    value_str);
         }
 
         if (!support_flow) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5525

Describe changes:
- Exception policy error out in case of invalid value - 6.0.x backport
- sphinx language setting fix - 6.0.x backport
