### PR TITLE
decode/vlan: Extend VLAN encapsulation support to 3 levels

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3915,6 +3915,9 @@
                         "vlan_qinq": {
                             "type": "integer"
                         },
+                        "vlan_qinqinq": {
+                            "type": "integer"
+                        },
                         "vntag": {
                             "type": "integer"
                         },

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -100,7 +100,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
     }
 
     if (vlan_id > 0) {
-        if (p->vlan_idx >= 2) {
+        if (p->vlan_idx > 2) {
             ENGINE_SET_EVENT(p,ERSPAN_TOO_MANY_VLAN_LAYERS);
             return TM_ECODE_FAILED;
         }

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -68,6 +68,8 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         StatsIncr(tv, dtv->counter_vlan);
     else if (p->vlan_idx == 1)
         StatsIncr(tv, dtv->counter_vlan_qinq);
+    else if (p->vlan_idx == 2)
+        StatsIncr(tv, dtv->counter_vlan_qinqinq);
 
     if(len < VLAN_HEADER_LEN)    {
         ENGINE_SET_INVALID_EVENT(p, VLAN_HEADER_TOO_SMALL);
@@ -76,7 +78,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (!PacketIncreaseCheckLayers(p)) {
         return TM_ECODE_FAILED;
     }
-    if (p->vlan_idx >= 2) {
+    if (p->vlan_idx > 2) {
         ENGINE_SET_EVENT(p,VLAN_HEADER_TOO_MANY_LAYERS);
         return TM_ECODE_FAILED;
     }
@@ -101,7 +103,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
 uint16_t DecodeVLANGetId(const Packet *p, uint8_t layer)
 {
-    if (unlikely(layer > 1))
+    if (unlikely(layer > 2))
         return 0;
     if (p->vlan_idx > layer) {
         return p->vlan_id[layer];

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -99,16 +99,6 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
     return TM_ECODE_OK;
-}
-
-uint16_t DecodeVLANGetId(const Packet *p, uint8_t layer)
-{
-    if (unlikely(layer > 2))
-        return 0;
-    if (p->vlan_idx > layer) {
-        return p->vlan_id[layer];
-    }
-    return 0;
 }
 
 typedef struct IEEE8021ahHdr_ {

--- a/src/decode-vlan.h
+++ b/src/decode-vlan.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,11 +35,6 @@ uint16_t DecodeVLANGetId(const struct Packet_ *, uint8_t layer);
 #define GET_VLAN_CFI(vlanh)         ((SCNtohs((vlanh)->vlan_cfi) & 0x0100) >> 12)
 #define GET_VLAN_ID(vlanh)          ((uint16_t)(SCNtohs((vlanh)->vlan_cfi) & 0x0FFF))
 #define GET_VLAN_PROTO(vlanh)       ((SCNtohs((vlanh)->protocol)))
-
-/* return vlan id in host byte order */
-#define VLAN_GET_ID1(p)             DecodeVLANGetId((p), 0)
-#define VLAN_GET_ID2(p)             DecodeVLANGetId((p), 1)
-#define VLAN_GET_ID3(p)             DecodeVLANGetId((p), 2)
 
 /** Vlan header struct */
 typedef struct VLANHdr_ {

--- a/src/decode-vlan.h
+++ b/src/decode-vlan.h
@@ -39,6 +39,7 @@ uint16_t DecodeVLANGetId(const struct Packet_ *, uint8_t layer);
 /* return vlan id in host byte order */
 #define VLAN_GET_ID1(p)             DecodeVLANGetId((p), 0)
 #define VLAN_GET_ID2(p)             DecodeVLANGetId((p), 1)
+#define VLAN_GET_ID3(p)             DecodeVLANGetId((p), 2)
 
 /** Vlan header struct */
 typedef struct VLANHdr_ {

--- a/src/decode.c
+++ b/src/decode.c
@@ -412,8 +412,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
     p->tenant_id = parent->tenant_id;
     /* tell new packet it's part of a tunnel */
     SET_TUNNEL_PKT(p);
-    p->vlan_id[0] = parent->vlan_id[0];
-    p->vlan_id[1] = parent->vlan_id[1];
+    memcpy(&p->vlan_id[0], &parent->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = parent->vlan_idx;
     p->livedev = parent->livedev;
 
@@ -548,6 +547,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_gre = StatsRegisterCounter("decoder.gre", tv);
     dtv->counter_vlan = StatsRegisterCounter("decoder.vlan", tv);
     dtv->counter_vlan_qinq = StatsRegisterCounter("decoder.vlan_qinq", tv);
+    dtv->counter_vlan_qinqinq = StatsRegisterCounter("decoder.vlan_qinqinq", tv);
     dtv->counter_vxlan = StatsRegisterCounter("decoder.vxlan", tv);
     dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -457,7 +457,7 @@ typedef struct Packet_
      * has the exact same tuple as the lower levels */
     uint8_t recursion_level;
 
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[3];
     uint8_t vlan_idx;
 
     /* flow */
@@ -693,6 +693,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_gre;
     uint16_t counter_vlan;
     uint16_t counter_vlan_qinq;
+    uint16_t counter_vlan_qinqinq;
     uint16_t counter_vxlan;
     uint16_t counter_vntag;
     uint16_t counter_ieee8021ah;
@@ -810,6 +811,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->pkt_src = 0;                                                                          \
         (p)->vlan_id[0] = 0;                                                                       \
         (p)->vlan_id[1] = 0;                                                                       \
+        (p)->vlan_id[2] = 0;                                                                       \
         (p)->vlan_idx = 0;                                                                         \
         (p)->ts.tv_sec = 0;                                                                        \
         (p)->ts.tv_usec = 0;                                                                       \
@@ -1342,7 +1344,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
         case ETHERNET_TYPE_VLAN:
         case ETHERNET_TYPE_8021AD:
         case ETHERNET_TYPE_8021QINQ:
-            if (p->vlan_idx >= 2) {
+            if (p->vlan_idx > 2) {
                 ENGINE_SET_EVENT(p,VLAN_HEADER_TOO_MANY_LAYERS);
             } else {
                 DecodeVLAN(tv, dtv, p, data, len);

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -465,7 +465,7 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *  Get a new defrag tracker. We're checking memcap first and will try to make room
  *  if the memcap is reached.
  *
- *  \retval dt *LOCKED* tracker on succes, NULL on error.
+ *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
 static DefragTracker *DefragTrackerGetNew(Packet *p)
 {

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -137,8 +137,7 @@ static void DefragTrackerInit(DefragTracker *dt, Packet *p)
         dt->af = AF_INET6;
     }
     dt->proto = IP_GET_IPPROTO(p);
-    dt->vlan_id[0] = p->vlan_id[0];
-    dt->vlan_id[1] = p->vlan_id[1];
+    memcpy(&dt->vlan_id[0], &p->vlan_id[0], sizeof(dt->vlan_id));
     dt->policy = DefragGetOsPolicy(p);
     dt->host_timeout = DefragPolicyGetHostTimeout(p);
     dt->remove = 0;
@@ -359,9 +358,10 @@ typedef struct DefragHashKey4_ {
         struct {
             uint32_t src, dst;
             uint32_t id;
-            uint16_t vlan_id[2];
+            uint16_t vlan_id[3];
+            uint16_t pad[1];
         };
-        uint32_t u32[4];
+        uint32_t u32[5];
     };
 } DefragHashKey4;
 
@@ -370,9 +370,10 @@ typedef struct DefragHashKey6_ {
         struct {
             uint32_t src[4], dst[4];
             uint32_t id;
-            uint16_t vlan_id[2];
+            uint16_t vlan_id[3];
+            uint16_t pad[1];
         };
-        uint32_t u32[10];
+        uint32_t u32[11];
     };
 } DefragHashKey6;
 
@@ -390,7 +391,7 @@ static inline uint32_t DefragHashGetKey(Packet *p)
     uint32_t key;
 
     if (p->ip4h != NULL) {
-        DefragHashKey4 dhk;
+        DefragHashKey4 dhk = { .pad[0] = 0 };
         if (p->src.addr_data32[0] > p->dst.addr_data32[0]) {
             dhk.src = p->src.addr_data32[0];
             dhk.dst = p->dst.addr_data32[0];
@@ -399,13 +400,13 @@ static inline uint32_t DefragHashGetKey(Packet *p)
             dhk.dst = p->src.addr_data32[0];
         }
         dhk.id = (uint32_t)IPV4_GET_IPID(p);
-        dhk.vlan_id[0] = p->vlan_id[0];
-        dhk.vlan_id[1] = p->vlan_id[1];
+        memcpy(&dhk.vlan_id[0], &p->vlan_id[0], sizeof(dhk.vlan_id));
 
-        uint32_t hash = hashword(dhk.u32, 4, defrag_config.hash_rand);
+        uint32_t hash =
+                hashword(dhk.u32, sizeof(dhk.u32) / sizeof(uint32_t), defrag_config.hash_rand);
         key = hash % defrag_config.hash_size;
     } else if (p->ip6h != NULL) {
-        DefragHashKey6 dhk;
+        DefragHashKey6 dhk = { .pad[0] = 0 };
         if (DefragHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             dhk.src[0] = p->src.addr_data32[0];
             dhk.src[1] = p->src.addr_data32[1];
@@ -426,10 +427,10 @@ static inline uint32_t DefragHashGetKey(Packet *p)
             dhk.dst[3] = p->src.addr_data32[3];
         }
         dhk.id = IPV6_EXTHDR_GET_FH_ID(p);
-        dhk.vlan_id[0] = p->vlan_id[0];
-        dhk.vlan_id[1] = p->vlan_id[1];
+        memcpy(&dhk.vlan_id[0], &p->vlan_id[0], sizeof(dhk.vlan_id));
 
-        uint32_t hash = hashword(dhk.u32, 10, defrag_config.hash_rand);
+        uint32_t hash =
+                hashword(dhk.u32, sizeof(dhk.u32) / sizeof(uint32_t), defrag_config.hash_rand);
         key = hash % defrag_config.hash_size;
     } else
         key = 0;
@@ -439,15 +440,12 @@ static inline uint32_t DefragHashGetKey(Packet *p)
 
 /* Since two or more trackers can have the same hash key, we need to compare
  * the tracker with the current tracker key. */
-#define CMP_DEFRAGTRACKER(d1,d2,id) \
-    (((CMP_ADDR(&(d1)->src_addr, &(d2)->src) && \
-       CMP_ADDR(&(d1)->dst_addr, &(d2)->dst)) || \
-      (CMP_ADDR(&(d1)->src_addr, &(d2)->dst) && \
-       CMP_ADDR(&(d1)->dst_addr, &(d2)->src))) && \
-     (d1)->proto == IP_GET_IPPROTO(d2) &&   \
-     (d1)->id == (id) && \
-     (d1)->vlan_id[0] == (d2)->vlan_id[0] && \
-     (d1)->vlan_id[1] == (d2)->vlan_id[1])
+#define CMP_DEFRAGTRACKER(d1, d2, id)                                                              \
+    (((CMP_ADDR(&(d1)->src_addr, &(d2)->src) && CMP_ADDR(&(d1)->dst_addr, &(d2)->dst)) ||          \
+             (CMP_ADDR(&(d1)->src_addr, &(d2)->dst) && CMP_ADDR(&(d1)->dst_addr, &(d2)->src))) &&  \
+            (d1)->proto == IP_GET_IPPROTO(d2) && (d1)->id == (id) &&                               \
+            (d1)->vlan_id[0] == (d2)->vlan_id[0] && (d1)->vlan_id[1] == (d2)->vlan_id[1] &&        \
+            (d1)->vlan_id[2] == (d2)->vlan_id[2])
 
 static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
 {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -23,7 +23,7 @@
  * Defragmentation module.
  * References:
  *   - RFC 815
- *   - OpenBSD PF's IP normalizaton (pf_norm.c)
+ *   - OpenBSD PF's IP normalization (pf_norm.c)
  *
  * \todo pool for frag packet storage
  * \todo policy bsd-right
@@ -218,8 +218,7 @@ DefragContextNew(void)
                            "defrag: Timeout less than minimum allowed value.");
         }
         else if (timeout > TIMEOUT_MAX) {
-                FatalError(SC_ERR_FATAL,
-                           "defrag: Tiemout greater than maximum allowed value.");
+            FatalError(SC_ERR_FATAL, "defrag: Timeout greater than maximum allowed value.");
         }
         dc->timeout = timeout;
     }
@@ -2082,7 +2081,7 @@ static int DefragTimeoutTest(void)
 {
     int i;
 
-    /* Setup a small numberr of trackers. */
+    /* Setup a small number of trackers. */
     FAIL_IF_NOT(ConfSet("defrag.trackers", "16"));
 
     DefragInit();

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -2253,6 +2253,41 @@ static int DefragVlanQinQTest(void)
     PASS;
 }
 
+/**
+ * Like DefragVlanTest, but for QinQinQ, testing the third level VLAN ID.
+ */
+static int DefragVlanQinQinQTest(void)
+{
+    Packet *p1 = NULL, *p2 = NULL, *r = NULL;
+
+    DefragInit();
+
+    p1 = BuildTestPacket(IPPROTO_ICMP, 1, 0, 1, 'A', 8);
+    FAIL_IF_NULL(p1);
+    p2 = BuildTestPacket(IPPROTO_ICMP, 1, 1, 0, 'B', 8);
+    FAIL_IF_NULL(p2);
+
+    /* With no VLAN IDs set, packets should re-assemble. */
+    FAIL_IF((r = Defrag(NULL, NULL, p1)) != NULL);
+    FAIL_IF((r = Defrag(NULL, NULL, p2)) == NULL);
+    SCFree(r);
+
+    /* With mismatched VLANs, packets should not re-assemble. */
+    p1->vlan_id[0] = 1;
+    p2->vlan_id[0] = 1;
+    p1->vlan_id[1] = 2;
+    p2->vlan_id[1] = 2;
+    p1->vlan_id[2] = 3;
+    p2->vlan_id[2] = 4;
+    FAIL_IF((r = Defrag(NULL, NULL, p1)) != NULL);
+    FAIL_IF((r = Defrag(NULL, NULL, p2)) != NULL);
+
+    SCFree(p1);
+    SCFree(p2);
+    DefragDestroy();
+
+    PASS;
+}
 static int DefragTrackerReuseTest(void)
 {
     int id = 1;
@@ -2502,6 +2537,7 @@ void DefragRegisterTests(void)
 
     UtRegisterTest("DefragVlanTest", DefragVlanTest);
     UtRegisterTest("DefragVlanQinQTest", DefragVlanQinQTest);
+    UtRegisterTest("DefragVlanQinQinQTest", DefragVlanQinQinQTest);
     UtRegisterTest("DefragTrackerReuseTest", DefragTrackerReuseTest);
     UtRegisterTest("DefragTimeoutTest", DefragTimeoutTest);
     UtRegisterTest("DefragMfIpv4Test", DefragMfIpv4Test);

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -84,7 +84,7 @@ typedef struct DefragTracker_ {
     SCMutex lock; /**< Mutex for locking list operations on
                            * this tracker. */
 
-    uint16_t vlan_id[2]; /**< VLAN ID tracker applies to. */
+    uint16_t vlan_id[3]; /**< VLAN ID tracker applies to. */
 
     uint32_t id; /**< IP ID for this tracker.  32 bits for IPv6, 16
                   * for IPv4. */

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -567,7 +567,7 @@ static inline void NoFlowHandleIPS(Packet *p)
  *  \param tv thread vars
  *  \param fls lookup support vars
  *
- *  \retval f *LOCKED* flow on succes, NULL on error.
+ *  \retval f *LOCKED* flow on success, NULL on error.
  */
 static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
@@ -631,7 +631,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     } else {
         /* flow has been recycled before it went into the spare queue */
 
-        /* flow is initialized (recylced) but *unlocked* */
+        /* flow is initialized (recycled) but *unlocked* */
     }
 
     FLOWLOCK_WRLOCK(f);
@@ -738,7 +738,7 @@ static inline bool FlowIsTimedOut(const Flow *f, const uint32_t sec, const bool 
  * flow pointer. Then compares the packet with the found flow to see if it is
  * the flow we need. If it isn't, walk the list until the right flow is found.
  *
- * If the flow is not found or the bucket was emtpy, a new flow is taken from
+ * If the flow is not found or the bucket was empty, a new flow is taken from
  * the spare pool. The pool will alloc new flows as long as we stay within our
  * memcap limit.
  *

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -90,8 +90,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_STREAM_EOF;
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
-    p->vlan_id[0] = f->vlan_id[0];
-    p->vlan_id[1] = f->vlan_id[1];
+    memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
     p->livedev = (struct LiveDevice_ *)f->livedev;
 

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -148,8 +148,7 @@ void FlowInit(Flow *f, const Packet *p)
 
     f->proto = p->proto;
     f->recursion_level = p->recursion_level;
-    f->vlan_id[0] = p->vlan_id[0];
-    f->vlan_id[1] = p->vlan_id[1];
+    memcpy(&f->vlan_id[0], &p->vlan_id[0], sizeof(f->vlan_id));
     f->vlan_idx = p->vlan_idx;
     f->livedev = p->livedev;
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -309,7 +309,7 @@ typedef struct FlowKey_
     Port sp, dp;
     uint8_t proto;
     uint8_t recursion_level;
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[3];
 } FlowKey;
 
 typedef struct FlowAddress_ {
@@ -374,7 +374,7 @@ typedef struct Flow_
     };
     uint8_t proto;
     uint8_t recursion_level;
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[3];
     /** how many references exist to this flow *right now*
      *
      *  On receiving a packet the counter is incremented while the flow

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -116,6 +116,9 @@ static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
         if (f->vlan_idx > 1) {
             jb_append_uint(jb, f->vlan_id[1]);
         }
+        if (f->vlan_idx > 2) {
+            jb_append_uint(jb, f->vlan_id[2]);
+        }
         jb_close(jb);
     }
 

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -120,6 +120,9 @@ static JsonBuilder *CreateEveHeaderFromNetFlow(const Flow *f, int dir)
         if (f->vlan_idx > 1) {
             jb_append_uint(js, f->vlan_id[1]);
         }
+        if (f->vlan_idx > 2) {
+            jb_append_uint(js, f->vlan_id[2]);
+        }
         jb_close(js);
     }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -862,6 +862,9 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         if (p->vlan_idx > 1) {
             jb_append_uint(js, p->vlan_id[1]);
         }
+        if (p->vlan_idx > 2) {
+            jb_append_uint(js, p->vlan_id[2]);
+        }
         jb_close(js);
     }
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2219,6 +2219,7 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
 
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2244,6 +2245,7 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2279,6 +2281,7 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
 
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2306,6 +2309,7 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2373,6 +2377,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[0]->port16[1] = htons(p->dp);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2397,6 +2402,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->port16[1] = htons(p->sp);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2430,6 +2436,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[0]->port16[1] = htons(GET_TCP_DST_PORT(p));
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2456,6 +2463,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->port16[1] = htons(GET_TCP_SRC_PORT(p));
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6187,8 +6187,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_HAS_FLOW;
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
-    np->vlan_id[0] = f->vlan_id[0];
-    np->vlan_id[1] = f->vlan_id[1];
+    memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
     np->livedev = (struct LiveDevice_ *)f->livedev;
 

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -757,6 +757,7 @@ static int EBPFForEachFlowV4Table(ThreadVars *th_v, LiveDevice *dev, const char 
         flow_key.dst.addr_data32[3] = 0;
         flow_key.vlan_id[0] = next_key.vlan0;
         flow_key.vlan_id[1] = next_key.vlan1;
+        flow_key.vlan_id[2] = next_key.vlan2;
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {
@@ -874,6 +875,7 @@ static int EBPFForEachFlowV6Table(ThreadVars *th_v,
         }
         flow_key.vlan_id[0] = next_key.vlan0;
         flow_key.vlan_id[1] = next_key.vlan1;
+        flow_key.vlan_id[2] = next_key.vlan2;
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -44,6 +44,7 @@ struct flowv4_keys {
     __u8 ip_proto:1;
     __u16 vlan0:15;
     __u16 vlan1;
+    __u16 vlan2;
 };
 
 struct flowv6_keys {
@@ -56,6 +57,7 @@ struct flowv6_keys {
     __u8 ip_proto:1;
     __u16 vlan0:15;
     __u16 vlan1;
+    __u16 vlan2;
 };
 
 struct pair {


### PR DESCRIPTION
Continuation of #7785

This PR extends Suricata's support for VLANs from 2 to 3 levels. There is no standard for 3 levels of VLANs but 3 levels are not uncommon in some environments.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2816](https://redmine.openinfosecfoundation.org/issues/2816)

Describe changes:
- Increase VLAN level support to 3 levels
- List all VLAN levels in output.
- Add "Q-in-Q-in-Q" unittest.

Updates
- Update zero-initializer to address Centos-7 failure.

suricata-verify-pr: 902
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
