### PR TITLE
output: allow arbitrary keys in metadata

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -258,6 +258,9 @@
                     "properties": {
                         "ip": {
                             "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -267,6 +270,9 @@
                     "properties": {
                         "ip": {
                             "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -244,12 +244,6 @@
                                 "type": "string"
                             }
                         },
-                        "tag": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "updated_at": {
                             "type": "array",
                             "items": {
@@ -257,7 +251,7 @@
                             }
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": true
                 },
                 "source": {
                     "type": "object",


### PR DESCRIPTION
Metadata keyword in signatures can have any key defined so we
should allow them.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- update schema.json
