### PR TITLE
divert changes for FreeBSD

### DIFF
--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -334,7 +334,11 @@ TmEcode ReceiveIPFWThreadInit(ThreadVars *tv, const void *initdata, void **data)
 
     IPFWMutexInit(nq);
     /* We need a divert socket to play with */
+#ifdef PF_DIVERT
+    if ((nq->fd = socket(PF_DIVERT, SOCK_RAW, 0)) == -1) {
+#else
     if ((nq->fd = socket(PF_INET, SOCK_RAW, IPPROTO_DIVERT)) == -1) {
+#endif
         SCLogError(SC_ERR_IPFW_SOCK,"Can't create divert socket: %s", strerror(errno));
         SCReturnInt(TM_ECODE_FAILED);
     }

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -323,7 +323,6 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 TmEcode ReceiveIPFWThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     struct timeval timev;
-    int flag;
     IPFWThreadVars *ntv = (IPFWThreadVars *) initdata;
     IPFWQueueVars *nq = IPFWGetQueue(ntv->ipfw_index);
 
@@ -347,15 +346,6 @@ TmEcode ReceiveIPFWThreadInit(ThreadVars *tv, const void *initdata, void **data)
 
     if (setsockopt(nq->fd, SOL_SOCKET, SO_RCVTIMEO, &timev, sizeof(timev)) == -1) {
         SCLogError(SC_ERR_IPFW_SETSOCKOPT,"Can't set IPFW divert socket timeout: %s", strerror(errno));
-        SCReturnInt(TM_ECODE_FAILED);
-    }
-
-    /* set SO_BROADCAST on the divert socket, otherwise sendto()
-     * returns EACCES when reinjecting broadcast packets. */
-    flag = 1;
-
-    if (setsockopt(nq->fd, SOL_SOCKET, SO_BROADCAST, &flag, sizeof(flag)) == -1) {
-        SCLogError(SC_ERR_IPFW_SETSOCKOPT,"Can't set IPFW divert socket broadcast flag: %s", strerror(errno));
         SCReturnInt(TM_ECODE_FAILED);
     }
 


### PR DESCRIPTION
You may skip the patch that removes SO_BROADCAST. I'm 99% sure this setsockopt() is useless, but I haven't tested.

The second patch is necessary to work on FreeBSD 14 and beyond without a warning message.