### PR TITLE
doc/http2: suricata.yaml max-streams parameter

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1725,6 +1725,11 @@ An app-layer event `protocol.too_many_transactions` is triggered when this value
 The point of this parameter is to find a balance between the completeness of analysis
 and the resource consumption.
 
+For HTTP2, this parameter is named `max-streams` as a HTTP2 stream will get translated
+into one Suricata transaction. This configuration parameter is used whatever the
+value of `SETTINGS_MAX_CONCURRENT_STREAMS` negotiated between a client and a server
+in a specific flow.
+
 Engine Logging
 --------------
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4949

Describe changes:
- Adds documentation about suricata.yaml `http2.max-streams` parameter