### PR TITLE
util-dpdk-i40e.c: fix warning with RSS queues

### DIFF
--- a/src/util-dpdk-i40e.c
+++ b/src/util-dpdk-i40e.c
@@ -160,8 +160,13 @@ static int i40eDeviceSetRSSFlowQueues(
     rss_action_conf.func = RTE_ETH_HASH_FUNCTION_DEFAULT;
     rss_action_conf.level = 0;
     rss_action_conf.types = 0; // queues region can not be configured with types
-    rss_action_conf.key = rss_conf.rss_key;
-    rss_action_conf.key_len = rss_conf.rss_key_len;
+    rss_action_conf.key_len = 0;
+    rss_action_conf.key = NULL;
+
+    if (nb_rx_queues == 0) {
+        FatalError(SC_ERR_FATAL, "The number of queues is 0");
+    }
+
     rss_action_conf.queue_num = nb_rx_queues;
     rss_action_conf.queue = queues;
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- rss_action_conf.key is set to NULL because a value before caused a DPDK warning "RSS key is ignored when queues specified" on NIC Intel X710.