### PR TITLE
detect: option to run flowbits on stream

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -21,9 +21,10 @@ Flowbits have different actions. These are:
 
 flowbits: set, name
   Will set the condition/'name', if present, in the flow.
-flowbits: isset, name
+flowbits: isset, name[, data]
   Can be used in the rule to make sure it generates an alert when the
-  rule matches and the condition is set in the flow.
+  rule matches and the condition is set in the flow. The data option
+  can be used to trigger inspection when data is available.
 flowbits: toggle, name
   Reverses the present setting. So for example if a condition is set,
   it will be unset and vice-versa.


### PR DESCRIPTION
When a flowbit is set on application layer tests, this has
for consequence that there is no point in checking it per packet.
This patch adds the `data` option to the flowbits keyword so
the evaluation is done at the stream level and not at the packet
one.

As a result, using the data option is preventing the bug
https://redmine.openinfosecfoundation.org/issues/2836
to appear.

Ticket: #2836

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2836

Describe changes:
- Add data option to flowbits

suricata-verify-pr: 924