### PR TITLE
Rust mimetype

### DIFF
--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -31,6 +31,15 @@ Example::
 
   fileext:"jpg";
 
+file.mime_type
+--------------
+
+Sticky buffer to match on the file mime type.
+
+Example::
+
+  file.mime_type; content:"application/x-executable";
+
 filemagic
 ---------
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -122,6 +122,9 @@
                     "magic": {
                         "type": "string"
                     },
+                    "mimetype": {
+                        "type": "string"
+                    },
                     "md5": {
                         "type": "string"
                     },
@@ -1248,6 +1251,9 @@
                     "type": "boolean"
                 },
                 "magic": {
+                    "type": "string"
+                },
+                "mimetype": {
                     "type": "string"
                 },
                 "md5": {

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -56,6 +56,7 @@ md-5 = "~0.10.1"
 regex = "~1.5.5"
 lazy_static = "~1.4.0"
 base64 = "~0.13.0"
+tree_magic_mini = "~3.0.3"
 
 suricata-derive = { path = "./derive" }
 

--- a/rust/src/filemimetype.rs
+++ b/rust/src/filemimetype.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,20 +15,12 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Victor Julien <victor@inliniac.net>
- */
+use crate::common::rust_string_to_c;
+use std::os::raw::c_char;
 
-#ifndef __DETECT_FILEMAGIC_H__
-#define __DETECT_FILEMAGIC_H__
-
-#ifdef HAVE_MAGIC
-/* prototypes */
-int FilemagicThreadLookup(magic_t *ctx, File *file);
-
-#endif
-void DetectFilemagicRegister (void);
-
-#endif /* __DETECT_FILEMAGIC_H__ */
+#[no_mangle]
+pub unsafe extern "C" fn rs_get_mime_type(input: *const u8, len: u32) -> * mut c_char {
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
+    let result = tree_magic_mini::from_u8(slice);
+    rust_string_to_c(result.to_string())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -100,6 +100,7 @@ pub mod applayer;
 pub mod frames;
 pub mod filecontainer;
 pub mod filetracker;
+pub mod filemimetype;
 pub mod kerberos;
 pub mod detect;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -161,6 +161,7 @@ noinst_HEADERS = \
 	detect-file-hash-common.h \
 	detect-filemagic.h \
 	detect-filemd5.h \
+	detect-file-mimetype.h \
 	detect-filename.h \
 	detect-filesha1.h \
 	detect-filesha256.h \
@@ -762,6 +763,7 @@ libsuricata_c_a_SOURCES = \
 	detect-file-hash-common.c \
 	detect-filemagic.c \
 	detect-filemd5.c \
+	detect-file-mimetype.c \
 	detect-filename.c \
 	detect-filesha1.c \
 	detect-filesha256.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -564,6 +564,7 @@ noinst_HEADERS = \
 	util-memcpy.h \
 	util-mem.h \
 	util-memrchr.h \
+	util-mimetype.h \
 	util-misc.h \
 	util-mpm-ac-bs.h \
 	util-mpm-ac.h \
@@ -1147,6 +1148,7 @@ libsuricata_c_a_SOURCES = \
 	util-mem.c \
 	util-memcmp.c \
 	util-memrchr.c \
+	util-mimetype.c \
 	util-misc.c \
 	util-mpm-ac-bs.c \
 	util-mpm-ac.c \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -126,6 +126,7 @@
 #include "detect-filesha1.h"
 #include "detect-filesha256.h"
 #include "detect-filesize.h"
+#include "detect-file-mimetype.h"
 #include "detect-dataset.h"
 #include "detect-datarep.h"
 #include "detect-dsize.h"
@@ -491,6 +492,7 @@ void SigTableSetup(void)
     DetectFileSha1Register();
     DetectFileSha256Register();
     DetectFilesizeRegister();
+    DetectFileMimetypeRegister();
 
     DetectHttpUARegister();
     DetectHttpHHRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -323,6 +323,8 @@ enum DetectKeywordId {
     DETECT_AL_IKE_NONCE,
     DETECT_AL_IKE_KEY_EXCHANGE,
 
+    DETECT_FILE_MIMETYPE,
+
     /* make sure this stays last */
     DETECT_TBLSIZE,
 };

--- a/src/detect-file-mimetype.c
+++ b/src/detect-file-mimetype.c
@@ -1,0 +1,214 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <el@stamus-networks.com>
+ *
+ */
+
+#include "suricata-common.h"
+#include "detect-file-mimetype.h"
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-engine-prefilter.h"
+#include "detect-engine-content-inspection.h"
+#include "rust.h"
+#include "util-mimetype.h"
+
+static int DetectFileMimetypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str);
+static int g_file_mimetype_buffer_id = 0;
+
+static int PrefilterMpmFileMimetypeRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
+        MpmCtx *mpm_ctx, const DetectBufferMpmRegistery *mpm_reg, int list_id);
+static uint8_t DetectEngineInspectFileMimetype(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
+
+void DetectFileMimetypeRegister(void)
+{
+    sigmatch_table[DETECT_FILE_MIMETYPE].name = "file.mime_type";
+    sigmatch_table[DETECT_FILE_MIMETYPE].desc = "sticky buffer to match on file mime type";
+    sigmatch_table[DETECT_FILE_MIMETYPE].url = "/rules/file-keywords.html#file-mime-type";
+    sigmatch_table[DETECT_FILE_MIMETYPE].Setup = DetectFileMimetypeSetup;
+    sigmatch_table[DETECT_FILE_MIMETYPE].flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+
+    AppProto protos_ts[] = { ALPROTO_HTTP1, ALPROTO_SMTP, ALPROTO_FTP, ALPROTO_FTPDATA, ALPROTO_SMB,
+        ALPROTO_NFS, 0 };
+    AppProto protos_tc[] = { ALPROTO_HTTP1, ALPROTO_FTP, ALPROTO_FTPDATA, ALPROTO_SMB, ALPROTO_NFS,
+        0 };
+
+    for (int i = 0; protos_ts[i] != 0; i++) {
+        DetectAppLayerInspectEngineRegister2("file.mime_type", protos_ts[i], SIG_FLAG_TOSERVER, 0,
+                DetectEngineInspectFileMimetype, NULL);
+
+        DetectAppLayerMpmRegister2("file.mime_type", SIG_FLAG_TOSERVER, 2,
+                PrefilterMpmFileMimetypeRegister, NULL, protos_ts[i], 0);
+    }
+    for (int i = 0; protos_tc[i] != 0; i++) {
+        DetectAppLayerInspectEngineRegister2("file.mime_type", protos_tc[i], SIG_FLAG_TOCLIENT, 0,
+                DetectEngineInspectFileMimetype, NULL);
+
+        DetectAppLayerMpmRegister2("file.mime_type", SIG_FLAG_TOCLIENT, 2,
+                PrefilterMpmFileMimetypeRegister, NULL, protos_tc[i], 0);
+    }
+
+    DetectBufferTypeSetDescriptionByName("file.mime_type", "file mime type");
+
+    g_file_mimetype_buffer_id = DetectBufferTypeGetByName("file.mime_type");
+
+    SCLogDebug("registering file mime type rule option");
+    return;
+}
+
+static int DetectFileMimetypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
+{
+    if (DetectBufferSetActiveList(s, g_file_mimetype_buffer_id) < 0)
+        return -1;
+    s->file_flags |= (FILE_SIG_NEED_FILE); /* FIXME do we need a custom need flag . */
+    return 0;
+}
+
+static InspectionBuffer *FileMimetypeGetDataCallback(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, uint8_t flow_flags, File *cur_file,
+        int list_id, int local_file_id, bool first)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_file_id);
+    if (buffer == NULL)
+        return NULL;
+    if (!first && buffer->inspect != NULL)
+        return buffer;
+
+    if (cur_file->mimetype == NULL)
+        FileMimetypeLookup(cur_file);
+    if (cur_file->mimetype == NULL)
+        return NULL;
+
+    const uint8_t *data = (uint8_t *)cur_file->mimetype;
+    uint32_t data_len = strlen(cur_file->mimetype);
+
+    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+
+    SCReturnPtr(buffer, "InspectionBuffer");
+}
+
+typedef struct PrefilterMpmFileMimetype {
+    int list_id;
+    const MpmCtx *mpm_ctx;
+    const DetectEngineTransforms *transforms;
+} PrefilterMpmFileMimetype;
+
+/** \brief Filedata Filedata Mpm prefilter callback
+ *
+ *  \param det_ctx detection engine thread ctx
+ *  \param p packet to inspect
+ *  \param f flow to inspect
+ *  \param txv tx to inspect
+ *  \param pectx inspection context
+ */
+static void PrefilterTxFileMimetype(DetectEngineThreadCtx *det_ctx, const void *pectx, Packet *p,
+        Flow *f, void *txv, const uint64_t idx, const uint8_t flags)
+{
+    SCEnter();
+
+    const PrefilterMpmFileMimetype *ctx = (const PrefilterMpmFileMimetype *)pectx;
+    const MpmCtx *mpm_ctx = ctx->mpm_ctx;
+    const int list_id = ctx->list_id;
+
+    FileContainer *ffc = AppLayerParserGetFiles(f, flags);
+    if (ffc != NULL) {
+        int local_file_id = 0;
+        for (File *file = ffc->head; file != NULL; file = file->next) {
+            if (file->txid != idx)
+                continue;
+
+            InspectionBuffer *buffer = FileMimetypeGetDataCallback(
+                    det_ctx, ctx->transforms, f, flags, file, list_id, local_file_id, true);
+            if (buffer == NULL)
+                continue;
+
+            if (buffer->inspect_len >= mpm_ctx->minlen) {
+                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq,
+                        buffer->inspect, buffer->inspect_len);
+            }
+            local_file_id++;
+        }
+    }
+}
+
+static void PrefilterMpmFileMimetypeFree(void *ptr)
+{
+    SCFree(ptr);
+}
+
+static int PrefilterMpmFileMimetypeRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
+        MpmCtx *mpm_ctx, const DetectBufferMpmRegistery *mpm_reg, int list_id)
+{
+    PrefilterMpmFileMimetype *pectx = SCCalloc(1, sizeof(*pectx));
+    if (pectx == NULL)
+        return -1;
+    pectx->list_id = list_id;
+    pectx->mpm_ctx = mpm_ctx;
+    pectx->transforms = &mpm_reg->transforms;
+
+    return PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxFileMimetype, mpm_reg->app_v2.alproto,
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmFileMimetypeFree, mpm_reg->pname);
+}
+
+static uint8_t DetectEngineInspectFileMimetype(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
+{
+    const DetectEngineTransforms *transforms = NULL;
+    if (!engine->mpm) {
+        transforms = engine->v2.transforms;
+    }
+
+    FileContainer *ffc = AppLayerParserGetFiles(f, flags);
+    if (ffc == NULL) {
+        return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+    }
+
+    uint8_t r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
+    int local_file_id = 0;
+    for (File *file = ffc->head; file != NULL; file = file->next) {
+        if (file->txid != tx_id)
+            continue;
+
+        InspectionBuffer *buffer = FileMimetypeGetDataCallback(
+                det_ctx, transforms, f, flags, file, engine->sm_list, local_file_id, false);
+        if (buffer == NULL)
+            continue;
+
+        det_ctx->buffer_offset = 0;
+        det_ctx->discontinue_matching = 0;
+        det_ctx->inspection_recursion_counter = 0;
+        int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
+                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        if (match == 1) {
+            return DETECT_ENGINE_INSPECT_SIG_MATCH;
+        } else {
+            r = DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
+        }
+        local_file_id++;
+    }
+    return r;
+}

--- a/src/detect-file-mimetype.h
+++ b/src/detect-file-mimetype.h
@@ -22,29 +22,10 @@
  *
  */
 
-#include "suricata-common.h"
-#include "util-mimetype.h"
-#include "rust.h"
+#ifndef __DETECT_FILE_MIMETYPE_H__
+#define __DETECT_FILE_MIMETYPE_H__
 
-#define FILE_MIMETYPE_MIN_SIZE 512
+/* prototypes */
+void DetectFileMimetypeRegister(void);
 
-int FileMimetypeLookup(File *file)
-{
-    if (file == NULL || FileDataSize(file) == 0) {
-        SCReturnInt(-1);
-    }
-
-    const uint8_t *data = NULL;
-    uint32_t data_len = 0;
-    uint64_t offset = 0;
-
-    StreamingBufferGetData(file->sb, &data, &data_len, &offset);
-    if (offset == 0) {
-        if (FileDataSize(file) >= FILE_MIMETYPE_MIN_SIZE) {
-            file->mimetype = rs_get_mime_type(data, data_len);
-        } else if (file->state >= FILE_STATE_CLOSED) {
-            file->mimetype = rs_get_mime_type(data, data_len);
-        }
-    }
-    SCReturnInt(0);
-}
+#endif /* __DETECT_FILE_MIMETYPE_H__ */

--- a/src/flow.h
+++ b/src/flow.h
@@ -139,18 +139,24 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOWFILE_NO_SIZE_TS             BIT_U16(10)
 #define FLOWFILE_NO_SIZE_TC             BIT_U16(11)
 
+/** no mime type tracking of files in this flow */
+#define FLOWFILE_NO_MIMETYPE_TS         BIT_U16(12)
+#define FLOWFILE_NO_MIMETYPE_TC         BIT_U16(13)
+
 #define FLOWFILE_NONE_TS (FLOWFILE_NO_MAGIC_TS | \
                           FLOWFILE_NO_STORE_TS | \
                           FLOWFILE_NO_MD5_TS   | \
                           FLOWFILE_NO_SHA1_TS  | \
                           FLOWFILE_NO_SHA256_TS| \
-                          FLOWFILE_NO_SIZE_TS)
+                          FLOWFILE_NO_SIZE_TS  |\
+                          FLOWFILE_NO_MIMETYPE_TS)
 #define FLOWFILE_NONE_TC (FLOWFILE_NO_MAGIC_TC | \
                           FLOWFILE_NO_STORE_TC | \
                           FLOWFILE_NO_MD5_TC   | \
                           FLOWFILE_NO_SHA1_TC  | \
                           FLOWFILE_NO_SHA256_TC| \
-                          FLOWFILE_NO_SIZE_TC)
+                          FLOWFILE_NO_SIZE_TC  | \
+                          FLOWFILE_NO_MIMETYPE_TC)
 #define FLOWFILE_NONE    (FLOWFILE_NONE_TS|FLOWFILE_NONE_TC)
 
 #define FLOW_IS_IPV4(f) \

--- a/src/flow.h
+++ b/src/flow.h
@@ -140,23 +140,15 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOWFILE_NO_SIZE_TC             BIT_U16(11)
 
 /** no mime type tracking of files in this flow */
-#define FLOWFILE_NO_MIMETYPE_TS         BIT_U16(12)
-#define FLOWFILE_NO_MIMETYPE_TC         BIT_U16(13)
+#define FLOWFILE_NO_MIMETYPE_TS BIT_U16(12)
+#define FLOWFILE_NO_MIMETYPE_TC BIT_U16(13)
 
-#define FLOWFILE_NONE_TS (FLOWFILE_NO_MAGIC_TS | \
-                          FLOWFILE_NO_STORE_TS | \
-                          FLOWFILE_NO_MD5_TS   | \
-                          FLOWFILE_NO_SHA1_TS  | \
-                          FLOWFILE_NO_SHA256_TS| \
-                          FLOWFILE_NO_SIZE_TS  |\
-                          FLOWFILE_NO_MIMETYPE_TS)
-#define FLOWFILE_NONE_TC (FLOWFILE_NO_MAGIC_TC | \
-                          FLOWFILE_NO_STORE_TC | \
-                          FLOWFILE_NO_MD5_TC   | \
-                          FLOWFILE_NO_SHA1_TC  | \
-                          FLOWFILE_NO_SHA256_TC| \
-                          FLOWFILE_NO_SIZE_TC  | \
-                          FLOWFILE_NO_MIMETYPE_TC)
+#define FLOWFILE_NONE_TS                                                                           \
+    (FLOWFILE_NO_MAGIC_TS | FLOWFILE_NO_STORE_TS | FLOWFILE_NO_MD5_TS | FLOWFILE_NO_SHA1_TS |      \
+            FLOWFILE_NO_SHA256_TS | FLOWFILE_NO_SIZE_TS | FLOWFILE_NO_MIMETYPE_TS)
+#define FLOWFILE_NONE_TC                                                                           \
+    (FLOWFILE_NO_MAGIC_TC | FLOWFILE_NO_STORE_TC | FLOWFILE_NO_MD5_TC | FLOWFILE_NO_SHA1_TC |      \
+            FLOWFILE_NO_SHA256_TC | FLOWFILE_NO_SIZE_TC | FLOWFILE_NO_MIMETYPE_TC)
 #define FLOWFILE_NONE    (FLOWFILE_NONE_TS|FLOWFILE_NONE_TC)
 
 #define FLOW_IS_IPV4(f) \

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -30,9 +30,11 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "detect-filemagic.h"
+#include "util-file.h"
 #include "util-profiling.h"
 #include "util-validate.h"
 #include "util-magic.h"
+#include "util-mimetype.h"
 
 bool g_file_logger_enabled = false;
 
@@ -135,6 +137,10 @@ static void OutputFileLogFfc(ThreadVars *tv, OutputFileLoggerThreadData *op_thre
                     FilemagicThreadLookup(&op_thread_data->magic_ctx, ff);
                 }
 #endif
+                if (FileForceMimetype() && ff->mimetype == NULL) {
+                    FileMimetypeLookup(ff);
+                }
+
                 const OutputFileLogger *logger = list;
                 const OutputLoggerThreadStore *store = op_thread_data->store;
                 while (logger && store) {

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -465,6 +465,12 @@ static OutputInitResult OutputFilestoreLogInitCtx(ConfNode *conf)
         SCLogConfig("Filestore (v2) forcing magic lookup for stored files");
     }
 
+    const char *force_mimetype = ConfNodeLookupChildValue(conf, "force-mimetype");
+    if (force_mimetype != NULL && ConfValIsTrue(force_mimetype)) {
+        FileForceMimetypeEnable();
+        SCLogConfig("forcing mimetype lookup for logged files");
+    }
+
     FileForceHashParseCfg(conf);
 
     /* The new filestore requires SHA256. */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -316,6 +316,12 @@ static OutputInitResult OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_c
             SCLogConfig("forcing magic lookup for logged files");
         }
 
+        const char *force_mimetype = ConfNodeLookupChildValue(conf, "force-mimetype");
+        if (force_mimetype != NULL && ConfValIsTrue(force_mimetype)) {
+            FileForceMimetypeEnable();
+            SCLogConfig("forcing mimetype lookup for logged files");
+        }
+
         FileForceHashParseCfg(conf);
     }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -144,6 +144,9 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const bool stored)
     if (ff->magic)
         jb_set_string(jb, "magic", (char *)ff->magic);
 #endif
+    if (ff->mimetype)
+        jb_set_string(jb, "mimetype", (char *)ff->mimetype);
+
     jb_set_bool(jb, "gaps", ff->flags & FILE_HAS_GAPS);
     switch (ff->state) {
         case FILE_STATE_CLOSED:

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -56,6 +56,11 @@ static int g_file_force_filestore = 0;
  */
 static int g_file_force_magic = 0;
 
+/** \brief switch to force mimetype checks on all files
+ *         regardless of the rules.
+ */
+static int g_file_force_mimetype = 0;
+
 /** \brief switch to force md5 calculation on all files
  *         regardless of the rules.
  */
@@ -102,6 +107,12 @@ void FileForceMagicEnable(void)
     g_file_flow_mask |= (FLOWFILE_NO_MAGIC_TS|FLOWFILE_NO_MAGIC_TC);
 }
 
+void FileForceMimetypeEnable(void)
+{
+    g_file_force_mimetype = 1;
+    g_file_flow_mask |= (FLOWFILE_NO_MIMETYPE_TS|FLOWFILE_NO_MIMETYPE_TC);
+}
+
 void FileForceMd5Enable(void)
 {
     g_file_force_md5 = 1;
@@ -142,6 +153,11 @@ uint32_t FileReassemblyDepth(void)
 int FileForceMagic(void)
 {
     return g_file_force_magic;
+}
+
+int FileForceMimetype(void)
+{
+    return g_file_force_mimetype;
 }
 
 int FileForceMd5(void)
@@ -524,6 +540,8 @@ static void FileFree(File *ff)
     if (ff->magic != NULL)
         SCFree(ff->magic);
 #endif
+    if (ff->mimetype != NULL)
+        rs_cstring_free(ff->mimetype);
     if (ff->sb != NULL) {
         StreamingBufferFree(ff->sb);
     }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -110,7 +110,7 @@ void FileForceMagicEnable(void)
 void FileForceMimetypeEnable(void)
 {
     g_file_force_mimetype = 1;
-    g_file_flow_mask |= (FLOWFILE_NO_MIMETYPE_TS|FLOWFILE_NO_MIMETYPE_TC);
+    g_file_flow_mask |= (FLOWFILE_NO_MIMETYPE_TS | FLOWFILE_NO_MIMETYPE_TC);
 }
 
 void FileForceMd5Enable(void)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -86,6 +86,7 @@ typedef struct File_ {
 #ifdef HAVE_MAGIC
     char *magic;
 #endif
+    char *mimetype;
     struct File_ *next;
     SCMd5 *md5_ctx;
     uint8_t md5[SC_MD5_LEN];
@@ -226,6 +227,9 @@ uint32_t FileReassemblyDepth(void);
 
 void FileForceMagicEnable(void);
 int FileForceMagic(void);
+
+void FileForceMimetypeEnable(void);
+int FileForceMimetype(void);
 
 void FileForceMd5Enable(void);
 int FileForceMd5(void);

--- a/src/util-mimetype.c
+++ b/src/util-mimetype.c
@@ -1,0 +1,54 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <el@stamus-networks.com>
+ *
+ */
+
+#include "suricata-common.h"
+#include "util-mimetype.h"
+#include "rust.h"
+
+#define FILE_MIMETYPE_MIN_SIZE  512
+
+int FileMimetypeLookup(File *file)
+{
+    if (file == NULL || FileDataSize(file) == 0) {
+        SCReturnInt(-1);
+    }
+
+    const uint8_t *data = NULL;
+    uint32_t data_len = 0;
+    uint64_t offset = 0;
+
+    StreamingBufferGetData(file->sb,
+                           &data, &data_len, &offset);
+    if (offset == 0) {
+        if (FileDataSize(file) >= FILE_MIMETYPE_MIN_SIZE) {
+            file->mimetype = rs_get_mime_type(data, data_len);
+        } else if (file->state >= FILE_STATE_CLOSED) {
+            file->mimetype = rs_get_mime_type(data, data_len);
+        }
+
+    }
+    SCReturnInt(0);
+}
+
+

--- a/src/util-mimetype.h
+++ b/src/util-mimetype.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,17 +18,13 @@
 /**
  * \file
  *
- * \author Victor Julien <victor@inliniac.net>
+ * \author Eric Leblond <el@stamus-networks.com>
+ *
  */
 
-#ifndef __DETECT_FILEMAGIC_H__
-#define __DETECT_FILEMAGIC_H__
+#ifndef __UTIL_MIMETYPE_H__
+#define __UTIL_MIMETYPE_H__
 
-#ifdef HAVE_MAGIC
-/* prototypes */
-int FilemagicThreadLookup(magic_t *ctx, File *file);
+int FileMimetypeLookup(File *file);
 
-#endif
-void DetectFilemagicRegister (void);
-
-#endif /* __DETECT_FILEMAGIC_H__ */
+#endif /* __UTIL_MIMETYPE_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -251,6 +251,7 @@ outputs:
             #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s]
         - files:
             force-magic: no   # force logging magic on all logged files
+            force-mimetype: no # force logging mime type on all logged files
             # force logging of checksums, available hash functions are md5,
             # sha1 and sha256
             #force-hash: [md5]


### PR DESCRIPTION
This patchset proposes an alternative to filemagic as it has multiple issues:

- filemagic is known for bad performance
- database is not consistent between system
- results are sometime too detailed (do we care about size of image)

This patchet uses a [rust crate](https://docs.rs/tree_magic_mini/latest/tree_magic_mini/) to extract the mime type instead of the magic:

- it is really faster than filemagic
- mimetype database is included in the crate
- mimetype are easier to predict

It thus fixes most of the issues present with filemagic and thus is a nice alternative.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- add mimetype computation
- add mimetype to fileinfo
- add file.mimetype keyword
