### PR TITLE
Http2 noalloc header compare 5454 backport6 v4

### DIFF
--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -165,7 +165,7 @@ impl HTTP2DecoderHalf {
         }
     }
 
-    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>) {
+    pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
         if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
             if *input == "gzip".as_bytes().to_vec() {
@@ -240,7 +240,7 @@ impl HTTP2Decoder {
         }
     }
 
-    pub fn http2_encoding_fromvec(&mut self, input: &Vec<u8>, dir: u8) {
+    pub fn http2_encoding_fromvec(&mut self, input: &[u8], dir: u8) {
         if dir == STREAM_TOCLIENT {
             self.decoder_tc.http2_encoding_fromvec(input);
         } else {

--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -168,13 +168,13 @@ impl HTTP2DecoderHalf {
     pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
         if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
-            if *input == "gzip".as_bytes().to_vec() {
+            if input == b"gzip" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingGzip;
                 self.decoder = HTTP2Decompresser::GZIP(GzDecoder::new(HTTP2cursor::new()));
-            } else if *input == "deflate".as_bytes().to_vec() {
+            } else if input == b"deflate" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingDeflate;
                 self.decoder = HTTP2Decompresser::DEFLATE(DeflateDecoder::new(HTTP2cursor::new()));
-            } else if *input == "br".as_bytes().to_vec() {
+            } else if input == b"br" {
                 self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingBr;
                 self.decoder = HTTP2Decompresser::BROTLI(brotli::Decompressor::new(
                     HTTP2cursor::new(),

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -489,7 +489,7 @@ fn http2_frames_get_header_firstvalue<'a>(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if block.name == name.as_bytes().to_vec() {
+                if block.name == name.as_bytes() {
                     return Ok(&block.value);
                 }
             }
@@ -512,7 +512,7 @@ fn http2_frames_get_header_value<'a>(
     for i in 0..frames.len() {
         if let Some(blocks) = http2_header_blocks(&frames[i]) {
             for block in blocks.iter() {
-                if block.name == name.as_bytes().to_vec() {
+                if block.name == name.as_bytes() {
                     if found == 0 {
                         single = Ok(&block.value);
                         found = 1;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -180,7 +180,7 @@ impl HTTP2Transaction {
     #[cfg(feature = "decompression")]
     fn handle_headers(&mut self, blocks: &Vec<parser::HTTP2FrameHeaderBlock>, dir: u8) {
         for i in 0..blocks.len() {
-            if blocks[i].name == "content-encoding".as_bytes().to_vec() {
+            if blocks[i].name == b"content-encoding" {
                 self.decoder.http2_encoding_fromvec(&blocks[i].value, dir);
             }
         }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -266,6 +266,7 @@ void EngineModeSetIDS(void)
     g_engine_mode = ENGINE_MODE_IDS;
 }
 
+#ifdef UNITTESTS
 int RunmodeIsUnittests(void)
 {
     if (run_mode == RUNMODE_UNITTEST)
@@ -273,6 +274,7 @@ int RunmodeIsUnittests(void)
 
     return 0;
 }
+#endif
 
 int RunmodeGetCurrent(void)
 {

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -178,7 +178,11 @@ extern uint16_t g_vlan_mask;
 void EngineStop(void);
 void EngineDone(void);
 
+#ifdef UNITTESTS
 int RunmodeIsUnittests(void);
+#else
+#define RunmodeIsUnittests() 0
+#endif
 int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Backport of https://redmine.openinfosecfoundation.org/issues/5454

Describe changes:
- http2: remove `to_vec` in comparisons (no need to alloc)

Modifies #7815 better cherry-picks from master