### PR TITLE
Smb file multiflow 4861 v2

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -102,6 +102,7 @@ pub mod filecontainer;
 pub mod filetracker;
 pub mod kerberos;
 pub mod detect;
+pub mod range;
 
 #[cfg(feature = "lua")]
 pub mod lua;

--- a/rust/src/range.rs
+++ b/rust/src/range.rs
@@ -1,0 +1,24 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+*/
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct FileContentRange {
+    pub start: i64,
+    pub end: i64,
+    pub size: i64,
+}

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -22,8 +22,10 @@ use crate::filecontainer::*;
 
 use crate::smb::smb::*;
 
+use std::os::raw::c_uchar;
+
 /// File tracking transaction. Single direction only.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SMBTransactionFile {
     pub direction: Direction,
     pub fuid: Vec<u8>,
@@ -33,14 +35,29 @@ pub struct SMBTransactionFile {
     /// after a gap, this will be set to a time in the future. If the file
     /// receives no updates before that, it will be considered complete.
     pub post_gap_ts: u64,
+    pub file_range: *mut HttpRangeContainerBlock,
+    pub multi: bool,
 }
 
 impl SMBTransactionFile {
     pub fn new() -> Self {
         return Self {
             file_tracker: FileTransferTracker::new(),
-            ..Default::default()
+            file_range: std::ptr::null_mut(),
+            multi: false,
+            post_gap_ts: 0,
+            direction: Direction::default(),
+            fuid: Vec::new(),
+            file_name: Vec::new(),
+            share_name: Vec::new(),
         }
+    }
+}
+
+impl Drop for SMBTransactionFile {
+    fn drop(&mut self) {
+        // should have been already closed
+        debug_validate_bug_on!(!self.file_range.is_null());
     }
 }
 
@@ -55,6 +72,13 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
                     chunk_size, 0, is_last, xid); }
         None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
+}
+
+// Defined in app-layer-htp-range.h
+extern "C" {
+    pub fn HttpRangeAppendData(
+        c: *mut HttpRangeContainerBlock, data: *const c_uchar, data_len: u32,
+    ) -> std::os::raw::c_int;
 }
 
 impl SMBState {
@@ -122,7 +146,7 @@ impl SMBState {
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32) -> u32 {
+    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32, eof: bool) -> u32 {
         let mut chunk_left = if direction == Direction::ToServer {
             self.file_ts_left
         } else {
@@ -175,6 +199,32 @@ impl SMBState {
                     }
 
                     let file_data = &data[0..data_to_handle_len];
+                    if !tdf.file_range.is_null() {
+                        unsafe {
+                            HttpRangeAppendData(tdf.file_range, file_data.as_ptr(), data_to_handle_len as u32);
+                        }
+                        if chunk_left == 0 || eof {
+                            let added = if let Some(c) = unsafe { SC } {
+                                let added = (c.HTPFileCloseHandleRange)(
+                                    files,
+                                    flags,
+                                    tdf.file_range,
+                                    std::ptr::null_mut(),
+                                    0,
+                                );
+                                (c.HttpRangeFreeBlock)(tdf.file_range);
+                                added
+                            } else {
+                                false
+                            };
+                            tdf.file_range = std::ptr::null_mut();
+                            if added {
+                                tx.tx_data.incr_files_opened();
+                            }
+                        }
+                    }
+
+                    //TODOsmbmulti5 use eof ?
                     let cs = tdf.file_tracker.update(files, flags, file_data, gap_size);
                     cs
                 } else {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -593,8 +593,9 @@ impl SMBTransaction {
     }
 
     pub fn free(&mut self) {
-        debug_validate_bug_on!(self.tx_data.files_opened > 1);
-        debug_validate_bug_on!(self.tx_data.files_logged > 1);
+        // there can be a multi file + a regular one logged
+        debug_validate_bug_on!(self.tx_data.files_opened > 2);
+        debug_validate_bug_on!(self.tx_data.files_logged > 2);
     }
 }
 
@@ -756,6 +757,8 @@ pub struct SMBState<> {
     pub ssn2vec_map: HashMap<SMBCommonHdr, Vec<u8>>,
     /// map guid to filename
     pub guid2name_map: HashMap<Vec<u8>, Vec<u8>>,
+    /// map guid to file size
+    pub guid2eof_map: HashMap<Vec<u8>, u64>,
     /// map ssn key to read offset
     pub ssn2vecoffset_map: HashMap<SMBCommonHdr, SMBFileGUIDOffset>,
 
@@ -828,6 +831,7 @@ impl SMBState {
         Self {
             ssn2vec_map:HashMap::new(),
             guid2name_map:HashMap::new(),
+            guid2eof_map:HashMap::new(),
             ssn2vecoffset_map:HashMap::new(),
             ssn2tree_map:HashMap::new(),
             ssnguid2vec_map:HashMap::new(),
@@ -1388,7 +1392,7 @@ impl SMBState {
                                         SCLogDebug!("SMB2: partial record {}",
                                                 &smb2_command_string(smb_record.command));
                                         if smb_record.command == SMB2_COMMAND_WRITE {
-                                            smb2_write_request_record(self, smb_record);
+                                            smb2_write_request_record(flow, self, smb_record);
 
                                             self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                             self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
@@ -1428,7 +1432,7 @@ impl SMBState {
         }
         // take care of in progress file chunk transfers
         // and skip buffer beyond it
-        let consumed = self.filetracker_update(Direction::ToServer, cur_i, 0);
+        let consumed = self.filetracker_update(Direction::ToServer, cur_i, 0, stream_slice.flags() & STREAM_EOF != 0);
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
@@ -1520,7 +1524,7 @@ impl SMBState {
                                                 self.add_smb2_ts_hdr_data_frames(flow, stream_slice, nbss_data, record_len, smb_record.header_len as i64);
                                                 SCLogDebug!("nbss_data_rem {}", nbss_data_rem.len());
                                                 if smb_record.is_request() {
-                                                    smb2_request_record(self, smb_record);
+                                                    smb2_request_record(flow, self, smb_record);
                                                 } else {
                                                     // If we recevied a response when expecting a request, set an event
                                                     // on the PDU frame instead of handling the response.
@@ -1760,7 +1764,7 @@ impl SMBState {
         }
         // take care of in progress file chunk transfers
         // and skip buffer beyond it
-        let consumed = self.filetracker_update(Direction::ToClient, cur_i, 0);
+        let consumed = self.filetracker_update(Direction::ToClient, cur_i, 0, stream_slice.flags() & STREAM_EOF != 0);
         if consumed > 0 {
             if consumed > cur_i.len() as u32 {
                 self.set_event(SMBEvent::InternalError);
@@ -1943,7 +1947,7 @@ impl SMBState {
             let new_gap_size = gap_size - consumed;
             let gap = vec![0; new_gap_size as usize];
 
-            let consumed2 = self.filetracker_update(Direction::ToServer, &gap, new_gap_size);
+            let consumed2 = self.filetracker_update(Direction::ToServer, &gap, new_gap_size, false);
             if consumed2 > new_gap_size {
                 SCLogDebug!("consumed more than GAP size: {} > {}", consumed2, new_gap_size);
                 self.set_event(SMBEvent::InternalError);
@@ -1964,7 +1968,7 @@ impl SMBState {
             let new_gap_size = gap_size - consumed;
             let gap = vec![0; new_gap_size as usize];
 
-            let consumed2 = self.filetracker_update(Direction::ToClient, &gap, new_gap_size);
+            let consumed2 = self.filetracker_update(Direction::ToClient, &gap, new_gap_size, false);
             if consumed2 > new_gap_size {
                 SCLogDebug!("consumed more than GAP size: {} > {}", consumed2, new_gap_size);
                 self.set_event(SMBEvent::InternalError);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -27,6 +27,10 @@ use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
 
+use std::os::raw::c_uchar;
+
+use crate::filecontainer::FileContainer;
+
 pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL:      u16 = 0;
 pub const SMB2_COMMAND_SESSION_SETUP:           u16 = 1;
 pub const SMB2_COMMAND_SESSION_LOGOFF:          u16 = 2;
@@ -264,7 +268,19 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+// Defined in app-layer-smb.h
+extern "C" {
+    pub fn SmbMultiSetFileSize(
+        f: *const Flow, guid: *const c_uchar, eof: u64, fname: *const c_uchar, namelen: u16,
+    );
+    pub fn SmbMultiStartFileChunk(
+        f: *const Flow, guid: *const c_uchar, flags: u16, fc: *mut FileContainer,
+        sbcfg: *const StreamingBufferConfig, added: &mut bool, offset: u64, rlen: u32,
+        data: *const c_uchar, data_len: u32,
+    ) -> *mut HttpRangeContainerBlock;
+}
+
+pub fn smb2_write_request_record<'b>(flow: *const Flow, state: &mut SMBState, r: &Smb2Record<'b>)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
@@ -298,6 +314,17 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             let found = match state.get_file_tx_by_fuid(&file_guid, Direction::ToServer) {
                 Some((tx, files, flags)) => {
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                        if tdf.multi {
+                            if let Some(sfcm) = unsafe {SURICATA_SMB_FILE_CONFIG} {
+                                let mut added = false;
+                                unsafe {
+                                    tdf.file_range = SmbMultiStartFileChunk(flow, file_guid.as_ptr(), flags, files, sfcm.files_sbcfg, &mut added, wr.wr_offset, wr.wr_len, wr.data.as_ptr(), wr.data.len() as u32);
+                                }
+                                if added {
+                                    tx.tx_data.incr_files_opened();
+                                }
+                            }
+                        }
                         let file_id : u32 = tx.id as u32;
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
@@ -360,11 +387,34 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     SCLogDebug!("non-DCERPC pipe: skip rest of the record");
                     state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                 } else {
+                    let mut multistart = wr.wr_offset > 0;
+                    if wr.wr_offset == 0 {
+                        if let Some(eof) = state.guid2eof_map.get(&file_guid) {
+                            // save ippair guid + eof
+                            unsafe {
+                                SmbMultiSetFileSize(flow, file_guid.as_ptr(), *eof, file_name.as_ptr(), file_name.len() as u16);
+                            }
+                            multistart = true;
+                        }
+                    }
                     let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, Direction::ToServer);
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
                     tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
                             r.session_id, r.tree_id, 0); // TODO move into new_file_tx
+
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                        if multistart {
+                            if let Some(sfcm) = unsafe {SURICATA_SMB_FILE_CONFIG} {
+                                let mut added = false;
+                                unsafe {
+                                    tdf.file_range = SmbMultiStartFileChunk(flow, file_guid.as_ptr(), flags, files, sfcm.files_sbcfg, &mut added, wr.wr_offset, wr.wr_len, wr.data.as_ptr(), wr.data.len() as u32);
+                                }
+                                tdf.multi = true;
+                                if added {
+                                    tx.tx_data.incr_files_opened();
+                                }
+                            }
+                        }
                         let file_id : u32 = tx.id as u32;
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
@@ -396,7 +446,9 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+const SMB_GUID_MAP_MAX_LEN : usize = 256;
+
+pub fn smb2_request_record<'b>(flow: *const Flow, state: &mut SMBState, r: &Smb2Record<'b>)
 {
     SCLogDebug!("SMBv2 request record, command {} tree {} session {}",
             &smb2_command_string(r.command), r.tree_id, r.session_id);
@@ -448,6 +500,16 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             tx.request_done = true;
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
+                        }
+                        Smb2SetInfoRequestData::EOF(ref eof) => {
+                            if let Some(_fname) = state.guid2name_map.get(rd.guid) {
+                                // gets removed on file close
+                                //TODOsmbmulti5 by the way guid2name_map never removed and not limited !
+                                if state.guid2eof_map.len() < SMB_GUID_MAP_MAX_LEN {
+                                    state.guid2eof_map.insert(rd.guid.to_vec(), eof.eof);
+                                }
+                            }
+                            false
                         }
                         _ => false,
                     }
@@ -580,12 +642,13 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             }
         },
         SMB2_COMMAND_WRITE => {
-            smb2_write_request_record(state, r);
+            smb2_write_request_record(flow, state, r);
             true // write handling creates both file tx and generic tx
         },
         SMB2_COMMAND_CLOSE => {
             match parse_smb2_request_close(r.data) {
                 Ok((_, cd)) => {
+                    state.guid2eof_map.remove(&cd.guid.to_vec());
                     let found_ts = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), Direction::ToServer) {
                         Some((tx, files, flags)) => {
                             if !tx.request_done {

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -374,8 +374,22 @@ pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2Se
 }
 
 #[derive(Debug)]
+pub struct Smb2SetInfoRequestEof {
+    pub eof: u64,
+}
+
+pub fn parse_smb2_request_setinfo_eof(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+    let (i, eof) = le_u64(i)?;
+    let record = Smb2SetInfoRequestData::EOF(Smb2SetInfoRequestEof {
+        eof: eof,
+    });
+    Ok((i, record))
+}
+
+#[derive(Debug)]
 pub enum Smb2SetInfoRequestData<'a> {
     DISPOSITION(Smb2SetInfoRequestDispoRecord),
+    EOF(Smb2SetInfoRequestEof),
     RENAME(Smb2SetInfoRequestRenameRecord<'a>),
     UNHANDLED,
 }
@@ -399,6 +413,9 @@ fn parse_smb2_request_setinfo_data(
             }
             0xd => {
                 return parse_smb2_request_setinfo_disposition(i);
+            }
+            0x14 => {
+                return parse_smb2_request_setinfo_eof(i);
             }
             _ => {}
         }

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -153,22 +153,6 @@ void AppLayerExpectationSetup(void)
     SC_ATOMIC_INIT(expectation_count);
 }
 
-static inline int GetFlowAddresses(Flow *f, Address *ip_src, Address *ip_dst)
-{
-    memset(ip_src, 0, sizeof(*ip_src));
-    memset(ip_dst, 0, sizeof(*ip_dst));
-    if (FLOW_IS_IPV4(f)) {
-        FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->src, ip_src);
-        FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->dst, ip_dst);
-    } else if (FLOW_IS_IPV6(f)) {
-        FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->src, ip_src);
-        FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->dst, ip_dst);
-    } else {
-        return -1;
-    }
-    return 0;
-}
-
 static ExpectationList *AppLayerExpectationLookup(Flow *f, IPPair **ipp)
 {
     Address ip_src, ip_dst;

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -162,7 +162,7 @@ end:
  *
  * @return HTP_OK on success, HTP_ERROR on failure.
  */
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
+int HTPParseContentRange(bstr *rawvalue, FileContentRange *range)
 {
     uint32_t len = bstr_len(rawvalue);
     return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
@@ -177,7 +177,7 @@ int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
  * @return HTP_OK on success, HTP_ERROR, -2, -3 on failure.
  */
 static int HTPParseAndCheckContentRange(
-        bstr *rawvalue, HTTPContentRange *range, HtpState *s, HtpTxUserData *htud)
+        bstr *rawvalue, FileContentRange *range, HtpState *s, HtpTxUserData *htud)
 {
     int r = HTPParseContentRange(rawvalue, range);
     if (r != 0) {
@@ -225,7 +225,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     DEBUG_VALIDATE_BUG_ON(s == NULL);
 
     // This function is only called STREAM_TOCLIENT from HtpResponseBodyHandle
-    HTTPContentRange crparsed;
+    FileContentRange crparsed;
     if (HTPParseAndCheckContentRange(rawvalue, &crparsed, s, htud) != 0) {
         // range is invalid, fall back to classic open
         return HTPFileOpen(s, txud, filename, filename_len, data, data_len, txid, STREAM_TOCLIENT);

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -29,7 +29,7 @@
 
 int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t,
         uint64_t, uint8_t);
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);
+int HTPParseContentRange(bstr *rawvalue, FileContentRange *range);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
         uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -360,7 +360,7 @@ static HttpRangeContainerBlock *HttpRangeOpenFile(HttpRangeContainerFile *c, uin
 }
 
 HttpRangeContainerBlock *HttpRangeContainerOpenFile(const uint8_t *key, uint32_t keylen,
-        const Flow *f, const HTTPContentRange *crparsed, const StreamingBufferConfig *sbcfg,
+        const Flow *f, const FileContentRange *crparsed, const StreamingBufferConfig *sbcfg,
         const uint8_t *name, uint16_t name_len, uint16_t flags, const uint8_t *data,
         uint32_t data_len)
 {

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -101,7 +101,7 @@ File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags);
 
 // HttpRangeContainerBlock but trouble with headers inclusion order
 HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,
-        const Flow *f, const HTTPContentRange *cr, const StreamingBufferConfig *sbcfg,
+        const Flow *f, const FileContentRange *cr, const StreamingBufferConfig *sbcfg,
         const unsigned char *name, uint16_t name_len, uint16_t flags, const unsigned char *data,
         uint32_t data_len);
 

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -773,6 +773,22 @@ static IPPair *IPPairGetUsedIPPair(void)
     return NULL;
 }
 
+int GetFlowAddresses(const Flow *f, Address *ip_src, Address *ip_dst)
+{
+    memset(ip_src, 0, sizeof(*ip_src));
+    memset(ip_dst, 0, sizeof(*ip_dst));
+    if (FLOW_IS_IPV4(f)) {
+        FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->src, ip_src);
+        FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->dst, ip_dst);
+    } else if (FLOW_IS_IPV6(f)) {
+        FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->src, ip_src);
+        FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->dst, ip_dst);
+    } else {
+        return -1;
+    }
+    return 0;
+}
+
 void IPPairRegisterUnittests(void)
 {
     RegisterIPPairStorageTests();

--- a/src/ippair.h
+++ b/src/ippair.h
@@ -155,4 +155,6 @@ int IPPairSetMemcap(uint64_t size);
 uint64_t IPPairGetMemcap(void);
 uint64_t IPPairGetMemuse(void);
 
+int GetFlowAddresses(const Flow *f, Address *ip_src, Address *ip_dst);
+
 #endif /* __IPPAIR_H__ */

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -251,7 +251,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
             jb_open_object(js, "content_range");
             jb_set_string_from_bytes(
                     js, "raw", bstr_ptr(h_content_range->value), bstr_len(h_content_range->value));
-            HTTPContentRange crparsed;
+            FileContentRange crparsed;
             if (HTPParseContentRange(h_content_range->value, &crparsed) == 0) {
                 if (crparsed.start >= 0)
                     jb_set_uint(js, "start", crparsed.start);

--- a/src/tests/app-layer-htp-file.c
+++ b/src/tests/app-layer-htp-file.c
@@ -25,7 +25,7 @@
 
 static int AppLayerHtpFileParseContentRangeTest01 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 12-25/100");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 12);
@@ -42,7 +42,7 @@ static int AppLayerHtpFileParseContentRangeTest01 (void)
 
 static int AppLayerHtpFileParseContentRangeTest02 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-27514354/");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -56,7 +56,7 @@ static int AppLayerHtpFileParseContentRangeTest02 (void)
 
 static int AppLayerHtpFileParseContentRangeTest03 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -71,7 +71,7 @@ static int AppLayerHtpFileParseContentRangeTest03 (void)
 
 static int AppLayerHtpFileParseContentRangeTest04 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 24-42/*");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 24);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4861

Describe changes:
- smb : handle multi-stream file transfers

This is a draft for feedback.

Based on a private pcap for testing, this uses SMB2_FILE_ENDOFFILE_INFO cf Wireshark filter `smb2.file_info.infolevel == 0x14 to start using multi-stream logic


Questions :
- How good is this `SMB2_FILE_ENDOFFILE_INFO` assumption ?
- How much should we use ippair logic ?
ippair is currently not used by the http range logic
ippair can improve the locking mechanisms
But then, it is harder to have a global memcap on the buffering done for multi-stream smb files...
This is the big question.
I am not sure about how much code HTTP range and smb should share...
Should multi-files share one memcap for instance ?
- Should we support parallel multiple multi-streams files transfers ?
That is between 2 IPs, multiple files (with their SMB guid) concurrently being transferred, each over multiple streams
- Should we handle reads as writes ? If so, I would need a pcap (cf SMB2_FILE_ENDOFFILE_INFO assumption)
- This draft is SMB2 only, would we want SMB1 ?
 
Also, the current multi-stream logic will not log a file until it is complete.
Because there may be a new flow coming that will complete the file.
And because to log it, we have to move its ownership from the global hash table to the transaction which will end up freeing it...
Thoughts about this ?