### PR TITLE
security: prevents process creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])
     AC_CHECK_FUNCS([socket setenv select putenv dup2 endgrent endpwent atexit munmap])
+    AC_CHECK_FUNCS([setrlimit])
 
     AC_CHECK_FUNCS([fwrite_unlocked])
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -37,6 +37,12 @@ Major changes
 ~~~~~~~~~~~~~
 - Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
 
+Security changes
+~~~~~~~~~~~~~~~~
+- Process creation by Suricata is now disabled by default, this can be configured with `security.limit-noproc` (for LUA scripts for instance)
+  This is done through the call of `setrlimit(RLIMIT_NPROC` cf `man setrlimit`.
+  This prevents potential exploits against Suricata to fork a new process, even if it does not prevent the call of `exec`.
+
 Removals
 ~~~~~~~~
 - The libprelude output plugin has been removed.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1991,6 +1991,11 @@ napatech:
     #
     hashmode: hash5tuplesorted
 
+security:
+  # if true, prevents process creation from Suricata by calling
+  # setrlimit(RLIMIT_NPROC, 0)
+  limit-noproc: yes
+
 ##
 ## Configure Suricata to load Suricata-Update managed rules.
 ##


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5373

Describe changes:
- optionally calls `setrlimit(RLIMIT_NPROC, 0)` to prevent process creation by Suricata process

Modifies #7458 by taking review comments into account