### PR TITLE
detect/tls.fingerprint: Improve rule processing time

### DIFF
--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -55,7 +55,6 @@
 
 #include "app-layer-htp.h"
 #include "detect-http-uri.h"
-#include "detect-uricontent.h"
 #include "stream-tcp.h"
 
 #ifdef UNITTESTS


### PR DESCRIPTION
This PR changes the inspection logic for `tls.fingerprint` to use that from `tls.cert-fingerprint` for improved processing time.

There is an *existing suricata-verify* test that checks for equivalence for these keywords: `tls-fingerprint-alert`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4581](https://redmine.openinfosecfoundation.org/issues/4581)

Describe changes:
- Use inspection logic from tls.cert-fingerprint

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
