### PR TITLE
util-dpdk-i40e.c: fix warning with number of queues for RSS configura…

### DIFF
--- a/src/util-dpdk-i40e.c
+++ b/src/util-dpdk-i40e.c
@@ -160,8 +160,14 @@ static int i40eDeviceSetRSSFlowQueues(
     rss_action_conf.func = RTE_ETH_HASH_FUNCTION_DEFAULT;
     rss_action_conf.level = 0;
     rss_action_conf.types = 0; // queues region can not be configured with types
-    rss_action_conf.key = rss_conf.rss_key;
-    rss_action_conf.key_len = rss_conf.rss_key_len;
+    rss_action_conf.key_len = 0;
+    rss_action_conf.key = NULL;
+
+    if (nb_rx_queues < 1) {
+        FatalError(SC_ERR_DPDK_CONF, "The number of queues for RSS configuration must be "
+                                     "configured with a positive number");
+    }
+
     rss_action_conf.queue_num = nb_rx_queues;
     rss_action_conf.queue = queues;
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

This is a follow-up of #7831 which fixes a warning "RSS key is ignored when queues specified" on NIC Intel X710.

Changelog from #7831:
- squash commits