### PR TITLE
security: prevents process creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])
     AC_CHECK_FUNCS([socket setenv select putenv dup2 endgrent endpwent atexit munmap])
+    AC_CHECK_FUNCS([setrlimit])
 
     AC_CHECK_FUNCS([fwrite_unlocked])
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2610,3 +2610,20 @@ detect thread. For each output script, a single state is used. Keep in
 mind that a rule reload temporary doubles the states requirement.
 
 .. _deprecation policy: https://suricata.io/about/deprecation-policy/
+
+.. _suricata-yaml-config-hardening:
+
+Configuration hardening
+-----------------------
+
+The `security` section of suricata.yaml is meant to provide in-depth security configuration options.
+
+For now, only one setting is available. `limit-noproc`: a boolean to prevent process creation by Suricata.
+If you do not need Suricata to create other processes (for LUA scripts for instance), enable this to
+call `setrlimit` with `RLIMIT_NPROC` argument (see `man setrlimit`).
+This prevents potential exploits against Suricata to fork a new process,
+even if it does not prevent the call of `exec`.
+
+Beyond suricata.yaml, other ways to harden Suricata are
+- compilation : enabling ASLR and other exploit mitigation techniques.
+- environment : running Suricata on a device that has no direct access to Internet

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -37,6 +37,11 @@ Major changes
 ~~~~~~~~~~~~~
 - Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
 
+Security changes
+~~~~~~~~~~~~~~~~
+- suricata.yaml now prevents process creation by Suricata by default with `security.limit-noproc`.
+  For more info, see :ref:`suricata-yaml-config-hardening`
+
 Removals
 ~~~~~~~~
 - The libprelude output plugin has been removed.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1991,6 +1991,11 @@ napatech:
     #
     hashmode: hash5tuplesorted
 
+security:
+  # if true, prevents process creation from Suricata by calling
+  # setrlimit(RLIMIT_NPROC, 0)
+  limit-noproc: yes
+
 ##
 ## Configure Suricata to load Suricata-Update managed rules.
 ##


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5373

Describe changes:
- optionally calls `setrlimit(RLIMIT_NPROC, 0)` to prevent process creation by Suricata process

Modifies #7858 with better doc

libhtp-pr: 366