### PR TITLE
Smb file multiflow 4861 v3

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -91,7 +91,7 @@ exclude = [
     "DetectEngineState",
     "Flow",
     "StreamingBufferConfig",
-    "HttpRangeContainerBlock",
+    "FileRangeContainerBlock",
     "FileContainer",
     "JsonT",
     "IKEState",

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -146,14 +146,14 @@ pub type AppLayerDecoderEventsFreeEventsFunc =
 pub enum StreamingBufferConfig {}
 
 // Opaque flow type (defined in C)
-pub enum HttpRangeContainerBlock {}
+pub enum FileRangeContainerBlock {}
 
 pub type SCHttpRangeFreeBlock = extern "C" fn (
-        c: *mut HttpRangeContainerBlock);
+        c: *mut FileRangeContainerBlock);
 pub type SCHTPFileCloseHandleRange = extern "C" fn (
         fc: *mut FileContainer,
         flags: u16,
-        c: *mut HttpRangeContainerBlock,
+        c: *mut FileRangeContainerBlock,
         data: *const u8,
         data_len: u32) -> bool;
 pub type SCFileOpenFileWithId = extern "C" fn (

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -133,7 +133,7 @@ pub struct HTTP2Transaction {
     pub frames_ts: Vec<HTTP2Frame>,
 
     decoder: decompression::HTTP2Decoder,
-    pub file_range: *mut HttpRangeContainerBlock,
+    pub file_range: *mut FileRangeContainerBlock,
 
     pub tx_data: AppLayerTxData,
     pub ft_tc: FileTransferTracker,

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -17,7 +17,7 @@
 
 use super::detect;
 use crate::core::{
-    Direction, Flow, HttpRangeContainerBlock, StreamingBufferConfig, SuricataFileContext, SC,
+    Direction, Flow, FileRangeContainerBlock, StreamingBufferConfig, SuricataFileContext, SC,
 };
 use crate::filecontainer::FileContainer;
 use crate::http2::http2::HTTP2Transaction;
@@ -151,7 +151,7 @@ pub fn http2_range_open(
     }
 }
 
-pub fn http2_range_append(fr: *mut HttpRangeContainerBlock, data: &[u8]) {
+pub fn http2_range_append(fr: *mut FileRangeContainerBlock, data: &[u8]) {
     unsafe {
         HttpRangeAppendData(fr, data.as_ptr(), data.len() as u32);
     }
@@ -185,9 +185,9 @@ extern "C" {
         key: *const c_uchar, keylen: u32, f: *const Flow, cr: &FileContentRange,
         sbcfg: *const StreamingBufferConfig, name: *const c_uchar, name_len: u16, flags: u16,
         data: *const c_uchar, data_len: u32,
-    ) -> *mut HttpRangeContainerBlock;
+    ) -> *mut FileRangeContainerBlock;
     pub fn HttpRangeAppendData(
-        c: *mut HttpRangeContainerBlock, data: *const c_uchar, data_len: u32,
+        c: *mut FileRangeContainerBlock, data: *const c_uchar, data_len: u32,
     ) -> std::os::raw::c_int;
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -102,6 +102,7 @@ pub mod filecontainer;
 pub mod filetracker;
 pub mod kerberos;
 pub mod detect;
+pub mod range;
 
 #[cfg(feature = "lua")]
 pub mod lua;

--- a/rust/src/range.rs
+++ b/rust/src/range.rs
@@ -1,0 +1,24 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+*/
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct FileContentRange {
+    pub start: i64,
+    pub end: i64,
+    pub size: i64,
+}

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -35,7 +35,7 @@ pub struct SMBTransactionFile {
     /// after a gap, this will be set to a time in the future. If the file
     /// receives no updates before that, it will be considered complete.
     pub post_gap_ts: u64,
-    pub file_range: *mut HttpRangeContainerBlock,
+    pub file_range: *mut FileRangeContainerBlock,
     pub multi: bool,
 }
 
@@ -77,7 +77,7 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
 // Defined in app-layer-htp-range.h
 extern "C" {
     pub fn HttpRangeAppendData(
-        c: *mut HttpRangeContainerBlock, data: *const c_uchar, data_len: u32,
+        c: *mut FileRangeContainerBlock, data: *const c_uchar, data_len: u32,
     ) -> std::os::raw::c_int;
 }
 

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -22,8 +22,10 @@ use crate::filecontainer::*;
 
 use crate::smb::smb::*;
 
+use std::os::raw::c_uchar;
+
 /// File tracking transaction. Single direction only.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SMBTransactionFile {
     pub direction: Direction,
     pub fuid: Vec<u8>,
@@ -33,14 +35,29 @@ pub struct SMBTransactionFile {
     /// after a gap, this will be set to a time in the future. If the file
     /// receives no updates before that, it will be considered complete.
     pub post_gap_ts: u64,
+    pub file_range: *mut HttpRangeContainerBlock,
+    pub multi: bool,
 }
 
 impl SMBTransactionFile {
     pub fn new() -> Self {
         return Self {
             file_tracker: FileTransferTracker::new(),
-            ..Default::default()
+            file_range: std::ptr::null_mut(),
+            multi: false,
+            post_gap_ts: 0,
+            direction: Direction::default(),
+            fuid: Vec::new(),
+            file_name: Vec::new(),
+            share_name: Vec::new(),
         }
+    }
+}
+
+impl Drop for SMBTransactionFile {
+    fn drop(&mut self) {
+        // should have been already closed
+        debug_validate_bug_on!(!self.file_range.is_null());
     }
 }
 
@@ -55,6 +72,13 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
                     chunk_size, 0, is_last, xid); }
         None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
+}
+
+// Defined in app-layer-htp-range.h
+extern "C" {
+    pub fn HttpRangeAppendData(
+        c: *mut HttpRangeContainerBlock, data: *const c_uchar, data_len: u32,
+    ) -> std::os::raw::c_int;
 }
 
 impl SMBState {
@@ -122,7 +146,7 @@ impl SMBState {
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32) -> u32 {
+    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32, eof: bool) -> u32 {
         let mut chunk_left = if direction == Direction::ToServer {
             self.file_ts_left
         } else {
@@ -175,6 +199,32 @@ impl SMBState {
                     }
 
                     let file_data = &data[0..data_to_handle_len];
+                    if !tdf.file_range.is_null() {
+                        unsafe {
+                            HttpRangeAppendData(tdf.file_range, file_data.as_ptr(), data_to_handle_len as u32);
+                        }
+                        if chunk_left == 0 || eof {
+                            let added = if let Some(c) = unsafe { SC } {
+                                let added = (c.HTPFileCloseHandleRange)(
+                                    files,
+                                    flags,
+                                    tdf.file_range,
+                                    std::ptr::null_mut(),
+                                    0,
+                                );
+                                (c.HttpRangeFreeBlock)(tdf.file_range);
+                                added
+                            } else {
+                                false
+                            };
+                            tdf.file_range = std::ptr::null_mut();
+                            if added {
+                                tx.tx_data.incr_files_opened();
+                            }
+                        }
+                    }
+
+                    //TODOsmbmulti5 use eof ?
                     let cs = tdf.file_tracker.update(files, flags, file_data, gap_size);
                     cs
                 } else {

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -278,7 +278,7 @@ extern "C" {
         f: *const Flow, guid: *const c_uchar, flags: u16, fc: *mut FileContainer,
         sbcfg: *const StreamingBufferConfig, added: &mut bool, offset: u64, rlen: u32,
         data: *const c_uchar, data_len: u32,
-    ) -> *mut HttpRangeContainerBlock;
+    ) -> *mut FileRangeContainerBlock;
 }
 
 pub fn smb2_write_request_record<'b>(flow: *const Flow, state: &mut SMBState, r: &Smb2Record<'b>)

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -27,6 +27,10 @@ use crate::smb::dcerpc::*;
 use crate::smb::events::*;
 use crate::smb::files::*;
 
+use std::os::raw::c_uchar;
+
+use crate::filecontainer::FileContainer;
+
 pub const SMB2_COMMAND_NEGOTIATE_PROTOCOL:      u16 = 0;
 pub const SMB2_COMMAND_SESSION_SETUP:           u16 = 1;
 pub const SMB2_COMMAND_SESSION_LOGOFF:          u16 = 2;
@@ -264,7 +268,20 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+// Defined in app-layer-smb.h
+extern "C" {
+    pub fn SmbMultiSetFileSize(
+        f: *const Flow, guid: *const c_uchar, eof: u64, fname: *const c_uchar, namelen: u16,
+        sbcfg: *const StreamingBufferConfig,
+    );
+    pub fn SmbMultiStartFileChunk(
+        f: *const Flow, guid: *const c_uchar, flags: u16, fc: *mut FileContainer,
+        sbcfg: *const StreamingBufferConfig, added: &mut bool, offset: u64, rlen: u32,
+        data: *const c_uchar, data_len: u32,
+    ) -> *mut HttpRangeContainerBlock;
+}
+
+pub fn smb2_write_request_record<'b>(flow: *const Flow, state: &mut SMBState, r: &Smb2Record<'b>)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
@@ -298,6 +315,17 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             let found = match state.get_file_tx_by_fuid(&file_guid, Direction::ToServer) {
                 Some((tx, files, flags)) => {
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                        if tdf.multi {
+                            if let Some(sfcm) = unsafe {SURICATA_SMB_FILE_CONFIG} {
+                                let mut added = false;
+                                unsafe {
+                                    tdf.file_range = SmbMultiStartFileChunk(flow, file_guid.as_ptr(), flags, files, sfcm.files_sbcfg, &mut added, wr.wr_offset, wr.wr_len, wr.data.as_ptr(), wr.data.len() as u32);
+                                }
+                                if added {
+                                    tx.tx_data.incr_files_opened();
+                                }
+                            }
+                        }
                         let file_id : u32 = tx.id as u32;
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
@@ -360,11 +388,35 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     SCLogDebug!("non-DCERPC pipe: skip rest of the record");
                     state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                 } else {
+                    let mut multistart = wr.wr_offset > 0;
+                    if wr.wr_offset == 0 {
+                        if let Some(eof) = state.guid2eof_map.get(&file_guid) {
+                            if let Some(sfcm) = unsafe {SURICATA_SMB_FILE_CONFIG} {
+                                unsafe {
+                                    SmbMultiSetFileSize(flow, file_guid.as_ptr(), *eof, file_name.as_ptr(), file_name.len() as u16, sfcm.files_sbcfg);
+                                }
+                            multistart = true;
+                            }
+                        }
+                    }
                     let (tx, files, flags) = state.new_file_tx(&file_guid, &file_name, Direction::ToServer);
                     tx.vercmd.set_smb2_cmd(SMB2_COMMAND_WRITE);
                     tx.hdr = SMBCommonHdr::new(SMBHDR_TYPE_HEADER,
                             r.session_id, r.tree_id, 0); // TODO move into new_file_tx
+
                     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
+                        if multistart {
+                            if let Some(sfcm) = unsafe {SURICATA_SMB_FILE_CONFIG} {
+                                let mut added = false;
+                                unsafe {
+                                    tdf.file_range = SmbMultiStartFileChunk(flow, file_guid.as_ptr(), flags, files, sfcm.files_sbcfg, &mut added, wr.wr_offset, wr.wr_len, wr.data.as_ptr(), wr.data.len() as u32);
+                                }
+                                tdf.multi = true;
+                                if added {
+                                    tx.tx_data.incr_files_opened();
+                                }
+                            }
+                        }
                         let file_id : u32 = tx.id as u32;
                         if wr.wr_offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
@@ -396,7 +448,9 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+const SMB_GUID_MAP_MAX_LEN : usize = 256;
+
+pub fn smb2_request_record<'b>(flow: *const Flow, state: &mut SMBState, r: &Smb2Record<'b>)
 {
     SCLogDebug!("SMBv2 request record, command {} tree {} session {}",
             &smb2_command_string(r.command), r.tree_id, r.session_id);
@@ -448,6 +502,16 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             tx.request_done = true;
                             tx.vercmd.set_smb2_cmd(SMB2_COMMAND_SET_INFO);
                             true
+                        }
+                        Smb2SetInfoRequestData::EOF(ref eof) => {
+                            if let Some(_fname) = state.guid2name_map.get(rd.guid) {
+                                // gets removed on file close
+                                //TODOsmbmulti5 by the way guid2name_map never removed and not limited !
+                                if state.guid2eof_map.len() < SMB_GUID_MAP_MAX_LEN {
+                                    state.guid2eof_map.insert(rd.guid.to_vec(), eof.eof);
+                                }
+                            }
+                            false
                         }
                         _ => false,
                     }
@@ -580,12 +644,13 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
             }
         },
         SMB2_COMMAND_WRITE => {
-            smb2_write_request_record(state, r);
+            smb2_write_request_record(flow, state, r);
             true // write handling creates both file tx and generic tx
         },
         SMB2_COMMAND_CLOSE => {
             match parse_smb2_request_close(r.data) {
                 Ok((_, cd)) => {
+                    state.guid2eof_map.remove(&cd.guid.to_vec());
                     let found_ts = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), Direction::ToServer) {
                         Some((tx, files, flags)) => {
                             if !tx.request_done {

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -374,8 +374,22 @@ pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2Se
 }
 
 #[derive(Debug)]
+pub struct Smb2SetInfoRequestEof {
+    pub eof: u64,
+}
+
+pub fn parse_smb2_request_setinfo_eof(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+    let (i, eof) = le_u64(i)?;
+    let record = Smb2SetInfoRequestData::EOF(Smb2SetInfoRequestEof {
+        eof: eof,
+    });
+    Ok((i, record))
+}
+
+#[derive(Debug)]
 pub enum Smb2SetInfoRequestData<'a> {
     DISPOSITION(Smb2SetInfoRequestDispoRecord),
+    EOF(Smb2SetInfoRequestEof),
     RENAME(Smb2SetInfoRequestRenameRecord<'a>),
     UNHANDLED,
 }
@@ -399,6 +413,9 @@ fn parse_smb2_request_setinfo_data(
             }
             0xd => {
                 return parse_smb2_request_setinfo_disposition(i);
+            }
+            0x14 => {
+                return parse_smb2_request_setinfo_eof(i);
             }
             _ => {}
         }

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -162,7 +162,7 @@ end:
  *
  * @return HTP_OK on success, HTP_ERROR on failure.
  */
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
+int HTPParseContentRange(bstr *rawvalue, FileContentRange *range)
 {
     uint32_t len = bstr_len(rawvalue);
     return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
@@ -177,7 +177,7 @@ int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
  * @return HTP_OK on success, HTP_ERROR, -2, -3 on failure.
  */
 static int HTPParseAndCheckContentRange(
-        bstr *rawvalue, HTTPContentRange *range, HtpState *s, HtpTxUserData *htud)
+        bstr *rawvalue, FileContentRange *range, HtpState *s, HtpTxUserData *htud)
 {
     int r = HTPParseContentRange(rawvalue, range);
     if (r != 0) {
@@ -225,7 +225,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     DEBUG_VALIDATE_BUG_ON(s == NULL);
 
     // This function is only called STREAM_TOCLIENT from HtpResponseBodyHandle
-    HTTPContentRange crparsed;
+    FileContentRange crparsed;
     if (HTPParseAndCheckContentRange(rawvalue, &crparsed, s, htud) != 0) {
         // range is invalid, fall back to classic open
         return HTPFileOpen(s, txud, filename, filename_len, data, data_len, txid, STREAM_TOCLIENT);

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -349,7 +349,7 @@ end:
  *  \retval true if reassembled file was added
  *  \retval false if no reassembled file was added
  */
-bool HTPFileCloseHandleRange(FileContainer *files, const uint16_t flags, HttpRangeContainerBlock *c,
+bool HTPFileCloseHandleRange(FileContainer *files, const uint16_t flags, FileRangeContainerBlock *c,
         const uint8_t *data, uint32_t data_len)
 {
     bool added = false;

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -33,7 +33,7 @@ int HTPParseContentRange(bstr *rawvalue, FileContentRange *range);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
         uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(
-        FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+        FileContainer *, const uint16_t, FileRangeContainerBlock *, const uint8_t *, uint32_t);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, HtpTxUserData *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -29,7 +29,7 @@
 
 int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t,
         uint64_t, uint8_t);
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);
+int HTPParseContentRange(bstr *rawvalue, FileContentRange *range);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
         uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -237,7 +237,7 @@ uint32_t HttpRangeContainersTimeoutHash(struct timeval *ts)
 /**
  * \returns locked data
  */
-static void *HttpRangeContainerUrlGet(const uint8_t *key, uint32_t keylen, const Flow *f)
+HttpRangeContainerFile *HttpRangeContainerUrlGet(const uint8_t *key, uint32_t keylen, const Flow *f)
 {
     const struct timeval *ts = &f->lastts;
     HttpRangeContainerFile lookup;
@@ -587,7 +587,7 @@ File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags)
     // wait until we merged all the buffers to update known size
     c->container->lastsize = f->size;
 
-    if (f->size >= c->container->totalsize) {
+    if (f->size >= c->container->totalsize && c->container->totalsize > 0) {
         // we finished the whole file
         HttpRangeFileClose(c->container, flags);
     } else {

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -360,7 +360,7 @@ static HttpRangeContainerBlock *HttpRangeOpenFile(HttpRangeContainerFile *c, uin
 }
 
 HttpRangeContainerBlock *HttpRangeContainerOpenFile(const uint8_t *key, uint32_t keylen,
-        const Flow *f, const HTTPContentRange *crparsed, const StreamingBufferConfig *sbcfg,
+        const Flow *f, const FileContentRange *crparsed, const StreamingBufferConfig *sbcfg,
         const uint8_t *name, uint16_t name_len, uint16_t flags, const uint8_t *data,
         uint32_t data_len)
 {

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -101,7 +101,7 @@ File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags);
 
 // HttpRangeContainerBlock but trouble with headers inclusion order
 HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,
-        const Flow *f, const HTTPContentRange *cr, const StreamingBufferConfig *sbcfg,
+        const Flow *f, const FileContentRange *cr, const StreamingBufferConfig *sbcfg,
         const unsigned char *name, uint16_t name_len, uint16_t flags, const unsigned char *data,
         uint32_t data_len);
 

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -107,4 +107,7 @@ HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, ui
 
 void HttpRangeFreeBlock(HttpRangeContainerBlock *b);
 
+HttpRangeContainerFile *HttpRangeContainerUrlGet(
+        const uint8_t *key, uint32_t keylen, const Flow *f);
+
 #endif /* __APP_LAYER_HTP_RANGE_H__ */

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -50,11 +50,11 @@ RB_PROTOTYPE(HTTP_RANGES, HttpRangeContainerBuffer, rb, HttpRangeContainerBuffer
 
 /** Item in hash table for a file in multiple ranges
  * Thread-safety is ensured with the thread-safe hash table cf THashData
- * The number of use is increased for each flow opening a new HttpRangeContainerBlock
- * until it closes this HttpRangeContainerBlock
+ * The number of use is increased for each flow opening a new FileRangeContainerBlock
+ * until it closes this FileRangeContainerBlock
  * The design goal is to have concurrency only on opening and closing a range request
  * and have a lock-free data structure belonging to one Flow
- * (see HttpRangeContainerBlock below)
+ * (see FileRangeContainerBlock below)
  * for every append in between (we suppose we have many appends per range request)
  */
 typedef struct HttpRangeContainerFile {
@@ -85,7 +85,7 @@ typedef struct HttpRangeContainerFile {
  * As this belongs to a flow, appending data to it is ensured to be thread-safe
  * Only one block per file has the pointer to the container
  */
-typedef struct HttpRangeContainerBlock {
+typedef struct FileRangeContainerBlock {
     /** state where we skip content */
     uint64_t toskip;
     /** current out of order range to write into */
@@ -94,18 +94,18 @@ typedef struct HttpRangeContainerBlock {
     HttpRangeContainerFile *container;
     /** file container we are owning for now */
     FileContainer *files;
-} HttpRangeContainerBlock;
+} FileRangeContainerBlock;
 
-int HttpRangeAppendData(HttpRangeContainerBlock *c, const uint8_t *data, uint32_t len);
-File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags);
+int HttpRangeAppendData(FileRangeContainerBlock *c, const uint8_t *data, uint32_t len);
+File *HttpRangeClose(FileRangeContainerBlock *c, uint16_t flags);
 
-// HttpRangeContainerBlock but trouble with headers inclusion order
-HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,
+// FileRangeContainerBlock but trouble with headers inclusion order
+FileRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,
         const Flow *f, const FileContentRange *cr, const StreamingBufferConfig *sbcfg,
         const unsigned char *name, uint16_t name_len, uint16_t flags, const unsigned char *data,
         uint32_t data_len);
 
-void HttpRangeFreeBlock(HttpRangeContainerBlock *b);
+void HttpRangeFreeBlock(FileRangeContainerBlock *b);
 
 HttpRangeContainerFile *HttpRangeContainerUrlGet(
         const uint8_t *key, uint32_t keylen, const Flow *f);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -258,7 +258,7 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
-    HttpRangeContainerBlock *file_range; /**< used to assign track ids to range file */
+    FileRangeContainerBlock *file_range; /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
     StreamSlice *slice;

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -28,6 +28,9 @@
 #include "app-layer-smb.h"
 #include "util-misc.h"
 
+#include "app-layer-htp-file.h"
+#include "app-layer-htp-range.h"
+#include "util-print.h"
 
 static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
 static SuricataFileContext sfc = { &sbcfg };
@@ -35,6 +38,75 @@ static SuricataFileContext sfc = { &sbcfg };
 #ifdef UNITTESTS
 static void SMBParserRegisterTests(void);
 #endif
+
+#define SMB_URL_PREFIX_LEN 6
+#define MAX_ADDR_LEN       46
+#define GUID_LEN           16
+
+static size_t SmbSetKey(const Flow *f, const uint8_t *guid, uint8_t *hkey)
+{
+    memcpy(hkey, "smb://", SMB_URL_PREFIX_LEN);
+    int printIp = FLOW_IS_IPV4(f) ? AF_INET : AF_INET6;
+    PrintInet(printIp, (const void *)&(f->src.address), (char *)(hkey + SMB_URL_PREFIX_LEN),
+            2 * GUID_LEN + MAX_ADDR_LEN + 1);
+    size_t key_len = strlen((const char *)hkey);
+    hkey[key_len] = '/';
+    key_len++;
+    rs_to_hex(hkey + key_len, sizeof(hkey) - key_len, guid, GUID_LEN);
+    key_len += 2 * GUID_LEN;
+    return key_len;
+}
+
+void SmbMultiSetFileSize(const Flow *f, const uint8_t *guid, uint64_t eof, const uint8_t *filename,
+        uint16_t name_len, const StreamingBufferConfig *files_sbcfg)
+{
+    uint8_t hkey[2 * GUID_LEN + MAX_ADDR_LEN + 1 + SMB_URL_PREFIX_LEN] = { 0 };
+    size_t keylen = SmbSetKey(f, guid, hkey);
+    uint16_t flags = FileFlowToFlags(f, STREAM_TOSERVER);
+
+    HttpRangeContainerFile *file_range_container = HttpRangeContainerUrlGet(hkey, keylen, f);
+    file_range_container->totalsize = eof;
+    if (file_range_container->files != NULL && file_range_container->files->tail == NULL) {
+        if (FileOpenFileWithId(file_range_container->files, files_sbcfg, 0, filename, name_len,
+                    NULL, 0, flags) != 0) {
+            SCLogDebug("open file for range failed");
+        }
+    } else {
+        FileSetName(file_range_container->files->tail, filename, name_len);
+    }
+    THashDecrUsecnt(file_range_container->hdata);
+    THashDataUnlock(file_range_container->hdata);
+}
+
+HttpRangeContainerBlock *SmbMultiStartFileChunk(const Flow *f, const uint8_t *guid, uint16_t flags,
+        FileContainer *fc, const StreamingBufferConfig *files_sbcfg, bool *added, uint64_t offset,
+        uint32_t rlen, const uint8_t *data, uint32_t data_len)
+{
+    HttpRangeContainerBlock *r = NULL;
+
+    FileContentRange fcr;
+    if (offset > INT64_MAX || offset + rlen > INT64_MAX) {
+        return NULL;
+    }
+    fcr.start = offset;
+    // total size is set by SmbMultiSetFileSize
+    fcr.size = 0;
+    fcr.end = offset + rlen;
+
+    uint8_t hkey[2 * GUID_LEN + MAX_ADDR_LEN + 1 + SMB_URL_PREFIX_LEN] = { 0 };
+    size_t key_len = SmbSetKey(f, guid, hkey);
+
+    r = HttpRangeContainerOpenFile(
+            hkey, key_len, f, &fcr, files_sbcfg, NULL, 0, flags, data, data_len);
+    if (r) {
+        if (data_len >= rlen) {
+            *added = HTPFileCloseHandleRange(fc, flags, r, NULL, 0);
+            HttpRangeFreeBlock(r);
+            r = NULL;
+        }
+    }
+    return r;
+}
 
 void RegisterSMBParsers(void)
 {

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -78,11 +78,11 @@ void SmbMultiSetFileSize(const Flow *f, const uint8_t *guid, uint64_t eof, const
     THashDataUnlock(file_range_container->hdata);
 }
 
-HttpRangeContainerBlock *SmbMultiStartFileChunk(const Flow *f, const uint8_t *guid, uint16_t flags,
+FileRangeContainerBlock *SmbMultiStartFileChunk(const Flow *f, const uint8_t *guid, uint16_t flags,
         FileContainer *fc, const StreamingBufferConfig *files_sbcfg, bool *added, uint64_t offset,
         uint32_t rlen, const uint8_t *data, uint32_t data_len)
 {
-    HttpRangeContainerBlock *r = NULL;
+    FileRangeContainerBlock *r = NULL;
 
     FileContentRange fcr;
     if (offset > INT64_MAX || offset + rlen > INT64_MAX) {

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -251,7 +251,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
             jb_open_object(js, "content_range");
             jb_set_string_from_bytes(
                     js, "raw", bstr_ptr(h_content_range->value), bstr_len(h_content_range->value));
-            HTTPContentRange crparsed;
+            FileContentRange crparsed;
             if (HTPParseContentRange(h_content_range->value, &crparsed) == 0) {
                 if (crparsed.start >= 0)
                     jb_set_uint(js, "start", crparsed.start);

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -26,7 +26,7 @@
 #include "app-layer-tftp.h" //TFTPState, TFTPTransaction
 
 // hack for include orders cf SCSha256
-typedef struct HttpRangeContainerBlock HttpRangeContainerBlock;
+typedef struct FileRangeContainerBlock FileRangeContainerBlock;
 
 struct AppLayerParser;
 
@@ -39,9 +39,9 @@ typedef struct SuricataContext_ {
     void (*AppLayerDecoderEventsFreeEvents)(AppLayerDecoderEvents **);
     void (*AppLayerParserTriggerRawStreamReassembly)(Flow *, int direction);
 
-    void (*HttpRangeFreeBlock)(HttpRangeContainerBlock *);
+    void (*HttpRangeFreeBlock)(FileRangeContainerBlock *);
     bool (*HTPFileCloseHandleRange)(
-            FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+            FileContainer *, const uint16_t, FileRangeContainerBlock *, const uint8_t *, uint32_t);
 
     int (*FileOpenFileWithId)(FileContainer *, const StreamingBufferConfig *,
         uint32_t track_id, const uint8_t *name, uint16_t name_len,

--- a/src/rust.h
+++ b/src/rust.h
@@ -20,7 +20,7 @@
 
 #include "util-lua.h"
 // hack for include orders cf SCSha256
-typedef struct HttpRangeContainerBlock HttpRangeContainerBlock;
+typedef struct FileRangeContainerBlock FileRangeContainerBlock;
 #include "detect-engine-state.h"
 #include "rust-context.h"
 #include "rust-bindings.h"

--- a/src/tests/app-layer-htp-file.c
+++ b/src/tests/app-layer-htp-file.c
@@ -25,7 +25,7 @@
 
 static int AppLayerHtpFileParseContentRangeTest01 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 12-25/100");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 12);
@@ -42,7 +42,7 @@ static int AppLayerHtpFileParseContentRangeTest01 (void)
 
 static int AppLayerHtpFileParseContentRangeTest02 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-27514354/");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -56,7 +56,7 @@ static int AppLayerHtpFileParseContentRangeTest02 (void)
 
 static int AppLayerHtpFileParseContentRangeTest03 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -71,7 +71,7 @@ static int AppLayerHtpFileParseContentRangeTest03 (void)
 
 static int AppLayerHtpFileParseContentRangeTest04 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 24-42/*");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 24);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -821,6 +821,20 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     SCReturnInt(0);
 }
 
+void FileSetName(File *f, const uint8_t *name, uint16_t name_len)
+{
+    if (f->name != NULL) {
+        SCFree(f->name);
+    }
+    f->name = SCMalloc(name_len);
+    if (f->name == NULL) {
+        return;
+    }
+
+    f->name_len = name_len;
+    memcpy(f->name, name, name_len);
+}
+
 /**
  *  \brief Open a new File
  *

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -193,6 +193,15 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
 int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
 
 /**
+ *  \brief Sets the name for a file.
+ *
+ *  \param ffc the file
+ *  \param filename the name
+ *  \param name_len the name's length
+ */
+void FileSetName(File *, const uint8_t *filename, uint16_t name_len);
+
+/**
  *  \brief Tag a file for storing
  *
  *  \param ff The file to store


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4861

Describe changes:
- smb : handle multi-stream file transfers

This is a draft for feedback.

Based on a private pcap for testing, this uses SMB2_FILE_ENDOFFILE_INFO cf Wireshark filter `smb2.file_info.infolevel == 0x14 to start using multi-stream logic


Questions :
- How good is this `SMB2_FILE_ENDOFFILE_INFO` assumption ?
- Should we handle reads as writes ? If so, I would need a pcap (cf SMB2_FILE_ENDOFFILE_INFO assumption)
- This draft is SMB2 only, would we want SMB1 ?
 
Also, the current multi-stream logic will not log a file until it is complete.
Because there may be a new flow coming that will complete the file.
And because to log it, we have to move its ownership from the global hash table to the transaction which will end up freeing it...
Thoughts about this ?
I now think the ownership should not be moved back to a transaction and the logging happen on its own...

Still TODO :
- more rename `HTTPRange` to `FileRange` + get commit order right
- Have a separate config memcap for SMB
- Other SMB tickets ?
- Update commit message with more details