### PR TITLE
ebpf: update deprecated API calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1623,11 +1623,18 @@
             AC_DEFINE([HAVE_PACKET_EBPF],[1],[Recent ebpf fanout support is available]),
             [],
             [[#include <linux/if_packet.h>]])
-        AC_CHECK_LIB(bpf, bpf_set_link_xdp_fd,have_xdp="yes")
+        # Check for XDP specific function.
+        AC_CHECK_LIB(bpf,bpf_xdp_attach,have_xdp="yes")
         if test "$have_xdp" = "yes"; then
             AC_DEFINE([HAVE_PACKET_XDP],[1],[XDP support is available])
+        else
+            # Check for legacy XDP function.
+            AC_CHECK_LIB(bpf,bpf_set_link_xdp_fd,have_xdp="yes")
+            if test "$have_xdp" = "yes"; then
+                AC_DEFINE([HAVE_PACKET_XDP],[1],[XDP support is available])
+            fi
         fi
-        AC_CHECK_FUNCS(bpf_program__section_name)
+        AC_CHECK_FUNCS([bpf_program__section_name bpf_xdp_attach bpf_program__set_type])
     fi;
 
   # Check for DAG support.


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Fix build errors when libbpf 1.0 is used, by changing the use of deprecated API functions that were still in use in Suricata's eBPF code and have been removed in that version. The new functions should be backwards compatible to at least libbpf 0.7. However, since Debian stable ships ancient libbpf versions (0.3 in stable bullseye!) the code also adjusts to compile on earlier versions, using the deprecated API calls.
