### PR TITLE
userguide/suricata-yaml: minor rewording and typo fixes - v2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -993,7 +993,7 @@ and prealloc for the following:
 
 The flow-engine has a management thread that operates independent from
 the packet processing. This thread is called the flow-manager. This
-thread ensures that wherever possible and within the memcap. there
+thread ensures that wherever possible and within the memcap. There
 will be 10000 flows prepared.
 
 In IPS mode, a memcap-policy exception policy can be set, telling Suricata
@@ -1251,13 +1251,13 @@ Application Layer Parsers
 
 The ``app-layer`` section holds application layer specific configurations.
 
-A in IPS mode, a global exception policy accessed via the ``error-policy``
+In IPS mode, a global exception policy accessed via the ``error-policy``
 setting can be defined to indicate what the engine should do in case if
 encounters an app-layer error. Possible values are "drop-flow", "pass-flow",
-"bypass", "drop-packet", "pass-packet", "reject" or "ignore" (which will mean
-keeping the default behavior).
+"bypass", "drop-packet", "pass-packet", "reject" or "ignore" (which maintains
+the default behavior).
 
-Each supported protocol will have a dedicated subsection under ``protocols``.
+Each supported protocol has a dedicated subsection under ``protocols``.
 
 Asn1_max_frames (new in 1.0.3 and 1.1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1684,15 +1684,14 @@ unlimited.
 MQTT
 ~~~~
 
-MQTT messages could theoretically be up to 256MB in size, potentially
-containing a lot of payload data (such as properties, topics, or
-published payloads) that would end up parsed and logged. To acknowledge
-the fact that most MQTT messages, however, will be quite small and to
-reduce the potential for denial of service issues, it is possible to limit
-the maximum length of a message that we are willing to parse. Any message
-larger than the limit will just be logged with reduced metadata, and rules
-will only be evaluated against a subset of fields.
-The default is 1 MB.
+The maximum size of a MQTT is 256MB, potentially containing a lot of payload
+data (such as properties, topics, or published payloads) that would end up
+parsed and logged. To acknowledge the fact that most MQTT messages, however,
+will be quite small and to reduce the potential for denial of service issues,
+it is possible to limit the maximum length of a message that Suricata should
+parse. Any message larger than the limit will just be logged with reduced
+metadata, and rules will only be evaluated against a subset of fields. The
+default is 1 MB.
 
 ::
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none

Previous PR: https://github.com/OISF/suricata/pull/7822

Updates from last PR: rebase and fix conflict.

Describe changes:
- fix typos and make some sentences clearer
(addressing comments done on PR: #7817)
Some paragraphs seem to have been fully changed. That's
due to trying to respect character limits for lines.