### PR TITLE
pgsql: config limit maximum number of live transactions

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1721,7 +1721,7 @@ incompatible with ``decode-mime``. If both are enabled,
 Maximum transactions
 ~~~~~~~~~~~~~~~~~~~~
 
-MQTT, FTP, and NFS have each a `max-tx` parameter that can be customized.
+MQTT, FTP, PostgreSQL and NFS have each a `max-tx` parameter that can be customized.
 `max-tx` refers to the maximum number of live transactions for each flow.
 An app-layer event `protocol.too_many_transactions` is triggered when this value is reached.
 The point of this parameter is to find a balance between the completeness of analysis

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -835,6 +835,8 @@ app-layer:
       enabled: no
       # Stream reassembly size for PostgreSQL. By default, track it completely.
       stream-depth: 0
+      # Maximum number of live PostgreSQL transactions per flow
+      # max-tx: 1024
     dcerpc:
       enabled: yes
     ftp:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5527

Describe changes:
- pgsql: configurable limit maximum number of live transactions
