### PR TITLE
6.0.x: content: don't error out on incomplete hex - v1

### DIFF
--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -109,10 +109,10 @@ typedef struct DetectContentData_ {
 /* prototypes */
 void DetectContentRegister (void);
 uint32_t DetectContentMaxId(DetectEngineCtx *);
-DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,
-                                      const char *contentstr);
-int DetectContentDataParse(const char *keyword, const char *contentstr,
-    uint8_t **pstr, uint16_t *plen);
+DetectContentData *DetectContentParse(
+        SpmGlobalThreadCtx *spm_global_thread_ctx, const char *contentstr, bool *warning);
+int DetectContentDataParse(
+        const char *keyword, const char *contentstr, uint8_t **pstr, uint16_t *plen, bool *warning);
 DetectContentData *DetectContentParseEncloseQuotes(SpmGlobalThreadCtx *spm_global_thread_ctx,
         const char *contentstr);
 

--- a/src/detect-fileext.c
+++ b/src/detect-fileext.c
@@ -149,7 +149,7 @@ static DetectFileextData *DetectFileextParse (DetectEngineCtx *de_ctx, const cha
 
     memset(fileext, 0x00, sizeof(DetectFileextData));
 
-    if (DetectContentDataParse("fileext", str, &fileext->ext, &fileext->len) == -1) {
+    if (DetectContentDataParse("fileext", str, &fileext->ext, &fileext->len, NULL) == -1) {
         goto error;
     }
     uint16_t u;

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -273,7 +273,7 @@ static DetectFilemagicData *DetectFilemagicParse (DetectEngineCtx *de_ctx, const
 
     memset(filemagic, 0x00, sizeof(DetectFilemagicData));
 
-    if (DetectContentDataParse ("filemagic", str, &filemagic->name, &filemagic->len) == -1) {
+    if (DetectContentDataParse("filemagic", str, &filemagic->name, &filemagic->len, NULL) == -1) {
         goto error;
     }
 

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -244,7 +244,7 @@ static DetectFilenameData *DetectFilenameParse (DetectEngineCtx *de_ctx, const c
 
     memset(filename, 0x00, sizeof(DetectFilenameData));
 
-    if (DetectContentDataParse ("filename", str, &filename->name, &filename->len) == -1) {
+    if (DetectContentDataParse("filename", str, &filename->name, &filename->len, NULL) == -1) {
         goto error;
     }
 

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -150,7 +150,8 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     }
     SCLogDebug("varcontent %s", &varcontent[varcontent_index]);
 
-    res = DetectContentDataParse("flowvar", &varcontent[varcontent_index], &content, &contentlen);
+    res = DetectContentDataParse(
+            "flowvar", &varcontent[varcontent_index], &content, &contentlen, NULL);
     if (res == -1)
         goto error;
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -339,6 +339,14 @@ void SigTableApplyStrictCommandlineOption(const char *str)
     SCFree(copy);
 }
 
+void SigTableClearStrictOption(const char *key)
+{
+    SigTableElmt *st = SigTableGet((char *)key);
+    if (st != NULL) {
+        st->flags &= ~SIGMATCH_STRICT_PARSING;
+    }
+}
+
 /**
  * \brief Append a SigMatch to the list type.
  *

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -76,6 +76,7 @@ const char *DetectListToHumanString(int list);
 const char *DetectListToString(int list);
 
 void SigTableApplyStrictCommandlineOption(const char *str);
+void SigTableClearStrictOption(const char *key);
 
 SigMatch *DetectGetLastSM(const Signature *);
 SigMatch *DetectGetLastSMFromMpmLists(const DetectEngineCtx *de_ctx, const Signature *s);

--- a/src/detect-pktvar.c
+++ b/src/detect-pktvar.c
@@ -127,7 +127,7 @@ static int DetectPktvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
         parse_content = varcontent;
     }
 
-    ret = DetectContentDataParse("pktvar", parse_content, &content, &len);
+    ret = DetectContentDataParse("pktvar", parse_content, &content, &len, NULL);
     if (ret == -1 || content == NULL) {
         pcre_free(varname);
         pcre_free(varcontent);

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -112,7 +112,7 @@ int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *replac
             return 0;
     }
 
-    int ret = DetectContentDataParse("replace", replacestr, &content, &len);
+    int ret = DetectContentDataParse("replace", replacestr, &content, &len, NULL);
     if (ret == -1)
         return -1;
 


### PR DESCRIPTION
Before 6.0.6 if hex content was incomplete, Suricata didn't error out.
With 6.0.6 incomplete hex was detected and errored on which is a
breaking change in a release branch.  Instead, only emit a warning
unless strict content checking has been requested.

To enable strict behaviour on incomplete content hex in a rule,
"--strict-rule-keywords=content" can be used on the command line.

Issue: https://redmine.openinfosecfoundation.org/issues/5546

For now there is no accompanying master commit, as the change in
behaviour for a major version is OK.
