### PR TITLE
userguide: add section about exception policy - v2

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -1,0 +1,101 @@
+.. _exception policies:
+
+Exception Policies
+==================
+
+Suricata has a set of configuration variables to indicate what should the engine
+do when certain exception conditions, such as hitting a memcap, are reached.
+
+They are called Exception Policies and are configurable via suricata.yaml. If
+enabled, the engine will call them when it  reaches exception states.
+
+For developers or for researching purposes, there are also simulation options
+exposed in debug mode and passed via command-line. These exist to force or
+simulate failures or errors and understand Suri behavior under such conditions.
+
+Exception Policies
+------------------
+
+Exception policies are implemented for:
+
+.. list-table:: Exception Policies configuration variables
+   :widths: 20, 18, 62
+   :header-rows: 1
+
+   * - Config setting
+     - Policy variable
+     - Expected behavior
+   * - stream.memcap
+     - memcap-policy
+     - If a stream session's memcap limits are reached, call the memcap policy
+       on the packet and flow.
+   * - stream.midstream
+     - midstream-policy
+     - If a session is picked up midstream, call the memcap policy on the packet
+       and flow.
+   * - stream.reassembly.memcap
+     - memcap-policy
+     - If stream reassembly reaches memcap limit, call the memcap policy on the
+       packet and flow.
+   * - flow.memcap
+     - memcap-policy
+     - Apply policy when the memcap limit for flow is reached and no flow could
+       be freed up.
+   * - defrag.memcap
+     - memcap-policy
+     - Apply policy when the memcap limit for defrag is reached and no tracker
+       could be picked up.
+   * - app-layer
+     - error-policy
+     - Apply policy if a parser reaches an error state.
+
+To change any of those, check the corresponding section in the suricata.yaml
+file. The possible values, and their resulting behaviors, are:
+
+- ``drop-flow``: disable inspection for the whole flow (packets, payload,
+  application layer protocol), drop the packet and all future packets in the
+  flow.
+- ``drop-packet``: drop the packet.
+- ``reject``: same as ``drop-flow``, but reject the first packet as well.
+- ``bypass``: bypass the flow. No further inspection is done. :ref:`Bypass
+  <bypass>` may be offloaded.
+- ``pass-flow``: disable payload and packet inspection, stream reassembly,
+  app-layer parsing and logging still happen.
+- ``pass-packet``: disables detection, still does stream updates and app-layer
+  parsing (depeding on which policy triggered it).
+- ``ignore``: do not apply exception policies (keeps default behavior).
+
+*Drop*, *pass* and *reject* have similar effects to the ones for :ref:`rule
+actions<suricata-yaml-action-order>`.
+
+Command-line Options for Simulating Exceptions
+----------------------------------------------
+
+It is also possible to force specific exception scenarios, to check engine
+behavior under failure or error conditions.
+
+The available command-line options are:
+
+- ``simulate-applayer-error-at-offset-ts``: force an applayer error in the to
+  server direction at the given offset.
+- ``simulate-applayer-error-at-offset-tc``: force an applayer error in the to
+  client direction at the given offset.
+- ``simulate-packet-loss``: simulate that the packet with the given number
+  (``pcap_cnt``) from the session was lost.
+- ``simulate-packet-tcp-reassembly-memcap``: simulate that the TCP stream
+  reassembly reached memcap for the specified packet.
+- ``simulate-packet-tcp-ssn-memcap``: simulate that the TCP session hit the
+  memcap for the specified packet.
+- ``simulate-packet-flow-memcap``: force the engine to assume that flow memcap is
+  hit at the given packet.
+- ``simulate-packet-defrag-memcap``: force Suricata to assume memcap is hit when
+  defragmenting specified packet.
+- ``simulate-alert-queue-realloc-failure``: prevent the engine from dynamically
+  growing the temporary alert queue, during alerts processing.
+
+Common abbreviations
+--------------------
+
+- applayer: application layer protocol
+- memcap: (maximum) memory capacity available
+- defrag: defragmentation

--- a/doc/userguide/configuration/index.rst
+++ b/doc/userguide/configuration/index.rst
@@ -5,6 +5,7 @@ Configuration
 
    suricata-yaml
    global-thresholds
+   exception-policies
    snort-to-suricata
    multi-tenant
    dropping-privileges

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -993,7 +993,7 @@ and prealloc for the following:
 
 The flow-engine has a management thread that operates independent from
 the packet processing. This thread is called the flow-manager. This
-thread ensures that wherever possible and within the memcap. there
+thread ensures that wherever possible and within the memcap. There
 will be 10000 flows prepared.
 
 In IPS mode, a memcap-policy exception policy can be set, telling Suricata
@@ -1251,13 +1251,13 @@ Application Layer Parsers
 
 The ``app-layer`` section holds application layer specific configurations.
 
-A in IPS mode, a global exception policy accessed via the ``error-policy``
+In IPS mode, a global exception policy accessed via the ``error-policy``
 setting can be defined to indicate what the engine should do in case if
 encounters an app-layer error. Possible values are "drop-flow", "pass-flow",
-"bypass", "drop-packet", "pass-packet", "reject" or "ignore" (which will mean
-keeping the default behavior).
+"bypass", "drop-packet", "pass-packet", "reject" or "ignore" (which maintains
+the default behavior).
 
-Each supported protocol will have a dedicated subsection under ``protocols``.
+Each supported protocol has a dedicated subsection under ``protocols``.
 
 Asn1_max_frames (new in 1.0.3 and 1.1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1684,15 +1684,14 @@ unlimited.
 MQTT
 ~~~~
 
-MQTT messages could theoretically be up to 256MB in size, potentially
-containing a lot of payload data (such as properties, topics, or
-published payloads) that would end up parsed and logged. To acknowledge
-the fact that most MQTT messages, however, will be quite small and to
-reduce the potential for denial of service issues, it is possible to limit
-the maximum length of a message that we are willing to parse. Any message
-larger than the limit will just be logged with reduced metadata, and rules
-will only be evaluated against a subset of fields.
-The default is 1 MB.
+The maximum size of a MQTT message is 256MB, potentially containing a lot of
+payload data (such as properties, topics, or published payloads) that would end
+up parsed and logged. To acknowledge the fact that most MQTT messages, however,
+will be quite small and to reduce the potential for denial of service issues,
+it is possible to limit the maximum length of a message that Suricata should
+parse. Any message larger than the limit will just be logged with reduced
+metadata, and rules will only be evaluated against a subset of fields. The
+default is 1 MB.
 
 ::
 

--- a/doc/userguide/performance/ignoring-traffic.rst
+++ b/doc/userguide/performance/ignoring-traffic.rst
@@ -78,6 +78,8 @@ after the initial handshake. By setting the `app-layer.protocols.tls.encryption-
 option to `bypass` the rest of this flow is ignored. If flow bypass is enabled,
 the bypass is done in the kernel or in hardware.
 
+.. _bypass:
+
 bypassing traffic
 -----------------
 

--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -39,6 +39,8 @@ are the options.
 We will be using the above signature as an example throughout
 this section, highlighting the different parts of the signature.
 
+.. _actions:
+
 Action
 ------
 .. container:: example-rule

--- a/doc/userguide/setting-up-ipsinline-for-linux.rst
+++ b/doc/userguide/setting-up-ipsinline-for-linux.rst
@@ -17,7 +17,7 @@ To check if you have NFQ enabled in your Suricata build, enter the following com
 
   suricata --build-info
 
-and make sure that NFS is listed in the output.
+and make sure that NFQ is listed in the output.
 
 To run Suricata with the NFQ mode, you have to make use of the ``-q`` option. This
 option tells Suricata which queue numbers it should use.

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -681,7 +681,7 @@ void StreamTcpFreeConfig(bool quiet)
 }
 
 /** \internal
- *  \brief The function is used to to fetch a TCP session from the
+ *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
  *
  *  \param p packet starting the new TCP session.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5475
https://redmine.openinfosecfoundation.org/issues/5515

Describe changes:
- add a configuration section describing the Exception Policies
- minor typo fixes and rewords
- incorporate what was in https://github.com/OISF/suricata/pull/7873

Updates from last PR (#7874 ):
- some rewords
- add references to bypassing and pass/rules actions
- organize available exception policies into a table, mention actual exception policies' config values, mention all exception policies
- remove mention of command-line options as a category of exception policies, reinforce the message that they're for devs and researchers