### PR TITLE
dpdk: count number of packets with invalid checksum v1

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -41,13 +41,13 @@
 #include "util-napatech.h"
 #endif /* HAVE_NAPATECH */
 
-
 typedef enum {
     CHECKSUM_VALIDATION_DISABLE,
     CHECKSUM_VALIDATION_ENABLE,
     CHECKSUM_VALIDATION_AUTO,
     CHECKSUM_VALIDATION_RXONLY,
     CHECKSUM_VALIDATION_KERNEL,
+    CHECKSUM_VALIDATION_OFFLOAD,
 } ChecksumValidationMode;
 
 enum PktSrcEnum {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1160,7 +1160,7 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
     DeviceInitPortConf(iconf, &dev_info, &port_conf);
     if (port_conf.rxmode.offloads & DEV_RX_OFFLOAD_CHECKSUM) {
         // Suricata does not need recalc checksums now
-        iconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
+        iconf->checksum_mode = CHECKSUM_VALIDATION_OFFLOAD;
     }
 
     retval = rte_eth_dev_configure(

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -364,6 +364,7 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
         for (uint16_t i = 0; i < nb_rx; i++) {
             p = PacketGetFromQueueOrAlloc();
             if (unlikely(p == NULL)) {
+                DPDKFreeMbufArray(ptv->received_mbufs, 1, i);
                 continue;
             }
             PKT_SET_SRC(p, PKT_SRC_WIRE);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5553) ticket:

Describe changes:
- fix a lost mbuf case when Suricata packet allocation failed, Suricata continued but the mbuf was never freed
- support counting packets with an invalid checksum
- add XSTATS output for a more detailed debug of NIC stats
