### PR TITLE
Implement extended security IP option

### DIFF
--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -67,7 +67,7 @@ static int IPV4OptValidateGeneric(Packet *p, const IPV4Opt *o)
         /* See: RFC 1108 */
         case IPV4_OPT_SEC:
         case IPV4_OPT_ESEC:
-            if (o->len != IPV4_OPT_SEC_LEN) {
+            if (unlikely(o->len < IPV4_OPT_SEC_MIN)) {
                 ENGINE_SET_INVALID_EVENT(p, IPV4_OPT_INVALID_LEN);
                 return -1;
             }
@@ -907,10 +907,8 @@ static int DecodeIPV4OptionsSECTest01(void)
 /** \test IPV4 with SEC option (invalid length). */
 static int DecodeIPV4OptionsSECTest02(void)
 {
-    uint8_t raw_opts[] = {
-        IPV4_OPT_SEC, 0x0a, 0xf1, 0x35, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-    };
+    uint8_t raw_opts[] = { IPV4_OPT_SEC, 0x02, 0xf1, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00 };
     Packet *p = PacketGetFromAlloc();
     FAIL_IF(unlikely(p == NULL));
 

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -44,11 +44,11 @@
 #define IPV4_OPT_RTRALT           0x94  /**< Option: Router Alert */
 
 /** IP Option Lengths (fixed) */
-#define IPV4_OPT_SEC_LEN          11    /**< SEC Option Fixed Length */
 #define IPV4_OPT_SID_LEN          4     /**< SID Option Fixed Length */
 #define IPV4_OPT_RTRALT_LEN       4     /**< RTRALT Option Fixed Length */
 
 /** IP Option Lengths (variable) */
+#define IPV4_OPT_SEC_MIN          3     /**< SEC, ESEC Option Min Length */
 #define IPV4_OPT_ROUTE_MIN        3     /**< RR, SRR, LTRR Option Min Length */
 #define IPV4_OPT_QS_MIN           8     /**< QS Option Min Length */
 #define IPV4_OPT_TS_MIN           5     /**< TS Option Min Length */

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -37,6 +37,7 @@
 #define IPV4_OPT_TS               0x44  /**< Option: Timestamp */
 #define IPV4_OPT_SEC              0x82  /**< Option: Security */
 #define IPV4_OPT_LSRR             0x83  /**< Option: Loose Source Route */
+#define IPV4_OPT_ESEC             0x85  /**< Option: Extended Security */
 #define IPV4_OPT_CIPSO            0x86  /**< Option: Commercial IP Security */
 #define IPV4_OPT_SID              0x88  /**< Option: Stream Identifier */
 #define IPV4_OPT_SSRR             0x89  /**< Option: Strict Source Route */
@@ -165,6 +166,7 @@ enum IPV4OptionFlags {
     IPV4_OPT_FLAG_SEC,
     IPV4_OPT_FLAG_CIPSO,
     IPV4_OPT_FLAG_RTRALT,
+    IPV4_OPT_FLAG_ESEC,
 };
 
 /* helper structure with parsed ipv4 info */

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -76,15 +76,46 @@ struct DetectIpOpts_ {
     const char *ipopt_name;   /**< ip option name */
     uint16_t code;   /**< ip option flag value */
 } ipopts[] = {
-    { "rr", IPV4_OPT_FLAG_RR, },
-    { "lsrr", IPV4_OPT_FLAG_LSRR, },
-    { "eol", IPV4_OPT_FLAG_EOL, },
-    { "nop", IPV4_OPT_FLAG_NOP, },
-    { "ts", IPV4_OPT_FLAG_TS, },
-    { "sec", IPV4_OPT_FLAG_SEC, },
-    { "ssrr", IPV4_OPT_FLAG_SSRR, },
-    { "satid", IPV4_OPT_FLAG_SID, },
-    { "any", 0xffff, },
+    {
+            "rr",
+            IPV4_OPT_FLAG_RR,
+    },
+    {
+            "lsrr",
+            IPV4_OPT_FLAG_LSRR,
+    },
+    {
+            "eol",
+            IPV4_OPT_FLAG_EOL,
+    },
+    {
+            "nop",
+            IPV4_OPT_FLAG_NOP,
+    },
+    {
+            "ts",
+            IPV4_OPT_FLAG_TS,
+    },
+    {
+            "sec",
+            IPV4_OPT_FLAG_SEC,
+    },
+    {
+            "esec",
+            IPV4_OPT_FLAG_ESEC,
+    },
+    {
+            "ssrr",
+            IPV4_OPT_FLAG_SSRR,
+    },
+    {
+            "satid",
+            IPV4_OPT_FLAG_SID,
+    },
+    {
+            "any",
+            0xffff,
+    },
     { NULL, 0 },
 };
 


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Actually implement `esec` option for the `ipopts` keyword as mentioned in the documentation.
- Change validation to not check for 11 bytes but to verify minimum field length for security   options, as defined in RFC 1108 (https://www.rfc-editor.org/rfc/rfc1108.html#section-2.2).
- Format previous code according to current standards.

suricata-verify-pr: 945
