### PR TITLE
requirements: use suricata-update 1.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 #
 #   name {repo} {branch|tag}
 libhtp https://github.com/OISF/libhtp 0.5.x
-suricata-update https://github.com/OISF/suricata-update 1.2.4
+suricata-update https://github.com/OISF/suricata-update 1.2.5


### PR DESCRIPTION
The next Suricata 6.0.x point release needs to be bundled with Suricata-Update 1.2.5.