### PR TITLE
test: do not output non ascii character

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -150,8 +150,10 @@ int DetectContentDataParse(const char *keyword, const char *contentstr,
                         // SCLogDebug("space as part of binary string");
                     }
                     else if (str[i] != ',') {
-                        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid hex code in "
-                                    "content - %s, hex %c. Invalidating signature.", str, str[i]);
+                        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                                "Invalid hex code in "
+                                "content - %s, hex %c. Invalidating signature.",
+                                contentstr, str[i]);
                         goto error;
                     }
                 } else if (escape) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5558

Describe changes:
- Fix CI by not having S-V hang indefinitely because of a non-ascii character in stderr

Replaces #7871 with ticket number

suricata-verify-pr: 939
