### PR TITLE
security: prevents process creation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])
     AC_CHECK_FUNCS([socket setenv select putenv dup2 endgrent endpwent atexit munmap])
+    AC_CHECK_FUNCS([setrlimit])
 
     AC_CHECK_FUNCS([fwrite_unlocked])
 

--- a/doc/userguide/configuration/landlock.rst
+++ b/doc/userguide/configuration/landlock.rst
@@ -1,3 +1,5 @@
+.. _landlock:
+
 Using Landlock LSM
 ==================
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2610,3 +2610,21 @@ detect thread. For each output script, a single state is used. Keep in
 mind that a rule reload temporary doubles the states requirement.
 
 .. _deprecation policy: https://suricata.io/about/deprecation-policy/
+
+.. _suricata-yaml-config-hardening:
+
+Configuration hardening
+-----------------------
+
+The `security` section of suricata.yaml is meant to provide in-depth security configuration options.
+
+Besides landlock, (see :ref:`landlock`), one setting is available.
+`limit-noproc` is a boolean to prevent process creation by Suricata.
+If you do not need Suricata to create other processes (for LUA scripts for instance), enable this to
+call `setrlimit` with `RLIMIT_NPROC` argument (see `man setrlimit`).
+This prevents potential exploits against Suricata to fork a new process,
+even if it does not prevent the call of `exec`.
+
+Beyond suricata.yaml, other ways to harden Suricata are
+- compilation : enabling ASLR and other exploit mitigation techniques.
+- environment : running Suricata on a device that has no direct access to Internet.

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -37,6 +37,11 @@ Major changes
 ~~~~~~~~~~~~~
 - Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
 
+Security changes
+~~~~~~~~~~~~~~~~
+- suricata.yaml now prevents process creation by Suricata by default with `security.limit-noproc`.
+  For more info, see :ref:`suricata-yaml-config-hardening`.
+
 Removals
 ~~~~~~~~
 - The libprelude output plugin has been removed.

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -30,6 +30,12 @@
 #if HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#ifndef OS_WIN32
+#ifdef HAVE_SYS_RESOURCE_H
+// setrlimit
+#include <sys/resource.h>
+#endif
+#endif
 
 #include "suricata.h"
 #include "decode.h"
@@ -2937,6 +2943,21 @@ int SuricataMain(int argc, char **argv)
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
         FatalError(SC_ERR_FATAL, "Engine initialization failed, "
                    "aborting...");
+    }
+
+    int limit_nproc = 0;
+    if (ConfGetBool("security.limit-noproc", &limit_nproc) == 0) {
+        limit_nproc = 0;
+    }
+    if (limit_nproc) {
+#ifdef HAVE_SYS_RESOURCE_H
+        struct rlimit r = { 0, 0 };
+        if (setrlimit(RLIMIT_NPROC, &r) != 0) {
+            SCLogWarning(SC_ERR_SYSCONF, "setrlimit failed to prevent process creation.");
+        }
+#else
+        SCLogWarning(SC_ERR_SYSCONF, "setrlimit unavailable.");
+#endif
     }
 
     SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1100,6 +1100,9 @@ asn1-max-frames: 256
 #  group: suri
 
 security:
+  # if true, prevents process creation from Suricata by calling
+  # setrlimit(RLIMIT_NPROC, 0)
+  limit-noproc: true
   # Use landlock security module under Linux
   landlock:
     enabled: no


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5373

Describe changes:
- optionally calls `setrlimit(RLIMIT_NPROC, 0)` to prevent process creation by Suricata process

Modifies #7914 with
- delayed call to setrlimit so that all threads have been created
- improved doc


I tested this way

1. Adding a dummy patch to call `system("ls");` just after potential call of setrlimit

2. Running as some non-root user:
`sudo ./src/suricata -c suricata.yaml -l log -v -k none --pcap=lo -S rules/http2-events.rules --set run-as.user=nonroot --set security.limit-noproc=false`

I see the contents of `ls` displayed

3. Running 
`sudo ./src/suricata -c suricata.yaml -l log -v -k none --pcap=lo -S rules/http2-events.rules --set run-as.user=ubuntu --set security.limit-noproc=true`

I no longer see the contents of `ls` displayed

Then running `kill -USR2 22432` with 22432 being the suricata PID
I get 
```
[22432] 26/9/2022 -- 09:43:44 - (detect-engine.c:4446) <Notice> (DetectEngineReload) -- rule reload starting
[22432] 26/9/2022 -- 09:43:44 - (detect-engine-loader.c:361) <Info> (SigLoadSignatures) -- 1 rule files processed. 12 rules successfully loaded, 0 rules failed
[22432] 26/9/2022 -- 09:43:44 - (detect-engine-build.c:1483) <Info> (SigAddressPrepareStage1) -- 12 signatures processed. 0 are IP-only rules, 0 are inspecting packet payload, 12 inspect application layer, 0 are decoder event only
[22432] 26/9/2022 -- 09:43:44 - (detect-engine-build.c:1780) <Info> (SigAddressCleanupStage1) -- cleaning up signature grouping structure... complete
[22432] 26/9/2022 -- 09:43:44 - (detect-engine.c:4520) <Notice> (DetectEngineReload) -- rule reload complete
```
