### PR TITLE
stream: fix reachable assertion

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4941,8 +4941,6 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
 
     SCLogDebug("p->pcap_cnt %"PRIu64, p->pcap_cnt);
 
-    HandleThreadId(tv, p, stt);
-
     TcpSession *ssn = (TcpSession *)p->flow->protoctx;
 
     /* track TCP flags */
@@ -5364,6 +5362,8 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueueNoLock *pq)
         StatsIncr(tv, stt->counter_tcp_no_flow);
         return TM_ECODE_OK;
     }
+
+    HandleThreadId(tv, p, stt);
 
     /* only TCP packets with a flow from here */
 


### PR DESCRIPTION
Fix `Flow::thread_id` not always getting properly set up, leading to a reachable assertion.

Bug #4582.