### PR TITLE
Smb file multiflow 4861 v7

### DIFF
--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -175,3 +175,18 @@ Updating Filestore Configuration
 .. toctree::
 
    config-update
+
+File extraction over multiple flows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Protocols such as HTTP and SMB allow to transfer a file using multiple flows.
+For example in HTTP, this is done with the `Range` header in requests.
+
+Suricata can manage to recombine the parts of files seen in the multiple flows
+to run the logic on the reassembled file.
+
+This is done using a hash table which has a timeout and a maximum memory capacity.
+These can be configured in suricata.yaml in `app-layer.protocols.protocol.byterange` sections,
+where `protocol` can be http or smb.
+
+The default memcap is 100 Mbytes and the default timeout is 60 seconds.

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -91,7 +91,7 @@ exclude = [
     "DetectEngineState",
     "Flow",
     "StreamingBufferConfig",
-    "HttpRangeContainerBlock",
+    "FileRangeContainerBlock",
     "FileContainer",
     "JsonT",
     "IKEState",

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -146,14 +146,14 @@ pub type AppLayerDecoderEventsFreeEventsFunc =
 pub enum StreamingBufferConfig {}
 
 // Opaque flow type (defined in C)
-pub enum HttpRangeContainerBlock {}
+pub enum FileRangeContainerBlock {}
 
-pub type SCHttpRangeFreeBlock = extern "C" fn (
-        c: *mut HttpRangeContainerBlock);
+pub type SCFileRangeFreeBlock = extern "C" fn (
+        c: *mut FileRangeContainerBlock);
 pub type SCHTPFileCloseHandleRange = extern "C" fn (
         fc: *mut FileContainer,
         flags: u16,
-        c: *mut HttpRangeContainerBlock,
+        c: *mut FileRangeContainerBlock,
         data: *const u8,
         data_len: u32) -> bool;
 pub type SCFileOpenFileWithId = extern "C" fn (
@@ -201,7 +201,7 @@ pub struct SuricataContext {
     AppLayerDecoderEventsFreeEvents: AppLayerDecoderEventsFreeEventsFunc,
     pub AppLayerParserTriggerRawStreamReassembly: AppLayerParserTriggerRawStreamReassemblyFunc,
 
-    pub HttpRangeFreeBlock: SCHttpRangeFreeBlock,
+    pub FileRangeFreeBlock: SCFileRangeFreeBlock,
     pub HTPFileCloseHandleRange: SCHTPFileCloseHandleRange,
 
     pub FileOpenFile: SCFileOpenFileWithId,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -133,7 +133,7 @@ pub struct HTTP2Transaction {
     pub frames_ts: Vec<HTTP2Frame>,
 
     decoder: decompression::HTTP2Decoder,
-    pub file_range: *mut HttpRangeContainerBlock,
+    pub file_range: *mut FileRangeContainerBlock,
 
     pub tx_data: AppLayerTxData,
     pub ft_tc: FileTransferTracker,
@@ -181,7 +181,7 @@ impl HTTP2Transaction {
                         std::ptr::null_mut(),
                         0,
                     );
-                    (c.HttpRangeFreeBlock)(self.file_range);
+                    (c.FileRangeFreeBlock)(self.file_range);
                     self.file_range = std::ptr::null_mut();
                 }
             }
@@ -445,7 +445,7 @@ impl HTTP2State {
                             std::ptr::null_mut(),
                             0,
                         );
-                        (c.HttpRangeFreeBlock)(tx.file_range);
+                        (c.FileRangeFreeBlock)(tx.file_range);
                         tx.file_range = std::ptr::null_mut();
                     }
                 }
@@ -486,7 +486,7 @@ impl HTTP2State {
                                 std::ptr::null_mut(),
                                 0,
                             );
-                            (c.HttpRangeFreeBlock)(tx.file_range);
+                            (c.FileRangeFreeBlock)(tx.file_range);
                             tx.file_range = std::ptr::null_mut();
                         }
                     }

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -21,6 +21,7 @@ use crate::core::{
 };
 use crate::filecontainer::FileContainer;
 use crate::http2::http2::HTTP2Transaction;
+use crate::range::FileContentRange;
 
 use nom7::branch::alt;
 use nom7::bytes::streaming::{take_till, take_while};
@@ -30,14 +31,6 @@ use nom7::error::{make_error, ErrorKind};
 use nom7::{Err, IResult};
 use std::os::raw::c_uchar;
 use std::str::FromStr;
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct FileContentRange {
-    pub start: i64,
-    pub end: i64,
-    pub size: i64,
-}
 
 pub fn http2_parse_content_range_star<'a>(input: &'a [u8]) -> IResult<&'a [u8], FileContentRange> {
     let (i2, _) = char('*')(input)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -102,6 +102,7 @@ pub mod filecontainer;
 pub mod filetracker;
 pub mod kerberos;
 pub mod detect;
+pub mod range;
 
 #[cfg(feature = "lua")]
 pub mod lua;

--- a/rust/src/range.rs
+++ b/rust/src/range.rs
@@ -1,0 +1,24 @@
+/* Copyright (C) 2022 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+*/
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct FileContentRange {
+    pub start: i64,
+    pub end: i64,
+    pub size: i64,
+}

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -22,8 +22,10 @@ use crate::filecontainer::*;
 
 use crate::smb::smb::*;
 
+use std::os::raw::c_uchar;
+
 /// File tracking transaction. Single direction only.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SMBTransactionFile {
     pub direction: Direction,
     pub fuid: Vec<u8>,
@@ -33,13 +35,43 @@ pub struct SMBTransactionFile {
     /// after a gap, this will be set to a time in the future. If the file
     /// receives no updates before that, it will be considered complete.
     pub post_gap_ts: u64,
+    pub file_range: *mut FileRangeContainerBlock,
+    pub multi: bool,
 }
 
 impl SMBTransactionFile {
     pub fn new() -> Self {
         return Self {
             file_tracker: FileTransferTracker::new(),
-            ..Default::default()
+            file_range: std::ptr::null_mut(),
+            multi: false,
+            post_gap_ts: 0,
+            direction: Direction::default(),
+            fuid: Vec::new(),
+            file_name: Vec::new(),
+            share_name: Vec::new(),
+        }
+    }
+}
+
+impl Drop for SMBTransactionFile {
+    fn drop(&mut self) {
+        // should have been already closed on real traffic
+        // but fuzzing does not cleanly times out flows with
+        // pseudo-packets cf fuzz_sigpcap FlowReset
+        if !self.file_range.is_null() {
+            if let Some(c) = unsafe { SC } {
+                //TODO get a file container instead of NULL
+                (c.HTPFileCloseHandleRange)(
+                    std::ptr::null_mut(),
+                    0,
+                    self.file_range,
+                    std::ptr::null_mut(),
+                    0,
+                );
+                (c.FileRangeFreeBlock)(self.file_range);
+                self.file_range = std::ptr::null_mut();
+            }
         }
     }
 }
@@ -55,6 +87,13 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
                     chunk_size, 0, is_last, xid); }
         None => panic!("no SURICATA_SMB_FILE_CONFIG"),
     }
+}
+
+// Defined in app-layer-htp-range.h
+extern "C" {
+    pub fn FileRangeAppendData(
+        c: *mut FileRangeContainerBlock, data: *const c_uchar, data_len: u32,
+    ) -> std::os::raw::c_int;
 }
 
 impl SMBState {
@@ -122,7 +161,7 @@ impl SMBState {
 
     // update in progress chunks for file transfers
     // return how much data we consumed
-    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32) -> u32 {
+    pub fn filetracker_update(&mut self, direction: Direction, data: &[u8], gap_size: u32, eof: bool) -> u32 {
         let mut chunk_left = if direction == Direction::ToServer {
             self.file_ts_left
         } else {
@@ -175,6 +214,32 @@ impl SMBState {
                     }
 
                     let file_data = &data[0..data_to_handle_len];
+                    if !tdf.file_range.is_null() {
+                        unsafe {
+                            FileRangeAppendData(tdf.file_range, file_data.as_ptr(), data_to_handle_len as u32);
+                        }
+                        if chunk_left == 0 || eof {
+                            let added = if let Some(c) = unsafe { SC } {
+                                let added = (c.HTPFileCloseHandleRange)(
+                                    files,
+                                    flags,
+                                    tdf.file_range,
+                                    std::ptr::null_mut(),
+                                    0,
+                                );
+                                (c.FileRangeFreeBlock)(tdf.file_range);
+                                added
+                            } else {
+                                false
+                            };
+                            tdf.file_range = std::ptr::null_mut();
+                            if added {
+                                tx.tx_data.incr_files_opened();
+                            }
+                        }
+                    }
+
+                    //TODOsmbmulti5 use eof ?
                     let cs = tdf.file_tracker.update(files, flags, file_data, gap_size);
                     cs
                 } else {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1399,7 +1399,7 @@ impl SMBState {
                                         SCLogDebug!("SMB2: partial record {}",
                                                 &smb2_command_string(smb_record.command));
                                         if smb_record.command == SMB2_COMMAND_WRITE {
-                                            smb2_write_request_record(flow, self, smb_record);
+                                            smb2_write_request_record(flow, self, smb_record, nbss_part_hdr.length as usize - nbss_part_hdr.data.len());
 
                                             self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                             self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -374,8 +374,22 @@ pub fn parse_smb2_request_setinfo_disposition(i: &[u8]) -> IResult<&[u8], Smb2Se
 }
 
 #[derive(Debug)]
+pub struct Smb2SetInfoRequestEof {
+    pub eof: u64,
+}
+
+pub fn parse_smb2_request_setinfo_eof(i: &[u8]) -> IResult<&[u8], Smb2SetInfoRequestData> {
+    let (i, eof) = le_u64(i)?;
+    let record = Smb2SetInfoRequestData::EOF(Smb2SetInfoRequestEof {
+        eof: eof,
+    });
+    Ok((i, record))
+}
+
+#[derive(Debug)]
 pub enum Smb2SetInfoRequestData<'a> {
     DISPOSITION(Smb2SetInfoRequestDispoRecord),
+    EOF(Smb2SetInfoRequestEof),
     RENAME(Smb2SetInfoRequestRenameRecord<'a>),
     UNHANDLED,
 }
@@ -399,6 +413,9 @@ fn parse_smb2_request_setinfo_data(
             }
             0xd => {
                 return parse_smb2_request_setinfo_disposition(i);
+            }
+            0x14 => {
+                return parse_smb2_request_setinfo_eof(i);
             }
             _ => {}
         }

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -29,11 +29,11 @@
 
 int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t,
         uint64_t, uint8_t);
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);
+int HTPParseContentRange(bstr *rawvalue, FileContentRange *range);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
         uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(
-        FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+        FileContainer *, const uint16_t, FileRangeContainerBlock *, const uint8_t *, uint32_t);
 int HTPFileStoreChunk(HtpState *, const uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, HtpTxUserData *, const uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -187,10 +187,9 @@ void FileRangeContainersDestroy(void)
     THashShutdown(ContainerUrlRangeList.ht);
 }
 
-uint32_t HttpRangeContainersTimeoutHash(struct timeval *ts)
+void HttpRangeContainersTimeoutHash(struct timeval *ts)
 {
     SCLogDebug("timeout: starting");
-    uint32_t cnt = 0;
 
     for (uint32_t i = 0; i < ContainerUrlRangeList.ht->config.hash_size; i++) {
         THashHashRow *hb = &ContainerUrlRangeList.ht->array[i];
@@ -231,7 +230,6 @@ uint32_t HttpRangeContainersTimeoutHash(struct timeval *ts)
     }
 
     SCLogDebug("timeout: ending");
-    return cnt;
 }
 
 /**

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -41,6 +41,8 @@ typedef struct HttpRangeContainerBuffer {
     uint64_t offset;
     /** number of gaped bytes */
     uint64_t gap;
+    /** pointer to hashtable, for memuse */
+    THashTableContext *ht;
 } HttpRangeContainerBuffer;
 
 int HttpRangeContainerBufferCompare(HttpRangeContainerBuffer *a, HttpRangeContainerBuffer *b);
@@ -66,6 +68,8 @@ typedef struct FileRangeContainerFile {
     uint32_t expire;
     /** pointer to hashtable data, for locking and use count */
     THashData *hdata;
+    /** pointer to hashtable, for memuse */
+    THashTableContext *ht;
     /** total expected size of the file in ranges */
     uint64_t totalsize;
     /** size of the file after last sync */
@@ -105,6 +109,13 @@ FileRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, ui
         const unsigned char *name, uint16_t name_len, uint16_t flags, const unsigned char *data,
         uint32_t data_len);
 
+FileRangeContainerBlock *SmbRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,
+        const Flow *f, const FileContentRange *cr, const StreamingBufferConfig *sbcfg,
+        const unsigned char *name, uint16_t name_len, uint16_t flags, const unsigned char *data,
+        uint32_t data_len);
+
 void FileRangeFreeBlock(FileRangeContainerBlock *b);
+
+FileRangeContainerFile *SmbRangeContainerUrlGet(const uint8_t *key, uint32_t keylen, const Flow *f);
 
 #endif /* __APP_LAYER_HTP_RANGE_H__ */

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -25,7 +25,7 @@
 
 void FileRangeContainersInit(void);
 void FileRangeContainersDestroy(void);
-uint32_t HttpRangeContainersTimeoutHash(struct timeval *ts);
+void HttpRangeContainersTimeoutHash(struct timeval *ts);
 
 // linked list of ranges : buffer with offset
 typedef struct HttpRangeContainerBuffer {

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -404,7 +404,7 @@ void HTPStateFree(void *state)
 
     if (s->file_range) {
         HTPFileCloseHandleRange(s->files_tc, 0, s->file_range, NULL, 0);
-        HttpRangeFreeBlock(s->file_range);
+        FileRangeFreeBlock(s->file_range);
     }
 
     FileContainerFree(s->files_ts);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -258,7 +258,7 @@ typedef struct HtpState_ {
     uint16_t events;
     uint16_t htp_messages_offset; /**< offset into conn->messages list */
     uint32_t file_track_id;             /**< used to assign file track ids to files */
-    HttpRangeContainerBlock *file_range; /**< used to assign track ids to range file */
+    FileRangeContainerBlock *file_range; /**< used to assign track ids to range file */
     uint64_t last_request_data_stamp;
     uint64_t last_response_data_stamp;
     StreamSlice *slice;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -250,7 +250,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
             jb_open_object(js, "content_range");
             jb_set_string_from_bytes(
                     js, "raw", bstr_ptr(h_content_range->value), bstr_len(h_content_range->value));
-            HTTPContentRange crparsed;
+            FileContentRange crparsed;
             if (HTPParseContentRange(h_content_range->value, &crparsed) == 0) {
                 if (crparsed.start >= 0)
                     jb_set_uint(js, "start", crparsed.start);

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -29,7 +29,7 @@ const SuricataContext suricata_context = {
     AppLayerDecoderEventsFreeEvents,
     AppLayerParserTriggerRawStreamReassembly,
 
-    HttpRangeFreeBlock,
+    FileRangeFreeBlock,
     HTPFileCloseHandleRange,
 
     FileOpenFileWithId,

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -26,7 +26,7 @@
 #include "app-layer-tftp.h" //TFTPState, TFTPTransaction
 
 // hack for include orders cf SCSha256
-typedef struct HttpRangeContainerBlock HttpRangeContainerBlock;
+typedef struct FileRangeContainerBlock FileRangeContainerBlock;
 
 struct AppLayerParser;
 
@@ -39,9 +39,9 @@ typedef struct SuricataContext_ {
     void (*AppLayerDecoderEventsFreeEvents)(AppLayerDecoderEvents **);
     void (*AppLayerParserTriggerRawStreamReassembly)(Flow *, int direction);
 
-    void (*HttpRangeFreeBlock)(HttpRangeContainerBlock *);
+    void (*FileRangeFreeBlock)(FileRangeContainerBlock *);
     bool (*HTPFileCloseHandleRange)(
-            FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+            FileContainer *, const uint16_t, FileRangeContainerBlock *, const uint8_t *, uint32_t);
 
     int (*FileOpenFileWithId)(FileContainer *, const StreamingBufferConfig *,
         uint32_t track_id, const uint8_t *name, uint16_t name_len,

--- a/src/rust.h
+++ b/src/rust.h
@@ -20,7 +20,7 @@
 
 #include "util-lua.h"
 // hack for include orders cf SCSha256
-typedef struct HttpRangeContainerBlock HttpRangeContainerBlock;
+typedef struct FileRangeContainerBlock FileRangeContainerBlock;
 #include "detect-engine-state.h"
 #include "rust-context.h"
 #include "rust-bindings.h"

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -405,7 +405,7 @@ static void GlobalsDestroy(SCInstance *suri)
     AppLayerDeSetup();
     DatasetsSave();
     DatasetsDestroy();
-    HttpRangeContainersDestroy();
+    FileRangeContainersDestroy();
     TagDestroyCtx();
 
     LiveDeviceListClean();
@@ -2153,7 +2153,7 @@ static int InitSignalHandler(SCInstance *suri)
  * Will be run once per pcap in unix-socket mode */
 void PreRunInit(const int runmode)
 {
-    HttpRangeContainersInit();
+    FileRangeContainersInit();
     if (runmode == RUNMODE_UNIX_SOCKET)
         return;
 

--- a/src/tests/app-layer-htp-file.c
+++ b/src/tests/app-layer-htp-file.c
@@ -25,7 +25,7 @@
 
 static int AppLayerHtpFileParseContentRangeTest01 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 12-25/100");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 12);
@@ -42,7 +42,7 @@ static int AppLayerHtpFileParseContentRangeTest01 (void)
 
 static int AppLayerHtpFileParseContentRangeTest02 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-27514354/");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -56,7 +56,7 @@ static int AppLayerHtpFileParseContentRangeTest02 (void)
 
 static int AppLayerHtpFileParseContentRangeTest03 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 15335424-");
     FAIL_IF(HTPParseContentRange(rawvalue, &range) == 0);
     bstr_free(rawvalue);
@@ -71,7 +71,7 @@ static int AppLayerHtpFileParseContentRangeTest03 (void)
 
 static int AppLayerHtpFileParseContentRangeTest04 (void)
 {
-    HTTPContentRange range;
+    FileContentRange range;
     bstr * rawvalue = bstr_dup_c("bytes 24-42/*");
     FAIL_IF_NOT(HTPParseContentRange(rawvalue, &range) == 0);
     FAIL_IF_NOT(range.start == 24);

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -156,7 +156,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             if (FlowChangeProto(f)) {
                 // exits if a protocol change is requested
                 alsize = 0;
-                break;
+                goto exit;
             }
             flags &= ~(STREAM_START);
             if (f->alparser &&
@@ -196,8 +196,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         memcpy(isolatedBuffer, albuffer, alsize);
         (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alsize);
         free(isolatedBuffer);
+        if (FlowChangeProto(f)) {
+            goto exit;
+        }
     }
 
+    (void)AppLayerParserParse(NULL, alp_tctx, f, f->alproto, STREAM_TOCLIENT | STREAM_EOF, NULL, 0);
+    if (FlowChangeProto(f)) {
+        goto exit;
+    }
+    (void)AppLayerParserParse(NULL, alp_tctx, f, f->alproto, STREAM_TOSERVER | STREAM_EOF, NULL, 0);
+exit:
     FLOWLOCK_UNLOCK(f);
     FlowFree(f);
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -820,6 +820,20 @@ int FileSetRange(FileContainer *ffc, uint64_t start, uint64_t end)
     SCReturnInt(0);
 }
 
+void FileSetName(File *f, const uint8_t *name, uint16_t name_len)
+{
+    if (f->name != NULL) {
+        SCFree(f->name);
+    }
+    f->name = SCMalloc(name_len);
+    if (f->name == NULL) {
+        return;
+    }
+
+    f->name_len = name_len;
+    memcpy(f->name, name, name_len);
+}
+
 /**
  *  \brief Open a new File
  *

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -193,6 +193,15 @@ void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
 int FileSetRange(FileContainer *, uint64_t start, uint64_t end);
 
 /**
+ *  \brief Sets the name for a file.
+ *
+ *  \param ffc the file
+ *  \param filename the name
+ *  \param name_len the name's length
+ */
+void FileSetName(File *, const uint8_t *filename, uint16_t name_len);
+
+/**
  *  \brief Tag a file for storing
  *
  *  \param ff The file to store


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4861

Describe changes:
- smb : handle multi-stream file transfers

Modifies #7929 with removing an assertion that gets triggered by fuzzing even if not on real traffic, as fuzz targets do not cleanly timeout flows... And checking a return value against NULL when memcap is reached
So, CI should be all green now

Actually, the last commit looks like a bug in current SMB implementation, all over the place.
And I think this should be fixed before adding this new fancy feature. Thoughts @victorjulien ?

This is a draft for feedback.

Questions :
- Should we handle reads as writes ?
- This draft is SMB2 only, would we want SMB1 ?
Style questions :
- Should we move `ContainerTHashTable ContainerSmbHt` to app-layer-smb.c ?
- Should app-layer-htp-range.h be renamed util-file-range.h ?
- Should we make `HTPFileCloseHandleRange` generic ?

_Blocker question_
Also, the current multi-stream logic will not log a file until it is complete.
Because there may be a new flow coming that will complete the file.
And because to log it, we have to move its ownership from the global hash table to the transaction which will end up freeing it...
Thoughts about this @victorjulien ?
I now think the ownership should not be moved back to a transaction and the logging happen on its own...

Could logging be called from `HttpRangeContainersTimeoutHash` ? which gets called by `FlowManager`
logging being `OutputFileLogFfc`

TODOs:
- There are other SMB tickets to create based on the comments
- get the answers to the questions above and act on them
