### PR TITLE
dpdk: count number of packets with invalid checksum v4

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -41,13 +41,13 @@
 #include "util-napatech.h"
 #endif /* HAVE_NAPATECH */
 
-
 typedef enum {
     CHECKSUM_VALIDATION_DISABLE,
     CHECKSUM_VALIDATION_ENABLE,
     CHECKSUM_VALIDATION_AUTO,
     CHECKSUM_VALIDATION_RXONLY,
     CHECKSUM_VALIDATION_KERNEL,
+    CHECKSUM_VALIDATION_OFFLOAD,
 } ChecksumValidationMode;
 
 enum PktSrcEnum {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1160,7 +1160,7 @@ static int DeviceConfigure(DPDKIfaceConfig *iconf)
     DeviceInitPortConf(iconf, &dev_info, &port_conf);
     if (port_conf.rxmode.offloads & DEV_RX_OFFLOAD_CHECKSUM) {
         // Suricata does not need recalc checksums now
-        iconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
+        iconf->checksum_mode = CHECKSUM_VALIDATION_OFFLOAD;
     }
 
     retval = rte_eth_dev_configure(

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -369,16 +369,34 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
             }
             PKT_SET_SRC(p, PKT_SRC_WIRE);
             p->datalink = LINKTYPE_ETHERNET;
-            if (ptv->checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
-                p->flags |= PKT_IGNORE_CHECKSUM;
-            }
-
             DPDKSetTimevalReal(&ptv->machine_start_time, &p->ts);
             p->dpdk_v.mbuf = ptv->received_mbufs[i];
             p->ReleasePacket = DPDKReleasePacket;
             p->dpdk_v.copy_mode = ptv->copy_mode;
             p->dpdk_v.out_port_id = ptv->out_port_id;
             p->dpdk_v.out_queue_id = ptv->queue_id;
+            p->livedev = ptv->livedev;
+
+            if (ptv->checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
+                p->flags |= PKT_IGNORE_CHECKSUM;
+            } else if (ptv->checksum_mode == CHECKSUM_VALIDATION_OFFLOAD) {
+                uint64_t ol_flags = ptv->received_mbufs[i]->ol_flags;
+                if ((ol_flags & RTE_MBUF_F_RX_IP_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_GOOD &&
+                        (ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_L4_CKSUM_GOOD) {
+                    SCLogDebug("HW detected GOOD IP and L4 chsum, ignoring validation");
+                    p->flags |= PKT_IGNORE_CHECKSUM;
+                } else {
+                    if ((ol_flags & RTE_MBUF_F_RX_IP_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_BAD) {
+                        SCLogDebug("HW detected BAD IP checksum");
+                        // chsum recalc will not be triggered but rule keyword check will be
+                        p->level3_comp_csum = 0;
+                    }
+                    if ((ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_L4_CKSUM_BAD) {
+                        SCLogDebug("HW detected BAD L4 chsum");
+                        p->level4_comp_csum = 0;
+                    }
+                }
+            }
 
             PacketSetData(p, rte_pktmbuf_mtod(p->dpdk_v.mbuf, uint8_t *),
                     rte_pktmbuf_pkt_len(p->dpdk_v.mbuf));

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -364,6 +364,7 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
         for (uint16_t i = 0; i < nb_rx; i++) {
             p = PacketGetFromQueueOrAlloc();
             if (unlikely(p == NULL)) {
+                DPDKFreeMbufArray(ptv->received_mbufs, 1, i);
                 continue;
             }
             PKT_SET_SRC(p, PKT_SRC_WIRE);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -510,6 +510,48 @@ fail:
     SCReturnInt(TM_ECODE_FAILED);
 }
 
+static void PrintDPDKPortXstats(uint32_t port_id, const char *port_name)
+{
+    struct rte_eth_xstat *xstats;
+    struct rte_eth_xstat_name *xstats_names;
+
+    int32_t len = rte_eth_xstats_get(port_id, NULL, 0);
+    if (len < 0)
+        FatalError(SC_ERR_DPDK_CONF, "Error (%s) getting count of rte_eth_xstats failed on port %s",
+                rte_strerror(-len), port_name);
+
+    xstats = SCCalloc(len, sizeof(*xstats));
+    if (xstats == NULL)
+        FatalError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for the rte_eth_xstat structure");
+
+    int32_t ret = rte_eth_xstats_get(port_id, xstats, len);
+    if (ret < 0 || ret > len) {
+        SCFree(xstats);
+        FatalError(SC_ERR_DPDK_CONF, "Error (%s) getting rte_eth_xstats failed on port %s",
+                rte_strerror(-ret), port_name);
+    }
+    xstats_names = SCCalloc(len, sizeof(*xstats_names));
+    if (xstats_names == NULL) {
+        SCFree(xstats);
+        FatalError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for the rte_eth_xstat_name array");
+    }
+    ret = rte_eth_xstats_get_names(port_id, xstats_names, len);
+    if (ret < 0 || ret > len) {
+        SCFree(xstats);
+        SCFree(xstats_names);
+        FatalError(SC_ERR_DPDK_CONF, "Error (%s) getting names of rte_eth_xstats failed on port %s",
+                rte_strerror(-ret), port_name);
+    }
+    for (int32_t i = 0; i < len; i++) {
+        if (xstats[i].value > 0)
+            SCLogPerf("Port %u (%s) - %s: %" PRIu64, port_id, port_name, xstats_names[i].name,
+                    xstats[i].value);
+    }
+
+    SCFree(xstats);
+    SCFree(xstats_names);
+}
+
 /**
  * \brief This function prints stats to the screen at exit.
  * \param tv pointer to ThreadVars
@@ -531,6 +573,9 @@ static void ReceiveDPDKThreadExitStats(ThreadVars *tv, void *data)
                     ptv->port_id, strerror(-retval));
             SCReturn;
         }
+
+        PrintDPDKPortXstats(ptv->port_id, port_name);
+
         retval = rte_eth_stats_get(ptv->port_id, &eth_stats);
         if (unlikely(retval != 0)) {
             SCLogError(SC_ERR_STAT, "Failed to get stats for interface %s: %s", port_name,


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5553) ticket:

Follow up of #7937

Describe changes:
- PR comments
- packets with invalid checksum are not immediately released, but, instead are only flagged for a match on invalid L3/L4 invalid checksum rule keywords in decode/detect modules