### PR TITLE
Make rule_perf.log JSON output newline-delimited

### DIFF
--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -347,7 +347,7 @@ static void DumpJson(FILE *fp, SCProfileSummary *summary,
 
     if (unlikely(js_s == NULL))
         return;
-    fprintf(fp, "%s", js_s);
+    fprintf(fp, "%s\n", js_s);
     free(js_s);
     json_decref(js);
 }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

☝🏻 N/A (I think... the guide does not speak to the `rule_perf.log` JSON format)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5562

Describe changes:

When rules profiling is turned on and configured for JSON output with no explicit sort order, all 7 orders are written to `rule_perf.log` as JSON objects concatenated without any delimiters or top-level JSON type. In this case the content of `rule_perf.log` is not valid JSON.

I suspect this bug was introduced in 75907fce0662b500b280a0493524daf06523aaae, in which case it would affect 4.0.0+ (but I have not confirmed this).

This change adds a newline making the `rule_perf.log` output valid a valid "newline-delimited JSON" which should be familiar to suricata users (like `eve.json`) and also easy to work with (i.e., reading with `jq`).

It is also a much simpler change than introducing a top-level structure like a JSON array (which would sometimes only have one element) to make the whole file's contents a valid JSON object.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
