### PR TITLE
rust: clippy fixups plus ci check - v1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,77 @@
+name: Check Rust
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check-rust:
+    name: Check Rust
+    runs-on: ubuntu-latest
+    container: almalinux:9
+    steps:
+      - name: Cache rust
+        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+        with:
+          path: ~/.cargo
+          key: check-rust
+
+      - name: Install system packages
+        run: |
+          dnf -y install dnf-plugins-core
+          dnf config-manager --set-enabled crb
+          dnf -y install \
+                autoconf \
+                automake \
+                cargo-vendor \
+                diffutils \
+                numactl-devel \
+                dpdk-devel \
+                file-devel \
+                gcc \
+                gcc-c++ \
+                git \
+                jansson-devel \
+                jq \
+                lua-devel \
+                libtool \
+                libyaml-devel \
+                libnfnetlink-devel \
+                libnetfilter_queue-devel \
+                libnet-devel \
+                libcap-ng-devel \
+                libevent-devel \
+                libmaxminddb-devel \
+                libpcap-devel \
+                libtool \
+                lz4-devel \
+                make \
+                nss-devel \
+                pcre2-devel \
+                pkgconfig \
+                python3-devel \
+                python3-sphinx \
+                python3-yaml \
+                sudo \
+                which \
+                zlib-devel
+
+      - name: Installing Rust
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install cbindgen
+        run: cargo install --debug cbindgen
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - run: ./scripts/bundle.sh
+      - run: ./autogen.sh
+      - run: ./configure
+      - run: cargo clippy --fix
+        working-directory: rust
+      - run: |
+          diff=$(git diff)
+          if [ "${diff}" ]; then
+              echo "::warning ::Clippy --fix made changes, please fix"
+          fi
+      - run: cargo clippy
+        working-directory: rust

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -662,18 +662,16 @@ pub trait AppLayerFrameType {
     fn to_cstring(&self) -> *const std::os::raw::c_char;
 
     /// Converts a C string formatted name to a frame type ID.
-    extern "C" fn ffi_id_from_name(name: *const std::os::raw::c_char) -> i32 where Self: Sized {
+    unsafe extern "C" fn ffi_id_from_name(name: *const std::os::raw::c_char) -> i32 where Self: Sized {
         if name.is_null() {
             return -1;
         }
-        unsafe {
-            let frame_id = if let Ok(s) = std::ffi::CStr::from_ptr(name).to_str() {
-                Self::from_str(s).map(|t| t.as_u8() as i32).unwrap_or(-1)
-            } else {
-                -1
-            };
-            frame_id
-        }
+        let frame_id = if let Ok(s) = std::ffi::CStr::from_ptr(name).to_str() {
+            Self::from_str(s).map(|t| t.as_u8() as i32).unwrap_or(-1)
+        } else {
+            -1
+        };
+        frame_id
     }
 
     /// Converts a variant ID to an FFI safe name.

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -678,6 +678,6 @@ pub trait AppLayerFrameType {
 
     /// Converts a variant ID to an FFI safe name.
     extern "C" fn ffi_name_from_id(id: u8) -> *const std::os::raw::c_char where Self: Sized {
-        Self::from_u8(id).map(|s| s.to_cstring()).unwrap_or_else(|| std::ptr::null())
+        Self::from_u8(id).map(|s| s.to_cstring()).unwrap_or_else(std::ptr::null)
     }
 }

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -134,10 +134,10 @@ impl Default for AppLayerTxData {
 
 impl Drop for AppLayerTxData {
     fn drop(&mut self) {
-        if self.de_state != std::ptr::null_mut() {
+        if !self.de_state.is_null() {
             core::sc_detect_engine_state_free(self.de_state);
         }
-        if self.events != std::ptr::null_mut() {
+        if !self.events.is_null() {
             core::sc_app_layer_decoder_events_free_events(&mut self.events);
         }
     }

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1094,9 +1094,9 @@ fn evaluate_stub_params(
     input: &[u8], input_len: u16, hdrflags: u8, lenleft: u16,
     stub_data_buffer: &mut Vec<u8>,stub_data_buffer_reset: &mut bool,
 ) -> u16 {
-    let stub_len: u16;
+    
     let fragtype = hdrflags & (PFC_FIRST_FRAG | PFC_LAST_FRAG);
-    stub_len = cmp::min(lenleft, input_len);
+    let stub_len: u16 = cmp::min(lenleft, input_len);
     if stub_len == 0 {
         return 0;
     }

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -86,7 +86,7 @@ fn match_backuuid(
             }
 
             if let Some(x) = &if_data.du16 {
-                if !detect_match_uint(&x, uuidentry.version) {
+                if !detect_match_uint(x, uuidentry.version) {
                     SCLogDebug!("Interface version did not match");
                     ret &= 0;
                 }

--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -123,14 +123,14 @@ fn log_dcerpc_header_udp(
 
 #[no_mangle]
 pub extern "C" fn rs_dcerpc_log_json_record_tcp(
-    state: &DCERPCState, tx: &DCERPCTransaction, mut jsb: &mut JsonBuilder,
+    state: &DCERPCState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
 ) -> bool {
-    log_dcerpc_header_tcp(&mut jsb, state, tx).is_ok()
+    log_dcerpc_header_tcp(jsb, state, tx).is_ok()
 }
 
 #[no_mangle]
 pub extern "C" fn rs_dcerpc_log_json_record_udp(
-    state: &DCERPCUDPState, tx: &DCERPCTransaction, mut jsb: &mut JsonBuilder,
+    state: &DCERPCUDPState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
 ) -> bool {
-    log_dcerpc_header_udp(&mut jsb, state, tx).is_ok()
+    log_dcerpc_header_udp(jsb, state, tx).is_ok()
 }

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -469,7 +469,7 @@ mod tests {
             nbytes: nbytes,
             offset: offset,
             oper: oper,
-            rvalue_str: if rvalue_str != "" {
+            rvalue_str: if !rvalue_str.is_empty() {
                 CString::new(rvalue_str).unwrap().into_raw()
             } else {
                 std::ptr::null_mut()

--- a/rust/src/detect/iprep.rs
+++ b/rust/src/detect/iprep.rs
@@ -76,7 +76,7 @@ extern "C" {
 
 pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData> {
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, cmd) = map_res(alpha0, |s: &str| DetectIPRepDataCmd::from_str(s))(i)?;
+    let (i, cmd) = map_res(alpha0, DetectIPRepDataCmd::from_str)(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = char(',')(i)?;
     let (i, _) = opt(is_a(" "))(i)?;

--- a/rust/src/detect/stream_size.rs
+++ b/rust/src/detect/stream_size.rs
@@ -59,7 +59,7 @@ pub struct DetectStreamSizeData {
 
 pub fn detect_parse_stream_size(i: &str) -> IResult<&str, DetectStreamSizeData> {
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, flags) = map_res(alpha0, |s: &str| DetectStreamSizeDataFlags::from_str(s))(i)?;
+    let (i, flags) = map_res(alpha0, DetectStreamSizeDataFlags::from_str)(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = char(',')(i)?;
     let (i, _) = opt(is_a(" "))(i)?;

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -42,7 +42,7 @@ fn parse_opcode(opcode: &str) -> Result<DetectDnsOpcode, ()> {
                 negated = true;
             }
             _ => {
-                let code: u8 = (&opcode[i..]).parse().map_err(|_| ())?;
+                let code: u8 = opcode[i..].parse().map_err(|_| ())?;
                 return Ok(DetectDnsOpcode {
                     negate: negated,
                     opcode: code,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -1474,7 +1474,7 @@ mod tests {
     #[test]
     fn test_dns_event_from_string() {
         let name = "malformed_data";
-        let event = DNSEvent::from_string(&name).unwrap();
+        let event = DNSEvent::from_string(name).unwrap();
         assert_eq!(event, DNSEvent::MalformedData);
         assert_eq!(event.to_cstring(), format!("{}\0", name));
     }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -659,13 +659,13 @@ pub extern "C" fn rs_dns_log_json_query(tx: &mut DNSTransaction,
 
 #[no_mangle]
 pub extern "C" fn rs_dns_log_json_answer(tx: &mut DNSTransaction,
-                                         flags: u64, mut js: &mut JsonBuilder)
+                                         flags: u64, js: &mut JsonBuilder)
                                          -> bool
 {
     if let &Some(ref response) = &tx.response {
         for query in &response.queries {
             if dns_log_rrtype_enabled(query.rrtype, flags) {
-                return dns_log_json_answer(&mut js, response, flags as u64).is_ok();
+                return dns_log_json_answer(js, response, flags as u64).is_ok();
             }
         }
     }

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -49,6 +49,7 @@ impl std::fmt::Debug for Frame {
 }
 
 impl Frame {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn new(
         flow: *const Flow, stream_slice: &StreamSlice, frame_start: &[u8], frame_len: i64,
         frame_type: u8,
@@ -92,18 +93,21 @@ impl Frame {
         }
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_len(&self, flow: *const Flow, len: i64) {
         unsafe {
             AppLayerFrameSetLengthById(flow, self.direction(), self.id, len);
         };
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn set_tx(&self, flow: *const Flow, tx_id: u64) {
         unsafe {
             AppLayerFrameSetTxIdById(flow, self.direction(), self.id, tx_id);
         };
     }
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn add_event(&self, flow: *const Flow, event: u8) {
         unsafe {
             AppLayerFrameAddEventById(flow, self.direction(), self.id, event);

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -256,7 +256,7 @@ fn http2_detect_settings_match(
                     return 1;
                 }
                 Some(x) => {
-                    if detect_match_uint(&x, set[i].value) {
+                    if detect_match_uint(x, set[i].value) {
                         return 1;
                     }
                 }
@@ -309,7 +309,7 @@ fn http2_detect_sizeupdate_match(
 ) -> std::os::raw::c_int {
     for block in blocks.iter() {
         if block.error == parser::HTTP2HeaderDecodeStatus::HTTP2HeaderDecodeSizeUpdate {
-            if detect_match_uint(&ctx, block.sizeupdate) {
+            if detect_match_uint(ctx, block.sizeupdate) {
                 return 1;
             }
         }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -57,7 +57,7 @@ impl std::str::FromStr for HTTP2FrameType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let su = s.to_uppercase();
-        let su_slice: &str = &*su;
+        let su_slice: &str = &su;
         match su_slice {
             "DATA" => Ok(HTTP2FrameType::DATA),
             "HEADERS" => Ok(HTTP2FrameType::HEADERS),
@@ -132,7 +132,7 @@ impl std::str::FromStr for HTTP2ErrorCode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let su = s.to_uppercase();
-        let su_slice: &str = &*su;
+        let su_slice: &str = &su;
         match su_slice {
             "NO_ERROR" => Ok(HTTP2ErrorCode::NOERROR),
             "PROTOCOL_ERROR" => Ok(HTTP2ErrorCode::PROTOCOLERROR),
@@ -702,7 +702,7 @@ impl std::str::FromStr for HTTP2SettingsId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let su = s.to_uppercase();
-        let su_slice: &str = &*su;
+        let su_slice: &str = &su;
         match su_slice {
             "SETTINGS_HEADER_TABLE_SIZE" => Ok(HTTP2SettingsId::SETTINGSHEADERTABLESIZE),
             "SETTINGS_ENABLE_PUSH" => Ok(HTTP2SettingsId::SETTINGSENABLEPUSH),

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -163,7 +163,7 @@ impl IKEState {
             .transactions
             .iter()
             .position(|tx| tx.tx_id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }

--- a/rust/src/ike/parser.rs
+++ b/rust/src/ike/parser.rs
@@ -471,7 +471,7 @@ pub fn parse_sa_attribute(i: &[u8]) -> IResult<&[u8], Vec<SaAttribute>> {
             },
             hex_value: match format.0 {
                 0 => variable_attribute_value
-                    .map(|_variable_attribute_value| to_hex(_variable_attribute_value)),
+                    .map(to_hex),
                 _ => None,
             },
         };

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -732,7 +732,7 @@ pub unsafe extern "C" fn jb_set_string_from_bytes(
 pub unsafe extern "C" fn jb_set_base64(
     js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
 ) -> bool {
-    if bytes == std::ptr::null() || len == 0 {
+    if bytes.is_null() || len == 0 {
         return false;
     }
     if let Ok(key) = CStr::from_ptr(key).to_str() {
@@ -746,7 +746,7 @@ pub unsafe extern "C" fn jb_set_base64(
 pub unsafe extern "C" fn jb_set_hex(
     js: &mut JsonBuilder, key: *const c_char, bytes: *const u8, len: u32,
 ) -> bool {
-    if bytes == std::ptr::null() || len == 0 {
+    if bytes.is_null() || len == 0 {
         return false;
     }
     if let Ok(key) = CStr::from_ptr(key).to_str() {
@@ -805,7 +805,7 @@ pub unsafe extern "C" fn jb_append_string_from_bytes(
 pub unsafe extern "C" fn jb_append_base64(
     js: &mut JsonBuilder, bytes: *const u8, len: u32,
 ) -> bool {
-    if bytes == std::ptr::null() || len == 0 {
+    if bytes.is_null() || len == 0 {
         return false;
     }
     let val = std::slice::from_raw_parts(bytes, len as usize);

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -121,7 +121,7 @@ trait MyFromStr {
 
 impl MyFromStr for EncryptionType {
     fn from_str(s: &str) -> Result<Self, String> {
-        let su_slice: &str = &*s;
+        let su_slice: &str = s;
         match su_slice {
             "des-cbc-crc" => Ok(EncryptionType::DES_CBC_CRC),
             "des-cbc-md4" => Ok(EncryptionType::DES_CBC_MD4),

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -218,7 +218,7 @@ impl KRB5State {
 
     fn free_tx(&mut self, tx_id: u64) {
         let tx = self.transactions.iter().position(|tx| tx.id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,6 +31,11 @@
 #![allow(clippy::let_and_return)]
 #![allow(clippy::needless_bool)]
 #![allow(clippy::char_lit_as_u8)]
+#![allow(clippy::len_without_is_empty)]
+
+// Would be good to fix, but needs more investigation with respect to
+// using as a library.
+#![allow(clippy::crate_in_macro_def)]
 
 // To be fixed, but remove the noise for now.
 #![allow(clippy::collapsible_if)]
@@ -63,6 +68,11 @@
 #![allow(clippy::while_let_loop)]
 #![allow(clippy::redundant_pattern_matching)]
 #![allow(clippy::field_reassign_with_default)]
+#![allow(clippy::bool_assert_comparison)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::manual_find)]
+#![allow(clippy::map_flatten)]
+#![allow(clippy::result_unit_err)]
 
 #[macro_use]
 extern crate bitflags;

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -46,7 +46,7 @@ lazy_static! {
     .unwrap();
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct DetectModbusRust {
     category: Option<Flags<CodeCategory>>,
     function: Option<FunctionCode>,
@@ -55,20 +55,6 @@ pub struct DetectModbusRust {
     unit_id: Option<Range<u16>>,
     address: Option<Range<u16>>,
     value: Option<Range<u16>>,
-}
-
-impl Default for DetectModbusRust {
-    fn default() -> Self {
-        DetectModbusRust {
-            category: None,
-            function: None,
-            subfunction: None,
-            access_type: None,
-            unit_id: None,
-            address: None,
-            value: None,
-        }
-    }
 }
 
 /// Compares a range from the alert signature to the transaction's unit_id/address/value

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -309,9 +309,9 @@ impl MQTTState {
             }
             MQTTOperation::CONNACK(ref _connack) => {
                 if let Some(tx) = self.get_tx_by_pkt_id(MQTT_CONNECT_PKT_ID) {
-                    (*tx).msg.push(msg);
-                    (*tx).complete = true;
-                    (*tx).pkt_id = None;
+                    tx.msg.push(msg);
+                    tx.complete = true;
+                    tx.pkt_id = None;
                     self.connected = true;
                 } else {
                     let mut tx = self.new_tx(msg, toclient);
@@ -327,7 +327,7 @@ impl MQTTState {
                     return;
                 }
                 if let Some(tx) = self.get_tx_by_pkt_id(v.message_id as u32) {
-                    (*tx).msg.push(msg);
+                    tx.msg.push(msg);
                 } else {
                     let mut tx = self.new_tx(msg, toclient);
                     MQTTState::set_event(&mut tx, MQTTEvent::MissingPublish);
@@ -342,9 +342,9 @@ impl MQTTState {
                     return;
                 }
                 if let Some(tx) = self.get_tx_by_pkt_id(v.message_id as u32) {
-                    (*tx).msg.push(msg);
-                    (*tx).complete = true;
-                    (*tx).pkt_id = None;
+                    tx.msg.push(msg);
+                    tx.complete = true;
+                    tx.pkt_id = None;
                 } else {
                     let mut tx = self.new_tx(msg, toclient);
                     MQTTState::set_event(&mut tx, MQTTEvent::MissingPublish);
@@ -359,9 +359,9 @@ impl MQTTState {
                     return;
                 }
                 if let Some(tx) = self.get_tx_by_pkt_id(suback.message_id as u32) {
-                    (*tx).msg.push(msg);
-                    (*tx).complete = true;
-                    (*tx).pkt_id = None;
+                    tx.msg.push(msg);
+                    tx.complete = true;
+                    tx.pkt_id = None;
                 } else {
                     let mut tx = self.new_tx(msg, toclient);
                     MQTTState::set_event(&mut tx, MQTTEvent::MissingSubscribe);
@@ -376,9 +376,9 @@ impl MQTTState {
                     return;
                 }
                 if let Some(tx) = self.get_tx_by_pkt_id(unsuback.message_id as u32) {
-                    (*tx).msg.push(msg);
-                    (*tx).complete = true;
-                    (*tx).pkt_id = None;
+                    tx.msg.push(msg);
+                    tx.complete = true;
+                    tx.pkt_id = None;
                 } else {
                     let mut tx = self.new_tx(msg, toclient);
                     MQTTState::set_event(&mut tx, MQTTEvent::MissingUnsubscribe);

--- a/rust/src/mqtt/mqtt_message.rs
+++ b/rust/src/mqtt/mqtt_message.rs
@@ -88,7 +88,7 @@ impl std::str::FromStr for MQTTTypeCode {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let su = s.to_uppercase();
-        let su_slice: &str = &*su;
+        let su_slice: &str = &su;
         match su_slice {
             "CONNECT" => Ok(MQTTTypeCode::CONNECT),
             "CONNACK" => Ok(MQTTTypeCode::CONNACK),

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -136,7 +136,7 @@ impl NTPState {
 
     fn free_tx(&mut self, tx_id: u64) {
         let tx = self.transactions.iter().position(|tx| tx.id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }

--- a/rust/src/quic/crypto.rs
+++ b/rust/src/quic/crypto.rs
@@ -99,7 +99,7 @@ impl PacketKey {
         let (buffer, tag) = payload.split_at_mut(tag_pos);
         let taga = GenericArray::from_slice(tag);
         self.key
-            .decrypt_in_place_detached(GenericArray::from_slice(&nonce), header, buffer, &taga)
+            .decrypt_in_place_detached(GenericArray::from_slice(&nonce), header, buffer, taga)
             .map_err(|_| ())?;
         Ok(&payload[..tag_pos])
     }

--- a/rust/src/quic/cyu.rs
+++ b/rust/src/quic/cyu.rs
@@ -62,7 +62,7 @@ impl Cyu {
                         let cyu_string = format!("{},{}", version, tags);
 
                         let mut hasher = Md5::new();
-                        hasher.update(&cyu_string.as_bytes());
+                        hasher.update(cyu_string.as_bytes());
                         let hash = hasher.finalize();
 
                         let cyu_hash = format!("{:x}", hash);

--- a/rust/src/quic/frames.rs
+++ b/rust/src/quic/frames.rs
@@ -203,14 +203,14 @@ pub struct QuicTlsExtension {
 }
 
 fn quic_tls_ja3_client_extends(ja3: &mut String, exts: Vec<TlsExtension>) {
-    ja3.push_str(",");
+    ja3.push(',');
     let mut dash = false;
     for e in &exts {
         match e {
             TlsExtension::EllipticCurves(x) => {
                 for ec in x {
                     if dash {
-                        ja3.push_str("-");
+                        ja3.push('-');
                     } else {
                         dash = true;
                     }
@@ -220,14 +220,14 @@ fn quic_tls_ja3_client_extends(ja3: &mut String, exts: Vec<TlsExtension>) {
             _ => {}
         }
     }
-    ja3.push_str(",");
+    ja3.push(',');
     dash = false;
     for e in &exts {
         match e {
             TlsExtension::EcPointFormats(x) => {
                 for ec in *x {
                     if dash {
-                        ja3.push_str("-");
+                        ja3.push('-');
                     } else {
                         dash = true;
                     }
@@ -250,7 +250,7 @@ fn quic_get_tls_extensions(
             for e in &exts {
                 let etype = TlsExtensionType::from(e);
                 if dash {
-                    ja3.push_str("-");
+                    ja3.push('-');
                 } else {
                     dash = true;
                 }
@@ -289,17 +289,17 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
             ClientHello(ch) => {
                 let mut ja3 = String::with_capacity(256);
                 ja3.push_str(&u16::from(ch.version).to_string());
-                ja3.push_str(",");
+                ja3.push(',');
                 let mut dash = false;
                 for c in &ch.ciphers {
                     if dash {
-                        ja3.push_str("-");
+                        ja3.push('-');
                     } else {
                         dash = true;
                     }
                     ja3.push_str(&u16::from(*c).to_string());
                 }
-                ja3.push_str(",");
+                ja3.push(',');
                 let ciphers = ch.ciphers;
                 let extv = quic_get_tls_extensions(ch.ext, &mut ja3, true);
                 return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));
@@ -307,9 +307,9 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
             ServerHello(sh) => {
                 let mut ja3 = String::with_capacity(256);
                 ja3.push_str(&u16::from(sh.version).to_string());
-                ja3.push_str(",");
+                ja3.push(',');
                 ja3.push_str(&u16::from(sh.cipher).to_string());
-                ja3.push_str(",");
+                ja3.push(',');
                 let ciphers = vec![sh.cipher];
                 let extv = quic_get_tls_extensions(sh.ext, &mut ja3, false);
                 return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -94,10 +94,10 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
         js.set_string("version", String::from(tx.header.version).as_str())?;
 
         if let Some(sni) = &tx.sni {
-            js.set_string("sni", &String::from_utf8_lossy(&sni))?;
+            js.set_string("sni", &String::from_utf8_lossy(sni))?;
         }
         if let Some(ua) = &tx.ua {
-            js.set_string("ua", &String::from_utf8_lossy(&ua))?;
+            js.set_string("ua", &String::from_utf8_lossy(ua))?;
         }
     }
     if tx.cyu.len() > 0 {
@@ -117,7 +117,7 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
         } else {
             js.open_object("ja3s")?;
         }
-        let hash = format!("{:x}", Md5::new().chain(&ja3).finalize());
+        let hash = format!("{:x}", Md5::new().chain(ja3).finalize());
         js.set_string("hash", &hash)?;
         js.set_string("string", ja3)?;
         js.close()?;

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -103,7 +103,7 @@ impl SIPState {
             .transactions
             .iter()
             .position(|tx| tx.id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -132,7 +132,7 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
                     }
                 }
 
-                if have_ntlmssp && kticket == None {
+                if have_ntlmssp && kticket.is_none() {
                     SCLogDebug!("parsing expected NTLMSSP");
                     ntlmssp = parse_ntlmssp_blob(os);
                 }

--- a/rust/src/smb/detect.rs
+++ b/rust/src/smb/detect.rs
@@ -160,7 +160,7 @@ pub extern "C" fn rs_smb_tx_get_dce_iface(state: &mut SMBState,
 
         if i.acked && i.ack_result == 0 && i.uuid == if_uuid {
             if let Some(x) = &dce_data.du16 {
-                if detect_match_uint(&x, i.ver) {
+                if detect_match_uint(x, i.ver) {
                     return 1;
                 }
             } else {

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -100,7 +100,7 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
         (true, ntstatus) => {
             let status = smb_ntstatus_string(ntstatus);
             match status {
-                Some(x) => jsb.set_string("status", &x)?,
+                Some(x) => jsb.set_string("status", x)?,
                 None => {
                     let status_str = format!("{}", ntstatus);
                     jsb.set_string("status", &status_str)?
@@ -446,14 +446,14 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_request(mut jsb: &mut JsonBuilder, state: &mut SMBState, tx: &mut SMBTransaction) -> bool
+pub extern "C" fn rs_smb_log_json_request(jsb: &mut JsonBuilder, state: &mut SMBState, tx: &mut SMBTransaction) -> bool
 {
-    smb_common_header(&mut jsb, state, tx).is_ok()
+    smb_common_header(jsb, state, tx).is_ok()
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_response(mut jsb: &mut JsonBuilder, state: &mut SMBState, tx: &mut SMBTransaction) -> bool
+pub extern "C" fn rs_smb_log_json_response(jsb: &mut JsonBuilder, state: &mut SMBState, tx: &mut SMBTransaction) -> bool
 {
-    smb_common_header(&mut jsb, state, tx).is_ok()
+    smb_common_header(jsb, state, tx).is_ok()
 }
 

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -646,7 +646,7 @@ fn smb1_response_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command
                                 },
                                 _ => { None },
                             };
-                            if d == None {
+                            if d.is_none() {
                                 tx.set_event(SMBEvent::NegotiateMalformedDialects);
                             }
                             (true, d)
@@ -865,7 +865,7 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 
             /* if we have a fid, store it so the response can pick it up */
             let mut pipe_dcerpc = false;
-            if rd.pipe != None {
+            if rd.pipe.is_some() {
                 let pipe = rd.pipe.unwrap();
                 state.ssn2vec_map.insert(SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID),
                         pipe.fid.to_vec());

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -114,7 +114,7 @@ pub fn parse_smb1_write_andx_request_record(i : &[u8], andx_offset: usize) -> IR
     let (i, _padding_evasion) = cond(data_offset > ax+4+2*(wct as u16), |b| take(data_offset - (ax+4+2*(wct as u16)))(b))(i)?;
     let (i, file_data) = rest(i)?;
     let record = Smb1WriteRequestRecord {
-        offset: if high_offset != None { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+        offset: if high_offset.is_some() { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
         len: (((data_len_high as u32) << 16) as u32)|(data_len_low as u32),
         fid,
         data: file_data,
@@ -514,7 +514,7 @@ pub fn parse_smb_read_andx_request_record(i: &[u8]) -> IResult<&[u8], SmbRequest
     let record = SmbRequestReadAndXRecord {
         fid,
         size: (((max_count_high as u64) << 16)|max_count_low as u64),
-        offset: if high_offset != None { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+        offset: if high_offset.is_some() { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
     };
     Ok((i, record))
 }

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -114,7 +114,7 @@ pub fn parse_smb1_write_andx_request_record(i : &[u8], andx_offset: usize) -> IR
     let (i, _padding_evasion) = cond(data_offset > ax+4+2*(wct as u16), |b| take(data_offset - (ax+4+2*(wct as u16)))(b))(i)?;
     let (i, file_data) = rest(i)?;
     let record = Smb1WriteRequestRecord {
-        offset: if high_offset.is_some() { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+        offset: high_offset.map(|ho| (ho as u64) << 32 | offset as u64).unwrap_or(0),
         len: (((data_len_high as u32) << 16) as u32)|(data_len_low as u32),
         fid,
         data: file_data,
@@ -514,7 +514,7 @@ pub fn parse_smb_read_andx_request_record(i: &[u8]) -> IResult<&[u8], SmbRequest
     let record = SmbRequestReadAndXRecord {
         fid,
         size: (((max_count_high as u64) << 16)|max_count_low as u64),
-        offset: if high_offset.is_some() { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+        offset: high_offset.map(|ho| (ho as u64) << 32 | offset as u64).unwrap_or(0),
     };
     Ok((i, record))
 }

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -218,7 +218,7 @@ impl<'a> SNMPState<'a> {
 
     fn free_tx(&mut self, tx_id: u64) {
         let tx = self.transactions.iter().position(|tx| tx.id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -231,7 +231,7 @@ impl TelnetState {
                                 self.state = TelnetProtocolState::PasswdRecv;
                             }
                             TelnetProtocolState::AuthOk => {
-                                let _message = std::str::from_utf8(&d);
+                                let _message = std::str::from_utf8(d);
                                 if let Ok(_message) = _message {
                                     SCLogDebug!("=> {}", _message);
                                 }
@@ -322,7 +322,7 @@ impl TelnetState {
                                 self.state = TelnetProtocolState::PasswdSent;
                             },
                             TelnetProtocolState::PasswdRecv => {
-                                if let Ok(message) = std::str::from_utf8(&d) {
+                                if let Ok(message) = std::str::from_utf8(d) {
                                     match message {
                                         "Login incorrect" => {
                                             SCLogDebug!("LOGIN FAILED");
@@ -339,7 +339,7 @@ impl TelnetState {
                                 }
                             },
                             TelnetProtocolState::AuthOk => {
-                                let _message = std::str::from_utf8(&d);
+                                let _message = std::str::from_utf8(d);
                                 if let Ok(_message) = _message {
                                     SCLogDebug!("<= {}", _message);
                                 }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -55,7 +55,7 @@ impl TFTPState {
 
     fn free_tx(&mut self, tx_id: u64) {
         let tx = self.transactions.iter().position(|tx| tx.id == tx_id + 1);
-        debug_assert!(tx != None);
+        debug_assert!(tx.is_some());
         if let Some(idx) = tx {
             let _ = self.transactions.remove(idx);
         }


### PR DESCRIPTION
A bunch of clippy fixups, mostly ones that could be done automatically.

Also adds a GitHub CI workflow to check cargo clippy.  `cargo clippy --fix`
shouldn't fix anything as this should be done during development.  And a plain
`cargo clippy` should be clean, with respect to the allow statements we have in
lib.rs.
