### PR TITLE
Notification of fully initialised Suricata v8

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -531,7 +531,7 @@ jobs:
           flags: suricata-verify
 
   fedora-36:
-    name: Fedora 36 (debug, clang, asan, wshadow, rust-strict)
+    name: Fedora 36 (debug, clang, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
     container: fedora:36
     needs: [prepare-deps, prepare-cbindgen]
@@ -578,6 +578,7 @@ jobs:
                 pkgconfig \
                 python3-yaml \
                 sudo \
+                systemd-devel \
                 which \
                 zlib-devel
       - uses: actions/checkout@v3.1.0
@@ -620,6 +621,8 @@ jobs:
       - run: make install
       - run: suricata-update -V
       - run: suricatasc -h
+      # Check compilation against systemd
+      - run: ldd src/suricata | grep libsystemd &> /dev/null
 
   fedora-35:
     name: Fedora 35 (debug, clang, asan, wshadow, rust-strict)

--- a/configure.ac
+++ b/configure.ac
@@ -607,6 +607,35 @@
         AC_MSG_RESULT(no)
     fi
 
+  #systemd
+    AC_ARG_WITH(systemd_includes,
+            [  --with-systemd-includes=DIR  systemd include directory],
+            [with_systemd_includes="$withval"],[with_systemd_includes=no])
+    AC_ARG_WITH(systemd_libraries,
+            [  --with-systemd-libraries=DIR    systemd library directory],
+            [with_systemd_libraries="$withval"],[with_systemd_libraries="no"])
+
+    AC_CHECK_HEADER(systemd/sd-daemon.h, SYSTEMD="yes",SYSTEMD="no")
+    if test "$SYSTEMD" = "yes"; then
+        if test "$with_systemd_libraries" != "no"; then
+            LDFLAGS="${LDFLAGS} -L${with_systemd_libraries}"
+        fi
+
+        if test "$with_systemd_includes" != "no"; then
+            CPPFLAGS="${CPPFLAGS} -I${with_systems_includes}"
+        fi
+
+        # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+        # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+        SYSTEMD=""
+        TMPLIBS="${LIBS}"
+        AC_CHECK_LIB(systemd,sd_notify,,SYSTEMD="no")
+
+        if test "$SYSTEMD" != "no"; then
+            LIBS="${TMPLIBS} -lsystemd"
+        fi
+    fi
+  
   # libhs
     enable_hyperscan="no"
 

--- a/doc/userguide/configuration/index.rst
+++ b/doc/userguide/configuration/index.rst
@@ -10,3 +10,4 @@ Configuration
    multi-tenant
    dropping-privileges
    landlock
+   systemd-notify

--- a/doc/userguide/configuration/systemd-notify.rst
+++ b/doc/userguide/configuration/systemd-notify.rst
@@ -1,0 +1,57 @@
+systemd notification
+====================
+
+Introduction
+------------
+Suricata supports systemd notification with the aim of notifying the service manager of successful
+initialisation. The purpose is to enable the ability to start upon/await successful start-up for
+services/test frameworks that depend on a fully initialised Suricata .
+
+During the initialisation phase Suricata synchronises the initialisation thread with all active
+threads to ensure they are in a running state. Once synchronisation has been completed a ``READY=1``
+status notification is sent to the service manager using ``sd_notify()``.
+
+Example
+-------
+A test framework requires Suricata to be capturing before the tests can be carried out.
+Writing a ``test.service`` and ensuring the correct execution order with ``After=suricata.service``
+forces the unit to be started after ``suricata.service``. This does not enforce Suricata has fully
+initialised. By configuring ``suricata.service`` as ``Type=notify`` instructs the service manager
+to wait for the notification before starting ``test.service``.
+
+Requirements
+------------
+This feature is only supported for distributions under the following conditions:
+
+1. Distribution contains ``libsystemd``
+2. Any distribution that runs under **systemd**
+3. Unit file configuration: ``Type=notify``
+4. Contains development files for systemd shared library
+
+To install development files:
+Fedora::
+
+    dnf -y install systemd-devel
+
+Ubuntu/Debian::
+
+    apt -y install systemd-dev
+
+This package shall be compile-time configured and therefore only built with distributions fulfilling
+requirements [1, 2]. For notification to the service manager the unit file must be configured as
+shown in requirement [3]. Upon all requirements being met the service manager will start and await
+``READY=1`` status from Suricata. Otherwise the service manager will treat the service unit as
+``Type=simple`` and consider it started immediately after the main process ``ExecStart=`` has been
+forked.
+
+Additional Information
+----------------------
+To confirm the system is running under systemd::
+
+    ps --no-headers -o comm 1
+
+See: https://man7.org/linux/man-pages/man3/sd_notify.3.html for a detailed description on
+``sd_notify``.
+
+See https://www.freedesktop.org/software/systemd/man/systemd.service.html for help
+writing systemd unit files.

--- a/src/counters.c
+++ b/src/counters.c
@@ -411,7 +411,7 @@ static void *StatsMgmtThread(void *arg)
     }
     SCLogDebug("stats_thread_data %p", &stats_thread_data);
 
-    TmThreadsSetFlag(tv_local, THV_INIT_DONE);
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
             TmThreadsSetFlag(tv_local, THV_PAUSED);
@@ -480,7 +480,8 @@ static void *StatsWakeupThread(void *arg)
         return NULL;
     }
 
-    TmThreadsSetFlag(tv_local, THV_INIT_DONE);
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
+
     while (1) {
         if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
             TmThreadsSetFlag(tv_local, THV_PAUSED);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -799,6 +799,8 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     GetWorkUnitSizing(rows, mp, emerg, &sleep_per_wu, &rows_per_wu, &rows_sec);
     StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_sec, rows_sec);
 
+    TmThreadsSetFlag(th_v, THV_RUNNING);
+
     while (1)
     {
         if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
@@ -1062,6 +1064,8 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
     uint64_t recycled_cnt = 0;
     struct timeval ts;
     memset(&ts, 0, sizeof(ts));
+
+    TmThreadsSetFlag(th_v, THV_RUNNING);
 
     while (1)
     {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -559,7 +559,6 @@ static void AFPPeersListReachedInc(void)
         return;
 
     if ((SC_ATOMIC_ADD(peerslist.reached, 1) + 1) == peerslist.turn) {
-        SCLogInfo("All AFP capture threads are running.");
         (void)SC_ATOMIC_SET(peerslist.reached, 0);
         /* Set turn to 0 to skip syncrhonization when ReceiveAFPLoop is
          * restarted.
@@ -1337,6 +1336,10 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
 
     fds.fd = ptv->socket;
     fds.events = POLLIN;
+
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
 
     while (1) {
         /* Start by checking the state of our interface */

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -338,6 +338,10 @@ ReceiveErfDagLoop(ThreadVars *tv, void *data, void *slot)
 
     dtv->slot = s->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -116,6 +116,10 @@ TmEcode ReceiveErfFileLoop(ThreadVars *tv, void *data, void *slot)
 
     etv->slot = ((TmSlot *)slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -239,6 +239,11 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
     SCLogInfo("Thread '%s' will run on port %d (item %d)",
               tv->name, nq->port_num, ptv->ipfw_index);
+
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (unlikely(suricata_ctl_flags != 0)) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -910,6 +910,10 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     TmSlot *s = (TmSlot *) slot;
     ntv->slot = s->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (!(suricata_ctl_flags & SURICATA_STOP)) {
         /* make sure we have at least one packet in the packet pool, to prevent
          * us from alloc'ing packets at line rate */

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -786,6 +786,11 @@ static TmEcode ReceiveNetmapLoop(ThreadVars *tv, void *data, void *slot)
     fds.events = POLLIN;
 
     SCLogDebug("thread %s polling on %d", tv->name, fds.fd);
+
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     for(;;) {
         if (unlikely(suricata_ctl_flags != 0)) {
             break;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -430,6 +430,10 @@ TmEcode ReceiveNFLOGLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags != 0)
             break;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1008,6 +1008,10 @@ TmEcode ReceiveNFQLoop(ThreadVars *tv, void *data, void *slot)
 
     ntv->slot = ((TmSlot *) slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while(1) {
         if (unlikely(suricata_ctl_flags != 0)) {
             NFQDestroyQueue(nq);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -171,6 +171,10 @@ TmEcode ReceivePcapFileLoop(ThreadVars *tv, void *data, void *slot)
     ptv->shared.slot = s->slot_next;
     ptv->shared.cb_result = TM_ECODE_OK;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     if(ptv->is_directory == 0) {
         SCLogInfo("Starting file run for %s", ptv->behavior.file->filename);
         status = PcapFileDispatch(ptv->behavior.file);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -312,6 +312,10 @@ static TmEcode ReceivePcapLoop(ThreadVars *tv, void *data, void *slot)
     ptv->slot = s->slot_next;
     ptv->cb_result = TM_ECODE_OK;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -361,6 +361,10 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while(1) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/source-windivert.c
+++ b/src/source-windivert.c
@@ -410,6 +410,10 @@ TmEcode ReceiveWinDivertLoop(ThreadVars *tv, void *data, void *slot)
     WinDivertThreadVars *wd_tv = (WinDivertThreadVars *)data;
     wd_tv->slot = ((TmSlot *)slot)->slot_next;
 
+    // Indicate that the thread is actually running its application level code (i.e., it can poll
+    // packets)
+    TmThreadsSetFlag(tv, THV_RUNNING);
+
     while (true) {
         if (suricata_ctl_flags & SURICATA_STOP) {
             SCReturnInt(TM_ECODE_OK);

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -52,6 +52,7 @@ struct TmSlot_;
  *  rule reloads even if no packets are read by the capture method. */
 #define THV_CAPTURE_INJECT_PKT  BIT_U32(11)
 #define THV_DEAD                BIT_U32(12) /**< thread has been joined with pthread_join() */
+#define THV_RUNNING             BIT_U32(13) /**< thread is running */
 
 /** \brief Per thread variable structure */
 typedef struct ThreadVars_ {

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -123,6 +123,8 @@ void TmThreadDisableReceiveThreads(void);
 
 uint32_t TmThreadCountThreadsByTmmFlags(uint8_t flags);
 
+TmEcode TmThreadWaitOnThreadRunning(void);
+
 static inline void TmThreadsCleanDecodePQ(PacketQueueNoLock *pq)
 {
     while (1) {

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1125,7 +1125,8 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
     th_v->cap_flags = 0;
     SCDropCaps(th_v);
 
-    TmThreadsSetFlag(th_v, THV_INIT_DONE);
+    TmThreadsSetFlag(th_v, THV_INIT_DONE | THV_RUNNING);
+
     while (1) {
         ret = UnixMain(&command);
         if (ret == 0) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5384

Describe changes:
- Altered commits that accounted for changes suggested in series of PRs to be in a more logical and readable order
- Updated ``TmThreadWaitOnThreadRunning()`` with functionality to print when the engine is running
- Updated ``TmThreadWaitOnThreadInit()`` to remove print of when engine is running
- Made ``OnNotifyRunning()`` ``void`` as this return was not used
- Updated ``systemd-notify.rst`` with suggested rewording
- Remove info print stating "All AFP capture threads are running." from ``source-af-packet.c``

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
