### PR TITLE
base64: add new mode as per RFC 4648

### DIFF
--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -96,7 +96,7 @@ int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s
 
     uint32_t consumed = 0, num_decoded = 0;
     (void)DecodeBase64(det_ctx->base64_decoded, det_ctx->base64_decoded_len_max, payload,
-            decode_len, &consumed, &num_decoded, BASE64_MODE_RELAX);
+            decode_len, &consumed, &num_decoded, BASE64_MODE_RFC4648);
     det_ctx->base64_decoded_len = num_decoded;
     SCLogDebug("Decoded %d bytes from base64 data.",
         det_ctx->base64_decoded_len);

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -155,6 +155,14 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
             memset(&b64, 0, sizeof(b64));
         }
     }
+
+    if (!valid && mode == BASE64_MODE_RFC4648) {
+        padding = B64_BLOCK - bbidx;
+        *decoded_bytes += ASCII_BLOCK - (B64_BLOCK - bbidx);
+        DecodeBase64Block(dptr, b64);
+        *consumed_bytes += bbidx;
+    }
+
     /* Finish remaining b64 bytes by padding */
     if (valid && bbidx > 0 && (mode != BASE64_MODE_RFC2045)) {
         /* Decode remaining */

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -35,6 +35,8 @@ typedef enum {
     BASE64_MODE_RELAX,
     BASE64_MODE_RFC2045, /* SPs are allowed during transfer but must be skipped by Decoder */
     BASE64_MODE_STRICT,
+    BASE64_MODE_RFC4648, /* reject the encoded data if it contains characters outside the base
+                            alphabet */
 } Base64Mode;
 
 typedef enum {


### PR DESCRIPTION
As per RFC 4648,
Implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise.

Add a new mode `BASE64_MODE_RFC4648`, and handle input strictly as per the specification.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5223

Draft bc
1. Trying to figure out if `sid:3` should alert with the fix (it does with this patch)
2. Needs more testing, only been tested on a small dataset