### PR TITLE
detect/alert: don't lose 'drop' alert - v4

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -177,9 +177,26 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
     }
 }
 
+/** \internal
+ */
+static inline PacketAlert PacketAlertSet(
+        DetectEngineThreadCtx *det_ctx, const Signature *s, uint64_t tx_id, uint8_t alert_flags)
+{
+    PacketAlert pa = { s->num, s->action, alert_flags, s, tx_id, 0 };
+    pa.num = s->num;
+    pa.action = s->action;
+    pa.s = (Signature *)s;
+    pa.flags = alert_flags;
+    /* Set tx_id if the frame has it */
+    pa.tx_id = (tx_id == UINT64_MAX) ? 0 : tx_id;
+    pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
+    return pa;
+}
+
 /** \brief Apply action(s) and Set 'drop' sig info,
  *         if applicable */
-static void PacketApplySignatureActions(Packet *p, const Signature *s, const uint8_t alert_flags)
+static void PacketApplySignatureActions(
+        DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const uint8_t alert_flags)
 {
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
             s->action, alert_flags);
@@ -190,9 +207,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
         PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {
-            p->alerts.drop.num = s->num;
-            p->alerts.drop.action = s->action;
-            p->alerts.drop.s = (Signature *)s;
+            p->alerts.drop = PacketAlertSet(det_ctx, s, 0, alert_flags);
         }
         if ((p->flow != NULL) && (alert_flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)) {
             RuleActionToFlow(s->action, p->flow);
@@ -249,22 +264,6 @@ static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
             det_ctx->alert_queue_capacity,
             (uintmax_t)(sizeof(PacketAlert) * det_ctx->alert_queue_capacity));
     return new_cap;
-}
-
-/** \internal
- */
-static inline PacketAlert PacketAlertSet(
-        DetectEngineThreadCtx *det_ctx, const Signature *s, uint64_t tx_id, uint8_t alert_flags)
-{
-    PacketAlert pa;
-    pa.num = s->num;
-    pa.action = s->action;
-    pa.s = (Signature *)s;
-    pa.flags = alert_flags;
-    /* Set tx_id if the frame has it */
-    pa.tx_id = (tx_id == UINT64_MAX) ? 0 : tx_id;
-    pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
-    return pa;
 }
 
 /**
@@ -382,7 +381,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                     p, &det_ctx->alert_queue[i], s, det_ctx->alert_queue[i].flags);
 
             /* set actions on packet */
-            PacketApplySignatureActions(p, s, det_ctx->alert_queue[i].flags);
+            PacketApplySignatureActions(det_ctx, p, s, det_ctx->alert_queue[i].flags);
         }
 
         /* Thresholding removes this alert */

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -233,6 +233,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx)
                 (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
     }
     det_ctx->alert_queue_capacity = packet_alert_max;
+    det_ctx->is_alert_queue_expand_failure = false;
     SCLogDebug("alert queue initialized to %u elements (%" PRIu64 " bytes)", packet_alert_max,
             (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
 }
@@ -255,6 +256,8 @@ static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
     void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
     if (unlikely(tmp_queue == NULL)) {
+        /* save this info, so we know to double check for DROP action in packet */
+        det_ctx->is_alert_queue_expand_failure = true;
         /* queue capacity didn't change */
         return det_ctx->alert_queue_capacity;
     }
@@ -396,12 +399,12 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
 {
     SCEnter();
 
-    /* sort the alert queue before thresholding and appending to Packet */
-    qsort(det_ctx->alert_queue, det_ctx->alert_queue_size, sizeof(PacketAlert),
-            AlertQueueSortHelper);
-
-    uint16_t i = 0;
+    int i = 0;
     uint16_t max_pos = det_ctx->alert_queue_size;
+    PacketAlert tmp_queue[max_pos];
+    uint16_t tmp_size = 0;
+    bool is_action_pass = false;
+    uint32_t pass_sid_num = 0;
 
     while (i < max_pos) {
         const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
@@ -413,20 +416,57 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
             p->alerts.suppressed++;
             SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
         } else if (res == 1) {
-            if (p->alerts.cnt < packet_alert_max) {
-                p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
-                SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
-                if (PacketTestAction(p, ACTION_PASS)) {
-                    /* Ok, reset the alert cnt to end in the previous of pass
-                     * so we ignore the rest with less prio */
-                    break;
-                }
-                p->alerts.cnt++;
-            } else {
-                p->alerts.discarded++;
+            tmp_queue[tmp_size] = det_ctx->alert_queue[i];
+            tmp_size++;
+            SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
+            if (PacketTestAction(p, ACTION_PASS) && !is_action_pass) {
+                /* Ok, reset the alert cnt to end in the previous of pass
+                 * so we ignore the rest with less prio */
+                pass_sid_num = s->num;
+                is_action_pass = true;
             }
         }
         i++;
+    }
+
+    if (packet_alert_max > tmp_size) {
+        p->alerts.cnt = tmp_size;
+    } else {
+        p->alerts.cnt = packet_alert_max;
+        // we also have discarded alerts in case of queue expansion failure, let's
+        // not miss that count
+        p->alerts.discarded += (tmp_size - packet_alert_max);
+    }
+    qsort(tmp_queue, tmp_size, sizeof(PacketAlert), AlertQueueSortHelper);
+
+    if (det_ctx->is_alert_queue_expand_failure) {
+        if (p->alerts.drop.action & ACTION_DROP) {
+            PacketAlertFinalize(de_ctx, det_ctx, p, &p->alerts.drop, p->alerts.drop.s);
+        }
+    }
+
+    if (is_action_pass) {
+        // this means we got a 'PASS' action for this Packet, pass_sid_num
+        // has the related signature's internal id
+        uint16_t j;
+        for (j = 0; j < p->alerts.cnt; j++) {
+            if (tmp_queue[j].num < pass_sid_num) {
+                // we add it to the final queue
+                p->alerts.alerts[j] = tmp_queue[j];
+            } else {
+                break;
+            }
+        }
+        if (PacketTestAction(p, ACTION_DROP)) {
+            if (p->alerts.drop.s->num > pass_sid_num) {
+                // if this should be a pass, then ignore drop action
+                p->alerts.drop.action = 0;
+                PacketPass(p);
+            }
+        }
+        p->alerts.cnt = j;
+    } else {
+        memcpy(p->alerts.alerts, tmp_queue, p->alerts.cnt * sizeof(PacketAlert));
     }
 
     /* At this point, we should have all the new alerts. Now check the tag

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -337,14 +337,62 @@ static inline void FlowApplySignatureActions(
 
 /**
  * \brief Check the threshold of the sigs that match, set actions, break on pass action
- *        This function iterate the packet alerts array, removing those that didn't match
+ *
+ * \param de_ctx detection engine context
+ * \param det_ctx detection engine thread context
+ * \param p pointer to the packet
+ *
+ * \retval 1 alert should be queued
+ * \retval 0 alert is discarded
+ */
+static uint8_t PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        Packet *p, PacketAlert *pa, const Signature *s)
+{
+    uint8_t res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+
+    if (res > 0) {
+        /* Now, if we have an alert, we have to check if we want
+         * to tag this session or src/dst host */
+        if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
+            KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
+            SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
+            while (1) {
+                /* tags are set only for alerts */
+                KEYWORD_PROFILING_START;
+                sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
+                KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
+
+        /* set actions on the flow */
+        FlowApplySignatureActions(p, pa, s, pa->flags);
+
+        /* set actions on packet */
+        PacketApplySignatureActions(det_ctx, p, s, pa->flags);
+    }
+
+    /* Thresholding removes this alert */
+    if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
+        /* we will not copy this to the AlertQueue */
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+/**
+ * \brief Check the threshold of the sigs that match, set actions, break on pass action
+ *        This function iterates the packet alerts array, removing those that didn't match
  *        the threshold, and those that match after a signature with the action "pass".
  *        The array is sorted by action priority/order
  * \param de_ctx detection engine context
  * \param det_ctx detection engine thread context
  * \param p pointer to the packet
  */
-void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
+void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
     SCEnter();
 
@@ -357,50 +405,26 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 
     while (i < max_pos) {
         const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
-        int res = PacketAlertHandle(de_ctx, det_ctx, s, p, &det_ctx->alert_queue[i]);
-
-        if (res > THRESHOLD_DONT_ALERT) {
-            /* Now, if we have an alert, we have to check if we want
-             * to tag this session or src/dst host */
-            if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
-                KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
-                SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
-                while (1) {
-                    /* tags are set only for alerts */
-                    KEYWORD_PROFILING_START;
-                    sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
-                    KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
-                    if (smd->is_last)
-                        break;
-                    smd++;
-                }
-            }
-
-            /* set actions on the flow */
-            FlowApplySignatureActions(
-                    p, &det_ctx->alert_queue[i], s, det_ctx->alert_queue[i].flags);
-
-            /* set actions on packet */
-            PacketApplySignatureActions(det_ctx, p, s, det_ctx->alert_queue[i].flags);
-        }
+        uint8_t res = PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
 
         /* Thresholding removes this alert */
-        if (res == THRESHOLD_SUPPRESSED || res == THRESHOLD_SILENT_MATCH ||
-                (s->flags & SIG_FLAG_NOALERT)) {
+        if (res == 0) {
             /* we will not copy this to the AlertQueue */
             p->alerts.suppressed++;
-        } else if (p->alerts.cnt < packet_alert_max) {
-            p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
-            SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
-
-            if (PacketTestAction(p, ACTION_PASS)) {
-                /* Ok, reset the alert cnt to end in the previous of pass
-                 * so we ignore the rest with less prio */
-                break;
+            SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
+        } else if (res == 1) {
+            if (p->alerts.cnt < packet_alert_max) {
+                p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
+                SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
+                if (PacketTestAction(p, ACTION_PASS)) {
+                    /* Ok, reset the alert cnt to end in the previous of pass
+                     * so we ignore the rest with less prio */
+                    break;
+                }
+                p->alerts.cnt++;
+            } else {
+                p->alerts.discarded++;
             }
-            p->alerts.cnt++;
-        } else {
-            p->alerts.discarded++;
         }
         i++;
     }

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertQueueFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -606,7 +606,7 @@ static SigThresholdResults ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Pa
 /**
  * \brief Make the threshold logic for signatures
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  * \param tsh_ptr Threshold element
  * \param p Packet structure
  * \param s Signature structure
@@ -657,7 +657,7 @@ SigThresholdResults PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineTh
 /**
  * \brief Init threshold context hash tables
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  *
  */
 void ThresholdHashInit(DetectEngineCtx *de_ctx)
@@ -731,7 +731,7 @@ void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
     if (de_ctx->ths_ctx.th_entry == NULL) {
         FatalError(SC_ERR_MEM_ALLOC,
                 "Error allocating memory for rule "
-                "thresholds (tried to allocate %" PRIu32 " th_entrys for "
+                "thresholds (tried to allocate %" PRIu32 " th_entries for "
                 "rule tracking)",
                 de_ctx->ths_ctx.th_size);
     }
@@ -740,7 +740,7 @@ void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
 /**
  * \brief Destroy threshold context hash tables
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  *
  */
 void ThresholdContextDestroy(DetectEngineCtx *de_ctx)

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -30,6 +30,15 @@
 #include "ippair.h"
 #include "host-storage.h"
 
+typedef enum SigThresholdResults_ {
+    THRESHOLD_DONT_ALERT = 0,
+    THRESHOLD_ALERT = 1,
+    THRESHOLD_SILENT_MATCH = 2,
+    THRESHOLD_SUPPRESSED = 0,
+    THRESHOLD_NOT_SUPPRESSED = 1,
+    THRESHOLD_SUPPRESS_NEED_ACTIONS = 2,
+} SigThresholdResults;
+
 void ThresholdInit(void);
 
 HostStorageId ThresholdHostStorageId(void);
@@ -39,9 +48,8 @@ int ThresholdIPPairHasThreshold(IPPair *pair);
 
 const DetectThresholdData *SigGetThresholdTypeIter(
         const Signature *, const SigMatchData **, int list);
-int PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
-        const DetectThresholdData *, Packet *,
-        const Signature *, PacketAlert *);
+SigThresholdResults PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
+        const DetectThresholdData *, Packet *, const Signature *, PacketAlert *);
 
 void ThresholdHashInit(DetectEngineCtx *);
 void ThresholdHashAllocate(DetectEngineCtx *);

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect.c
+++ b/src/detect.c
@@ -927,11 +927,11 @@ static inline void DetectRunPostRules(
     }
 
     /* so now let's iterate the alerts and remove the ones after a pass rule
-     * matched (if any). This is done inside PacketAlertFinalize() */
+     * matched (if any). This is done inside PacketAlertQueueFinalize() */
     /* PR: installed "tag" keywords are handled after the threshold inspection */
 
     PACKET_PROFILING_DETECT_START(p, PROF_DETECT_ALERT);
-    PacketAlertFinalize(de_ctx, det_ctx, p);
+    PacketAlertQueueFinalize(de_ctx, det_ctx, p);
     if (p->alerts.cnt > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts, (uint64_t)p->alerts.cnt);
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -1100,6 +1100,7 @@ typedef struct DetectEngineThreadCtx_ {
     uint16_t alert_queue_size;
     uint16_t alert_queue_capacity;
     PacketAlert *alert_queue;
+    bool is_alert_queue_expand_failure;
 
     SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5180

This work is sort of a continuation of https://github.com/OISF/suricata/pull/7969 but with some smaller optimizations to functions in detect-engine-alert and detect-engine-threshold.

We're trying to optimize how we process the PacketAlertQueue and also make sure that a drop action won't be lost in case we have a failure when trying to grow the PacketAlertQueue with malloc.

This is a draft because it is failing the SV test exception-policy-default-01, showing that the way I'm trying to post-process the Pass action isn't enough. I have tried a few things to try to fix/improve that, to no avail.

Changes from previous PR:
Trying to fix a bug that is being reported by the CIFuzz (https://github.com/OISF/suricata/actions/runs/3186046936/jobs/5196260225#step:5:468)

Describe changes:
- remove magic numbers from function returns in detect-engine-alert and detect-engine-threshold
- extract packet alerts processing to functions
- move packet alert queue sorting to after the alerts are processed