### PR TITLE
6.0.x Backport: detect/tls.fingerprint: Improve rule processing time 

### DIFF
--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -55,7 +55,6 @@
 
 #include "app-layer-htp.h"
 #include "detect-http-uri.h"
-#include "detect-uricontent.h"
 #include "stream-tcp.h"
 
 #ifdef UNITTESTS

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2011-2012 ANSSI
+ * Copyright (C) 2022 Open Information Security Foundation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,6 +58,7 @@
 
 #include "app-layer-ssl.h"
 #include "detect-tls.h"
+#include "detect-tls-cert-fingerprint.h"
 
 #include "stream-tcp.h"
 
@@ -83,9 +85,10 @@ static int DetectTlsIssuerDNMatch (DetectEngineThreadCtx *,
 static int DetectTlsIssuerDNSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTlsIssuerDNFree(DetectEngineCtx *, void *);
 
-static int DetectTlsFingerprintMatch (DetectEngineThreadCtx *,
-        Flow *, uint8_t, void *, void *,
-        const Signature *, const SigMatchCtx *);
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id);
+
 static int DetectTlsFingerprintSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTlsFingerprintFree(DetectEngineCtx *, void *);
 
@@ -94,16 +97,7 @@ static int DetectTlsStorePostMatch (DetectEngineThreadCtx *det_ctx,
         Packet *, const Signature *s, const SigMatchCtx *unused);
 
 static int g_tls_cert_list_id = 0;
-
-static int InspectTlsCert(ThreadVars *tv,
-        DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const Signature *s, const SigMatchData *smd,
-        Flow *f, uint8_t flags, void *alstate,
-        void *txv, uint64_t tx_id)
-{
-    return DetectEngineInspectGenericList(tv, de_ctx, det_ctx, s, smd,
-                                          f, flags, alstate, txv, tx_id);
-}
+static int g_tls_cert_fingerprint_list_id = 0;
 
 /**
  * \brief Registration function for keyword: tls.version
@@ -131,7 +125,6 @@ void DetectTlsRegister (void)
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].name = "tls.fingerprint";
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].desc = "match TLS/SSL certificate SHA1 fingerprint";
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].url = "/rules/tls-keywords.html#tls-fingerprint";
-    sigmatch_table[DETECT_AL_TLS_FINGERPRINT].AppLayerTxMatch = DetectTlsFingerprintMatch;
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].Setup = DetectTlsFingerprintSetup;
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].Free  = DetectTlsFingerprintFree;
     sigmatch_table[DETECT_AL_TLS_FINGERPRINT].flags = SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION;
@@ -150,10 +143,32 @@ void DetectTlsRegister (void)
     DetectSetupParseRegexes(PARSE_REGEX_FINGERPRINT, &fingerprint_parse_regex);
 
     g_tls_cert_list_id = DetectBufferTypeRegister("tls_cert");
+    g_tls_cert_fingerprint_list_id = DetectBufferTypeRegister("tls.cert_fingerprint");
 
-    DetectAppLayerInspectEngineRegister("tls_cert",
-            ALPROTO_TLS, SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
-            InspectTlsCert);
+    DetectAppLayerInspectEngineRegister2("tls_cert", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
+            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+}
+
+static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        const SSLState *ssl_state = (SSLState *)f->alstate;
+
+        if (ssl_state->server_connp.cert0_fingerprint == NULL) {
+            return NULL;
+        }
+
+        const uint32_t data_len = strlen(ssl_state->server_connp.cert0_fingerprint);
+        const uint8_t *data = (uint8_t *)ssl_state->server_connp.cert0_fingerprint;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
 }
 
 /**
@@ -545,129 +560,6 @@ static void DetectTlsIssuerDNFree(DetectEngineCtx *de_ctx, void *ptr)
  * \retval pointer to DetectTlsData on success
  * \retval NULL on failure
  */
-static DetectTlsData *DetectTlsFingerprintParse (DetectEngineCtx *de_ctx, const char *str, bool negate)
-{
-    DetectTlsData *tls = NULL;
-    int ret = 0, res = 0;
-    int ov[MAX_SUBSTRINGS];
-    const char *str_ptr;
-    char *orig;
-    char *tmp_str;
-    uint32_t flag = 0;
-
-    ret = DetectParsePcreExec(&fingerprint_parse_regex, str, 0, 0, ov, MAX_SUBSTRINGS);
-    if (ret != 2) {
-        SCLogError(SC_ERR_PCRE_MATCH, "invalid tls.fingerprint option");
-        goto error;
-    }
-
-    if (negate)
-        flag = DETECT_CONTENT_NEGATED;
-
-    res = pcre_get_substring((char *)str, ov, MAX_SUBSTRINGS, 1, &str_ptr);
-    if (res < 0) {
-        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
-        goto error;
-    }
-
-    /* We have a correct id option */
-    tls = SCMalloc(sizeof(DetectTlsData));
-    if (unlikely(tls == NULL))
-        goto error;
-    tls->fingerprint = NULL;
-    tls->flags = flag;
-
-    orig = SCStrdup((char*)str_ptr);
-    if (unlikely(orig == NULL)) {
-        goto error;
-    }
-    pcre_free_substring(str_ptr);
-
-    tmp_str=orig;
-
-    /* Let's see if we need to escape "'s */
-    if (tmp_str[0] == '"')
-    {
-        tmp_str[strlen(tmp_str) - 1] = '\0';
-        tmp_str += 1;
-    }
-
-    tls->fingerprint = SCStrdup(tmp_str);
-    if (tls->fingerprint == NULL) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate fingerprint");
-    }
-
-    SCFree(orig);
-
-    SCLogDebug("will look for TLS fingerprint %s", tls->fingerprint);
-
-    return tls;
-
-error:
-    if (tls != NULL)
-        DetectTlsFingerprintFree(de_ctx, tls);
-    return NULL;
-
-}
-/**
- * \brief match the specified fingerprint on a tls session
- *
- * \param t pointer to thread vars
- * \param det_ctx pointer to the pattern matcher thread
- * \param p pointer to the current packet
- * \param m pointer to the sigmatch that we will cast into DetectTlsData
- *
- * \retval 0 no match
- * \retval 1 match
- */
-static int DetectTlsFingerprintMatch (DetectEngineThreadCtx *det_ctx,
-        Flow *f, uint8_t flags, void *state, void *txv,
-        const Signature *s, const SigMatchCtx *m)
-{
-    SCEnter();
-    const DetectTlsData *tls_data = (const DetectTlsData *)m;
-    SSLState *ssl_state = (SSLState *)state;
-    if (ssl_state == NULL) {
-        SCLogDebug("no tls state, no match");
-        SCReturnInt(0);
-    }
-
-    int ret = 0;
-
-    SSLStateConnp *connp = NULL;
-    if (flags & STREAM_TOSERVER) {
-        connp = &ssl_state->client_connp;
-    } else {
-        connp = &ssl_state->server_connp;
-    }
-
-    if (connp->cert0_fingerprint != NULL) {
-        SCLogDebug("TLS: Fingerprint is [%s], looking for [%s]\n",
-                   connp->cert0_fingerprint,
-                   tls_data->fingerprint);
-
-        if (tls_data->fingerprint &&
-            (strstr(connp->cert0_fingerprint,
-                    tls_data->fingerprint) != NULL)) {
-            if (tls_data->flags & DETECT_CONTENT_NEGATED) {
-                ret = 0;
-            } else {
-                ret = 1;
-
-            }
-        } else {
-            if (tls_data->flags & DETECT_CONTENT_NEGATED) {
-                ret = 1;
-            } else {
-                ret = 0;
-            }
-        }
-    } else {
-        ret = 0;
-    }
-
-    SCReturnInt(ret);
-}
 
 /**
  * \brief this function is used to add the parsed "fingerprint" option
@@ -682,35 +574,16 @@ static int DetectTlsFingerprintMatch (DetectEngineThreadCtx *det_ctx,
  */
 static int DetectTlsFingerprintSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectTlsData *tls = NULL;
-    SigMatch *sm = NULL;
 
-    if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
+    if (DetectContentSetup(de_ctx, s, str) < 0) {
+        return -1;
+    }
+
+    if (DetectEngineContentModifierBufferSetup(de_ctx, s, NULL, DETECT_AL_TLS_CERT_FINGERPRINT,
+                g_tls_cert_fingerprint_list_id, ALPROTO_TLS) < 0)
         return -1;
 
-    tls = DetectTlsFingerprintParse(de_ctx, str, s->init_data->negated);
-    if (tls == NULL)
-        goto error;
-
-    /* Okay so far so good, lets get this into a SigMatch
-     * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_TLS_FINGERPRINT;
-    sm->ctx = (void *)tls;
-
-    SigMatchAppendSMToList(s, sm, g_tls_cert_list_id);
     return 0;
-
-error:
-    if (tls != NULL)
-        DetectTlsFingerprintFree(de_ctx, tls);
-    if (sm != NULL)
-        SCFree(sm);
-    return -1;
-
 }
 
 /**


### PR DESCRIPTION
continuation of #7977 

Backport of tls.fingerprint improvements.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5565](https://redmine.openinfosecfoundation.org/issues/5565)

Describe changes:
- Backport of fix for issue [4581](https://redmine.openinfosecfoundation.org/issues/4581)

Updates:
- Formatting fixups

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
