### PR TITLE
rust: fix lint warning about enum's name

### DIFF
--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -27,11 +27,11 @@ pub const HTTP2_DECOMPRESSION_CHUNK_SIZE: usize = 0x1000; // 4096
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Debug)]
 pub enum HTTP2ContentEncoding {
-    HTTP2ContentEncodingUnknown = 0,
-    HTTP2ContentEncodingGzip = 1,
-    HTTP2ContentEncodingBr = 2,
-    HTTP2ContentEncodingDeflate = 3,
-    HTTP2ContentEncodingUnrecognized = 4,
+    Unknown = 0,
+    Gzip = 1,
+    Br = 2,
+    Deflate = 3,
+    Unrecognized = 4,
 }
 
 //a cursor turning EOF into blocking errors
@@ -160,28 +160,28 @@ fn http2_decompress<'a>(
 impl HTTP2DecoderHalf {
     pub fn new() -> HTTP2DecoderHalf {
         HTTP2DecoderHalf {
-            encoding: HTTP2ContentEncoding::HTTP2ContentEncodingUnknown,
+            encoding: HTTP2ContentEncoding::Unknown,
             decoder: HTTP2Decompresser::UNASSIGNED,
         }
     }
 
     pub fn http2_encoding_fromvec(&mut self, input: &[u8]) {
         //use first encoding...
-        if self.encoding == HTTP2ContentEncoding::HTTP2ContentEncodingUnknown {
+        if self.encoding == HTTP2ContentEncoding::Unknown {
             if input == b"gzip" {
-                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingGzip;
+                self.encoding = HTTP2ContentEncoding::Gzip;
                 self.decoder = HTTP2Decompresser::GZIP(GzDecoder::new(HTTP2cursor::new()));
             } else if input == b"deflate" {
-                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingDeflate;
+                self.encoding = HTTP2ContentEncoding::Deflate;
                 self.decoder = HTTP2Decompresser::DEFLATE(DeflateDecoder::new(HTTP2cursor::new()));
             } else if input == b"br" {
-                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingBr;
+                self.encoding = HTTP2ContentEncoding::Br;
                 self.decoder = HTTP2Decompresser::BROTLI(brotli::Decompressor::new(
                     HTTP2cursor::new(),
                     HTTP2_DECOMPRESSION_CHUNK_SIZE,
                 ));
             } else {
-                self.encoding = HTTP2ContentEncoding::HTTP2ContentEncodingUnrecognized;
+                self.encoding = HTTP2ContentEncoding::Unrecognized;
             }
         }
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -53,7 +53,6 @@
 #![allow(clippy::match_ref_pats)]
 #![allow(clippy::module_inception)]
 #![allow(clippy::needless_range_loop)]
-#![allow(clippy::enum_variant_names)]
 #![allow(clippy::if_same_then_else)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::extra_unused_lifetimes)]

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -30,34 +30,34 @@ use std::fmt;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum MessageCode {
-	SshMsgDisconnect,
-	SshMsgIgnore,
-	SshMsgUnimplemented,
-	SshMsgDebug,
-	SshMsgServiceRequest,
-	SshMsgServiceAccept,
-	SshMsgKexinit,
-	SshMsgNewKeys,
-	SshMsgKexdhInit,
-	SshMsgKexdhReply,
+	Disconnect,
+	Ignore,
+	Unimplemented,
+	Debug,
+	ServiceRequest,
+	ServiceAccept,
+	Kexinit,
+	NewKeys,
+	KexdhInit,
+	KexdhReply,
 	
-	SshMsgUndefined(u8),
+	Undefined(u8),
 }
 
 impl MessageCode {
     fn from_u8(value: u8) -> MessageCode {
         match value {
-            1 => MessageCode::SshMsgDisconnect,
-            2 => MessageCode::SshMsgIgnore,
-            3 => MessageCode::SshMsgUnimplemented,
-            4 => MessageCode::SshMsgDebug,
-            5 => MessageCode::SshMsgServiceRequest,
-            6 => MessageCode::SshMsgServiceAccept,
-            20 => MessageCode::SshMsgKexinit,
-            21 => MessageCode::SshMsgNewKeys,
-            30 => MessageCode::SshMsgKexdhInit,
-            31 => MessageCode::SshMsgKexdhReply,
-            _ => MessageCode::SshMsgUndefined(value),
+            1 => MessageCode::Disconnect,
+            2 => MessageCode::Ignore,
+            3 => MessageCode::Unimplemented,
+            4 => MessageCode::Debug,
+            5 => MessageCode::ServiceRequest,
+            6 => MessageCode::ServiceAccept,
+            20 => MessageCode::Kexinit,
+            21 => MessageCode::NewKeys,
+            30 => MessageCode::KexdhInit,
+            31 => MessageCode::KexdhReply,
+            _ => MessageCode::Undefined(value),
         }
     }
 }


### PR DESCRIPTION
- [X] I have read the contributing guidelines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)fixes lint warnings in the rust code

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4597) ticket:

Previous PR: https://github.com/OISF/suricata/pull/7988

Describe changes:
- Squash the commits 
