### PR TITLE
rust: fix lint warnings about ptr_arg

### DIFF
--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -240,7 +240,7 @@ impl DHCPLogger {
 
 }
 
-fn format_addr_hex(input: &Vec<u8>) -> String {
+fn format_addr_hex(input: &[u8]) -> String {
     let parts: Vec<String> = input.iter()
         .map(|b| format!("{:02x}", b))
         .collect();

--- a/rust/src/ike/ikev1.rs
+++ b/rust/src/ike/ikev1.rs
@@ -53,10 +53,10 @@ impl Ikev1ParticipantData {
     }
 
     pub fn update(
-        &mut self, key_exchange: &String, nonce: &String, transforms: &Vec<Vec<SaAttribute>>,
+        &mut self, key_exchange: &str, nonce: &str, transforms: &Vec<Vec<SaAttribute>>,
     ) {
-        self.key_exchange = key_exchange.clone();
-        self.nonce = nonce.clone();
+        self.key_exchange = key_exchange.to_string();
+        self.nonce = nonce.to_string();
         if self.nb_transforms == 0 && transforms.len() > 0 {
             self.transform.extend(transforms[0].iter().cloned());
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -47,7 +47,6 @@
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::single_match)]
 #![allow(clippy::upper_case_acronyms)]
-#![allow(clippy::ptr_arg)]
 #![allow(clippy::new_without_default)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::match_ref_pats)]

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -81,7 +81,7 @@ fn nfs_handle2hex(bytes: &Vec<u8>) -> String {
     strings.join("")
 }
 */
-fn nfs_handle2crc(bytes: &Vec<u8>) -> u32 {
+fn nfs_handle2crc(bytes: &[u8]) -> u32 {
     let c = crc32::checksum_ieee(bytes);
     c
 }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -286,7 +286,7 @@ impl NFSRequestXidMap {
 
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, name: &Vec<u8>, data: &[u8],
+        flags: u16, name: &[u8], data: &[u8],
         chunk_offset: u64, chunk_size: u32, fill_bytes: u8, is_last: bool, xid: &u32)
 {
     match unsafe {SURICATA_NFS_FILE_CONFIG} {
@@ -685,7 +685,7 @@ impl NFSState {
         }
     }
 
-    pub fn new_file_tx(&mut self, file_handle: &Vec<u8>, file_name: &Vec<u8>, direction: Direction)
+    pub fn new_file_tx(&mut self, file_handle: &[u8], file_name: &[u8], direction: Direction)
         -> &mut NFSTransaction
     {
         let mut tx = self.new_tx();
@@ -709,7 +709,7 @@ impl NFSState {
         return tx_ref.unwrap();
     }
 
-    pub fn get_file_tx_by_handle(&mut self, file_handle: &Vec<u8>, direction: Direction)
+    pub fn get_file_tx_by_handle(&mut self, file_handle: &[u8], direction: Direction)
         -> Option<&mut NFSTransaction>
     {
         let fh = file_handle.to_vec();

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -129,7 +129,7 @@ impl NFSState {
 
     fn new_tx_v4<'b>(
         &mut self, r: &RpcPacket<'b>, xidmap: &NFSRequestXidMap, procedure: u32,
-        _aux_opcodes: &Vec<u32>,
+        _aux_opcodes: &[u32],
     ) {
         let mut tx = self.new_tx();
         tx.xid = r.hdr.xid;

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -52,7 +52,7 @@ impl SMBTransactionFile {
 
 /// little wrapper around the FileTransferTracker::new_chunk method
 pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, name: &Vec<u8>, data: &[u8],
+        flags: u16, name: &[u8], data: &[u8],
         chunk_offset: u64, chunk_size: u32, is_last: bool, xid: &u32)
 {
     match unsafe {SURICATA_SMB_FILE_CONFIG} {
@@ -64,7 +64,7 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
 }
 
 impl SMBState {
-    pub fn new_file_tx(&mut self, fuid: &Vec<u8>, file_name: &Vec<u8>, direction: Direction)
+    pub fn new_file_tx(&mut self, fuid: &[u8], file_name: &[u8], direction: Direction)
         -> &mut SMBTransaction
     {
         let mut tx = self.new_tx();
@@ -89,7 +89,7 @@ impl SMBState {
         return tx_ref.unwrap();
     }
 
-    pub fn get_file_tx_by_fuid(&mut self, fuid: &Vec<u8>, direction: Direction)
+    pub fn get_file_tx_by_fuid(&mut self, fuid: &[u8], direction: Direction)
         -> Option<&mut SMBTransaction>
     {
         let f = fuid.to_vec();

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1001,7 +1001,7 @@ impl SMBState {
         return None;
     }
 
-    pub fn new_create_tx(&mut self, file_name: &Vec<u8>,
+    pub fn new_create_tx(&mut self, file_name: &[u8],
             disposition: u32, del: bool, dir: bool,
             hdr: SMBCommonHdr)
         -> &mut SMBTransaction

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -148,7 +148,7 @@ pub fn smb1_check_tx(cmd: u8) -> bool {
     }
 }
 
-fn smb1_close_file(state: &mut SMBState, fid: &Vec<u8>, direction: Direction)
+fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction)
 {
     if let Some(tx) = state.get_file_tx_by_fuid(fid, direction) {
         SCLogDebug!("found tx {}", tx.id);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -571,7 +571,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     state.ssn2vec_map.insert(name_key, cr.data.to_vec());
 
                     let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
-                    let tx = state.new_create_tx(&cr.data.to_vec(),
+                    let tx = state.new_create_tx(cr.data,
                             cr.disposition, del, dir, tx_hdr);
                     tx.vercmd.set_smb2_cmd(r.command);
                     SCLogDebug!("TS CREATE TX {} created", tx.id);
@@ -590,7 +590,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
         SMB2_COMMAND_CLOSE => {
             match parse_smb2_request_close(r.data) {
                 Ok((_, cd)) => {
-                    let found_ts = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), Direction::ToServer) {
+                    let found_ts = match state.get_file_tx_by_fuid(cd.guid, Direction::ToServer) {
                         Some(tx) => {
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
@@ -605,7 +605,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         },
                         None => { false },
                     };
-                    let found_tc = match state.get_file_tx_by_fuid(&cd.guid.to_vec(), Direction::ToClient) {
+                    let found_tc = match state.get_file_tx_by_fuid(cd.guid, Direction::ToClient) {
                         Some(tx) => {
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4599

Describe changes:
- Fix ptr_arg clippy lint warnings
- Remove `#![allow(clippy::ptr_arg)]` from rust/src/lib.rs

