### PR TITLE
detect/alert: don't lose 'drop' alert - v5

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -177,9 +177,20 @@ static inline void RuleActionToFlow(const uint8_t action, Flow *f)
     }
 }
 
+/** \internal
+ */
+static inline PacketAlert PacketAlertSet(
+        DetectEngineThreadCtx *det_ctx, const Signature *s, uint64_t tx_id, uint8_t alert_flags)
+{
+    PacketAlert pa = { s->num, s->action, alert_flags, s, (tx_id == UINT64_MAX) ? 0 : tx_id,
+        (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0 };
+    return pa;
+}
+
 /** \brief Apply action(s) and Set 'drop' sig info,
  *         if applicable */
-static void PacketApplySignatureActions(Packet *p, const Signature *s, const uint8_t alert_flags)
+static void PacketApplySignatureActions(
+        DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const uint8_t alert_flags)
 {
     SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x", p->pcap_cnt, s->id,
             s->action, alert_flags);
@@ -190,9 +201,7 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const uin
         PacketDrop(p, s->action, PKT_DROP_REASON_RULES);
 
         if (p->alerts.drop.action == 0) {
-            p->alerts.drop.num = s->num;
-            p->alerts.drop.action = s->action;
-            p->alerts.drop.s = (Signature *)s;
+            p->alerts.drop = PacketAlertSet(det_ctx, s, 0, alert_flags);
         }
         if ((p->flow != NULL) && (alert_flags & PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)) {
             RuleActionToFlow(s->action, p->flow);
@@ -249,22 +258,6 @@ static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
             det_ctx->alert_queue_capacity,
             (uintmax_t)(sizeof(PacketAlert) * det_ctx->alert_queue_capacity));
     return new_cap;
-}
-
-/** \internal
- */
-static inline PacketAlert PacketAlertSet(
-        DetectEngineThreadCtx *det_ctx, const Signature *s, uint64_t tx_id, uint8_t alert_flags)
-{
-    PacketAlert pa;
-    pa.num = s->num;
-    pa.action = s->action;
-    pa.s = (Signature *)s;
-    pa.flags = alert_flags;
-    /* Set tx_id if the frame has it */
-    pa.tx_id = (tx_id == UINT64_MAX) ? 0 : tx_id;
-    pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
-    return pa;
 }
 
 /**
@@ -382,7 +375,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                     p, &det_ctx->alert_queue[i], s, det_ctx->alert_queue[i].flags);
 
             /* set actions on packet */
-            PacketApplySignatureActions(p, s, det_ctx->alert_queue[i].flags);
+            PacketApplySignatureActions(det_ctx, p, s, det_ctx->alert_queue[i].flags);
         }
 
         /* Thresholding removes this alert */

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -330,15 +330,66 @@ static inline void FlowApplySignatureActions(
 }
 
 /**
- * \brief Check the threshold of the sigs that match, set actions, break on pass action
- *        This function iterate the packet alerts array, removing those that didn't match
- *        the threshold, and those that match after a signature with the action "pass".
- *        The array is sorted by action priority/order
+ * \brief Check the threshold of the sigs that match, check if tags should be applied,
+ * call functions to set actions to packet and flow
+ *
+ * \param de_ctx detection engine context
+ * \param det_ctx detection engine thread context
+ * \param p pointer to the packet
+ * \param pa pointer to packet alert being processed
+ * \param s pointer to signature that generated alert
+ *
+ * \retval 1 alert should be queued
+ * \retval 0 alert is discarded
+ */
+static uint8_t PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        Packet *p, PacketAlert *pa, const Signature *s)
+{
+    uint8_t res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+
+    if (res > 0) {
+        /* Now, if we have an alert, we have to check if we want
+         * to tag this session or src/dst host */
+        if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
+            KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
+            SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
+            while (1) {
+                /* tags are set only for alerts */
+                KEYWORD_PROFILING_START;
+                sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
+                KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
+
+        /* set actions on the flow */
+        FlowApplySignatureActions(p, pa, s, pa->flags);
+
+        /* set actions on packet */
+        PacketApplySignatureActions(det_ctx, p, s, pa->flags);
+    }
+
+    /* Thresholding removes this alert */
+    if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
+        /* we will not copy this to the AlertQueue */
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+/**
+ * \brief Iterate over the packet alerts queue, removing those that didn't match
+ *        the threshold, and those that match after a signature with the action
+ *        "pass". The queue is sorted by action priority/order
+ *
  * \param de_ctx detection engine context
  * \param det_ctx detection engine thread context
  * \param p pointer to the packet
  */
-void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
+void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p)
 {
     SCEnter();
 
@@ -351,49 +402,26 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 
     while (i < max_pos) {
         const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
-        int res = PacketAlertHandle(de_ctx, det_ctx, s, p, &det_ctx->alert_queue[i]);
-
-        if (res > 0) {
-            /* Now, if we have an alert, we have to check if we want
-             * to tag this session or src/dst host */
-            if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
-                KEYWORD_PROFILING_SET_LIST(det_ctx, DETECT_SM_LIST_TMATCH);
-                SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_TMATCH];
-                while (1) {
-                    /* tags are set only for alerts */
-                    KEYWORD_PROFILING_START;
-                    sigmatch_table[smd->type].Match(det_ctx, p, (Signature *)s, smd->ctx);
-                    KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
-                    if (smd->is_last)
-                        break;
-                    smd++;
-                }
-            }
-
-            /* set actions on the flow */
-            FlowApplySignatureActions(
-                    p, &det_ctx->alert_queue[i], s, det_ctx->alert_queue[i].flags);
-
-            /* set actions on packet */
-            PacketApplySignatureActions(det_ctx, p, s, det_ctx->alert_queue[i].flags);
-        }
+        uint8_t res = PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
 
         /* Thresholding removes this alert */
-        if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
+        if (res == 0) {
             /* we will not copy this to the AlertQueue */
             p->alerts.suppressed++;
-        } else if (p->alerts.cnt < packet_alert_max) {
-            p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
-            SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
-
-            if (PacketTestAction(p, ACTION_PASS)) {
-                /* Ok, reset the alert cnt to end in the previous of pass
-                 * so we ignore the rest with less prio */
-                break;
+            SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
+        } else if (res == 1) {
+            if (p->alerts.cnt < packet_alert_max) {
+                p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
+                SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
+                if (PacketTestAction(p, ACTION_PASS)) {
+                    /* Ok, reset the alert cnt to end in the previous of pass
+                     * so we ignore the rest with less prio */
+                    break;
+                }
+                p->alerts.cnt++;
+            } else {
+                p->alerts.discarded++;
             }
-            p->alerts.cnt++;
-        } else {
-            p->alerts.discarded++;
         }
         i++;
     }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -227,6 +227,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx)
                 (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
     }
     det_ctx->alert_queue_capacity = packet_alert_max;
+    det_ctx->is_alert_queue_expand_failure = false;
     SCLogDebug("alert queue initialized to %u elements (%" PRIu64 " bytes)", packet_alert_max,
             (uint64_t)(packet_alert_max * sizeof(PacketAlert)));
 }
@@ -243,12 +244,16 @@ void AlertQueueFree(DetectEngineThreadCtx *det_ctx)
 static uint16_t AlertQueueExpand(DetectEngineThreadCtx *det_ctx)
 {
 #ifdef DEBUG
-    if (unlikely(g_eps_is_alert_queue_fail_mode))
+    if (unlikely(g_eps_is_alert_queue_fail_mode)) {
+        det_ctx->is_alert_queue_expand_failure = true;
         return det_ctx->alert_queue_capacity;
+    }
 #endif
     uint16_t new_cap = det_ctx->alert_queue_capacity * 2;
     void *tmp_queue = SCRealloc(det_ctx->alert_queue, (size_t)(sizeof(PacketAlert) * new_cap));
     if (unlikely(tmp_queue == NULL)) {
+        /* save this info, so we know to double check for DROP action in packet */
+        det_ctx->is_alert_queue_expand_failure = true;
         /* queue capacity didn't change */
         return det_ctx->alert_queue_capacity;
     }
@@ -393,37 +398,76 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
 {
     SCEnter();
 
-    /* sort the alert queue before thresholding and appending to Packet */
-    qsort(det_ctx->alert_queue, det_ctx->alert_queue_size, sizeof(PacketAlert),
-            AlertQueueSortHelper);
-
-    uint16_t i = 0;
     uint16_t max_pos = det_ctx->alert_queue_size;
 
-    while (i < max_pos) {
-        const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
-        uint8_t res = PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
+    /* If there are alerts for this packet, process them */
+    if (max_pos > 0) {
+        PacketAlert tmp_queue[max_pos];
+        uint16_t tmp_size = 0;
+        bool is_action_pass = false;
+        uint32_t pass_sid_num = 0;
 
-        /* Thresholding removes this alert */
-        if (res == 0) {
-            /* we will not copy this to the AlertQueue */
-            p->alerts.suppressed++;
-            SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
-        } else if (res == 1) {
-            if (p->alerts.cnt < packet_alert_max) {
-                p->alerts.alerts[p->alerts.cnt] = det_ctx->alert_queue[i];
-                SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
-                if (PacketTestAction(p, ACTION_PASS)) {
-                    /* Ok, reset the alert cnt to end in the previous of pass
-                     * so we ignore the rest with less prio */
-                    break;
-                }
-                p->alerts.cnt++;
-            } else {
-                p->alerts.discarded++;
+        for (uint16_t i = 0; i < max_pos; i++) {
+            const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
+            uint8_t res = PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
+
+            /* Thresholding removes this alert */
+            if (res == 0) {
+                /* we will not copy this to the AlertQueue */
+                p->alerts.suppressed++;
+                SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);
+                continue;
+            }
+            tmp_queue[tmp_size] = det_ctx->alert_queue[i];
+            tmp_size++;
+            SCLogDebug("Appending sid %" PRIu32 " alert to Packet::alerts at pos %u", s->id, i);
+            if (PacketTestAction(p, ACTION_PASS) && !is_action_pass) {
+                /* Ok, reset the alert cnt to end in the previous of pass
+                 * so we ignore the rest with less prio */
+                pass_sid_num = s->num;
+                is_action_pass = true;
             }
         }
-        i++;
+
+        if (packet_alert_max > tmp_size) {
+            p->alerts.cnt = tmp_size;
+        } else {
+            p->alerts.cnt = packet_alert_max;
+            // we also have discarded alerts in case of queue expansion failure, let's
+            // not miss that count
+            p->alerts.discarded += (tmp_size - packet_alert_max);
+        }
+        qsort(tmp_queue, tmp_size, sizeof(PacketAlert), AlertQueueSortHelper);
+
+        if (det_ctx->is_alert_queue_expand_failure) {
+            if (p->alerts.drop.action & ACTION_DROP) {
+                PacketAlertFinalize(de_ctx, det_ctx, p, &p->alerts.drop, p->alerts.drop.s);
+            }
+        }
+
+        if (is_action_pass) {
+            // this means we got a 'PASS' action for this Packet, pass_sid_num
+            // has the related signature's internal id
+            uint16_t j = 0;
+            for (; j < p->alerts.cnt; j++) {
+                if (tmp_queue[j].num < pass_sid_num) {
+                    // we add it to the final queue
+                    p->alerts.alerts[j] = tmp_queue[j];
+                } else {
+                    break;
+                }
+            }
+            if (PacketTestAction(p, ACTION_DROP)) {
+                if (p->alerts.drop.s->num > pass_sid_num) {
+                    // if this should be a pass, then ignore drop action
+                    p->alerts.drop.action = 0;
+                    PacketPass(p);
+                }
+            }
+            p->alerts.cnt = j;
+        } else {
+            memcpy(p->alerts.alerts, tmp_queue, p->alerts.cnt * sizeof(PacketAlert));
+        }
     }
 
     /* At this point, we should have all the new alerts. Now check the tag

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -68,19 +68,20 @@ PacketAlert *PacketAlertGetTag(void)
  * \param sig Signature pointer
  * \param p Packet structure
  *
- * \retval 1 alert is not suppressed
- * \retval 0 alert is suppressed
+ * \retval THRESHOLD_SILENT_MATCH alert is suppressed, but rule actions apply
+ * \retval THRESHOLD_NOT_SUPPRESSED alert is not suppressed
+ * \retval THRESHOLD_SUPPRESSED alert is suppressed
  */
-static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-                             const Signature *s, Packet *p, PacketAlert *pa)
+static SigThresholdResults PacketAlertHandle(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, PacketAlert *pa)
 {
     SCEnter();
-    int ret = 1;
+    SigThresholdResults ret = THRESHOLD_NOT_SUPPRESSED;
     const DetectThresholdData *td = NULL;
     const SigMatchData *smd;
 
     if (!(PKT_IS_IPV4(p) || PKT_IS_IPV6(p))) {
-        SCReturnInt(1);
+        SCReturnInt(THRESHOLD_NOT_SUPPRESSED);
     }
 
     /* handle suppressions first */
@@ -92,11 +93,11 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
             if (td != NULL) {
                 SCLogDebug("td %p", td);
 
-                /* PacketAlertThreshold returns 2 if the alert is suppressed but
-                 * we do need to apply rule actions to the packet. */
+                /* PacketAlertThreshold returns THRESHOLD_SILENT_MATCH if the alert is suppressed
+                 * but we do need to apply rule actions to the packet. */
                 KEYWORD_PROFILING_START;
                 ret = PacketAlertThreshold(de_ctx, det_ctx, td, p, s, pa);
-                if (ret == 0 || ret == 2) {
+                if (ret == THRESHOLD_SUPPRESSED || ret == THRESHOLD_SILENT_MATCH) {
                     KEYWORD_PROFILING_END(det_ctx, DETECT_THRESHOLD, 0);
                     /* It doesn't match threshold, remove it */
                     SCReturnInt(ret);
@@ -115,11 +116,11 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
             if (td != NULL) {
                 SCLogDebug("td %p", td);
 
-                /* PacketAlertThreshold returns 2 if the alert is suppressed but
-                 * we do need to apply rule actions to the packet. */
+                /* PacketAlertThreshold returns THRESHOLD_SILENT_MATCH if the alert is suppressed
+                 * but we do need to apply rule actions to the packet. */
                 KEYWORD_PROFILING_START;
                 ret = PacketAlertThreshold(de_ctx, det_ctx, td, p, s, pa);
-                if (ret == 0 || ret == 2) {
+                if (ret == THRESHOLD_SUPPRESSED || ret == THRESHOLD_SILENT_MATCH) {
                     KEYWORD_PROFILING_END(det_ctx, DETECT_THRESHOLD ,0);
                     /* It doesn't match threshold, remove it */
                     SCReturnInt(ret);
@@ -128,7 +129,7 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
             }
         } while (smd != NULL);
     }
-    SCReturnInt(1);
+    SCReturnInt(THRESHOLD_NOT_SUPPRESSED);
 }
 
 /**
@@ -344,15 +345,15 @@ static inline void FlowApplySignatureActions(
  * \param pa pointer to packet alert being processed
  * \param s pointer to signature that generated alert
  *
- * \retval 1 alert should be queued
- * \retval 0 alert is discarded
+ * \retval THRESHOLD_NOT_SUPPRESSED alert should be queued
+ * \retval THRESHOLD_SUPPRESSED alert is discarded
  */
-static uint8_t PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        Packet *p, PacketAlert *pa, const Signature *s)
+static SigThresholdResults PacketAlertFinalize(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, Packet *p, PacketAlert *pa, const Signature *s)
 {
-    uint8_t res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
+    SigThresholdResults res = PacketAlertHandle(de_ctx, det_ctx, s, p, pa);
 
-    if (res > 0) {
+    if (res > THRESHOLD_DONT_ALERT) {
         /* Now, if we have an alert, we have to check if we want
          * to tag this session or src/dst host */
         if (s->sm_arrays[DETECT_SM_LIST_TMATCH] != NULL) {
@@ -377,11 +378,12 @@ static uint8_t PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCt
     }
 
     /* Thresholding removes this alert */
-    if (res == 0 || res == 2 || (s->flags & SIG_FLAG_NOALERT)) {
+    if (res == THRESHOLD_SUPPRESSED || res == THRESHOLD_SILENT_MATCH ||
+            (s->flags & SIG_FLAG_NOALERT)) {
         /* we will not copy this to the AlertQueue */
-        return 0;
+        return THRESHOLD_SUPPRESSED;
     } else {
-        return 1;
+        return THRESHOLD_NOT_SUPPRESSED;
     }
 }
 
@@ -409,10 +411,11 @@ void PacketAlertQueueFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *de
 
         for (uint16_t i = 0; i < max_pos; i++) {
             const Signature *s = de_ctx->sig_array[det_ctx->alert_queue[i].num];
-            uint8_t res = PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
+            SigThresholdResults res =
+                    PacketAlertFinalize(de_ctx, det_ctx, p, &det_ctx->alert_queue[i], s);
 
             /* Thresholding removes this alert */
-            if (res == 0) {
+            if (res == THRESHOLD_SUPPRESSED) {
                 /* we will not copy this to the AlertQueue */
                 p->alerts.suppressed++;
                 SCLogDebug("Suppressing sid %" PRIu32 " alert from alerts' queue", s->id);

--- a/src/detect-engine-alert.h
+++ b/src/detect-engine-alert.h
@@ -32,7 +32,7 @@ void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
 void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
-void PacketAlertFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
+void PacketAlertQueueFinalize(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 int PacketAlertCheck(Packet *, uint32_t);
 void PacketAlertTagInit(void);
 PacketAlert *PacketAlertGetTag(void);

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -255,10 +255,22 @@ static DetectThresholdEntry *ThresholdIPPairLookupEntry(IPPair *pair,
     return e;
 }
 
-static int ThresholdHandlePacketSuppress(Packet *p,
-        const DetectThresholdData *td, uint32_t sid, uint32_t gid)
+/**
+ * \brief Check if packet should be suppressed due to thresholding
+ *
+ * \param p Packet structure
+ * \param td DetectThresholdData structure
+ * \param sid Signature id
+ * \param gid Signature group id
+ *
+ * \retval THRESHOLD_NOT_SUPPRESSED alert is not suppressed
+ * \retval THRESHOLD_SUPPRESSED alert is suppressed
+ * \retval THRESHOLD_SILENT_MATCH alert is suppressed but actions must be applied
+ */
+static SigThresholdResults ThresholdHandlePacketSuppress(
+        Packet *p, const DetectThresholdData *td, uint32_t sid, uint32_t gid)
 {
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_SUPPRESSED;
     DetectAddress *m = NULL;
     switch (td->track) {
         case TRACK_DST:
@@ -284,9 +296,9 @@ static int ThresholdHandlePacketSuppress(Packet *p,
             break;
     }
     if (m == NULL)
-        ret = 1;
+        ret = THRESHOLD_NOT_SUPPRESSED;
     else
-        ret = 2; /* suppressed but still need actions */
+        ret = THRESHOLD_SILENT_MATCH;
 
     return ret;
 }
@@ -317,18 +329,20 @@ static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_a
 }
 
 /**
-* \brief Check if the entry reached threshold count limit
-*
-* \param lookup_tsh Current threshold entry
-* \param td Threshold settings
-* \param packet_time used to compare against previous detection and to set timeouts
-*
-* \retval int 1 if threshold reached for this entry
-*
-*/
-static int IsThresholdReached(DetectThresholdEntry* lookup_tsh, const DetectThresholdData *td, struct timeval packet_time)
+ * \brief Check if the entry reached threshold count limit
+ *
+ * \param lookup_tsh Current threshold entry
+ * \param td Threshold settings
+ * \param packet_time used to compare against previous detection and to set timeouts
+ *
+ * \retval bool true if threshold reached for this entry
+ * \retval bool false if threshold not reached
+ *
+ */
+static bool IsThresholdReached(
+        DetectThresholdEntry *lookup_tsh, const DetectThresholdData *td, struct timeval packet_time)
 {
-    int ret = 0;
+    bool ret = false;
 
     /* Check if we have a timeout enabled, if so,
     * we still matching (and enabling the new_action) */
@@ -339,7 +353,7 @@ static int IsThresholdReached(DetectThresholdEntry* lookup_tsh, const DetectThre
         }
         else {
             /* Already matching */
-            ret = 1;
+            ret = true;
         } /* else - if ((packet_time - lookup_tsh->tv_timeout) > td->timeout) */
 
     }
@@ -352,7 +366,7 @@ static int IsThresholdReached(DetectThresholdEntry* lookup_tsh, const DetectThre
                 /* Then we must enable the new action by setting a
                 * timeout */
                 lookup_tsh->tv_timeout = packet_time.tv_sec;
-                ret = 1;
+                ret = true;
             }
         } else {
             lookup_tsh->tv1 = packet_time;
@@ -386,18 +400,18 @@ static void AddEntryToIPPairStorage(IPPair *pair, DetectThresholdEntry *e, struc
 }
 
 /**
- *  \retval 2 silent match (no alert but apply actions)
- *  \retval 1 normal match
- *  \retval 0 no match
+ *  \retval THRESHOLD_SILENT_MATCH silent match (no alert but apply actions)
+ *  \retval THRESHOLD_ALERT normal match
+ *  \retval THRESHOLD_DONT_ALERT no match
  *
  *  If a new DetectThresholdEntry is generated to track the threshold
  *  for this rule, then it will be returned in new_tsh.
  */
-static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
-        DetectThresholdEntry **new_tsh, const DetectThresholdData *td,
-        uint32_t sid, uint32_t gid, PacketAlert *pa)
+static SigThresholdResults ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
+        DetectThresholdEntry **new_tsh, const DetectThresholdData *td, uint32_t sid, uint32_t gid,
+        PacketAlert *pa)
 {
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_DONT_ALERT;
 
     switch(td->type)   {
         case TYPE_LIMIT:
@@ -410,20 +424,20 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count <= td->count) {
-                        ret = 1;
+                        ret = THRESHOLD_ALERT;
                     } else {
-                        ret = 2;
+                        ret = THRESHOLD_SILENT_MATCH;
                     }
                 } else {
                     lookup_tsh->tv1 = p->ts;
                     lookup_tsh->current_count = 1;
 
-                    ret = 1;
+                    ret = THRESHOLD_ALERT;
                 }
             } else {
                 *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
 
-                ret = 1;
+                ret = THRESHOLD_ALERT;
             }
             break;
         }
@@ -437,7 +451,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count >= td->count) {
-                        ret = 1;
+                        ret = THRESHOLD_ALERT;
                         lookup_tsh->current_count = 0;
                     }
                 } else {
@@ -446,7 +460,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                 }
             } else {
                 if (td->count == 1)  {
-                    ret = 1;
+                    ret = THRESHOLD_ALERT;
                 } else {
                     *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
                 }
@@ -464,10 +478,10 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
 
                     lookup_tsh->current_count++;
                     if (lookup_tsh->current_count == td->count) {
-                        ret = 1;
+                        ret = THRESHOLD_ALERT;
                     } else if (lookup_tsh->current_count > td->count) {
                         /* silent match */
-                        ret = 2;
+                        ret = THRESHOLD_SILENT_MATCH;
                     }
                 } else {
                     /* expired, so reset */
@@ -476,7 +490,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
 
                     /* if we have a limit of 1, this is a match */
                     if (lookup_tsh->current_count == td->count) {
-                        ret = 1;
+                        ret = THRESHOLD_ALERT;
                     }
                 }
             } else {
@@ -485,7 +499,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                 /* for the first match we return 1 to
                  * indicate we should alert */
                 if (td->count == 1)  {
-                    ret = 1;
+                    ret = THRESHOLD_ALERT;
                 }
             }
             break;
@@ -501,7 +515,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     /* within timeout */
                     lookup_tsh->current_count++;
                     if (lookup_tsh->current_count > td->count) {
-                        ret = 1;
+                        ret = THRESHOLD_ALERT;
                     }
                 } else {
                     /* expired, reset */
@@ -517,7 +531,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
         case TYPE_RATE:
         {
             SCLogDebug("rate_filter");
-            ret = 1;
+            ret = THRESHOLD_ALERT;
             if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts)) {
                 RateFilterSetAction(p, pa, td->new_action);
             } else if (!lookup_tsh) {
@@ -532,10 +546,10 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
     return ret;
 }
 
-static int ThresholdHandlePacketIPPair(IPPair *pair, Packet *p, const DetectThresholdData *td,
-    uint32_t sid, uint32_t gid, PacketAlert *pa)
+static SigThresholdResults ThresholdHandlePacketIPPair(IPPair *pair, Packet *p,
+        const DetectThresholdData *td, uint32_t sid, uint32_t gid, PacketAlert *pa)
 {
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_DONT_ALERT;
 
     DetectThresholdEntry *lookup_tsh = ThresholdIPPairLookupEntry(pair, sid, gid);
     SCLogDebug("ippair lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
@@ -550,14 +564,14 @@ static int ThresholdHandlePacketIPPair(IPPair *pair, Packet *p, const DetectThre
 }
 
 /**
- *  \retval 2 silent match (no alert but apply actions)
- *  \retval 1 normal match
- *  \retval 0 no match
+ *  \retval THRESHOLD_SILENT_MATCH silent match (no alert but apply actions)
+ *  \retval THRESHOLD_MATCH normal match
+ *  \retval THRESHOLD_NO_MATCH no match
  */
-static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdData *td,
-        uint32_t sid, uint32_t gid, PacketAlert *pa)
+static SigThresholdResults ThresholdHandlePacketHost(Host *h, Packet *p,
+        const DetectThresholdData *td, uint32_t sid, uint32_t gid, PacketAlert *pa)
 {
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_DONT_ALERT;
     DetectThresholdEntry *lookup_tsh = ThresholdHostLookupEntry(h, sid, gid);
     SCLogDebug("lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
 
@@ -569,10 +583,10 @@ static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdDa
     return ret;
 }
 
-static int ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
+static SigThresholdResults ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
         const DetectThresholdData *td, const Signature *s, PacketAlert *pa)
 {
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_DONT_ALERT;
 
     DetectThresholdEntry* lookup_tsh = (DetectThresholdEntry *)de_ctx->ths_ctx.th_entry[s->num];
     SCLogDebug("by_rule lookup_tsh %p num %u", lookup_tsh, s->num);
@@ -597,18 +611,18 @@ static int ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
  * \param p Packet structure
  * \param s Signature structure
  *
- * \retval 2 silent match (no alert but apply actions)
- * \retval 1 alert on this event
- * \retval 0 do not alert on this event
+ *  \retval THRESHOLD_SILENT_MATCH silent match (no alert but apply actions)
+ *  \retval THRESHOLD_MATCH normal match
+ *  \retval THRESHOLD_NO_MATCH no match
  */
-int PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+SigThresholdResults PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectThresholdData *td, Packet *p, const Signature *s, PacketAlert *pa)
 {
     SCEnter();
 
-    int ret = 0;
+    SigThresholdResults ret = THRESHOLD_SUPPRESSED;
     if (td == NULL) {
-        SCReturnInt(0);
+        SCReturnInt(THRESHOLD_DONT_ALERT);
     }
 
     if (td->type == TYPE_SUPPRESS) {

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -592,7 +592,7 @@ static int ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
 /**
  * \brief Make the threshold logic for signatures
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  * \param tsh_ptr Threshold element
  * \param p Packet structure
  * \param s Signature structure
@@ -643,7 +643,7 @@ int PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 /**
  * \brief Init threshold context hash tables
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  *
  */
 void ThresholdHashInit(DetectEngineCtx *de_ctx)
@@ -717,7 +717,7 @@ void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
     if (de_ctx->ths_ctx.th_entry == NULL) {
         FatalError(SC_ERR_MEM_ALLOC,
                 "Error allocating memory for rule "
-                "thresholds (tried to allocate %" PRIu32 " th_entrys for "
+                "thresholds (tried to allocate %" PRIu32 " th_entries for "
                 "rule tracking)",
                 de_ctx->ths_ctx.th_size);
     }
@@ -726,7 +726,7 @@ void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
 /**
  * \brief Destroy threshold context hash tables
  *
- * \param de_ctx Dectection Context
+ * \param de_ctx Detection Context
  *
  */
 void ThresholdContextDestroy(DetectEngineCtx *de_ctx)

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -30,6 +30,14 @@
 #include "ippair.h"
 #include "host-storage.h"
 
+typedef enum SigThresholdResults_ {
+    THRESHOLD_DONT_ALERT = 0,     // Rule doesn't match
+    THRESHOLD_ALERT = 1,          // Rule match
+    THRESHOLD_SILENT_MATCH = 2,   // Rule match, alert is suppressed, rule actions apply
+    THRESHOLD_SUPPRESSED = 0,     // Alert suppressed due to thresholding
+    THRESHOLD_NOT_SUPPRESSED = 1, // Rule match, alert not suppressed
+} SigThresholdResults;
+
 void ThresholdInit(void);
 
 HostStorageId ThresholdHostStorageId(void);
@@ -39,9 +47,8 @@ int ThresholdIPPairHasThreshold(IPPair *pair);
 
 const DetectThresholdData *SigGetThresholdTypeIter(
         const Signature *, const SigMatchData **, int list);
-int PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
-        const DetectThresholdData *, Packet *,
-        const Signature *, PacketAlert *);
+SigThresholdResults PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
+        const DetectThresholdData *, Packet *, const Signature *, PacketAlert *);
 
 void ThresholdHashInit(DetectEngineCtx *);
 void ThresholdHashAllocate(DetectEngineCtx *);

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect.c
+++ b/src/detect.c
@@ -927,11 +927,11 @@ static inline void DetectRunPostRules(
     }
 
     /* so now let's iterate the alerts and remove the ones after a pass rule
-     * matched (if any). This is done inside PacketAlertFinalize() */
+     * matched (if any). This is done inside PacketAlertQueueFinalize() */
     /* PR: installed "tag" keywords are handled after the threshold inspection */
 
     PACKET_PROFILING_DETECT_START(p, PROF_DETECT_ALERT);
-    PacketAlertFinalize(de_ctx, det_ctx, p);
+    PacketAlertQueueFinalize(de_ctx, det_ctx, p);
     if (p->alerts.cnt > 0) {
         StatsAddUI64(tv, det_ctx->counter_alerts, (uint64_t)p->alerts.cnt);
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -1100,6 +1100,7 @@ typedef struct DetectEngineThreadCtx_ {
     uint16_t alert_queue_size;
     uint16_t alert_queue_capacity;
     PacketAlert *alert_queue;
+    bool is_alert_queue_expand_failure;
 
     SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5180

This work is sort of a continuation of https://github.com/OISF/suricata/pull/7969 but with some smaller optimizations to functions in detect-engine-alert and detect-engine-threshold.

We're trying to optimize how we process the PacketAlertQueue and also make sure that a drop action won't be lost in case we have a failure when trying to grow the PacketAlertQueue with malloc.

This is a draft because it is failing the SV test exception-policy-default-01, showing that the way I'm trying to post-process the Pass action isn't enough. I have tried a few things to try to fix/improve that, to no avail.

Previous PR: #7976

Changes from previous PR:
- improve code documentation
- simplify processing loop in `PacketAlertQueueFinalize`
- fix wrong type declarations in a few places
- reduce number of enum variants and comment each one
- clean up commit history a bit

Describe changes:
- remove magic numbers from function returns in detect-engine-alert and detect-engine-threshold
- extract packet alerts processing to functions
- move packet alert queue sorting to after the alerts are processed
- only process alerts queue if there are actual alerts for the packet