### PR TITLE
decode/vlan: Extend VLAN encapsulation support to 3 levels; flowhash livedev

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3997,6 +3997,9 @@
                         "vlan_qinq": {
                             "type": "integer"
                         },
+                        "vlan_qinqinq": {
+                            "type": "integer"
+                        },
                         "vntag": {
                             "type": "integer"
                         },

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -100,7 +100,7 @@ int DecodeERSPAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
     }
 
     if (vlan_id > 0) {
-        if (p->vlan_idx >= 2) {
+        if (p->vlan_idx > VLAN_MAX_LAYER_IDX) {
             ENGINE_SET_EVENT(p,ERSPAN_TOO_MANY_VLAN_LAYERS);
             return TM_ECODE_FAILED;
         }

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -93,16 +93,6 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
     return TM_ECODE_OK;
-}
-
-uint16_t DecodeVLANGetId(const Packet *p, uint8_t layer)
-{
-    if (unlikely(layer > 2))
-        return 0;
-    if (p->vlan_idx > layer) {
-        return p->vlan_id[layer];
-    }
-    return 0;
 }
 
 typedef struct IEEE8021ahHdr_ {

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -62,6 +62,8 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         StatsIncr(tv, dtv->counter_vlan);
     else if (p->vlan_idx == 1)
         StatsIncr(tv, dtv->counter_vlan_qinq);
+    else if (p->vlan_idx == 2)
+        StatsIncr(tv, dtv->counter_vlan_qinqinq);
 
     if(len < VLAN_HEADER_LEN)    {
         ENGINE_SET_INVALID_EVENT(p, VLAN_HEADER_TOO_SMALL);
@@ -70,7 +72,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (!PacketIncreaseCheckLayers(p)) {
         return TM_ECODE_FAILED;
     }
-    if (p->vlan_idx >= 2) {
+    if (p->vlan_idx > VLAN_MAX_LAYER_IDX) {
         ENGINE_SET_EVENT(p,VLAN_HEADER_TOO_MANY_LAYERS);
         return TM_ECODE_FAILED;
     }
@@ -95,7 +97,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
 uint16_t DecodeVLANGetId(const Packet *p, uint8_t layer)
 {
-    if (unlikely(layer > 1))
+    if (unlikely(layer > 2))
         return 0;
     if (p->vlan_idx > layer) {
         return p->vlan_id[layer];

--- a/src/decode-vlan.h
+++ b/src/decode-vlan.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -35,11 +35,6 @@ uint16_t DecodeVLANGetId(const struct Packet_ *, uint8_t layer);
 #define GET_VLAN_CFI(vlanh)         ((SCNtohs((vlanh)->vlan_cfi) & 0x0100) >> 12)
 #define GET_VLAN_ID(vlanh)          ((uint16_t)(SCNtohs((vlanh)->vlan_cfi) & 0x0FFF))
 #define GET_VLAN_PROTO(vlanh)       ((SCNtohs((vlanh)->protocol)))
-
-/* return vlan id in host byte order */
-#define VLAN_GET_ID1(p)             DecodeVLANGetId((p), 0)
-#define VLAN_GET_ID2(p)             DecodeVLANGetId((p), 1)
-#define VLAN_GET_ID3(p)             DecodeVLANGetId((p), 2)
 
 /** Vlan header struct */
 typedef struct VLANHdr_ {

--- a/src/decode-vlan.h
+++ b/src/decode-vlan.h
@@ -39,6 +39,7 @@ uint16_t DecodeVLANGetId(const struct Packet_ *, uint8_t layer);
 /* return vlan id in host byte order */
 #define VLAN_GET_ID1(p)             DecodeVLANGetId((p), 0)
 #define VLAN_GET_ID2(p)             DecodeVLANGetId((p), 1)
+#define VLAN_GET_ID3(p)             DecodeVLANGetId((p), 2)
 
 /** Vlan header struct */
 typedef struct VLANHdr_ {
@@ -50,6 +51,10 @@ typedef struct VLANHdr_ {
 #define VLAN_HEADER_LEN 4
 
 void DecodeVLANRegisterTests(void);
+
+/** VLAN max encapsulation layer count/index */
+#define VLAN_MAX_LAYERS    3
+#define VLAN_MAX_LAYER_IDX (VLAN_MAX_LAYERS - 1)
 
 #endif /* __DECODE_VLAN_H__ */
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -408,8 +408,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
     p->tenant_id = parent->tenant_id;
     /* tell new packet it's part of a tunnel */
     SET_TUNNEL_PKT(p);
-    p->vlan_id[0] = parent->vlan_id[0];
-    p->vlan_id[1] = parent->vlan_id[1];
+    memcpy(&p->vlan_id[0], &parent->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = parent->vlan_idx;
     p->livedev = parent->livedev;
 
@@ -544,6 +543,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_gre = StatsRegisterCounter("decoder.gre", tv);
     dtv->counter_vlan = StatsRegisterCounter("decoder.vlan", tv);
     dtv->counter_vlan_qinq = StatsRegisterCounter("decoder.vlan_qinq", tv);
+    dtv->counter_vlan_qinqinq = StatsRegisterCounter("decoder.vlan_qinqinq", tv);
     dtv->counter_vxlan = StatsRegisterCounter("decoder.vxlan", tv);
     dtv->counter_vntag = StatsRegisterCounter("decoder.vntag", tv);
     dtv->counter_ieee8021ah = StatsRegisterCounter("decoder.ieee8021ah", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -233,7 +233,6 @@ typedef struct Address_ {
     (p)->pktlen = (len); \
     } while (0)
 
-
 /* Port is just a uint16_t */
 typedef uint16_t Port;
 #define SET_PORT(v, p) ((p) = (v))
@@ -459,7 +458,7 @@ typedef struct Packet_
      * has the exact same tuple as the lower levels */
     uint8_t recursion_level;
 
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[VLAN_MAX_LAYERS];
     uint8_t vlan_idx;
 
     /* flow */
@@ -695,6 +694,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_gre;
     uint16_t counter_vlan;
     uint16_t counter_vlan_qinq;
+    uint16_t counter_vlan_qinqinq;
     uint16_t counter_vxlan;
     uint16_t counter_vntag;
     uint16_t counter_ieee8021ah;
@@ -1230,7 +1230,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
         case ETHERNET_TYPE_VLAN:
         case ETHERNET_TYPE_8021AD:
         case ETHERNET_TYPE_8021QINQ:
-            if (p->vlan_idx >= 2) {
+            if (p->vlan_idx > VLAN_MAX_LAYER_IDX) {
                 ENGINE_SET_EVENT(p,VLAN_HEADER_TOO_MANY_LAYERS);
             } else {
                 DecodeVLAN(tv, dtv, p, data, len);

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -465,7 +465,7 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *  Get a new defrag tracker. We're checking memcap first and will try to make room
  *  if the memcap is reached.
  *
- *  \retval dt *LOCKED* tracker on succes, NULL on error.
+ *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
 static DefragTracker *DefragTrackerGetNew(Packet *p)
 {

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -23,7 +23,7 @@
  * Defragmentation module.
  * References:
  *   - RFC 815
- *   - OpenBSD PF's IP normalizaton (pf_norm.c)
+ *   - OpenBSD PF's IP normalization (pf_norm.c)
  *
  * \todo pool for frag packet storage
  * \todo policy bsd-right
@@ -218,8 +218,7 @@ DefragContextNew(void)
                            "defrag: Timeout less than minimum allowed value.");
         }
         else if (timeout > TIMEOUT_MAX) {
-                FatalError(SC_ERR_FATAL,
-                           "defrag: Tiemout greater than maximum allowed value.");
+            FatalError(SC_ERR_FATAL, "defrag: Timeout greater than maximum allowed value.");
         }
         dc->timeout = timeout;
     }
@@ -2083,7 +2082,7 @@ static int DefragTimeoutTest(void)
 {
     int i;
 
-    /* Setup a small numberr of trackers. */
+    /* Setup a small number of trackers. */
     FAIL_IF_NOT(ConfSet("defrag.trackers", "16"));
 
     DefragInit();

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -2254,6 +2254,41 @@ static int DefragVlanQinQTest(void)
     PASS;
 }
 
+/**
+ * Like DefragVlanTest, but for QinQinQ, testing the third level VLAN ID.
+ */
+static int DefragVlanQinQinQTest(void)
+{
+    Packet *r = NULL;
+
+    DefragInit();
+
+    Packet *p1 = BuildTestPacket(IPPROTO_ICMP, 1, 0, 1, 'A', 8);
+    FAIL_IF_NULL(p1);
+    Packet *p2 = BuildTestPacket(IPPROTO_ICMP, 1, 1, 0, 'B', 8);
+    FAIL_IF_NULL(p2);
+
+    /* With no VLAN IDs set, packets should re-assemble. */
+    FAIL_IF((r = Defrag(NULL, NULL, p1)) != NULL);
+    FAIL_IF((r = Defrag(NULL, NULL, p2)) == NULL);
+    SCFree(r);
+
+    /* With mismatched VLANs, packets should not re-assemble. */
+    p1->vlan_id[0] = 1;
+    p2->vlan_id[0] = 1;
+    p1->vlan_id[1] = 2;
+    p2->vlan_id[1] = 2;
+    p1->vlan_id[2] = 3;
+    p2->vlan_id[2] = 4;
+    FAIL_IF((r = Defrag(NULL, NULL, p1)) != NULL);
+    FAIL_IF((r = Defrag(NULL, NULL, p2)) != NULL);
+
+    PacketFree(p1);
+    PacketFree(p2);
+    DefragDestroy();
+
+    PASS;
+}
 static int DefragTrackerReuseTest(void)
 {
     int id = 1;
@@ -2503,6 +2538,7 @@ void DefragRegisterTests(void)
 
     UtRegisterTest("DefragVlanTest", DefragVlanTest);
     UtRegisterTest("DefragVlanQinQTest", DefragVlanQinQTest);
+    UtRegisterTest("DefragVlanQinQinQTest", DefragVlanQinQinQTest);
     UtRegisterTest("DefragTrackerReuseTest", DefragTrackerReuseTest);
     UtRegisterTest("DefragTimeoutTest", DefragTimeoutTest);
     UtRegisterTest("DefragMfIpv4Test", DefragMfIpv4Test);

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -85,7 +85,7 @@ typedef struct DefragTracker_ {
     SCMutex lock; /**< Mutex for locking list operations on
                            * this tracker. */
 
-    uint16_t vlan_id[2]; /**< VLAN ID tracker applies to. */
+    uint16_t vlan_id[VLAN_MAX_LAYERS]; /**< VLAN ID tracker applies to. */
 
     uint32_t id; /**< IP ID for this tracker.  32 bits for IPv6, 16
                   * for IPv4. */

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -42,6 +42,7 @@
 
 #include "util-time.h"
 #include "util-debug.h"
+#include "util-device.h"
 
 #include "util-hash-lookup3.h"
 
@@ -87,8 +88,9 @@ typedef struct FlowHashKey4_ {
         struct {
             uint32_t addrs[2];
             uint16_t ports[2];
-            uint16_t proto; /**< u16 so proto and recur add up to u32 */
-            uint16_t recur; /**< u16 so proto and recur add up to u32 */
+            uint8_t proto; /**< u8 so proto and recur and livedev add up to u32 */
+            uint8_t recur;
+            uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
             uint16_t pad[1];
         };
@@ -101,8 +103,9 @@ typedef struct FlowHashKey6_ {
         struct {
             uint32_t src[4], dst[4];
             uint16_t ports[2];
-            uint16_t proto; /**< u16 so proto and recur add up to u32 */
-            uint16_t recur; /**< u16 so proto and recur add up to u32 */
+            uint8_t proto; /**< u8 so proto and recur and livedev add up to u32 */
+            uint8_t recur;
+            uint16_t livedev;
             uint16_t vlan_id[VLAN_MAX_LAYERS];
             uint16_t pad[1];
         };
@@ -139,8 +142,12 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1-pi] = p->sp;
             fhk.ports[pi] = p->dp;
 
-            fhk.proto = (uint16_t)p->proto;
-            fhk.recur = (uint16_t)p->recursion_level;
+            fhk.proto = p->proto;
+            fhk.recur = p->recursion_level;
+            /* g_livedev_mask sets the livedev ids to 0 if livedev.use-for-tracking
+             * is disabled. */
+            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            fhk.livedev = devid & g_livedev_mask;
             /* g_vlan_mask sets the vlan_ids to 0 if vlan.use-for-tracking
              * is disabled. */
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
@@ -162,8 +169,10 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.ports[1-pi] = p->icmpv4vars.emb_sport;
             fhk.ports[pi] = p->icmpv4vars.emb_dport;
 
-            fhk.proto = (uint16_t)ICMPV4_GET_EMB_PROTO(p);
-            fhk.recur = (uint16_t)p->recursion_level;
+            fhk.proto = ICMPV4_GET_EMB_PROTO(p);
+            fhk.recur = p->recursion_level;
+            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            fhk.livedev = devid & g_livedev_mask;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
             fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
@@ -177,8 +186,10 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.addrs[ai] = p->dst.addr_data32[0];
             fhk.ports[0] = 0xfeed;
             fhk.ports[1] = 0xbeef;
-            fhk.proto = (uint16_t)p->proto;
-            fhk.recur = (uint16_t)p->recursion_level;
+            fhk.proto = p->proto;
+            fhk.recur = p->recursion_level;
+            uint16_t devid = p->livedev ? p->livedev->id : 0;
+            fhk.livedev = devid & g_livedev_mask;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
             fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
@@ -210,8 +221,10 @@ static inline uint32_t FlowGetHash(const Packet *p)
         const int pi = (p->sp > p->dp);
         fhk.ports[1-pi] = p->sp;
         fhk.ports[pi] = p->dp;
-        fhk.proto = (uint16_t)p->proto;
-        fhk.recur = (uint16_t)p->recursion_level;
+        fhk.proto = p->proto;
+        fhk.recur = p->recursion_level;
+        uint16_t devid = p->livedev ? p->livedev->id : 0;
+        fhk.livedev = devid & g_livedev_mask;
         fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
@@ -244,8 +257,9 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.ports[1-pi] = fk->sp;
         fhk.ports[pi] = fk->dp;
 
-        fhk.proto = (uint16_t)fk->proto;
-        fhk.recur = (uint16_t)fk->recursion_level;
+        fhk.proto = fk->proto;
+        fhk.recur = fk->recursion_level;
+        fhk.livedev = fk->livedev_id & g_livedev_mask;
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
@@ -277,8 +291,9 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         const int pi = (fk->sp > fk->dp);
         fhk.ports[1-pi] = fk->sp;
         fhk.ports[pi] = fk->dp;
-        fhk.proto = (uint16_t)fk->proto;
-        fhk.recur = (uint16_t)fk->recursion_level;
+        fhk.proto = fk->proto;
+        fhk.recur = fk->recursion_level;
+        fhk.livedev = fk->livedev_id & g_livedev_mask;
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
         fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
@@ -316,6 +331,12 @@ static inline bool CmpVlanIds(
            ((vlan_id1[2] ^ vlan_id2[2]) & g_vlan_mask) == 0;
 }
 
+static inline bool CmpLiveDevIds(const LiveDevice *livedev, const uint16_t id)
+{
+    uint16_t devid = livedev ? livedev->id : 0;
+    return (((devid ^ id) & g_livedev_mask) == 0);
+}
+
 /* Since two or more flows can have the same hash key, we need to compare
  * the flow with the current packet or flow key. */
 static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
@@ -324,10 +345,9 @@ static inline bool CmpFlowPacket(const Flow *f, const Packet *p)
     const uint32_t *f_dst = f->dst.address.address_un_data32;
     const uint32_t *p_src = p->src.address.address_un_data32;
     const uint32_t *p_dst = p->dst.address.address_un_data32;
-    return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp,
-                            p->dp) && f->proto == p->proto &&
-            f->recursion_level == p->recursion_level &&
-            CmpVlanIds(f->vlan_id, p->vlan_id);
+    return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, p_src, p_dst, p->sp, p->dp) &&
+           f->proto == p->proto && f->recursion_level == p->recursion_level &&
+           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
 }
 
 static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
@@ -336,10 +356,9 @@ static inline bool CmpFlowKey(const Flow *f, const FlowKey *k)
     const uint32_t *f_dst = f->dst.address.address_un_data32;
     const uint32_t *k_src = k->src.address.address_un_data32;
     const uint32_t *k_dst = k->dst.address.address_un_data32;
-    return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp,
-                            k->dp) && f->proto == k->proto &&
-            f->recursion_level == k->recursion_level &&
-            CmpVlanIds(f->vlan_id, k->vlan_id);
+    return CmpAddrsAndPorts(f_src, f_dst, f->sp, f->dp, k_src, k_dst, k->sp, k->dp) &&
+           f->proto == k->proto && f->recursion_level == k->recursion_level &&
+           CmpVlanIds(f->vlan_id, k->vlan_id) && CmpLiveDevIds(f->livedev, k->livedev_id);
 }
 
 static inline bool CmpAddrsAndICMPTypes(const uint32_t src1[4],
@@ -362,10 +381,10 @@ static inline bool CmpFlowICMPPacket(const Flow *f, const Packet *p)
     const uint32_t *f_dst = f->dst.address.address_un_data32;
     const uint32_t *p_src = p->src.address.address_un_data32;
     const uint32_t *p_dst = p->dst.address.address_un_data32;
-    return CmpAddrsAndICMPTypes(f_src, f_dst, f->icmp_s.type,
-                f->icmp_d.type, p_src, p_dst, p->icmp_s.type, p->icmp_d.type) &&
-            f->proto == p->proto && f->recursion_level == p->recursion_level &&
-            CmpVlanIds(f->vlan_id, p->vlan_id);
+    return CmpAddrsAndICMPTypes(f_src, f_dst, f->icmp_s.type, f->icmp_d.type, p_src, p_dst,
+                   p->icmp_s.type, p->icmp_d.type) &&
+           f->proto == p->proto && f->recursion_level == p->recursion_level &&
+           CmpVlanIds(f->vlan_id, p->vlan_id) && (f->livedev == p->livedev || g_livedev_mask == 0);
 }
 
 /**
@@ -388,7 +407,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                 (f->dst.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
                 f->sp == p->icmpv4vars.emb_sport && f->dp == p->icmpv4vars.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) && f->recursion_level == p->recursion_level &&
-                CmpVlanIds(f->vlan_id, p->vlan_id)) {
+                CmpVlanIds(f->vlan_id, p->vlan_id) &&
+                (f->livedev == p->livedev || g_livedev_mask == 0)) {
             return 1;
 
         /* check the less likely case where the ICMP error was a response to
@@ -397,7 +417,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
                    (f->src.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
                    f->dp == p->icmpv4vars.emb_sport && f->sp == p->icmpv4vars.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
-                   f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id)) {
+                   f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id) &&
+                   (f->livedev == p->livedev || g_livedev_mask == 0)) {
             return 1;
         }
 
@@ -428,7 +449,7 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
 
     return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
            f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id) &&
-           f->esp.spi == ESP_GET_SPI(p);
+           f->esp.spi == ESP_GET_SPI(p) && (f->livedev == p->livedev || g_livedev_mask == 0);
 }
 
 void FlowSetupPacket(Packet *p)
@@ -1018,6 +1039,7 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     f->sp = key->sp;
     f->dp = key->dp;
     f->recursion_level = 0;
+    // f->livedev is set by caller EBPFCreateFlowForKey
     f->flow_hash = hash;
     if (key->src.family == AF_INET) {
         f->flags |= FLOW_IPV4;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -568,7 +568,7 @@ static inline void NoFlowHandleIPS(Packet *p)
  *  \param tv thread vars
  *  \param fls lookup support vars
  *
- *  \retval f *LOCKED* flow on succes, NULL on error.
+ *  \retval f *LOCKED* flow on success, NULL on error.
  */
 static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
@@ -632,7 +632,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     } else {
         /* flow has been recycled before it went into the spare queue */
 
-        /* flow is initialized (recylced) but *unlocked* */
+        /* flow is initialized (recycled) but *unlocked* */
     }
 
     FLOWLOCK_WRLOCK(f);
@@ -739,7 +739,7 @@ static inline bool FlowIsTimedOut(const Flow *f, const uint32_t sec, const bool 
  * flow pointer. Then compares the packet with the found flow to see if it is
  * the flow we need. If it isn't, walk the list until the right flow is found.
  *
- * If the flow is not found or the bucket was emtpy, a new flow is taken from
+ * If the flow is not found or the bucket was empty, a new flow is taken from
  * the spare pool. The pool will alloc new flows as long as we stay within our
  * memcap limit.
  *

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -89,9 +89,10 @@ typedef struct FlowHashKey4_ {
             uint16_t ports[2];
             uint16_t proto; /**< u16 so proto and recur add up to u32 */
             uint16_t recur; /**< u16 so proto and recur add up to u32 */
-            uint16_t vlan_id[2];
+            uint16_t vlan_id[VLAN_MAX_LAYERS];
+            uint16_t pad[1];
         };
-        const uint32_t u32[5];
+        const uint32_t u32[6];
     };
 } FlowHashKey4;
 
@@ -102,9 +103,10 @@ typedef struct FlowHashKey6_ {
             uint16_t ports[2];
             uint16_t proto; /**< u16 so proto and recur add up to u32 */
             uint16_t recur; /**< u16 so proto and recur add up to u32 */
-            uint16_t vlan_id[2];
+            uint16_t vlan_id[VLAN_MAX_LAYERS];
+            uint16_t pad[1];
         };
-        const uint32_t u32[11];
+        const uint32_t u32[12];
     };
 } FlowHashKey6;
 
@@ -127,7 +129,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
     if (p->ip4h != NULL) {
         if (p->tcph != NULL || p->udph != NULL) {
-            FlowHashKey4 fhk;
+            FlowHashKey4 fhk = { .pad[0] = 0 };
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
@@ -143,13 +145,14 @@ static inline uint32_t FlowGetHash(const Packet *p)
              * is disabled. */
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
-            hash = hashword(fhk.u32, 5, flow_config.hash_rand);
+            hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
 
         } else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
             uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
             uint32_t pdst = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
-            FlowHashKey4 fhk;
+            FlowHashKey4 fhk = { .pad[0] = 0 };
 
             const int ai = (psrc > pdst);
             fhk.addrs[1-ai] = psrc;
@@ -163,11 +166,12 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.recur = (uint16_t)p->recursion_level;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
-            hash = hashword(fhk.u32, 5, flow_config.hash_rand);
+            hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
 
         } else {
-            FlowHashKey4 fhk;
+            FlowHashKey4 fhk = { .pad[0] = 0 };
             const int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
             fhk.addrs[1-ai] = p->src.addr_data32[0];
             fhk.addrs[ai] = p->dst.addr_data32[0];
@@ -177,11 +181,12 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.recur = (uint16_t)p->recursion_level;
             fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
             fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+            fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
-            hash = hashword(fhk.u32, 5, flow_config.hash_rand);
+            hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
         }
     } else if (p->ip6h != NULL) {
-        FlowHashKey6 fhk;
+        FlowHashKey6 fhk = { .pad[0] = 0 };
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];
             fhk.src[1] = p->src.addr_data32[1];
@@ -209,8 +214,9 @@ static inline uint32_t FlowGetHash(const Packet *p)
         fhk.recur = (uint16_t)p->recursion_level;
         fhk.vlan_id[0] = p->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = p->vlan_id[1] & g_vlan_mask;
+        fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
-        hash = hashword(fhk.u32, 11, flow_config.hash_rand);
+        hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
     }
 
     return hash;
@@ -242,8 +248,9 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.recur = (uint16_t)fk->recursion_level;
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
+        fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
 
-        hash = hashword(fhk.u32, 5, flow_config.hash_rand);
+        hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
     } else {
         FlowHashKey6 fhk;
         if (FlowHashRawAddressIPv6GtU32(fk->src.address.address_un_data32,
@@ -274,8 +281,9 @@ uint32_t FlowKeyGetHash(FlowKey *fk)
         fhk.recur = (uint16_t)fk->recursion_level;
         fhk.vlan_id[0] = fk->vlan_id[0] & g_vlan_mask;
         fhk.vlan_id[1] = fk->vlan_id[1] & g_vlan_mask;
+        fhk.vlan_id[2] = fk->vlan_id[2] & g_vlan_mask;
 
-        hash = hashword(fhk.u32, 11, flow_config.hash_rand);
+        hash = hashword(fhk.u32, sizeof(fhk.u32) / sizeof(uint32_t), flow_config.hash_rand);
     }
     return hash;
 }
@@ -300,10 +308,12 @@ static inline bool CmpAddrsAndPorts(const uint32_t src1[4],
             src_port1 == dst_port2 && dst_port1 == src_port2);
 }
 
-static inline bool CmpVlanIds(const uint16_t vlan_id1[2], const uint16_t vlan_id2[2])
+static inline bool CmpVlanIds(
+        const uint16_t vlan_id1[VLAN_MAX_LAYERS], const uint16_t vlan_id2[VLAN_MAX_LAYERS])
 {
     return ((vlan_id1[0] ^ vlan_id2[0]) & g_vlan_mask) == 0 &&
-           ((vlan_id1[1] ^ vlan_id2[1]) & g_vlan_mask) == 0;
+           ((vlan_id1[1] ^ vlan_id2[1]) & g_vlan_mask) == 0 &&
+           ((vlan_id1[2] ^ vlan_id2[2]) & g_vlan_mask) == 0;
 }
 
 /* Since two or more flows can have the same hash key, we need to compare
@@ -940,8 +950,8 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
         return NULL;
     }
     f->proto = key->proto;
-    f->vlan_id[0] = key->vlan_id[0];
-    f->vlan_id[1] = key->vlan_id[1];
+    memcpy(&f->vlan_id[0], &key->vlan_id[0], sizeof(f->vlan_id));
+    ;
     f->src.addr_data32[0] = key->src.addr_data32[0];
     f->src.addr_data32[1] = key->src.addr_data32[1];
     f->src.addr_data32[2] = key->src.addr_data32[2];

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -921,6 +921,61 @@ Flow *FlowGetExistingFlowFromFlowId(int64_t flow_id)
     return f;
 }
 
+/** \brief Look for existing Flow using a FlowKey
+ *
+ * Hash retrieval function for flows. Looks up the hash bucket containing the
+ * flow pointer. Then compares the packet with the found flow to see if it is
+ * the flow we need. If it isn't, walk the list until the right flow is found.
+ *
+ *
+ *  \param key Pointer to FlowKey build using flow to look for
+ *  \param hash Value of the flow hash
+ *  \retval f *LOCKED* flow or NULL
+ */
+static Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
+{
+    /* get our hash bucket and lock it */
+    FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];
+    FBLOCK_LOCK(fb);
+
+    SCLogDebug("fb %p fb->head %p", fb, fb->head);
+
+    /* return if the bucket don't have a flow */
+    if (fb->head == NULL) {
+        FBLOCK_UNLOCK(fb);
+        return NULL;
+    }
+
+    /* ok, we have a flow in the bucket. Let's find out if it is our flow */
+    Flow *f = fb->head;
+
+    /* see if this is the flow we are looking for */
+    if (FlowCompareKey(f, key) == 0) {
+        while (f) {
+            f = f->next;
+
+            if (f == NULL) {
+                FBLOCK_UNLOCK(fb);
+                return NULL;
+            }
+
+            if (FlowCompareKey(f, key) != 0) {
+                /* found our flow, lock & return */
+                FLOWLOCK_WRLOCK(f);
+
+                FBLOCK_UNLOCK(fb);
+                return f;
+            }
+        }
+    }
+
+    /* lock & return */
+    FLOWLOCK_WRLOCK(f);
+
+    FBLOCK_UNLOCK(fb);
+    return f;
+}
+
 /** \brief Get or create a Flow using a FlowKey
  *
  * Hash retrieval function for flows. Looks up the hash bucket containing the
@@ -982,61 +1037,6 @@ Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t ha
     f->next = fb->head;
     fb->head = f;
     FLOWLOCK_WRLOCK(f);
-    FBLOCK_UNLOCK(fb);
-    return f;
-}
-
-/** \brief Look for existing Flow using a FlowKey
- *
- * Hash retrieval function for flows. Looks up the hash bucket containing the
- * flow pointer. Then compares the packet with the found flow to see if it is
- * the flow we need. If it isn't, walk the list until the right flow is found.
- *
- *
- *  \param key Pointer to FlowKey build using flow to look for
- *  \param hash Value of the flow hash
- *  \retval f *LOCKED* flow or NULL
- */
-Flow *FlowGetExistingFlowFromHash(FlowKey *key, const uint32_t hash)
-{
-    /* get our hash bucket and lock it */
-    FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];
-    FBLOCK_LOCK(fb);
-
-    SCLogDebug("fb %p fb->head %p", fb, fb->head);
-
-    /* return if the bucket don't have a flow */
-    if (fb->head == NULL) {
-        FBLOCK_UNLOCK(fb);
-        return NULL;
-    }
-
-    /* ok, we have a flow in the bucket. Let's find out if it is our flow */
-    Flow *f = fb->head;
-
-    /* see if this is the flow we are looking for */
-    if (FlowCompareKey(f, key) == 0) {
-        while (f) {
-            f = f->next;
-
-            if (f == NULL) {
-                FBLOCK_UNLOCK(fb);
-                return NULL;
-            }
-
-            if (FlowCompareKey(f, key) != 0) {
-                /* found our flow, lock & return */
-                FLOWLOCK_WRLOCK(f);
-
-                FBLOCK_UNLOCK(fb);
-                return f;
-            }
-        }
-    }
-
-    /* lock & return */
-    FLOWLOCK_WRLOCK(f);
-
     FBLOCK_UNLOCK(fb);
     return f;
 }

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -82,7 +82,6 @@ typedef struct FlowBucket_ {
 Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
 
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
-Flow *FlowGetExistingFlowFromHash(FlowKey * key, uint32_t hash);
 Flow *FlowGetExistingFlowFromFlowId(int64_t flow_id);
 uint32_t FlowKeyGetHash(FlowKey *flow_key);
 

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -90,8 +90,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     p->flags |= PKT_STREAM_EOF;
     p->flags |= PKT_HAS_FLOW;
     p->flags |= PKT_PSEUDO_STREAM_END;
-    p->vlan_id[0] = f->vlan_id[0];
-    p->vlan_id[1] = f->vlan_id[1];
+    memcpy(&p->vlan_id[0], &f->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = f->vlan_idx;
     p->livedev = (struct LiveDevice_ *)f->livedev;
 

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -148,8 +148,7 @@ void FlowInit(Flow *f, const Packet *p)
 
     f->proto = p->proto;
     f->recursion_level = p->recursion_level;
-    f->vlan_id[0] = p->vlan_id[0];
-    f->vlan_id[1] = p->vlan_id[1];
+    memcpy(&f->vlan_id[0], &p->vlan_id[0], sizeof(f->vlan_id));
     f->vlan_idx = p->vlan_idx;
     f->livedev = p->livedev;
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -312,6 +312,7 @@ typedef struct FlowKey_
     Port sp, dp;
     uint8_t proto;
     uint8_t recursion_level;
+    uint16_t livedev_id;
     uint16_t vlan_id[VLAN_MAX_LAYERS];
 } FlowKey;
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -312,7 +312,7 @@ typedef struct FlowKey_
     Port sp, dp;
     uint8_t proto;
     uint8_t recursion_level;
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[VLAN_MAX_LAYERS];
 } FlowKey;
 
 typedef struct FlowAddress_ {
@@ -377,7 +377,7 @@ typedef struct Flow_
     };
     uint8_t proto;
     uint8_t recursion_level;
-    uint16_t vlan_id[2];
+    uint16_t vlan_id[VLAN_MAX_LAYERS];
     /** how many references exist to this flow *right now*
      *
      *  On receiving a packet the counter is incremented while the flow

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -115,6 +115,9 @@ static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
         if (f->vlan_idx > 1) {
             jb_append_uint(jb, f->vlan_id[1]);
         }
+        if (f->vlan_idx > 2) {
+            jb_append_uint(jb, f->vlan_id[2]);
+        }
         jb_close(jb);
     }
 

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -119,6 +119,9 @@ static JsonBuilder *CreateEveHeaderFromNetFlow(const Flow *f, int dir)
         if (f->vlan_idx > 1) {
             jb_append_uint(js, f->vlan_id[1]);
         }
+        if (f->vlan_idx > 2) {
+            jb_append_uint(js, f->vlan_id[2]);
+        }
         jb_close(js);
     }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -850,6 +850,9 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         if (p->vlan_idx > 1) {
             jb_append_uint(js, p->vlan_id[1]);
         }
+        if (p->vlan_idx > 2) {
+            jb_append_uint(js, p->vlan_id[2]);
+        }
         jb_close(js);
     }
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2219,6 +2219,7 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
 
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2244,6 +2245,7 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
@@ -2279,6 +2281,7 @@ static int AFPBypassCallback(Packet *p)
         keys[0]->port16[1] = GET_TCP_DST_PORT(p);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
 
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
@@ -2306,6 +2309,7 @@ static int AFPBypassCallback(Packet *p)
         keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
 
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
@@ -2373,6 +2377,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[0]->port16[1] = htons(p->dp);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
         if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2397,6 +2402,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->port16[1] = htons(p->sp);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v4_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {
@@ -2430,6 +2436,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[0]->port16[1] = htons(GET_TCP_DST_PORT(p));
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
+        keys[0]->vlan2 = p->vlan_id[2];
         if (IPV6_GET_NH(p) == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
@@ -2456,6 +2463,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[1]->port16[1] = htons(GET_TCP_SRC_PORT(p));
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
+        keys[1]->vlan2 = p->vlan_id[2];
         keys[1]->ip_proto = keys[0]->ip_proto;
         if (AFPInsertHalfFlow(p->afp_v.v6_map_fd, keys[1],
                               p->afp_v.nr_cpus) == 0) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6231,8 +6231,7 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->flags |= PKT_HAS_FLOW;
     np->flags |= PKT_IGNORE_CHECKSUM;
     np->flags |= PKT_PSEUDO_DETECTLOG_FLUSH;
-    np->vlan_id[0] = f->vlan_id[0];
-    np->vlan_id[1] = f->vlan_id[1];
+    memcpy(&np->vlan_id[0], &f->vlan_id[0], sizeof(np->vlan_id));
     np->vlan_idx = f->vlan_idx;
     np->livedev = (struct LiveDevice_ *)f->livedev;
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -186,6 +186,10 @@ int g_disable_randomness = 1;
   * comparing flows */
 uint16_t g_vlan_mask = 0xffff;
 
+/** determine (without branching) if we include the livedev ids when hashing or
+ * comparing flows */
+uint16_t g_livedev_mask = 0xffff;
+
 /* flag to disable hashing almost globally, to be similar to disabling nss
  * support */
 bool g_disable_hashing = false;
@@ -2824,13 +2828,16 @@ int SuricataMain(int argc, char **argv)
         exit(EXIT_SUCCESS);
     }
 
-    int vlan_tracking = 1;
-    if (ConfGetBool("vlan.use-for-tracking", &vlan_tracking) == 1 && !vlan_tracking) {
+    int tracking = 1;
+    if (ConfGetBool("vlan.use-for-tracking", &tracking) == 1 && !tracking) {
         /* Ignore vlan_ids when comparing flows. */
         g_vlan_mask = 0x0000;
     }
-    SCLogDebug("vlan tracking is %s", vlan_tracking == 1 ? "enabled" : "disabled");
-
+    SCLogDebug("vlan tracking is %s", tracking == 1 ? "enabled" : "disabled");
+    if (ConfGetBool("livedev.use-for-tracking", &tracking) == 1 && !tracking) {
+        /* Ignore livedev id when comparing flows. */
+        g_livedev_mask = 0x0000;
+    }
     SetupUserMode(&suricata);
     InitRunAs(&suricata);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -169,6 +169,7 @@ void GlobalsInitPreConfig(void);
 extern volatile uint8_t suricata_ctl_flags;
 extern int g_disable_randomness;
 extern uint16_t g_vlan_mask;
+extern uint16_t g_livedev_mask;
 
 /* Flag to disable hashing (almost) globally. */
 extern bool g_disable_hashing;

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -132,6 +132,12 @@ int LiveRegisterDevice(const char *dev)
         return -1;
     }
 
+    int id = LiveGetDeviceCount();
+    if (id > UINT16_MAX) {
+        SCFree(pd);
+        return -1;
+    }
+
     pd->dev = SCStrdup(dev);
     if (unlikely(pd->dev == NULL)) {
         SCFree(pd);
@@ -143,7 +149,7 @@ int LiveRegisterDevice(const char *dev)
     SC_ATOMIC_INIT(pd->pkts);
     SC_ATOMIC_INIT(pd->drop);
     SC_ATOMIC_INIT(pd->invalid_checksums);
-    pd->id = LiveGetDeviceCount();
+    pd->id = (uint16_t)id;
     TAILQ_INSERT_TAIL(&live_devices, pd, next);
 
     SCLogDebug("Device \"%s\" registered and created.", dev);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -41,7 +41,7 @@ typedef struct LiveDevice_ {
     char dev_short[MAX_DEVNAME + 1];
     bool tenant_id_set;
 
-    int id;
+    uint16_t id;
 
     SC_ATOMIC_DECLARE(uint64_t, pkts);
     SC_ATOMIC_DECLARE(uint64_t, drop);

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -772,6 +772,7 @@ static int EBPFForEachFlowV4Table(ThreadVars *th_v, LiveDevice *dev, const char 
         flow_key.dst.addr_data32[3] = 0;
         flow_key.vlan_id[0] = next_key.vlan0;
         flow_key.vlan_id[1] = next_key.vlan1;
+        flow_key.vlan_id[2] = next_key.vlan2;
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {
@@ -889,6 +890,7 @@ static int EBPFForEachFlowV6Table(ThreadVars *th_v,
         }
         flow_key.vlan_id[0] = next_key.vlan0;
         flow_key.vlan_id[1] = next_key.vlan1;
+        flow_key.vlan_id[2] = next_key.vlan2;
         if (next_key.ip_proto == 1) {
             flow_key.proto = IPPROTO_TCP;
         } else {

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -779,6 +779,7 @@ static int EBPFForEachFlowV4Table(ThreadVars *th_v, LiveDevice *dev, const char 
             flow_key.proto = IPPROTO_UDP;
         }
         flow_key.recursion_level = 0;
+        flow_key.livedev_id = dev->id;
         dead_flow = EBPFOpFlowForKey(&flowstats, dev, &next_key, sizeof(next_key), &flow_key,
                                      ctime, pkts_cnt, bytes_cnt,
                                      mapfd, tcfg->cpus_count);
@@ -897,6 +898,7 @@ static int EBPFForEachFlowV6Table(ThreadVars *th_v,
             flow_key.proto = IPPROTO_UDP;
         }
         flow_key.recursion_level = 0;
+        flow_key.livedev_id = dev->id;
         pkts_cnt = EBPFOpFlowForKey(&flowstats, dev, &next_key, sizeof(next_key), &flow_key,
                                     ctime, pkts_cnt, bytes_cnt,
                                     mapfd, tcfg->cpus_count);

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -44,6 +44,7 @@ struct flowv4_keys {
     __u8 ip_proto:1;
     __u16 vlan0:15;
     __u16 vlan1;
+    __u16 vlan2;
 };
 
 struct flowv6_keys {
@@ -56,6 +57,7 @@ struct flowv6_keys {
     __u8 ip_proto:1;
     __u16 vlan0:15;
     __u16 vlan1;
+    __u16 vlan2;
 };
 
 struct pair {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1326,6 +1326,12 @@ flow:
 vlan:
   use-for-tracking: true
 
+# This option controls the use of livedev ids in the flow (and defrag)
+# hashing. This is enabled by default and should be disabled if
+# multiple live devices are used to capture traffic from the same network
+livedev:
+  use-for-tracking: true
+
 # Specific timeouts for flows. Here you can specify the timeouts that the
 # active flows will wait to transit from the current state to another, on each
 # protocol. The value of "new" determines the seconds to wait after a handshake or


### PR DESCRIPTION
Continuation of #7982

This PR extends Suricata's support for VLANs from 2 to 3 levels. There is no standard for 3 levels of VLANs but 3 levels are not uncommon in some environments.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- [2816](https://redmine.openinfosecfoundation.org/issues/2816)
- [5270](https://redmine.openinfosecfoundation.org/issues/5270)

Describe changes:
- Increase VLAN level support to 3 levels
- List all VLAN levels in output.
- Add "Q-in-Q-in-Q" unittest.
- flow: optionally use livedev for hash
- Add defines for VLAN max layer and max index
- Unit test updates per review

Updates
- Removed unused `PACKET_*` macros from `decode.h`
- livedev tracking via id, not pointer.

suricata-verify-pr: 902
