### PR TITLE
rust: fix lint warnings about is same then else

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -65,12 +65,11 @@ impl std::fmt::Display for Direction {
 
 impl From<u8> for Direction {
     fn from(d: u8) -> Self {
+         // d contém DIR_TOSERVER união DIR_TOCLIENT
         if d & (DIR_TOSERVER | DIR_TOCLIENT) == (DIR_TOSERVER | DIR_TOCLIENT) {
             debug_validate_fail!("Both directions are set");
             Direction::ToServer
-        } else if d & DIR_TOSERVER != 0 {
-            Direction::ToServer
-        } else if d & DIR_TOCLIENT != 0 {
+        } else if d & DIR_TOCLIENT != 0 { 
             Direction::ToClient
         } else {
             debug_validate_fail!("Unknown direction!!");

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1243,13 +1243,13 @@ pub unsafe extern "C" fn rs_dcerpc_get_alstate_progress(tx: *mut std::os::raw::c
     let tx = cast_pointer!(tx, DCERPCTransaction);
     if direction == Direction::ToServer.into() && tx.req_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.call_id, tx);
-        return 1;
     } else if direction == Direction::ToClient.into() && tx.resp_done {
-        SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.call_id, tx);
-        return 1;
+        SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.call_id, tx); 
+    } else{
+        SCLogDebug!("tx {} direction {} progress 0", tx.call_id, direction);
+        return 0;
     }
-    SCLogDebug!("tx {} direction {} progress 0", tx.call_id, direction);
-    return 0;
+    return 1;
 }
 
 #[no_mangle]

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -131,11 +131,11 @@ pub fn http2_range_open(
     tx: &mut HTTP2Transaction, v: &HTTPContentRange, flow: *const Flow,
     cfg: &'static SuricataFileContext, dir: Direction, data: &[u8],
 ) {
-    if v.end <= 0 || v.size <= 0 {
-        // skipped for incomplete range information
-        return;
-    } else if v.end == v.size - 1 && v.start == 0 {
+    if (v.end <= 0 || v.size <= 0)
+        // skipped for incomplete range information 
+    || (v.end == v.size - 1 && v.start == 0)
         // whole file in one range
+    {
         return;
     }
     let (_, flags) = tx.files.get(dir);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -54,7 +54,7 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::enum_variant_names)]
-#![allow(clippy::if_same_then_else)]
+//#![allow(clippy::if_same_then_else)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::mixed_case_hex_literals)]

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1668,11 +1668,8 @@ pub unsafe extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c
                                                   -> std::os::raw::c_int
 {
     let tx = cast_pointer!(tx, NFSTransaction);
-    if direction == Direction::ToServer.into() && tx.request_done {
+    if (direction == Direction::ToServer.into() && tx.request_done)||(direction == Direction::ToClient.into() && tx.response_done) {
         //SCLogNotice!("TOSERVER progress 1");
-        return 1;
-    } else if direction == Direction::ToClient.into() && tx.response_done {
-        //SCLogNotice!("TOCLIENT progress 1");
         return 1;
     } else {
         //SCLogNotice!("{} progress 0", direction);
@@ -1829,11 +1826,11 @@ pub fn nfs_probe_udp(i: &[u8], direction: Direction) -> i32 {
     } else {
         match parse_rpc_udp_request(i) {
             Ok((_, ref rpc)) => {
-                if i.len() >= 48 && rpc.hdr.msgtype == 0 && rpc.progver == 3 && rpc.program == 100003 {
-                    return 1;
-                } else if i.len() >= 48 && rpc.hdr.msgtype == 0 && rpc.progver == 2 && rpc.program == 100003 {
-                    SCLogDebug!("NFSv2!");
-                    return 1;
+                if i.len() >= 48 && rpc.hdr.msgtype == 0 && (rpc.progver == 3 || rpc.progver == 2 )&& rpc.program == 100003 {
+                    if rpc.progver == 2 {
+                        SCLogDebug!("NFSv2!");
+                    }
+                    return 1;    
                 } else {
                     return -1;
                 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2201,14 +2201,15 @@ pub unsafe extern "C" fn rs_smb_tx_get_alstate_progress(tx: *mut ffi::c_void,
 
     if direction == Direction::ToServer as u8 && tx.request_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.id, tx);
-        return 1;
     } else if direction == Direction::ToClient as u8 && tx.response_done {
         SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.id, tx);
-        return 1;
+
     } else {
         SCLogDebug!("tx {} direction {} progress 0 => {:?}", tx.id, direction, tx);
         return 0;
     }
+    return 1;
+
 }
 
 


### PR DESCRIPTION
Ticket: [#4609](https://redmine.openinfosecfoundation.org/issues/4609)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ :white_check_mark: ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ :white_check_mark: ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4609) ticket:

Describe changes:
- Fix if_same_then_else  lint warnings
