### PR TITLE
rust: fix lint warnings about if same then else

### DIFF
--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -131,11 +131,11 @@ pub fn http2_range_open(
     tx: &mut HTTP2Transaction, v: &HTTPContentRange, flow: *const Flow,
     cfg: &'static SuricataFileContext, dir: Direction, data: &[u8],
 ) {
-    if v.end <= 0 || v.size <= 0 {
-        // skipped for incomplete range information
-        return;
-    } else if v.end == v.size - 1 && v.start == 0 {
+    if (v.end <= 0 || v.size <= 0)
+        // skipped for incomplete range information 
+    || (v.end == v.size - 1 && v.start == 0)
         // whole file in one range
+    {
         return;
     }
     let (_, flags) = tx.files.get(dir);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -54,7 +54,6 @@
 #![allow(clippy::module_inception)]
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::enum_variant_names)]
-#![allow(clippy::if_same_then_else)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::mixed_case_hex_literals)]

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1668,11 +1668,8 @@ pub unsafe extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c
                                                   -> std::os::raw::c_int
 {
     let tx = cast_pointer!(tx, NFSTransaction);
-    if direction == Direction::ToServer.into() && tx.request_done {
-        //SCLogNotice!("TOSERVER progress 1");
-        return 1;
-    } else if direction == Direction::ToClient.into() && tx.response_done {
-        //SCLogNotice!("TOCLIENT progress 1");
+    if (direction == Direction::ToServer.into() && tx.request_done) || (direction == Direction::ToClient.into() && tx.response_done) {
+        //SCLogNotice!("TOSERVER progress 1"); or SCLogNotice!("TOCLIENT progress 1");
         return 1;
     } else {
         //SCLogNotice!("{} progress 0", direction);


### PR DESCRIPTION
Ticket: [#4609](https://redmine.openinfosecfoundation.org/issues/4609)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ :white_check_mark: ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ :white_check_mark: ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Previous PR: #8004 

Describe changes:
- Since I was using clippy with the wrong parameters different parts of the code had to be optimized,so I applied the right parameters to clippy
- Removed the linter ignore line 
- Fix if_same_then_else lint warnings
