### PR TITLE
detect/content: Consider distance in validation

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -273,13 +273,26 @@ You can also use the negation (!) before isdataat.
 bsize
 -----
 
-With the bsize keyword, you can match on the length of a buffer. This adds precision to the content match, previously this could have been done with isdataat.
+With the ``bsize`` keyword, you can match on the length of the buffer. This adds
+precision to the content match, previously this could have been done with ``isdataat``.
+
+An optional operator can be specified; if no operator is present, the operator will
+default to '='. When a relational operator is used, e.g., '<', '>' or '<>' (range),
+the bsize value will be compared using the relational operator. Ranges are inclusive.
+
+If one or more ``content`` keywords precedes ``bsize``, each occurrence of ``content``
+will be inspected and an error will be raised if the content length and the bsize
+value prevent a match.
 
 Format::
 
   bsize:<number>;
+  bsize:=<number>;
+  bsize:<<number>;
+  bsize:><number>;
+  bsize:<lo-number><><hi-number>;
 
-Examples of bsize values:
+Examples of ``bsize`` in a rule:
 
 .. container:: example-rule
 
@@ -294,6 +307,19 @@ Examples of bsize values:
    alert dns any any -> any any (msg:"bsize buffer greater than or equal value"; dns.query; content:"google.com"; bsize:>=8; sid:5; rev:1;)
 
    alert dns any any -> any any (msg:"bsize buffer range value"; dns.query; content:"google.com"; bsize:8<>20; sid:6; rev:1;)
+
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"short"; bsize:<10; sid:124; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"longer string"; bsize:>10; sid:125; rev:1;)
+
+.. container:: example-rule
+
+   alert dns any any -> any any (msg:"test bsize rule"; dns.query; content:"middle"; bsize:6<>15; sid:126; rev:1;)
 
 dsize
 -----

--- a/src/detect-bsize.h
+++ b/src/detect-bsize.h
@@ -26,5 +26,6 @@
 
 void DetectBsizeRegister(void);
 int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eof);
+bool DetectBsizeValidateContentCallback(Signature *s, int list);
 
 #endif	/* __DETECT_URILEN_H__ */

--- a/src/detect-bsize.h
+++ b/src/detect-bsize.h
@@ -24,8 +24,6 @@
 #ifndef __DETECT_BSIZE_H__
 #define	__DETECT_BSIZE_H__
 
-//bool DetectBsizeValidateContent(const Signature *s, int list, const char **);
-//void DetectBsizeApplyToContent(Signature *s, int list);
 void DetectBsizeRegister(void);
 int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eof);
 

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -392,9 +392,78 @@ void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
     SCReturn;
 }
 
+/*
+ *  \brief Determine the size needed to accommodate the content
+ *  elements of a signature
+ *  \param s signature to get dsize value from
+ *  \param max_size Maximum buffer/data size allowed.
+ *  \param list signature match list.
+ *  \param len Maximum length required
+ *  \param offset Maximum offset encounted
+ *
+ *  Note that negated content does not contribute to the maximum
+ *  required size value. However, each negated content's values
+ *  must not exceed the size value.
+ *
+ *  Values from negated content blocks are used to determine if the
+ *  negated content block requires a value that exceeds "max_size". The
+ *  distance and within values from negated content blocks are added to
+ *  the running total of required content size to see if the max_size
+ *  would be exceeded.
+ *
+ *  - Non-negated content contributes to the required size (content length, distance)
+ *  - Negated content values are checked but not accumulated for the required size.
+ */
+void SigParseRequiredContentSize(
+        const Signature *s, const int max_size, int list, int *len, int *offset)
+{
+    if (list > (int)s->init_data->smlists_array_size) {
+        return;
+    }
+
+    SigMatch *sm = s->init_data->smlists[list];
+    int max_offset = 0, total_len = 0;
+    bool first = true;
+    for (; sm != NULL; sm = sm->next) {
+        if (sm->type != DETECT_CONTENT || sm->ctx == NULL) {
+            continue;
+        }
+
+        DetectContentData *cd = (DetectContentData *)sm->ctx;
+        SCLogDebug("content_len %d; negated: %s; distance: %d, offset: %d, depth: %d",
+                cd->content_len, cd->flags & DETECT_CONTENT_NEGATED ? "yes" : "no", cd->distance,
+                cd->offset, cd->depth);
+
+        if (!first) {
+            /* only count content with relative modifiers */
+            if (!((cd->flags & DETECT_CONTENT_DISTANCE) || (cd->flags & DETECT_CONTENT_WITHIN)))
+                continue;
+
+            if (cd->flags & DETECT_CONTENT_NEGATED) {
+                /* Check if distance/within cause max to be exceeded */
+                int check = total_len + cd->distance + cd->within;
+                if (max_size < check) {
+                    *len = check;
+                    return;
+                }
+
+                continue;
+            }
+        }
+        SCLogDebug("content_len %d; distance: %d, offset: %d, depth: %d", cd->content_len,
+                cd->distance, cd->offset, cd->depth);
+        total_len += cd->content_len + cd->distance;
+        max_offset = MAX(max_offset, cd->offset);
+        first = false;
+    }
+
+    *len = total_len;
+    *offset = max_offset;
+}
+
 /**
- *  \retval 1 valid
- *  \retval 0 invalid
+ *  \retval true valid
+ *  \retval false invalid
  */
 bool DetectContentPMATCHValidateCallback(const Signature *s)
 {
@@ -409,25 +478,17 @@ bool DetectContentPMATCHValidateCallback(const Signature *s)
 
     uint32_t max_right_edge = (uint32_t)max_right_edge_i;
 
-    const SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH];
-    for ( ; sm != NULL; sm = sm->next) {
-        if (sm->type != DETECT_CONTENT)
-            continue;
-        const DetectContentData *cd = (const DetectContentData *)sm->ctx;
-        uint32_t right_edge = cd->content_len + cd->offset;
-        if (cd->content_len > max_right_edge) {
+    int min_dsize_required = SigParseMaxRequiredDsize(s);
+    if (min_dsize_required >= 0) {
+        SCLogDebug("min_dsize %d; max_right_edge %d", min_dsize_required, max_right_edge);
+        if ((uint32_t)min_dsize_required > max_right_edge) {
             SCLogError(SC_ERR_INVALID_SIGNATURE,
-                    "signature can't match as content length %u is bigger than dsize %u.",
-                    cd->content_len, max_right_edge);
-            return false;
-        }
-        if (right_edge > max_right_edge) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE,
-                    "signature can't match as content length %u with offset %u (=%u) is bigger than dsize %u.",
-                    cd->content_len, cd->offset, right_edge, max_right_edge);
+                    "signature can't match as required content length %d exceeds dsize value %d",
+                    min_dsize_required, max_right_edge);
             return false;
         }
     }
+
     return true;
 }
 
@@ -2636,7 +2697,7 @@ static int SigTest42TestNegatedContent(void)
 /**
  * \test A negative test that checks that the content string doesn't contain
  *       the negated content within the specified depth, and also after the
- *       specified offset. Since the content is there, the match fails. 
+ *       specified offset. Since the content is there, the match fails.
  *
  *       Match is at offset:23, depth:34
  */

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1400,7 +1400,7 @@ static int DetectContentParseTest09(void)
 }
 
 /**
- * \test Test cases where if within specified is < content lenggth we invalidate
+ * \test Test cases where if within specified is < content length we invalidate
  *       the sig.
  */
 static int DetectContentParseTest17(void)

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -220,13 +220,11 @@ DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,
         return NULL;
     }
 
-    cd = SCMalloc(sizeof(DetectContentData) + len);
+    cd = SCCalloc(1, sizeof(DetectContentData) + len);
     if (unlikely(cd == NULL)) {
         SCFree(content);
         exit(EXIT_FAILURE);
     }
-
-    memset(cd, 0, sizeof(DetectContentData) + len);
 
     cd->content = (uint8_t *)cd + sizeof(DetectContentData);
     memcpy(cd->content, content, len);

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -124,5 +124,7 @@ bool DetectContentPMATCHValidateCallback(const Signature *s);
 void DetectContentPropagateLimits(Signature *s);
 
 void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
+void SigParseRequiredContentSize(
+        const Signature *s, const int max, int list, int *len, int *offset);
 
 #endif /* __DETECT_CONTENT_H__ */

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -287,6 +287,48 @@ void SigParseSetDsizePair(Signature *s)
 
         SCLogDebug("low %u, high %u, mode %u", low, high, dd->mode);
     }
+}
+
+/**
+ *  \brief Determine the required dsize for the signature
+ *  \param s signature to get dsize value from
+ *
+ *  Note that negated content does not contribute to the maximum
+ *  required dsize value. However, each negated content's values
+ *  must not exceed the dsize value. See SigParseRequiredContentSize.
+ *
+ * \retval -1 Signature doesn't have a dsize keyword
+ * \retval >= 0 Dsize value required to not exclude content matches
+ */
+int SigParseMaxRequiredDsize(const Signature *s)
+{
+    SCEnter();
+
+    if (!(s->flags & SIG_FLAG_DSIZE)) {
+        SCReturnInt(-1);
+    }
+
+    const int dsize = SigParseGetMaxDsize(s);
+    if (dsize < 0) {
+        /* nothing to do */
+        SCReturnInt(-1);
+    }
+
+    int total_length, offset;
+    SigParseRequiredContentSize(s, dsize, DETECT_SM_LIST_PMATCH, &total_length, &offset);
+    SCLogDebug("dsize: %d  len: %d; offset: %d [%s]", dsize, total_length, offset, s->sig_str);
+
+    if (total_length > dsize) {
+        SCLogDebug("required_dsize: %d exceeds dsize: %d", total_length, dsize);
+        return total_length;
+    }
+
+    if ((total_length + offset) > dsize) {
+        SCLogDebug("length + offset: %d exceeds dsize: %d", total_length + offset, dsize);
+        return total_length + offset;
+    }
+
+    SCReturnInt(-1);
 }
 
 /**

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -29,6 +29,7 @@
 /* prototypes */
 void DetectDsizeRegister (void);
 
+int SigParseMaxRequiredDsize(const Signature *s);
 int SigParseGetMaxDsize(const Signature *s);
 void SigParseSetDsizePair(Signature *s);
 void SigParseApplyDsizeToContent(Signature *s);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -199,7 +199,7 @@ static bool DetectHttpHostValidateCallback(const Signature *s, const char **sige
                 }
                 if (u != cd->content_len) {
                     *sigerror = "A pattern with "
-                                "uppercase chararacters detected for http.host. "
+                                "uppercase characters detected for http.host. "
                                 "The hostname buffer is normalized to lowercase, "
                                 "please specify a lowercase pattern.";
                     SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -34,6 +34,7 @@
 #include "detect-engine-build.h"
 
 #include "detect-content.h"
+#include "detect-bsize.h"
 #include "detect-pcre.h"
 #include "detect-uricontent.h"
 #include "detect-reference.h"
@@ -1725,6 +1726,10 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
             }
 
             if (!DetectEngineBufferRunValidateCallback(de_ctx, x, s, &de_ctx->sigerror)) {
+                SCReturnInt(0);
+            }
+
+            if (!DetectBsizeValidateContentCallback(s, x)) {
                 SCReturnInt(0);
             }
         }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -38,6 +38,7 @@
 #include "util-runmodes.h"
 #include "util-ioctl.h"
 #include "util-byte.h"
+#include "util-time.h"
 
 #ifdef HAVE_NETMAP
 #define NETMAP_WITH_LIBS

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2020 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -96,32 +96,65 @@ static int DetectBsizeTest04(void)
 #undef TEST_OK
 #undef TEST_FAIL
 
-#define TEST_OK(rule)                                                                       \
-{                                                                                           \
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                        \
-    FAIL_IF_NULL(de_ctx);                                                                   \
-    Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                   \
-    FAIL_IF_NULL(s);                                                                        \
-    DetectEngineCtxFree(de_ctx);                                                            \
-}
+#define TEST_OK(rule)                                                                              \
+    {                                                                                              \
+        DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                           \
+        FAIL_IF_NULL(de_ctx);                                                                      \
+        SCLogNotice("rule: %s", rule);                                                             \
+        Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                      \
+        FAIL_IF_NULL(s);                                                                           \
+        DetectEngineCtxFree(de_ctx);                                                               \
+    }
 
-#define TEST_FAIL(rule)                                                                     \
-{                                                                                           \
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                        \
-    FAIL_IF_NULL(de_ctx);                                                                   \
-    Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                   \
-    FAIL_IF_NOT_NULL(s);                                                                    \
-    DetectEngineCtxFree(de_ctx);                                                            \
-}
+#define TEST_FAIL(rule)                                                                            \
+    {                                                                                              \
+        DetectEngineCtx *de_ctx = DetectEngineCtxInit();                                           \
+        FAIL_IF_NULL(de_ctx);                                                                      \
+        SCLogNotice("rule: %s", rule);                                                             \
+        Signature *s = DetectEngineAppendSig(de_ctx, (rule));                                      \
+        FAIL_IF_NOT_NULL(s);                                                                       \
+        DetectEngineCtxFree(de_ctx);                                                               \
+    }
 
 static int DetectBsizeSigTest01(void)
 {
+#if 0
     TEST_OK("alert http any any -> any any (http_request_line; bsize:10; sid:1;)");
     TEST_OK("alert http any any -> any any (file_data; bsize:>1000; sid:2;)");
 
     TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
     TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
     TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
+
+    /* bsize validation with buffer */
+    TEST_OK("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; "
+            "sid:6;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; "
+            "sid:7;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; "
+            "sid:8;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; "
+            " sid:9;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; "
+            "sid:10;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; "
+              "sid:11;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; "
+              "sid:12;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
+              "sid:13;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12; "
+              "bsize:3; sid:14;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; "
+              "bsize:3; sid:15;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; "
+              "bsize:1; sid:16;)");
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; bsize:3; "
+              "sid:17;)");
+
+#endif
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:65535; bsize:3; "
+              "sid:18;)");
     PASS;
 }
 

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -118,41 +118,42 @@ static int DetectBsizeTest04(void)
 
 static int DetectBsizeSigTest01(void)
 {
-#if 0
     TEST_OK("alert http any any -> any any (http_request_line; bsize:10; sid:1;)");
     TEST_OK("alert http any any -> any any (file_data; bsize:>1000; sid:2;)");
-
-    TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
-    TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
-    TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; sid:5;)");
 
     /* bsize validation with buffer */
     TEST_OK("alert http any any -> any any (http.uri; content:\"/index.php\"; bsize:>1024; "
             "sid:6;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:1; "
-            "sid:7;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"g\"; bsize:4; "
-            "sid:8;)");
     TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<20; "
             " sid:9;)");
     TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:15<>25; "
             "sid:10;)");
+    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
+            "sid:13;)");
+
+    TEST_FAIL("alert tcp any any -> any any (content:\"abc\"; bsize:10; sid:3;)");
+    TEST_FAIL("alert http any any -> any any (content:\"GET\"; http_method; bsize:10; sid:4;)");
+    TEST_FAIL("alert http any any -> any any (http_request_line; content:\"GET\"; bsize:<10>; "
+              "sid:5;)");
+
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:2; "
               "sid:11;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:<13; "
               "sid:12;)");
-    TEST_OK("alert http any any -> any any (http.uri; content:\"abcdefgh123456\"; bsize:10<>15; "
-              "sid:13;)");
+    TEST_FAIL(
+            "alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"g\"; bsize:1; "
+            "sid:7;)");
+    TEST_FAIL(
+            "alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"g\"; bsize:4; "
+            "sid:8;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdefghi123456\"; offset:12; "
               "bsize:3; sid:14;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; depth:3; "
               "bsize:3; sid:15;)");
-    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abdcef\"; content: \"gh\"; "
+    TEST_FAIL("alert http any any -> any any (http.uri; content:\"abcdef\"; content: \"gh\"; "
               "bsize:1; sid:16;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:3; bsize:3; "
               "sid:17;)");
-
-#endif
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:65535; bsize:3; "
               "sid:18;)");
     PASS;

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -156,6 +156,8 @@ static int DetectBsizeSigTest01(void)
               "sid:17;)");
     TEST_FAIL("alert http any any -> any any (http.uri; content:\"abc\"; offset:65535; bsize:3; "
               "sid:18;)");
+    TEST_FAIL("alert http any any -> any any (http.user_agent; content:\"Suricata-UA\"; bsize:11; "
+              "content:!\"abc\"; distance:2; within:3;  sid: 19;)");
     PASS;
 }
 


### PR DESCRIPTION
Continuation of #8017

This commit modifies the validation callback to include the distance
during validation.

Values of distance that cause the right edge to be exceeded are
considered an error and the signature will be rejected.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2982](https://redmine.openinfosecfoundation.org/issues/2982)

Describe changes:
- Semantic validation of dsize and bsize keyword values.

Updates:
- Move `bsize` validity check so all `content` values are considered.
- Clang formatting fixup in bsize tests (for real this time)

suricata-verify-pr: 950
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
