### PR TITLE
docs: remove outdated constraint of negation support for ssl_state v3

### DIFF
--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -246,8 +246,6 @@ The ``ssl_state`` keyword matches the state of the SSL connection. The possible 
 are ``client_hello``, ``server_hello``, ``client_keyx``, ``server_keyx`` and ``unknown``.
 You can specify several states with ``|`` (OR) to check for any of the specified states.
 
-Negation support is not available yet, see https://redmine.openinfosecfoundation.org/issues/1231
-
 tls.random
 ----------
 


### PR DESCRIPTION
Follow up of #8026

Based on https://github.com/OISF/suricata/pull/2261 and https://redmine.openinfosecfoundation.org/issues/1231 the issue should be already resolved and negation does work with ssl_state.

Changes:
- commit title change