### PR TITLE
dns/eve: add 'HTTPS' type logging

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -81,6 +81,7 @@ pub const DNS_RECORD_TYPE_TLSA        : u16 = 52;
 pub const DNS_RECORD_TYPE_HIP         : u16 = 55;
 pub const DNS_RECORD_TYPE_CDS         : u16 = 59;
 pub const DNS_RECORD_TYPE_CDNSKEY     : u16 = 60;
+pub const DNS_RECORD_TYPE_HTTPS       : u16 = 65;
 pub const DNS_RECORD_TYPE_SPF         : u16 = 99;  // Obsolete
 pub const DNS_RECORD_TYPE_TKEY        : u16 = 249;
 pub const DNS_RECORD_TYPE_TSIG        : u16 = 250;
@@ -207,6 +208,8 @@ pub enum DNSRData {
     SOA(DNSRDataSOA),
     SRV(DNSRDataSRV),
     SSHFP(DNSRDataSSHFP),
+    // RData description to be added
+    HTTPS(Vec<u8>),
     // RData for remaining types is sometimes ignored
     Unknown(Vec<u8>),
 }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -86,6 +86,7 @@ pub const LOG_URI        : u64 = BIT_U64!(59);
 
 pub const LOG_FORMAT_GROUPED  : u64 = BIT_U64!(60);
 pub const LOG_FORMAT_DETAILED : u64 = BIT_U64!(61);
+pub const LOG_HTTPS      : u64 = BIT_U64!(62);
 
 fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
 {
@@ -249,6 +250,9 @@ fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
         }
         DNS_RECORD_TYPE_CDNSKEY => {
             return flags & LOG_CDNSKEY != 0;
+        }
+        DNS_RECORD_TYPE_HTTPS => {
+            return flags & LOG_HTTPS != 0;
         }
         DNS_RECORD_TYPE_SPF => {
             return flags & LOG_SPF != 0;
@@ -460,6 +464,7 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         DNSRData::NS(bytes) |
         DNSRData::TXT(bytes) |
         DNSRData::NULL(bytes) |
+        DNSRData::HTTPS(bytes) |
         DNSRData::PTR(bytes) => {
             jsa.set_string_from_bytes("rdata", bytes)?;
         }
@@ -539,6 +544,7 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
                     DNSRData::NS(bytes) |
                     DNSRData::TXT(bytes) |
                     DNSRData::NULL(bytes) |
+                    DNSRData::HTTPS(bytes) |
                     DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
                             answer_types.insert(type_string.to_string(),

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -179,6 +179,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                 DNSRData::NS(ref bytes) |
                 DNSRData::TXT(ref bytes) |
                 DNSRData::NULL(ref bytes) |
+                DNSRData::HTTPS(ref bytes) |
                 DNSRData::PTR(ref bytes) |
                 DNSRData::Unknown(ref bytes) => {
                     if bytes.len() > 0 {

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -237,6 +237,10 @@ fn dns_parse_rdata_ns<'a>(input: &'a [u8], message: &'a [u8]) -> IResult<&'a [u8
     dns_parse_name(input, message).map(|(input, name)| (input, DNSRData::NS(name)))
 }
 
+fn dns_parse_rdata_https<'a>(input: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
+    rest(input).map(|(input, data)| (input, DNSRData::HTTPS(data.to_vec())))
+}
+
 fn dns_parse_rdata_ptr<'a>(input: &'a [u8], message: &'a [u8]) -> IResult<&'a [u8], DNSRData> {
     dns_parse_name(input, message).map(|(input, name)| (input, DNSRData::PTR(name)))
 }
@@ -330,6 +334,7 @@ pub fn dns_parse_rdata<'a>(
         DNS_RECORD_TYPE_NS => dns_parse_rdata_ns(input, message),
         DNS_RECORD_TYPE_TXT => dns_parse_rdata_txt(input),
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
+        DNS_RECORD_TYPE_HTTPS => dns_parse_rdata_https(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
         DNS_RECORD_TYPE_SRV => dns_parse_rdata_srv(input, message),
         _ => dns_parse_rdata_unknown(input),

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -118,6 +118,7 @@
 
 #define LOG_FORMAT_GROUPED     BIT_U64(60)
 #define LOG_FORMAT_DETAILED    BIT_U64(61)
+#define LOG_HTTPS      BIT_U64(62)
 
 #define LOG_FORMAT_ALL (LOG_FORMAT_GROUPED|LOG_FORMAT_DETAILED)
 #define LOG_ALL_RRTYPES (~(uint64_t)(LOG_QUERIES|LOG_ANSWERS|LOG_FORMAT_DETAILED|LOG_FORMAT_GROUPED))
@@ -175,6 +176,7 @@ typedef enum {
     DNS_RRTYPE_HIP,
     DNS_RRTYPE_CDS,
     DNS_RRTYPE_CDNSKEY,
+    DNS_RRTYPE_HTTPS,
     DNS_RRTYPE_SPF,
     DNS_RRTYPE_TKEY,
     DNS_RRTYPE_TSIG,
@@ -240,6 +242,7 @@ static struct {
    { "hip", LOG_HIP },
    { "cds", LOG_CDS },
    { "cdnskey", LOG_CDNSKEY },
+   { "https", LOG_HTTPS},
    { "spf", LOG_SPF },
    { "tkey", LOG_TKEY },
    { "tsig", LOG_TSIG },


### PR DESCRIPTION

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4751) ticket.

Draft PR to gather feedback.

Previous PR: #8011

Describe changes:
- Added logic to parse rrtype: HTTPS
