### PR TITLE
src: Use WARN_UNUSED for ByteExtract* functions

### DIFF
--- a/src/app-layer-enip-common.c
+++ b/src/app-layer-enip-common.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -64,14 +64,16 @@ static int ENIPExtractUint8(uint8_t *res, const uint8_t *input, uint16_t *offset
 static int ENIPExtractUint16(uint16_t *res, const uint8_t *input, uint16_t *offset, uint32_t input_len)
 {
 
-    if (input_len < sizeof(uint16_t) || *offset > (input_len - sizeof(uint16_t)))
-    {
+    if (input_len < sizeof(uint16_t) || *offset > (input_len - sizeof(uint16_t))) {
         SCLogDebug("ENIPExtractUint16: Parsing beyond payload length");
         return 0;
     }
 
-    ByteExtractUint16(res, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
-            (const uint8_t *) (input + *offset));
+    if (ByteExtractUint16(res, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+                (const uint8_t *)(input + *offset)) == -1) {
+        return 0;
+    }
+
     *offset += sizeof(uint16_t);
     return 1;
 }
@@ -91,8 +93,11 @@ static int ENIPExtractUint32(uint32_t *res, const uint8_t *input, uint16_t *offs
         return 0;
     }
 
-    ByteExtractUint32(res, BYTE_LITTLE_ENDIAN, sizeof(uint32_t),
-            (const uint8_t *) (input + *offset));
+    if (ByteExtractUint32(res, BYTE_LITTLE_ENDIAN, sizeof(uint32_t),
+                (const uint8_t *)(input + *offset)) == -1) {
+        return 0;
+    }
+
     *offset += sizeof(uint32_t);
     return 1;
 }
@@ -112,8 +117,11 @@ static int ENIPExtractUint64(uint64_t *res, const uint8_t *input, uint16_t *offs
         return 0;
     }
 
-    ByteExtractUint64(res, BYTE_LITTLE_ENDIAN, sizeof(uint64_t),
-            (const uint8_t *) (input + *offset));
+    if (ByteExtractUint64(res, BYTE_LITTLE_ENDIAN, sizeof(uint64_t),
+                (const uint8_t *)(input + *offset)) == -1) {
+        return 0;
+    }
+
     *offset += sizeof(uint64_t);
     return 1;
 }
@@ -375,8 +383,7 @@ int DecodeCommonPacketFormatPDU(const uint8_t *input, uint32_t input_len,
         enip_data->encap_data_item.sequence_count = data_sequence_count;
     }
 
-    switch (enip_data->encap_data_item.type)
-    {
+    switch (enip_data->encap_data_item.type) {
         case CONNECTED_DATA_ITEM:
             SCLogDebug(
                     "DecodeCommonPacketFormat - CONNECTED DATA ITEM - parse CIP");
@@ -872,8 +879,11 @@ int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
     //use temp_offset just to grab the service offset, don't want to use and push offset
     uint16_t temp_offset = offset;
     uint16_t num_services;
-    ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
-            (const uint8_t *) (input + temp_offset));
+    if (ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+                (const uint8_t *)(input + temp_offset)) == -1) {
+        return 0;
+    }
+
     temp_offset += sizeof(uint16_t);
     //SCLogDebug("DecodeCIPRequestMSP number of services %d",num_services);
 
@@ -886,8 +896,10 @@ int DecodeCIPRequestMSPPDU(const uint8_t *input, uint32_t input_len,
         }
 
         uint16_t svc_offset; //read set of service offsets
-        ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
-                (const uint8_t *) (input + temp_offset));
+        if (ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+                    (const uint8_t *)(input + temp_offset)) == -1) {
+            return 0;
+        }
         temp_offset += sizeof(uint16_t);
         //SCLogDebug("parseCIPRequestMSP service %d offset %d",svc, svc_offset);
 
@@ -920,13 +932,14 @@ int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
     //use temp_offset just to grab the service offset, don't want to use and push offset
     uint16_t temp_offset = offset;
     uint16_t num_services;
-    ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
-            (const uint8_t *) (input + temp_offset));
+    if (ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+                (const uint8_t *)(input + temp_offset)) == -1) {
+        return 0;
+    }
     temp_offset += sizeof(uint16_t);
     //SCLogDebug("DecodeCIPResponseMSP number of services %d", num_services);
 
-    for (int svc = 0; svc < num_services; svc++)
-    {
+    for (int svc = 0; svc < num_services; svc++) {
         if (temp_offset >= (input_len - sizeof(uint16_t)))
         {
             SCLogDebug("DecodeCIPResponseMSP: Parsing beyond payload length");
@@ -934,8 +947,10 @@ int DecodeCIPResponseMSPPDU(const uint8_t *input, uint32_t input_len,
         }
 
         uint16_t svc_offset; //read set of service offsets
-        ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
-                (const uint8_t *) (input + temp_offset));
+        if (ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+                    (const uint8_t *)(input + temp_offset)) == -1) {
+            return 0;
+        }
         temp_offset += sizeof(uint16_t);
         //SCLogDebug("parseCIPResponseMSP service %d offset %d", svc, svc_offset);
 

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -94,7 +94,7 @@ void BytesToStringBuffer(const uint8_t *bytes, size_t nbytes, char *outstr, size
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractUint64(uint64_t *res, int e, uint16_t len, const uint8_t *bytes);
+int WARN_UNUSED ByteExtractUint64(uint64_t *res, int e, uint16_t len, const uint8_t *bytes);
 
 /**
  * Extract bytes from a byte string and convert to a uint32_t.
@@ -107,7 +107,7 @@ int ByteExtractUint64(uint64_t *res, int e, uint16_t len, const uint8_t *bytes);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes);
+int WARN_UNUSED ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes);
 
 /**
  * Extract bytes from a byte string and convert to a unint16_t.
@@ -120,7 +120,7 @@ int ByteExtractUint32(uint32_t *res, int e, uint16_t len, const uint8_t *bytes);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes);
+int WARN_UNUSED ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes);
 
 /**
  * Extract unsigned integer value from a string.
@@ -134,7 +134,8 @@ int ByteExtractUint16(uint16_t *res, int e, uint16_t len, const uint8_t *bytes);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractString(uint64_t *res, int base, size_t len, const char *str, bool strict);
+int WARN_UNUSED ByteExtractString(
+        uint64_t *res, int base, size_t len, const char *str, bool strict);
 
 /**
  * Extract unsigned integer value from a string as uint64_t.
@@ -147,7 +148,7 @@ int ByteExtractString(uint64_t *res, int base, size_t len, const char *str, bool
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint32_t.
@@ -160,7 +161,7 @@ int ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint32(uint32_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringUint32(uint32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint16_t.
@@ -173,7 +174,7 @@ int ByteExtractStringUint32(uint32_t *res, int base, size_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint16(uint16_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringUint16(uint16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint8_t.
@@ -186,7 +187,7 @@ int ByteExtractStringUint16(uint16_t *res, int base, size_t len, const char *str
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringUint8(uint8_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringUint8(uint8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string.
@@ -200,7 +201,8 @@ int ByteExtractStringUint8(uint8_t *res, int base, size_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringSigned(int64_t *res, int base, size_t len, const char *str, bool strict);
+int WARN_UNUSED ByteExtractStringSigned(
+        int64_t *res, int base, size_t len, const char *str, bool strict);
 
 /**
  * Extract signed integer value from a string as uint64_t.
@@ -213,7 +215,7 @@ int ByteExtractStringSigned(int64_t *res, int base, size_t len, const char *str,
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint32_t.
@@ -226,7 +228,7 @@ int ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt32(int32_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringInt32(int32_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint16_t.
@@ -239,7 +241,7 @@ int ByteExtractStringInt32(int32_t *res, int base, size_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt16(int16_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringInt16(int16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as uint8_t.
@@ -252,7 +254,7 @@ int ByteExtractStringInt16(int16_t *res, int base, size_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int ByteExtractStringInt8(int8_t *res, int base, size_t len, const char *str);
+int WARN_UNUSED ByteExtractStringInt8(int8_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract unsigned integer value from a string as uint64_t strictly.
@@ -475,7 +477,7 @@ void ByteRegisterTests(void);
 #endif /* UNITTESTS */
 
 /** ------ Inline functions ----- */
-static inline int ByteExtract(uint64_t *res, int e, uint16_t len, const uint8_t *bytes)
+static inline int WARN_UNUSED ByteExtract(uint64_t *res, int e, uint16_t len, const uint8_t *bytes)
 {
     if ((e != BYTE_BIG_ENDIAN) && (e != BYTE_LITTLE_ENDIAN)) {
         /** \todo Need standard return values */


### PR DESCRIPTION

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

LLink to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues/3658) ticket:

Previous PR: https://github.com/OISF/suricata/pull/8024

Describe new changes:
- Fix clang errors