### PR TITLE
detect-filename: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -505,11 +505,9 @@ static int DetectFilenameSignatureParseTest01(void)
 static int DetectFilenameTestParse01 (void)
 {
     DetectFilenameData *dnd = DetectFilenameParse(NULL, "secret.pdf", false);
-    if (dnd != NULL) {
-        DetectFilenameFree(NULL, dnd);
-        return 1;
-    }
-    return 0;
+    FAIL_IF_NULL(dnd);
+    DetectFilenameFree(NULL, dnd);
+    PASS;
 }
 
 /**
@@ -517,18 +515,12 @@ static int DetectFilenameTestParse01 (void)
  */
 static int DetectFilenameTestParse02 (void)
 {
-    int result = 0;
-
     DetectFilenameData *dnd = DetectFilenameParse(NULL, "backup.tar.gz", false);
-    if (dnd != NULL) {
-        if (dnd->len == 13 && memcmp(dnd->name, "backup.tar.gz", 13) == 0) {
-            result = 1;
-        }
-
-        DetectFilenameFree(NULL, dnd);
-        return result;
-    }
-    return 0;
+    FAIL_IF_NULL(dnd);
+    FAIL_IF_NOT(dnd->len == 13);
+    FAIL_IF_NOT(memcmp(dnd->name, "backup.tar.gz", 13) == 0);
+    DetectFilenameFree(NULL, dnd);
+    PASS;
 }
 
 /**
@@ -536,18 +528,12 @@ static int DetectFilenameTestParse02 (void)
  */
 static int DetectFilenameTestParse03 (void)
 {
-    int result = 0;
-
     DetectFilenameData *dnd = DetectFilenameParse(NULL, "cmd.exe", false);
-    if (dnd != NULL) {
-        if (dnd->len == 7 && memcmp(dnd->name, "cmd.exe", 7) == 0) {
-            result = 1;
-        }
-
-        DetectFilenameFree(NULL, dnd);
-        return result;
-    }
-    return 0;
+    FAIL_IF_NULL(dnd);
+    FAIL_IF_NOT(dnd->len == 7);
+    FAIL_IF_NOT(memcmp(dnd->name, "cmd.exe", 7) == 0);
+    DetectFilenameFree(NULL, dnd);
+    PASS;
 }
 
 


### PR DESCRIPTION
Task: #4036

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4036

Describe changes:
- Update detect-filename unit tests to use FAIL/PASS APIs.

