### PR TITLE
runmodes: enable IPS in DPDK runmode v1

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -31,6 +31,7 @@
  */
 
 #include "suricata-common.h"
+#include "suricata.h"
 #include "tm-threads.h"
 #include "conf.h"
 #include "runmodes.h"
@@ -691,7 +692,7 @@ static int AFPConfigGeThreadsCount(void *conf)
     return afp->threads;
 }
 
-int AFPRunModeIsIPS()
+static int AFPRunModeIsIPS(void)
 {
     int nlive = LiveGetDeviceCount();
     int ldev;
@@ -769,6 +770,14 @@ int AFPRunModeIsIPS()
     return has_ips;
 }
 
+static void AFPRunModeEnableIPS(void)
+{
+    if (AFPRunModeIsIPS()) {
+        SCLogInfo("AF_PACKET: Setting IPS mode");
+        EngineModeSetIPS();
+    }
+}
+
 #endif
 
 
@@ -793,11 +802,8 @@ int RunModeIdsAFPAutoFp(void)
         FatalError(SC_ERR_FATAL, "Unable to init peers list.");
     }
 
-    ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig,
-                              AFPConfigGeThreadsCount,
-                              "ReceiveAFP",
-                              "DecodeAFP", thread_name_autofp,
-                              live_dev);
+    ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig, AFPRunModeEnableIPS, AFPConfigGeThreadsCount,
+            "ReceiveAFP", "DecodeAFP", thread_name_autofp, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }
@@ -874,11 +880,8 @@ int RunModeIdsAFPWorkers(void)
         FatalError(SC_ERR_FATAL, "Unable to init peers list.");
     }
 
-    ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig,
-                                    AFPConfigGeThreadsCount,
-                                    "ReceiveAFP",
-                                    "DecodeAFP", thread_name_workers,
-                                    live_dev);
+    ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig, AFPRunModeEnableIPS, AFPConfigGeThreadsCount,
+            "ReceiveAFP", "DecodeAFP", thread_name_workers, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }

--- a/src/runmode-af-packet.h
+++ b/src/runmode-af-packet.h
@@ -28,6 +28,5 @@ int RunModeIdsAFPAutoFp(void);
 int RunModeIdsAFPWorkers(void);
 void RunModeIdsAFPRegister(void);
 const char *RunModeAFPGetDefaultMode(void);
-int AFPRunModeIsIPS(void);
 
 #endif /* __RUNMODE_AF_PACKET_H__ */

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -102,12 +102,8 @@ int RunModeIdsErfDagAutoFp(void)
 
     TimeModeSetLive();
 
-    ret = RunModeSetLiveCaptureAutoFp(ParseDagConfig,
-        DagConfigGetThreadCount,
-        "ReceiveErfDag",
-        "DecodeErfDag",
-        thread_name_autofp,
-        NULL);
+    ret = RunModeSetLiveCaptureAutoFp(ParseDagConfig, NULL, DagConfigGetThreadCount,
+            "ReceiveErfDag", "DecodeErfDag", thread_name_autofp, NULL);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "DAG autofp runmode failed to start");
     }
@@ -127,12 +123,8 @@ int RunModeIdsErfDagWorkers(void)
 
     TimeModeSetLive();
 
-    ret = RunModeSetLiveCaptureWorkers(ParseDagConfig,
-        DagConfigGetThreadCount,
-        "ReceiveErfDag",
-        "DecodeErfDag",
-        thread_name_workers,
-        NULL);
+    ret = RunModeSetLiveCaptureWorkers(ParseDagConfig, NULL, DagConfigGetThreadCount,
+            "ReceiveErfDag", "DecodeErfDag", thread_name_workers, NULL);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "DAG workers runmode failed to start");
     }

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -271,9 +271,8 @@ static int NapatechInit(int runmode)
 
     switch (runmode) {
         case NT_RUNMODE_WORKERS:
-            status = RunModeSetLiveCaptureWorkers(NapatechConfigParser,
-                    NapatechGetThreadsCount,
-                    "NapatechStream", "NapatechDecode",
+            status = RunModeSetLiveCaptureWorkers(NapatechConfigParser, NULL,
+                    NapatechGetThreadsCount, "NapatechStream", "NapatechDecode",
                     thread_name_workers, NULL);
             break;
         default:

--- a/src/runmode-netmap.h
+++ b/src/runmode-netmap.h
@@ -28,6 +28,5 @@ int RunModeIdsNetmapAutoFp(void);
 int RunModeIdsNetmapWorkers(void);
 void RunModeIdsNetmapRegister(void);
 const char *RunModeNetmapGetDefaultMode(void);
-int NetmapRunModeIsIPS(void);
 
 #endif /* __RUNMODE_NETMAP_H__ */

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -156,7 +156,7 @@ static int RunModeIdsNflogAutoFp(void)
     RunModeInitialize();
     TimeModeSetLive();
 
-    int ret = RunModeSetLiveCaptureAutoFp(ParseNflogConfig, NflogConfigGeThreadsCount,
+    int ret = RunModeSetLiveCaptureAutoFp(ParseNflogConfig, NULL, NflogConfigGeThreadsCount,
             "ReceiveNFLOG", "DecodeNFLOG", thread_name_autofp, NULL);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Unable to start runmode");
@@ -196,7 +196,7 @@ static int RunModeIdsNflogWorkers(void)
     RunModeInitialize();
     TimeModeSetLive();
 
-    int ret = RunModeSetLiveCaptureWorkers(ParseNflogConfig, NflogConfigGeThreadsCount,
+    int ret = RunModeSetLiveCaptureWorkers(ParseNflogConfig, NULL, NflogConfigGeThreadsCount,
             "ReceiveNFLOG", "DecodeNFLOG", thread_name_workers, NULL);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Unable to start runmode");

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -281,11 +281,8 @@ int RunModeIdsPcapAutoFp(void)
 
     (void) ConfGet("pcap.single-pcap-dev", &live_dev);
 
-    ret = RunModeSetLiveCaptureAutoFp(ParsePcapConfig,
-                              PcapConfigGeThreadsCount,
-                              "ReceivePcap",
-                              "DecodePcap", thread_name_autofp,
-                              live_dev);
+    ret = RunModeSetLiveCaptureAutoFp(ParsePcapConfig, NULL, PcapConfigGeThreadsCount,
+            "ReceivePcap", "DecodePcap", thread_name_autofp, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
@@ -312,11 +309,8 @@ int RunModeIdsPcapWorkers(void)
 
     (void) ConfGet("pcap.single-pcap-dev", &live_dev);
 
-    ret = RunModeSetLiveCaptureWorkers(ParsePcapConfig,
-                                    PcapConfigGeThreadsCount,
-                                    "ReceivePcap",
-                                    "DecodePcap", thread_name_workers,
-                                    live_dev);
+    ret = RunModeSetLiveCaptureWorkers(ParsePcapConfig, NULL, PcapConfigGeThreadsCount,
+            "ReceivePcap", "DecodePcap", thread_name_workers, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Unable to start runmode");
     }

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -476,11 +476,8 @@ int RunModeIdsPfringAutoFp(void)
                            "Unable to get parser and interface params");
     }
 
-    ret = RunModeSetLiveCaptureAutoFp(tparser,
-                              PfringConfigGetThreadsCount,
-                              "ReceivePfring",
-                              "DecodePfring", thread_name_autofp,
-                              live_dev);
+    ret = RunModeSetLiveCaptureAutoFp(tparser, NULL, PfringConfigGetThreadsCount, "ReceivePfring",
+            "DecodePfring", thread_name_autofp, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Runmode start failed");
     }
@@ -546,11 +543,8 @@ int RunModeIdsPfringWorkers(void)
                            "Unable to get parser and interface params");
     }
 
-    ret = RunModeSetLiveCaptureWorkers(tparser,
-                              PfringConfigGetThreadsCount,
-                              "ReceivePfring",
-                              "DecodePfring", thread_name_workers,
-                              live_dev);
+    ret = RunModeSetLiveCaptureWorkers(tparser, NULL, PfringConfigGetThreadsCount, "ReceivePfring",
+            "DecodePfring", thread_name_workers, live_dev);
     if (ret != 0) {
         FatalError(SC_ERR_FATAL, "Runmode start failed");
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2455,24 +2455,6 @@ void PostConfLoadedDetectSetup(SCInstance *suri)
 static int PostDeviceFinalizedSetup(SCInstance *suri)
 {
     SCEnter();
-
-#ifdef HAVE_AF_PACKET
-    if (suri->run_mode == RUNMODE_AFP_DEV) {
-        if (AFPRunModeIsIPS()) {
-            SCLogInfo("AF_PACKET: Setting IPS mode");
-            EngineModeSetIPS();
-        }
-    }
-#endif
-#ifdef HAVE_NETMAP
-    if (suri->run_mode == RUNMODE_NETMAP) {
-        if (NetmapRunModeIsIPS()) {
-            SCLogInfo("Netmap: Setting IPS mode");
-            EngineModeSetIPS();
-        }
-    }
-#endif
-
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -85,11 +85,9 @@ char *RunmodeAutoFpCreatePickupQueuesString(int n)
 /**
  */
 int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
-                              ConfigIfaceThreadsCountFunc ModThreadsCount,
-                              const char *recv_mod_name,
-                              const char *decode_mod_name,
-                              const char *thread_name,
-                              const char *live_dev)
+        ConfigRunmodeEnableIPSFunc runmodeEnableIPSFunc,
+        ConfigIfaceThreadsCountFunc ModThreadsCount, const char *recv_mod_name,
+        const char *decode_mod_name, const char *thread_name, const char *live_dev)
 {
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
@@ -101,6 +99,10 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     char *queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
         FatalError(SC_ERR_RUNMODE, "RunmodeAutoFpCreatePickupQueuesString failed");
+    }
+
+    if (runmodeEnableIPSFunc != NULL) {
+        runmodeEnableIPSFunc();
     }
 
     if ((nlive <= 1) && (live_dev != NULL)) {
@@ -328,14 +330,17 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
 }
 
 int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
-                              ConfigIfaceThreadsCountFunc ModThreadsCount,
-                              const char *recv_mod_name,
-                              const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev)
+        ConfigRunmodeEnableIPSFunc runmodeEnableIPSFunc,
+        ConfigIfaceThreadsCountFunc ModThreadsCount, const char *recv_mod_name,
+        const char *decode_mod_name, const char *thread_name, const char *live_dev)
 {
     int nlive = LiveGetDeviceCount();
     void *aconf;
     int ldev;
+
+    if (runmodeEnableIPSFunc != NULL) {
+        runmodeEnableIPSFunc();
+    }
 
     for (ldev = 0; ldev < nlive; ldev++) {
         const char *live_dev_c = NULL;

--- a/src/util-runmodes.h
+++ b/src/util-runmodes.h
@@ -25,6 +25,7 @@
 
 typedef void *(*ConfigIfaceParserFunc) (const char *);
 typedef void *(*ConfigIPSParserFunc) (int);
+typedef void (*ConfigRunmodeEnableIPSFunc)(void);
 typedef int (*ConfigIfaceThreadsCountFunc) (void *);
 
 int RunModeSetLiveCaptureAuto(ConfigIfaceParserFunc configparser,
@@ -34,10 +35,9 @@ int RunModeSetLiveCaptureAuto(ConfigIfaceParserFunc configparser,
                               const char *live_dev);
 
 int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc configparser,
-                              ConfigIfaceThreadsCountFunc ModThreadsCount,
-                              const char *recv_mod_name,
-                              const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+        ConfigRunmodeEnableIPSFunc runmodeEnableIPSFunc,
+        ConfigIfaceThreadsCountFunc ModThreadsCount, const char *recv_mod_name,
+        const char *decode_mod_name, const char *thread_name, const char *live_dev);
 
 int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
@@ -46,10 +46,9 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc configparser,
                               const char *live_dev);
 
 int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc configparser,
-                              ConfigIfaceThreadsCountFunc ModThreadsCount,
-                              const char *recv_mod_name,
-                              const char *decode_mod_name, const char *thread_name,
-                              const char *live_dev);
+        ConfigRunmodeEnableIPSFunc runmodeEnableIPSFunc,
+        ConfigIfaceThreadsCountFunc ModThreadsCount, const char *recv_mod_name,
+        const char *decode_mod_name, const char *thread_name, const char *live_dev);
 
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         const char *recv_mod_name,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5580#change-24800) :ticket::

Describe changes:
- prototype changes of RunModeSetLiveCaptureAutoFp and RunModeSetLiveCaptureWorkers functions to move the IPS enable logic out of suricata.c file
- added support for enabling IPS support in DPDK mode