### PR TITLE
doc/devguide: Installing Suricata from Git

### DIFF
--- a/doc/userguide/devguide/codebase/index.rst
+++ b/doc/userguide/devguide/codebase/index.rst
@@ -10,3 +10,4 @@ Working with the Codebase
    testing
    unittests-c
    unittests-rust
+   installation-from-git

--- a/doc/userguide/devguide/codebase/installation-from-git.rst
+++ b/doc/userguide/devguide/codebase/installation-from-git.rst
@@ -1,0 +1,168 @@
+Installation from GIT
+=====================
+
+Ubuntu Installation from GIT
+----------------------------
+
+This document will explain how to install and use the most recent code of
+**Suricata** on Ubuntu. Installing from GIT or other operating systems is
+basically the same, except that some commands are Ubuntu-specific
+(like sudo and apt-get). In case you are using another operating system,
+you should replace those commands with your OS-specific commands.
+
+Pre-installation requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before you can build **Suricata** for your system, run the following command
+to ensure that you have everything you need for the installation.
+
+.. code-block:: bash
+
+  sudo apt-get -y install libpcre3 libpcre3-dbg libpcre3-dev \
+  build-essential autoconf automake libtool libpcap-dev libnet1-dev \
+  libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev libcap-ng-dev \
+  libcap-ng0 make libmagic-dev libjansson-dev rustc cargo jq git-core
+
+Add ``${HOME}/.cargo/bin`` to your path.
+
+.. code-block:: bash
+
+  export PATH=$PATH:${HOME}/.cargo/bin
+  cargo install --force cbindgen
+
+Depending on the current status of your system, it may take a while to
+complete this process.
+
+**IPS**
+
+By default, Suricata works as an IDS. If you want to use it as a IDS and IPS
+program, enter:
+
+.. code-block:: bash
+
+  sudo apt-get -y install libnetfilter-queue-dev libnetfilter-queue1 \
+  libnfnetlink-dev libnfnetlink0
+
+Suricata
+~~~~~~~~
+
+First, it is convenient to create a directory for Suricata.
+Name it 'suricata' for example. Open the terminal and enter:
+
+.. code-block:: bash
+
+  mkdir suricata
+
+
+Followed by:
+
+.. code-block:: bash
+
+  cd suricata
+
+Next, enter the following line in the terminal:
+
+.. code-block:: bash
+
+  git clone git@github.com:OISF/suricata.git
+  cd suricata
+
+Libhtp is not bundled. Get libhtp by doing:
+
+.. code-block:: bash
+
+  ./scripts/bundle.sh libhtp
+
+Followed by:
+
+.. code-block:: bash
+
+  ./autogen.sh
+
+
+To configure, please enter:
+
+.. code-block:: bash
+
+  ./configure
+
+
+To compile, please enter:
+
+.. code-block:: bash
+
+  make
+
+To install Suricata, enter:
+
+.. code-block:: bash
+
+  sudo make install
+  sudo ldconfig
+
+To install suricata-update
+
+Follow the instructions found
+https://suricata-update.readthedocs.io/en/latest/quickstart.html
+
+.. note:: If you would like to build ``suricata-update`` from source, enter:
+
+  .. code-block:: bash
+
+    ./scripts/bundle.sh suricata-update
+    cd suricata-update
+    python setup.py build
+    sudo python setup.py install
+    sudo suricata-update
+
+Auto setup
+~~~~~~~~~~
+
+You can also use the available auto setup features of Suricata:
+
+
+ex:
+
+.. code-block:: bash
+
+  ./configure && make && sudo make install-conf
+
+*make install-conf*
+would do the regular "make install" and then it would automatically
+create/setup all the necessary directories and ``suricata.yaml`` for you.
+
+.. code-block:: bash
+
+  ./configure && make && make install-rules
+
+*make install-rules*
+would do the regular "make install" and then it would automatically download
+and set up the latest ruleset from Emerging Threats available for Suricata
+
+.. code-block:: bash
+
+  ./configure && make && make install-full
+
+*make install-full*
+would combine everything mentioned above (install-conf and install-rules) -
+and will present you with a ready to run (configured and set up) Suricata
+
+
+Please continue with
+`Basic Setup <https://redmine.openinfosecfoundation.org/projects/suricata/
+wiki/Basic_Setup>`_.
+
+In case you have already made a map for the most recent code, download the
+code into that map, and want to download recent code again, please enter:
+
+.. code-block:: bash
+
+  cd suricata/suricata
+
+next, enter:
+
+.. code-block:: bash
+
+  git pull
+
+After that, you start again at running *./autogen.sh*.


### PR DESCRIPTION
As part of the process of moving documentation from redmine to "Read the Docs", this commit moves installing Suricata using git from redmine wiki into Suricata Developer Guide section. It also updates the necessary steps.

Signed-off-by: Bazzan <donbazzan@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#5585](https://redmine.openinfosecfoundation.org/issues/5585)

Describe changes:
- Move redmine documentation to Read the Docs.
- Create `installation-from-git.rst` file in `userguide/devguide/codebase`
-  Update the ways to install `suricata-update`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
