### PR TITLE
dns/eve: add 'HTTPS' type logging

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -81,6 +81,7 @@ pub const DNS_RECORD_TYPE_TLSA        : u16 = 52;
 pub const DNS_RECORD_TYPE_HIP         : u16 = 55;
 pub const DNS_RECORD_TYPE_CDS         : u16 = 59;
 pub const DNS_RECORD_TYPE_CDNSKEY     : u16 = 60;
+pub const DNS_RECORD_TYPE_HTTPS       : u16 = 65;
 pub const DNS_RECORD_TYPE_SPF         : u16 = 99;  // Obsolete
 pub const DNS_RECORD_TYPE_TKEY        : u16 = 249;
 pub const DNS_RECORD_TYPE_TSIG        : u16 = 250;

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -86,6 +86,7 @@ pub const LOG_URI        : u64 = BIT_U64!(59);
 
 pub const LOG_FORMAT_GROUPED  : u64 = BIT_U64!(60);
 pub const LOG_FORMAT_DETAILED : u64 = BIT_U64!(61);
+pub const LOG_HTTPS      : u64 = BIT_U64!(62);
 
 fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
 {
@@ -250,6 +251,9 @@ fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool
         DNS_RECORD_TYPE_CDNSKEY => {
             return flags & LOG_CDNSKEY != 0;
         }
+        DNS_RECORD_TYPE_HTTPS => {
+            return flags & LOG_HTTPS != 0;
+        }
         DNS_RECORD_TYPE_SPF => {
             return flags & LOG_SPF != 0;
         }
@@ -324,6 +328,7 @@ pub fn dns_rrtype_string(rrtype: u16) -> String {
         DNS_RECORD_TYPE_HIP => "HIP",
         DNS_RECORD_TYPE_CDS => "CDS",
         DNS_RECORD_TYPE_CDNSKEY => "CDSNKEY",
+        DNS_RECORD_TYPE_HTTPS => "HTTPS",
         DNS_RECORD_TYPE_MAILA => "MAILA",
         DNS_RECORD_TYPE_URI => "URI",
         DNS_RECORD_TYPE_MB => "MB",

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -118,6 +118,7 @@
 
 #define LOG_FORMAT_GROUPED     BIT_U64(60)
 #define LOG_FORMAT_DETAILED    BIT_U64(61)
+#define LOG_HTTPS              BIT_U64(62)
 
 #define LOG_FORMAT_ALL (LOG_FORMAT_GROUPED|LOG_FORMAT_DETAILED)
 #define LOG_ALL_RRTYPES (~(uint64_t)(LOG_QUERIES|LOG_ANSWERS|LOG_FORMAT_DETAILED|LOG_FORMAT_GROUPED))
@@ -175,6 +176,7 @@ typedef enum {
     DNS_RRTYPE_HIP,
     DNS_RRTYPE_CDS,
     DNS_RRTYPE_CDNSKEY,
+    DNS_RRTYPE_HTTPS,
     DNS_RRTYPE_SPF,
     DNS_RRTYPE_TKEY,
     DNS_RRTYPE_TSIG,
@@ -188,6 +190,7 @@ static struct {
     const char *config_rrtype;
     uint64_t flags;
 } dns_rrtype_fields[] = {
+    // clang-format off
    { "a", LOG_A },
    { "ns", LOG_NS },
    { "md", LOG_MD },
@@ -246,6 +249,7 @@ static struct {
    { "maila", LOG_MAILA },
    { "any", LOG_ANY },
    { "uri", LOG_URI }
+    // clang-format on
 };
 
 typedef struct LogDnsFileCtx_ {


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4751) ticket.

Previous PR: https://github.com/OISF/suricata/pull/8031

Describe new changes:

- Added logic to parse rrtype: HTTPS
-  Modified output-json-dns.c file

suricata-verify-pr: 969