### PR TITLE
detect-filesha256: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-filesha256.c
+++ b/src/detect-filesha256.c
@@ -79,57 +79,45 @@ static int DetectFileSha256Setup (DetectEngineCtx *de_ctx, Signature *s, const c
 static int SHA256MatchLookupString(ROHashTable *hash, const char *string)
 {
     uint8_t sha256[32];
-    if (ReadHashString(sha256, string, "file", 88, 64) == 1) {
-        void *ptr = ROHashLookup(hash, &sha256, (uint16_t)sizeof(sha256));
-        if (ptr == NULL)
-            return 0;
-        else
-            return 1;
-    }
-    return 0;
+    FAIL_IF_NOT(ReadHashString(sha256, string, "file", 88, 64) == 1);
+    void *ptr = ROHashLookup(hash, &sha256, (uint16_t)sizeof(sha256));
+    FAIL_IF_NULL(ptr);
+    PASS;
 }
 
 static int SHA256MatchTest01(void)
 {
     ROHashTable *hash = ROHashInit(4, 32);
-    if (hash == NULL) {
-        return 0;
-    }
-    if (LoadHashTable(hash, "9c891edb5da763398969b6aaa86a5d46971bd28a455b20c2067cb512c9f9a0f8", "file", 1, DETECT_FILESHA256) != 1)
-        return 0;
-    if (LoadHashTable(hash, "6eee51705f34b6cfc7f0c872a7949ec3e3172a908303baf5d67d03b98f70e7e3", "file", 2, DETECT_FILESHA256) != 1)
-        return 0;
-    if (LoadHashTable(hash, "b12c7d57507286bbbe36d7acf9b34c22c96606ffd904e3c23008399a4a50c047", "file", 3, DETECT_FILESHA256) != 1)
-        return 0;
-    if (LoadHashTable(hash, "ca496e1ddadc290050339dd75ce8830ad3028ce1556a5368874a4aec3aee114b", "file", 4, DETECT_FILESHA256) != 1)
-        return 0;
-    if (LoadHashTable(hash, "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f", "file", 5, DETECT_FILESHA256) != 1)
-        return 0;
-    if (LoadHashTable(hash, "d765e722e295969c0a5c2d90f549db8b89ab617900bf4698db41c7cdad993bb9", "file", 6, DETECT_FILESHA256) != 1)
-        return 0;
-
-    if (ROHashInitFinalize(hash) != 1) {
-        return 0;
-    }
-
-    if (SHA256MatchLookupString(hash, "9c891edb5da763398969b6aaa86a5d46971bd28a455b20c2067cb512c9f9a0f8") != 1)
-        return 0;
-    if (SHA256MatchLookupString(hash, "6eee51705f34b6cfc7f0c872a7949ec3e3172a908303baf5d67d03b98f70e7e3") != 1)
-        return 0;
-    if (SHA256MatchLookupString(hash, "b12c7d57507286bbbe36d7acf9b34c22c96606ffd904e3c23008399a4a50c047") != 1)
-        return 0;
-    if (SHA256MatchLookupString(hash, "ca496e1ddadc290050339dd75ce8830ad3028ce1556a5368874a4aec3aee114b") != 1)
-        return 0;
-    if (SHA256MatchLookupString(hash, "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f") != 1)
-        return 0;
-    if (SHA256MatchLookupString(hash, "d765e722e295969c0a5c2d90f549db8b89ab617900bf4698db41c7cdad993bb9") != 1)
-        return 0;
-    /* Shouldn't match */
-    if (SHA256MatchLookupString(hash, "3333333333333333333333333333333333333333333333333333333333333333") == 1)
-        return 0;
-
+    FAIL_IF_NULL(hash);
+    FAIL_IF(LoadHashTable(hash, "9c891edb5da763398969b6aaa86a5d46971bd28a455b20c2067cb512c9f9a0f8",
+                    "file", 1, DETECT_FILESHA256) != 1);
+    FAIL_IF(LoadHashTable(hash, "6eee51705f34b6cfc7f0c872a7949ec3e3172a908303baf5d67d03b98f70e7e3",
+                    "file", 2, DETECT_FILESHA256) != 1);
+    FAIL_IF(LoadHashTable(hash, "b12c7d57507286bbbe36d7acf9b34c22c96606ffd904e3c23008399a4a50c047",
+                    "file", 3, DETECT_FILESHA256) != 1);
+    FAIL_IF(LoadHashTable(hash, "ca496e1ddadc290050339dd75ce8830ad3028ce1556a5368874a4aec3aee114b",
+                    "file", 4, DETECT_FILESHA256) != 1);
+    FAIL_IF(LoadHashTable(hash, "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+                    "file", 5, DETECT_FILESHA256) != 1);
+    FAIL_IF(LoadHashTable(hash, "d765e722e295969c0a5c2d90f549db8b89ab617900bf4698db41c7cdad993bb9",
+                    "file", 6, DETECT_FILESHA256) != 1);
+    FAIL_IF(ROHashInitFinalize(hash) != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "9c891edb5da763398969b6aaa86a5d46971bd28a455b20c2067cb512c9f9a0f8") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "6eee51705f34b6cfc7f0c872a7949ec3e3172a908303baf5d67d03b98f70e7e3") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "b12c7d57507286bbbe36d7acf9b34c22c96606ffd904e3c23008399a4a50c047") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "ca496e1ddadc290050339dd75ce8830ad3028ce1556a5368874a4aec3aee114b") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "d765e722e295969c0a5c2d90f549db8b89ab617900bf4698db41c7cdad993bb9") != 1);
+    FAIL_IF(SHA256MatchLookupString(
+                    hash, "3333333333333333333333333333333333333333333333333333333333333333") == 1);
     ROHashFree(hash);
-    return 1;
+    PASS;
 }
 
 void DetectFileSha256RegisterTests(void)


### PR DESCRIPTION
Task: #4038

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4038

Describe changes:
- Update detect-filesha256 unit tests to use FAIL/PASS APIs.