### PR TITLE
detect-itype: remove unittests

### DIFF
--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -347,86 +347,6 @@ static int DetectITypeParseTest08(void)
 }
 
 /**
- * \test DetectITypeMatchTest01 is a test for checking the working of itype
- *       keyword by creating 5 rules and matching a crafted packet against
- *       them. 4 out of 5 rules shall trigger.
- */
-static int DetectITypeMatchTest01(void)
-{
-
-    Packet *p = NULL;
-    Signature *s = NULL;
-    ThreadVars th_v;
-    DetectEngineThreadCtx *det_ctx;
-    int result = 0;
-
-    memset(&th_v, 0, sizeof(th_v));
-
-    p = UTHBuildPacket(NULL, 0, IPPROTO_ICMP);
-    p->icmpv4h->type = 10;
-
-    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
-
-    de_ctx->flags |= DE_QUIET;
-
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert icmp any any -> any any (itype:10; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:<15; sid:2;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:>20; sid:3;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:8<>20; sid:4;)");
-    if (s == NULL) {
-        goto end;
-    }
-
-    // no longer accept itype:20<>8
-
-    SigGroupBuild(de_ctx);
-    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-
-    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (PacketAlertCheck(p, 1) == 0) {
-        SCLogDebug("sid 1 did not alert, but should have");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 2) == 0) {
-        SCLogDebug("sid 2 did not alert, but should have");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 3)) {
-        SCLogDebug("sid 3 alerted, but should not have");
-        goto cleanup;
-    } else if (PacketAlertCheck(p, 4) == 0) {
-        SCLogDebug("sid 4 did not alert, but should have");
-        goto cleanup;
-    }
-
-    result = 1;
-
-cleanup:
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
-
-    DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
-    DetectEngineCtxFree(de_ctx);
-
-    UTHFreePackets(&p, 1);
-end:
-    return result;
-}
-
-/**
  * \brief this function registers unit tests for DetectIType
  */
 void DetectITypeRegisterTests(void)
@@ -439,6 +359,5 @@ void DetectITypeRegisterTests(void)
     UtRegisterTest("DetectITypeParseTest06", DetectITypeParseTest06);
     UtRegisterTest("DetectITypeParseTest07", DetectITypeParseTest07);
     UtRegisterTest("DetectITypeParseTest08", DetectITypeParseTest08);
-    UtRegisterTest("DetectITypeMatchTest01", DetectITypeMatchTest01);
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/5590

Describe changes:

-  remove unittests that have been converted to Suricata-Verify : `DetectITypeMatchTest01`

suricata-verify-pr: 970