### PR TITLE
detect-icmp-seq: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -337,11 +337,10 @@ static int DetectIcmpSeqParseTest01 (void)
 {
     DetectIcmpSeqData *iseq = NULL;
     iseq = DetectIcmpSeqParse(NULL, "300");
-    if (iseq != NULL && htons(iseq->seq) == 300) {
-        DetectIcmpSeqFree(NULL, iseq);
-        return 1;
-    }
-    return 0;
+    FAIL_IF_NULL(iseq);
+    FAIL_IF_NOT(htons(iseq->seq) == 300);
+    DetectIcmpSeqFree(NULL, iseq);
+    PASS;
 }
 
 /**
@@ -352,11 +351,10 @@ static int DetectIcmpSeqParseTest02 (void)
 {
     DetectIcmpSeqData *iseq = NULL;
     iseq = DetectIcmpSeqParse(NULL, "  300  ");
-    if (iseq != NULL && htons(iseq->seq) == 300) {
-        DetectIcmpSeqFree(NULL, iseq);
-        return 1;
-    }
-    return 0;
+    FAIL_IF_NULL(iseq);
+    FAIL_IF_NOT(htons(iseq->seq) == 300);
+    DetectIcmpSeqFree(NULL, iseq);
+    PASS;
 }
 
 /**
@@ -364,13 +362,9 @@ static int DetectIcmpSeqParseTest02 (void)
  */
 static int DetectIcmpSeqParseTest03 (void)
 {
-    DetectIcmpSeqData *iseq = NULL;
-    iseq = DetectIcmpSeqParse(NULL, "badc");
-    if (iseq != NULL) {
-        DetectIcmpSeqFree(NULL, iseq);
-        return 0;
-    }
-    return 1;
+    DetectIcmpSeqData *iseq = DetectIcmpSeqParse(NULL, "badc");
+    FAIL_IF_NOT_NULL(iseq);
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Task: #4043

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4043

Previous PR: https://github.com/OISF/suricata/pull/8080

Describe changes:
- Update detect-icmp-seq to use FAIL/PASS API