### PR TITLE
detect-icmp-id: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -331,13 +331,11 @@ static bool PrefilterIcmpIdIsPrefilterable(const Signature *s)
  */
 static int DetectIcmpIdParseTest01 (void)
 {
-    DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse(NULL, "300");
-    if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(NULL, iid);
-        return 1;
-    }
-    return 0;
+    DetectIcmpIdData *iid = DetectIcmpIdParse(NULL, "300");
+    FAIL_IF_NULL(iid);
+    FAIL_IF_NOT(iid->id == htons(300));
+    DetectIcmpIdFree(NULL, iid);
+    PASS;
 }
 
 /**
@@ -346,13 +344,11 @@ static int DetectIcmpIdParseTest01 (void)
  */
 static int DetectIcmpIdParseTest02 (void)
 {
-    DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse(NULL, "  300  ");
-    if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(NULL, iid);
-        return 1;
-    }
-    return 0;
+    DetectIcmpIdData *iid = DetectIcmpIdParse(NULL, "  300  ");
+    FAIL_IF_NULL(iid);
+    FAIL_IF_NOT(iid->id == htons(300));
+    DetectIcmpIdFree(NULL, iid);
+    PASS;
 }
 
 /**
@@ -361,13 +357,11 @@ static int DetectIcmpIdParseTest02 (void)
  */
 static int DetectIcmpIdParseTest03 (void)
 {
-    DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse(NULL, "\"300\"");
-    if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(NULL, iid);
-        return 1;
-    }
-    return 0;
+    DetectIcmpIdData *iid = DetectIcmpIdParse(NULL, "\"300\"");
+    FAIL_IF_NULL(iid);
+    FAIL_IF_NOT(iid->id == htons(300));
+    DetectIcmpIdFree(NULL, iid);
+    PASS;
 }
 
 /**
@@ -376,13 +370,11 @@ static int DetectIcmpIdParseTest03 (void)
  */
 static int DetectIcmpIdParseTest04 (void)
 {
-    DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse(NULL, "   \"   300 \"");
-    if (iid != NULL && iid->id == htons(300)) {
-        DetectIcmpIdFree(NULL, iid);
-        return 1;
-    }
-    return 0;
+    DetectIcmpIdData *iid = DetectIcmpIdParse(NULL, "   \"   300 \"");
+    FAIL_IF_NULL(iid);
+    FAIL_IF_NOT(iid->id == htons(300));
+    DetectIcmpIdFree(NULL, iid);
+    PASS;
 }
 
 /**
@@ -391,13 +383,9 @@ static int DetectIcmpIdParseTest04 (void)
  */
 static int DetectIcmpIdParseTest05 (void)
 {
-    DetectIcmpIdData *iid = NULL;
-    iid = DetectIcmpIdParse(NULL, "\"300");
-    if (iid == NULL) {
-        DetectIcmpIdFree(NULL, iid);
-        return 1;
-    }
-    return 0;
+    DetectIcmpIdData *iid = DetectIcmpIdParse(NULL, "\"300");
+    FAIL_IF_NOT_NULL(iid);
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Task: #4042

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4042

Describe changes:
- Update detect-icmp-id to use FAIL/PASS API
