### PR TITLE
dnp3: fixups to work with unified json tx logger - v5

### DIFF
--- a/src/app-layer-dnp3.h
+++ b/src/app-layer-dnp3.h
@@ -208,37 +208,20 @@ typedef struct DNP3Transaction_ {
     AppLayerTxData         tx_data;
 
     uint64_t tx_num; /**< Internal transaction ID. */
+    bool is_request; /**< Is this tx a request? */
 
     struct DNP3State_ *dnp3;
 
-    uint8_t                has_request;
-    uint8_t                request_done;
-    DNP3LinkHeader         request_lh;
-    DNP3TransportHeader    request_th;
-    DNP3ApplicationHeader  request_ah;
-    uint8_t               *request_buffer; /**< Reassembled request
-                                            * buffer. */
-    uint32_t               request_buffer_len;
-    uint8_t                request_complete; /**< Was the decode
-                                        * complete.  It will not be
-                                        * complete if we hit objects
-                                        * we do not know. */
-    DNP3ObjectList         request_objects;
-
-    uint8_t                has_response;
-    uint8_t                response_done;
-    DNP3LinkHeader         response_lh;
-    DNP3TransportHeader    response_th;
-    DNP3ApplicationHeader  response_ah;
-    DNP3InternalInd        response_iin;
-    uint8_t               *response_buffer; /**< Reassembed response
-                                             * buffer. */
-    uint32_t               response_buffer_len;
-    uint8_t                response_complete; /**< Was the decode
-                                         * complete.  It will not be
-                                         * complete if we hit objects
-                                         * we do not know. */
-    DNP3ObjectList         response_objects;
+    uint8_t *buffer; /**< Reassembled request buffer. */
+    uint32_t buffer_len;
+    DNP3ObjectList objects;
+    DNP3LinkHeader lh;
+    DNP3TransportHeader th;
+    DNP3ApplicationHeader ah;
+    DNP3InternalInd iin;
+    uint8_t done;
+    uint8_t complete; /**< Was the decode complete.  It will not be
+                         complete if we hit objects we do not know. */
 
     TAILQ_ENTRY(DNP3Transaction_) next;
 } DNP3Transaction;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -198,13 +198,13 @@ static void AlertJsonDnp3(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
             jb_get_mark(js, &mark);
             bool logged = false;
             jb_open_object(js, "dnp3");
-            if (tx->has_request && tx->request_done) {
+            if (tx->is_request && tx->done) {
                 jb_open_object(js, "request");
                 JsonDNP3LogRequest(js, tx);
                 jb_close(js);
                 logged = true;
             }
-            if (tx->has_response && tx->response_done) {
+            if (!tx->is_request && tx->done) {
                 jb_open_object(js, "response");
                 JsonDNP3LogResponse(js, tx);
                 jb_close(js);

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -446,13 +446,6 @@ typedef enum {
     LOGGER_TLS_STORE,
     LOGGER_TLS,
     LOGGER_JSON_TX,
-
-    /* DNP3 loggers. These ones don't fit the common model of a
-       transaction logger yet so are left with their own IDs for
-       now. */
-    LOGGER_JSON_DNP3_TS,
-    LOGGER_JSON_DNP3_TC,
-
     LOGGER_FILE,
     LOGGER_FILEDATA,
 

--- a/src/util-lua-dnp3.c
+++ b/src/util-lua-dnp3.c
@@ -106,21 +106,21 @@ static void DNP3PushRequest(lua_State *luastate, DNP3Transaction *tx)
     /* Link header. */
     lua_pushliteral(luastate, "link_header");
     lua_newtable(luastate);
-    DNP3PushLinkHeader(luastate, &tx->request_lh);
+    DNP3PushLinkHeader(luastate, &tx->lh);
     lua_settable(luastate, -3);
 
     /* Transport header. */
-    LUA_PUSHT_INT(luastate, "transport_header", tx->request_th);
+    LUA_PUSHT_INT(luastate, "transport_header", tx->th);
 
     /* Application header. */
     lua_pushliteral(luastate, "application_header");
     lua_newtable(luastate);
-    DNP3PushApplicationHeader(luastate, &tx->request_ah);
+    DNP3PushApplicationHeader(luastate, &tx->ah);
     lua_settable(luastate, -3);
 
     lua_pushliteral(luastate, "objects");
     lua_newtable(luastate);
-    DNP3PushObjects(luastate, &tx->request_objects);
+    DNP3PushObjects(luastate, &tx->objects);
     lua_settable(luastate, -3);
 }
 
@@ -129,25 +129,24 @@ static void DNP3PushResponse(lua_State *luastate, DNP3Transaction *tx)
     /* Link header. */
     lua_pushliteral(luastate, "link_header");
     lua_newtable(luastate);
-    DNP3PushLinkHeader(luastate, &tx->response_lh);
+    DNP3PushLinkHeader(luastate, &tx->lh);
     lua_settable(luastate, -3);
 
     /* Transport header. */
-    LUA_PUSHT_INT(luastate, "transport_header", tx->response_th);
+    LUA_PUSHT_INT(luastate, "transport_header", tx->th);
 
     /* Application header. */
     lua_pushliteral(luastate, "application_header");
     lua_newtable(luastate);
-    DNP3PushApplicationHeader(luastate, &tx->response_ah);
+    DNP3PushApplicationHeader(luastate, &tx->ah);
     lua_settable(luastate, -3);
 
     /* Internal indicators. */
-    LUA_PUSHT_INT(luastate, "indicators",
-        tx->response_iin.iin1 << 8 | tx->response_iin.iin2);
+    LUA_PUSHT_INT(luastate, "indicators", tx->iin.iin1 << 8 | tx->iin.iin2);
 
     lua_pushliteral(luastate, "objects");
     lua_newtable(luastate);
-    DNP3PushObjects(luastate, &tx->response_objects);
+    DNP3PushObjects(luastate, &tx->objects);
     lua_settable(luastate, -3);
 }
 
@@ -168,22 +167,22 @@ static int DNP3GetTx(lua_State *luastate)
     lua_pushinteger(luastate, tx->tx_num);
     lua_settable(luastate, -3);
 
-    LUA_PUSHT_INT(luastate, "has_request", tx->has_request);
-    if (tx->has_request) {
+    LUA_PUSHT_INT(luastate, "has_request", tx->is_request ? 1 : 0);
+    if (tx->is_request) {
         lua_pushliteral(luastate, "request");
         lua_newtable(luastate);
-        LUA_PUSHT_INT(luastate, "done", tx->request_done);
-        LUA_PUSHT_INT(luastate, "complete", tx->request_complete);
+        LUA_PUSHT_INT(luastate, "done", tx->done);
+        LUA_PUSHT_INT(luastate, "complete", tx->complete);
         DNP3PushRequest(luastate, tx);
         lua_settable(luastate, -3);
     }
 
-    LUA_PUSHT_INT(luastate, "has_response", tx->has_response);
-    if (tx->has_response) {
+    LUA_PUSHT_INT(luastate, "has_response", tx->is_request ? 0 : 1);
+    if (!tx->is_request) {
         lua_pushliteral(luastate, "response");
         lua_newtable(luastate);
-        LUA_PUSHT_INT(luastate, "done", tx->response_done);
-        LUA_PUSHT_INT(luastate, "complete", tx->response_complete);
+        LUA_PUSHT_INT(luastate, "done", tx->done);
+        LUA_PUSHT_INT(luastate, "complete", tx->complete);
         DNP3PushResponse(luastate, tx);
         lua_settable(luastate, -3);
     }

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1262,8 +1262,6 @@ const char * PacketProfileLoggertIdToString(LoggerId id)
         CASE_CODE(LOGGER_TLS_STORE);
         CASE_CODE(LOGGER_TLS);
         CASE_CODE(LOGGER_JSON_TX);
-        CASE_CODE(LOGGER_JSON_DNP3_TS);
-        CASE_CODE(LOGGER_JSON_DNP3_TC);
         CASE_CODE(LOGGER_FILE);
         CASE_CODE(LOGGER_FILEDATA);
         CASE_CODE (LOGGER_ALERT_DEBUG);


### PR DESCRIPTION
Update DNP3 to work with a single TX logger, and just register one
logger instead of 2.

This primarily creates a TX per message instead of correlating replies
to requests, which fits the DNP3 model better, but we didn't really have
this concept nailed down when DNP3 was written.

This is a continuation of PR: https://github.com/OISF/suricata/pull/8006
- Rebased

