### PR TITLE
detect/dataset: fix dataset set logic

### DIFF
--- a/src/detect-dataset.h
+++ b/src/detect-dataset.h
@@ -36,7 +36,14 @@
 typedef struct DetectDatasetData_ {
     Dataset *set;
     uint8_t cmd;
+    int thread_ctx_id;
 } DetectDatasetData;
+
+typedef struct DetectDatasetMatchData_ {
+    uint8_t *data;
+    uint32_t data_len;
+    uint32_t data_len_max;
+} DetectDatasetMatchData;
 
 int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
     const DetectDatasetData *sd,


### PR DESCRIPTION
The set operation of dataset keyword was not done only signature when there is a full match. This was not correct with regards to expectation.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Move dataset set to post match
- Keep backward compat

suricata-verify-pr: 959
