### PR TITLE
detect/dataset: fix dataset set logic

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -41,8 +41,7 @@
 #include "util-path.h"
 #include "util-conf.h"
 
-int DetectDatasetMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
-        const Signature *, const SigMatchCtx *);
+int DetectDatasetMatch(DetectEngineThreadCtx *, Packet *, const Signature *, const SigMatchCtx *);
 static int DetectDatasetSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectDatasetFree (DetectEngineCtx *, void *);
 
@@ -53,6 +52,7 @@ void DetectDatasetRegister (void)
     sigmatch_table[DETECT_DATASET].url = "/rules/dataset-keywords.html#dataset";
     sigmatch_table[DETECT_DATASET].Setup = DetectDatasetSetup;
     sigmatch_table[DETECT_DATASET].Free  = DetectDatasetFree;
+    sigmatch_table[DETECT_DATASET].Match = DetectDatasetMatch;
 }
 
 /*
@@ -86,15 +86,40 @@ int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
         }
         case DETECT_DATASET_CMD_SET: {
             //PrintRawDataFp(stdout, data, data_len);
-            int r = DatasetAdd(sd->set, data, data_len);
-            if (r == 1)
-                return 1;
-            break;
+            /* Simulate original behavior where there is no alert when data is in set */
+            int r = DatasetLookup(sd->set, data, data_len);
+            if (r == 1) {
+                return 0;
+            }
+            DetectDatasetMatchData *dmd =
+                    (DetectDatasetMatchData *)DetectThreadCtxGetKeywordThreadCtx(
+                            det_ctx, sd->thread_ctx_id);
+            if (dmd == NULL) {
+                return 0;
+            }
+            dmd->data_len = data_len;
+            dmd->data = data;
+            return 1;
         }
         default:
             abort();
     }
     return 0;
+}
+
+int DetectDatasetMatch(
+        DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const SigMatchCtx *ctx)
+{
+    const DetectDatasetData *sd = (DetectDatasetData *)ctx;
+    DetectDatasetMatchData *dmd = (DetectDatasetMatchData *)DetectThreadCtxGetKeywordThreadCtx(
+            det_ctx, sd->thread_ctx_id);
+
+    if (dmd == NULL || dmd->data_len == 0) {
+        return 0;
+    }
+    int r = DatasetAdd(sd->set, dmd->data, dmd->data_len);
+    dmd->data_len = 0;
+    return r;
 }
 
 static int DetectDatasetParse(const char *str, char *cmd, int cmd_len, char *name, int name_len,
@@ -328,10 +353,32 @@ static int SetupSavePath(const DetectEngineCtx *de_ctx,
     return 0;
 }
 
+static void *DetectDatasetMatchDataThreadInit(void *data)
+{
+    DetectDatasetMatchData *scmd = SCCalloc(1, sizeof(DetectDatasetMatchData));
+    if (unlikely(scmd == NULL))
+        return NULL;
+
+    scmd->data = NULL;
+    scmd->data_len = 0;
+    scmd->data_len_max = 0;
+    return scmd;
+}
+
+static void DetectDatasetMatchDataThreadFree(void *ctx)
+{
+    if (ctx != NULL) {
+        DetectDatasetMatchData *scmd = (DetectDatasetMatchData *)ctx;
+        SCFree(scmd);
+    }
+}
+
 int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectDatasetData *cd = NULL;
+    DetectDatasetData *scd = NULL;
     SigMatch *sm = NULL;
+    SigMatch *smp = NULL;
     uint8_t cmd = 0;
     uint64_t memcap = 0;
     uint32_t hashsize = 0;
@@ -419,6 +466,30 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
     if (sm == NULL)
         goto error;
 
+    if (cmd == DETECT_DATASET_CMD_SET) {
+        smp = SigMatchAlloc();
+        if (smp == NULL)
+            goto error;
+
+        scd = SCCalloc(1, sizeof(DetectDatasetData));
+        if (unlikely(scd == NULL))
+            goto error;
+
+        cd->thread_ctx_id = DetectRegisterThreadCtxFuncs(de_ctx, "dataset",
+                DetectDatasetMatchDataThreadInit, (void *)cd, DetectDatasetMatchDataThreadFree, 0);
+        if (cd->thread_ctx_id == -1)
+            goto error;
+        scd->thread_ctx_id = cd->thread_ctx_id;
+
+        scd->set = set;
+        scd->cmd = cmd;
+
+        smp->type = DETECT_DATASET;
+        smp->ctx = (SigMatchCtx *)scd;
+
+        SigMatchAppendSMToList(s, smp, DETECT_SM_LIST_POSTMATCH);
+    }
+
     sm->type = DETECT_DATASET;
     sm->ctx = (SigMatchCtx *)cd;
     SigMatchAppendSMToList(s, sm, list);
@@ -429,6 +500,10 @@ error:
         SCFree(cd);
     if (sm != NULL)
         SCFree(sm);
+    if (smp != NULL)
+        SCFree(smp);
+    if (scd != NULL)
+        SCFree(scd);
     return -1;
 }
 

--- a/src/detect-dataset.h
+++ b/src/detect-dataset.h
@@ -36,7 +36,14 @@
 typedef struct DetectDatasetData_ {
     Dataset *set;
     uint8_t cmd;
+    int thread_ctx_id;
 } DetectDatasetData;
+
+typedef struct DetectDatasetMatchData_ {
+    const uint8_t *data;
+    uint32_t data_len;
+    uint32_t data_len_max;
+} DetectDatasetMatchData;
 
 int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
     const DetectDatasetData *sd,


### PR DESCRIPTION
Update of #8114.

The set operation of dataset keyword was not done only signature when there is a full match. This was not correct with regards to expectation.

This patch changes the behavior of the dataset keyword to do a match and a post match for the set operation. In the match, the buffer data that needs to end up in the set is captured and in post match the dataset is updated (if ever the signature is fully matching).

Ticket: #5576

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5576

Describe changes:
- Don't use memcpy to transmit data

suricata-verify-pr: 959

