### PR TITLE
Smtp server detection 1125 v9

### DIFF
--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -18,7 +18,103 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+use nom7::bytes::complete::take_while1;
+use nom7::character::complete::char;
+use nom7::character::{is_alphabetic, is_alphanumeric};
+use nom7::combinator::verify;
+use nom7::multi::many1_count;
+use nom7::IResult;
+
 #[no_mangle]
 pub unsafe extern "C" fn rs_check_utf8(val: *const c_char) -> bool {
     CStr::from_ptr(val).to_str().is_ok()
+}
+
+fn is_alphanumeric_or_hyphen(chr: u8) -> bool {
+    return is_alphanumeric(chr) || chr == b'-';
+}
+
+fn parse_domain_label(i: &[u8]) -> IResult<&[u8], ()> {
+    let (i, _) = verify(take_while1(is_alphanumeric_or_hyphen), |x: &[u8]| {
+        is_alphabetic(x[0]) && x[x.len() - 1] != b'-'
+    })(i)?;
+    return Ok((i, ()));
+}
+
+fn parse_subdomain(input: &[u8]) -> IResult<&[u8], ()> {
+    let (input, _) = parse_domain_label(input)?;
+    let (input, _) = char('.')(input)?;
+    return Ok((input, ()));
+}
+
+fn parse_domain(input: &[u8]) -> IResult<&[u8], ()> {
+    let (input, _) = many1_count(parse_subdomain)(input)?;
+    let (input, _) = parse_domain_label(input)?;
+    return Ok((input, ()));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_validate_domain(input: *const u8, in_len: u32) -> u32 {
+    let islice = build_slice!(input, in_len as usize);
+    match parse_domain(islice) {
+        Ok((rem, _)) => {
+            return (islice.len() - rem.len()) as u32;
+        }
+        _ => {
+            return 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse_domain() {
+        let buf0: &[u8] = "a-1.oisf.net more".as_bytes();
+        let r0 = parse_domain(buf0);
+        match r0 {
+            Ok((rem, _)) => {
+                // And we should have 5 bytes left.
+                assert_eq!(rem.len(), 5);
+            }
+            _ => {
+                panic!("Result should have been ok.");
+            }
+        }
+        let buf1: &[u8] = "justatext".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "1.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "a-.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+        let buf1: &[u8] = "a(x)y.com".as_bytes();
+        let r1 = parse_domain(buf1);
+        match r1 {
+            Ok((_, _)) => {
+                panic!("Result should not have been ok.");
+            }
+            _ => {}
+        }
+    }
 }

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -287,6 +287,10 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
     uint8_t pm_results_bf[(ALPROTO_MAX / 8) + 1];
     memset(pm_results_bf, 0, sizeof(pm_results_bf));
 
+    // Do not take pm_ctx->pp_max_len of all probing parsers,
+    // but only the the probing parsers which matched a pattern.
+    uint32_t pp_max_len = pm_ctx->mpm_ctx.maxdepth;
+
     /* loop through unique pattern id's. Can't use search_cnt here,
      * as that contains all matches, tctx->pmq.pattern_id_array_cnt
      * contains only *unique* matches. */
@@ -296,6 +300,9 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
             AppProto proto = AppLayerProtoDetectPMMatchSignature(
                     s, tctx, f, flags, buf, buflen, searchlen, rflow);
 
+            if (s->pp_max_depth > pp_max_len) {
+                pp_max_len = s->pp_max_depth;
+            }
             /* store each unique proto once */
             if (AppProtoIsValid(proto) &&
                 !(pm_results_bf[proto / 8] & (1 << (proto % 8))) )
@@ -306,7 +313,7 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
             s = s->next;
         }
     }
-    if (pm_matches == 0 && buflen >= pm_ctx->pp_max_len) {
+    if (pm_matches == 0 && buflen >= pp_max_len) {
         pm_matches = -2;
     }
     PmqReset(&tctx->pmq);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1614,6 +1614,50 @@ static int SMTPStateGetEventInfoById(int event_id, const char **event_name,
     return 0;
 }
 
+static AppProto SMTPServerProbingParser(
+        Flow *f, uint8_t direction, const uint8_t *input, uint32_t len, uint8_t *rdir)
+{
+    // another check for minimum length
+    if (len < 5) {
+        return ALPROTO_UNKNOWN;
+    }
+    // begins by 220
+    if (input[0] != '2' || input[1] != '2' || input[2] != '0') {
+        return ALPROTO_FAILED;
+    }
+    // followed by space or hypen
+    if (input[3] != ' ' && input[3] != '-') {
+        return ALPROTO_FAILED;
+    }
+    // If client side is SMTP, do not validate domain
+    // so that server banner can be parsed first.
+    if (f->alproto_ts == ALPROTO_SMTP) {
+        for (uint32_t i = 4; i < len; i++) {
+            if (input[i] == '\n') {
+                return ALPROTO_SMTP;
+            }
+        }
+        return ALPROTO_UNKNOWN;
+    }
+    AppProto r = ALPROTO_UNKNOWN;
+    if (f->todstbytecnt > 4 && f->alproto_ts == ALPROTO_UNKNOWN) {
+        // Only validates SMTP if client side is unknown
+        // despite having received bytes.
+        r = ALPROTO_SMTP;
+    }
+    uint32_t offset = rs_validate_domain(input + 4, len - 4);
+    if (offset == 0) {
+        return ALPROTO_FAILED;
+    }
+    for (uint32_t i = offset + 4; i < len; i++) {
+        if (input[i] == '\n') {
+            return r;
+        }
+    }
+    // This should not go forever because of engine limiting probing parsers.
+    return ALPROTO_UNKNOWN;
+}
+
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
@@ -1629,6 +1673,19 @@ static int SMTPRegisterPatternsForProtocolDetection(void)
     if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "QUIT", 4, 0, STREAM_TOSERVER) < 0)
     {
+        return -1;
+    }
+    if (!AppLayerProtoDetectPPParseConfPorts(
+                "tcp", IPPROTO_TCP, "smtp", ALPROTO_SMTP, 0, 5, NULL, SMTPServerProbingParser)) {
+        AppLayerProtoDetectPPRegister(IPPROTO_TCP, "25", ALPROTO_SMTP, 0, 5, STREAM_TOSERVER, NULL,
+                SMTPServerProbingParser);
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP, "220 ", 4, 0,
+                STREAM_TOCLIENT, SMTPServerProbingParser, 5, 5) < 0) {
+        return -1;
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_SMTP, "220-", 4, 0,
+                STREAM_TOCLIENT, SMTPServerProbingParser, 5, 5) < 0) {
         return -1;
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/1125

Describe changes:
- smtp : adds server side detection
- ftp : adds server side detection
- protocoldetect: use stricter max depth

The most special trick is that the (server) probing parser waits for the client side to have seen some data to take a definitive positive decision.
So that If it looks like a SMTP server (it could be a FTP server), let's see if the client looks like SMTP or FTP or something unknown...

Modifies #8135 by relaxing smtp probing parser in case client side was already recognized as SMTP.

I wonder if SMTP parser should also relax its condition to set `state->parser_state |= SMTP_PARSER_STATE_FIRST_REPLY_SEEN;` 

suricata-verify-pr: 1000

https://github.com/OISF/suricata-verify/pull/1000