### PR TITLE
Quic ja3 hash 5624 v2

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -475,7 +475,7 @@ static inline int TlsDecodeHSCertificateFingerprint(
     if (unlikely(connp->cert0_fingerprint != NULL))
         return 0;
 
-    connp->cert0_fingerprint = SCCalloc(1, SHA1_STRING_LENGTH * sizeof(char));
+    connp->cert0_fingerprint = SCCalloc(1, SHA1_STRING_LENGTH);
     if (connp->cert0_fingerprint == NULL)
         return -1;
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1912,6 +1912,12 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     }
 #endif
 
+    if (s->init_data->init_flags & SIG_FLAG_INIT_JA3 && s->alproto != ALPROTO_UNKNOWN &&
+            s->alproto != ALPROTO_TLS && s->alproto != ALPROTO_QUIC) {
+        SCLogError(SC_ERR_INVALID_SIGNATURE, "Cannot have ja3 with protocol %s.",
+                AppProtoToString(s->alproto));
+        SCReturnInt(0);
+    }
     if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0 ||
         (s->init_data->init_flags & SIG_FLAG_INIT_FILEDATA)) {
         if (s->alproto != ALPROTO_UNKNOWN &&

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -135,6 +135,7 @@ static int DetectTlsJa3HashSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
         }
         return -2;
     }
+    s->init_data->init_flags |= SIG_FLAG_INIT_JA3;
 
     return 0;
 }

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -179,7 +179,7 @@ static bool DetectTlsJa3HashValidateCallback(const Signature *s,
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
         }
 
-        if (cd->content_len == 32)
+        if (cd->content_len == SC_MD5_HEX_LEN)
             return true;
 
         *sigerror = "Invalid length of the specified JA3 hash (should "

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -68,30 +68,6 @@ static bool DetectTlsJa3HashValidateCallback(const Signature *s,
        const char **sigerror);
 static int g_tls_ja3_hash_buffer_id = 0;
 
-static InspectionBuffer *GetJa3Data(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
-{
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        uint32_t b_len = 0;
-        const uint8_t *b = NULL;
-
-        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
-            return NULL;
-        if (b == NULL || b_len == 0)
-            return NULL;
-
-        uint8_t ja3_hash[SC_MD5_HEX_LEN + 1];
-        // this adds a final zero
-        SCMd5HashBufferToHex(b, b_len, ja3_hash, SC_MD5_HEX_LEN + 1);
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, ja3_hash, SC_MD5_HEX_LEN);
-        InspectionBufferApplyTransforms(buffer, transforms);
-    }
-    return buffer;
-}
-
 /**
  * \brief Registration function for keyword: ja3_hash
  */
@@ -112,10 +88,10 @@ void DetectTlsJa3HashRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
     DetectAppLayerMpmRegister2("ja3.hash", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetJa3Data, ALPROTO_QUIC, 1);
+            Ja3DetectGetHash, ALPROTO_QUIC, 1);
 
     DetectAppLayerInspectEngineRegister2("ja3.hash", ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1,
-            DetectEngineInspectBufferGeneric, GetJa3Data);
+            DetectEngineInspectBufferGeneric, Ja3DetectGetHash);
 
     DetectBufferTypeSetDescriptionByName("ja3.hash", "TLS JA3 hash");
 

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -124,6 +124,7 @@ static int DetectTlsJa3StringSetup(DetectEngineCtx *de_ctx, Signature *s, const 
         }
         return -2;
     }
+    s->init_data->init_flags |= SIG_FLAG_INIT_JA3;
 
     return 0;
 }

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -64,26 +64,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        void *txv, const int list_id);
 static int g_tls_ja3_str_buffer_id = 0;
 
-static InspectionBuffer *GetJa3Data(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
-{
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        uint32_t b_len = 0;
-        const uint8_t *b = NULL;
-
-        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
-            return NULL;
-        if (b == NULL || b_len == 0)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
-    }
-    return buffer;
-}
-
 /**
  * \brief Registration function for keyword: ja3.string
  */
@@ -104,10 +84,10 @@ void DetectTlsJa3StringRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
     DetectAppLayerMpmRegister2("ja3.string", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetJa3Data, ALPROTO_QUIC, 1);
+            Ja3DetectGetString, ALPROTO_QUIC, 1);
 
     DetectAppLayerInspectEngineRegister2("ja3.string", ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1,
-            DetectEngineInspectBufferGeneric, GetJa3Data);
+            DetectEngineInspectBufferGeneric, Ja3DetectGetString);
 
     DetectBufferTypeSetDescriptionByName("ja3.string", "TLS JA3 string");
 

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -68,6 +68,30 @@ static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
        const char **sigerror);
 static int g_tls_ja3s_hash_buffer_id = 0;
 
+static InspectionBuffer *GetJa3Data(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        uint8_t ja3_hash[SC_MD5_HEX_LEN + 1];
+        // this adds a final zero
+        SCMd5HashBufferToHex(b, b_len, ja3_hash, SC_MD5_HEX_LEN + 1);
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, ja3_hash, SC_MD5_HEX_LEN);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
 /**
  * \brief Registration function for keyword: ja3s.hash
  */
@@ -85,6 +109,12 @@ void DetectTlsJa3SHashRegister(void)
 
     DetectAppLayerMpmRegister2("ja3s.hash", SIG_FLAG_TOCLIENT, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
+
+    DetectAppLayerMpmRegister2("ja3s.hash", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetJa3Data, ALPROTO_QUIC, 1);
+
+    DetectAppLayerInspectEngineRegister2("ja3s.hash", ALPROTO_QUIC, SIG_FLAG_TOCLIENT, 1,
+            DetectEngineInspectBufferGeneric, GetJa3Data);
 
     DetectBufferTypeSetDescriptionByName("ja3s.hash", "TLS JA3S hash");
 
@@ -112,8 +142,10 @@ static int DetectTlsJa3SHashSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectBufferSetActiveList(s, g_tls_ja3s_hash_buffer_id) < 0)
         return -1;
 
-    if (DetectSignatureSetAppProto(s, ALPROTO_TLS) < 0)
+    if (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_TLS && s->alproto != ALPROTO_QUIC) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS, "rule contains conflicting protocols.");
         return -1;
+    }
 
     /* try to enable JA3 */
     SSLEnableJA3();

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -177,7 +177,7 @@ static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
             SCLogWarning(SC_WARN_POOR_RULE, "rule %u: %s", s->id, *sigerror);
         }
 
-        if (cd->content_len == 32)
+        if (cd->content_len == SC_MD5_HEX_LEN)
             return true;
 
         *sigerror = "Invalid length of the specified JA3S hash (should "

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -133,6 +133,7 @@ static int DetectTlsJa3SHashSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         }
         return -2;
     }
+    s->init_data->init_flags |= SIG_FLAG_INIT_JA3;
 
     return 0;
 }

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -124,6 +124,7 @@ static int DetectTlsJa3SStringSetup(DetectEngineCtx *de_ctx, Signature *s, const
         }
         return -2;
     }
+    s->init_data->init_flags |= SIG_FLAG_INIT_JA3;
 
     return 0;
 }

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -64,26 +64,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        void *txv, const int list_id);
 static int g_tls_ja3s_str_buffer_id = 0;
 
-static InspectionBuffer *GetJa3Data(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
-{
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        uint32_t b_len = 0;
-        const uint8_t *b = NULL;
-
-        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
-            return NULL;
-        if (b == NULL || b_len == 0)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
-    }
-    return buffer;
-}
-
 /**
  * \brief Registration function for keyword: ja3s.string
  */
@@ -104,10 +84,10 @@ void DetectTlsJa3SStringRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
 
     DetectAppLayerMpmRegister2("ja3s.string", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetJa3Data, ALPROTO_QUIC, 1);
+            Ja3DetectGetString, ALPROTO_QUIC, 1);
 
     DetectAppLayerInspectEngineRegister2("ja3s.string", ALPROTO_QUIC, SIG_FLAG_TOCLIENT, 1,
-            DetectEngineInspectBufferGeneric, GetJa3Data);
+            DetectEngineInspectBufferGeneric, Ja3DetectGetString);
 
     DetectBufferTypeSetDescriptionByName("ja3s.string", "TLS JA3S string");
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -255,6 +255,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICT          BIT_U32(8)  /**< priority is explicitly set by the priority keyword */
 #define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
+#define SIG_FLAG_INIT_JA3                   BIT_U32(10) /**< signature has ja3 keyword */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -524,7 +524,7 @@ static void SetBpfStringFromFile(char *filename)
     }
     bpf_len = st.st_size + 1;
 
-    bpf_filter = SCMalloc(bpf_len * sizeof(char));
+    bpf_filter = SCMalloc(bpf_len);
     if (unlikely(bpf_filter == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate buffer for bpf filter in file %s", filename);
         exit(EXIT_FAILURE);

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -30,8 +30,6 @@
 
 #include "detect-engine.h"
 
-#define MD5_STRING_LENGTH 33
-
 /**
  * \brief Allocate new buffer.
  *
@@ -226,14 +224,14 @@ char *Ja3GenerateHash(JA3Buffer *buffer)
         return NULL;
     }
 
-    char *ja3_hash = SCMalloc(MD5_STRING_LENGTH);
+    char *ja3_hash = SCMalloc(SC_MD5_HEX_LEN + 1);
     if (ja3_hash == NULL) {
         SCLogError(SC_ERR_MEM_ALLOC,
                    "Error allocating memory for JA3 hash");
         return NULL;
     }
 
-    SCMd5HashBufferToHex((unsigned char *)buffer->data, buffer->used, ja3_hash, MD5_STRING_LENGTH);
+    SCMd5HashBufferToHex((unsigned char *)buffer->data, buffer->used, ja3_hash, SC_MD5_HEX_LEN + 1);
     return ja3_hash;
 }
 

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -83,7 +83,7 @@ static int Ja3BufferResizeIfFull(JA3Buffer *buffer, uint32_t len)
     while (buffer->used + len + 2 > buffer->size)
     {
         buffer->size *= 2;
-        char *tmp = SCRealloc(buffer->data, buffer->size * sizeof(char));
+        char *tmp = SCRealloc(buffer->data, buffer->size);
         if (tmp == NULL) {
             SCLogError(SC_ERR_MEM_ALLOC, "Error resizing JA3 buffer");
             return -1;
@@ -177,7 +177,7 @@ int Ja3BufferAddValue(JA3Buffer **buffer, uint32_t value)
     }
 
     if ((*buffer)->data == NULL) {
-        (*buffer)->data = SCMalloc(JA3_BUFFER_INITIAL_SIZE * sizeof(char));
+        (*buffer)->data = SCMalloc(JA3_BUFFER_INITIAL_SIZE);
         if ((*buffer)->data == NULL) {
             SCLogError(SC_ERR_MEM_ALLOC,
                        "Error allocating memory for JA3 data");
@@ -226,15 +226,14 @@ char *Ja3GenerateHash(JA3Buffer *buffer)
         return NULL;
     }
 
-    char *ja3_hash = SCMalloc(MD5_STRING_LENGTH * sizeof(char));
+    char *ja3_hash = SCMalloc(MD5_STRING_LENGTH);
     if (ja3_hash == NULL) {
         SCLogError(SC_ERR_MEM_ALLOC,
                    "Error allocating memory for JA3 hash");
         return NULL;
     }
 
-    SCMd5HashBufferToHex((unsigned char *)buffer->data, buffer->used, ja3_hash,
-            MD5_STRING_LENGTH * sizeof(char));
+    SCMd5HashBufferToHex((unsigned char *)buffer->data, buffer->used, ja3_hash, MD5_STRING_LENGTH);
     return ja3_hash;
 }
 

--- a/src/util-ja3.h
+++ b/src/util-ja3.h
@@ -26,6 +26,8 @@
 
 #define JA3_BUFFER_INITIAL_SIZE 128
 
+#include "detect.h"
+
 typedef struct JA3Buffer_ {
     char *data;
     size_t size;
@@ -38,6 +40,14 @@ int Ja3BufferAppendBuffer(JA3Buffer **, JA3Buffer **);
 int Ja3BufferAddValue(JA3Buffer **, uint32_t);
 char *Ja3GenerateHash(JA3Buffer *);
 int Ja3IsDisabled(const char *);
+
+InspectionBuffer *Ja3DetectGetHash(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
+
+InspectionBuffer *Ja3DetectGetString(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
 
 #endif /* __UTIL_JA3_H__ */
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5624

Describe changes:
- Allows keyword ja3.hash to work on quic (as does already ja3.string)
- Some cleaning around it

suricata-verify-pr: 1001
https://github.com/OISF/suricata-verify/pull/1001

Modifies https://github.com/OISF/suricata/pull/8145 by adding a last commit to fix memory leak found by fuzzing something like `alert tcp any any -> any any (ja3.string; content: "toto"; http.uri; content: "tata")`