### PR TITLE
detect: fix memory leak when parsing signature

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -493,7 +493,6 @@ static void DetectFrameInspectEngineCopy(DetectEngineCtx *de_ctx, int sm_list, i
             }
 
             list->next = new_engine;
-            break;
         }
         t = t->next;
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5529

Describe changes:
- detect: fix memory leak when parsing signature with frames

`break` wrongly introduced by https://github.com/OISF/suricata/commit/40c315aa35d277653dd6bb46cdaab6af71499df2