### PR TITLE
swf-decompression: Disable by default.

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -54,6 +54,8 @@ Other changes
 - NSS is no longer required. File hashing and JA3 can now be used without the NSS compile time dependency.
 - If installing Suricata without the bundled Suricata-Update, the ``default-rule-path`` has been changed from ``/etc/suricata/rules`` to ``/var/lib/suricata/rules`` to be consistent with Suricata when installed with Suricata-Update.
 - FTP has been updated with a maximum command request and response line length of 4096 bytes. To change the default see :ref:`suricata-yaml-configure-ftp`.
+- SWF decompression in http has been disabled by default. To change the default see :ref:`suricata-yaml-configure-libhtp`.
+  See https://redmine.openinfosecfoundation.org/issues/5632 for more information.
 
 Logging changes
 ~~~~~~~~~~~~~~~

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -961,7 +961,7 @@ app-layer:
            # auto will use http-body-inline mode in IPS mode, yes or no set it statically
            http-body-inline: auto
 
-           # Decompress SWF files.
+           # Decompress SWF files. Disabled by default.
            # Two types: 'deflate', 'lzma', 'both' will decompress deflate and lzma
            # compress-depth:
            # Specifies the maximum amount of data to decompress,
@@ -970,7 +970,7 @@ app-layer:
            # Specifies the maximum amount of decompressed data to obtain,
            # set 0 for unlimited.
            swf-decompression:
-             enabled: yes
+             enabled: no
              type: both
              compress-depth: 100kb
              decompress-depth: 100kb


### PR DESCRIPTION
Add an entry to the upgrade guide noting the change.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5632) ticket: 5632

Describe changes:
- Disable swf decompression by default
- Add entry in upgrade.rst noting the change and linking to the ticket


Since disabling swf decompression by default is actually not related to how we do lzma decompression (#8132), we can separate these changes.