### PR TITLE
rust: explicitly convert from Direct to u8 , otherwise when add serde_…

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -42,7 +42,7 @@ pub const DIR_BOTH:        u8 = 0b0000_1100;
 const DIR_TOSERVER:        u8 = 0b0000_0100;
 const DIR_TOCLIENT:        u8 = 0b0000_1000;
 
-#[repr(C)]
+#[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Direction {
     ToServer = 0x04,

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1258,10 +1258,10 @@ pub unsafe extern "C" fn rs_dcerpc_get_tx_cnt(vtx: *mut std::os::raw::c_void) ->
 pub unsafe extern "C" fn rs_dcerpc_get_alstate_progress(tx: *mut std::os::raw::c_void, direction: u8
                                                  )-> std::os::raw::c_int {
     let tx = cast_pointer!(tx, DCERPCTransaction);
-    if direction == Direction::ToServer.into() && tx.req_done {
+    if direction == Direction::ToServer as u8 && tx.req_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.call_id, tx);
         return 1;
-    } else if direction == Direction::ToClient.into() && tx.resp_done {
+    } else if direction == Direction::ToClient as u8 && tx.resp_done {
         SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.call_id, tx);
         return 1;
     }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -950,7 +950,7 @@ pub unsafe extern "C" fn rs_dns_probe_tcp(
         } else {
             Direction::ToClient
         };
-        if (direction & DIR_BOTH) != dir.into() {
+        if (direction & DIR_BOTH) != dir as u8 {
             *rdir = dir as u8;
         }
         return ALPROTO_DNS;

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -681,7 +681,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_status(
 pub unsafe extern "C" fn rs_http2_tx_get_cookie(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if direction == Direction::ToServer.into() {
+    if direction == Direction::ToServer as u8 {
         if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, "cookie") {
             *buffer = value.as_ptr(); //unsafe
             *buffer_len = value.len() as u32;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1697,10 +1697,10 @@ pub unsafe extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c
                                                   -> std::os::raw::c_int
 {
     let tx = cast_pointer!(tx, NFSTransaction);
-    if direction == Direction::ToServer.into() && tx.request_done {
+    if direction == Direction::ToServer as u8 && tx.request_done {
         SCLogDebug!("TOSERVER progress 1");
         return 1;
-    } else if direction == Direction::ToClient.into() && tx.response_done {
+    } else if direction == Direction::ToClient as u8 && tx.response_done {
         SCLogDebug!("TOCLIENT progress 1");
         return 1;
     } else {
@@ -1886,7 +1886,7 @@ pub unsafe extern "C" fn rs_nfs_probe_ms(
     let mut adirection : u8 = 0;
     match nfs_probe_dir(slice, &mut adirection) {
         1 => {
-            if adirection == Direction::ToServer.into() {
+            if adirection == Direction::ToServer as u8 {
                 SCLogDebug!("nfs_probe_dir said Direction::ToServer");
             } else {
                 SCLogDebug!("nfs_probe_dir said Direction::ToClient");

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -404,7 +404,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_flags(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> SSHConnectionState {
     let tx = cast_pointer!(tx, SSHTransaction);
-    if direction == Direction::ToServer.into() {
+    if direction == Direction::ToServer as u8 {
         return tx.cli_hdr.flags;
     } else {
         return tx.srv_hdr.flags;
@@ -423,7 +423,7 @@ pub unsafe extern "C" fn rs_ssh_tx_get_alstate_progress(
         return SSHConnectionState::SshStateFinished as i32;
     }
 
-    if direction == Direction::ToServer.into() {
+    if direction == Direction::ToServer as u8 {
         if tx.cli_hdr.flags >= SSHConnectionState::SshStateBannerDone {
             return SSHConnectionState::SshStateBannerDone as i32;
         }


### PR DESCRIPTION

We are writing custom app protocol in rust. When we need add serde_json package. It always got error such like 
>note: multiple `impl`s satisfying `u8: PartialEq<_>` found in the following crates: `core`, `serde_json`:
And we think it is good do the conversion explicitly. Follow the suggestion from https://github.com/rust-lang/rust/issues/103968. 

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- explicitly comvert Direction to u8 
