### PR TITLE
src: Use uniform type for tenant_id 

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2931,7 +2931,7 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
     DetectEngineTenantMapping *map_array = NULL;
     uint32_t map_array_size = 0;
     uint32_t map_cnt = 0;
-    int max_tenant_id = 0;
+    uint32_t max_tenant_id = 0;
     DetectEngineCtx *list = master->list;
     HashTable *mt_det_ctxs_hash = NULL;
 
@@ -4280,7 +4280,7 @@ static uint32_t DetectEngineTentantGetIdFromPcap(const void *ctx, const Packet *
     return p->pcap_v.tenant_id;
 }
 
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id)
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -106,7 +106,7 @@ uint32_t DetectEngineGetVersion(void);
 void DetectEngineBumpVersion(void);
 int DetectEngineAddToMaster(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineGetCurrent(void);
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id);
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);

--- a/src/detect.h
+++ b/src/detect.h
@@ -785,7 +785,7 @@ typedef struct DetectEngineCtx_ {
     uint8_t flags;
     int failure_fatal;
 
-    int tenant_id;
+    uint32_t tenant_id;
 
     Signature *sig_list;
     uint32_t sig_cnt;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -59,7 +59,7 @@ int unix_socket_mode_is_running = 0;
 typedef struct PcapFiles_ {
     char *filename;
     char *output_dir;
-    int tenant_id;
+    uint32_t tenant_id;
     time_t delay;
     time_t poll_interval;
     bool continuous;
@@ -265,16 +265,8 @@ static void PcapFilesFree(PcapFiles *cfile)
  *
  * \retval 0 in case of error, 1 in case of success
  */
-static TmEcode UnixListAddFile(
-    PcapCommand *this,
-    const char *filename,
-    const char *output_dir,
-    int tenant_id,
-    bool continuous,
-    bool should_delete,
-    time_t delay,
-    time_t poll_interval
-)
+static TmEcode UnixListAddFile(PcapCommand *this, const char *filename, const char *output_dir,
+        uint32_t tenant_id, bool continuous, bool should_delete, time_t delay, time_t poll_interval)
 {
     PcapFiles *cfile = NULL;
     if (filename == NULL || this == NULL)
@@ -327,7 +319,7 @@ static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data
     PcapCommand *this = (PcapCommand *) data;
     const char *filename;
     const char *output_dir;
-    int tenant_id = 0;
+    uint32_t tenant_id = 0;
     bool should_delete = false;
     time_t delay = 30;
     time_t poll_interval = 5;
@@ -390,7 +382,7 @@ static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data
                                 json_string("tenant is not a number"));
             return TM_ECODE_FAILED;
         }
-        tenant_id = json_number_value(targ);
+        tenant_id = json_integer_value(targ);
     }
 
     json_t *delete_arg = json_object_get(cmd, "delete-when-done");
@@ -882,7 +874,7 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -963,7 +955,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -1048,7 +1040,7 @@ TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1124,7 +1116,7 @@ TmEcode UnixSocketReloadTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1194,7 +1186,7 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     SCLogInfo("remove-tenant: removing tenant %d", tenant_id);
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5186

Describe changes:
The tenant_id property is defined as an int in some structures and as uint32_t in some structures.
In some edge case values of tenant_id (For eg. 2^32), this can cause problems.

To address the issue, the following changes have been made:
tenant_id's type has been updated to uint32_t in several files

Please note that this is the same as #7542 . I messed that one up with an incorrect rebase and hence submitting it again. Apologies for the mixup and trouble.


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
