### PR TITLE
Include less v16

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -225,11 +225,11 @@ jobs:
                 texlive-upquote \
                 texlive-capt-of \
                 texlive-needspace
-      #- name: Setup cppclean
-      #  run: |
-      #    git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
-      #    cd cppclean
-      #    python3 setup.py install
+      - name: Setup cppclean
+        run: |
+          git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
+          cd cppclean
+          python3 setup.py install
       - name: Configuring
         run: |
           ./autogen.sh
@@ -342,11 +342,11 @@ jobs:
                 texlive-upquote \
                 texlive-capt-of \
                 texlive-needspace
-      #- name: Setup cppclean
-      #  run: |
-      #    git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
-      #    cd cppclean
-      #    python3 setup.py install
+      - name: Setup cppclean
+        run: |
+          git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
+          cd cppclean
+          python3 setup.py install
       - name: Configuring
         run: |
           ./autogen.sh

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1456,6 +1456,7 @@ jobs:
                 libjansson-dev \
                 libgeoip-dev \
                 liblua5.1-dev \
+                libluajit-5.1-dev \
                 libhiredis-dev \
                 libevent-dev \
                 libtool \
@@ -1482,7 +1483,7 @@ jobs:
           cp prep/cbindgen $HOME/.cargo/bin
           chmod 755 $HOME/.cargo/bin/cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-luajit
       - run: make -j2
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -815,6 +815,7 @@ jobs:
                 libnfnetlink0 \
                 libnuma-dev \
                 libhiredis-dev \
+                libhyperscan-dev \
                 liblua5.1-dev \
                 libjansson-dev \
                 libevent-dev \

--- a/scripts/cppclean_check.py
+++ b/scripts/cppclean_check.py
@@ -17,11 +17,26 @@ for l in sys.stdin:
     if included == "conf.h" and includer == "src/suricata-plugin.h":
         # SCEveFileType structure field Init being a function pointer using a parameter ConfNode defined in conf.h
         continue
+    if included == "util-prefilter.h" and includer == "src/util-mpm.h":
+        # MpmTableElmt_ structure field Search being a function pointer using a parameter PrefilterRuleStore
+        continue
+    if included == "flow.h" and includer == "src/output-tx.h":
+        # TxLogger type being a function pointer using a parameter Flow
+        continue
     if included == "util-debug-filters.h" and includer == "src/util-debug.h":
         # Macro SCEnter using SCLogCheckFDFilterEntry defined in util-debug-filters.h
         continue
     if included == "util-spm-bs.h" and includer == "src/util-spm.h":
         # Macro SpmSearch using BasicSearch defined in util-spm-bs.h
+        continue
+    if included == "util-cpu.h" and includer == "src/threads-profile.h":
+        # Macro SCSpinLock_profile using UtilCpuGetTicks
+        continue
+    if included == "util-profiling-locks.h" and includer == "src/util-profiling.h":
+        # Macro SCSpinLock_profile using SCProfilingAddPacketLocks
+        continue
+    if included == "threads.h" and includer == "src/util-debug-filters.h":
+        # pthread_t needed on Windows
         continue
 
     print("Unnecessary include from %s for %s" % (includer, included))

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -54,6 +54,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 #define DEFAULT_LOG_FILENAME "fast.log"
 
 #define MODULE_NAME "AlertFastLog"

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -48,6 +48,8 @@
 #include "util-syslog.h"
 #include "util-optimize.h"
 #include "util-logopenfile.h"
+// ACTION_DROP
+#include "action-globals.h"
 
 #ifndef OS_WIN32
 

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -62,7 +62,6 @@
 #include "util-memcmp.h"
 #include "util-spm.h"
 #include "util-debug.h"
-#include "util-validate.h"
 
 #include "runmodes.h"
 

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -34,8 +34,6 @@
 #include "app-layer-dnp3.h"
 #include "app-layer-dnp3-objects.h"
 
-/* For hexdump(). */
-
 /* Default number of unreplied requests to be considered a flood. */
 #define DNP3_DEFAULT_REQ_FLOOD_COUNT 500
 

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -25,6 +25,7 @@
  */
 
 #include "suricata-common.h"
+#include "suricata.h"
 
 #include "util-debug.h"
 #include "util-byte.h"

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -48,7 +48,6 @@
 
 #include "detect-parse.h"
 #include "detect-engine.h"
-#include "util-byte.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "pkt-var.h"
@@ -607,13 +606,8 @@ void RegisterENIPTCPParsers(void)
 
 /* UNITTESTS */
 #ifdef UNITTESTS
-#include "app-layer-parser.h"
-#include "detect-parse.h"
-#include "detect-engine.h"
 #include "flow-util.h"
 #include "stream-tcp.h"
-#include "util-unittest.h"
-#include "util-unittest-helper.h"
 
 static uint8_t listIdentity[] = {/* List ID */    0x63, 0x00,
                                  /* Length */     0x00, 0x00,

--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -29,8 +29,11 @@
 #include "app-layer-htp.h"
 #include "app-layer-htp-xff.h"
 
-#include "util-misc.h"
+#ifndef HAVE_MEMRCHR
 #include "util-memrchr.h"
+#endif
+
+#include "util-misc.h"
 #include "util-unittest.h"
 
 /** XFF header value minimal length */

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -62,6 +62,7 @@ void RegisterModbusParsers(void)
 #include "detect-engine.h"
 #include "detect-parse.h"
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 
 #include "flow-util.h"
 

--- a/src/app-layer-rfb.c
+++ b/src/app-layer-rfb.c
@@ -32,7 +32,7 @@
 #include "app-layer-parser.h"
 #include "app-layer-rfb.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 static int RFBRegisterPatternsForProtocolDetection(void)
 {

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1781,6 +1781,7 @@ void SMTPParserCleanup(void)
 /***************************************Unittests******************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static void SMTPTestInitConfig(void)
 {

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1178,7 +1178,6 @@ void AppLayerDeSetupCounters()
 
 #ifdef UNITTESTS
 #include "pkt-var.h"
-#include "stream-tcp.h"
 #include "stream-tcp-util.h"
 #include "stream.h"
 #include "util-unittest.h"

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -520,6 +520,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 }
 
 #ifdef UNITTESTS
+#include "packet.h"
 #include "util-unittest-helper.h"
 
 static int ICMPV6CalculateValidChecksumtest01(void)

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -650,6 +650,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 /**
  * \test fragment decoding

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -75,6 +75,7 @@ int DecodeRaw(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 /** DecodeRawtest01
  *  \brief Valid Raw packet

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -271,6 +271,7 @@ int DecodeTCP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 static int TCPCalculateValidChecksumtest01(void)
 {

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -135,6 +135,7 @@ int DecodeIEEE8021ah(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 /** \todo Must GRE+VLAN and Multi-Vlan packets to
  * create more tests

--- a/src/decode-vntag.c
+++ b/src/decode-vntag.c
@@ -84,6 +84,7 @@ int DecodeVNTag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t 
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 /**
  * \test DecodeVNTagTest01 test if vntag header is too small.

--- a/src/decode.c
+++ b/src/decode.c
@@ -67,6 +67,8 @@
 #include "util-print.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+// ACTION_DROP
+#include "action-globals.h"
 
 uint32_t default_packet_size = 0;
 extern bool stats_decoder_events;

--- a/src/decode.h
+++ b/src/decode.h
@@ -79,8 +79,6 @@ enum PktSrcEnum {
 #include "source-pfring.h"
 #endif
 
-#include "action-globals.h"
-
 #include "decode-ethernet.h"
 #include "decode-gre.h"
 #include "decode-ppp.h"

--- a/src/defrag-queue.h
+++ b/src/defrag-queue.h
@@ -25,7 +25,6 @@
 #define __DEFRAG_QUEUE_H__
 
 #include "suricata-common.h"
-#include "decode.h"
 #include "defrag.h"
 
 /** Spinlocks or Mutex for the defrag tracker queues. */

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -63,8 +63,6 @@
 #include "util-unittest.h"
 #endif
 
-#include "util-validate.h"
-
 #define DEFAULT_DEFRAG_HASH_SIZE 0xffff
 #define DEFAULT_DEFRAG_POOL_SIZE 0xffff
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1078,6 +1078,8 @@ void DefragDestroy(void)
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
+
 #define IP_MF 0x2000
 
 /**

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -26,6 +26,8 @@
 
 #include "threads.h"
 #include "util-pool.h"
+#include "threadvars.h"
+#include "decode.h"
 
 /**
  * A context for an instance of a fragmentation re-assembler, in case

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -431,6 +431,7 @@ int DetectAppLayerEventPrepare(DetectEngineCtx *de_ctx, Signature *s)
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp.h"
+#include "detect-engine-alert.h"
 
 #define APP_LAYER_EVENT_TEST_MAP_EVENT1 0
 #define APP_LAYER_EVENT_TEST_MAP_EVENT2 1

--- a/src/detect-base64-data.c
+++ b/src/detect-base64-data.c
@@ -77,8 +77,6 @@ int DetectBase64DataDoMatch(DetectEngineCtx *de_ctx,
 
 #ifdef UNITTESTS
 
-#include "detect-engine.h"
-
 static int g_file_data_buffer_id = 0;
 
 static int DetectBase64DataSetupTest01(void)

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -422,6 +422,7 @@ SigMatch *DetectByteMathRetrieveSMVar(const char *arg, const Signature *s)
 
 /*************************************Unittests********************************/
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 #include "app-layer-parser.h"
 

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -424,8 +424,6 @@ SigMatch *DetectByteMathRetrieveSMVar(const char *arg, const Signature *s)
 #ifdef UNITTESTS
 #include "detect-engine-alert.h"
 
-#include "app-layer-parser.h"
-
 static int DetectByteMathParseTest01(void)
 {
 

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -740,6 +740,8 @@ void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, siz
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
+#include "detect-engine-alert.h"
+#include "packet.h"
 
 static bool TestLastContent(const Signature *s, uint16_t o, uint16_t d)
 {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -997,7 +997,6 @@ static int DetectCsumValidArgsTestParse03(void)
 #undef TEST3
 #undef mystr
 
-#include "detect-engine.h"
 #include "stream-tcp.h"
 
 static int DetectCsumICMPV6Test01(void)

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -899,6 +899,9 @@ static void DetectICMPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "detect-engine.h"
+#include "detect-engine-alert.h"
+#include "packet.h"
 
 #define mystr(s) #s
 #define TEST1(kwstr) {\

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -181,6 +181,7 @@ static int DetectDceStubDataSetup(DetectEngineCtx *de_ctx, Signature *s, const c
 /************************************Unittests*********************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int DetectDceStubDataTestParse01(void)
 {

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -273,8 +273,11 @@ static void DetectDetectionFilterFree(DetectEngineCtx *de_ctx, void *df_ptr)
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
 #include "detect-engine-threshold.h"
+#include "detect-engine-alert.h"
 #include "util-time.h"
 #include "util-hashlist.h"
+#include "action-globals.h"
+#include "packet.h"
 
 /**
  * \test DetectDetectionFilterTestParse01 is a test for a valid detection_filter options

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -597,7 +597,6 @@ void DetectDNP3Register(void)
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "app-layer-parser.h"
-#include "detect-engine.h"
 #include "flow-util.h"
 #include "stream-tcp.h"
 

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -262,6 +262,7 @@ static int DetectDnsQuerySetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 #ifdef UNITTESTS
 #include "detect-isdataat.h"
+#include "detect-engine-alert.h"
 
 /** \test simple google.com query matching */
 static int DetectDnsQueryTest01(void)

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -375,6 +375,9 @@ void SigParseApplyDsizeToContent(Signature *s)
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "detect-engine.h"
+#include "detect-engine-alert.h"
+#include "packet.h"
 
 /**
  * \test this is a test for a valid dsize value 1

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -35,6 +35,9 @@
 #include "util-profiling.h"
 #include "util-validate.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 /** tag signature we use for tag alerts */
 static Signature g_tag_signature;
 /** tag packet alert structure for tag alerts */

--- a/src/detect-engine-dcepayload.c
+++ b/src/detect-engine-dcepayload.c
@@ -57,6 +57,7 @@ static int g_dce_stub_data_buffer_id = 0;
 /**************************************Unittests*******************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /**
  * \test Test the working of byte_test endianness.

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -373,6 +373,7 @@ uint8_t DetectEngineInspectStream(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /** \test Not the first but the second occurence of "abc" should be used
   *       for the 2nd match */

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1498,6 +1498,8 @@ void DetectPortHashFree(DetectEngineCtx *de_ctx)
 /*---------------------- Unittests -------------------------*/
 
 #ifdef UNITTESTS
+#include "packet.h"
+
 /**
  * \brief Do a sorted insert, where the top of the list should be the biggest
  * port range.

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -295,6 +295,7 @@ void DetectEngineStateResetTxs(Flow *f)
 /*********Unittests*********/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int DeStateTest01(void)
 {

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -68,6 +68,9 @@
 #include "util-var-name.h"
 #include "tm-threads.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 static HostStorageId host_threshold_id = { .id = -1 };     /**< host storage id for thresholds */
 static IPPairStorageId ippair_threshold_id = { .id = -1 }; /**< ip pair storage id for thresholds */
 

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -365,6 +365,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
 /*----------------------------------Unittests---------------------------------*/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 static int DetectFastPatternStickySingle(const char *sticky, const int list)
 {
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -163,7 +163,6 @@ static void DetectFilesizeFree(DetectEngineCtx *de_ctx, void *ptr)
 #include "stream.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
-#include "detect-engine.h"
 #include "detect-engine-mpm.h"
 #include "app-layer-parser.h"
 

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -483,6 +483,7 @@ static bool PrefilterFlowIsPrefilterable(const Signature *s)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectFlowTestParse01 is a test to make sure that we return "something"

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -428,6 +428,7 @@ void DetectFlowintFree(DetectEngineCtx *de_ctx, void *tmp)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 /**
  * \brief This is a helper funtion used for debugging purposes
  */

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -40,7 +40,6 @@
 #include "util-var-name.h"
 #include "util-debug.h"
 #include "util-print.h"
-#include "util-spm.h"
 
 #define PARSE_REGEX         "(.*),(.*)"
 static DetectParseRegex parse_regex;

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -386,6 +386,7 @@ static bool PrefilterFragBitsIsPrefilterable(const Signature *s)
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "packet.h"
 
 /**
  * \test FragBitsTestParse01 is a test for a  valid fragbits value

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -328,6 +328,8 @@ static bool PrefilterFragOffsetIsPrefilterable(const Signature *s)
 
 #ifdef UNITTESTS
 #include "util-unittest-helper.h"
+#include "detect-engine.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectFragOffsetParseTest01 is a test for setting a valid fragoffset value

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -241,6 +241,7 @@ int DetectFtpbounceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *ftpb
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectFtpbounceTestSetup01 is a test for the Setup ftpbounce

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -389,6 +389,7 @@ static int PrefilterMpmHttpRequestBodyRegister(DetectEngineCtx *de_ctx, SigGroup
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 #include "tests/detect-http-client-body.c"
 #endif /* UNITTESTS */
 

--- a/src/detect-http-header-common.c
+++ b/src/detect-http-header-common.c
@@ -52,8 +52,6 @@
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 
-#include "util-print.h"
-
 #include "detect-http-header-common.h"
 
 void *HttpHeaderThreadDataInit(void *data)

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -63,8 +63,6 @@
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 
-#include "util-print.h"
-
 #define KEYWORD_NAME "http.header_names"
 #define KEYWORD_NAME_LEGACY "http_header_names"
 #define KEYWORD_DOC "http-keywords.html#http-header-names"

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -29,7 +29,7 @@
 #include "suricata-common.h"
 #include "flow.h"
 
-#include "app-layer-htp.h"
+#include <htp/htp.h>
 
 #include "detect.h"
 #include "detect-parse.h"

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -63,8 +63,6 @@
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 
-#include "util-print.h"
-
 #define KEYWORD_NAME "http.protocol"
 #define KEYWORD_NAME_LEGACY "http_protocol"
 #define KEYWORD_DOC "http-keywords.html#http-protocol"

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -62,8 +62,6 @@
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 
-#include "util-print.h"
-
 #define KEYWORD_NAME "http.start"
 #define KEYWORD_NAME_LEGACY "http_start"
 #define KEYWORD_DOC "http-keywords.html#http-start"

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -30,6 +30,7 @@
 #include "detect-parse.h"
 #include "detect-engine-prefilter-common.h"
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 
 #include "detect-icmp-id.h"
 

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -327,6 +327,9 @@ static bool PrefilterIcmpSeqIsPrefilterable(const Signature *s)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectIcmpSeqParseTest01 is a test for setting a valid icmp_seq value

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -198,6 +198,7 @@ static bool PrefilterICodeIsPrefilterable(const Signature *s)
 #ifdef UNITTESTS
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectICodeParseTest01 is a test for setting a valid icode value

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -31,7 +31,7 @@
 #include "util-byte.h"
 #include "util-unittest.h"
 
-#include "rust-bindings.h"
+#include "rust.h"
 
 /**
  *   [ike.chosen_sa_attribute]:<sa_attribute>=<type>;

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -455,6 +455,7 @@ static void DetectIPProtoFree(DetectEngineCtx *de_ctx, void *ptr)
 
 /* UNITTESTS */
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectIPProtoTestParse01 is a test for an invalid proto number

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -255,6 +255,9 @@ void DetectIPRepFree (DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS
+#include "packet.h"
+#include "action-globals.h"
+
 static FILE *DetectIPRepGenerateCategoriesDummy(void)
 {
     FILE *fd = NULL;

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -108,6 +108,7 @@ error:
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectL3protoTestSig01 is a test for checking the working of ttl keyword

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -1163,6 +1163,8 @@ static void DetectLuaFree(DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
+
 /** \test http buffer */
 static int LuaMatchTest01(void)
 {

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -49,7 +49,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-profiling.h"

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -49,7 +49,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-profiling.h"

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -70,6 +70,9 @@
 #include "detect-engine-iponly.h"
 #include "app-layer-detect-proto.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 /* Table with all SigMatch registrations */
 SigTableElmt sigmatch_table[DETECT_TBLSIZE];
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2619,6 +2619,9 @@ void DetectSetupParseRegexes(const char *parse_str, DetectParseRegex *detect_par
  */
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
+#include "packet.h"
+
 static int SigParseTest01 (void)
 {
     int result = 1;

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -962,6 +962,7 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
+#include "detect-engine-alert.h"
 static int g_file_data_buffer_id = 0;
 static int g_http_header_buffer_id = 0;
 static int g_dce_stub_data_buffer_id = 0;

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -249,6 +249,7 @@ void DetectQuicCyuHashRegister(void)
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "flow-util.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectQuicCyuHashTest01 is a test for a valid quic packet, matching

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -205,6 +205,7 @@ void DetectQuicCyuStringRegister(void)
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 #include "flow-util.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectQuicCyuStringTest01 is a test for a valid quic packet, matching

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -236,6 +236,8 @@ void DetectReplaceFreeInternal(DetectReplaceList *replist)
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
+#include "detect-engine-alert.h"
+#include "packet.h"
 
 /**
  * \test Test packet Matches

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -306,6 +306,7 @@ void DetectRpcFree(DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 /**
  * \test DetectRpcTestParse01 is a test to make sure that we return "something"
  *  when given valid rpc opt

--- a/src/detect-sameip.c
+++ b/src/detect-sameip.c
@@ -115,6 +115,7 @@ error:
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 /* NOTE: No parameters, so no parse tests */
 

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -272,6 +272,7 @@ void DetectSshVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectSshVersionTestParse01 is a test to make sure that we parse

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -261,6 +261,7 @@ static void DetectSshSoftwareVersionFree(DetectEngineCtx *de_ctx, void *ptr)
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
+#include "detect-engine-alert.h"
 
 /**
  * \test DetectSshSoftwareVersionTestParse01 is a test to make sure that we parse

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -208,6 +208,7 @@ static bool PrefilterTcpAckIsPrefilterable(const Signature *s)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 /**
  * \internal
  * \brief This test tests sameip success and failure.

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -147,5 +147,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 #include "tests/detect-template-buffer.c"
 #endif

--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -126,6 +126,7 @@ static uint8_t DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
 #include "detect-parse.h"
 #include "flow-util.h"
 #include "stream-tcp.h"
+#include "detect-engine-alert.h"
 
 static int DetectTemplateRustBufferTest(void)
 {

--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -121,9 +121,6 @@ static uint8_t DetectEngineInspectTemplateRustBuffer(DetectEngineCtx *de_ctx,
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
-#include "app-layer-parser.h"
-#include "detect-engine.h"
-#include "detect-parse.h"
 #include "flow-util.h"
 #include "stream-tcp.h"
 #include "detect-engine-alert.h"

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -340,9 +340,11 @@ error:
 #ifdef UNITTESTS
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
+#include "detect-engine-alert.h"
 #include "util-time.h"
 #include "util-hashlist.h"
-
+#include "packet.h"
+#include "action-globals.h"
 /**
  * \test ThresholdTestParse01 is a test for a valid threshold options
  *

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -226,5 +226,6 @@ static void DetectTlsFingerprintSetupCallback(const DetectEngineCtx *de_ctx,
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 #include "tests/detect-tls-cert-fingerprint.c"
 #endif

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -41,7 +41,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -40,7 +40,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -40,7 +40,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -41,7 +41,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -43,7 +43,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -44,7 +44,6 @@
 #include "conf-yaml-loader.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-ja3.h"

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -44,7 +44,6 @@
 #include "conf-yaml-loader.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-ja3.h"

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -44,7 +44,6 @@
 #include "conf-yaml-loader.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-ja3.h"

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -44,7 +44,6 @@
 #include "conf-yaml-loader.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 #include "util-ja3.h"

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -39,7 +39,6 @@
 #include "flow-var.h"
 
 #include "util-debug.h"
-#include "util-unittest.h"
 #include "util-spm.h"
 #include "util-print.h"
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -235,7 +235,6 @@ bool DetectUrilenValidateContent(const Signature *s, int list, const char **sige
 #include "stream.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
-#include "detect-engine.h"
 #include "detect-engine-mpm.h"
 #include "app-layer-parser.h"
 #include "detect-engine-alert.h"

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -238,6 +238,7 @@ bool DetectUrilenValidateContent(const Signature *s, int list, const char **sige
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
 #include "app-layer-parser.h"
+#include "detect-engine-alert.h"
 
 /** \test   Test the Urilen keyword setup */
 static int DetectUrilenParseTest01(void)

--- a/src/detect.c
+++ b/src/detect.c
@@ -65,6 +65,9 @@
 #include "util-detect.h"
 #include "util-profiling.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 typedef struct DetectRunScratchpad {
     const AppProto alproto;
     const uint8_t flow_flags; /* flow/state flags: STREAM_* */

--- a/src/device-storage.c
+++ b/src/device-storage.c
@@ -25,6 +25,7 @@
 
 #include "suricata-common.h"
 #include "device-storage.h"
+#include "util-storage.h"
 #include "util-unittest.h"
 
 unsigned int LiveDevStorageSize(void)

--- a/src/device-storage.h
+++ b/src/device-storage.h
@@ -27,7 +27,6 @@
 #define __DEVICE_STORAGE_H__
 
 #include "util-device.h"
-#include "util-storage.h"
 
 typedef struct LiveDevStorageId_ {
     int id;

--- a/src/flow-bypass.h
+++ b/src/flow-bypass.h
@@ -24,7 +24,6 @@
 #ifndef __FLOW_BYPASS_H__
 #define __FLOW_BYPASS_H__
 
-#include "threadvars.h"
 #include "flow.h"
 
 struct flows_stats {

--- a/src/flow-storage.c
+++ b/src/flow-storage.c
@@ -29,6 +29,7 @@
 #include "flow-storage.h"
 #include "flow-hash.h"
 #include "flow-util.h"
+#include "util-storage.h"
 #include "util-unittest.h"
 
 unsigned int FlowStorageSize(void)

--- a/src/flow-storage.h
+++ b/src/flow-storage.h
@@ -27,7 +27,6 @@
 #define __FLOW_STORAGE_H__
 
 #include "flow.h"
-#include "util-storage.h"
 
 typedef struct FlowStorageId {
     int id;

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -26,6 +26,7 @@
 #ifndef __OUTPUT_FLOW_H__
 #define __OUTPUT_FLOW_H__
 
+#include "tm-modules.h"
 
 /** flow logger function pointer type */
 typedef int (*FlowLogger)(ThreadVars *, void *thread_data, Flow *f);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -88,6 +88,9 @@
 #include "util-buffer.h"
 #include "util-validate.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 #define MODULE_NAME "JsonAlertLog"
 
 #define LOG_JSON_PAYLOAD           BIT_U16(0)

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -55,7 +55,6 @@
 #include "app-layer-frames.h"
 #include "util-classification-config.h"
 #include "util-syslog.h"
-#include "util-logopenfile.h"
 #include "log-pcap.h"
 
 #include "output.h"

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -56,6 +56,9 @@
 #include "util-time.h"
 #include "util-buffer.h"
 
+// ACTION_DROP
+#include "action-globals.h"
+
 #define MODULE_NAME "JsonDropLog"
 
 #define LOG_DROP_ALERTS 1

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -68,7 +68,7 @@
 #include "flow-bit.h"
 #include "flow-storage.h"
 
-#include "source-pcap-file.h"
+#include "source-pcap-file-helper.h"
 
 #include "suricata-plugin.h"
 

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -26,6 +26,8 @@
 #ifndef __OUTPUT_STATS_H__
 #define __OUTPUT_STATS_H__
 
+#include "tm-modules.h"
+
 typedef struct StatsRecord_ {
     const char *name;
     const char *tm_name;

--- a/src/output.c
+++ b/src/output.c
@@ -64,7 +64,6 @@
 #include "output-json-stats.h"
 #include "log-tcp-data.h"
 #include "log-stats.h"
-#include "output-json.h"
 #include "output-json-nfs.h"
 #include "output-json-ftp.h"
 #include "output-json-tftp.h"

--- a/src/packet.c
+++ b/src/packet.c
@@ -21,6 +21,7 @@
 #include "host.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "action-globals.h"
 
 /** \brief issue drop action
  *

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -26,6 +26,7 @@
  */
 
 #include "suricata-common.h"
+#include "detect.h"
 #include "reputation.h"
 #include "threads.h"
 #include "conf.h"

--- a/src/reputation.h
+++ b/src/reputation.h
@@ -42,8 +42,6 @@ typedef struct SReputation_ {
     uint8_t rep[SREP_MAX_CATS];
 } SReputation;
 
-#include "detect.h"
-
 void SRepFreeHostData(Host *h);
 uint8_t SRepCatGetByShortname(char *shortname);
 int SRepInit(struct DetectEngineCtx_ *de_ctx);

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -43,7 +43,6 @@
 #ifdef HAVE_NETMAP
 #define NETMAP_WITH_LIBS
 #include <net/netmap_user.h>
-#include "util-time.h"
 #endif /* HAVE_NETMAP */
 
 #include "source-netmap.h"

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -28,6 +28,7 @@
 #ifdef UNITTESTS
 #include "detect-parse.h"
 #include "detect-engine.h"
+#include "detect-engine-alert.h"
 #include "detect-engine-address.h"
 #include "detect-engine-proto.h"
 #include "detect-engine-port.h"

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -60,6 +60,7 @@
 #include "runmodes.h"
 #include "flow-storage.h"
 #include "util-validate.h"
+#include "action-globals.h"
 
 #ifdef HAVE_AF_PACKET
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -73,7 +73,6 @@
 #endif
 
 #ifdef HAVE_PACKET_EBPF
-#include "util-ebpf.h"
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #endif

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -41,6 +41,7 @@
 #include "tm-threads.h"
 #include "tmqh-packetpool.h"
 #include "util-privs.h"
+#include "action-globals.h"
 
 #ifndef HAVE_DPDK
 

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -112,4 +112,6 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv);
  */
 TmEcode ValidateLinkType(int datalink, DecoderFunc *decoder);
 
+const char *PcapFileGetFilename(void);
+
 #endif /* __SOURCE_PCAP_FILE_HELPER_H__ */

--- a/src/source-pcap-file.h
+++ b/src/source-pcap-file.h
@@ -30,7 +30,6 @@ void TmModuleDecodePcapFileRegister (void);
 void PcapIncreaseInvalidChecksum(void);
 
 void PcapFileGlobalInit(void);
-const char *PcapFileGetFilename(void);
 
 #endif /* __SOURCE_PCAP_FILE_H__ */
 

--- a/src/stream-tcp-cache.c
+++ b/src/stream-tcp-cache.c
@@ -25,6 +25,7 @@
 #include "suricata.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-cache.h"
+#include "util-debug.h"
 
 typedef struct TcpPoolCache {
     bool cache_enabled; /**< cache should only be enabled for worker threads */

--- a/src/stream-tcp-cache.c
+++ b/src/stream-tcp-cache.c
@@ -22,6 +22,7 @@
  */
 
 #include "suricata-common.h"
+#include "suricata.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-cache.h"
 

--- a/src/stream-tcp-cache.h
+++ b/src/stream-tcp-cache.h
@@ -24,8 +24,6 @@
 #ifndef __STREAM_TCP_CACHE_H__
 #define __STREAM_TCP_CACHE_H__
 
-#include "suricata.h"
-#include "flow.h"
 #include "stream-tcp-private.h"
 
 void StreamTcpThreadCacheEnable(void);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -78,6 +78,7 @@
 #include "util-time.h"
 
 #include "source-pcap-file.h"
+#include "action-globals.h"
 
 //#define DEBUG
 

--- a/src/tests/detect-http-cookie.c
+++ b/src/tests/detect-http-cookie.c
@@ -43,6 +43,7 @@
 #include "../app-layer-protos.h"
 #include "../detect-isdataat.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 /***********************************Unittests**********************************/
 

--- a/src/tests/detect-http-header.c
+++ b/src/tests/detect-http-header.c
@@ -42,6 +42,7 @@
 #include "../detect-http-header.h"
 #include "../detect-http-header-common.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 #include "../detect-isdataat.h"
 

--- a/src/tests/detect-http-host.c
+++ b/src/tests/detect-http-host.c
@@ -43,6 +43,7 @@
 #include "app-layer-htp.h"
 #include "app-layer-protos.h"
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test Test that the http_host content matches against a http request

--- a/src/tests/detect-http-method.c
+++ b/src/tests/detect-http-method.c
@@ -43,6 +43,7 @@
 #include "../app-layer-protos.h"
 #include "../detect-isdataat.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 /**
  * \test Test that the http_method content matches against a http request

--- a/src/tests/detect-http-raw-header.c
+++ b/src/tests/detect-http-raw-header.c
@@ -40,6 +40,7 @@
 #include "../detect-isdataat.h"
 #include "../detect-pcre.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 #include "../stream-tcp.h"
 #include "../app-layer.h"

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -29,6 +29,7 @@
 #include "../flow.h"
 #include "../detect.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 /**
  * \test Test parser accepting valid rules and rejecting invalid rules

--- a/src/tests/detect-http-stat-code.c
+++ b/src/tests/detect-http-stat-code.c
@@ -39,6 +39,7 @@
 #include "../app-layer-htp.h"
 #include "../app-layer-protos.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 static int DetectEngineHttpStatCodeTest01(void)
 {

--- a/src/tests/detect-http-stat-msg.c
+++ b/src/tests/detect-http-stat-msg.c
@@ -39,6 +39,7 @@
 #include "../app-layer-htp.h"
 #include "../app-layer-protos.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 static int DetectEngineHttpStatMsgTest01(void)
  {

--- a/src/tests/detect-http-uri.c
+++ b/src/tests/detect-http-uri.c
@@ -33,6 +33,7 @@
 
 #include "../detect-isdataat.h"
 #include "../detect-engine-build.h"
+#include "../detect-engine-alert.h"
 
 /** \test Test a simple uricontent option */
 static int UriTestSig01(void)

--- a/src/tests/detect-http-user-agent.c
+++ b/src/tests/detect-http-user-agent.c
@@ -42,6 +42,7 @@
 #include "app-layer-htp.h"
 #include "app-layer-protos.h"
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 
 static int DetectEngineHttpUATest(
         const uint8_t *buf, const uint32_t buf_len, const char *sig, const bool expect)

--- a/src/tests/detect-snmp-community.c
+++ b/src/tests/detect-snmp-community.c
@@ -23,6 +23,7 @@
 #include "flow-util.h"
 #include "stream-tcp.h"
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 
 static int DetectSNMPCommunityTest(void)
 {

--- a/src/tests/detect-tls-cert-issuer.c
+++ b/src/tests/detect-tls-cert-issuer.c
@@ -24,6 +24,7 @@
 
 #include "detect-engine-build.h"
 #include "app-layer-parser.h"
+#include "detect-engine-alert.h"
 
 /**
  * \test Test that a signature containing a tls_cert_issuer is correctly parsed

--- a/src/tests/detect-tls-cert-serial.c
+++ b/src/tests/detect-tls-cert-serial.c
@@ -23,6 +23,7 @@
  */
 
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 #include "app-layer-parser.h"
 
 /**

--- a/src/tests/detect-tls-cert-subject.c
+++ b/src/tests/detect-tls-cert-subject.c
@@ -23,6 +23,7 @@
  */
 
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 #include "app-layer-parser.h"
 
 /**

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -23,6 +23,7 @@
  */
 
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 #include "app-layer-parser.h"
 
 /**

--- a/src/tests/detect-tls-certs.c
+++ b/src/tests/detect-tls-certs.c
@@ -23,6 +23,7 @@
  */
 
 #include "detect-engine-build.h"
+#include "detect-engine-alert.h"
 #include "app-layer-parser.h"
 
 /**

--- a/src/tests/detect-ttl.c
+++ b/src/tests/detect-ttl.c
@@ -18,6 +18,9 @@
 
 #include "../util-unittest.h"
 #include "../util-unittest-helper.h"
+#include "detect-engine.h"
+#include "detect-engine-alert.h"
+#include "detect-engine-build.h"
 
 /**
  * \test DetectTtlParseTest01 is a test for setting up an valid ttl value.

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -27,6 +27,7 @@
 #include "tm-modules.h"
 #include "tmqh-packetpool.h"
 #include "util-conf.h"
+#include "packet.h"
 
 #include <fuzz_pcap.h>
 

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -29,6 +29,7 @@
 #include "tmqh-packetpool.h"
 #include "util-file.h"
 #include "util-conf.h"
+#include "packet.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -28,6 +28,7 @@
 #include "tm-modules.h"
 #include "tmqh-packetpool.h"
 #include "util-conf.h"
+#include "packet.h"
 
 #include <fuzz_pcap.h>
 

--- a/src/threads-profile.h
+++ b/src/threads-profile.h
@@ -26,6 +26,7 @@
 #ifndef __THREADS_PROFILE_H__
 #define __THREADS_PROFILE_H__
 
+// UtilCpuGetTicks
 #include "util-cpu.h"
 
 #define PROFILING_MAX_LOCKS 64

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -33,6 +33,7 @@
 #include "packet.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "action-globals.h"
 
 /* Number of freed packet to save for one pool before freeing them. */
 #define MAX_PENDING_RETURN_PACKETS 32

--- a/src/util-debug-filters.h
+++ b/src/util-debug-filters.h
@@ -24,6 +24,7 @@
 #ifndef __DEBUG_FILTERS_H__
 #define __DEBUG_FILTERS_H__
 
+// pthread_t
 #include "threads.h"
 
 /**

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -25,6 +25,7 @@
 #include "util-exception-policy.h"
 #include "util-misc.h"
 #include "stream-tcp-reassemble.h"
+#include "action-globals.h"
 
 void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason)
 {

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -56,6 +56,7 @@
 
 #include "util-lua.h"
 #include "util-lua-common.h"
+#include "action-globals.h"
 
 int LuaCallbackError(lua_State *luastate, const char *msg)
 {

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -29,6 +29,7 @@
 #ifndef __UTIL_MEMCMP_H__
 #define __UTIL_MEMCMP_H__
 
+#include "suricata-common.h"
 #include "util-optimize.h"
 
 /** \brief compare two patterns, converting the 2nd to lowercase

--- a/src/util-memcpy.h
+++ b/src/util-memcpy.h
@@ -27,6 +27,8 @@
 #ifndef __UTIL_MEMCPY_H__
 #define __UTIL_MEMCPY_H__
 
+#include "suricata-common.h"
+
 /**
  * \internal
  * \brief Does a memcpy of the input string to lowercase.

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -1405,6 +1405,7 @@ void SCACBSPrintInfo(MpmCtx *mpm_ctx)
 /*************************************Unittests********************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int SCACBSTest01(void)
 {

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -1480,6 +1480,7 @@ void MpmACTileRegister(void)
 /*************************************Unittests********************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int SCACTileTest01(void)
 {

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1251,6 +1251,7 @@ void MpmACRegister(void)
 /*************************************Unittests********************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int SCACTest01(void)
 {

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -1094,6 +1094,7 @@ void MpmHSGlobalCleanup(void)
 /*************************************Unittests********************************/
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
 
 static int SCHSTest01(void)
 {

--- a/src/util-privs.h
+++ b/src/util-privs.h
@@ -24,8 +24,6 @@
 #ifndef _UTIL_PRIVS_H
 #define	_UTIL_PRIVS_H
 
-#include "threadvars.h"
-
 #define SC_CAP_NONE             0x01
 #define SC_CAP_SYS_ADMIN        0x02
 #define SC_CAP_SYS_RAW_IO       0x04
@@ -35,11 +33,9 @@
 #define SC_CAP_NET_BIND_SERVICE 0x40
 #define SC_CAP_NET_BROADCAST    0x80
 
-#ifndef HAVE_LIBCAP_NG
-#define SCDropCaps(...)
-#define SCDropMainThreadCaps(...)
-#else
+#ifdef HAVE_LIBCAP_NG
 #include <cap-ng.h>
+#include "threadvars.h"
 
 /**Drop the previliges of the given thread tv, based on the thread cap_flags
  * which implies the capability requirement of the given thread. Initially all
@@ -89,6 +85,9 @@ void SCDropCaps(ThreadVars *tv);
 */
 void SCDropMainThreadCaps(uint32_t , uint32_t );
 
+#else
+#define SCDropCaps(...)
+#define SCDropMainThreadCaps(...)
 #endif /* HAVE_LIBCAP_NG */
 
 int SCGetUserID(const char *, const char *, uint32_t *, uint32_t *);

--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -28,7 +28,6 @@
 #ifdef PROFILING
 
 #include "detect.h"
-#include "util-cpu.h"
 #include "util-profiling-locks.h"
 
 extern int profiling_rules_enabled;

--- a/src/util-random.c
+++ b/src/util-random.c
@@ -61,6 +61,7 @@ static long int RandomGetPosix(void)
 #endif /* !(defined(HAVE_WINCRYPT_H) &&  defined(OS_WIN32)) */
 
 #if defined(HAVE_WINCRYPT_H) && defined(OS_WIN32)
+#include "util-debug.h"
 #include <wincrypt.h>
 
 long int RandomGet(void)

--- a/src/util-random.c
+++ b/src/util-random.c
@@ -61,7 +61,6 @@ static long int RandomGetPosix(void)
 #endif /* !(defined(HAVE_WINCRYPT_H) &&  defined(OS_WIN32)) */
 
 #if defined(HAVE_WINCRYPT_H) && defined(OS_WIN32)
-#include "util-debug.h"
 #include <wincrypt.h>
 
 long int RandomGet(void)

--- a/src/util-rule-vars.h
+++ b/src/util-rule-vars.h
@@ -24,6 +24,8 @@
 #ifndef __UTIL_RULE_VARS_H__
 #define __UTIL_RULE_VARS_H__
 
+#include "detect.h"
+
 /** Enum indicating the various vars type in the yaml conf file */
 typedef enum {
     SC_RULE_VARS_ADDRESS_GROUPS,

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1117,6 +1117,9 @@ int SCThresholdConfParseFile(DetectEngineCtx *de_ctx, FILE *fp)
 }
 
 #ifdef UNITTESTS
+#include "detect-engine-alert.h"
+#include "packet.h"
+#include "action-globals.h"
 
 /**
  * \brief Creates a dummy threshold file, with all valid options, for testing purposes.

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -35,6 +35,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-engine.h"
+#include "detect-engine-alert.h"
 #include "detect-engine-sigorder.h"
 #include "detect-engine-build.h"
 

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -27,13 +27,8 @@
 #if defined(UNITTESTS)
 #include "packet.h"
 #include "flow.h"
-#include "stream-tcp.h"
 #include "detect.h"
-#include "detect-engine.h"
-#include "detect-engine-alert.h"
-#include "detect-engine-build.h"
 #elif defined(FUZZ)
-#include "packet.h"
 #include "flow.h"
 #endif
 

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -25,7 +25,6 @@
 #define __UTIL_UNITTEST_HELPER__
 
 #if defined(UNITTESTS)
-#include "packet.h"
 #include "flow.h"
 #include "detect.h"
 #elif defined(FUZZ)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/945

Describe changes:
- Remove unused includes in c files
- adds some options in CI : hyperscan, luajit

Follows #8142 with 
- completing removal of double inclusion, like src/runmode-netmap.c was now including twice "util-time.h"
- Rebase (especially after app-layer-dcerpc-common.h was removed by another PR)

Still TODO after that : run script mininc.py