### PR TITLE
classification: continue processing on parse error

### DIFF
--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -350,15 +350,17 @@ static bool SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
 {
     char line[1024];
     uint16_t i = 1;
+    int errors = 0;
 
     while (fgets(line, sizeof(line), fd) != NULL) {
         if (SCClassConfIsLineBlankOrComment(line))
             continue;
 
         if (SCClassConfAddClasstype(de_ctx, line, i) == -1) {
-            return false;
+            errors++;
+        } else {
+            i++;
         }
-        i++;
     }
 
 #ifdef UNITTESTS
@@ -366,7 +368,7 @@ static bool SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
               de_ctx->class_conf_ht->count);
 #endif
 
-    return true;
+    return errors == 0;
 }
 
 /**


### PR DESCRIPTION
Instead of returning on the first line that fails to parse, log the
error and continue instead of returning.

The fail fast makes sense in test mode, but not in a normal run mode
where you don't want one bad line to abort processing the whole file.

This will still fail out in test mode.

Related issue: 4554
