### PR TITLE
Add derive to implement many common State functions

### DIFF
--- a/rust/derive/src/applayerevent.rs
+++ b/rust/derive/src/applayerevent.rs
@@ -20,6 +20,8 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{self, parse_macro_input, DeriveInput};
 
+use crate::utils;
+
 pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
@@ -33,7 +35,7 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
         syn::Data::Enum(ref data) => {
             for (i, v) in (&data.variants).into_iter().enumerate() {
                 fields.push(v.ident.clone());
-                let name = transform_name(&v.ident.to_string());
+                let name = utils::transform_name(&v.ident.to_string(), '_');
                 let cname = format!("{}\0", name);
                 names.push(name);
                 cstrings.push(cname);
@@ -102,35 +104,4 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
     };
 
     proc_macro::TokenStream::from(expanded)
-}
-
-/// Transform names such as "OneTwoThree" to "one_two_three".
-pub fn transform_name(in_name: &str) -> String {
-    let mut out = String::new();
-    for (i, c) in in_name.chars().enumerate() {
-        if i == 0 {
-            out.push_str(&c.to_lowercase().to_string());
-        } else if c.is_uppercase() {
-            out.push('_');
-            out.push_str(&c.to_lowercase().to_string());
-        } else {
-            out.push(c);
-        }
-    }
-    out
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_transform_name() {
-        assert_eq!(transform_name("One"), "one".to_string());
-        assert_eq!(transform_name("SomeEvent"), "some_event".to_string());
-        assert_eq!(
-            transform_name("UnassignedMsgType"),
-            "unassigned_msg_type".to_string()
-        );
-    }
 }

--- a/rust/derive/src/applayerevent.rs
+++ b/rust/derive/src/applayerevent.rs
@@ -45,17 +45,7 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
         _ => panic!("AppLayerEvent can only be derived for enums"),
     }
 
-    // If we're being used from within Suricata we have to reference the internal name space with
-    // "crate", but if we're being used by a library or plugin user we need to reference the
-    // Suricata name space as "suricata". Check the CARGO_PKG_NAME environment variable to
-    // determine what identifier to setup.
-    let is_suricata = std::env::var("CARGO_PKG_NAME").map(|var| var == "suricata").unwrap_or(false);
-    let crate_id = if is_suricata {
-        syn::Ident::new("crate", proc_macro2::Span::call_site())
-    } else {
-        syn::Ident::new("suricata", proc_macro2::Span::call_site())
-    };
-
+    let crate_id = utils::crate_id();
     let expanded = quote! {
         impl #crate_id::applayer::AppLayerEvent for #name {
             fn from_id(id: i32) -> Option<#name> {

--- a/rust/derive/src/applayerframetype.rs
+++ b/rust/derive/src/applayerframetype.rs
@@ -20,6 +20,8 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{self, parse_macro_input, DeriveInput};
 
+use crate::utils;
+
 pub fn derive_app_layer_frame_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = input.ident;
@@ -33,7 +35,7 @@ pub fn derive_app_layer_frame_type(input: TokenStream) -> TokenStream {
         syn::Data::Enum(ref data) => {
             for (i, v) in (&data.variants).into_iter().enumerate() {
                 fields.push(v.ident.clone());
-                let name = transform_name(&v.ident.to_string());
+                let name = utils::transform_name(&v.ident.to_string(), '.');
                 let cname = format!("{}\0", name);
                 names.push(name);
                 cstrings.push(cname);
@@ -75,31 +77,4 @@ pub fn derive_app_layer_frame_type(input: TokenStream) -> TokenStream {
     };
 
     proc_macro::TokenStream::from(expanded)
-}
-
-fn transform_name(name: &str) -> String {
-    let mut xname = String::new();
-    let chars: Vec<char> = name.chars().collect();
-    for i in 0..chars.len() {
-        if i > 0 && i < chars.len() - 1 && chars[i].is_uppercase() && chars[i + 1].is_lowercase() {
-            xname.push('.');
-        }
-        xname.push_str(&chars[i].to_lowercase().to_string());
-    }
-    xname
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_transform_name() {
-        assert_eq!(transform_name("One"), "one");
-        assert_eq!(transform_name("OneTwo"), "one.two");
-        assert_eq!(transform_name("OneTwoThree"), "one.two.three");
-        assert_eq!(transform_name("NBSS"), "nbss");
-        assert_eq!(transform_name("NBSSHdr"), "nbss.hdr");
-        assert_eq!(transform_name("SMB3Data"), "smb3.data");
-    }
 }

--- a/rust/derive/src/applayerstate.rs
+++ b/rust/derive/src/applayerstate.rs
@@ -1,0 +1,175 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{self, parse_macro_input, DeriveInput};
+
+use crate::utils;
+
+pub fn derive_app_layer_state(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let state_type = input.ident;
+    let state_name = utils::transform_name(&state_type.to_string(), '_');
+
+    let mut transaction_type: Option<syn::Ident> = None;
+    match input.data {
+        syn::Data::Struct(data) => {
+            if let syn::Fields::Named(fields) = &data.fields {
+                for field in &fields.named {
+                    if &field.ident.as_ref().unwrap().to_string() == "transactions" {
+                        let (_, inner) = split_generic(&field.ty)
+                            .unwrap_or_else(|| panic!("transactions must be a collection"));
+                        transaction_type = Some(inner);
+                    }
+                }
+            }
+        }
+        _ => panic!("AppLayerState can only be derived for structs"),
+    }
+
+    if transaction_type.is_none() {
+        panic!("AppLayerState unable to detect Transaction type");
+    }
+
+    if let Some(transaction_type) = transaction_type {
+        let crate_id = utils::crate_id();
+        let c_new = format_ident!("rs_{}_new", state_name);
+        let c_free = format_ident!("rs_{}_free", state_name);
+        let c_tx_free = format_ident!("rs_{}_tx_free", state_name);
+        let c_get_tx = format_ident!("rs_{}_get_tx", state_name);
+        let c_get_tx_count = format_ident!("rs_{}_get_tx_count", state_name);
+        let c_get_data = format_ident!("rs_{}_get_data", state_name);
+
+        let stream = quote! {
+            impl State<#transaction_type> for #state_type {
+                fn get_transaction_count(&self) -> usize {
+                    self.transactions.len()
+                }
+
+                fn get_transaction_by_index(&self, index: usize) -> Option<&#transaction_type> {
+                    self.transactions.get(index)
+                }
+            }
+
+            impl #state_type {
+                /// Construct a new `#transaction_type`
+                pub fn new_tx(&mut self) -> #transaction_type {
+                    self.tx_id += 1;
+                    #transaction_type::new(self.tx_id)
+                }
+
+                /// Free transaction by id
+                pub fn free_tx(&mut self, tx_id: u64) {
+                    if let Some(index) = self.transactions.iter().position(|tx| tx.id() == tx_id + 1) {
+                        self.transactions.remove(index);
+                    }
+                }
+
+                /// Get transaction with id, if it exists
+                pub fn get_tx(&self, tx_id: u64) -> Option<&#transaction_type> {
+                    self.transactions.iter().find(|tx| tx.id() == tx_id + 1)
+                }
+
+                /// Get mutable transaction with id, if it exists
+                pub fn get_tx_mut(&mut self, tx_id: u64) -> Option<&mut #transaction_type> {
+                    self.transactions.iter_mut().find(|tx| tx.id() == tx_id + 1)
+                }
+
+                /// Get current transaction, if it exists
+                fn get_current_tx(&self) -> Option<&#transaction_type> {
+                    self.transactions.iter().find(|tx| tx.id() == self.tx_id)
+                }
+
+                /// Get mutable current transaction, if it exists
+                fn get_current_tx_mut(&mut self) -> Option<&mut #transaction_type> {
+                    let tx_id = self.tx_id;
+                    self.transactions.iter_mut().find(|tx| tx.id() == tx_id)
+                }
+            }
+
+            // C exports
+            #[no_mangle]
+            pub extern "C" fn #c_new(
+                _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+            ) -> *mut std::os::raw::c_void {
+                let state = #state_type::new();
+                let boxed = Box::new(state);
+                return Box::into_raw(boxed) as *mut std::os::raw::c_void;
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #c_free(state: *mut std::os::raw::c_void) {
+                std::mem::drop(Box::from_raw(state as *mut #state_type));
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #c_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+                let state = cast_pointer!(state, #state_type);
+                state.free_tx(tx_id);
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #c_get_tx(
+                state: *mut std::os::raw::c_void, tx_id: u64,
+            ) -> *mut std::os::raw::c_void {
+                let state = cast_pointer!(state, #state_type);
+                match state.get_tx_mut(tx_id) {
+                    Some(tx) => {
+                        return tx as *const _ as *mut _;
+                    }
+                    None => {
+                        return std::ptr::null_mut();
+                    }
+                }
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #c_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+                let state = cast_pointer!(state, #state_type);
+                return state.tx_id;
+            }
+
+            #[no_mangle]
+            pub unsafe extern "C" fn #c_get_data(state: *mut std::os::raw::c_void)
+                -> *mut #crate_id::applayer::AppLayerStateData
+            {
+                let state = &mut *(state as *mut #state_type);
+                &mut state.state_data
+            }
+        };
+
+        proc_macro::TokenStream::from(stream)
+    } else {
+        panic!("AppLayerState unable to detect Transaction type");
+    }
+}
+
+/// Get outer and inner types of a generic data type
+/// Returns `None` if there isn't exactly 1 generic
+///
+/// # Example
+/// ```ignore
+/// Vec<u8> -> Some(Vec, u8)
+/// Option<String> -> Some(Option, String)
+/// ```
+fn split_generic(ty: &syn::Type) -> Option<(syn::Ident, syn::Ident)> {
+    if let syn::Type::Path(ty) = ty {
+        if let Some((ident, arg)) = split_generic_helper(ty) {
+            if let Some(inner_ident) = arg.path.get_ident() {
+                return Some((ident, (*inner_ident).clone()));
+            }
+        }
+    }
+    None
+}
+
+fn split_generic_helper(ty: &syn::TypePath) -> Option<(syn::Ident, syn::TypePath)> {
+    let segment = &ty.path.segments.first().expect("Path with no segments");
+    if let syn::PathArguments::AngleBracketed(arguments) = &segment.arguments {
+        if arguments.args.len() == 1 {
+            if let syn::GenericArgument::Type(syn::Type::Path(arg)) = &arguments.args[0] {
+                return Some((segment.ident.clone(), arg.clone()));
+            }
+        }
+    }
+    None
+}

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -21,6 +21,7 @@ use proc_macro::TokenStream;
 
 mod applayerevent;
 mod applayerframetype;
+mod applayerstate;
 mod utils;
 
 /// The `AppLayerEvent` derive macro generates a `AppLayerEvent` trait
@@ -46,4 +47,23 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(AppLayerFrameType)]
 pub fn derive_app_layer_frame_type(input: TokenStream) -> TokenStream {
     applayerframetype::derive_app_layer_frame_type(input)
+}
+
+/// The `AppLayerState` derive macro generates `State` trait implementation,
+/// C FFI interface, and helper functions for AppLayerState; specifically
+///
+/// new_tx() -> Transaction
+/// free_tx()
+/// get_tx() -> Option<&Transaction>
+/// get_tx_mut() -> Option<&mut Transaction>
+/// get_current_tx() -> Option<&Transaction>
+/// get_current_tx_mut() -> Option<&mut Transaction>
+///
+/// The struct must have `transactions` a collection of `AppLayerTransaction`
+/// and tx_id: u64, and requires the associated transaction to support an 
+/// extension of the Transaction trait:
+/// fn new(tx_id: u64) -> Self
+#[proc_macro_derive(AppLayerState)]
+pub fn derive_app_layer_state(input: TokenStream) -> TokenStream {
+    applayerstate::derive_app_layer_state(input)
 }

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -21,6 +21,7 @@ use proc_macro::TokenStream;
 
 mod applayerevent;
 mod applayerframetype;
+mod utils;
 
 /// The `AppLayerEvent` derive macro generates a `AppLayerEvent` trait
 /// implementation for enums that define AppLayerEvents.

--- a/rust/derive/src/utils.rs
+++ b/rust/derive/src/utils.rs
@@ -15,6 +15,21 @@
  * 02110-1301, USA.
  */
 
+/// If we're being used from within Suricata we have to reference the internal name space with
+/// "crate", but if we're being used by a library or plugin user we need to reference the
+/// Suricata name space as "suricata". Check the CARGO_PKG_NAME environment variable to
+/// determine what identifier to setup.
+pub fn crate_id() -> syn::Ident {
+    let is_suricata = std::env::var("CARGO_PKG_NAME")
+        .map(|var| var == "suricata")
+        .unwrap_or(false);
+    if is_suricata {
+        syn::Ident::new("crate", proc_macro2::Span::call_site())
+    } else {
+        syn::Ident::new("suricata", proc_macro2::Span::call_site())
+    }
+}
+
 /// Transform names such as "OneTwoThree" to "one_two_three".
 pub fn transform_name(name: &str, delim: char) -> String {
     let mut out = String::new();

--- a/rust/derive/src/utils.rs
+++ b/rust/derive/src/utils.rs
@@ -1,0 +1,60 @@
+/* Copyright (C) 2021 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/// Transform names such as "OneTwoThree" to "one_two_three".
+pub fn transform_name(name: &str, delim: char) -> String {
+    let mut out = String::new();
+    let chars: Vec<char> = name.chars().collect();
+
+    for i in 0..chars.len() {
+        if i > 0
+            && i < chars.len() - 1
+            && chars[i].is_uppercase()
+            && (chars[i - 1].is_lowercase() || chars[i + 1].is_lowercase())
+        {
+            out.push(delim);
+        }
+        out.push_str(&chars[i].to_lowercase().to_string());
+    }
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_transform_name() {
+        assert_eq!(&transform_name("One", '_'), "one");
+        assert_eq!(&transform_name("SomeEvent", '_'), "some_event");
+        assert_eq!(
+            &transform_name("UnassignedMsgType", '_'),
+            "unassigned_msg_type"
+        );
+        assert_eq!(&transform_name("ABCName", '_'), "abc_name");
+        assert_eq!(
+            &transform_name("MiddleABCAcronym", '_'),
+            "middle_abc_acronym"
+        );
+        assert_eq!(&transform_name("One", '.'), "one");
+        assert_eq!(&transform_name("OneTwo", '.'), "one.two");
+        assert_eq!(&transform_name("OneTwoThree", '.'), "one.two.three");
+        assert_eq!(&transform_name("NBSS", '.'), "nbss");
+        assert_eq!(&transform_name("NBSSHdr", '.'), "nbss.hdr");
+        assert_eq!(&transform_name("SMB3Data", '.'), "smb3.data");
+    }
+}

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -25,9 +25,9 @@ use std::os::raw::{c_void,c_char,c_int};
 use crate::core::SC;
 use std::ffi::CStr;
 
-// Make the AppLayerEvent derive macro available to users importing
+// Make the AppLayerEvent and State derive macro available to users importing
 // AppLayerEvent from this module.
-pub use suricata_derive::AppLayerEvent;
+pub use suricata_derive::{AppLayerEvent, AppLayerState};
 
 #[repr(C)]
 pub struct StreamSlice {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1723,7 +1723,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterSMTPParsers();
     rs_dns_udp_register_parser();
     rs_dns_tcp_register_parser();
-    rs_bittorrent_dht_udp_register_parser();
+    rs_bit_torrent_dht_udp_register_parser();
     RegisterModbusParsers();
     RegisterENIPUDPParsers();
     RegisterENIPTCPParsers();


### PR DESCRIPTION
Describe changes:
- Add derive to implement many common State functions, not useable for all State, but handles the general case
- Use AppLayerState where possible