### PR TITLE
github-ci: non-root builder - v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -624,6 +624,74 @@ jobs:
       # Check compilation against systemd
       - run: ldd src/suricata | grep libsystemd &> /dev/null
 
+  fedora-36-non-root:
+    name: Fedora 36 (non-root, debug, clang, asan, wshadow, rust-strict, systemd)
+    runs-on: ubuntu-latest
+    container: fedora:36
+    needs: [prepare-deps, prepare-cbindgen]
+    steps:
+      - run: |
+          dnf -y install \
+                autoconf \
+                automake \
+                cargo \
+                ccache \
+                clang \
+                diffutils \
+                file-devel \
+                gcc \
+                gcc-c++ \
+                git \
+                hiredis-devel \
+                jansson-devel \
+                jq \
+                lua-devel \
+                libasan \
+                libtool \
+                libyaml-devel \
+                libnfnetlink-devel \
+                libnetfilter_queue-devel \
+                libnet-devel \
+                libcap-ng-devel \
+                libevent-devel \
+                libmaxminddb-devel \
+                libpcap-devel \
+                libtool \
+                lz4-devel \
+                make \
+                nss-softokn-devel \
+                pcre2-devel \
+                pkgconfig \
+                python3-yaml \
+                sudo \
+                systemd-devel \
+                which \
+                zlib-devel
+      - run: adduser suricata
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: mkdir /home/suricata/suricata
+      - run: cp -a . /home/suricata/suricata
+      - run: chown -R suricata:suricata /home/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh cbindgen
+        working-directory: /home/suricata/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh autogen
+        working-directory: /home/suricata/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh configure
+        working-directory: /home/suricata/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh make
+        working-directory: /home/suricata/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh unit-test
+        working-directory: /home/suricata/suricata
+      - run: sudo -u suricata -s ./.github/workflows/scripts/fedora-non-root.sh verify
+        working-directory: /home/suricata/suricata
+
   fedora-35:
     name: Fedora 35 (debug, clang, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/fedora-non-root.sh
+++ b/.github/workflows/scripts/fedora-non-root.sh
@@ -1,0 +1,47 @@
+#! /usr/bin/env bash
+#
+# Helper script for Fedora build as a non-root user.
+#
+# We break the build up into parts that need to be called individually
+# to avoid outputting too much data in a single step so we can see the
+# output in the UI.
+
+set -e
+set -x
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+case "$1" in
+    cbindgen)
+        # Setup cbindgen.
+        mkdir -p $HOME/.cargo/bin
+        cp prep/cbindgen $HOME/.cargo/bin
+        chmod 755 $HOME/.cargo/bin/cbindgen
+        ;;
+    autogen)
+        ./autogen.sh
+        ;;
+    configure)
+        ac_cv_func_realloc_0_nonnull="yes" \
+            ac_cv_func_malloc_0_nonnull="yes" \
+            LDFLAGS="-fsanitize=address" \
+            CC="clang" \
+            CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" \
+            ./configure \
+            --enable-debug \
+            --enable-unittests \
+            --disable-shared \
+            --enable-rust-strict \
+            --enable-hiredis \
+            --enable-nfqueue
+        ;;
+    make)
+        make -j2
+        ;;
+    unit-test)
+        ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
+        ;;
+    verify)
+        python3 ./suricata-verify/run.py
+        ;;
+esac


### PR DESCRIPTION
All the GitHub CI jobs run as root inside a container. This means the
testing is done in a different environment than a developer typically
uses, running as a user.

Add a job that does the build as a non-root user.

Previous PR: https://github.com/OISF/suricata/pull/8099