### PR TITLE
decode-udp: Add exception for invalid length on padded packets v1

### DIFF
--- a/src/decode-ethernet.h
+++ b/src/decode-ethernet.h
@@ -25,6 +25,7 @@
 #define __DECODE_ETHERNET_H__
 
 #define ETHERNET_HEADER_LEN           14
+#define ETHERNET_PKT_MIN_LEN          60 // Min. transmission unit on Ethernet is 64B (4B for FCS)
 
 /* Cisco Fabric Path / DCE header length. */
 #define ETHERNET_DCE_HEADER_LEN       (ETHERNET_HEADER_LEN + 2)

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -56,7 +56,9 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_
         return -1;
     }
 
-    if (unlikely(len != UDP_GET_LEN(p))) {
+    if (unlikely(len != UDP_GET_LEN(p) &&
+                 // avoid flagging IP padded packets to the minimal Ethernet unit as invalid HLEN
+                 (p->ethh != NULL && p->pktlen > ETHERNET_PKT_MIN_LEN))) {
         ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_INVALID);
         return -1;
     }


### PR DESCRIPTION
If the original packet is shorter than Ethernet's minimal transmission unit (64B), the transmitting device pads the packet to the given size. Padding is added to the IP layer but the UDP layer remains unaffected. As a result, the UDP header length does not reach the end of the packet as there is still padding after the UDP layer.

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5693) ticket:

Describe changes:
- add header length check exception

suricata-verify-pr: 1009
