### PR TITLE
afpacket/netmap: warn about mixed ips, ids/tap deprecation - v2

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -738,7 +738,10 @@ int AFPRunModeIsIPS()
     }
 
     if (has_ids && has_ips) {
-        SCLogInfo("AF_PACKET mode using IPS and IDS mode");
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "AF_PACKET using both IPS and TAP/IDS mode, this will not "
+                "be allowed in Suricata 8 due to undefined behavior. See "
+                "https://redmine.openinfosecfoundation.org/issues/5588");
         for (ldev = 0; ldev < nlive; ldev++) {
             const char *live_dev = LiveGetDeviceName(ldev);
             if (live_dev == NULL) {

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -374,7 +374,10 @@ int NetmapRunModeIsIPS()
     }
 
     if (has_ids && has_ips) {
-        SCLogInfo("Netmap mode using IPS and IDS mode");
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "Netmap using both IPS and TAP/IDS mode, this will not be "
+                "allowed in Suricata 8 due to undefined behavior. See "
+                "https://redmine.openinfosecfoundation.org/issues/5588");
         for (ldev = 0; ldev < nlive; ldev++) {
             const char *live_dev = LiveGetDeviceName(ldev);
             if (live_dev == NULL) {


### PR DESCRIPTION
Suricata already logs if AF_PACKET or Netmap are running in a mixed IPS
and IDS/TAP mode.  As the behavior is undefined when these modes are
mixed, it is best to deprecate and to not allow this behavior. For now
warn that it will be unsupported and fail in Suricata 8.

Ticket: 5587
