### PR TITLE
Http2 decompression fixes 5691 v1

### DIFF
--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -50,6 +50,11 @@ impl HTTP2cursor {
     pub fn set_position(&mut self, pos: u64) {
         return self.cursor.set_position(pos);
     }
+
+    pub fn clear(&mut self) {
+        self.cursor.get_mut().clear();
+        self.cursor.set_position(0);
+    }
 }
 
 // we need to implement this as flate2 and brotli crates
@@ -156,8 +161,7 @@ fn http2_decompress<'a>(
         }
     }
     //brotli does not consume all input if it reaches some end
-
-    decoder.get_mut().set_position(0);
+    decoder.get_mut().clear();
     return Ok(&output[..offset]);
 }
 

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -933,6 +933,7 @@ impl HTTP2State {
                     let over = head.flags & parser::HTTP2_FLAG_HEADER_EOS != 0;
                     let ftype = head.ftype;
                     let sid = head.stream_id;
+                    let padded = head.flags & parser::HTTP2_FLAG_HEADER_PADDED != 0;
                     if dir == Direction::ToServer {
                         tx.frames_ts.push(HTTP2Frame {
                             header: head,
@@ -956,9 +957,12 @@ impl HTTP2State {
                                     } else {
                                         tx_same.ft_ts.tx_id = tx_same.tx_id - 1;
                                     };
-
+                                    let mut dinput = &rem[..hlsafe];
+                                    if padded && rem.len() > 0 && usize::from(rem[0]) < hlsafe{
+                                        dinput = &rem[1..hlsafe - usize::from(rem[0])];
+                                    }
                                     match tx_same.decompress(
-                                        &rem[..hlsafe],
+                                        dinput,
                                         dir,
                                         sfcm,
                                         over,

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -585,7 +585,7 @@ pub struct HTTP2FrameHeaders {
 //end stream
 pub const HTTP2_FLAG_HEADER_EOS: u8 = 0x1;
 pub const HTTP2_FLAG_HEADER_END_HEADERS: u8 = 0x4;
-const HTTP2_FLAG_HEADER_PADDED: u8 = 0x8;
+pub const HTTP2_FLAG_HEADER_PADDED: u8 = 0x8;
 const HTTP2_FLAG_HEADER_PRIORITY: u8 = 0x20;
 
 fn http2_parse_headers_blocks<'a>(


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5691

Should this ticket be split in 2 ? (for the 2 bugs in the 2 commits)

Describe changes:
- http2: Handles padding in DATA frames
- http2: fixes decompression rust structures logic

suricata-verify-pr: 1007
https://github.com/OISF/suricata-verify/pull/1007
