### PR TITLE
github-ci: more caching - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -395,6 +395,13 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/yum
+          key: ${{ github.job }}-yum
+      - run: echo "keepcache=1" >> /etc/yum.conf
+
       - name: Install system dependencies
         run: |
           yum -y install epel-release

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -38,11 +38,6 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-latest
     steps:
-      - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
-        with:
-          path: ~/.cargo
-          key: cargo
       - run: sudo apt update && sudo apt -y install jq curl
       - name: Parse repo and branch information
         env:
@@ -126,7 +121,7 @@ jobs:
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
           path: ~/.cargo
-          key: cbindgen
+          key: ${{ github.job }}-cargo
       - name: Installing Rust
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -152,8 +147,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - uses: actions/checkout@v3.1.0
 
@@ -260,8 +255,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - uses: actions/checkout@v3.1.0
 
@@ -380,6 +375,11 @@ jobs:
     container: centos:7
     needs: [prepare-deps, alma-8]
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - name: Install system dependencies
         run: |
           yum -y install epel-release
@@ -451,8 +451,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - run: |
           dnf -y install \
@@ -541,8 +541,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - run: |
           dnf -y install \
@@ -635,8 +635,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - run: |
           dnf -y install \
@@ -726,8 +726,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - run: |
           dnf -y install \
@@ -789,6 +789,11 @@ jobs:
     container: ubuntu:22.04
     needs: [prepare-deps, prepare-cbindgen]
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - name: Install dependencies
         run: |
           apt update
@@ -901,6 +906,11 @@ jobs:
     container: ubuntu:22.04
     needs: [prepare-deps, prepare-cbindgen]
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - name: Install dependencies
         run: |
           apt update
@@ -993,6 +1003,11 @@ jobs:
     container: ubuntu:20.04
     needs: [prepare-deps, prepare-cbindgen]
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - name: Install dependencies
         run: |
@@ -1077,6 +1092,11 @@ jobs:
     container: ubuntu:20.04
     needs: alma-8
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - name: Install dependencies
         run: |
           apt update
@@ -1135,8 +1155,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - name: Install dependencies
         run: |
@@ -1207,8 +1227,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - name: Install dependencies
         run: |
@@ -1302,8 +1322,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - name: Install dependencies
         run: |
@@ -1365,8 +1385,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
 
       - run: |
           apt update
@@ -1435,6 +1455,11 @@ jobs:
     container: debian:9
     needs: [prepare-deps, prepare-cbindgen]
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - run: |
           apt update
           apt -y install \
@@ -1503,8 +1528,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
         with:
-          path: ~/.cargo/registry
-          key: cargo-registry
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - run: |
          brew install \
           autoconf \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1591,7 +1591,7 @@ jobs:
           rust \
           xz
       - name: Install cbindgen
-        run: cargo install --force --debug --version 0.24.3 cbindgen
+        run: cargo install --debug --version 0.24.3 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: pip3 install PyYAML
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -150,6 +150,13 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
       - uses: actions/checkout@v3.1.0
 
       # Download and extract dependency archives created during prep
@@ -257,6 +264,13 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
       - uses: actions/checkout@v3.1.0
 
@@ -380,6 +394,7 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
+
       - name: Install system dependencies
         run: |
           yum -y install epel-release
@@ -453,6 +468,13 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
       - run: |
           dnf -y install \
@@ -543,6 +565,13 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
       - run: |
           dnf -y install \
@@ -638,6 +667,13 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
       - run: |
           dnf -y install \
                 autoconf \
@@ -728,6 +764,13 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
       - run: |
           dnf -y install \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1622,6 +1622,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - uses: actions/checkout@v3.1.0
       - uses: msys2/setup-msys2@fa138fa56e2558760b9f2205135313c7345c5f3f
         with:
@@ -1673,6 +1678,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
       - uses: actions/checkout@v3.1.0
       - uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
- github-ci: better .cargo caching
- github-ci: cache RPMs on dnf distros
- github-ci/macos: don't force cbindgen
- github-ci/windows: cache cargo artifacts
- github-ci/centos:7: cache yum RPMs
