### PR TITLE
landlock: fix filestore support

### DIFF
--- a/src/util-landlock.c
+++ b/src/util-landlock.c
@@ -79,7 +79,8 @@ static inline int landlock_restrict_self(const int ruleset_fd, const __u32 flags
 
 #define _LANDLOCK_SURI_ACCESS_FS_WRITE                                                             \
     (LANDLOCK_ACCESS_FS_WRITE_FILE | LANDLOCK_ACCESS_FS_MAKE_DIR | LANDLOCK_ACCESS_FS_MAKE_REG |   \
-            LANDLOCK_ACCESS_FS_REMOVE_FILE | LANDLOCK_ACCESS_FS_MAKE_SOCK)
+            LANDLOCK_ACCESS_FS_REMOVE_FILE | LANDLOCK_ACCESS_FS_MAKE_SOCK |                        \
+            LANDLOCK_ACCESS_FS_REFER)
 
 struct landlock_ruleset {
     int fd;


### PR DESCRIPTION
The file moving capability was missing from the set of permission.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5704

Describe changes:
- Add missing flag in write permission

