### PR TITLE
6.0.x - afpacket/netmap: warn about mixed ips, ids/tap deprecation - v1

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -764,7 +764,9 @@ int AFPRunModeIsIPS()
     }
 
     if (has_ids && has_ips) {
-        SCLogInfo("AF_PACKET mode using IPS and IDS mode");
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "AF_PACKET using both IPS and TAP/IDS mode, this will not "
+                "be allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
             const char *live_dev = LiveGetDeviceName(ldev);
             if (live_dev == NULL) {

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -420,7 +420,9 @@ int NetmapRunModeIsIPS()
     }
 
     if (has_ids && has_ips) {
-        SCLogInfo("Netmap mode using IPS and IDS mode");
+        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                "Netmap using both IPS and TAP/IDS mode, this will not be "
+                "allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
             const char *live_dev = LiveGetDeviceName(ldev);
             if (live_dev == NULL) {


### PR DESCRIPTION
Backport to 6.0.x.

Primary ticket: https://redmine.openinfosecfoundation.org/issues/5587
Master PR: https://github.com/OISF/suricata/pull/8190
