### PR TITLE
Http2 decompression fixes 5691 v1 backport6

### DIFF
--- a/rust/src/http2/decompression.rs
+++ b/rust/src/http2/decompression.rs
@@ -50,6 +50,11 @@ impl HTTP2cursor {
     pub fn set_position(&mut self, pos: u64) {
         return self.cursor.set_position(pos);
     }
+
+    pub fn clear(&mut self) {
+        self.cursor.get_mut().clear();
+        self.cursor.set_position(0);
+    }
 }
 
 // we need to implement this as flate2 and brotli crates
@@ -152,8 +157,7 @@ fn http2_decompress<'a>(
         }
     }
     //brotli does not consume all input if it reaches some end
-
-    decoder.get_mut().set_position(0);
+    decoder.get_mut().clear();
     return Ok(&output[..offset]);
 }
 

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -832,6 +832,7 @@ impl HTTP2State {
                     let over = head.flags & parser::HTTP2_FLAG_HEADER_EOS != 0;
                     let ftype = head.ftype;
                     let sid = head.stream_id;
+                    let padded = head.flags & parser::HTTP2_FLAG_HEADER_PADDED != 0;
                     if dir == STREAM_TOSERVER {
                         tx.frames_ts.push(HTTP2Frame {
                             header: head,
@@ -851,8 +852,12 @@ impl HTTP2State {
                                 if index > 0 {
                                     let tx_same = &mut self.transactions[index - 1];
                                     let (files, flags) = self.files.get(dir);
+                                    let mut dinput = &rem[..hlsafe];
+                                    if padded && rem.len() > 0 && usize::from(rem[0]) < hlsafe{
+                                        dinput = &rem[1..hlsafe - usize::from(rem[0])];
+                                    }
                                     match tx_same.decompress(
-                                        &rem[..hlsafe],
+                                        dinput,
                                         dir,
                                         sfcm,
                                         over,

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -610,7 +610,7 @@ pub struct HTTP2FrameHeaders {
 //end stream
 pub const HTTP2_FLAG_HEADER_EOS: u8 = 0x1;
 pub const HTTP2_FLAG_HEADER_END_HEADERS: u8 = 0x4;
-const HTTP2_FLAG_HEADER_PADDED: u8 = 0x8;
+pub const HTTP2_FLAG_HEADER_PADDED: u8 = 0x8;
 const HTTP2_FLAG_HEADER_PRIORITY: u8 = 0x20;
 
 pub fn http2_parse_frame_headers<'a>(

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -133,6 +133,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             memcpy(isolatedBuffer, albuffer, alnext - albuffer);
             (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alnext - albuffer);
             free(isolatedBuffer);
+            if (FlowChangeProto(f)) {
+                // exits if a protocol change is requested
+                alsize = 0;
+                break;
+            }
             flags &= ~(STREAM_START);
             if (f->alparser &&
                    (((flags & STREAM_TOSERVER) != 0 &&


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5691

Describe changes:
- Backport of #8194 