### PR TITLE
quic: do not use stack for inspection buffer

### DIFF
--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -277,7 +277,8 @@ InspectionBuffer *Ja3DetectGetHash(DetectEngineThreadCtx *det_ctx,
         // this adds a final zero
         SCMd5HashBufferToHex(b, b_len, (char *)ja3_hash, SC_MD5_HEX_LEN + 1);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, ja3_hash, SC_MD5_HEX_LEN);
+        InspectionBufferSetup(det_ctx, list_id, buffer, NULL, 0);
+        InspectionBufferCopy(buffer, ja3_hash, SC_MD5_HEX_LEN);
         InspectionBufferApplyTransforms(buffer, transforms);
     }
     return buffer;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5707

Describe changes:
- quic: do not use stack for inspection buffer

Or do I need the buffer to have the same scope as a quic transaction?..