### PR TITLE
decode-udp:  Allow shorter UDP packets than the remaining payload length

### DIFF
--- a/src/decode-ethernet.h
+++ b/src/decode-ethernet.h
@@ -25,6 +25,7 @@
 #define __DECODE_ETHERNET_H__
 
 #define ETHERNET_HEADER_LEN           14
+#define ETHERNET_PKT_MIN_LEN          60 // Min. transmission unit on Ethernet is 64B (4B for FCS)
 
 /* Cisco Fabric Path / DCE header length. */
 #define ETHERNET_DCE_HEADER_LEN       (ETHERNET_HEADER_LEN + 2)

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -266,10 +266,6 @@ const struct DecodeEvents_ DEvents[] = {
             "decoder.udp.hlen_too_small",
             UDP_HLEN_TOO_SMALL,
     },
-    {
-            "decoder.udp.hlen_invalid",
-            UDP_HLEN_INVALID,
-    },
 
     /* SLL EVENTS */
     {

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -102,7 +102,6 @@ enum {
     /* UDP EVENTS */
     UDP_PKT_TOO_SMALL,  /**< udp packet smaller than minimum size */
     UDP_HLEN_TOO_SMALL, /**< udp header smaller than minimum size */
-    UDP_HLEN_INVALID,   /**< invalid len of upd header */
 
     /* SLL EVENTS */
     SLL_PKT_TOO_SMALL, /**< sll packet smaller than minimum size */

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -56,11 +56,6 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_
         return -1;
     }
 
-    if (unlikely(len != UDP_GET_LEN(p))) {
-        ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_INVALID);
-        return -1;
-    }
-
     SET_UDP_SRC_PORT(p,&p->sp);
     SET_UDP_DST_PORT(p,&p->dp);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5693) ticket:

Follow-up of #8189 

Describe changes:
- allow a UDP layer of any size to be shorter than the remaining payload size 
