### PR TITLE
doc/userguide: ubuntu: install software-properties-common

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -122,6 +122,7 @@ For Ubuntu, the OISF maintains a PPA ``suricata-stable`` that always contains th
 
 To use it::
 
+    sudo apt-get install software-properties-common
     sudo add-apt-repository ppa:oisf/suricata-stable
     sudo apt-get update
     sudo apt-get install suricata


### PR DESCRIPTION
This package likely needs to be installed when starting with an Ubuntu
container or other minimal Ubuntu install.

Ticket: https://redmine.openinfosecfoundation.org/issues/5616
