### PR TITLE
dpdk: decrease intensity of warnings related to NUMA placement

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1358,6 +1358,7 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface)
     (void)SC_ATOMIC_ADD(iconf->ref, iconf->threads);
     // This counter is increased by worker threads that individually pick queue IDs.
     SC_ATOMIC_RESET(iconf->queue_id);
+    SC_ATOMIC_RESET(iconf->inconsitent_numa_cnt);
     return iconf;
 }
 

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -69,6 +69,7 @@ typedef struct DPDKIfaceConfig_ {
     SC_ATOMIC_DECLARE(unsigned int, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
+    SC_ATOMIC_DECLARE(uint16_t, inconsitent_numa_cnt);
     void (*DerefFunc)(void *);
 
     struct rte_flow *flow[100];


### PR DESCRIPTION
Change per-thread warning about incorrect NUMA node placement to one warning per incorrectly configured Suricata interface. With verbose logging, it still reminds the user about the suboptimal configuration on a per-thread basis.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5617
