### PR TITLE
 eve: add common options to loggers missing it

### DIFF
--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -170,8 +170,8 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv,
             WARN_ONCE(SC_ERR_SPRINTF,
                 "Failed to write file info record. Output filename truncated.");
         } else {
-            JsonBuilder *js_fileinfo = JsonBuildFileInfoRecord(p, ff, true, dir,
-                    ctx->xff_cfg);
+            JsonBuilder *js_fileinfo =
+                    JsonBuildFileInfoRecord(p, ff, true, dir, ctx->xff_cfg, NULL);
             if (likely(js_fileinfo != NULL)) {
                 jb_close(js_fileinfo);
                 FILE *out = fopen(js_metadata_filename, "w");

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -50,6 +50,7 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(jb == NULL)) {
         return TM_ECODE_FAILED;
     }
+    EveAddCommonOptions(&thread->ctx->cfg, p, f, jb);
 
     jb_open_object(jb, "dcerpc");
     if (p->proto == IPPROTO_TCP) {

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -25,9 +25,10 @@
 #define __OUTPUT_JSON_FILE_H__
 
 #include "app-layer-htp-xff.h"
+#include "output-json.h"
 
 void JsonFileLogRegister(void);
-JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff,
-        const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg);
+JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool stored,
+        uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCommonSettings *cfg);
 
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -52,6 +52,7 @@
 typedef struct LogMQTTFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogMQTTFileCtx;
 
 typedef struct LogMQTTLogThread_ {
@@ -90,6 +91,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
+    EveAddCommonOptions(&thread->mqttlog_ctx->cfg, p, f, js);
 
     if (!rs_mqtt_logger_log(state, tx, thread->mqttlog_ctx->flags, js))
         goto error;
@@ -137,6 +139,7 @@ static OutputInitResult OutputMQTTLogInitSub(ConfNode *conf,
         return result;
     }
     mqttlog_ctx->file_ctx = ajt->file_ctx;
+    mqttlog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -49,6 +49,7 @@
 typedef struct LogRFBFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t    flags;
+    OutputJsonCommonSettings cfg;
 } LogRFBFileCtx;
 
 typedef struct LogRFBLogThread_ {
@@ -79,6 +80,8 @@ static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
+
+    EveAddCommonOptions(&thread->rfblog_ctx->cfg, p, f, js);
 
     if (!rs_rfb_logger_log(NULL, tx, js)) {
         goto error;
@@ -113,6 +116,7 @@ static OutputInitResult OutputRFBLogInitSub(ConfNode *conf,
         return result;
     }
     rfblog_ctx->file_ctx = ajt->file_ctx;
+    rfblog_ctx->cfg = ajt->cfg;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
     if (unlikely(output_ctx == NULL)) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5723

Describe changes:
-  eve: add common options to loggers missing it

So that we get community id for RFB events (for example)

suricata-verify-pr: 1022
