### PR TITLE
http: logs custom headers in a subobject

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1685,6 +1685,10 @@
                     },
                     "additionalProperties": false
                 },
+                "custom": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "http2": {
                     "type": "object",
                     "properties": {

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -269,6 +269,7 @@ static void EveHttpLogJSONCustom(LogHttpFileCtx *http_ctx, JsonBuilder *js, htp_
     char *c;
     HttpField f;
 
+    jb_open_object(js, "custom");
     for (f = HTTP_FIELD_ACCEPT; f < HTTP_FIELD_SIZE; f++)
     {
         if ((http_ctx->fields & (1ULL<<f)) != 0)
@@ -302,6 +303,7 @@ static void EveHttpLogJSONCustom(LogHttpFileCtx *http_ctx, JsonBuilder *js, htp_
             }
         }
     }
+    jb_close(js);
 }
 
 static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5320

Describe changes:
- http: logs custom headers in a subobject

To avoid collisions, for instance for `content_range`

With this PR, the output will be
```
    "content_range": {
      "raw": "bytes 10-20/69",
      "start": 10,
      "end": 20,
      "size": 69
    },
    "custom": {
      "content_range": "bytes 10-20/69"
    }
```

instead of 
```
    "content_range": {
      "raw": "bytes 10-20/69",
      "start": 10,
      "end": 20,
      "size": 69
    },
   "content_range": "bytes 10-20/69"
```

suricata-verify-pr: 1023
