### PR TITLE
dns: parse and alert on invalid opcodes - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -960,6 +960,10 @@
                 "version": {
                     "type": "integer"
                 },
+                "opcode": {
+                    "description": "DNS opcode as an integer",
+                    "type": "integer"
+                },
                 "answers": {
                     "type": "array",
                     "items": {
@@ -1074,6 +1078,10 @@
                             },
                             "z": {
                                 "type": "boolean"
+                            },
+                            "opcode": {
+                                "description": "DNS opcode as an integer",
+                                "type": "integer"
                             }
                         },
                         "additionalProperties": false
@@ -1110,6 +1118,10 @@
                             "type": "string"
                         },
                         "version": {
+                            "type": "integer"
+                        },
+                        "opcode": {
+                            "description": "DNS opcode as an integer",
                             "type": "integer"
                         }
                     },

--- a/rules/dns-events.rules
+++ b/rules/dns-events.rules
@@ -7,3 +7,4 @@ alert dns any any -> any any (msg:"SURICATA DNS Not a request"; flow:to_server; 
 alert dns any any -> any any (msg:"SURICATA DNS Not a response"; flow:to_client; app-layer-event:dns.not_a_response; classtype:protocol-command-decode; sid:2240005; rev:2;)
 # Z flag (reserved) not 0
 alert dns any any -> any any (msg:"SURICATA DNS Z flag set"; app-layer-event:dns.z_flag_set; classtype:protocol-command-decode; sid:2240006; rev:2;)
+alert dns any any -> any any (msg:"SURICATA DNS Invalid opcode"; app-layer-event:dns.invalid_opcode; classtype:protocol-command-decode; sid:2240007; rev:1;)

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -512,6 +512,9 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
         js.set_bool("z", true)?;
     }
 
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    js.set_uint("opcode", opcode as u64)?;
+
     for query in &response.queries {
         js.set_string_from_bytes("rrname", &query.name)?;
         js.set_string("rrtype", &dns_rrtype_string(query.rrtype))?;
@@ -637,6 +640,8 @@ fn dns_log_query(tx: &mut DNSTransaction,
                 if request.header.flags & 0x0040 != 0 {
                     jb.set_bool("z", true)?;
                 }
+                let opcode = ((request.header.flags >> 11) & 0xf) as u8;
+                jb.set_uint("opcode", opcode as u64)?;
                 return Ok(true);
             }
         }


### PR DESCRIPTION
Accept DNS messages with an invalid opcode that are otherwise
valid. Such DNS message will create a parser event.

This is a change of behavior, previously an invalid opcode would cause
the DNS message to not be detected or parsed as DNS.

Issue: https://redmine.openinfosecfoundation.org/issues/5444

suricata-verify-pr: 1024
