### PR TITLE
Schema emptyarrays 5167 v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -110,6 +110,7 @@
         },
         "files": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "type": "object",
                 "optional": true,
@@ -152,6 +153,7 @@
                     },
                     "sid": {
                         "type": "array",
+                        "minItems": 1,
                         "items": {
                             "type": "integer"
                         }
@@ -162,6 +164,7 @@
         },
         "vlan": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "type": "number"
             }
@@ -202,60 +205,70 @@
                     "properties": {
                         "affected_product": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "attack_target": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "created_at": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "deployment": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "former_category": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "malware_family": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "policy": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "signature_severity": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "tag": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "updated_at": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -453,6 +466,7 @@
                 },
                 "interfaces": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -549,18 +563,21 @@
                 },
                 "dns_servers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "params": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "routers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -592,6 +609,7 @@
                         },
                         "objects": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -621,6 +639,7 @@
                                     },
                                     "points": {
                                         "type": "array",
+                                        "minItems": 1,
                                         "items": {
                                             "type": "object",
                                             "additionalProperties": true
@@ -680,6 +699,7 @@
                     "properties": {
                         "indicators": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -710,6 +730,7 @@
                                 },
                                 "objects": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -739,6 +760,7 @@
                                             },
                                             "points": {
                                                 "type": "array",
+                                                "minItems": 1,
                                                 "items": {
                                                     "type": "object",
                                                     "additionalProperties": true
@@ -819,6 +841,7 @@
                                 },
                                 "objects": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -848,6 +871,7 @@
                                             },
                                             "points": {
                                                 "type": "array",
+                                                "minItems": 1,
                                                 "items": {
                                                     "type": "object",
                                                     "additionalProperties": true
@@ -907,6 +931,7 @@
                             "properties": {
                                 "indicators": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "string"
                                     }
@@ -962,6 +987,7 @@
                 },
                 "answers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "optional": true,
@@ -1003,6 +1029,7 @@
                 },
                 "authorities": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "optional": true,
@@ -1053,6 +1080,7 @@
                 },
                 "query": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "optional": true,
@@ -1121,42 +1149,49 @@
                     "properties": {
                         "A": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "AAAA": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "CNAME": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "MX": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "NULL": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "PTR": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
                         },
                         "SRV": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "object",
                                 "optional": true,
@@ -1179,6 +1214,7 @@
                         },
                         "TXT": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -1292,18 +1328,21 @@
                 },
                 "url": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "attachment": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "to": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -1348,12 +1387,14 @@
                 },
                 "dest_macs": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "src_macs": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -1406,6 +1447,7 @@
                 },
                 "sid": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "integer"
                     }
@@ -1547,12 +1589,14 @@
                 },
                 "completion_code": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "reply": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -1633,6 +1677,7 @@
                 },
                 "request_headers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -1651,6 +1696,7 @@
                 },
                 "response_headers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -1702,6 +1748,7 @@
                                 },
                                 "settings": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -1726,6 +1773,7 @@
                                 },
                                 "settings": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -1772,6 +1820,7 @@
                 },
                 "request_headers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -1790,6 +1839,7 @@
                 },
                 "response_headers": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -1908,6 +1958,7 @@
                 },
                 "payload": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -1923,6 +1974,7 @@
                         },
                         "vendor_ids": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -1944,6 +1996,7 @@
                                 },
                                 "proposals": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -2075,12 +2128,14 @@
             "properties": {
                 "flowbits": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "flowvars": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -2099,6 +2154,7 @@
                 },
                 "pktvars": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -2584,6 +2640,7 @@
                         },
                         "qos_granted": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "integer"
                             }
@@ -2608,6 +2665,7 @@
                         },
                         "topics": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -2641,6 +2699,7 @@
                         },
                         "reason_codes": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "integer"
                             }
@@ -2665,6 +2724,7 @@
                         },
                         "topics": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -2831,6 +2891,7 @@
                             "properties": {
                                 "optional_parameters": {
                                     "type": "array",
+                                    "minItems": 1,
                                     "items": {
                                         "type": "object",
                                         "properties": {
@@ -2903,6 +2964,7 @@
                         },
                         "parameter_status": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -2976,6 +3038,7 @@
             "properties": {
                 "cyu": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -2991,6 +3054,7 @@
                 },
                 "extensions": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -3002,6 +3066,7 @@
                             },
                             "values": {
                                 "type": "array",
+                                "minItems": 1,
                                 "items": {
                                     "type": "string"
                                 }
@@ -3063,6 +3128,7 @@
                 },
                 "channels": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -3105,6 +3171,7 @@
                         },
                         "capabilities": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -3403,6 +3470,7 @@
                 },
                 "client_dialects": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -3462,6 +3530,7 @@
                         },
                         "interfaces": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "object",
                                 "optional": true,
@@ -3520,6 +3589,7 @@
                         },
                         "snames": {
                             "type": "array",
+                            "minItems": 1,
                             "items": {
                                 "type": "string"
                             }
@@ -3597,6 +3667,7 @@
                 },
                 "rcpt_to": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -3622,6 +3693,7 @@
                 },
                 "vars": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
@@ -4743,6 +4815,7 @@
                         },
                         "engines": {
                             "type": "array",
+                            "minItems": 1,
                             "items": [
                                 {
                                     "type": "object",
@@ -5347,12 +5420,14 @@
             "properties": {
                 "id": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }
                 },
                 "label": {
                     "type": "array",
+                    "minItems": 1,
                     "items": {
                         "type": "string"
                     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -269,6 +269,7 @@ JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id)
     if (queryjb == NULL) {
         return NULL;
     }
+    bool has_query = false;
 
     for (uint16_t i = 0; i < UINT16_MAX; i++) {
         JsonBuilder *js = jb_new_object();
@@ -277,8 +278,14 @@ JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id)
             break;
         }
         jb_close(js);
+        has_query = true;
         jb_append_object(queryjb, js);
         jb_free(js);
+    }
+
+    if (!has_query) {
+        jb_free(queryjb);
+        return NULL;
     }
 
     jb_close(queryjb);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5167

Describe changes:
- eve/schema : forbid empty arrays
- dns: do not log empty array

Replaces https://github.com/OISF/suricata/pull/7918 with DNS fix