### PR TITLE
github-ci: fix rust clippy checks - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -631,7 +631,7 @@ jobs:
           chmod 755 $HOME/.cargo/bin/cbindgen
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-lua
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,8 @@ jobs:
       - run: |
           diff=$(git diff)
           if [ "${diff}" ]; then
-              echo "::warning ::Clippy --fix made changes, please fix"
+              echo "::error ::Clippy --fix made changes, please fix"
+              exit 1
           fi
       - run: cargo clippy --all-features
         working-directory: rust

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -958,7 +958,7 @@ impl HTTP2State {
                                         tx_same.ft_ts.tx_id = tx_same.tx_id - 1;
                                     };
                                     let mut dinput = &rem[..hlsafe];
-                                    if padded && rem.len() > 0 && usize::from(rem[0]) < hlsafe{
+                                    if padded && !rem.is_empty() && usize::from(rem[0]) < hlsafe{
                                         dinput = &rem[1..hlsafe - usize::from(rem[0])];
                                     }
                                     match tx_same.decompress(


### PR DESCRIPTION
The test for fixable lints wasn't only warning and not erroring.  And given
that it fixed the lint, the following check for clippy would pass.

Instead, have the check for any changes made by fix be a hard error.

Commit summary:
- github-ci: fail if cargo clippy --fix creates a changes
- rust/http2: fix clippy lint for is_empty()

Also enabled Lua on one more build.
