### PR TITLE
draft: dns: parser and alert on invalid opcodes - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -985,6 +985,10 @@
                 "version": {
                     "type": "integer"
                 },
+                "opcode": {
+                    "description": "DNS opcode as an integer",
+                    "type": "integer"
+                },
                 "answers": {
                     "type": "array",
                     "minItems": 1,
@@ -1102,6 +1106,10 @@
                             },
                             "z": {
                                 "type": "boolean"
+                            },
+                            "opcode": {
+                                "description": "DNS opcode as an integer",
+                                "type": "integer"
                             }
                         },
                         "additionalProperties": false
@@ -1138,6 +1146,10 @@
                             "type": "string"
                         },
                         "version": {
+                            "type": "integer"
+                        },
+                        "opcode": {
+                            "description": "DNS opcode as an integer",
                             "type": "integer"
                         }
                     },

--- a/rules/dns-events.rules
+++ b/rules/dns-events.rules
@@ -7,3 +7,4 @@ alert dns any any -> any any (msg:"SURICATA DNS Not a request"; flow:to_server; 
 alert dns any any -> any any (msg:"SURICATA DNS Not a response"; flow:to_client; app-layer-event:dns.not_a_response; classtype:protocol-command-decode; sid:2240005; rev:2;)
 # Z flag (reserved) not 0
 alert dns any any -> any any (msg:"SURICATA DNS Z flag set"; app-layer-event:dns.z_flag_set; classtype:protocol-command-decode; sid:2240006; rev:2;)
+alert dns any any -> any any (msg:"SURICATA DNS Invalid opcode"; app-layer-event:dns.invalid_opcode; classtype:protocol-command-decode; sid:2240007; rev:1;)

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -130,6 +130,7 @@ pub enum DNSEvent {
     NotRequest,
     NotResponse,
     ZFlagSet,
+    InvalidOpcode,
 }
 
 #[derive(Debug,PartialEq, Eq)]
@@ -396,6 +397,7 @@ impl DNSState {
                 }
 
                 let z_flag = request.header.flags & 0x0040 != 0;
+                let opcode = ((request.header.flags >> 11) & 0xf) as u8;
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
@@ -404,6 +406,10 @@ impl DNSState {
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
                     self.set_event(DNSEvent::ZFlagSet);
+                }
+
+                if opcode >= 7 {
+                    self.set_event(DNSEvent::InvalidOpcode);
                 }
 
                 return true;
@@ -447,6 +453,7 @@ impl DNSState {
                 }
 
                 let z_flag = response.header.flags & 0x0040 != 0;
+                let opcode = ((response.header.flags >> 11) & 0xf) as u8;
 
                 let mut tx = self.new_tx();
                 if let Some(ref mut config) = &mut self.config {
@@ -460,6 +467,10 @@ impl DNSState {
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
                     self.set_event(DNSEvent::ZFlagSet);
+                }
+
+                if opcode >= 7 {
+                    self.set_event(DNSEvent::InvalidOpcode);
                 }
 
                 return true;
@@ -596,11 +607,6 @@ impl DNSState {
 const DNS_HEADER_SIZE: usize = 12;
 
 fn probe_header_validity(header: DNSHeader, rlen: usize) -> (bool, bool, bool) {
-    let opcode = ((header.flags >> 11) & 0xf) as u8;
-    if opcode >= 7 {
-        //unassigned opcode
-        return (false, false, false);
-    }
     if 2 * (header.additional_rr as usize
         + header.answer_rr as usize
         + header.authority_rr as usize

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -512,6 +512,9 @@ fn dns_log_json_answer(js: &mut JsonBuilder, response: &DNSResponse, flags: u64)
         js.set_bool("z", true)?;
     }
 
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    js.set_uint("opcode", opcode as u64)?;
+
     if let Some(query) = response.queries.first() {
         js.set_string_from_bytes("rrname", &query.name)?;
         js.set_string("rrtype", &dns_rrtype_string(query.rrtype))?;
@@ -636,6 +639,8 @@ fn dns_log_query(tx: &mut DNSTransaction,
                 if request.header.flags & 0x0040 != 0 {
                     jb.set_bool("z", true)?;
                 }
+                let opcode = ((request.header.flags >> 11) & 0xf) as u8;
+                jb.set_uint("opcode", opcode as u64)?;
                 return Ok(true);
             }
         }


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/8228

Draft: Trying to resolve .app_layer.error.dns_udp.parser as seen at
https://github.com/OISF/suricata/pull/8228#issuecomment-1332728829.

suricata-verify-pr: 1024
