### PR TITLE
6.0.x backport - ebpf: update deprecated API calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1820,11 +1820,18 @@
             AC_DEFINE([HAVE_PACKET_EBPF],[1],[Recent ebpf fanout support is available]),
             [],
             [[#include <linux/if_packet.h>]])
-        AC_CHECK_LIB(bpf, bpf_set_link_xdp_fd,have_xdp="yes")
+        # Check for XDP specific function.
+        AC_CHECK_LIB(bpf,bpf_xdp_attach,have_xdp="yes")
         if test "$have_xdp" = "yes"; then
             AC_DEFINE([HAVE_PACKET_XDP],[1],[XDP support is available])
+        else
+            # Check for legacy XDP function.
+            AC_CHECK_LIB(bpf,bpf_set_link_xdp_fd,have_xdp="yes")
+            if test "$have_xdp" = "yes"; then
+                AC_DEFINE([HAVE_PACKET_XDP],[1],[XDP support is available])
+            fi
         fi
-        AC_CHECK_FUNCS(bpf_program__section_name)
+        AC_CHECK_FUNCS([bpf_program__section_name bpf_xdp_attach bpf_program__set_type])
     fi;
 
   # Check for DAG support.

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -372,9 +372,19 @@ int EBPFLoadFile(const char *iface, const char *path, const char * section,
 #endif
         if (!strcmp(title, section)) {
             if (config->flags & EBPF_SOCKET_FILTER) {
+#ifdef HAVE_BPF_PROGRAM__SET_TYPE
+                bpf_program__set_type(bpfprog, BPF_PROG_TYPE_SOCKET_FILTER);
+#else
+                /* Fall back to legacy API */
                 bpf_program__set_socket_filter(bpfprog);
+#endif
             } else {
+#ifdef HAVE_BPF_PROGRAM__SET_TYPE
+                bpf_program__set_type(bpfprog, BPF_PROG_TYPE_XDP);
+#else
+                /* Fall back to legacy API */
                 bpf_program__set_xdp(bpfprog);
+#endif
             }
             found = true;
             break;
@@ -488,7 +498,12 @@ int EBPFSetupXDP(const char *iface, int fd, uint8_t flags)
                 "Unknown interface '%s'", iface);
         return -1;
     }
+#ifdef HAVE_BPF_XDP_ATTACH
+    int err = bpf_xdp_attach(ifindex, fd, flags, NULL);
+#else
+    /* Fall back to legacy API */
     int err = bpf_set_link_xdp_fd(ifindex, fd, flags);
+#endif
     if (err != 0) {
         char buf[129];
         libbpf_strerror(err, buf, sizeof(buf));


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Be aware of breaking changes in the libbpf 1.0 API.
- Backport for 6.0.x of #7870. Also see https://forum.suricata.io/t/suricata-6-0-9-no-xdp-support-with-libbpf-1-x/3033.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
