### PR TITLE
fuzz: fix use of uninitialized value

### DIFF
--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -117,11 +117,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     // loop over packets
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header.ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec % 1000000;
+    p->ts.tv_usec = ((header.ts.tv_usec % 1000000) + 1000000) % 1000000;
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -143,12 +143,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = FPC_next(&pkts, &header, &pkt);
-        if (header.ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);
         p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec % 1000000;
+        p->ts.tv_usec = ((header.ts.tv_usec % 1000000) + 1000000) % 1000000;
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -160,11 +160,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     //loop over packets
     r = pcap_next_ex(pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header->ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->ts.tv_sec = header->ts.tv_sec;
-    p->ts.tv_usec = header->ts.tv_usec % 1000000;
+    p->ts.tv_usec = ((header->ts.tv_usec % 1000000) + 1000000) % 1000000;
     p->datalink = pcap_datalink(pkts);
     p->pkt_src = PKT_SRC_WIRE;
     while (r > 0) {
@@ -187,12 +187,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = pcap_next_ex(pkts, &header, &pkt);
-        if (header->ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);
         p->ts.tv_sec = header->ts.tv_sec;
-        p->ts.tv_usec = header->ts.tv_usec % 1000000;
+        p->ts.tv_usec = ((header->ts.tv_usec % 1000000) + 1000000) % 1000000;
         p->datalink = pcap_datalink(pkts);
         p->pkt_src = PKT_SRC_WIRE;
         pcap_cnt++;

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -157,12 +157,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     // loop over packets
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header.ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->pkt_src = PKT_SRC_WIRE;
     p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec % 1000000;
+    // positive C modulo
+    p->ts.tv_usec = ((header.ts.tv_usec % 1000000) + 1000000) % 1000000;
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -184,13 +185,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = FPC_next(&pkts, &header, &pkt);
-        if (header.ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);
         p->pkt_src = PKT_SRC_WIRE;
         p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec % 1000000;
+        p->ts.tv_usec = ((header.ts.tv_usec % 1000000) + 1000000) % 1000000;
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None cf https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54111

Describe changes:
- fuzz targets: fix use of uninitialized value

Replaces #8256 with review taken into account