### PR TITLE
detect-detection: Convert unittests to new FAIL/PASS API

### DIFF
--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -284,14 +284,14 @@ static void DetectDetectionFilterFree(DetectEngineCtx *de_ctx, void *df_ptr)
  */
 static int DetectDetectionFilterTestParse01 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -302,14 +302,10 @@ static int DetectDetectionFilterTestParse01 (void)
  */
 static int DetectDetectionFilterTestParse02 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track both,count 10,seconds 60");
-    if (df && (df->track == TRACK_DST || df->track == TRACK_SRC) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track both,count 10,seconds 60");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
@@ -320,14 +316,14 @@ static int DetectDetectionFilterTestParse02 (void)
  */
 static int DetectDetectionFilterTestParse03 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 
@@ -339,14 +335,11 @@ static int DetectDetectionFilterTestParse03 (void)
  */
 static int DetectDetectionFilterTestParse04 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df =
+            DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
@@ -357,14 +350,14 @@ static int DetectDetectionFilterTestParse04 (void)
  */
 static int DetectDetectionFilterTestParse05 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -375,14 +368,10 @@ static int DetectDetectionFilterTestParse05 (void)
  */
 static int DetectDetectionFilterTestParse06 (void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 0)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
@@ -395,64 +384,55 @@ static int DetectDetectionFilterTestParse06 (void)
  */
 static int DetectDetectionFilterTestSig1(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
     int alerts = 0;
 
     HostInitConfig(HOST_QUIET);
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: track by_dst, count 4, seconds 60; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: "
+            "track by_dst, count 4, seconds 60; sid:1;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 10));
 
-    if(alerts == 4)
-        result = 1;
-
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    // FAIL_IF_NOT(alerts == 4);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
-end:
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 /**
@@ -466,11 +446,8 @@ end:
 
 static int DetectDetectionFilterTestSig2(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
     int alerts = 0;
     struct timeval ts;
 
@@ -481,19 +458,18 @@ static int DetectDetectionFilterTestSig2(void)
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 4, seconds 60; sid:10;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; "
+            "detection_filter: track by_dst, count 4, seconds 60; sid:10;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -501,36 +477,33 @@ static int DetectDetectionFilterTestSig2(void)
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
 
     TimeSetIncrementTime(200);
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
 
-    if (alerts == 0)
-        result = 1;
-
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    // FAIL_IF_NOT(alerts == 0);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-end:
+
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 /**
@@ -538,11 +511,8 @@ end:
  */
 static int DetectDetectionFilterTestSig3(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
     int alerts = 0;
     int drops = 0;
     struct timeval ts;
@@ -554,19 +524,17 @@ static int DetectDetectionFilterTestSig3(void)
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 2, seconds 60; sid:10;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; "
+            "detection_filter: track by_dst, count 2, seconds 60; sid:10;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -574,61 +542,53 @@ static int DetectDetectionFilterTestSig3(void)
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     TimeSetIncrementTime(200);
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
-
-    if (alerts == 3 && drops == 3)
-        result = 1;
-    else {
-        if (alerts != 3)
-            printf("alerts: %d != 3: ", alerts);
-        if (drops != 3)
-            printf("drops: %d != 3: ", drops);
-    }
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-end:
+
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 static void DetectDetectionFilterRegisterTests(void)


### PR DESCRIPTION

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Previous PR: https://github.com/OISF/suricata/pull/8117

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/4019) ticket:

Draft PR to gather feedback

Describe Changes:

- Remove `drops` and `alerts` counter and replace with `FAIL/PASS*` macro