### PR TITLE
exceptions: add exception policy master switch - v1

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -66,10 +66,10 @@ are:
 - ``pass-flow``: disable payload and packet detection; stream reassembly,
   app-layer parsing and logging still happen.
 - ``pass-packet``: disable detection, still does stream updates and app-layer
-  parsing (depeding on which policy triggered it).
+  parsing (depending on which policy triggered it).
 - ``ignore``: do not apply exception policies (default behavior).
 
-The *Drop*, *pass* and *reject* are similar to the rule actions described in :ref:`rule
+The *drop*, *pass* and *reject* are similar to the rule actions described in :ref:`rule
 actions<suricata-yaml-action-order>`.
 
 Command-line Options for Simulating Exceptions

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -16,6 +16,28 @@ simulate failures or errors and understand Suricata behavior under such conditio
 Exception Policies
 ------------------
 
+Master Switch
+~~~~~~~~~~~~~
+
+In IPS mode, the default behavior for all exception policies is to drop packets
+and/or flows. It is possible to disable this default, by setting the exception
+policies "master switch" yaml config option, to ``disabled``:
+
+::
+
+   # Define a common behavior for all exception policies
+   # the default is drop-packet/drop-flow. To fallback to old behavior (setting
+   # each of them individually, or ignoring all), disable it.
+   # Possible values: auto (drop-packet/drop-flow), perfomance (bypass),
+   # disabled
+   exception-policy-master-switch: disabled
+
+This value will be overwritten by specific exception policies whose settings are
+also defined in the yaml file.
+
+Specific settings
+~~~~~~~~~~~~~~~~~
+
 Exception policies are implemented for:
 
 .. list-table:: Exception Policy configuration variables

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -125,6 +125,7 @@
 #include "util-device.h"
 #include "util-dpdk.h"
 #include "util-ebpf.h"
+#include "util-exception-policy.h"
 #include "util-host-os-info.h"
 #include "util-ioctl.h"
 #include "util-landlock.h"
@@ -2677,6 +2678,8 @@ int PostConfLoadedSetup(SCInstance *suri)
     RegisterFlowBypassInfo();
 
     MacSetRegisterFlowStorage();
+
+    setMasterExceptionPolicy();
 
     AppLayerSetup();
 

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -27,6 +27,8 @@
 #include "stream-tcp-reassemble.h"
 #include "action-globals.h"
 
+ExceptionPolicyMasterSwitch g_eps_master_switch = EXCEPTION_POLICY_SWITCH_DEFAULT;
+
 void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason)
 {
     SCLogDebug("start: pcap_cnt %" PRIu64 ", policy %u", p->pcap_cnt, policy);
@@ -73,6 +75,83 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
     SCLogDebug("end");
 }
 
+/* Should I make a separate enum for this? With a separate function?
+   This seems to make sense in my head right now, as then things would be more logically containted,
+   and then I could call the master-switch function from within the ExceptionPolicyParse function...
+ */
+
+void setMasterExceptionPolicy()
+{
+    const char *switch_str = NULL;
+    if (EngineModeIsIPS()) {
+        g_eps_master_switch = EXCEPTION_POLICY_SWITCH_DEFAULT;
+        if (ConfGet("exception-policy-master-switch", &switch_str) == 1 && switch_str != NULL) {
+            if (strcmp(switch_str, "auto") == 0) {
+                SCLogConfig("Exception Policies set to 'drop-packet/drop-flow' via "
+                            "master switch: 'auto' mode");
+                g_eps_master_switch = EXCEPTION_POLICY_SWITCH_DEFAULT;
+            } else if (strcmp(switch_str, "performance") == 0) {
+                SCLogConfig("Exception Policies set to 'bypass-flow' via master switch: "
+                            "'performance' mode");
+                g_eps_master_switch = EXCEPTION_POLICY_SWITCH_PERFORMANCE;
+            } else if (strcmp(switch_str, "disabled") == 0) {
+                SCLogConfig("master switch for exception policies is disabled, "
+                            "exception policies should be configured individually.");
+                g_eps_master_switch = EXCEPTION_POLICY_SWITCH_DISABLED;
+            } else {
+                FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                        "\"%s\" is not a valid master switch value for the exception policy."
+                        " Valid options are auto, performance or disabled.",
+                        switch_str);
+            }
+        } else {
+            /* not enabled, we won't change the master exception policy,
+             for now */
+            SCLogWarning(SC_ERR_CONF_YAML_ERROR,
+                    "exception-policy-master-switch value not set, so ignoring it."
+                    " This behavior will change in Suricata 8, so please update your"
+                    " config. See ticket #5219 for more details.");
+            g_eps_master_switch = EXCEPTION_POLICY_SWITCH_DISABLED;
+        }
+    }
+}
+
+/** brief Set a master Exception Policy, if one has been defined
+ *
+ *  \retval true if the master Exception Policy has been set
+ *  \retval false if the master switch is disabled and no policy was set
+ */
+static bool getMasterExceptionPolicy(const char *option, enum ExceptionPolicy *policy)
+{
+    bool is_master_policy = true;
+    if (EngineModeIsIPS()) {
+        switch (g_eps_master_switch) {
+            case EXCEPTION_POLICY_SWITCH_DEFAULT:
+                SCLogConfig("%s set to 'drop-packet/drop-flow' via master"
+                            "switch: 'auto' mode",
+                        option);
+                *policy = EXCEPTION_POLICY_DROP_FLOW;
+                is_master_policy = true;
+                break;
+            case EXCEPTION_POLICY_SWITCH_PERFORMANCE:
+                SCLogConfig("%s set to 'bypass-flow' via master switch: "
+                            "'performance' mode",
+                        option);
+                *policy = EXCEPTION_POLICY_BYPASS_FLOW;
+                is_master_policy = true;
+                break;
+            case EXCEPTION_POLICY_SWITCH_DISABLED:
+                is_master_policy = false;
+                break;
+            default:
+                is_master_policy = false;
+        }
+    } else {
+        is_master_policy = false;
+    }
+    return is_master_policy;
+}
+
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow)
 {
     enum ExceptionPolicy policy = EXCEPTION_POLICY_IGNORE;
@@ -116,7 +195,17 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support
         }
 
     } else {
-        SCLogConfig("%s: ignore", option);
+        /* Exception Policy was not defined individually */
+        enum ExceptionPolicy master_policy;
+        bool hasMasterPolicy = getMasterExceptionPolicy(option, &master_policy);
+        if (!hasMasterPolicy) {
+            SCLogConfig("%s: ignore", option);
+        } else {
+            /* If the master switch was set and the Exception Policy option was not
+            individually set, use the defined master Exception Policy */
+            SCLogConfig("%s: defined via Exception Policy master switch", option);
+            policy = master_policy;
+        }
     }
     return policy;
 }

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -34,10 +34,18 @@ enum ExceptionPolicy {
     EXCEPTION_POLICY_REJECT,
 };
 
+typedef enum ExceptionPolicyMasterSwitch_ {
+    EXCEPTION_POLICY_SWITCH_DISABLED = 0,
+    EXCEPTION_POLICY_SWITCH_DEFAULT,
+    EXCEPTION_POLICY_SWITCH_PERFORMANCE,
+} ExceptionPolicyMasterSwitch;
+
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);
+void setMasterExceptionPolicy(void);
 
+extern ExceptionPolicyMasterSwitch g_eps_master_switch;
 #ifdef DEBUG
 extern uint64_t g_eps_applayer_error_offset_ts;
 extern uint64_t g_eps_applayer_error_offset_tc;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1272,6 +1272,15 @@ legacy:
 # packet. Default is 15
 #packet-alert-max: 15
 
+# IPS Mode - Exception Policies
+#
+# Define a common behavior for all exception policies
+# the default is drop-packet/drop-flow. To fallback to old behavior (setting
+# each of them individually, or ignoring all), set this to false.
+# Possible values: auto (drop-packet/drop-flow), perfomance (bypass), disabled
+# (do not use the master switch)
+exception-policy-master-switch: auto
+
 # IP Reputation
 #reputation-categories-file: @e_sysconfdir@iprep/categories.txt
 #default-reputation-path: @e_sysconfdir@iprep


### PR DESCRIPTION

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5219

Describe changes:
- add a master switch for the exception policies, allowing one to set a single policy to all traffic exceptions
- document said feature
- add note about that in the upgrading section

The current behavior considers that the default behavior for 7 will still be to have this disabled as built-in, but enabled via config file.

Jason has argued in the ticket that we might as well introduce this as a breaking change from 7, already, and just document it. This PR is also to gather feedback on the current approach, in case we want to switch for the directly breaking one.

suricata-verify-pr: 1036
https://github.com/OISF/suricata-verify/pull/1036