### PR TITLE
radix: fix ipv6 address parsing warning

### DIFF
--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -1078,14 +1078,19 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
     }
 
     if (netmask != 128) {
-        struct in6_addr mask6;
+        struct in6_addr mask6, check;
         CIDRGetIPv6(netmask, &mask6);
+        memcpy(&check, &addr, sizeof(check));
+        bool diff = false;
         for (int i = 0; i < 16; i++) {
             addr.s6_addr[i] &= mask6.s6_addr[i];
+            diff |= (addr.s6_addr[i] != check.s6_addr[i]);
         }
-        char nstr[64];
-        PrintInet(AF_INET6, (void *)&addr.s6_addr, nstr, sizeof(nstr));
-        SCLogWarning(SC_ERR_INVALID_IP_NETBLOCK, "adding '%s' as '%s/%u'", str, nstr, netmask);
+        if (diff) {
+            char nstr[64];
+            PrintInet(AF_INET6, (void *)&addr.s6_addr, nstr, sizeof(nstr));
+            SCLogWarning(SC_ERR_INVALID_IP_NETBLOCK, "adding '%s' as '%s/%u'", str, nstr, netmask);
+        }
 #if defined(DEBUG_VALIDATION) || defined(UNITTESTS)
         SCRadixValidateIPv6Key((uint8_t *)&addr.s6_addr, netmask);
 #endif


### PR DESCRIPTION
The check meant to see if the ip address part of the ip/cidr combo was more specific than needed wasn't fully implemented, leading to warnings being issued on completely valid and correct input.

This patch implements the same logic as in IPv4. If the ip address as specified is different from the ip after the mask has been applied, a warning is displayed.

Bug: #5747.
(cherry picked from commit 991f9fde3292d45eefcfe9e01ef8480e5864977b)
