### PR TITLE
devguide/install: add note about ubuntu version - v1

### DIFF
--- a/doc/userguide/devguide/codebase/installation-from-git.rst
+++ b/doc/userguide/devguide/codebase/installation-from-git.rst
@@ -10,6 +10,10 @@ basically the same, except that some commands are Ubuntu-specific
 (like sudo and apt-get). In case you are using another operating system,
 you should replace those commands with your OS-specific commands.
 
+.. note::
+
+   These instructions were tested on Ubuntu 22.04.
+
 Pre-installation requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
We want to make it clear with which system the instructions for installing from were tested with.

Addressing https://github.com/OISF/suricata/pull/8172#issuecomment-1342909401