### PR TITLE
exceptions: add exception policy master switch - v2.1

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -66,10 +66,10 @@ are:
 - ``pass-flow``: disable payload and packet detection; stream reassembly,
   app-layer parsing and logging still happen.
 - ``pass-packet``: disable detection, still does stream updates and app-layer
-  parsing (depeding on which policy triggered it).
+  parsing (depending on which policy triggered it).
 - ``ignore``: do not apply exception policies (default behavior).
 
-The *Drop*, *pass* and *reject* are similar to the rule actions described in :ref:`rule
+The *drop*, *pass* and *reject* are similar to the rule actions described in :ref:`rule
 actions<suricata-yaml-action-order>`.
 
 Command-line Options for Simulating Exceptions

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -16,6 +16,37 @@ simulate failures or errors and understand Suricata behavior under such conditio
 Exception Policies
 ------------------
 
+.. _master-switch:
+
+Master Switch
+~~~~~~~~~~~~~
+
+It is possible to set all configuration policies via what we call "master
+switch". This offers a quick way to define what the engine should do, in case of
+traffic exceptions, while still allowing for the flexibility of indicating a
+different behavior for specific exception policies your setup/environment may
+have the need to.
+
+In IPS mode, the default behavior for all exception policies is to drop packets
+and/or flows. It is possible to disable this default, by setting the exception
+policies "master switch" yaml config option, to ``disabled``:
+
+::
+
+   # In IPS mode, the default is drop-packet/drop-flow. To fallback to old behavior
+   # (setting each of them individually, or ignoring all), set this to disabled.
+   # All values available for exception policies can be used, and there are extra
+   # handles: auto (drop-packet/drop-flow), perfomance (bypass), disabled (do not
+   # use the master switch).
+   # Exception policy values are: drop-packet, drop-flow, reject, bypass,
+   # pass-packet, pass-flow, ignore (disable)
+
+This value will be overwritten by specific exception policies whose settings are
+also defined in the yaml file.
+
+Specific settings
+~~~~~~~~~~~~~~~~~
+
 Exception policies are implemented for:
 
 .. list-table:: Exception Policy configuration variables

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -36,6 +36,11 @@ Upgrading 6.0 to 7.0
 Major changes
 ~~~~~~~~~~~~~
 - Upgrade of PCRE1 to PCRE2. See :ref:`pcre-update-v1-to-v2` for more details.
+- Introducing the :ref:`Exception Policy's Master Switch <master-switch>`. This
+  allows to setup a single policy for all traffic exceptions. This is a breaking
+  change for the default behavior in the Exception Policies: in IPS mode, if an
+  exception policy is not set, it will fall back to the the master switch now,
+  instead of being ignored. Prevent this by disabling the master switch.
 
 Security changes
 ~~~~~~~~~~~~~~~~

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -156,7 +156,7 @@ struct AppLayerParserState_ {
     FramesContainer *frames;
 };
 
-enum ExceptionPolicy g_applayerparser_error_policy = EXCEPTION_POLICY_IGNORE;
+enum ExceptionPolicy g_applayerparser_error_policy = EXCEPTION_POLICY_NOT_SET;
 
 static void AppLayerConfg(void)
 {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -946,7 +946,7 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
             SCLogDebug("Midstream not enabled, so won't pick up a session");
             return 0;
         }
-        if (!(stream_config.midstream_policy == EXCEPTION_POLICY_IGNORE ||
+        if (!(stream_config.midstream_policy == EXCEPTION_POLICY_NOT_SET ||
                     stream_config.midstream_policy == EXCEPTION_POLICY_PASS_FLOW ||
                     stream_config.midstream_policy == EXCEPTION_POLICY_PASS_PACKET)) {
             SCLogDebug("Midstream policy not permissive, so won't pick up a session");
@@ -1119,7 +1119,7 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
             SCLogDebug("Midstream not enabled, so won't pick up a session");
             return 0;
         }
-        if (!(stream_config.midstream_policy == EXCEPTION_POLICY_IGNORE ||
+        if (!(stream_config.midstream_policy == EXCEPTION_POLICY_NOT_SET ||
                     stream_config.midstream_policy == EXCEPTION_POLICY_PASS_FLOW ||
                     stream_config.midstream_policy == EXCEPTION_POLICY_PASS_PACKET)) {
             SCLogDebug("Midstream policy not permissive, so won't pick up a session");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -125,6 +125,7 @@
 #include "util-device.h"
 #include "util-dpdk.h"
 #include "util-ebpf.h"
+#include "util-exception-policy.h"
 #include "util-host-os-info.h"
 #include "util-ioctl.h"
 #include "util-landlock.h"
@@ -2677,6 +2678,8 @@ int PostConfLoadedSetup(SCInstance *suri)
     RegisterFlowBypassInfo();
 
     MacSetRegisterFlowStorage();
+
+    SetMasterExceptionPolicy();
 
     AppLayerSetup();
 

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -81,6 +81,15 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
                 DecodeSetNoPacketInspectionFlag(p);
                 break;
         }
+    } else if (g_eps_master_switch == EXCEPTION_POLICY_BYPASS_FLOW) {
+        PacketBypassCallback(p);
+        SCLogDebug("EXCEPTION_POLICY_PASS_FLOW");
+        if (p->flow) {
+            p->flow->flags |= FLOW_ACTION_PASS;
+            FlowSetNoPacketInspectionFlag(p->flow); // TODO util func
+        }
+        DecodeSetNoPayloadInspectionFlag(p);
+        DecodeSetNoPacketInspectionFlag(p);
     }
     SCLogDebug("end");
 }

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -25,7 +25,7 @@
 #include "decode.h"
 
 enum ExceptionPolicy {
-    EXCEPTION_POLICY_IGNORE = 0,
+    EXCEPTION_POLICY_NOT_SET = 0,
     EXCEPTION_POLICY_PASS_PACKET,
     EXCEPTION_POLICY_PASS_FLOW,
     EXCEPTION_POLICY_BYPASS_FLOW,
@@ -34,10 +34,12 @@ enum ExceptionPolicy {
     EXCEPTION_POLICY_REJECT,
 };
 
+void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);
 
+extern enum ExceptionPolicy g_eps_master_switch;
 #ifdef DEBUG
 extern uint64_t g_eps_applayer_error_offset_ts;
 extern uint64_t g_eps_applayer_error_offset_tc;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1272,6 +1272,18 @@ legacy:
 # packet. Default is 15
 #packet-alert-max: 15
 
+# Exception Policies
+#
+# Define a common behavior for all exception policies.
+# In IPS mode, the default is drop-packet/drop-flow. To fallback to old behavior
+# (setting each of them individually, or ignoring all), set this to disabled.
+# All values available for exception policies can be used, and there are extra
+# handles: auto (drop-packet/drop-flow), perfomance (bypass), disabled (do not
+# use the master switch).
+# Exception policy values are: drop-packet, drop-flow, reject, bypass,
+# pass-packet, pass-flow, ignore (disable).
+exception-policy: auto
+
 # IP Reputation
 #reputation-categories-file: @e_sysconfdir@iprep/categories.txt
 #default-reputation-path: @e_sysconfdir@iprep


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: 5219

Previous PR: #8266 

Changes from previous PR:
- use the same Exception Policies enum for the master switch
- simplify the config set name to ``exception-policy``
- accept all exception policy values, in addition to "auto", "performance" and "disabled"
- simplify how the master switch is processed
- accept performance policy for IDS mode as well

suricata-verify-pr: 1037
https://github.com/OISF/suricata-verify/pull/1037
