### PR TITLE
detect-detection: Convert unittests to new FAIL/PASS API

### DIFF
--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -1,19 +1,19 @@
 /* Copyright (C) 2007-2020 Open Information Security Foundation
-  *
-  * You can copy, redistribute or modify this Program under the terms of
-  * the GNU General Public License version 2 as published by the Free
-  * Software Foundation.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * version 2 along with this program; if not, write to the Free Software
-  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-  * 02110-1301, USA.
-  */
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
 
 /**
  * \file
@@ -40,18 +40,20 @@
 #include "util-debug.h"
 #include "detect-engine-build.h"
 
-#define TRACK_DST      1
-#define TRACK_SRC      2
+#define TRACK_DST 1
+#define TRACK_SRC 2
 
 /**
  *\brief Regex for parsing our detection_filter options
  */
-#define PARSE_REGEX "^\\s*(track|count|seconds)\\s+(by_src|by_dst|\\d+)\\s*,\\s*(track|count|seconds)\\s+(by_src|by_dst|\\d+)\\s*,\\s*(track|count|seconds)\\s+(by_src|by_dst|\\d+)\\s*$"
+#define PARSE_REGEX                                                                                \
+    "^\\s*(track|count|seconds)\\s+(by_src|by_dst|\\d+)\\s*,\\s*(track|count|seconds)\\s+(by_src|" \
+    "by_dst|\\d+)\\s*,\\s*(track|count|seconds)\\s+(by_src|by_dst|\\d+)\\s*$"
 
 static DetectParseRegex parse_regex;
 
-static int DetectDetectionFilterMatch(DetectEngineThreadCtx *,
-        Packet *, const Signature *, const SigMatchCtx *);
+static int DetectDetectionFilterMatch(
+        DetectEngineThreadCtx *, Packet *, const Signature *, const SigMatchCtx *);
 static int DetectDetectionFilterSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectDetectionFilterRegisterTests(void);
@@ -61,10 +63,11 @@ static void DetectDetectionFilterFree(DetectEngineCtx *, void *);
 /**
  * \brief Registration function for detection_filter: keyword
  */
-void DetectDetectionFilterRegister (void)
+void DetectDetectionFilterRegister(void)
 {
     sigmatch_table[DETECT_DETECTION_FILTER].name = "detection_filter";
-    sigmatch_table[DETECT_DETECTION_FILTER].desc = "alert on every match after a threshold has been reached";
+    sigmatch_table[DETECT_DETECTION_FILTER].desc =
+            "alert on every match after a threshold has been reached";
     sigmatch_table[DETECT_DETECTION_FILTER].url = "/rules/thresholding.html#detection-filter";
     sigmatch_table[DETECT_DETECTION_FILTER].Match = DetectDetectionFilterMatch;
     sigmatch_table[DETECT_DETECTION_FILTER].Setup = DetectDetectionFilterSetup;
@@ -78,28 +81,29 @@ void DetectDetectionFilterRegister (void)
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
-static int DetectDetectionFilterMatch (DetectEngineThreadCtx *det_ctx,
-        Packet *p, const Signature *s, const SigMatchCtx *ctx)
+static int DetectDetectionFilterMatch(
+        DetectEngineThreadCtx *det_ctx, Packet *p, const Signature *s, const SigMatchCtx *ctx)
 {
     return 1;
 }
 
 /**
  * \internal
- * \brief This function is used to parse detection_filter options passed via detection_filter: keyword
+ * \brief This function is used to parse detection_filter options passed via detection_filter:
+ * keyword
  *
  * \param rawstr Pointer to the user provided detection_filter options
  *
  * \retval df pointer to DetectThresholdData on success
  * \retval NULL on failure
  */
-static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
+static DetectThresholdData *DetectDetectionFilterParse(const char *rawstr)
 {
     DetectThresholdData *df = NULL;
     int ret = 0, res = 0;
     size_t pcre2_len;
     const char *str_ptr = NULL;
-    char *args[6] = { NULL, NULL, NULL, NULL, NULL, NULL};
+    char *args[6] = { NULL, NULL, NULL, NULL, NULL, NULL };
     char *copy_str = NULL, *df_opt = NULL;
     int seconds_found = 0, count_found = 0, track_found = 0;
     int seconds_pos = 0, count_pos = 0;
@@ -112,15 +116,14 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
         goto error;
     }
 
-    for (pos = 0, df_opt = strtok_r(copy_str,",", &saveptr);
-         pos < strlen(copy_str) && df_opt != NULL;
-         pos++, df_opt = strtok_r(NULL,",", &saveptr))
-    {
-        if(strstr(df_opt,"count"))
+    for (pos = 0, df_opt = strtok_r(copy_str, ",", &saveptr);
+            pos < strlen(copy_str) && df_opt != NULL;
+            pos++, df_opt = strtok_r(NULL, ",", &saveptr)) {
+        if (strstr(df_opt, "count"))
             count_found++;
-        if(strstr(df_opt,"second"))
+        if (strstr(df_opt, "second"))
             seconds_found++;
-        if(strstr(df_opt,"track"))
+        if (strstr(df_opt, "track"))
             track_found++;
     }
     SCFree(copy_str);
@@ -131,7 +134,8 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
 
     ret = DetectParsePcreExec(&parse_regex, rawstr, 0, 0);
     if (ret < 5) {
-        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, rawstr);
+        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret,
+                rawstr);
         goto error;
     }
 
@@ -139,7 +143,7 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
     if (unlikely(df == NULL))
         goto error;
 
-    memset(df,0,sizeof(DetectThresholdData));
+    memset(df, 0, sizeof(DetectThresholdData));
 
     df->type = TYPE_DETECTION;
 
@@ -153,27 +157,25 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
 
         args[i] = (char *)str_ptr;
 
-        if (strncasecmp(args[i],"by_dst",strlen("by_dst")) == 0)
+        if (strncasecmp(args[i], "by_dst", strlen("by_dst")) == 0)
             df->track = TRACK_DST;
-        if (strncasecmp(args[i],"by_src",strlen("by_src")) == 0)
+        if (strncasecmp(args[i], "by_src", strlen("by_src")) == 0)
             df->track = TRACK_SRC;
-        if (strncasecmp(args[i],"count",strlen("count")) == 0)
-            count_pos = i+1;
-        if (strncasecmp(args[i],"seconds",strlen("seconds")) == 0)
-            seconds_pos = i+1;
+        if (strncasecmp(args[i], "count", strlen("count")) == 0)
+            count_pos = i + 1;
+        if (strncasecmp(args[i], "seconds", strlen("seconds")) == 0)
+            seconds_pos = i + 1;
     }
 
     if (args[count_pos] == NULL || args[seconds_pos] == NULL) {
         goto error;
     }
 
-    if (StringParseUint32(&df->count, 10, strlen(args[count_pos]),
-                args[count_pos]) <= 0) {
+    if (StringParseUint32(&df->count, 10, strlen(args[count_pos]), args[count_pos]) <= 0) {
         goto error;
     }
 
-    if (StringParseUint32(&df->seconds, 10, strlen(args[seconds_pos]),
-                args[seconds_pos]) <= 0) {
+    if (StringParseUint32(&df->seconds, 10, strlen(args[seconds_pos]), args[seconds_pos]) <= 0) {
         goto error;
     }
 
@@ -182,14 +184,14 @@ static DetectThresholdData *DetectDetectionFilterParse (const char *rawstr)
         goto error;
     }
 
-    for (i = 0; i < 6; i++){
+    for (i = 0; i < 6; i++) {
         if (args[i] != NULL)
             pcre2_substring_free((PCRE2_UCHAR *)args[i]);
     }
     return df;
 
 error:
-    for (i = 0; i < 6; i++){
+    for (i = 0; i < 6; i++) {
         if (args[i] != NULL)
             pcre2_substring_free((PCRE2_UCHAR *)args[i]);
     }
@@ -210,7 +212,7 @@ error:
  * \retval 0 on Success
  * \retval -1 on Failure
  */
-static int DetectDetectionFilterSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
+static int DetectDetectionFilterSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     SCEnter();
     DetectThresholdData *df = NULL;
@@ -220,13 +222,15 @@ static int DetectDetectionFilterSetup (DetectEngineCtx *de_ctx, Signature *s, co
     /* checks if there's a previous instance of threshold */
     tmpm = DetectGetLastSMFromLists(s, DETECT_THRESHOLD, -1);
     if (tmpm != NULL) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "\"detection_filter\" and \"threshold\" are not allowed in the same rule");
+        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                "\"detection_filter\" and \"threshold\" are not allowed in the same rule");
         SCReturnInt(-1);
     }
     /* checks there's no previous instance of detection_filter */
     tmpm = DetectGetLastSMFromLists(s, DETECT_DETECTION_FILTER, -1);
     if (tmpm != NULL) {
-        SCLogError(SC_ERR_INVALID_SIGNATURE, "At most one \"detection_filter\" is allowed per rule");
+        SCLogError(
+                SC_ERR_INVALID_SIGNATURE, "At most one \"detection_filter\" is allowed per rule");
         SCReturnInt(-1);
     }
 
@@ -282,7 +286,7 @@ static void DetectDetectionFilterFree(DetectEngineCtx *de_ctx, void *df_ptr)
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse01 (void)
+static int DetectDetectionFilterTestParse01(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
@@ -300,7 +304,7 @@ static int DetectDetectionFilterTestParse01 (void)
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse02 (void)
+static int DetectDetectionFilterTestParse02(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track both,count 10,seconds 60");
@@ -313,12 +317,13 @@ static int DetectDetectionFilterTestParse02 (void)
 }
 
 /**
- * \test DetectDetectionfilterTestParse03 is a test for a valid detection_filter options in any order
+ * \test DetectDetectionfilterTestParse03 is a test for a valid detection_filter options in any
+ * order
  *
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse03 (void)
+static int DetectDetectionFilterTestParse03(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
@@ -330,14 +335,14 @@ static int DetectDetectionFilterTestParse03 (void)
     return 0;
 }
 
-
 /**
- * \test DetectDetectionFilterTestParse04 is a test for an invalid detection_filter options in any order
+ * \test DetectDetectionFilterTestParse04 is a test for an invalid detection_filter options in any
+ * order
  *
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse04 (void)
+static int DetectDetectionFilterTestParse04(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
@@ -350,12 +355,13 @@ static int DetectDetectionFilterTestParse04 (void)
 }
 
 /**
- * \test DetectDetectionFilterTestParse05 is a test for a valid detection_filter options in any order
+ * \test DetectDetectionFilterTestParse05 is a test for a valid detection_filter options in any
+ * order
  *
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse05 (void)
+static int DetectDetectionFilterTestParse05(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
@@ -373,7 +379,7 @@ static int DetectDetectionFilterTestParse05 (void)
  *  \retval 1 on succces
  *  \retval 0 on failure
  */
-static int DetectDetectionFilterTestParse06 (void)
+static int DetectDetectionFilterTestParse06(void)
 {
     DetectThresholdData *df = NULL;
     df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
@@ -386,9 +392,9 @@ static int DetectDetectionFilterTestParse06 (void)
 }
 
 /**
- * \test DetectDetectionFilterTestSig1 is a test for checking the working of detection_filter keyword
- *       by setting up the signature and later testing its working by matching
- *       the received packet against the sig.
+ * \test DetectDetectionFilterTestSig1 is a test for checking the working of detection_filter
+ * keyword by setting up the signature and later testing its working by matching the received packet
+ * against the sig.
  *
  *  \retval 1 on succces
  *  \retval 0 on failure
@@ -456,9 +462,9 @@ end:
 }
 
 /**
- * \test DetectDetectionFilterTestSig2 is a test for checking the working of detection_filter keyword
- *       by setting up the signature and later testing its working by matching
- *       the received packet against the sig.
+ * \test DetectDetectionFilterTestSig2 is a test for checking the working of detection_filter
+ * keyword by setting up the signature and later testing its working by matching the received packet
+ * against the sig.
  *
  *  \retval 1 on succces
  *  \retval 0 on failure
@@ -476,7 +482,7 @@ static int DetectDetectionFilterTestSig2(void)
 
     HostInitConfig(HOST_QUIET);
 
-    memset (&ts, 0, sizeof(struct timeval));
+    memset(&ts, 0, sizeof(struct timeval));
     TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
@@ -549,7 +555,7 @@ static int DetectDetectionFilterTestSig3(void)
 
     HostInitConfig(HOST_QUIET);
 
-    memset (&ts, 0, sizeof(struct timeval));
+    memset(&ts, 0, sizeof(struct timeval));
     TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
@@ -633,23 +639,14 @@ end:
 
 static void DetectDetectionFilterRegisterTests(void)
 {
-    UtRegisterTest("DetectDetectionFilterTestParse01",
-                   DetectDetectionFilterTestParse01);
-    UtRegisterTest("DetectDetectionFilterTestParse02",
-                   DetectDetectionFilterTestParse02);
-    UtRegisterTest("DetectDetectionFilterTestParse03",
-                   DetectDetectionFilterTestParse03);
-    UtRegisterTest("DetectDetectionFilterTestParse04",
-                   DetectDetectionFilterTestParse04);
-    UtRegisterTest("DetectDetectionFilterTestParse05",
-                   DetectDetectionFilterTestParse05);
-    UtRegisterTest("DetectDetectionFilterTestParse06",
-                   DetectDetectionFilterTestParse06);
-    UtRegisterTest("DetectDetectionFilterTestSig1",
-                   DetectDetectionFilterTestSig1);
-    UtRegisterTest("DetectDetectionFilterTestSig2",
-                   DetectDetectionFilterTestSig2);
-    UtRegisterTest("DetectDetectionFilterTestSig3",
-                   DetectDetectionFilterTestSig3);
+    UtRegisterTest("DetectDetectionFilterTestParse01", DetectDetectionFilterTestParse01);
+    UtRegisterTest("DetectDetectionFilterTestParse02", DetectDetectionFilterTestParse02);
+    UtRegisterTest("DetectDetectionFilterTestParse03", DetectDetectionFilterTestParse03);
+    UtRegisterTest("DetectDetectionFilterTestParse04", DetectDetectionFilterTestParse04);
+    UtRegisterTest("DetectDetectionFilterTestParse05", DetectDetectionFilterTestParse05);
+    UtRegisterTest("DetectDetectionFilterTestParse06", DetectDetectionFilterTestParse06);
+    UtRegisterTest("DetectDetectionFilterTestSig1", DetectDetectionFilterTestSig1);
+    UtRegisterTest("DetectDetectionFilterTestSig2", DetectDetectionFilterTestSig2);
+    UtRegisterTest("DetectDetectionFilterTestSig3", DetectDetectionFilterTestSig3);
 }
 #endif /* UNITTESTS */

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -283,112 +283,89 @@ static void DetectDetectionFilterFree(DetectEngineCtx *de_ctx, void *df_ptr)
 /**
  * \test DetectDetectionFilterTestParse01 is a test for a valid detection_filter options
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse01(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track by_dst,count 10,seconds 60");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 /**
  * \test DetectDetectionFilterTestParse02 is a test for a invalid detection_filter options
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse02(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track both,count 10,seconds 60");
-    if (df && (df->track == TRACK_DST || df->track == TRACK_SRC) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track both,count 10,seconds 60");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
  * \test DetectDetectionfilterTestParse03 is a test for a valid detection_filter options in any
  * order
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse03(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("track by_dst, seconds 60, count 10");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 /**
  * \test DetectDetectionFilterTestParse04 is a test for an invalid detection_filter options in any
  * order
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse04(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df =
+            DetectDetectionFilterParse("count 10, track by_dst, seconds 60, count 10");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
  * \test DetectDetectionFilterTestParse05 is a test for a valid detection_filter options in any
  * order
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse05(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 60)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 1;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("count 10, track by_dst, seconds 60");
+    FAIL_IF_NULL(df);
+    FAIL_IF_NOT(df->track == TRACK_DST);
+    FAIL_IF_NOT(df->count == 10);
+    FAIL_IF_NOT(df->seconds == 60);
+    DetectDetectionFilterFree(NULL, df);
 
-    return 0;
+    PASS;
 }
 
 /**
  * \test DetectDetectionFilterTestParse06 is a test for an invalid value in detection_filter
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestParse06(void)
 {
-    DetectThresholdData *df = NULL;
-    df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
-    if (df && (df->track == TRACK_DST) && (df->count == 10) && (df->seconds == 0)) {
-        DetectDetectionFilterFree(NULL, df);
-        return 0;
-    }
+    DetectThresholdData *df = DetectDetectionFilterParse("count 10, track by_dst, seconds 0");
+    FAIL_IF_NOT_NULL(df);
 
-    return 1;
+    PASS;
 }
 
 /**
@@ -396,69 +373,55 @@ static int DetectDetectionFilterTestParse06(void)
  * keyword by setting up the signature and later testing its working by matching the received packet
  * against the sig.
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 static int DetectDetectionFilterTestSig1(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
-    int alerts = 0;
 
     HostInitConfig(HOST_QUIET);
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: track by_dst, count 4, seconds 60; sid:1;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: "
+            "track by_dst, count 4, seconds 60; sid:1;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF_NOT(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF_NOT(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
+    FAIL_IF_NOT(PacketAlertCheck(p, 1));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 1);
-
-    if(alerts == 4)
-        result = 1;
-
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    FAIL_IF_NOT(PacketAlertCheck(p, 1));
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
-end:
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 /**
@@ -466,18 +429,12 @@ end:
  * keyword by setting up the signature and later testing its working by matching the received packet
  * against the sig.
  *
- *  \retval 1 on succces
- *  \retval 0 on failure
  */
 
 static int DetectDetectionFilterTestSig2(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
-    int alerts = 0;
     struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
@@ -487,19 +444,18 @@ static int DetectDetectionFilterTestSig2(void)
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 4, seconds 60; sid:10;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; "
+            "detection_filter: track by_dst, count 4, seconds 60; sid:10;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -507,36 +463,31 @@ static int DetectDetectionFilterTestSig2(void)
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
 
     TimeSetIncrementTime(200);
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
+    FAIL_IF(PacketAlertCheck(p, 10));
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-
-    if (alerts == 0)
-        result = 1;
-
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
+    FAIL_IF(PacketAlertCheck(p, 10));
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-end:
+
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 /**
@@ -544,13 +495,8 @@ end:
  */
 static int DetectDetectionFilterTestSig3(void)
 {
-    Packet *p = NULL;
-    Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    int result = 0;
-    int alerts = 0;
-    int drops = 0;
     struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
@@ -560,19 +506,17 @@ static int DetectDetectionFilterTestSig3(void)
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
+    Packet *p = UTHBuildPacketReal(NULL, 0, IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 2, seconds 60; sid:10;)");
-    if (s == NULL) {
-        goto end;
-    }
+    Signature *s = DetectEngineAppendSig(de_ctx,
+            "drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; "
+            "detection_filter: track by_dst, count 2, seconds 60; sid:10;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -580,61 +524,50 @@ static int DetectDetectionFilterTestSig3(void)
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts = PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     TimeSetIncrementTime(200);
     TimeGet(&p->ts);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF(PacketAlertCheck(p, 10));
+    FAIL_IF(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    alerts += PacketAlertCheck(p, 10);
-    drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
+    FAIL_IF_NOT(PacketAlertCheck(p, 10));
+    FAIL_IF_NOT(PacketTestAction(p, ACTION_DROP));
     p->action = 0;
-
-    if (alerts == 3 && drops == 3)
-        result = 1;
-    else {
-        if (alerts != 3)
-            printf("alerts: %d != 3: ", alerts);
-        if (drops != 3)
-            printf("drops: %d != 3: ", drops);
-    }
-
-    SigGroupCleanup(de_ctx);
-    SigCleanSignatures(de_ctx);
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-end:
+
     UTHFreePackets(&p, 1);
     HostShutdown();
-    return result;
+
+    PASS;
 }
 
 static void DetectDetectionFilterRegisterTests(void)


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5741) ticket:

Previous PR: https://github.com/OISF/suricata/pull/8278

Describe changes:

- Remove accidental comments
- Remove `retval` from the test function documentation block.