### PR TITLE
Feature: extract message body for smtp protocol

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -358,6 +358,10 @@ static void SMTPConfigure(void) {
         if (ret) {
             smtp_config.mime_config.body_md5 = val;
         }
+        ret = ConfGetChildValueBool(config, "body", &val);
+        if (ret) {
+            smtp_config.mime_config.body = val;
+        }
     }
 
     /* Pass mime config data to MimeDec API */
@@ -619,6 +623,13 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
         }
     } else {
         SCLogDebug("Body not a Ctnt_attachment");
+        if (MimeDecGetConfig()->body) {
+            if(state->body_len+len<=SMTP_MAX_BODY_SIZE){
+                memcpy(state->body+state->body_len,chunk,len);
+                state->body_len+=len;
+            }
+        }
+   
     }
     SCReturnInt(ret);
 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -358,7 +358,7 @@ static void SMTPConfigure(void) {
         if (ret) {
             smtp_config.mime_config.body_md5 = val;
         }
-	    ret = ConfGetChildValueBool(config, "body", &val);
+        ret = ConfGetChildValueBool(config, "body", &val);
         if (ret) {
             smtp_config.mime_config.body = val;
         }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -624,14 +624,14 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
         }
     } else if (entity->ctnt_flags & CTNT_IS_BODYPART && ( entity->ctnt_flags & CTNT_IS_TEXT ||  entity->ctnt_flags & CTNT_IS_HTML)) {
         if (MimeDecGetConfig()->body) {
-            if( len>= DATA_CHUNK_SIZE) {
+            if (len >= DATA_CHUNK_SIZE) {
                 memcpy(state->body,chunk,DATA_CHUNK_SIZE-1);
                 state->body_len = DATA_CHUNK_SIZE;
             } else {
                 memcpy(state->body,chunk,len);
                 state->body_len = len;
             }
-            state->body[DATA_CHUNK_SIZE-1] = 0;
+            state->body[DATA_CHUNK_SIZE - 1] = 0;
         }
         
     } else {

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -625,7 +625,6 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
     } else if (entity->ctnt_flags & CTNT_IS_BODYPART && ( entity->ctnt_flags & CTNT_IS_TEXT ||  entity->ctnt_flags & CTNT_IS_HTML)) {
         if (MimeDecGetConfig()->body) {
             if( len>= DATA_CHUNK_SIZE) {
-                SCLogDebug("[SMTPProcessDataChunk] len[%d] is more then 3072",len);
                 memcpy(state->body,chunk,DATA_CHUNK_SIZE-1);
                 state->body_len = DATA_CHUNK_SIZE;
             } else {
@@ -633,7 +632,6 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 state->body_len = len;
             }
             state->body[DATA_CHUNK_SIZE-1] = 0;
-            SCLogNotice("[SMTPProcessDataChunk] state->body_len=%d len=%d" , state->body_len,len);
         }
         
     } else {

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -142,6 +142,13 @@ static void EveEmailLogJSONMd5(OutputJsonEmailCtx *email_ctx, JsonBuilder *js, S
         }
     }
 }
+static void EveEmailLogJSONBody(OutputJsonEmailCtx *email_ctx, JsonBuilder *js, SMTPTransaction *tx)
+{
+    MimeDecParseState *mime_state = tx->mime_state;
+    if (mime_state && mime_state->body_len > 0 ) {
+        jb_set_string(js, "body", mime_state->body);
+    }
+}
 
 static int JsonEmailAddToJsonArray(const uint8_t *val, size_t len, void *data)
 {
@@ -371,7 +378,7 @@ TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *
     if (!g_disable_hashing) {
         EveEmailLogJSONMd5(email_ctx, js, tx);
     }
-
+	EveEmailLogJSONBody(email_ctx, js, tx);
     jb_close(js);
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -145,7 +145,7 @@ static void EveEmailLogJSONMd5(OutputJsonEmailCtx *email_ctx, JsonBuilder *js, S
 }
 static void EveEmailLogJSONBody(OutputJsonEmailCtx *email_ctx, JsonBuilder *js, SMTPTransaction *tx)
 {
-    if (email_ctx->flags & LOG_EMAIL_BODY_MD5) {
+    if (email_ctx->flags & LOG_EMAIL_BODY) {
         MimeDecParseState *mime_state = tx->mime_state;
         if (mime_state && mime_state->body_len > 0 ) {
             jb_set_string(js, "body", (const char*)mime_state->body);

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -61,7 +61,7 @@
 
 /* Publicly exposed size constants */
 #define DATA_CHUNK_SIZE  3072  /* Should be divisible by 3 */
- 
+
 /* Mime Parser Constants */
 #define HEADER_READY    0x01
 #define HEADER_STARTED  0x02

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -61,8 +61,7 @@
 
 /* Publicly exposed size constants */
 #define DATA_CHUNK_SIZE  3072  /* Should be divisible by 3 */
-#define SMTP_MAX_BODY_SIZE  998  /* max length of smtp body */
-
+ 
 /* Mime Parser Constants */
 #define HEADER_READY    0x01
 #define HEADER_STARTED  0x02
@@ -98,7 +97,7 @@ typedef struct MimeDecConfig {
                                          extract urls  */
     bool log_url_scheme;            /**< Log the scheme of extracted URLs */
     bool body_md5;                  /**< Compute md5 sum of body */
-    bool body;                  /**< Compute md5 sum of body */
+    bool body;                  	/**< message body */
     uint32_t header_value_depth;  /**< Depth of which to store header values
                                        (Default is 2000) */
 } MimeDecConfig;
@@ -205,7 +204,7 @@ typedef struct MimeDecParseState {
     int body_end;  /**< Currently at end of body */
     uint8_t current_line_delimiter_len; /**< Length of line delimiter */
     void *data;  /**< Pointer to data specific to the caller */
-    uint8_t body[SMTP_MAX_BODY_SIZE]; 
+    uint8_t body[DATA_CHUNK_SIZE]; 
     uint32_t body_len; 
     int (*DataChunkProcessorFunc) (const uint8_t *chunk, uint32_t len,
             struct MimeDecParseState *state);  /**< Data chunk processing function callback */

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -61,6 +61,7 @@
 
 /* Publicly exposed size constants */
 #define DATA_CHUNK_SIZE  3072  /* Should be divisible by 3 */
+#define SMTP_MAX_BODY_SIZE  998  /* max length of smtp body */
 
 /* Mime Parser Constants */
 #define HEADER_READY    0x01
@@ -97,6 +98,7 @@ typedef struct MimeDecConfig {
                                          extract urls  */
     bool log_url_scheme;            /**< Log the scheme of extracted URLs */
     bool body_md5;                  /**< Compute md5 sum of body */
+    bool body;                  /**< Compute md5 sum of body */
     uint32_t header_value_depth;  /**< Depth of which to store header values
                                        (Default is 2000) */
 } MimeDecConfig;
@@ -203,6 +205,8 @@ typedef struct MimeDecParseState {
     int body_end;  /**< Currently at end of body */
     uint8_t current_line_delimiter_len; /**< Length of line delimiter */
     void *data;  /**< Pointer to data specific to the caller */
+    uint8_t body[SMTP_MAX_BODY_SIZE]; 
+    uint32_t body_len; 
     int (*DataChunkProcessorFunc) (const uint8_t *chunk, uint32_t len,
             struct MimeDecParseState *state);  /**< Data chunk processing function callback */
 } MimeDecParseState;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -270,6 +270,8 @@ outputs:
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
             #md5: [body, subject]
+            #  for the body you need to set app-layer.protocols.smtp.mime.body to yes
+            #body: yes
 
         #- dnp3
         - ftp
@@ -937,6 +939,8 @@ app-layer:
         # Log the scheme of URLs that are extracted
         # (default is no)
         #log-url-scheme: yes
+	# Extract body,  set eve-log.types.smtp.body as yes to enable save body in eve log
+	#body: yes
         # Set to yes to compute the md5 of the mail body. You will then
         # be able to journalize it.
         body-md5: no

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -270,7 +270,7 @@ outputs:
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
             #md5: [body, subject]
-            #  for the body you need to set app-layer.protocols.smtp.mime.body to yes
+            #  for the body you need to set app-layer.protocols.smtp.mime.body as yes
             #body: yes
 
         #- dnp3


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5737) ticket

Describe changes:
- extract body message from smtp  protocol
- enable or disable to extract smtp body message in suricata.yaml.in
- enable or disable to save smtp body message to eve-log in suricata.yaml.in

