### PR TITLE
Update tls-keywords.rst

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -388,6 +388,8 @@ For more advanced configuration options, see :ref:`Eve JSON Output <eve-json-out
 
 The format is documented in :ref:`Eve JSON Format <eve-json-format>`.
 
+.. _suricata-yaml-outputs-tls:
+
 TLS parameters and certificates logging (tls.log)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -237,7 +237,8 @@ The tls.fingerprint buffer is lower case so you must use lower case letters for 
 tls.store
 ---------
 
-store TLS/SSL certificate on disk
+store TLS/SSL certificate on disk.
+The location can be specified in the `output.tls-store.certs-log-dir` parameter of the yaml configuration file, cf :ref:`suricata-yaml-outputs-tls`..
 
 ssl_state
 ---------


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Update the doc to link tis-store keyword to the suricata.yaml config option about where the certificates are logged

Replaces #8281