### PR TITLE
decode/stat: Add decode counters for unknown/arp

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3772,7 +3772,7 @@
                         "error": {
                             "type": "object",
                             "properties": {
-                                "bittorrent-dht": { 
+                                "bittorrent-dht": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "dcerpc_tcp": {
@@ -4127,6 +4127,12 @@
                             "type": "integer"
                         },
                         "ethernet": {
+                            "type": "integer"
+                        },
+                        "arp": {
+                            "type": "integer"
+                        },
+                        "unknown_ethertype": {
                             "type": "integer"
                         },
                         "geneve": {

--- a/src/decode.c
+++ b/src/decode.c
@@ -534,6 +534,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_ipv4 = StatsRegisterCounter("decoder.ipv4", tv);
     dtv->counter_ipv6 = StatsRegisterCounter("decoder.ipv6", tv);
     dtv->counter_eth = StatsRegisterCounter("decoder.ethernet", tv);
+    dtv->counter_arp = StatsRegisterCounter("decoder.arp", tv);
+    dtv->counter_unknown = StatsRegisterCounter("decoder.unknown_ethertype", tv);
     dtv->counter_chdlc = StatsRegisterCounter("decoder.chdlc", tv);
     dtv->counter_raw = StatsRegisterCounter("decoder.raw", tv);
     dtv->counter_null = StatsRegisterCounter("decoder.null", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -683,6 +683,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_udp;
     uint16_t counter_icmpv4;
     uint16_t counter_icmpv6;
+    uint16_t counter_arp;
+    uint16_t counter_unknown;
 
     uint16_t counter_sll;
     uint16_t counter_raw;
@@ -1188,6 +1190,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             DecodeIEEE8021ah(tv, dtv, p, data, len);
             break;
         case ETHERNET_TYPE_ARP:
+            StatsIncr(tv, dtv->counter_arp);
             break;
         case ETHERNET_TYPE_MPLS_UNICAST:
         case ETHERNET_TYPE_MPLS_MULTICAST:
@@ -1208,6 +1211,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             break;
         default:
             SCLogDebug("unknown ether type: %" PRIx16 "", proto);
+            StatsIncr(tv, dtv->counter_unknown);
             return false;
     }
     return true;


### PR DESCRIPTION
Issue: 5761

This commit adds statistics for ARP and unknown ethertype packets for diagnostic purposes.


Describe changes:
- Update eve.schema with new counters
- Update decode logic to increment arp/unknown counters when appropriate

suricata-verify-pr: 1042
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
