### PR TITLE
detect/pcre: don't use JIT if disabled

### DIFF
--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -874,11 +874,14 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
         goto error;
 
 #ifdef PCRE_HAVE_JIT_EXEC
-    /* Deliberately silent on failures. Not having a context id means
-     * JIT will be bypassed */
-    pd->thread_ctx_jit_stack_id = DetectRegisterThreadCtxFuncs(de_ctx, "pcre",
-            DetectPcreThreadInit, (void *)pd,
-            DetectPcreThreadFree, 1);
+    if (pcre_use_jit) {
+        /* Deliberately silent on failures. Not having a context id means
+         * JIT will be bypassed */
+        pd->thread_ctx_jit_stack_id = DetectRegisterThreadCtxFuncs(
+                de_ctx, "pcre", DetectPcreThreadInit, (void *)pd, DetectPcreThreadFree, 1);
+    } else {
+        pd->thread_ctx_jit_stack_id = -1;
+    }
 #endif
 
     int sm_list = -1;


### PR DESCRIPTION
If we determined not to use JIT at start up, really don't use JIT.

Bug: #5762. https://redmine.openinfosecfoundation.org/issues/5762