### PR TITLE
detect/cert: Use client side certs

### DIFF
--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -91,6 +91,12 @@ void DetectTlsFingerprintRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
+    DetectAppLayerInspectEngineRegister2("tls.cert_fingerprint", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+
+    DetectAppLayerMpmRegister2("tls.cert_fingerprint", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+
     DetectBufferTypeSetDescriptionByName("tls.cert_fingerprint",
             "TLS certificate fingerprint");
 
@@ -132,13 +138,20 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         const SSLState *ssl_state = (SSLState *)f->alstate;
+        const SSLStateConnp *connp;
 
-        if (ssl_state->server_connp.cert0_fingerprint == NULL) {
+        if (flow_flags & STREAM_TOSERVER) {
+            connp = &ssl_state->client_connp;
+        } else {
+            connp = &ssl_state->server_connp;
+        }
+
+        if (connp->cert0_fingerprint == NULL) {
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.cert0_fingerprint);
-        const uint8_t *data = (uint8_t *)ssl_state->server_connp.cert0_fingerprint;
+        const uint32_t data_len = strlen(connp->cert0_fingerprint);
+        const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -79,6 +79,12 @@ void DetectTlsIssuerRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
+    DetectAppLayerInspectEngineRegister2("tls.cert_issuer", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+
+    DetectAppLayerMpmRegister2("tls.cert_issuer", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+
     DetectAppLayerInspectEngineRegister2("tls.cert_issuer", ALPROTO_TLS,
             SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
             DetectEngineInspectBufferGeneric, GetData);
@@ -122,13 +128,19 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         const SSLState *ssl_state = (SSLState *)f->alstate;
+        const SSLStateConnp *connp;
+        if (flow_flags & STREAM_TOSERVER) {
+            connp = &ssl_state->client_connp;
+        } else {
+            connp = &ssl_state->server_connp;
+        }
 
-        if (ssl_state->server_connp.cert0_issuerdn == NULL) {
+        if (connp->cert0_issuerdn == NULL) {
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.cert0_issuerdn);
-        const uint8_t *data = (uint8_t *)ssl_state->server_connp.cert0_issuerdn;
+        const uint32_t data_len = strlen(connp->cert0_issuerdn);
+        const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -91,6 +91,12 @@ void DetectTlsSerialRegister(void)
             PrefilterGenericMpmRegister, GetData, ALPROTO_TLS,
             TLS_STATE_CERT_READY);
 
+    DetectAppLayerInspectEngineRegister2("tls.cert_serial", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+
+    DetectAppLayerMpmRegister2("tls.cert_serial", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+
     DetectBufferTypeSetDescriptionByName("tls.cert_serial",
             "TLS certificate serial number");
 
@@ -131,13 +137,20 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         const SSLState *ssl_state = (SSLState *)f->alstate;
+        const SSLStateConnp *connp;
 
-        if (ssl_state->server_connp.cert0_serial == NULL) {
+        if (flow_flags & STREAM_TOSERVER) {
+            connp = &ssl_state->client_connp;
+        } else {
+            connp = &ssl_state->server_connp;
+        }
+
+        if (connp->cert0_serial == NULL) {
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.cert0_serial);
-        const uint8_t *data = (uint8_t *)ssl_state->server_connp.cert0_serial;
+        const uint32_t data_len = strlen(connp->cert0_serial);
+        const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -143,6 +143,9 @@ void DetectTlsRegister (void)
 
     DetectAppLayerInspectEngineRegister2("tls_cert", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
             TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
+
+    DetectAppLayerInspectEngineRegister2("tls_cert", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
 }
 
 /**
@@ -619,6 +622,14 @@ static int DetectTlsStorePostMatch (DetectEngineThreadCtx *det_ctx,
         SCReturnInt(0);
     }
 
-    ssl_state->server_connp.cert_log_flag |= SSL_TLS_LOG_PEM;
+    SSLStateConnp *connp;
+
+    if (p->flow->flags & STREAM_TOSERVER) {
+        connp = &ssl_state->client_connp;
+    } else {
+        connp = &ssl_state->server_connp;
+    }
+
+    connp->cert_log_flag |= SSL_TLS_LOG_PEM;
     SCReturnInt(1);
 }


### PR DESCRIPTION
Issue: 5516

This commit modifies the detect logic to choose the certificate based on the flow direction -- to server or to client.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5516](https://redmine.openinfosecfoundation.org/issues/5516)

Describe changes:
- Determine which certificate based on flow direction
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
