### PR TITLE
detect/frames: fix crash when parsing bad rule

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -436,7 +436,8 @@ SigMatch *DetectGetLastSMFromMpmLists(const DetectEngineCtx *de_ctx, const Signa
     uint32_t sm_type;
 
     /* if we have a sticky buffer, use that */
-    if (s->init_data->list != DETECT_SM_LIST_NOTSET) {
+    if (s->init_data->list != DETECT_SM_LIST_NOTSET &&
+            s->init_data->list < (int)s->init_data->smlists_array_size) {
         if (!(DetectEngineBufferTypeSupportsMpmGetById(de_ctx, s->init_data->list))) {
             return NULL;
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5530

Describe changes:
- detect/frames: fix crash when parsing bad rule

Like https://github.com/OISF/suricata/commit/e902aaf838acb552350078070092a2c61b918b19

Rebased #8150 