### PR TITLE
fix bug in SSLParser

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1067,7 +1067,7 @@ invalid_length:
 static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
                                           const uint8_t * const initial_input,
                                           const uint32_t input_len,
-                                          JA3Buffer *ja3_elliptic_curves)
+                                          JA3Buffer **ja3_elliptic_curves)
 {
     const uint8_t *input = initial_input;
 
@@ -1097,7 +1097,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
             input += 2;
 
             if (TLSDecodeValueIsGREASE(elliptic_curve) != 1) {
-                int rc = Ja3BufferAddValue(&ja3_elliptic_curves,
+                int rc = Ja3BufferAddValue(ja3_elliptic_curves,
                                            elliptic_curve);
                 if (rc != 0)
                     return -1;
@@ -1124,7 +1124,7 @@ invalid_length:
 static inline int TLSDecodeHSHelloExtensionEllipticCurvePF(SSLState *ssl_state,
                                             const uint8_t * const initial_input,
                                             const uint32_t input_len,
-                                            JA3Buffer *ja3_elliptic_curves_pf)
+                                            JA3Buffer **ja3_elliptic_curves_pf)
 {
     const uint8_t *input = initial_input;
 
@@ -1151,7 +1151,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurvePF(SSLState *ssl_state,
             input += 1;
 
             if (TLSDecodeValueIsGREASE(elliptic_curve_pf) != 1) {
-                int rc = Ja3BufferAddValue(&ja3_elliptic_curves_pf,
+                int rc = Ja3BufferAddValue(ja3_elliptic_curves_pf,
                                            elliptic_curve_pf);
                 if (rc != 0)
                     return -1;
@@ -1253,7 +1253,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 /* coverity[tainted_data] */
                 ret = TLSDecodeHSHelloExtensionEllipticCurves(ssl_state, input,
                                                               ext_len,
-                                                              ja3_elliptic_curves);
+                                                              &ja3_elliptic_curves);
                 if (ret < 0)
                     goto end;
 
@@ -1267,7 +1267,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 /* coverity[tainted_data] */
                 ret = TLSDecodeHSHelloExtensionEllipticCurvePF(ssl_state, input,
                                                                ext_len,
-                                                               ja3_elliptic_curves_pf);
+                                                               &ja3_elliptic_curves_pf);
                 if (ret < 0)
                     goto end;
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5767

Describe changes:
- When pass a `JA3Buffer *ja3_elliptic_curves` into function `TLSDecodeHSHelloExtensionEllipticCurves`, the buffer may be freed by `Ja3BufferAddValue` and set to NULL. But the raw pointer of the buffer will not change in this case.
- The same thing also happened in function `TLSDecodeHSHelloExtensionEllipticCurvePF`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
