### PR TITLE
logging: sync log levels between Rust and C

### DIFF
--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -26,9 +26,6 @@ use crate::core::*;
 pub enum Level {
     NotSet = -1,
     None = 0,
-    Emergency,
-    Alert,
-    Critical,
     Error,
     Warning,
     Notice,

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -43,7 +43,9 @@
 /**
  * \brief The various log levels
  * NOTE: when adding new level, don't forget to update SCLogMapLogLevelToSyslogLevel()
-  *      or it may result in logging to syslog with LOG_EMERG priority.
+ *       or it may result in logging to syslog with LOG_EMERG priority.
+ *
+ * NOTE: The Level enum in log.rs also needs to be updated to match.
  */
 typedef enum {
     SC_LOG_NOTSET = -1,


### PR DESCRIPTION
Rust has its own enum of log levels that needs to be kept in C.

Ideally we'd have one definition, but the log levels are required in the
C before we can reasonably include "rust.h" at this time.
