### PR TITLE
logging: add ISO-like timestamp option - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1780,8 +1780,11 @@ Default Configuration Example
     # something reasonable if not provided.  Can be overridden in an
     # output section.  You can leave this out to get the default.
     #
-    # This value is overridden by the SC_LOG_FORMAT env var.
-    #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+    # This console log format value can be overridden by the SC_LOG_FORMAT env var.
+    #default-log-format: "%D: %S: %M"
+    #
+    # For the pre-7.0 log format use:
+    #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
     # A regex to filter output.  Can be overridden in an output section.
     # Defaults to empty (no filter).
@@ -1799,6 +1802,7 @@ Default Configuration Example
         enabled: yes
         level: info
         filename: suricata.log
+        # format: "[%i - %m] %z %d: %S: %M"
         # type: json
     - syslog:
         enabled: no
@@ -1850,8 +1854,8 @@ specified signs:
 
 ::
 
-  t:      Time, timestamp, time and date
-			example: 15/10/2010 - -11:40:07
+  z:      ISO-like formatted timestamp: YYYY-MM-DD HH:MM:SS
+  t:      Original Suricata log timestamp: DD/MM/YYYY -- HH:MM::SS
   p:      Process ID. Suricata's whole processing consists of multiple threads.
   i:      Thread ID. ID of individual threads.
   m:      Thread module name. (Outputs, Detect etc.)

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -74,7 +74,7 @@ typedef enum {
 } SCLogOPType;
 
 /* The default log_format, if it is not supplied by the user */
-#define SC_LOG_DEF_FILE_FORMAT      "[%i - %m] %t %d: %S: %M"
+#define SC_LOG_DEF_FILE_FORMAT      "[%i - %m] %z %d: %S: %M"
 #define SC_LOG_DEF_LOG_FORMAT_REL   "%D: %S: %M"
 #define SC_LOG_DEF_LOG_FORMAT_RELV  "%d: %S: %M"
 #define SC_LOG_DEF_LOG_FORMAT_RELVV "[%i] %d: %S: %M"

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -188,7 +188,8 @@ typedef struct SCLogConfig_ {
 } SCLogConfig;
 
 /* The different log format specifiers supported by the API */
-#define SC_LOG_FMT_TIME             't' /* Timestamp in standard format */
+#define SC_LOG_FMT_TIME             'z' /* Timestamp in RFC3339 like format */
+#define SC_LOG_FMT_TIME_LEGACY      't' /* Timestamp in legacy format */
 #define SC_LOG_FMT_PID              'p' /* PID */
 #define SC_LOG_FMT_TID              'i' /* Thread ID */
 #define SC_LOG_FMT_TM               'm' /* Thread module name */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -550,7 +550,10 @@ logging:
   # something reasonable if not provided.  Can be overridden in an
   # output section.  You can leave this out to get the default.
   #
-  # This console log format value can be  overridden by the SC_LOG_FORMAT env var.
+  # This console log format value can be overridden by the SC_LOG_FORMAT env var.
+  #default-log-format: "%D: %S: %M"
+  #
+  # For the pre-7.0 log format use:
   #default-log-format: "[%i] %t [%S] - (%f:%l) <%d> (%n) -- "
 
   # A regex to filter output.  Can be overridden in an output section.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -577,6 +577,7 @@ logging:
       enabled: yes
       level: info
       filename: suricata.log
+      # format: "[%i - %m] %z %d: %S: %M"
       # type: json
   - syslog:
       enabled: no


### PR DESCRIPTION
Add a new log format specifier `%z` to use a more ISO-like timestamp format `YYYY-MM-DD HH:MM:SS` that is more commonly used in logs these days.

- Make this the default in the file log option.

Ticket: https://redmine.openinfosecfoundation.org/issues/5764
