### PR TITLE
Filestore alertlog 4881 v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -121,6 +121,9 @@
                     "filename": {
                         "type": "string"
                     },
+                    "file_id": {
+                        "type": "integer"
+                    },
                     "gaps": {
                         "type": "boolean"
                     },

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -616,7 +616,7 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
                 jb_open_array(jb, "files");
             }
             jb_start_object(jb);
-            EveFileInfo(jb, file, tx_id, file->flags & FILE_STORED);
+            EveFileInfo(jb, file, tx_id, file->flags & (FILE_STORE | FILE_STORED));
             jb_close(jb);
             file = file->next;
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4881

Describe changes:
- mark file as stored in alert when it is planned to be stored...
- Add missing field to json schema

suricata-verify-pr: 965
