### PR TITLE
Simple fixes v1

### DIFF
--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1397,7 +1397,7 @@ impl SMBState {
                                             if smb_record.is_request() {
                                                 smb1_request_record(self, smb_record);
                                             } else {
-                                                // If we recevied a response when expecting a request, set an event
+                                                // If we received a response when expecting a request, set an event
                                                 // on the PDU frame instead of handling the response.
                                                 SCLogDebug!("SMB1 reply seen from client to server");
                                                 if let Some(frame) = pdu_frame {
@@ -1426,7 +1426,7 @@ impl SMBState {
                                                 if smb_record.is_request() {
                                                     smb2_request_record(self, smb_record);
                                                 } else {
-                                                    // If we recevied a response when expecting a request, set an event
+                                                    // If we received a response when expecting a request, set an event
                                                     // on the PDU frame instead of handling the response.
                                                     SCLogDebug!("SMB2 reply seen from client to server");
                                                     if let Some(frame) = pdu_frame {

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -405,8 +405,8 @@ static int DecodeICMPV4test01(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -455,8 +455,8 @@ static int DecodeICMPV4test02(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -503,8 +503,8 @@ static int DecodeICMPV4test03(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -582,8 +582,8 @@ static int DecodeICMPV4test04(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -651,8 +651,8 @@ static int DecodeICMPV4test05(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -757,8 +757,8 @@ static int ICMPV4InvalidType07(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
@@ -800,8 +800,8 @@ static int DecodeICMPV4test08(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");;
-    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");;
+    p->src.addr_data32[0] = UTHSetIPv4Address("4.3.2.1");
+    p->dst.addr_data32[0] = UTHSetIPv4Address("1.2.3.4");
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -2530,7 +2530,6 @@ static int PortParseTest14Spaces(void)
     const char *str = "              45";
     DetectPort *dp = PortParse(str);
     FAIL_IF_NULL(dp);
-    FAIL_IF_NULL(dp);
     FAIL_IF(dp->port != 45);
     FAIL_IF(dp->port2 != 45);
     DetectPortFree(NULL, dp);
@@ -2542,7 +2541,6 @@ static int PortParseTestMoreThan14Spaces(void)
 {
     const char *str = "                                   45";
     DetectPort *dp = PortParse(str);
-    FAIL_IF_NULL(dp);
     FAIL_IF_NULL(dp);
     FAIL_IF(dp->port != 45);
     FAIL_IF(dp->port2 != 45);

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -127,7 +127,7 @@ static int DetectFragOffsetMatch (DetectEngineThreadCtx *det_ctx,
         return 0;
     }
 
-    return FragOffsetMatch(frag, fragoff->mode, fragoff->frag_off);;
+    return FragOffsetMatch(frag, fragoff->mode, fragoff->frag_off);
 }
 
 /**

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -75,7 +75,7 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
 
     /* verify other conditions. */
-    DetectContentData *cd = (DetectContentData *)pm->ctx;;
+    DetectContentData *cd = (DetectContentData *)pm->ctx;
 
     if (cd->flags & DETECT_CONTENT_NOCASE) {
         SCLogError("can't use multiple nocase modifiers with the same content");

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2380,7 +2380,7 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
         if (sw_temp.s != NULL) {
             sw_next = HashListTableLookup(de_ctx->dup_sig_hash_table,
                                           (void *)&sw_temp, 0);
-            sw_next->s_prev = sw_dup->s_prev;;
+            sw_next->s_prev = sw_dup->s_prev;
         }
         SigFree(de_ctx, sw_dup->s);
     }

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -269,7 +269,7 @@ static time_t DateStringToEpoch (char *string)
 
     time_t epoch = StringIsEpoch(string);
     if (epoch != -1) {
-        return epoch;;
+        return epoch;
     }
 
     r = SCStringPatternToTime(string, patterns, 10, &tm);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -682,8 +682,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         JsonAddrInfoInit(p, LOG_DIR_PACKET, &addr);
 
         /* Check for XFF, overwriting address info if needed. */
-        HttpXFFCfg *xff_cfg = json_output_ctx->xff_cfg != NULL ?
-            json_output_ctx->xff_cfg : json_output_ctx->parent_xff_cfg;;
+        HttpXFFCfg *xff_cfg = json_output_ctx->xff_cfg != NULL ? json_output_ctx->xff_cfg
+                                                               : json_output_ctx->parent_xff_cfg;
         int have_xff_ip = 0;
         char xff_buffer[XFF_MAXLEN];
         xff_buffer[0] = 0;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -204,8 +204,8 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx,
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff, void *tx,
         const uint64_t tx_id, uint8_t dir, OutputJsonCtx *eve_ctx)
 {
-    HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
-        aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;
+    HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ? aft->filelog_ctx->xff_cfg
+                                                            : aft->filelog_ctx->parent_xff_cfg;
     JsonBuilder *js = JsonBuildFileInfoRecord(
             p, ff, tx, tx_id, ff->flags & FILE_STORED ? true : false, dir, xff_cfg, eve_ctx);
     if (unlikely(js == NULL)) {

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -2194,7 +2194,7 @@ static int SigTest28TCPV6Keyword(void)
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
-    p2->payload = invalid_raw_ipv6 + 54 + 20;;
+    p2->payload = invalid_raw_ipv6 + 54 + 20;
     p2->payload_len = 12;
     p2->proto = IPPROTO_TCP;
 
@@ -2320,7 +2320,7 @@ static int SigTest29NegativeTCPV6Keyword(void)
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
-    p2->payload = invalid_raw_ipv6 + 54 + 20;;
+    p2->payload = invalid_raw_ipv6 + 54 + 20;
     p2->payload_len = 12;
     p2->proto = IPPROTO_TCP;
 

--- a/src/tm-modules.c
+++ b/src/tm-modules.c
@@ -75,7 +75,7 @@ int TmModuleGetIdByName(const char *name)
 {
     TmModule *tm = TmModuleGetByName(name);
     if (tm == NULL)
-        return -1;;
+        return -1;
     return TmModuleGetIDForTM(tm);
 }
 

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -119,7 +119,7 @@ static inline void MacUpdateEntry(MacSet *ms, uint8_t *addr, int side, ThreadVar
 {
     switch (ms->state[side]) {
         case EMPTY_SET:
-            memcpy(ms->singles[side], addr, sizeof(MacAddr));;
+            memcpy(ms->singles[side], addr, sizeof(MacAddr));
             ms->state[side] = SINGLE_MAC;
             if (tv != NULL)
                 StatsSetUI64(tv, ctr, 1);

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -1163,7 +1163,7 @@ uint32_t SCACBSSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                     ascii_codes = state_table_mod_pointers[state & 0x7FFF] + 1;
                     buf_local = u8_tolower(buf[i]);
                     if (buf_local == ascii_codes[0]) {
-                        state = *(ascii_codes + no_of_entries);;
+                        state = *(ascii_codes + no_of_entries);
                     } else {
                         state = zero_state[buf_local];
                     }
@@ -1246,9 +1246,9 @@ uint32_t SCACBSSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                     ascii_codes = state_table_mod_pointers[state & 0x00FFFFFF] + 1;
                     buf_local = u8_tolower(buf[i]);
                     if (buf_local == ascii_codes[0]) {
-                        state = *(ascii_codes + no_of_entries);;
+                        state = *(ascii_codes + no_of_entries);
                     } else {
-                        state = zero_state[buf_local];;
+                        state = zero_state[buf_local];
                     }
                 } else {
                     if (no_of_entries == 0) {

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -217,7 +217,7 @@ static void SCACShrinkState(SCACCtx *ctx)
 
 static inline int SCACInitNewState(MpmCtx *mpm_ctx)
 {
-    SCACCtx *ctx = (SCACCtx *)mpm_ctx->ctx;;
+    SCACCtx *ctx = (SCACCtx *)mpm_ctx->ctx;
 
     /* Exponentially increase the allocated space when needed. */
     if (ctx->allocated_state_count < ctx->state_count + 1) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- fix a typo in comments
- remove duplicate test

I am more worried that the `PortParseTest14Spaces` and `PortParseTestMoreThan14Spaces` tests comment is the opposite of what is tested.
Maybe this is because these tests miss the negation as in `!45`
cf https://github.com/OISF/suricata/pull/8137/commits/aeb0c0e71a998aceaad5140fa106e8609b1683ee