### PR TITLE
test: do not output non ascii character

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -151,7 +151,7 @@ int DetectContentDataParse(const char *keyword, const char *contentstr,
                     else if (str[i] != ',') {
                         SCLogError("Invalid hex code in "
                                    "content - %s, hex %c. Invalidating signature.",
-                                str, str[i]);
+                                contentstr, str[i]);
                         goto error;
                     }
                 } else if (escape) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5558

Describe changes:
- Fix CI by not having S-V hang indefinitely because of a non-ascii character in stderr

Replaces approved #7917 with needed rebase

suricata-verify-pr: 939
