### PR TITLE
mqtt: add unittests for nom7 parsers

### DIFF
--- a/rust/src/mqtt/mqtt_property.rs
+++ b/rust/src/mqtt/mqtt_property.rs
@@ -24,7 +24,7 @@ use nom7::IResult;
 
 // TODO: It might be useful to also add detection on property presence and
 // content, e.g. mqtt.property: AUTHENTICATION_METHOD.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, PartialOrd)]
 #[allow(non_camel_case_types)]
 pub enum MQTTProperty {
     UNKNOWN,

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -242,7 +242,8 @@ fn parse_connack(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTC
 
 #[inline]
 fn parse_publish(
-    protocol_version: u8, has_id: bool,
+    protocol_version: u8,
+    has_id: bool,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTPublishData> {
     move |i: &[u8]| {
         let (i, topic) = parse_mqtt_string(i)?;
@@ -413,7 +414,8 @@ fn parse_unsuback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTT
 
 #[inline]
 fn parse_disconnect(
-    remaining_len: usize, protocol_version: u8,
+    remaining_len: usize,
+    protocol_version: u8,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTDisconnectData> {
     move |input: &[u8]| {
         if protocol_version < 5 {
@@ -484,7 +486,11 @@ fn parse_auth(i: &[u8]) -> IResult<&[u8], MQTTAuthData> {
 
 #[inline]
 fn parse_remaining_message<'a>(
-    full: &'a [u8], len: usize, skiplen: usize, header: FixedHeader, message_type: MQTTTypeCode,
+    full: &'a [u8],
+    len: usize,
+    skiplen: usize,
+    header: FixedHeader,
+    message_type: MQTTTypeCode,
     protocol_version: u8,
 ) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], MQTTMessage> {
     move |input: &'a [u8]| {
@@ -626,7 +632,9 @@ fn parse_remaining_message<'a>(
 }
 
 pub fn parse_message(
-    input: &[u8], protocol_version: u8, max_msg_size: usize,
+    input: &[u8],
+    protocol_version: u8,
+    max_msg_size: usize,
 ) -> IResult<&[u8], MQTTMessage> {
     // Parse the fixed header first. This is identical across versions and can
     // be between 2 and 5 bytes long.


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5741) ticket:
https://redmine.openinfosecfoundation.org/issues/5742

Previous PR: #8333 

Describe changes:
- Remove `Eq, Ord`
