### PR TITLE
decode-udp:  Allow shorter UDP packets than the remaining payload length

### DIFF
--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -56,11 +56,6 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_
         return -1;
     }
 
-    if (unlikely(len != UDP_GET_LEN(p))) {
-        ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_INVALID);
-        return -1;
-    }
-
     SET_UDP_SRC_PORT(p,&p->sp);
     SET_UDP_DST_PORT(p,&p->dp);
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -160,6 +160,9 @@ static DetectEngineEventData *DetectEngineEventParse (const char *rawstr)
 
     if (de->event == STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA) {
         StreamTcpReassembleConfigEnableOverlapCheck();
+    } else if (de->event == UDP_HLEN_INVALID) {
+        SCLogWarning("Rule uses decode-event \"udp.hlen_invalid\" which will be deprecated in "
+                     "Suricata 8.0");
     }
     return de;
 


### PR DESCRIPTION
If the packet is shorter than IP payload length we no longer flag it as an invalid UDP packet. UDP packet can be therefore shorter than IP payload.

Redmine ticket: #5693

Changes:
- Rebased on the new master