### PR TITLE
detect/content: Impose limits for distance/within keywords

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -197,6 +197,8 @@ distance:5; means the pattern can be anywhere after the previous
 match + 5 bytes. For limiting how far after the last match Suricata
 needs to look, use 'within'.
 
+The absolute value for distance must be less than or equal to 1MB (1048576).
+
 Examples of distance:
 
 .. image:: payload-keywords/distance5.png
@@ -222,6 +224,8 @@ within comes with a mandatory numeric value. Using within makes sure
 there will only be a match if the content matches with the payload
 within the set amount of bytes. Within can not be 0 (zero)
 
+The absolute value for within must be less than or equal to 1MB (1048576).
+
 Example:
 
 .. image:: payload-keywords/within2.png
@@ -243,7 +247,7 @@ payload for a match, use within.
 rawbytes
 --------
 
-The rawbytes keyword has no effect but is included to be comaptible with
+The rawbytes keyword has no effect but is included to be compatible with
 signatures that use it, for example signatures used with Snort.
 
 isdataat

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -838,7 +838,7 @@ static int DetectContentDepthTest01(void)
     TEST_RUN("content:\"=\"; offset:4; depth:9; content:\"=&\"; distance:55; within:2;", 60, 70);
 
     // distance value is too high so we bail and not set anything on this content
-    TEST_RUN("content:\"0123456789\"; content:\"abcdef\"; distance:2147483647;", 0, 0);
+    TEST_RUN("content:\"0123456789\"; content:\"abcdef\"; distance:1048576;", 0, 0);
 
     // Bug #5162.
     TEST_RUN("content:\"SMB\"; depth:8; content:\"|09 00|\"; distance:8; within:2;", 11, 18);

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -80,6 +80,11 @@
                                        ((c)->flags & DETECT_CONTENT_OFFSET)   || \
                                        ((c)->flags & DETECT_CONTENT_FAST_PATTERN_CHOP))
 
+/*
+ * Values for distance, and within must be less than or equal
+ * to this value (absolute value where required).
+ */
+#define DETECT_CONTENT_VALUE_MAX 1024 * 1024
 
 #include "util-spm.h"
 

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -119,7 +119,8 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
         cd->distance = index;
         cd->flags |= DETECT_CONTENT_DISTANCE_VAR;
     } else {
-        if (StringParseInt32(&cd->distance, 0, 0, str) < 0) {
+        if ((StringParseInt32(&cd->distance, 0, 0, str) < 0) ||
+                (abs(cd->distance) > DETECT_CONTENT_VALUE_MAX)) {
             SCLogError("invalid value for distance: %s", str);
             goto end;
         }

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -116,7 +116,8 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
         cd->within = index;
         cd->flags |= DETECT_CONTENT_WITHIN_VAR;
     } else {
-        if (StringParseInt32(&cd->within, 0, 0, str) < 0) {
+        if ((StringParseInt32(&cd->within, 0, 0, str) < 0) ||
+                (abs(cd->within) > DETECT_CONTENT_VALUE_MAX)) {
             SCLogError("invalid value for within: %s", str);
             goto end;
         }


### PR DESCRIPTION
Continuation of #8260

This PR constrains the values for the distance and within keywords to 1MB. Values must be within the range of [-1MB, 1MB] for the rule to be used.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5740](https://redmine.openinfosecfoundation.org/issues/5740)

Describe changes:
- Add preprocessor value for limit
- Document change
- Update test case using a now invalid value
- Enforce limit when parsing distance and keyword values.

Updates
- Rebase
- Updates due to custom error enum removal

suricata-verify-pr: 1034
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
