### PR TITLE
github-ci: check for new authors

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -1,0 +1,57 @@
+name: New Author Check
+
+on:
+  - pull_request
+
+jobs:
+  check-id:
+    name: Check Author ID
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt -y install git
+      - uses: actions/checkout@v3.2.0
+        with:
+          fetch-depth: 0
+      - name: Export all previous authors
+        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF} | sort | uniq > authors.txt
+      - run: cat authors.txt
+      - name: Get authors of new commits
+        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > commit-authors.txt
+      - run: cat commit-authors.txt
+      - name: Check new authors
+        run: |
+          while read -r author; do
+             echo "Checking author: ${author}"
+             if ! grep -q "^${author}\$" authors.txt; then
+                 echo "ERROR: ${author} NOT FOUND"
+                 echo "::error ::New author found: ${author}"
+                 echo "${author}" >> new-authors.txt
+                 echo has_new_authors="yes" >> $GITHUB_ENV
+             fi
+          done < commit-authors.txt
+      - if: ${{ env.has_new_authors == 'yes' }}
+        run: cat new-authors.txt
+      - if: ${{ env.has_new_authors == 'yes' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          retries: 3
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This pull request contains *NEW* authors.'
+            })
+      - if: ${{ env.has_new_authors != 'yes' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          retries: 3
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This pull request contains NO new authors.'
+            })


### PR DESCRIPTION
Add a GitHub CI job that checks the commits in a pull requests for new
authors that have not been seen before. If a new author is found, the
job will contain some error annotations with the new authors and a
comment will be added to the pull request.

Example pull request with new authors:
https://github.com/jasonish/suricata/pull/148

Job annotations:
https://github.com/jasonish/suricata/actions/runs/3848850381
