### PR TITLE
tls: accept validity before 1970

### DIFF
--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -203,19 +203,19 @@ static int DetectTlsValidityMatch (DetectEngineThreadCtx *det_ctx,
  * \param string Date string.
  *
  * \retval epoch time on success.
- * \retval 0 on failure.
+ * \retval LONG_MIN on failure.
  */
 static time_t StringIsEpoch (char *string)
 {
     if (strlen(string) == 0)
-        return -1;
+        return LONG_MIN;
 
     /* We assume that the date string is epoch if it consists of only
        digits. */
     char *sp = string;
     while (*sp) {
         if (isdigit(*sp++) == 0)
-            return -1;
+            return LONG_MIN;
     }
 
     return strtol(string, NULL, 10);
@@ -268,14 +268,14 @@ static time_t DateStringToEpoch (char *string)
     }
 
     time_t epoch = StringIsEpoch(string);
-    if (epoch != -1) {
-        return epoch;;
+    if (epoch != LONG_MIN) {
+        return epoch;
     }
 
     r = SCStringPatternToTime(string, patterns, 10, &tm);
 
     if (r != 0)
-        return -1;
+        return LONG_MIN;
 
     return SCMkTimeUtc(&tm);
 }
@@ -373,7 +373,7 @@ static DetectTlsValidityData *DetectTlsValidityParse (const char *rawstr)
 
     /* set the first value */
     dd->epoch = DateStringToEpoch(value1);
-    if (dd->epoch == -1)
+    if (dd->epoch == LONG_MIN)
         goto error;
 
     /* set the second value if specified */
@@ -384,7 +384,7 @@ static DetectTlsValidityData *DetectTlsValidityParse (const char *rawstr)
         }
 
         dd->epoch2 = DateStringToEpoch(value2);
-        if (dd->epoch2 == -1)
+        if (dd->epoch2 == LONG_MIN)
             goto error;
 
         if (dd->epoch2 <= dd->epoch) {

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -383,6 +383,43 @@ static int ValidityTestParse23 (void)
 }
 
 /**
+ * \test This is a test for a valid value of 1970-01-01T00:00:00
+ * that is at epoch 0, within the range of acceptable
+ * values (1950-2049) as per RFC 5280. (https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1)
+ *
+ * \retval 1 on success.
+ * \retval 0 on failure.
+ */
+static int ValidityTestParse24(void)
+{
+    DetectTlsValidityData *dd = NULL;
+    dd = DetectTlsValidityParse("1970-01-01T00:00:00");
+    FAIL_IF_NULL(dd);
+    FAIL_IF_NOT(dd->epoch == 0 && dd->mode == DETECT_TLS_VALIDITY_EQ);
+    DetectTlsValidityFree(NULL, dd);
+    PASS;
+}
+
+/**
+ * \test This is a test for a valid value of 1965-10-22T23:59:59
+ * that is lower than epoch 0, but within the range of
+ * acceptable values (1950-2049) as per RFC 5280.
+ * (https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1)
+ *
+ * \retval 1 on success.
+ * \retval 0 on failure.
+ */
+static int ValidityTestParse25(void)
+{
+    DetectTlsValidityData *dd = NULL;
+    dd = DetectTlsValidityParse("1969-12-31T23:59:59");
+    FAIL_IF_NULL(dd);
+    FAIL_IF_NOT(dd->epoch == -1 && dd->mode == DETECT_TLS_VALIDITY_EQ);
+    DetectTlsValidityFree(NULL, dd);
+    PASS;
+}
+
+/**
  * \test Test matching on validity dates in a certificate.
  *
  * \retval 1 on success.
@@ -1345,6 +1382,8 @@ void TlsNotBeforeRegisterTests(void)
     UtRegisterTest("ValidityTestParse19", ValidityTestParse19);
     UtRegisterTest("ValidityTestParse21", ValidityTestParse21);
     UtRegisterTest("ValidityTestParse23", ValidityTestParse23);
+    UtRegisterTest("ValidityTestParse24", ValidityTestParse24);
+    UtRegisterTest("ValidityTestParse25", ValidityTestParse25);
     UtRegisterTest("ValidityTestDetect01", ValidityTestDetect01);
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3253

Describe changes:
- tls: accept validity before 1970 as per rfc5280#section-4.1.2.5.1

Replaces #8324 by me taking ownership of the commit  