### PR TITLE
smb: check file lengths against nbss records length

### DIFF
--- a/rules/smb-events.rules
+++ b/rules/smb-events.rules
@@ -26,9 +26,9 @@ alert smb any any -> any any (msg:"SURICATA SMB max response READ size exceeded"
 # checks negotiated max-write-size and 'app-layer.protocols.smb.max-write-size`
 alert smb any any -> any any (msg:"SURICATA SMB max WRITE size exceeded"; flow:to_server; app-layer-event:smb.write_request_too_large; classtype:protocol-command-decode; sid:2225011; rev:1;)
 
-# checks 'app-layer.protocols.smb.max-read-size` against NEGOTIATE PROTOCOL response
+# checks 'app-layer.protocols.smb.max-read-size`, NEGOTIATE PROTOCOL response, and NBSS record length against SMB read data length
 alert smb any any -> any any (msg:"SURICATA SMB supported READ size exceeded"; flow:to_client; app-layer-event:smb.negotiate_max_read_size_too_large; classtype:protocol-command-decode; sid:2225012; rev:1;)
-# checks 'app-layer.protocols.smb.max-write-size` against NEGOTIATE PROTOCOL response
+# checks 'app-layer.protocols.smb.max-write-size`, NEGOTIATE PROTOCOL response, NBSS record length against SMB write data length
 alert smb any any -> any any (msg:"SURICATA SMB supported WRITE size exceeded"; flow:to_server; app-layer-event:smb.negotiate_max_write_size_too_large; classtype:protocol-command-decode; sid:2225013; rev:1;)
 
 # checks 'app-layer.protocols.smb.max-write-queue-size` against out of order chunks

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1302,7 +1302,7 @@ impl SMBState {
                                 if is_pipe {
                                     return 0;
                                 }
-                                smb1_write_request_record(self, r, SMB1_HEADER_SIZE, SMB1_COMMAND_WRITE_ANDX);
+                                smb1_write_request_record(self, r, SMB1_HEADER_SIZE, SMB1_COMMAND_WRITE_ANDX, nbss_part_hdr.length as usize - nbss_part_hdr.data.len());
                                 
                                 self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                 self.add_smb1_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
@@ -1318,7 +1318,7 @@ impl SMBState {
                             SCLogDebug!("SMB2: partial record {}",
                                         &smb2_command_string(smb_record.command));
                             if smb_record.command == SMB2_COMMAND_WRITE {
-                                smb2_write_request_record(self, smb_record);
+                                smb2_write_request_record(self, smb_record, nbss_part_hdr.length as usize - nbss_part_hdr.data.len());
                                 
                                 self.add_nbss_ts_frames(flow, stream_slice, input, nbss_part_hdr.length as i64);
                                 self.add_smb2_ts_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
@@ -1637,7 +1637,7 @@ impl SMBState {
                                 self.add_smb1_tc_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
                                 self.add_smb1_tc_hdr_data_frames(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
 
-                                smb1_read_response_record(self, r, SMB1_HEADER_SIZE);
+                                smb1_read_response_record(self, r, SMB1_HEADER_SIZE, nbss_part_hdr.length as usize - nbss_part_hdr.data.len());
                                 let consumed = input.len() - output.len();
                                 return consumed;
                             }
@@ -1654,7 +1654,7 @@ impl SMBState {
                                 self.add_smb2_tc_pdu_frame(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64);
                                 self.add_smb2_tc_hdr_data_frames(flow, stream_slice, nbss_part_hdr.data, nbss_part_hdr.length as i64, smb_record.header_len as i64);
 
-                                smb2_read_response_record(self, smb_record);
+                                smb2_read_response_record(self, smb_record, nbss_part_hdr.length as usize - nbss_part_hdr.data.len());
                                 let consumed = input.len() - output.len();
                                 return consumed;
                             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5770

Describe changes:
- smb : fix evasions by abusing length field

I still need to create a pcap with this attack...

suricata-verify-pr: 1049

Replacing #8331 with code review taken into account