### PR TITLE
Filestore alertlog 4881 v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -121,6 +121,9 @@
                     "filename": {
                         "type": "string"
                     },
+                    "file_id": {
+                        "type": "integer"
+                    },
                     "gaps": {
                         "type": "boolean"
                     },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -151,6 +151,9 @@
                     "stored": {
                         "type": "boolean"
                     },
+                    "storing": {
+                        "type": "boolean"
+                    },
                     "tx_id": {
                         "type": "integer"
                     },
@@ -1449,6 +1452,9 @@
                     "type": "string"
                 },
                 "stored": {
+                    "type": "boolean"
+                },
+                "storing": {
                     "type": "boolean"
                 },
                 "tx_id": {

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -167,8 +167,12 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv, const OutputFilestoreLo
                 == (int)sizeof(js_metadata_filename)) {
             WARN_ONCE(WOT_SNPRINTF, "Failed to write file info record. Output filename truncated.");
         } else {
+            // Set temporarily flag that file is stored for logging.
+            // CloseFile in output-filedata.c will soon set it for good.
+            uint16_t prev_flags = ff->flags;
+            ff->flags |= FILE_STORED;
             JsonBuilder *js_fileinfo =
-                    JsonBuildFileInfoRecord(p, ff, tx, tx_id, true, dir, ctx->xff_cfg, NULL);
+                    JsonBuildFileInfoRecord(p, ff, tx, tx_id, dir, ctx->xff_cfg, NULL);
             if (likely(js_fileinfo != NULL)) {
                 jb_close(js_fileinfo);
                 FILE *out = fopen(js_metadata_filename, "w");
@@ -179,6 +183,7 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv, const OutputFilestoreLo
                 }
                 jb_free(js_fileinfo);
             }
+            ff->flags = prev_flags;
         }
     }
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -616,7 +616,7 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
                 jb_open_array(jb, "files");
             }
             jb_start_object(jb);
-            EveFileInfo(jb, file, tx_id, file->flags & FILE_STORED);
+            EveFileInfo(jb, file, tx_id, file->flags);
             jb_close(jb);
             file = file->next;
         }

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -81,8 +81,7 @@ typedef struct JsonFileLogThread_ {
 } JsonFileLogThread;
 
 JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx,
-        const uint64_t tx_id, const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg,
-        OutputJsonCtx *eve_ctx)
+        const uint64_t tx_id, uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCtx *eve_ctx)
 {
     enum OutputJsonLogDirection fdir = LOG_DIR_FLOW;
 
@@ -186,7 +185,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx,
     jb_set_string(js, "app_proto", AppProtoToString(p->flow->alproto));
 
     jb_open_object(js, "fileinfo");
-    EveFileInfo(js, ff, tx_id, stored);
+    EveFileInfo(js, ff, tx_id, ff->flags);
     jb_close(js);
 
     /* xff header */
@@ -206,8 +205,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 {
     HttpXFFCfg *xff_cfg = aft->filelog_ctx->xff_cfg != NULL ?
         aft->filelog_ctx->xff_cfg : aft->filelog_ctx->parent_xff_cfg;;
-    JsonBuilder *js = JsonBuildFileInfoRecord(
-            p, ff, tx, tx_id, ff->flags & FILE_STORED ? true : false, dir, xff_cfg, eve_ctx);
+    JsonBuilder *js = JsonBuildFileInfoRecord(p, ff, tx, tx_id, dir, xff_cfg, eve_ctx);
     if (unlikely(js == NULL)) {
         return;
     }

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -30,7 +30,6 @@ typedef struct OutputJsonCtx_ OutputJsonCtx;
 
 void JsonFileLogRegister(void);
 JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx,
-        const uint64_t tx_id, const bool stored, uint8_t dir, HttpXFFCfg *xff_cfg,
-        OutputJsonCtx *eve_ctx);
+        const uint64_t tx_id, uint8_t dir, HttpXFFCfg *xff_cfg, OutputJsonCtx *eve_ctx);
 
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -128,7 +128,7 @@ json_t *SCJsonString(const char *val)
 /* Default Sensor ID value */
 static int64_t sensor_id = -1; /* -1 = not defined */
 
-void EveFileInfo(JsonBuilder *jb, const File *ff, const uint64_t tx_id, const bool stored)
+void EveFileInfo(JsonBuilder *jb, const File *ff, const uint64_t tx_id, uint16_t flags)
 {
     jb_set_string_from_bytes(jb, "filename", ff->name, ff->name_len);
 
@@ -170,11 +170,14 @@ void EveFileInfo(JsonBuilder *jb, const File *ff, const uint64_t tx_id, const bo
         jb_set_hex(jb, "sha256", (uint8_t *)ff->sha256, (uint32_t)sizeof(ff->sha256));
     }
 
-    if (stored) {
+    if (flags & FILE_STORED) {
         JB_SET_TRUE(jb, "stored");
         jb_set_uint(jb, "file_id", ff->file_store_id);
     } else {
         JB_SET_FALSE(jb, "stored");
+        if (flags & FILE_STORE) {
+            JB_SET_TRUE(jb, "storing");
+        }
     }
 
     jb_set_uint(jb, "size", FileTrackedSize(ff));

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -95,7 +95,7 @@ typedef struct OutputJsonThreadCtx_ {
 json_t *SCJsonString(const char *val);
 
 void CreateEveFlowId(JsonBuilder *js, const Flow *f);
-void EveFileInfo(JsonBuilder *js, const File *file, const uint64_t tx_id, const bool stored);
+void EveFileInfo(JsonBuilder *js, const File *file, const uint64_t tx_id, uint16_t flags);
 void EveTcpFlags(uint8_t flags, JsonBuilder *js);
 void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4881

Describe changes:
- mark file as `storing` in alert when it is planned to be stored...
- Add missing field to json schema

suricata-verify-pr: 1058
https://github.com/OISF/suricata-verify/pull/1058

Replaces https://github.com/OISF/suricata/pull/8350 by fixing S-V filestore-v2.4-forced-with-meta 