### PR TITLE
stream: fix memory leak when failing to insert segment

### DIFF
--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -703,6 +703,9 @@ int StreamTcpReassembleInsertSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             }
 #endif
         }
+    } else {
+        // EINVAL
+        StreamTcpSegmentReturntoPool(seg);
     }
 
     SCReturnInt(0);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5777

Describe changes:
- stream: fix memory leak when failing to insert segment

Should make CI green again :-)

Fixes leak introduced by commit f848e34bcc266a2a4d8f5fc2661d2b430449b190