### PR TITLE
github-ci: Check for new authors - v8

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -1,0 +1,34 @@
+name: New Author Check
+
+on:
+  - pull_request
+
+jobs:
+  check-id:
+    name: New Author Check
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt -y install git
+      - uses: actions/checkout@v3.2.0
+        with:
+          fetch-depth: 0
+      - name: Export all previous authors
+        run: git log --format="%an <%ae>" origin/master | sort | uniq > authors.txt
+      - run: cat authors.txt
+      - name: Get authors of new commits
+        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > commit-authors.txt
+      - run: cat commit-authors.txt
+      - name: Check new authors
+        run: |
+          touch new-authors.txt
+          while read -r author; do
+             echo "Checking author: ${author}"
+             if ! grep -q "^${author}\$" authors.txt; then
+                 echo "ERROR: ${author} NOT FOUND"
+                 echo "::error ::New author found: ${author}"
+                 echo "${author}" >> new-authors.txt
+                 echo has_new_authors="yes" >> $GITHUB_ENV
+             fi
+          done < commit-authors.txt
+      - if: ${{ env.has_new_authors == 'yes' }}
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ A: If you really think it is, we can discuss how to improve it. But don't come t
 __Q: do you require signing of a contributor license agreement?__
 
 A: Yes, we do this to keep the ownership of Suricata in one hand: the Open Information Security Foundation. See http://suricata.io/about/open-source/ and http://suricata.io/about/contribution-agreement/
+


### PR DESCRIPTION
Add a GitHub CI job that checks the commits in a pull requests for new
authors that have not been seen before. If a new author is found, the
job will error out with the unknown authors listed as error annotations.

Note the list of previous authors is taken from the master branch, so
there is a chance an author might not be detected as an existing author.

This is a job that simply fails that has the unfortunate affect of making the
PR look like it failed.  The various continue on fail options has more to do
with running subsequent jobs in a work flow, but not actually letting a work
flow fail for informational purposes.
