### PR TITLE
smb: fix wrong endian conversion when parse NTLM Negotiate Flags - V2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3615,6 +3615,13 @@
                         },
                         "user": {
                             "type": "string"
+                        },
+                        "version": {
+                            "type": "string",
+                            "optional": true
+                        },
+                        "warning": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -20,16 +20,17 @@ use crate::kerberos::*;
 use crate::smb::ntlmssp_records::*;
 use crate::smb::smb::*;
 
-use nom7::{Err, IResult};
 use der_parser::ber::BerObjectContent;
 use der_parser::der::{parse_der_oid, parse_der_sequence};
+use nom7::{Err, IResult};
 
-fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
-{
+fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError> {
     let (rem, base_o) = der_parser::parse_der(blob).map_err(Err::convert)?;
     SCLogDebug!("parse_secblob_get_spnego: base_o {:?}", base_o);
     let d = match base_o.content.as_slice() {
-        Err(_) => { return Err(Err::Error(SecBlobError::NotSpNego)); },
+        Err(_) => {
+            return Err(Err::Error(SecBlobError::NotSpNego));
+        }
         Ok(d) => d,
     };
     let (next, o) = parse_der_oid(d).map_err(Err::convert)?;
@@ -39,17 +40,17 @@ fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
         Ok(oid) => oid,
         Err(_) => {
             return Err(Err::Error(SecBlobError::NotSpNego));
-        },
+        }
     };
     SCLogDebug!("oid {}", oid.to_string());
 
     match oid.to_string().as_str() {
         "1.3.6.1.5.5.2" => {
             SCLogDebug!("SPNEGO {}", oid);
-        },
+        }
         _ => {
             return Err(Err::Error(SecBlobError::NotSpNego));
-        },
+        }
     }
 
     SCLogDebug!("parse_secblob_get_spnego: next {:?}", next);
@@ -57,17 +58,16 @@ fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
     Ok((rem, next))
 }
 
-fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
-{
+fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError> {
     let (rem, o) = der_parser::parse_der(blob).map_err(Err::convert)?;
     let d = match o.content.as_slice() {
         Ok(d) => {
-            SCLogDebug!("d: next data len {}",d.len());
+            SCLogDebug!("d: next data len {}", d.len());
             d
-        },
+        }
         _ => {
             return Err(Err::Error(SecBlobError::NotSpNego));
-        },
+        }
     };
     Ok((rem, d))
 }
@@ -78,27 +78,32 @@ pub struct SpnegoRequest {
     pub ntlmssp: Option<NtlmsspData>,
 }
 
-fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
-{
+fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest> {
     let mut have_ntlmssp = false;
     let mut have_kerberos = false;
-    let mut kticket : Option<Kerberos5Ticket> = None;
-    let mut ntlmssp : Option<NtlmsspData> = None;
+    let mut kticket: Option<Kerberos5Ticket> = None;
+    let mut ntlmssp: Option<NtlmsspData> = None;
 
     let o = match parse_der_sequence(blob) {
         Ok((_, o)) => o,
-        _ => { return None; },
+        _ => {
+            return None;
+        }
     };
     for s in o {
         SCLogDebug!("s {:?}", s);
 
         let n = match s.content.as_slice() {
             Ok(s) => s,
-            _ => { continue; },
+            _ => {
+                continue;
+            }
         };
         let o = match der_parser::parse_der(n) {
-            Ok((_,x)) => x,
-            _ => { continue; },
+            Ok((_, x)) => x,
+            _ => {
+                continue;
+            }
         };
         SCLogDebug!("o {:?}", o);
         match o.content {
@@ -109,20 +114,40 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
                         BerObjectContent::OID(ref oid) => {
                             SCLogDebug!("OID {:?}", oid);
                             match oid.to_string().as_str() {
-                                "1.2.840.48018.1.2.2" => { SCLogDebug!("Microsoft Kerberos 5"); },
-                                "1.2.840.113554.1.2.2" => { SCLogDebug!("Kerberos 5"); have_kerberos = true; },
-                                "1.2.840.113554.1.2.2.1" => { SCLogDebug!("krb5-name"); },
-                                "1.2.840.113554.1.2.2.2" => { SCLogDebug!("krb5-principal"); },
-                                "1.2.840.113554.1.2.2.3" => { SCLogDebug!("krb5-user-to-user-mech"); },
-                                "1.3.6.1.4.1.311.2.2.10" => { SCLogDebug!("NTLMSSP"); have_ntlmssp = true; },
-                                "1.3.6.1.4.1.311.2.2.30" => { SCLogDebug!("NegoEx"); },
-                                _ => { SCLogDebug!("unexpected OID {:?}", oid); },
+                                "1.2.840.48018.1.2.2" => {
+                                    SCLogDebug!("Microsoft Kerberos 5");
+                                }
+                                "1.2.840.113554.1.2.2" => {
+                                    SCLogDebug!("Kerberos 5");
+                                    have_kerberos = true;
+                                }
+                                "1.2.840.113554.1.2.2.1" => {
+                                    SCLogDebug!("krb5-name");
+                                }
+                                "1.2.840.113554.1.2.2.2" => {
+                                    SCLogDebug!("krb5-principal");
+                                }
+                                "1.2.840.113554.1.2.2.3" => {
+                                    SCLogDebug!("krb5-user-to-user-mech");
+                                }
+                                "1.3.6.1.4.1.311.2.2.10" => {
+                                    SCLogDebug!("NTLMSSP");
+                                    have_ntlmssp = true;
+                                }
+                                "1.3.6.1.4.1.311.2.2.30" => {
+                                    SCLogDebug!("NegoEx");
+                                }
+                                _ => {
+                                    SCLogDebug!("unexpected OID {:?}", oid);
+                                }
                             }
-                        },
-                        _ => { SCLogDebug!("expected OID, got {:?}", se); },
+                        }
+                        _ => {
+                            SCLogDebug!("expected OID, got {:?}", se);
+                        }
                     }
                 }
-            },
+            }
             BerObjectContent::OctetString(os) => {
                 if have_kerberos {
                     if let Ok((_, t)) = parse_kerberos5_request(os) {
@@ -134,8 +159,8 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
                     SCLogDebug!("parsing expected NTLMSSP");
                     ntlmssp = parse_ntlmssp_blob(os);
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 
@@ -146,7 +171,7 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
     Some(s)
 }
 
-#[derive(Debug,PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NtlmsspData {
     pub host: Vec<u8>,
     pub user: Vec<u8>,
@@ -156,27 +181,29 @@ pub struct NtlmsspData {
 }
 
 /// take in blob, search for the header and parse it
-fn parse_ntlmssp_blob(blob: &[u8]) -> Option<NtlmsspData>
-{
-    let mut ntlmssp_data : Option<NtlmsspData> = None;
+fn parse_ntlmssp_blob(blob: &[u8]) -> Option<NtlmsspData> {
+    let mut ntlmssp_data: Option<NtlmsspData> = None;
 
     SCLogDebug!("NTLMSSP {:?}", blob);
     if let Ok((_, nd)) = parse_ntlmssp(blob) {
-        SCLogDebug!("NTLMSSP TYPE {}/{} nd {:?}",
-                    nd.msg_type, &ntlmssp_type_string(nd.msg_type), nd);
+        SCLogDebug!(
+            "NTLMSSP TYPE {}/{} nd {:?}",
+            nd.msg_type,
+            &ntlmssp_type_string(nd.msg_type),
+            nd
+        );
         match nd.msg_type {
-            NTLMSSP_NEGOTIATE => {
-            },
+            NTLMSSP_NEGOTIATE => {}
             NTLMSSP_AUTH => {
                 if let Ok((_, ad)) = parse_ntlm_auth_record(nd.data) {
                     SCLogDebug!("auth data {:?}", ad);
                     let mut host = ad.host.to_vec();
-                    host.retain(|&i|i != 0x00);
+                    host.retain(|&i| i != 0x00);
                     let mut user = ad.user.to_vec();
-                    user.retain(|&i|i != 0x00);
+                    user.retain(|&i| i != 0x00);
                     let mut domain = ad.domain.to_vec();
-                    domain.retain(|&i|i != 0x00);
-                    
+                    domain.retain(|&i| i != 0x00);
+
                     let d = NtlmsspData {
                         host,
                         user,
@@ -186,47 +213,38 @@ fn parse_ntlmssp_blob(blob: &[u8]) -> Option<NtlmsspData>
                     };
                     ntlmssp_data = Some(d);
                 }
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
     return ntlmssp_data;
 }
 
 // if spnego parsing fails try to fall back to ntlmssp
-pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest>
-{
+pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest> {
     match parse_secblob_get_spnego(blob) {
-        Ok((_, spnego)) => {
-            match parse_secblob_spnego_start(spnego) {
-                Ok((_, spnego_start)) => {
-                    parse_secblob_spnego(spnego_start)
-                },
-                _ => {
-                    match parse_ntlmssp_blob(blob) {
-                        Some(n) => {
-                            let s = SpnegoRequest {
-                                krb: None,
-                                ntlmssp: Some(n),
-                            };
-                            Some(s)
-                        },
-                        None => { None },
-                    }
-                },
-            }
-        },
-        _ => {
-            match parse_ntlmssp_blob(blob) {
+        Ok((_, spnego)) => match parse_secblob_spnego_start(spnego) {
+            Ok((_, spnego_start)) => parse_secblob_spnego(spnego_start),
+            _ => match parse_ntlmssp_blob(blob) {
                 Some(n) => {
                     let s = SpnegoRequest {
                         krb: None,
-                         ntlmssp: Some(n),
+                        ntlmssp: Some(n),
                     };
                     Some(s)
-                },
-                None => { None },
+                }
+                None => None,
+            },
+        },
+        _ => match parse_ntlmssp_blob(blob) {
+            Some(n) => {
+                let s = SpnegoRequest {
+                    krb: None,
+                    ntlmssp: Some(n),
+                };
+                Some(s)
             }
+            None => None,
         },
     }
 }

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -72,6 +72,7 @@ fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError
     Ok((rem, d))
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SpnegoRequest {
     pub krb: Option<Kerberos5Ticket>,
     pub ntlmssp: Option<NtlmsspData>,
@@ -227,5 +228,32 @@ pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest>
                 None => { None },
             }
         },
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_parse_secblob() {
+        let blob = hex::decode("a18202313082022da0030a0101a28202100482020c4e544c4d5353500003000000180018009c00000048014801b40000001e001e005800000008000800760000001e001e007e00000010001000fc010000158288e20a005a290000000fc6107a73184fb65fe684f6a1641464be4400450053004b0054004f0050002d0032004100450046004d003700470075007300650072004400450053004b0054004f0050002d0032004100450046004d003700470000000000000000000000000000000000000000000000000028a0c9f4e792c408913d2878feaa9a22010100000000000078a7ed218527d2010cf876f08a0b3bfa0000000002001e004400450053004b0054004f0050002d00560031004600410030005500510001001e004400450053004b0054004f0050002d00560031004600410030005500510004001e004400450053004b0054004f0050002d00560031004600410030005500510003001e004400450053004b0054004f0050002d0056003100460041003000550051000700080078a7ed218527d20106000400020000000800300030000000000000000100000000200000ad865b6d08a95d0e76a94e2ca013ab3f69c4fd945cca01b277700fd2b305ca010a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100390039002e003100330033000000000000000000000000005858824ec4a47b3b42ad3132ab84a5c3a31204100100000092302d756840453f00000000").unwrap();
+        let result = parse_secblob(&blob);
+        assert_eq!(
+            result,
+            Some(SpnegoRequest {
+                krb: None,
+                ntlmssp: Some(NtlmsspData {
+                    host: b"DESKTOP-2AEFM7G".to_vec(),
+                    user: b"user".to_vec(),
+                    domain: b"DESKTOP-2AEFM7G".to_vec(),
+                    version: Some(NTLMSSPVersion {
+                        ver_major: 10,
+                        ver_minor: 0,
+                        ver_build: 10586,
+                        ver_ntlm_rev: 15,
+                    },),
+                    warning: false,
+                }),
+            })
+        );
     }
 }

--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -68,8 +68,8 @@ pub struct NTLMSSPAuthRecord<'a> {
     pub warning: bool,
 }
 
-fn parse_ntlm_auth_nego_flags(i: &[u8]) -> IResult<&[u8], (u8, u8, u32)> {
-    bits(tuple((take_bits(6u8), take_bits(1u8), take_bits(25u32))))(i)
+fn parse_ntlm_auth_nego_flags(i: &[u8]) -> IResult<&[u8], (u32, u8, u8)> {
+    bits(tuple((take_bits(25u8), take_bits(1u8), take_bits(6u32))))(i)
 }
 
 const NTLMSSP_IDTYPE_LEN: usize = 12;
@@ -153,4 +153,30 @@ pub fn parse_ntlmssp(i: &[u8]) -> IResult<&[u8], NTLMSSPRecord> {
     let (i, data) = rest(i)?;
     let record = NTLMSSPRecord { msg_type, data };
     Ok((i, record))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom7::Err;
+    #[test]
+    fn test_parse_auth_nego_flags() {
+        let blob = [0x15, 0x82, 0x88, 0xe2];
+        let result = parse_ntlm_auth_nego_flags(&blob);
+        match result {
+            Ok((remainder, (_, version_flag, _))) => {
+                assert_eq!(version_flag, 1);
+                assert_eq!(remainder.len(), 0);
+            }
+            Err(Err::Error(err)) => {
+                panic!("Result should not be an error: {:?}.", err.code);
+            }
+            Err(Err::Incomplete(_)) => {
+                panic!("Result should not have been incomplete.");
+            }
+            _ => {
+                panic!("Unexpected behavior!");
+            }
+        }
+    }
 }


### PR DESCRIPTION

Ticket: https://redmine.openinfosecfoundation.org/issues/5783

Previous PR: https://github.com/OISF/suricata/pull/8372

Changes from last PR:
    - fix invalid json schema error 
    - keep the formatting changes in a separate commit
    - fix email in commit message
  
Signed-off-by: b1tg [b1tg@protonmail.ch](mailto:b1tg@protonmail.ch)