### PR TITLE
ftp: completely resets port_line

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -645,6 +645,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
                             FTPFree(state->port_line, state->port_line_size);
                             state->port_line = NULL;
                             state->port_line_size = 0;
+                            state->port_line_len = 0;
                         }
                         SCReturnStruct(APP_LAYER_OK);
                     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5701

Describe changes:
- ftp: completely resets port_line

As approved on Gitlab