### PR TITLE
Fuzz target fix v4

### DIFF
--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -117,7 +117,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     // loop over packets
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header.ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->ts.tv_sec = header.ts.tv_sec;
@@ -143,7 +143,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = FPC_next(&pkts, &header, &pkt);
-        if (header.ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -160,7 +160,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     //loop over packets
     r = pcap_next_ex(pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600 || header->ts.tv_usec < 0) {
         goto bail;
     }
     p->ts.tv_sec = header->ts.tv_sec;
@@ -187,7 +187,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = pcap_next_ex(pkts, &header, &pkt);
-        if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600 || header->ts.tv_usec < 0) {
             goto bail;
         }
         PacketRecycle(p);

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -160,7 +160,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     //loop over packets
     r = pcap_next_ex(pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header->ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->ts.tv_sec = header->ts.tv_sec;
@@ -187,7 +187,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = pcap_next_ex(pkts, &header, &pkt);
-        if (header->ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -157,7 +157,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     // loop over packets
     r = FPC_next(&pkts, &header, &pkt);
     p = PacketGetFromAlloc();
-    if (header.ts.tv_sec >= INT_MAX - 3600) {
+    if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
     p->pkt_src = PKT_SRC_WIRE;
@@ -184,7 +184,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             }
         }
         r = FPC_next(&pkts, &header, &pkt);
-        if (header.ts.tv_sec >= INT_MAX - 3600) {
+        if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
             goto bail;
         }
         PacketRecycle(p);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54111

Describe changes:
- fuzz: fix use of uninitialized value 
- fuzz: do not trust libpcap to supply a positive number of microseconds for packet timestamp

As first packet may fail...

Replaces #8367 with adding second commit