### PR TITLE
Dropped flows still logged - 5802 - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4930,6 +4930,9 @@
                                         "closed": {
                                             "type": "integer"
                                         },
+                                        "dropped": {
+                                            "type": "integer"
+                                        },
                                         "local_bypassed": {
                                             "type": "integer"
                                         },

--- a/src/detect.c
+++ b/src/detect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/detect.c
+++ b/src/detect.c
@@ -1667,6 +1667,12 @@ static void DetectFlow(ThreadVars *tv,
 {
     Flow *const f = p->flow;
 
+    /* if flow is set to drop, we enforce that here */
+    if (f->flags & FLOW_ACTION_DROP) {
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        SCReturn;
+    }
+
     if (p->flags & PKT_NOPACKET_INSPECTION) {
         /* hack: if we are in pass the entire flow mode, we need to still
          * update the inspect_id forward. So test for the condition here,
@@ -1682,12 +1688,6 @@ static void DetectFlow(ThreadVars *tv,
         SCLogDebug("p->pcap %"PRIu64": no detection on packet, "
                 "PKT_NOPACKET_INSPECTION is set", p->pcap_cnt);
         return;
-    }
-
-    /* if flow is set to drop, we enforce that here */
-    if (f->flags & FLOW_ACTION_DROP) {
-        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
-        SCReturn;
     }
 
     /* see if the packet matches one or more of the sigs */

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2017 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -362,7 +362,7 @@ void FlowForceReassemblyForFlow(Flow *f)
  * done are:
  * - code consistency
  * - silence complaining profilers
- * - allow us to aggressively check using debug valdation assertions
+ * - allow us to aggressively check using debug validation assertions
  * - be robust in case of future changes
  * - locking overhead if neglectable when no other thread fights us
  *

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -249,6 +249,8 @@ void FlowEndCountersRegister(ThreadVars *t, FlowEndCounters *fec)
             name = "flow.end.state.established";
         } else if (i == FLOW_STATE_CLOSED) {
             name = "flow.end.state.closed";
+        } else if (i == FLOW_STATE_DROPPED) {
+            name = "flow.end.state.dropped";
         } else if (i == FLOW_STATE_LOCAL_BYPASSED) {
             name = "flow.end.state.local_bypassed";
 #ifdef CAPTURE_OFFLOAD

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2020 Open Information Security Foundation
+/* Copyright (C) 2016-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/flow.c
+++ b/src/flow.c
@@ -63,6 +63,8 @@
 #include "detect.h"
 #include "detect-engine-state.h"
 #include "stream.h"
+#include "packet.h"
+#include "action-globals.h"
 
 #include "app-layer-parser.h"
 #include "app-layer-expectation.h"
@@ -513,6 +515,11 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
         SCLogDebug("setting FLOW_NOPAYLOAD_INSPECTION flag on flow %p", f);
         DecodeSetNoPayloadInspectionFlag(p);
+    }
+    if (f->flags & FLOW_ACTION_DROP) {
+        SCLogDebug("flow drop flag set. Drop packet on flow %p", f);
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+        FlowUpdateState(f, FLOW_STATE_DROPPED);
     }
 }
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -534,7 +534,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
 void FlowHandlePacket(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
     /* Get this packet's flow from the hash. FlowHandlePacket() will setup
-     * a new flow if nescesary. If we get NULL, we're out of flow memory.
+     * a new flow if necessary. If we get NULL, we're out of flow memory.
      * The returned flow is locked. */
     Flow *f = FlowGetFlowFromHash(tv, fls, p, &p->flow);
     if (f == NULL)

--- a/src/flow.h
+++ b/src/flow.h
@@ -512,15 +512,16 @@ enum FlowState {
     FLOW_STATE_NEW = 0,
     FLOW_STATE_ESTABLISHED,
     FLOW_STATE_CLOSED,
+    FLOW_STATE_DROPPED,
     FLOW_STATE_LOCAL_BYPASSED,
 #ifdef CAPTURE_OFFLOAD
     FLOW_STATE_CAPTURE_BYPASSED,
 #endif
 };
 #ifdef CAPTURE_OFFLOAD
-#define FLOW_STATE_SIZE 5
+#define FLOW_STATE_SIZE 6
 #else
-#define FLOW_STATE_SIZE 4
+#define FLOW_STATE_SIZE 5
 #endif
 
 typedef struct FlowProtoTimeout_ {
@@ -723,6 +724,17 @@ static inline bool FlowIsBypassed(const Flow *f)
             f->flow_state == FLOW_STATE_CAPTURE_BYPASSED ||
 #endif
             f->flow_state == FLOW_STATE_LOCAL_BYPASSED) {
+        return true;
+    }
+    return false;
+}
+
+static inline bool FlowIsDropped(const Flow *f)
+{
+    if (f == NULL) {
+        return false;
+    }
+    if (f->flow_state == FLOW_STATE_DROPPED) {
         return true;
     }
     return false;

--- a/src/flow.h
+++ b/src/flow.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -31,6 +31,8 @@
 #include "app-layer-parser.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "action-globals.h"
+#include "packet.h"
 
 /** per thread data for this module, contains a list of per thread
  *  data for the packet loggers. */
@@ -333,7 +335,7 @@ static void OutputTxLogCallLoggers(ThreadVars *tv, OutputTxLoggerThreadData *op_
 static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
 {
     DEBUG_VALIDATE_BUG_ON(thread_data == NULL);
-    if (p->flow == NULL)
+    if (p->flow == NULL || PacketCheckAction(p, ACTION_DROP))
         return TM_ECODE_OK;
     if (!((PKT_IS_PSEUDOPKT(p)) || (p->flags & PKT_APPLAYER_UPDATE) != 0)) {
         SCLogDebug("not pseudo, no app update: skip");


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5802

While working on #8310 (and testing that against https://github.com/OISF/suricata-verify/pull/1046) we noticed that Suri would still log app-layer events from the dropped flow. This is a WIP trying to fix that. 

Describe changes:
- Add a Flow state dropped, in an attempt to better track and check for dropped flow (and all its consequences)
- Add more checks for dropped flow along the flow processing
- check for dropped flow when logging the transaction - while debugging, this seemed to be the place from where the unwanted app-layer events were coming. But not sure if true or not, yet.

Not done/ to further investigate:
- do we properly close all transactions from a flow, after we drop it? The `flow` log output makes me think we don't:
```
{"flow":{"pkts_toserver":4,"pkts_toclient":5,"bytes_toserver":495,"bytes_toclient":351,"start":"2016-07-13T22:42:07.199672+0000","end":"2016-07-13T22:42:07.573174+0000","age":0,"state":"new","reason":"shutdown","alerted":false,"action":"drop"}}
```
(of note, to me, are: `state: new` and `reason: shutdown`)
- make sure that the closed transactions will be logged out - in the drop event? the info associated with the transaction. This should be true for dropped packet, as well - as of now, this output happens in an app-layer event right after the drop log event.
- make sure that there aren't stream left overs -- right now, we will see them happening with the SV tests for `threshold-config-rate-filter` for `drop` and `reject`.
- add SV tests to check and reinforce all cases that we can think of