### PR TITLE
ftp: completely resets port_line (backport6)

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -656,6 +656,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state,
                             FTPFree(state->port_line, state->port_line_size);
                             state->port_line = NULL;
                             state->port_line_size = 0;
+                            state->port_line_len = 0;
                         }
                         SCReturnStruct(APP_LAYER_OK);
                     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5804

Describe changes:
- backport of recently merged #8379 

Clean cherry-pick