### PR TITLE
time: Replace struct timeval with scalar value

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -162,7 +162,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
 
     MemBufferReset(aft->buffer);
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     MemBufferWriteString(aft->buffer, "+================\n"
                          "TIME:              %s\n", timebuf);
@@ -206,7 +206,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     if (p->flow != NULL) {
         int applayer = 0;
         applayer = StreamTcpAppLayerIsDisabled(p->flow);
-        CreateTimeString(&p->flow->startts, timebuf, sizeof(timebuf));
+        CreateTimeString(p->flow->startts, timebuf, sizeof(timebuf));
         MemBufferWriteString(aft->buffer, "FLOW Start TS:     %s\n", timebuf);
         MemBufferWriteString(aft->buffer, "FLOW PKTS TODST:   %"PRIu32"\n"
                              "FLOW PKTS TOSRC:   %"PRIu32"\n"
@@ -324,7 +324,7 @@ static TmEcode AlertDebugLogDecoderEvent(ThreadVars *tv, const Packet *p, void *
 
     MemBufferReset(aft->buffer);
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     MemBufferWriteString(aft->buffer,
                          "+================\n"

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -106,7 +106,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     char timebuf[64];
     int decoder_event = 0;
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     char srcip[46], dstip[46];
     if (PKT_IS_IPV4(p)) {

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -71,7 +71,7 @@ SC_ATOMIC_DECLARE(uint32_t, expectation_count);
 #define EXPECTATION_MAX_LEVEL 10
 
 typedef struct Expectation_ {
-    struct timeval ts;
+    SCTime_t ts;
     Port sp;
     Port dp;
     AppProto alproto;
@@ -317,8 +317,6 @@ AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags)
     if (exp_list == NULL)
         goto out;
 
-    time_t ctime = f->lastts.tv_sec;
-
     CIRCLEQ_FOREACH_SAFE(exp, &exp_list->list, entries, lexp) {
         if ((exp->direction & flags) && ((exp->sp == 0) || (exp->sp == f->sp)) &&
                 ((exp->dp == 0) || (exp->dp == f->dp))) {
@@ -346,7 +344,7 @@ AppProto AppLayerExpectationHandle(Flow *f, uint8_t flags)
             continue;
         }
         /* Cleaning remove old entries */
-        if (ctime > exp->ts.tv_sec + EXPECTATION_TIMEOUT) {
+        if (SCTIME_SECS(f->lastts) > SCTIME_SECS(exp->ts) + EXPECTATION_TIMEOUT) {
             exp_list = AppLayerExpectationRemove(ipp, exp_list, exp);
             if (exp_list == NULL)
                 goto out;

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -25,7 +25,7 @@
 
 void HttpRangeContainersInit(void);
 void HttpRangeContainersDestroy(void);
-uint32_t HttpRangeContainersTimeoutHash(struct timeval *ts);
+uint32_t HttpRangeContainersTimeoutHash(const SCTime_t ts);
 
 // linked list of ranges : buffer with offset
 typedef struct HttpRangeContainerBuffer {

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -837,7 +837,8 @@ static int Setup(Flow *f, HtpState *hstate)
 
     SCLogDebug("New hstate->connp %p", hstate->connp);
 
-    htp_connp_open(hstate->connp, NULL, f->sp, NULL, f->dp, &f->startts);
+    struct timeval tv = { SCTIME_SECS(f->startts), SCTIME_USECS(f->startts) };
+    htp_connp_open(hstate->connp, NULL, f->sp, NULL, f->dp, &tv);
 
     StreamTcpReassemblySetMinInspectDepth(f->protoctx, STREAM_TOSERVER,
             htp_cfg_rec->request.inspect_min_size);
@@ -880,7 +881,7 @@ static AppLayerResult HTPHandleRequestData(Flow *f, void *htp_state, AppLayerPar
     const uint8_t *input = StreamSliceGetData(&stream_slice);
     uint32_t input_len = StreamSliceGetDataLen(&stream_slice);
 
-    htp_time_t ts = { f->lastts.tv_sec, f->lastts.tv_usec };
+    htp_time_t ts = { SCTIME_SECS(f->startts), SCTIME_USECS(f->startts) };
     /* pass the new data to the htp parser */
     if (input_len > 0) {
         const int r = htp_connp_req_data(hstate->connp, &ts, input, input_len);
@@ -947,7 +948,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
     DEBUG_VALIDATE_BUG_ON(hstate->connp == NULL);
     hstate->slice = &stream_slice;
 
-    htp_time_t ts = { f->lastts.tv_sec, f->lastts.tv_usec };
+    htp_time_t ts = { SCTIME_SECS(f->startts), SCTIME_USECS(f->startts) };
     htp_tx_t *tx = NULL;
     size_t consumed = 0;
     if (input_len > 0) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -329,8 +329,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->recursion_level = parent->recursion_level + 1;
     DEBUG_VALIDATE_BUG_ON(parent->nb_decoded_layers >= decoder_max_layers);
     p->nb_decoded_layers = parent->nb_decoded_layers + 1;
-    p->ts.tv_sec = parent->ts.tv_sec;
-    p->ts.tv_usec = parent->ts.tv_usec;
+    p->ts = parent->ts;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
     p->livedev = parent->livedev;
@@ -408,8 +407,7 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
         PacketCopyData(p, pkt, len);
     }
     p->recursion_level = parent->recursion_level; /* NOT incremented */
-    p->ts.tv_sec = parent->ts.tv_sec;
-    p->ts.tv_usec = parent->ts.tv_usec;
+    p->ts = parent->ts;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
     /* tell new packet it's part of a tunnel */

--- a/src/decode.h
+++ b/src/decode.h
@@ -468,7 +468,7 @@ typedef struct Packet_
      * hash size still */
     uint32_t flow_hash;
 
-    struct timeval ts;
+    SCTime_t ts;
 
     union {
         /* nfq stuff */

--- a/src/defrag-timeout.c
+++ b/src/defrag-timeout.c
@@ -36,7 +36,7 @@
  *  \retval 0 not timed out just yet
  *  \retval 1 fully timed out, lets kill it
  */
-static int DefragTrackerTimedOut(DefragTracker *dt, struct timeval *ts)
+static int DefragTrackerTimedOut(DefragTracker *dt, SCTime_t ts)
 {
     /** never prune a trackers that is used by a packet
      *  we are currently processing in one of the threads */
@@ -45,7 +45,7 @@ static int DefragTrackerTimedOut(DefragTracker *dt, struct timeval *ts)
     }
 
     /* retain if remove is not set and not timed out */
-    if (!dt->remove && timercmp(&dt->timeout, ts, >))
+    if (!dt->remove && SCTIME_CMP_GT(dt->timeout, ts))
         return 0;
 
     return 1;
@@ -62,7 +62,8 @@ static int DefragTrackerTimedOut(DefragTracker *dt, struct timeval *ts)
  *
  *  \retval cnt timed out tracker
  */
-static uint32_t DefragTrackerHashRowTimeout(DefragTrackerHashRow *hb, DefragTracker *dt, struct timeval *ts)
+static uint32_t DefragTrackerHashRowTimeout(
+        DefragTrackerHashRow *hb, DefragTracker *dt, SCTime_t ts)
 {
     uint32_t cnt = 0;
 
@@ -117,7 +118,7 @@ static uint32_t DefragTrackerHashRowTimeout(DefragTrackerHashRow *hb, DefragTrac
  *
  *  \retval cnt number of timed out tracker
  */
-uint32_t DefragTimeoutHash(struct timeval *ts)
+uint32_t DefragTimeoutHash(SCTime_t ts)
 {
     uint32_t idx = 0;
     uint32_t cnt = 0;

--- a/src/defrag-timeout.h
+++ b/src/defrag-timeout.h
@@ -24,7 +24,7 @@
 #ifndef __DEFRAG_TIMEOUT_H__
 #define __DEFRAG_TIMEOUT_H__
 
-uint32_t DefragTimeoutHash(struct timeval *ts);
+uint32_t DefragTimeoutHash(SCTime_t ts);
 
 uint32_t DefragGetSpareCount(void);
 uint32_t DefragGetActiveCount(void);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -628,7 +628,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     }
 
     /* Update timeout. */
-    tracker->timeout = TimevalWithSeconds(&p->ts, tracker->host_timeout);
+    tracker->timeout = SCTIME_SECS(p->ts) + tracker->host_timeout;
 
     Frag *prev = NULL, *next = NULL;
     bool overlap = false;
@@ -1104,7 +1104,9 @@ static Packet *BuildTestPacket(uint8_t proto, uint16_t id, uint16_t off, int mf,
 
     PacketInit(p);
 
-    gettimeofday(&p->ts, NULL);
+    struct timeval tval;
+    gettimeofday(&tval, NULL);
+    p->ts = SCTIME_FROM_TIMEVAL(&tval);
     //p->ip4h = (IPV4Hdr *)GET_PKT_DATA(p);
     ip4h.ip_verhl = 4 << 4;
     ip4h.ip_verhl |= hlen >> 2;
@@ -1174,7 +1176,9 @@ static Packet *IPV6BuildTestPacket(uint8_t proto, uint32_t id, uint16_t off,
 
     PacketInit(p);
 
-    gettimeofday(&p->ts, NULL);
+    struct timeval tval;
+    gettimeofday(&tval, NULL);
+    p->ts = SCTIME_FROM_TIMEVAL(&tval);
 
     ip6h.s_ip6_nxt = 44;
     ip6h.s_ip6_hlim = 2;
@@ -2104,7 +2108,7 @@ static int DefragTimeoutTest(void)
     Packet *p = BuildTestPacket(IPPROTO_ICMP, 99, 0, 1, 'A' + i, 16);
     FAIL_IF_NULL(p);
 
-    p->ts.tv_sec += (defrag_context->timeout + 1);
+    p->ts += SCTIME_FROM_SECS(defrag_context->timeout + 1);
     Packet *tp = Defrag(NULL, NULL, p);
     FAIL_IF_NOT_NULL(tp);
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -628,7 +628,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     }
 
     /* Update timeout. */
-    tracker->timeout = SCTIME_SECS(p->ts) + tracker->host_timeout;
+    tracker->timeout = SCTIME_FROM_SECS(SCTIME_SECS(p->ts) + tracker->host_timeout);
 
     Frag *prev = NULL, *next = NULL;
     bool overlap = false;
@@ -2108,7 +2108,7 @@ static int DefragTimeoutTest(void)
     Packet *p = BuildTestPacket(IPPROTO_ICMP, 99, 0, 1, 'A' + i, 16);
     FAIL_IF_NULL(p);
 
-    p->ts += SCTIME_FROM_SECS(defrag_context->timeout + 1);
+    p->ts = SCTIME_ADD_SECS(p->ts, defrag_context->timeout + 1);
     Packet *tp = Defrag(NULL, NULL, p);
     FAIL_IF_NOT_NULL(tp);
 

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -106,7 +106,7 @@ typedef struct DefragTracker_ {
     Address src_addr; /**< Source address for this tracker. */
     Address dst_addr; /**< Destination address for this tracker. */
 
-    struct timeval timeout; /**< When this tracker will timeout. */
+    SCTime_t timeout;       /**< When this tracker will timeout. */
     uint32_t host_timeout;  /**< Host timeout, statically assigned from the yaml */
 
     /** use cnt, reference counter */

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -435,12 +435,8 @@ static int DetectDetectionFilterTestSig2(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset(&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -460,7 +456,7 @@ static int DetectDetectionFilterTestSig2(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(PacketAlertCheck(p, 10));
@@ -470,7 +466,7 @@ static int DetectDetectionFilterTestSig2(void)
     FAIL_IF(PacketAlertCheck(p, 10));
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(PacketAlertCheck(p, 10));
@@ -497,12 +493,8 @@ static int DetectDetectionFilterTestSig3(void)
 {
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset(&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -521,7 +513,7 @@ static int DetectDetectionFilterTestSig3(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(PacketAlertCheck(p, 10));
@@ -539,7 +531,7 @@ static int DetectDetectionFilterTestSig3(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(PacketAlertCheck(p, 10));

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -556,7 +556,7 @@ int TagTimeoutCheck(Host *host, SCTime_t ts)
     prev = NULL;
     while (tmp != NULL) {
         SCTime_t timeout_at = SCTIME_FROM_SECS(tmp->last_ts + TAG_MAX_LAST_TIME_SEEN);
-        if (timeout_at >= ts) {
+        if (SCTIME_CMP_GTE(timeout_at, ts)) {
             prev = tmp;
             tmp = tmp->next;
             retval = 0;

--- a/src/detect-engine-tag.h
+++ b/src/detect-engine-tag.h
@@ -31,7 +31,7 @@
 #include "detect.h"
 #include "detect-tag.h"
 
-/* This limit should be overwriten/predefined at the config file
+/* This limit should be overwritten/predefined at the config file
  * to limit the options to prevent possible DOS situations. We should also
  * create a limit for bytes and a limit for number of packets */
 #define TAG_MAX_LAST_TIME_SEEN 600
@@ -53,7 +53,7 @@ void TagInitCtx(void);
 void TagDestroyCtx(void);
 void TagRestartCtx(void);
 
-int TagTimeoutCheck(Host *, struct timeval *);
+int TagTimeoutCheck(Host *, SCTime_t);
 
 int TagHostHasTag(Host *host);
 

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -166,8 +166,8 @@ static DetectThresholdEntry *ThresholdTimeoutCheck(DetectThresholdEntry *head, S
         /* check if the 'check' timestamp is not before the creation ts.
          * This can happen due to the async nature of the host timeout
          * code that also calls this code from a management thread. */
-        SCTime_t entry = tmp->tv1 + SCTIME_FROM_SECS((time_t)tmp->seconds);
-        if (ts <= entry) {
+        SCTime_t entry = SCTIME_ADD_SECS(tmp->tv1, (time_t)tmp->seconds);
+        if (SCTIME_CMP_LTE(ts, entry)) {
             prev = tmp;
             tmp = tmp->next;
             continue;
@@ -343,8 +343,8 @@ static int IsThresholdReached(
     }
     else {
         /* Update the matching state with the timeout interval */
-        SCTime_t entry = lookup_tsh->tv1 + SCTIME_FROM_SECS(td->seconds);
-        if (packet_time <= entry) {
+        SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
+        if (SCTIME_CMP_LTE(packet_time, entry)) {
             lookup_tsh->current_count++;
             if (lookup_tsh->current_count > td->count) {
                 /* Then we must enable the new action by setting a
@@ -403,8 +403,8 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             SCLogDebug("limit");
 
             if (lookup_tsh != NULL)  {
-                SCTime_t entry = lookup_tsh->tv1 + SCTIME_FROM_SECS(td->seconds);
-                if (p->ts <= entry) {
+                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
+                if (SCTIME_CMP_LTE(p->ts, entry)) {
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count <= td->count) {
@@ -430,8 +430,8 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             SCLogDebug("threshold");
 
             if (lookup_tsh != NULL)  {
-                SCTime_t entry = lookup_tsh->tv1 + SCTIME_FROM_SECS(td->seconds);
-                if (p->ts <= entry) {
+                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
+                if (SCTIME_CMP_LTE(p->ts, entry)) {
                     lookup_tsh->current_count++;
 
                     if (lookup_tsh->current_count >= td->count) {
@@ -456,8 +456,8 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             SCLogDebug("both");
 
             if (lookup_tsh != NULL) {
-                SCTime_t entry = lookup_tsh->tv1 + SCTIME_FROM_SECS(td->seconds);
-                if (p->ts <= entry) {
+                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
+                if (SCTIME_CMP_LTE(p->ts, entry)) {
                     /* within time limit */
 
                     lookup_tsh->current_count++;
@@ -494,8 +494,8 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             SCLogDebug("detection_filter");
 
             if (lookup_tsh != NULL) {
-                SCTime_t entry = lookup_tsh->tv1 + SCTIME_FROM_SECS(td->seconds);
-                if (p->ts <= entry) {
+                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
+                if (SCTIME_CMP_LTE(p->ts, entry)) {
                     /* within timeout */
                     lookup_tsh->current_count++;
                     if (lookup_tsh->current_count > td->count) {

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -47,8 +47,8 @@ void ThresholdHashInit(DetectEngineCtx *);
 void ThresholdHashAllocate(DetectEngineCtx *);
 void ThresholdContextDestroy(DetectEngineCtx *);
 
-int ThresholdHostTimeoutCheck(Host *, struct timeval *);
-int ThresholdIPPairTimeoutCheck(IPPair *, struct timeval *);
+int ThresholdHostTimeoutCheck(Host *, SCTime_t);
+int ThresholdIPPairTimeoutCheck(IPPair *, SCTime_t);
 void ThresholdListFree(void *ptr);
 
 #endif /* __DETECT_ENGINE_THRESHOLD_H__ */

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -29,7 +29,7 @@ static int DetectFlowAgeMatch(
     if (p->flow == NULL) {
         return 0;
     }
-    uint32_t age = p->flow->lastts.tv_sec - p->flow->startts.tv_sec;
+    uint32_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
 
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
     return DetectU32Match(age, du32);

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -105,7 +105,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_src);
 
-            HostBitToggle(p->host_src,fd->idx,p->ts.tv_sec + fd->expire);
+            HostBitToggle(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -117,7 +117,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_dst);
 
-            HostBitToggle(p->host_dst,fd->idx,p->ts.tv_sec + fd->expire);
+            HostBitToggle(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_dst);
             break;
     }
@@ -165,7 +165,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            HostBitSet(p->host_src,fd->idx,p->ts.tv_sec + fd->expire);
+            HostBitSet(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -176,7 +176,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            HostBitSet(p->host_dst,fd->idx, p->ts.tv_sec + fd->expire);
+            HostBitSet(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_dst);
             break;
     }
@@ -195,7 +195,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsset(p->host_src,fd->idx, p->ts.tv_sec);
+            r = HostBitIsset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -206,7 +206,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsset(p->host_dst,fd->idx, p->ts.tv_sec);
+            r = HostBitIsset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
             HostUnlock(p->host_dst);
             return r;
     }
@@ -225,7 +225,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsnotset(p->host_src,fd->idx, p->ts.tv_sec);
+            r = HostBitIsnotset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -236,7 +236,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsnotset(p->host_dst,fd->idx, p->ts.tv_sec);
+            r = HostBitIsnotset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
             HostUnlock(p->host_dst);
             return r;
     }

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -106,7 +106,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
 
             tde.sid = s->id;
             tde.gid = s->gid;
-            tde.last_ts = tde.first_ts = p->ts.tv_sec;
+            tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
             tde.metric = td->metric;
             tde.count = td->count;
             if (td->direction == DETECT_TAG_DIR_SRC)
@@ -123,7 +123,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
                 /* If it already exists it will be updated */
                 tde.sid = s->id;
                 tde.gid = s->gid;
-                tde.last_ts = tde.first_ts = p->ts.tv_sec;
+                tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
                 tde.metric = td->metric;
                 tde.count = td->count;
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -1672,6 +1672,7 @@ static int DetectThresholdTestSig14(void)
     FAIL_IF(alerts1 != 2);
     FAIL_IF(alerts2 != 2);
 
+    TimeSetIncrementTime(70);
     p1->ts = TimeGet();
     p2->ts = TimeGet();
 

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -673,13 +673,9 @@ static int DetectThresholdTestSig3(void)
     DetectEngineThreadCtx *det_ctx;
     int result = 0;
     int alerts = 0;
-    struct timeval ts;
     DetectThresholdEntry *lookup_tsh = NULL;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -700,7 +696,7 @@ static int DetectThresholdTestSig3(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
@@ -720,7 +716,7 @@ static int DetectThresholdTestSig3(void)
     HostRelease(host);
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
@@ -778,12 +774,8 @@ static int DetectThresholdTestSig4(void)
     DetectEngineThreadCtx *det_ctx;
     int result = 0;
     int alerts = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -804,7 +796,7 @@ static int DetectThresholdTestSig4(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
@@ -813,7 +805,7 @@ static int DetectThresholdTestSig4(void)
     alerts += PacketAlertCheck(p, 10);
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1022,12 +1014,8 @@ static int DetectThresholdTestSig7(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1048,7 +1036,7 @@ static int DetectThresholdTestSig7(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1065,7 +1053,7 @@ static int DetectThresholdTestSig7(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1116,12 +1104,8 @@ static int DetectThresholdTestSig8(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1142,7 +1126,7 @@ static int DetectThresholdTestSig8(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1159,7 +1143,7 @@ static int DetectThresholdTestSig8(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1210,12 +1194,8 @@ static int DetectThresholdTestSig9(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1236,7 +1216,7 @@ static int DetectThresholdTestSig9(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1253,7 +1233,7 @@ static int DetectThresholdTestSig9(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1304,12 +1284,8 @@ static int DetectThresholdTestSig10(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1330,7 +1306,7 @@ static int DetectThresholdTestSig10(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1347,7 +1323,7 @@ static int DetectThresholdTestSig10(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1398,12 +1374,8 @@ static int DetectThresholdTestSig11(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1424,7 +1396,7 @@ static int DetectThresholdTestSig11(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1441,7 +1413,7 @@ static int DetectThresholdTestSig11(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1492,12 +1464,8 @@ static int DetectThresholdTestSig12(void)
     int result = 0;
     int alerts = 0;
     int drops = 0;
-    struct timeval ts;
 
     HostInitConfig(HOST_QUIET);
-
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -1518,7 +1486,7 @@ static int DetectThresholdTestSig12(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts = PacketAlertCheck(p, 10);
     drops += ((PacketTestAction(p, ACTION_DROP)) ? 1 : 0);
@@ -1535,7 +1503,7 @@ static int DetectThresholdTestSig12(void)
     p->action = 0;
 
     TimeSetIncrementTime(200);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 10);
@@ -1621,7 +1589,7 @@ static int DetectThresholdTestSig13(void)
     FAIL_IF(alerts != 2);
 
     TimeSetIncrementTime(70);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts += PacketAlertCheck(p, 1);
@@ -1704,9 +1672,8 @@ static int DetectThresholdTestSig14(void)
     FAIL_IF(alerts1 != 2);
     FAIL_IF(alerts2 != 2);
 
-    TimeSetIncrementTime(70);
-    TimeGet(&p1->ts);
-    TimeGet(&p2->ts);
+    p1->ts = TimeGet();
+    p2->ts = TimeGet();
 
     /* Now they should both alert again after previous alerts expire */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -72,7 +72,7 @@ typedef struct DetectThresholdEntry_ {
     uint32_t current_count; /**< Var for count control */
     int track;          /**< Track type: by_src, by_src */
 
-    struct timeval tv1;     /**< Var for time control */
+    SCTime_t tv1; /**< Var for time control */
     struct DetectThresholdEntry_ *next;
 } DetectThresholdEntry;
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -186,11 +186,9 @@ static int DetectTlsValidityMatch (DetectEngineThreadCtx *det_ctx,
     else if ((dd->mode & DETECT_TLS_VALIDITY_RA) &&
             cert_epoch >= dd->epoch && cert_epoch <= dd->epoch2)
         ret = 1;
-    else if ((dd->mode & DETECT_TLS_VALIDITY_EX) &&
-            f->lastts.tv_sec > cert_epoch)
+    else if ((dd->mode & DETECT_TLS_VALIDITY_EX) && (time_t)SCTIME_SECS(f->lastts) > cert_epoch)
         ret = 1;
-    else if ((dd->mode & DETECT_TLS_VALIDITY_VA) &&
-            f->lastts.tv_sec <= cert_epoch)
+    else if ((dd->mode & DETECT_TLS_VALIDITY_VA) && (time_t)SCTIME_SECS(f->lastts) <= cert_epoch)
         ret = 1;
 
     SCReturnInt(ret);

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -88,7 +88,7 @@ static int DetectIPPairbitMatchToggle (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitToggle(pair,fd->idx,p->ts.tv_sec + fd->expire);
+    IPPairBitToggle(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
     IPPairRelease(pair);
     return 1;
 }
@@ -111,7 +111,7 @@ static int DetectIPPairbitMatchSet (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitSet(pair, fd->idx, p->ts.tv_sec + fd->expire);
+    IPPairBitSet(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
     IPPairRelease(pair);
     return 1;
 }
@@ -123,7 +123,7 @@ static int DetectIPPairbitMatchIsset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    r = IPPairBitIsset(pair,fd->idx,p->ts.tv_sec);
+    r = IPPairBitIsset(pair, fd->idx, SCTIME_SECS(p->ts));
     IPPairRelease(pair);
     return r;
 }
@@ -135,7 +135,7 @@ static int DetectIPPairbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 1;
 
-    r = IPPairBitIsnotset(pair,fd->idx,p->ts.tv_sec);
+    r = IPPairBitIsnotset(pair, fd->idx, SCTIME_SECS(p->ts));
     IPPairRelease(pair);
     return r;
 }

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -248,7 +248,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     }
 
     memset(&p->ts, 0, sizeof(struct timeval));
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     if (direction == 0) {
         if (f->alparser && !STREAM_HAS_SEEN_DATA(&ssn->client)) {

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -193,11 +193,11 @@ void FlowInit(Flow *f, const Packet *p)
         /* nothing to do for this IP proto. */
         SCLogDebug("no special setup for IP proto %u", p->proto);
     }
-    COPY_TIMESTAMP(&p->ts, &f->startts);
+    f->startts = p->ts;
 
     f->protomap = FlowGetProtoMapping(f->proto);
     f->timeout_policy = FlowGetTimeoutPolicy(f);
-    const uint32_t timeout_at = (uint32_t)f->startts.tv_sec + f->timeout_policy;
+    const uint32_t timeout_at = (uint32_t)SCTIME_SECS(f->startts) + f->timeout_policy;
     f->timeout_at = timeout_at;
 
     if (MacSetFlowStorageEnabled()) {

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -27,52 +27,54 @@
 #include "flow.h"
 #include "stream-tcp-private.h"
 
-#define COPY_TIMESTAMP(src,dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec)
+#define COPY_TIMESTAMP(src, dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec)
 
-#define RESET_COUNTERS(f) do { \
-        (f)->todstpktcnt = 0; \
-        (f)->tosrcpktcnt = 0; \
-        (f)->todstbytecnt = 0; \
-        (f)->tosrcbytecnt = 0; \
+#define RESET_COUNTERS(f)                                                                          \
+    do {                                                                                           \
+        (f)->todstpktcnt = 0;                                                                      \
+        (f)->tosrcpktcnt = 0;                                                                      \
+        (f)->todstbytecnt = 0;                                                                     \
+        (f)->tosrcbytecnt = 0;                                                                     \
     } while (0)
 
-#define FLOW_INITIALIZE(f) do { \
-        (f)->sp = 0; \
-        (f)->dp = 0; \
-        (f)->proto = 0; \
-        (f)->livedev = NULL; \
-        (f)->timeout_at = 0; \
-        (f)->timeout_policy = 0; \
-        (f)->vlan_idx = 0; \
-        (f)->next = NULL; \
-        (f)->flow_state = 0; \
-        (f)->use_cnt = 0; \
-        (f)->tenant_id = 0; \
-        (f)->parent_id = 0; \
-        (f)->probing_parser_toserver_alproto_masks = 0; \
-        (f)->probing_parser_toclient_alproto_masks = 0; \
-        (f)->flags = 0; \
-        (f)->file_flags = 0; \
-        (f)->protodetect_dp = 0; \
-        (f)->lastts.tv_sec = 0; \
-        (f)->lastts.tv_usec = 0; \
-        FLOWLOCK_INIT((f)); \
-        (f)->protoctx = NULL; \
-        (f)->flow_end_flags = 0; \
-        (f)->alproto = 0; \
-        (f)->alproto_ts = 0; \
-        (f)->alproto_tc = 0; \
-        (f)->alproto_orig = 0; \
-        (f)->alproto_expect = 0; \
-        (f)->de_ctx_version = 0; \
-        (f)->thread_id[0] = 0; \
-        (f)->thread_id[1] = 0; \
-        (f)->alparser = NULL; \
-        (f)->alstate = NULL; \
-        (f)->sgh_toserver = NULL; \
-        (f)->sgh_toclient = NULL; \
-        (f)->flowvar = NULL; \
-        RESET_COUNTERS((f)); \
+#define FLOW_INITIALIZE(f)                                                                         \
+    do {                                                                                           \
+        (f)->sp = 0;                                                                               \
+        (f)->dp = 0;                                                                               \
+        (f)->proto = 0;                                                                            \
+        (f)->livedev = NULL;                                                                       \
+        (f)->timeout_at = 0;                                                                       \
+        (f)->timeout_policy = 0;                                                                   \
+        (f)->vlan_idx = 0;                                                                         \
+        (f)->next = NULL;                                                                          \
+        (f)->flow_state = 0;                                                                       \
+        (f)->use_cnt = 0;                                                                          \
+        (f)->tenant_id = 0;                                                                        \
+        (f)->parent_id = 0;                                                                        \
+        (f)->probing_parser_toserver_alproto_masks = 0;                                            \
+        (f)->probing_parser_toclient_alproto_masks = 0;                                            \
+        (f)->flags = 0;                                                                            \
+        (f)->file_flags = 0;                                                                       \
+        (f)->protodetect_dp = 0;                                                                   \
+        (f)->lastts.tv_sec = 0;                                                                    \
+        (f)->lastts.tv_usec = 0;                                                                   \
+        FLOWLOCK_INIT((f));                                                                        \
+        (f)->protoctx = NULL;                                                                      \
+        (f)->flow_end_flags = 0;                                                                   \
+        (f)->alproto = 0;                                                                          \
+        (f)->alproto_ts = 0;                                                                       \
+        (f)->alproto_tc = 0;                                                                       \
+        (f)->alproto_orig = 0;                                                                     \
+        (f)->alproto_expect = 0;                                                                   \
+        (f)->de_ctx_version = 0;                                                                   \
+        (f)->thread_id[0] = 0;                                                                     \
+        (f)->thread_id[1] = 0;                                                                     \
+        (f)->alparser = NULL;                                                                      \
+        (f)->alstate = NULL;                                                                       \
+        (f)->sgh_toserver = NULL;                                                                  \
+        (f)->sgh_toclient = NULL;                                                                  \
+        (f)->flowvar = NULL;                                                                       \
+        RESET_COUNTERS((f));                                                                       \
     } while (0)
 
 /** \brief macro to recycle a flow before it goes into the spare queue for reuse.
@@ -80,59 +82,61 @@
  *  Note that the lnext, lprev, hnext fields are untouched, those are
  *  managed by the queueing code. Same goes for fb (FlowBucket ptr) field.
  */
-#define FLOW_RECYCLE(f) do { \
-        FlowCleanupAppLayer((f)); \
-        (f)->sp = 0; \
-        (f)->dp = 0; \
-        (f)->proto = 0; \
-        (f)->livedev = NULL; \
-        (f)->vlan_idx = 0; \
-        (f)->ffr = 0; \
-        (f)->next = NULL; \
-        (f)->timeout_at = 0; \
-        (f)->timeout_policy = 0; \
-        (f)->flow_state = 0; \
-        (f)->use_cnt = 0; \
-        (f)->tenant_id = 0; \
-        (f)->parent_id = 0; \
-        (f)->probing_parser_toserver_alproto_masks = 0; \
-        (f)->probing_parser_toclient_alproto_masks = 0; \
-        (f)->flags = 0; \
-        (f)->file_flags = 0; \
-        (f)->protodetect_dp = 0; \
-        (f)->lastts.tv_sec = 0; \
-        (f)->lastts.tv_usec = 0; \
-        (f)->protoctx = NULL; \
-        (f)->flow_end_flags = 0; \
-        (f)->alparser = NULL; \
-        (f)->alstate = NULL; \
-        (f)->alproto = 0; \
-        (f)->alproto_ts = 0; \
-        (f)->alproto_tc = 0; \
-        (f)->alproto_orig = 0; \
-        (f)->alproto_expect = 0; \
-        (f)->de_ctx_version = 0; \
-        (f)->thread_id[0] = 0; \
-        (f)->thread_id[1] = 0; \
-        (f)->sgh_toserver = NULL; \
-        (f)->sgh_toclient = NULL; \
-        GenericVarFree((f)->flowvar); \
-        (f)->flowvar = NULL; \
-        if (MacSetFlowStorageEnabled()) { \
-            MacSet *ms = FlowGetStorageById((f), MacSetGetFlowStorageID()); \
-            if (ms != NULL) { \
-                MacSetReset(ms); \
-            } \
-        } \
-        RESET_COUNTERS((f)); \
-    } while(0)
+#define FLOW_RECYCLE(f)                                                                            \
+    do {                                                                                           \
+        FlowCleanupAppLayer((f));                                                                  \
+        (f)->sp = 0;                                                                               \
+        (f)->dp = 0;                                                                               \
+        (f)->proto = 0;                                                                            \
+        (f)->livedev = NULL;                                                                       \
+        (f)->vlan_idx = 0;                                                                         \
+        (f)->ffr = 0;                                                                              \
+        (f)->next = NULL;                                                                          \
+        (f)->timeout_at = 0;                                                                       \
+        (f)->timeout_policy = 0;                                                                   \
+        (f)->flow_state = 0;                                                                       \
+        (f)->use_cnt = 0;                                                                          \
+        (f)->tenant_id = 0;                                                                        \
+        (f)->parent_id = 0;                                                                        \
+        (f)->probing_parser_toserver_alproto_masks = 0;                                            \
+        (f)->probing_parser_toclient_alproto_masks = 0;                                            \
+        (f)->flags = 0;                                                                            \
+        (f)->file_flags = 0;                                                                       \
+        (f)->protodetect_dp = 0;                                                                   \
+        (f)->lastts.tv_sec = 0;                                                                    \
+        (f)->lastts.tv_usec = 0;                                                                   \
+        (f)->protoctx = NULL;                                                                      \
+        (f)->flow_end_flags = 0;                                                                   \
+        (f)->alparser = NULL;                                                                      \
+        (f)->alstate = NULL;                                                                       \
+        (f)->alproto = 0;                                                                          \
+        (f)->alproto_ts = 0;                                                                       \
+        (f)->alproto_tc = 0;                                                                       \
+        (f)->alproto_orig = 0;                                                                     \
+        (f)->alproto_expect = 0;                                                                   \
+        (f)->de_ctx_version = 0;                                                                   \
+        (f)->thread_id[0] = 0;                                                                     \
+        (f)->thread_id[1] = 0;                                                                     \
+        (f)->sgh_toserver = NULL;                                                                  \
+        (f)->sgh_toclient = NULL;                                                                  \
+        GenericVarFree((f)->flowvar);                                                              \
+        (f)->flowvar = NULL;                                                                       \
+        if (MacSetFlowStorageEnabled()) {                                                          \
+            MacSet *ms = FlowGetStorageById((f), MacSetGetFlowStorageID());                        \
+            if (ms != NULL) {                                                                      \
+                MacSetReset(ms);                                                                   \
+            }                                                                                      \
+        }                                                                                          \
+        RESET_COUNTERS((f));                                                                       \
+    } while (0)
 
-#define FLOW_DESTROY(f) do { \
-        FlowCleanupAppLayer((f)); \
-        \
-        FLOWLOCK_DESTROY((f)); \
-        GenericVarFree((f)->flowvar); \
-    } while(0)
+#define FLOW_DESTROY(f)                                                                            \
+    do {                                                                                           \
+        FlowCleanupAppLayer((f));                                                                  \
+                                                                                                   \
+        FLOWLOCK_DESTROY((f));                                                                     \
+        GenericVarFree((f)->flowvar);                                                              \
+    } while (0)
 
 /** \brief check if a memory alloc would fit in the memcap
  *
@@ -141,8 +145,9 @@
  *  \retval 1 it fits
  *  \retval 0 no fit
  */
-#define FLOW_CHECK_MEMCAP(size) \
-    ((((uint64_t)SC_ATOMIC_GET(flow_memuse) + (uint64_t)(size)) <= SC_ATOMIC_GET(flow_config.memcap)))
+#define FLOW_CHECK_MEMCAP(size)                                                                    \
+    ((((uint64_t)SC_ATOMIC_GET(flow_memuse) + (uint64_t)(size)) <=                                 \
+            SC_ATOMIC_GET(flow_config.memcap)))
 
 Flow *FlowAlloc(void);
 Flow *FlowAllocDirect(void);
@@ -174,4 +179,3 @@ static inline void FlowEndCountersUpdate(ThreadVars *tv, FlowEndCounters *fec, F
 void FlowEndCountersRegister(ThreadVars *t, FlowEndCounters *fec);
 
 #endif /* __FLOW_UTIL_H__ */
-

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -56,7 +56,7 @@
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \
-        (f)->lastts = 0;                                                                           \
+        SCTIME_INIT((f)->lastts);                                                                  \
         FLOWLOCK_INIT((f));                                                                        \
         (f)->protoctx = NULL;                                                                      \
         (f)->flow_end_flags = 0;                                                                   \
@@ -102,7 +102,7 @@
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \
-        (f)->lastts = 0;                                                                           \
+        SCTIME_INIT((f)->lastts);                                                                  \
         (f)->protoctx = NULL;                                                                      \
         (f)->flow_end_flags = 0;                                                                   \
         (f)->alparser = NULL;                                                                      \

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -56,8 +56,7 @@
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \
-        (f)->lastts.tv_sec = 0;                                                                    \
-        (f)->lastts.tv_usec = 0;                                                                   \
+        (f)->lastts = 0;                                                                           \
         FLOWLOCK_INIT((f));                                                                        \
         (f)->protoctx = NULL;                                                                      \
         (f)->flow_end_flags = 0;                                                                   \
@@ -103,8 +102,7 @@
         (f)->flags = 0;                                                                            \
         (f)->file_flags = 0;                                                                       \
         (f)->protodetect_dp = 0;                                                                   \
-        (f)->lastts.tv_sec = 0;                                                                    \
-        (f)->lastts.tv_usec = 0;                                                                   \
+        (f)->lastts = 0;                                                                           \
         (f)->protoctx = NULL;                                                                      \
         (f)->flow_end_flags = 0;                                                                   \
         (f)->alparser = NULL;                                                                      \

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -511,7 +511,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     /* update time */
     if (!(PKT_IS_PSEUDOPKT(p))) {
-        TimeSetByThread(tv->id, &p->ts);
+        TimeSetByThread(tv->id, p->ts);
     }
 
     /* handle Flow */

--- a/src/flow.c
+++ b/src/flow.c
@@ -418,9 +418,9 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     if (state != FLOW_STATE_CAPTURE_BYPASSED) {
 #endif
         /* update the last seen timestamp of this flow */
-        if (timercmp(&p->ts, &f->lastts, >)) {
-            COPY_TIMESTAMP(&p->ts, &f->lastts);
-            const uint32_t timeout_at = (uint32_t)f->lastts.tv_sec + f->timeout_policy;
+        if (SCTIME_CMP_GT(p->ts, f->lastts)) {
+            f->lastts = p->ts;
+            const uint32_t timeout_at = (uint32_t)SCTIME_SECS(f->lastts) + f->timeout_policy;
             if (timeout_at != f->timeout_at) {
                 f->timeout_at = timeout_at;
             }
@@ -428,9 +428,9 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
 #ifdef CAPTURE_OFFLOAD
     } else {
         /* still seeing packet, we downgrade to local bypass */
-        if (p->ts.tv_sec - f->lastts.tv_sec > FLOW_BYPASSED_TIMEOUT / 2) {
+        if (SCTIME_SECS(p->ts) - SCTIME_SECS(f->lastts) > FLOW_BYPASSED_TIMEOUT / 2) {
             SCLogDebug("Downgrading flow to local bypass");
-            COPY_TIMESTAMP(&p->ts, &f->lastts);
+            f->lastts = p->ts;
             FlowUpdateState(f, FLOW_STATE_LOCAL_BYPASSED);
         } else {
             /* In IPS mode the packet could come from the other interface so it would
@@ -1192,7 +1192,7 @@ void FlowUpdateState(Flow *f, const enum FlowState s)
         const uint32_t timeout_policy = FlowGetTimeoutPolicy(f);
         if (timeout_policy != f->timeout_policy) {
             f->timeout_policy = timeout_policy;
-            const uint32_t timeout_at = (uint32_t)f->lastts.tv_sec + timeout_policy;
+            const uint32_t timeout_at = (uint32_t)SCTIME_SECS(f->lastts) + timeout_policy;
             if (timeout_at != f->timeout_at)
                 f->timeout_at = timeout_at;
         }
@@ -1217,8 +1217,8 @@ void FlowUpdateState(Flow *f, const enum FlowState s)
  */
 void FlowGetLastTimeAsParts(Flow *flow, uint64_t *secs, uint64_t *usecs)
 {
-    *secs = (uint64_t)flow->lastts.tv_sec;
-    *usecs = (uint64_t)flow->lastts.tv_usec;
+    *secs = (uint64_t)SCTIME_SECS(flow->lastts);
+    *usecs = (uint64_t)SCTIME_USECS(flow->lastts);
 }
 
 /**

--- a/src/flow.h
+++ b/src/flow.h
@@ -28,6 +28,7 @@
 typedef struct FlowStorageId FlowStorageId;
 
 #include "decode.h"
+#include "util-time.h"
 #include "util-exception-policy.h"
 #include "util-var.h"
 #include "util-optimize.h"
@@ -414,7 +415,7 @@ typedef struct Flow_
     /* time stamp of last update (last packet). Set/updated under the
      * flow and flow hash row locks, safe to read under either the
      * flow lock or flow hash row lock. */
-    struct timeval lastts;
+    SCTime_t lastts;
 
     /* end of flow "header" */
 
@@ -500,7 +501,7 @@ typedef struct Flow_
 
     struct FlowBucket_ *fb;
 
-    struct timeval startts;
+    SCTime_t startts;
 
     uint32_t todstpktcnt;
     uint32_t tosrcpktcnt;
@@ -691,8 +692,8 @@ static inline void FlowDeReference(Flow **d)
  */
 static inline int64_t FlowGetId(const Flow *f)
 {
-    int64_t id = (uint64_t)(f->startts.tv_sec & 0x0000FFFF) << 48 |
-                 (uint64_t)(f->startts.tv_usec & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
+    int64_t id = (uint64_t)(SCTIME_SECS(f->startts) & 0x0000FFFF) << 48 |
+                 (uint64_t)(f->startts & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
     /* reduce to 51 bits as Javascript and even JSON often seem to
      * max out there. */
     id &= 0x7ffffffffffffLL;

--- a/src/flow.h
+++ b/src/flow.h
@@ -693,7 +693,7 @@ static inline void FlowDeReference(Flow **d)
 static inline int64_t FlowGetId(const Flow *f)
 {
     int64_t id = (uint64_t)(SCTIME_SECS(f->startts) & 0x0000FFFF) << 48 |
-                 (uint64_t)(f->startts & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
+                 (uint64_t)(SCTIME_USECS(f->startts) & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
     /* reduce to 51 bits as Javascript and even JSON often seem to
      * max out there. */
     id &= 0x7ffffffffffffLL;

--- a/src/host-bit.c
+++ b/src/host-bit.c
@@ -64,13 +64,13 @@ int HostHasHostBits(Host *host)
 
 /** \retval 1 host timed out wrt xbits
   * \retval 0 host still has active (non-expired) xbits */
-int HostBitsTimedoutCheck(Host *h, struct timeval *ts)
+int HostBitsTimedoutCheck(Host *h, SCTime_t ts)
 {
     GenericVar *gv = HostGetStorageById(h, host_bit_id);
     for ( ; gv != NULL; gv = gv->next) {
         if (gv->type == DETECT_XBITS) {
             XBit *xb = (XBit *)gv;
-            if (xb->expire > (uint32_t)ts->tv_sec)
+            if (xb->expire > (uint32_t)SCTIME_SECS(ts))
                 return 0;
         }
     }

--- a/src/host-bit.h
+++ b/src/host-bit.h
@@ -31,7 +31,7 @@ void HostBitInitCtx(void);
 void HostBitRegisterTests(void);
 
 int HostHasHostBits(Host *host);
-int HostBitsTimedoutCheck(Host *h, struct timeval *ts);
+int HostBitsTimedoutCheck(Host *h, SCTime_t ts);
 
 void HostBitSet(Host *, uint32_t, uint32_t);
 void HostBitUnset(Host *, uint32_t);

--- a/src/host-timeout.c
+++ b/src/host-timeout.c
@@ -51,7 +51,7 @@ uint32_t HostGetActiveCount(void)
  *  \retval 0 not timed out just yet
  *  \retval 1 fully timed out, lets kill it
  */
-static int HostHostTimedOut(Host *h, struct timeval *ts)
+static int HostHostTimedOut(Host *h, SCTime_t ts)
 {
     int tags = 0;
     int thresholds = 0;
@@ -98,7 +98,7 @@ static int HostHostTimedOut(Host *h, struct timeval *ts)
  *
  *  \retval cnt timed out hosts
  */
-static uint32_t HostHashRowTimeout(HostHashRow *hb, Host *h, struct timeval *ts)
+static uint32_t HostHashRowTimeout(HostHashRow *hb, Host *h, SCTime_t ts)
 {
     uint32_t cnt = 0;
 
@@ -153,7 +153,7 @@ static uint32_t HostHashRowTimeout(HostHashRow *hb, Host *h, struct timeval *ts)
  *
  *  \retval cnt number of timed out host
  */
-uint32_t HostTimeoutHash(struct timeval *ts)
+uint32_t HostTimeoutHash(SCTime_t ts)
 {
     uint32_t idx = 0;
     uint32_t cnt = 0;

--- a/src/host-timeout.h
+++ b/src/host-timeout.h
@@ -24,7 +24,7 @@
 #ifndef __HOST_TIMEOUT_H__
 #define __HOST_TIMEOUT_H__
 
-uint32_t HostTimeoutHash(struct timeval *ts);
+uint32_t HostTimeoutHash(SCTime_t ts);
 
 uint32_t HostGetSpareCount(void);
 uint32_t HostGetActiveCount(void);

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -64,13 +64,13 @@ int IPPairHasBits(IPPair *ippair)
 
 /** \retval 1 ippair timed out wrt xbits
   * \retval 0 ippair still has active (non-expired) xbits */
-int IPPairBitsTimedoutCheck(IPPair *h, struct timeval *ts)
+int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts)
 {
     GenericVar *gv = IPPairGetStorageById(h, g_ippair_bit_storage_id);
     for ( ; gv != NULL; gv = gv->next) {
         if (gv->type == DETECT_XBITS) {
             XBit *xb = (XBit *)gv;
-            if (xb->expire > (uint32_t)ts->tv_sec)
+            if (xb->expire > (uint32_t)SCTIME_SECS(ts))
                 return 0;
         }
     }

--- a/src/ippair-bit.h
+++ b/src/ippair-bit.h
@@ -30,7 +30,7 @@ void IPPairBitInitCtx(void);
 void IPPairBitRegisterTests(void);
 
 int IPPairHasBits(IPPair *host);
-int IPPairBitsTimedoutCheck(IPPair *h, struct timeval *ts);
+int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts);
 
 void IPPairBitSet(IPPair *, uint32_t, uint32_t);
 void IPPairBitUnset(IPPair *, uint32_t);

--- a/src/ippair-timeout.c
+++ b/src/ippair-timeout.c
@@ -46,7 +46,7 @@ uint32_t IPPairGetActiveCount(void)
  *  \retval 0 not timed out just yet
  *  \retval 1 fully timed out, lets kill it
  */
-static int IPPairTimedOut(IPPair *h, struct timeval *ts)
+static int IPPairTimedOut(IPPair *h, SCTime_t ts)
 {
     int vars = 0;
     int thresholds = 0;
@@ -84,7 +84,7 @@ static int IPPairTimedOut(IPPair *h, struct timeval *ts)
  *
  *  \retval cnt timed out ippairs
  */
-static uint32_t IPPairHashRowTimeout(IPPairHashRow *hb, IPPair *h, struct timeval *ts)
+static uint32_t IPPairHashRowTimeout(IPPairHashRow *hb, IPPair *h, SCTime_t ts)
 {
     uint32_t cnt = 0;
 
@@ -139,7 +139,7 @@ static uint32_t IPPairHashRowTimeout(IPPairHashRow *hb, IPPair *h, struct timeva
  *
  *  \retval cnt number of timed out ippair
  */
-uint32_t IPPairTimeoutHash(struct timeval *ts)
+uint32_t IPPairTimeoutHash(SCTime_t ts)
 {
     uint32_t idx = 0;
     uint32_t cnt = 0;

--- a/src/ippair-timeout.h
+++ b/src/ippair-timeout.h
@@ -24,7 +24,7 @@
 #ifndef __IPPAIR_TIMEOUT_H__
 #define __IPPAIR_TIMEOUT_H__
 
-uint32_t IPPairTimeoutHash(struct timeval *ts);
+uint32_t IPPairTimeoutHash(SCTime_t ts);
 
 uint32_t IPPairGetSpareCount(void);
 uint32_t IPPairGetActiveCount(void);

--- a/src/log-cf-common.c
+++ b/src/log-cf-common.c
@@ -208,9 +208,10 @@ void LogCustomFormatAddNode(LogCustomFormat *cf, LogCustomFormatNode *node)
  *  \param const struct timeveal *ts  - the timetstamp
  *
  */
-void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const struct timeval *ts) {
+void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const SCTime_t ts)
+{
 
-    time_t time = ts->tv_sec;
+    time_t time = SCTIME_SECS(ts);
     struct tm local_tm;
     struct tm *timestamp = SCLocalTime(time, &local_tm);
     char buf[128] = {0};
@@ -242,15 +243,14 @@ static int LogCustomFormatTest01(void)
     tm.tm_wday = 1;
     tm.tm_yday = 13;
     tm.tm_isdst = 0;
-    time_t secs = mktime(&tm);
-    struct timeval ts = {secs, 0};
+    SCTime_t ts = SCTIME_FROM_SECS(mktime(&tm));
 
     MemBuffer *buffer = MemBufferCreateNew(62);
     if (!buffer) {
         return 0;
     }
 
-    LogCustomFormatWriteTimestamp(buffer, "", &ts);
+    LogCustomFormatWriteTimestamp(buffer, "", ts);
     /*
      * {buffer = "01/13/14-04:30:00", size = 62, offset = 17}
      */

--- a/src/log-cf-common.h
+++ b/src/log-cf-common.h
@@ -84,7 +84,7 @@ void LogCustomFormatFree(LogCustomFormat *cf);
 void LogCustomFormatAddNode(LogCustomFormat *cf, LogCustomFormatNode *node);
 int LogCustomFormatParse(LogCustomFormat *cf, const char *format);
 
-void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const struct timeval *ts);
+void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const SCTime_t ts);
 void LogCustomFormatRegister(void);
 
 #endif /* __LOG_CF_COMMON_H__ */

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -126,8 +126,8 @@ static uint32_t GetCookieValue(uint8_t *rawcookies, uint32_t rawcookies_len, cha
 }
 
 /* Custom format logging */
-static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct timeval *ts,
-                                            char *srcip, Port sp, char *dstip, Port dp)
+static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t ts, char *srcip,
+        Port sp, char *dstip, Port dp)
 {
     LogHttpFileCtx *httplog_ctx = aft->httplog_ctx;
     uint32_t i;
@@ -155,14 +155,14 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                 break;
             case LOG_CF_TIMESTAMP:
             /* TIMESTAMP */
-                LogCustomFormatWriteTimestamp(aft->buffer, node->data, ts);
-                break;
+            LogCustomFormatWriteTimestamp(aft->buffer, node->data, ts);
+            break;
             case LOG_CF_TIMESTAMP_U:
             /* TIMESTAMP USECONDS */
-                snprintf(buf, sizeof(buf), "%06u", (unsigned int) ts->tv_usec);
-                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                            aft->buffer->size, (uint8_t *)buf, MIN(strlen(buf),6));
-                break;
+            snprintf(buf, sizeof(buf), "%06u", (unsigned int)SCTIME_USECS(ts));
+            PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
+                    (uint8_t *)buf, MIN(strlen(buf), 6));
+            break;
             case LOG_CF_CLIENT_IP:
             /* CLIENT IP ADDRESS */
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
@@ -385,7 +385,7 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
     char timebuf[64];
 
     /* check if we have HTTP state or not */
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     char srcip[46], dstip[46];
     Port sp, dp;
@@ -427,7 +427,7 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
     MemBufferReset(aft->buffer);
 
     if (hlog->flags & LOG_HTTP_CUSTOM) {
-        LogHttpLogCustom(aft, tx, &p->ts, srcip, sp, dstip, dp);
+        LogHttpLogCustom(aft, tx, p->ts, srcip, sp, dstip, dp);
     } else {
         /* time */
         MemBufferWriteString(aft->buffer, "%s ", timebuf);

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -64,11 +64,9 @@ static int CreateFileName(const Packet *p, SSLState *state, char *filename, size
     /* Use format : packet time + incremental ID
      * When running on same pcap it will overwrite
      * On a live device, we will not be able to overwrite */
-    if (snprintf(path, sizeof(path), "%s/%ld.%ld-%d.pem",
-             tls_logfile_base_dir,
-             (long int)p->ts.tv_sec,
-             (long int)p->ts.tv_usec,
-             file_id) == sizeof(path))
+    if (snprintf(path, sizeof(path), "%s/%ld.%ld-%d.pem", tls_logfile_base_dir,
+                (long int)SCTIME_SECS(p->ts), (long int)SCTIME_USECS(p->ts),
+                file_id) == sizeof(path))
         return 0;
 
     strlcpy(filename, path, filename_size);
@@ -160,7 +158,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
         char srcip[PRINT_BUF_LEN], dstip[PRINT_BUF_LEN];
         char timebuf[64];
         Port sp, dp;
-        CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+        CreateTimeString(p->ts, timebuf, sizeof(timebuf));
         if (!TLSGetIPInformations(p, srcip, PRINT_BUF_LEN, &sp, dstip, PRINT_BUF_LEN, &dp, ipproto))
             goto end_fwrite_fpmeta;
         if (fprintf(fpmeta, "TIME:              %s\n", timebuf) < 0)

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -161,10 +161,9 @@ static void OutputFilestoreFinalizeFiles(ThreadVars *tv, const OutputFilestoreLo
 
     if (ctx->fileinfo) {
         char js_metadata_filename[PATH_MAX];
-        if (snprintf(js_metadata_filename, sizeof(js_metadata_filename),
-                        "%s.%"PRIuMAX".%u.json", final_filename,
-                        (uintmax_t)p->ts.tv_sec, ff->file_store_id)
-                == (int)sizeof(js_metadata_filename)) {
+        if (snprintf(js_metadata_filename, sizeof(js_metadata_filename), "%s.%" PRIuMAX ".%u.json",
+                    final_filename, (uintmax_t)SCTIME_SECS(p->ts),
+                    ff->file_store_id) == (int)sizeof(js_metadata_filename)) {
             WARN_ONCE(WOT_SNPRINTF, "Failed to write file info record. Output filename truncated.");
         } else {
             JsonBuilder *js_fileinfo =

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -852,7 +852,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
     if (p->alerts.cnt == 0)
         return TM_ECODE_OK;
 
-    CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(p->ts, timebuf, sizeof(timebuf));
 
     for (int i = 0; i < p->alerts.cnt; i++) {
         const PacketAlert *pa = &p->alerts.alerts[i];

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -62,11 +62,9 @@ static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
         return NULL;
     }
 
-    struct timeval tv;
-    memset(&tv, 0x00, sizeof(tv));
-    TimeGet(&tv);
+    SCTime_t ts = TimeGet();
 
-    CreateIsoTimeString(&tv, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(ts, timebuf, sizeof(timebuf));
 
     if ((f->flags & FLOW_DIR_REVERSED) == 0) {
         if (FLOW_IS_IPV4(f)) {
@@ -209,7 +207,7 @@ void EveAddFlow(Flow *f, JsonBuilder *js)
     }
 
     char timebuf1[64];
-    CreateIsoTimeString(&f->startts, timebuf1, sizeof(timebuf1));
+    CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
     jb_set_string(js, "start", timebuf1);
 }
 
@@ -221,10 +219,10 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
     EveAddFlow(f, jb);
 
     char timebuf2[64];
-    CreateIsoTimeString(&f->lastts, timebuf2, sizeof(timebuf2));
+    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
     jb_set_string(jb, "end", timebuf2);
 
-    int32_t age = f->lastts.tv_sec - f->startts.tv_sec;
+    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
     jb_set_uint(jb, "age", age);
 
     if (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY)

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -59,11 +59,9 @@ static JsonBuilder *CreateEveHeaderFromNetFlow(const Flow *f, int dir)
     if (unlikely(js == NULL))
         return NULL;
 
-    struct timeval tv;
-    memset(&tv, 0x00, sizeof(tv));
-    TimeGet(&tv);
+    SCTime_t ts = TimeGet();
 
-    CreateIsoTimeString(&tv, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(ts, timebuf, sizeof(timebuf));
 
     /* reverse header direction if the flow started out wrong */
     dir ^= ((f->flags & FLOW_DIR_REVERSED) != 0);
@@ -186,13 +184,13 @@ static void NetFlowLogEveToServer(JsonBuilder *js, Flow *f)
 
     char timebuf1[64], timebuf2[64];
 
-    CreateIsoTimeString(&f->startts, timebuf1, sizeof(timebuf1));
-    CreateIsoTimeString(&f->lastts, timebuf2, sizeof(timebuf2));
+    CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
+    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
 
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = f->lastts.tv_sec - f->startts.tv_sec;
+    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
     jb_set_uint(js, "age", age);
 
     jb_set_uint(js, "min_ttl", f->min_ttl_toserver);
@@ -230,13 +228,13 @@ static void NetFlowLogEveToClient(JsonBuilder *js, Flow *f)
 
     char timebuf1[64], timebuf2[64];
 
-    CreateIsoTimeString(&f->startts, timebuf1, sizeof(timebuf1));
-    CreateIsoTimeString(&f->lastts, timebuf2, sizeof(timebuf2));
+    CreateIsoTimeString(f->startts, timebuf1, sizeof(timebuf1));
+    CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
 
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = f->lastts.tv_sec - f->startts.tv_sec;
+    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
     jb_set_uint(js, "age", age);
 
     /* To client is zero if we did not see any packet */

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -76,7 +76,6 @@ typedef struct JsonStatsLogThread_ {
 static json_t *EngineStats2Json(const DetectEngineCtx *de_ctx,
                                 const OutputEngineInfo output)
 {
-    struct timeval last_reload;
     char timebuf[64];
     const SigFileLoaderStat *sig_stat = NULL;
 
@@ -86,8 +85,8 @@ static json_t *EngineStats2Json(const DetectEngineCtx *de_ctx,
     }
 
     if (output == OUTPUT_ENGINE_LAST_RELOAD || output == OUTPUT_ENGINE_ALL) {
-        last_reload = de_ctx->last_reload;
-        CreateIsoTimeString(&last_reload, timebuf, sizeof(timebuf));
+        SCTime_t last_reload = SCTIME_FROM_TIMEVAL(&de_ctx->last_reload);
+        CreateIsoTimeString(last_reload, timebuf, sizeof(timebuf));
         json_object_set_new(jdata, "last_reload", json_string(timebuf));
     }
 
@@ -301,7 +300,7 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
     if (unlikely(js == NULL))
         return 0;
     char timebuf[64];
-    CreateIsoTimeString(&tval, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(SCTIME_FROM_TIMEVAL(&tval), timebuf, sizeof(timebuf));
     json_object_set_new(js, "timestamp", json_string(timebuf));
     json_object_set_new(js, "event_type", json_string("stats"));
 

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -169,10 +169,8 @@ static void JsonTlsLogNotBefore(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_before != 0) {
         char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = ssl_state->server_connp.cert0_not_before;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
+        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_before);
+        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
         jb_set_string(js, "notbefore", timebuf);
     }
 }
@@ -181,10 +179,8 @@ static void JsonTlsLogNotAfter(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_after != 0) {
         char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = ssl_state->server_connp.cert0_not_after;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
+        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_after);
+        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
         jb_set_string(js, "notafter", timebuf);
     }
 }
@@ -305,18 +301,14 @@ static void JsonTlsLogClientCert(
     }
     if (connp->cert0_not_before != 0) {
         char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = connp->cert0_not_before;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
+        SCTime_t ts = SCTIME_FROM_SECS(connp->cert0_not_before);
+        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
         jb_set_string(js, "notbefore", timebuf);
     }
     if (connp->cert0_not_after != 0) {
         char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = connp->cert0_not_after;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
+        SCTime_t ts = SCTIME_FROM_SECS(connp->cert0_not_after);
+        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
         jb_set_string(js, "notafter", timebuf);
     }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -804,7 +804,7 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         return NULL;
     }
 
-    CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(p->ts, timebuf, sizeof(timebuf));
 
     jb_set_string(js, "timestamp", timebuf);
 

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -173,7 +173,7 @@ static int LuaPacketLoggerAlerts(ThreadVars *tv, void *thread_data, const Packet
     LogLuaThreadCtx *td = (LogLuaThreadCtx *)thread_data;
 
     char timebuf[64];
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     if (!(PKT_IS_IPV4(p)) && !(PKT_IS_IPV6(p))) {
         /* decoder event */
@@ -243,7 +243,7 @@ static int LuaPacketLogger(ThreadVars *tv, void *thread_data, const Packet *p)
         goto not_supported;
     }
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     /* loop through alerts stored in the packet */
     SCMutexLock(&td->lua_ctx->m);

--- a/src/packet.c
+++ b/src/packet.c
@@ -102,8 +102,7 @@ void PacketReinit(Packet *p)
     p->vlan_id[0] = 0;
     p->vlan_id[1] = 0;
     p->vlan_idx = 0;
-    p->ts.tv_sec = 0;
-    p->ts.tv_usec = 0;
+    p->ts = 0;
     p->datalink = 0;
     p->drop_reason = 0;
 #define PACKET_RESET_ACTION(p) (p)->action = 0

--- a/src/packet.c
+++ b/src/packet.c
@@ -102,7 +102,7 @@ void PacketReinit(Packet *p)
     p->vlan_id[0] = 0;
     p->vlan_id[1] = 0;
     p->vlan_idx = 0;
-    p->ts = 0;
+    SCTIME_INIT(p->ts);
     p->datalink = 0;
     p->drop_reason = 0;
 #define PACKET_RESET_ACTION(p) (p)->action = 0

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -796,8 +796,8 @@ static void AFPReadFromRingSetupPacket(
     p->afp_v.peer = (p->afp_v.copy_mode == AFP_COPY_MODE_NONE) ? NULL : ptv->mpeer->peer;
 
     /* Timestamp */
-    p->ts.tv_sec = h.h2->tp_sec;
-    p->ts.tv_usec = h.h2->tp_nsec / 1000;
+    p->ts = SCTIME_FROM_SECS(h.h2->tp_sec);
+    p->ts += SCTIME_FROM_USECS(h.h2->tp_nsec / 1000);
     SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)", GET_PKT_LEN(p), p, GET_PKT_DATA(p));
 
     /* We only check for checksum disable */
@@ -958,8 +958,8 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
     p->afp_v.peer = (p->afp_v.copy_mode == AFP_COPY_MODE_NONE) ? NULL : ptv->mpeer->peer;
 
     /* Timestamp */
-    p->ts.tv_sec = ppd->tp_sec;
-    p->ts.tv_usec = ppd->tp_nsec/1000;
+    p->ts = SCTIME_FROM_SECS(ppd->tp_sec);
+    p->ts += SCTIME_FROM_USECS(ppd->tp_nsec / 1000);
     SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)",
             GET_PKT_LEN(p), p, GET_PKT_DATA(p));
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -796,8 +796,7 @@ static void AFPReadFromRingSetupPacket(
     p->afp_v.peer = (p->afp_v.copy_mode == AFP_COPY_MODE_NONE) ? NULL : ptv->mpeer->peer;
 
     /* Timestamp */
-    p->ts = SCTIME_FROM_SECS(h.h2->tp_sec);
-    p->ts += SCTIME_FROM_USECS(h.h2->tp_nsec / 1000);
+    p->ts = (SCTime_t){ .secs = h.h2->tp_sec, .usecs = h.h2->tp_nsec / 1000 };
     SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)", GET_PKT_LEN(p), p, GET_PKT_DATA(p));
 
     /* We only check for checksum disable */
@@ -958,8 +957,7 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
     p->afp_v.peer = (p->afp_v.copy_mode == AFP_COPY_MODE_NONE) ? NULL : ptv->mpeer->peer;
 
     /* Timestamp */
-    p->ts = SCTIME_FROM_SECS(ppd->tp_sec);
-    p->ts += SCTIME_FROM_USECS(ppd->tp_nsec / 1000);
+    p->ts = (SCTime_t){ .secs = ppd->tp_sec, .usecs = ppd->tp_nsec / 1000 };
     SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)",
             GET_PKT_LEN(p), p, GET_PKT_DATA(p));
 

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -775,7 +775,7 @@ static TmEcode ReceiveAFXDPLoop(ThreadVars *tv, void *data, void *slot)
             p->ReleasePacket = AFXDPReleasePacket;
             p->flags |= PKT_IGNORE_CHECKSUM;
 
-            p->ts = ts;
+            p->ts = SCTIME_FROM_TIMEVAL(&ts);
 
             uint64_t addr = xsk_ring_cons__rx_desc(&ptv->xsk.rx, idx_rx)->addr;
             uint32_t len = xsk_ring_cons__rx_desc(&ptv->xsk.rx, idx_rx++)->len;

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -178,9 +178,11 @@ void DPDKSetTimevalOfMachineStart(void)
  * @param machine_start_tv - timestamp when the machine was started
  * @param real_tv
  */
-static void DPDKSetTimevalReal(struct timeval *machine_start_tv, struct timeval *real_tv)
+static SCTime_t DPDKSetTimevalReal(struct timeval *machine_start_tv)
 {
-    CyclesAddToTimeval(rte_get_tsc_cycles(), machine_start_tv, real_tv);
+    struct timeval real_tv;
+    CyclesAddToTimeval(rte_get_tsc_cycles(), machine_start_tv, &real_tv);
+    return SCTIME_FROM_TIMEVAL(&real_tv);
 }
 
 /* get number of seconds from the reset of TSC counter (typically from the machine start) */
@@ -377,7 +379,7 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
                 p->flags |= PKT_IGNORE_CHECKSUM;
             }
 
-            DPDKSetTimevalReal(&machine_start_time, &p->ts);
+            p->ts = DPDKSetTimevalReal(&machine_start_time);
             p->dpdk_v.mbuf = ptv->received_mbufs[i];
             p->ReleasePacket = DPDKReleasePacket;
             p->dpdk_v.copy_mode = ptv->copy_mode;

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -510,14 +510,15 @@ ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
 
     /* Convert ERF time to timeval - from libpcap. */
     uint64_t ts = dr->ts;
-    p->ts.tv_sec = ts >> 32;
+    p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
-    p->ts.tv_usec = ts >> 32;
-    if (p->ts.tv_usec >= 1000000) {
-        p->ts.tv_usec -= 1000000;
-        p->ts.tv_sec++;
+    uint64_t usecs = ts >> 32;
+    if (usecs >= 1000000) {
+        usecs -= 1000000;
+        p->ts += SCTIME_FROM_SECS(1);
     }
+    p->ts += SCTIME_FROM_USECS(usecs);
 
     StatsIncr(ewtn->tv, ewtn->packets);
     ewtn->bytes += wlen;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -197,14 +197,16 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
 
     /* Convert ERF time to timeval - from libpcap. */
     uint64_t ts = dr.ts;
-    p->ts.tv_sec = ts >> 32;
+    p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
-    p->ts.tv_usec = ts >> 32;
-    if (p->ts.tv_usec >= 1000000) {
-        p->ts.tv_usec -= 1000000;
-        p->ts.tv_sec++;
+    uint64_t usecs = (ts >> 32);
+    if (usecs >= 1000000) {
+        usecs -= 1000000;
+        p->ts += SCTIME_FROM_SECS(1);
+        usecs++;
     }
+    p->ts += SCTIME_FROM_USECS(usecs);
 
     etv->pkts++;
     etv->bytes += wlen;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -203,10 +203,10 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     uint64_t usecs = (ts >> 32);
     if (usecs >= 1000000) {
         usecs -= 1000000;
-        p->ts += SCTIME_FROM_SECS(1);
+        p->ts = SCTIME_ADD_SECS(p->ts, 1);
         usecs++;
     }
-    p->ts += SCTIME_FROM_USECS(usecs);
+    p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     etv->pkts++;
     etv->bytes += wlen;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -289,8 +289,7 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
         SCLogDebug("Received Packet Len: %d", pktlen);
 
-        p->ts.tv_sec = IPFWts.tv_sec;
-        p->ts.tv_usec = IPFWts.tv_usec;
+        p->ts = SCTIME_FROM_TIMEVAL(&IPFWts);
 
         ptv->pkts++;
         ptv->bytes += pktlen;

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -949,21 +949,24 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
          */
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
-                p->ts.tv_sec = pkt_ts / 100000000;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
+                p->ts = SCTIME_FROM_SECS(pkt_ts / 100000000);
+                p->ts += SCTIME_FROM_USECS(
+                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
-                p->ts.tv_sec = pkt_ts >> 32;
-                p->ts.tv_usec = pkt_ts & 0xFFFFFFFF;
+                p->ts = SCTIME_FROM_SECS(pkt_ts >> 32);
+                p->ts += SCTIME_FROM_USECS(pkt_ts & 0xFFFFFFFF);
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
-                p->ts.tv_sec = pkt_ts >> 32;
-                p->ts.tv_usec = ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0);
+                p->ts = SCTIME_FROM_SECS(pkt_ts >> 32);
+                p->ts += SCTIME_FROM_USECS(
+                        ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
-                p->ts.tv_sec = (pkt_ts / 100000000) - 11644473600;
-                p->ts.tv_usec = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0);
+                p->ts = SCTIME_FROM_SECS((pkt_ts / 100000000) - 11644473600);
+                p->ts += SCTIME_FROM_USECS(
+                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             default:
                 SCLogError("Packet from Napatech Stream: %u does not have a supported timestamp "

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -666,7 +666,7 @@ static void NetmapProcessPacket(NetmapThreadVars *ntv, const struct nm_pkthdr *p
     PKT_SET_SRC(p, PKT_SRC_WIRE);
     p->livedev = ntv->livedev;
     p->datalink = LINKTYPE_ETHERNET;
-    p->ts = ph->ts;
+    p->ts = SCTIME_FROM_TIMEVAL(&ph->ts);
     ntv->pkts++;
     ntv->bytes += ph->len;
 

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -461,11 +461,13 @@ static int NFQSetupPkt (Packet *p, struct nfq_q_handle *qh, void *data)
         SET_PKT_LEN(p, 0);
     }
 
-    ret = nfq_get_timestamp(tb, &p->ts);
-    if (ret != 0 || p->ts.tv_sec == 0) {
-        memset (&p->ts, 0, sizeof(struct timeval));
-        gettimeofday(&p->ts, NULL);
+    struct timeval tv;
+    ret = nfq_get_timestamp(tb, &tv);
+    if (ret != 0 || tv.tv_sec == 0) {
+        memset(&tv, 0, sizeof(tv));
+        gettimeofday(&tv, NULL);
     }
+    p->ts = SCTIME_FROM_TIMEVAL(&tv);
 
     p->datalink = DLT_RAW;
     return 0;

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -77,9 +77,8 @@ void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
     PACKET_PROFILING_TMM_START(p, TMM_RECEIVEPCAPFILE);
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
-    p->ts.tv_sec = h->ts.tv_sec;
-    p->ts.tv_usec = h->ts.tv_usec % 1000000;
-    SCLogDebug("p->ts.tv_sec %"PRIuMAX"", (uintmax_t)p->ts.tv_sec);
+    p->ts = SCTIME_FROM_TIMEVAL(&h->ts);
+    SCLogDebug("p->ts.tv_sec %" PRIuMAX "", (uintmax_t)SCTIME_SECS(p->ts));
     p->datalink = ptv->datalink;
     p->pcap_cnt = ++pcap_g.cnt;
 
@@ -130,7 +129,7 @@ TmEcode PcapFileDispatch(PcapFileFileVars *ptv)
 
     /* initialize all the thread's initial timestamp */
     if (likely(ptv->first_pkt_hdr != NULL)) {
-        TmThreadsInitThreadsTimestamp(&ptv->first_pkt_ts);
+        TmThreadsInitThreadsTimestamp(SCTIME_FROM_TIMEVAL(&ptv->first_pkt_ts));
         PcapFileCallbackLoop((char *)ptv, ptv->first_pkt_hdr,
                 (u_char *)ptv->first_pkt_data);
         ptv->first_pkt_hdr = NULL;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -246,7 +246,7 @@ static void PcapCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
     p->ts = SCTIME_FROM_TIMEVAL(&h->ts);
-    SCLogDebug("p->ts.tv_sec %" PRIuMAX "", SCTIME_SECS((uintmax_t)p->ts));
+    SCLogDebug("p->ts.tv_sec %" PRIuMAX "", (uintmax_t)SCTIME_SECS(p->ts));
     p->datalink = ptv->datalink;
 
     ptv->pkts++;

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -234,8 +234,7 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
         gettimeofday((struct timeval *)&h->ts, NULL);
     }
 
-    p->ts.tv_sec = h->ts.tv_sec;
-    p->ts.tv_usec = h->ts.tv_usec;
+    p->ts = SCTIME_FROM_TIMEVAL(&h->ts);
 
     /* PF_RING all packets are marked as a link type of ethernet
      * so that is what we do here. */
@@ -423,9 +422,9 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
             }
 
             /* Trigger one dump of stats every second */
-            if (p->ts.tv_sec != last_dump) {
+            if (SCTIME_SECS(p->ts) != last_dump) {
                 PfringDumpCounters(ptv);
-                last_dump = p->ts.tv_sec;
+                last_dump = SCTIME_SECS(p->ts);
             }
         } else if (unlikely(r == 0)) {
             if (suricata_ctl_flags & SURICATA_STOP) {

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -566,8 +566,8 @@ static int DoHandleData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 static void StreamTcpSegmentAddPacketDataDo(TcpSegment *seg, const Packet *rp, const Packet *pp)
 {
     if (GET_PKT_DATA(rp) != NULL && GET_PKT_LEN(rp) > pp->payload_len) {
-        seg->pcap_hdr_storage->ts.tv_sec = rp->ts.tv_sec;
-        seg->pcap_hdr_storage->ts.tv_usec = rp->ts.tv_usec;
+        seg->pcap_hdr_storage->ts.tv_sec = SCTIME_SECS(rp->ts);
+        seg->pcap_hdr_storage->ts.tv_usec = SCTIME_USECS(rp->ts);
         seg->pcap_hdr_storage->pktlen = GET_PKT_LEN(rp) - pp->payload_len;
         /*
          * pkt_hdr members are initially allocated 64 bytes of memory. Thus,

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -497,6 +497,7 @@ typedef void lua_State;
 
 #include "tm-threads-common.h"
 #include "util-optimize.h"
+#include "util-time.h"
 #include "util-mem.h"
 #include "util-memcmp.h"
 #include "util-atomic.h"

--- a/src/tests/detect-tls-cert-validity.c
+++ b/src/tests/detect-tls-cert-validity.c
@@ -960,7 +960,7 @@ static int ExpiredTestDetect01(void)
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
     p3->pcap_cnt = 3;
 
-    f.lastts.tv_sec = 1474978656; /* 2016-09-27 */
+    f.lastts = SCTIME_FROM_SECS(1474978656L); /* 2016-09-27 */
 
     StreamTcpInitConfig(true);
 
@@ -1268,7 +1268,7 @@ static int ValidTestDetect01(void)
     p3->flowflags |= FLOW_PKT_ESTABLISHED;
     p3->pcap_cnt = 3;
 
-    f.lastts.tv_sec = 1474978656; /* 2016-09-27 */
+    f.lastts = SCTIME_FROM_SECS(1474978656L); /* 2016-09-27 */
 
     StreamTcpInitConfig(true);
 

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -120,8 +120,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (r <= 0 || header.ts.tv_sec >= INT_MAX - 3600) {
         goto bail;
     }
-    p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec % 1000000;
+    p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -147,8 +146,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             goto bail;
         }
         PacketRecycle(p);
-        p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec % 1000000;
+        p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -163,8 +163,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (r <= 0 || header->ts.tv_sec >= INT_MAX - 3600 || header->ts.tv_usec < 0) {
         goto bail;
     }
-    p->ts.tv_sec = header->ts.tv_sec;
-    p->ts.tv_usec = header->ts.tv_usec % 1000000;
+    p->ts = SCTIME_FROM_TIMEVAL(&header->ts);
     p->datalink = pcap_datalink(pkts);
     p->pkt_src = PKT_SRC_WIRE;
     while (r > 0) {
@@ -191,8 +190,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             goto bail;
         }
         PacketRecycle(p);
-        p->ts.tv_sec = header->ts.tv_sec;
-        p->ts.tv_usec = header->ts.tv_usec % 1000000;
+        p->ts = SCTIME_FROM_TIMEVAL(&header->ts);
         p->datalink = pcap_datalink(pkts);
         p->pkt_src = PKT_SRC_WIRE;
         pcap_cnt++;

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -161,8 +161,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         goto bail;
     }
     p->pkt_src = PKT_SRC_WIRE;
-    p->ts.tv_sec = header.ts.tv_sec;
-    p->ts.tv_usec = header.ts.tv_usec % 1000000;
+    p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
     p->datalink = pkts.datalink;
     while (r > 0) {
         if (PacketCopyData(p, pkt, header.caplen) == 0) {
@@ -189,8 +188,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         }
         PacketRecycle(p);
         p->pkt_src = PKT_SRC_WIRE;
-        p->ts.tv_sec = header.ts.tv_sec;
-        p->ts.tv_usec = header.ts.tv_usec % 1000000;
+        p->ts = SCTIME_FROM_TIMEVAL(&header.ts);
         p->datalink = pkts.datalink;
         pcap_cnt++;
         p->pcap_cnt = pcap_cnt;

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -255,8 +255,8 @@ int TmThreadsRegisterThread(ThreadVars *tv, const int type);
 void TmThreadsUnregisterThread(const int id);
 void TmThreadsInjectFlowById(Flow *f, const int id);
 
-void TmThreadsInitThreadsTimestamp(const struct timeval *ts);
-void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
+void TmThreadsInitThreadsTimestamp(const SCTime_t ts);
+void TmThreadsSetThreadTimestamp(const int id, const SCTime_t ts);
 void TmThreadsGetMinimalTimestamp(struct timeval *ts);
 uint16_t TmThreadsGetWorkerThreadMax(void);
 bool TmThreadsTimeSubsysIsReady(void);

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -199,9 +199,9 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
 
 /**
  */
-static int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,
-        SCLogLevel log_level, const char *file, unsigned line, const char *function,
-        const char *module, const char *message)
+static int SCLogMessageJSON(SCTime_t tval, char *buffer, size_t buffer_size, SCLogLevel log_level,
+        const char *file, unsigned line, const char *function, const char *module,
+        const char *message)
 {
     JsonBuilder *js = jb_new_object();
     if (unlikely(js == NULL))
@@ -341,10 +341,9 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
  *
  * \retval 0 on success; else a negative value on error
  */
-static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPType type,
-        char *buffer, size_t buffer_size, const char *log_format, const SCLogLevel log_level,
-        const char *file, const unsigned int line, const char *function, const char *module,
-        const char *message)
+static SCError SCLogMessageGetBuffer(SCTime_t tval, int color, SCLogOPType type, char *buffer,
+        size_t buffer_size, const char *log_format, const SCLogLevel log_level, const char *file,
+        const unsigned int line, const char *function, const char *module, const char *message)
 {
     if (type == SC_LOG_OP_TYPE_JSON)
         return SCLogMessageJSON(
@@ -393,7 +392,7 @@ static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPTyp
             case SC_LOG_FMT_TIME:
                 temp_fmt[0] = '\0';
 
-                tms = SCLocalTime(tval->tv_sec, &local_tm);
+                tms = SCLocalTime(SCTIME_SECS(tval), &local_tm);
 
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
                         "%s%s%04d-%02d-%02d %02d:%02d:%02d%s", substr, green, tms->tm_year + 1900,
@@ -410,7 +409,7 @@ static SCError SCLogMessageGetBuffer(struct timeval *tval, int color, SCLogOPTyp
             case SC_LOG_FMT_TIME_LEGACY:
                 temp_fmt[0] = '\0';
 
-                tms = SCLocalTime(tval->tv_sec, &local_tm);
+                tms = SCLocalTime(SCTIME_SECS(tval), &local_tm);
 
                 cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer),
                               "%s%s%d/%d/%04d -- %02d:%02d:%02d%s",
@@ -667,8 +666,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigne
     }
 
     /* get ts here so we log the same ts to each output */
-    struct timeval tval;
-    gettimeofday(&tval, NULL);
+    SCTime_t ts = TimeGet();
 
     op_iface_ctx = sc_log_config->op_ifaces;
     while (op_iface_ctx != NULL) {
@@ -679,8 +677,8 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigne
 
         switch (op_iface_ctx->iface) {
             case SC_LOG_OP_IFACE_CONSOLE:
-                if (SCLogMessageGetBuffer(&tval, op_iface_ctx->use_color, op_iface_ctx->type,
-                            buffer, sizeof(buffer),
+                if (SCLogMessageGetBuffer(ts, op_iface_ctx->use_color, op_iface_ctx->type, buffer,
+                            sizeof(buffer),
                             op_iface_ctx->log_format ? op_iface_ctx->log_format
                                                      : sc_log_config->log_format,
                             log_level, file, line, function, module, message) == 0) {
@@ -688,7 +686,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigne
                 }
                 break;
             case SC_LOG_OP_IFACE_FILE:
-                if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
+                if (SCLogMessageGetBuffer(ts, 0, op_iface_ctx->type, buffer, sizeof(buffer),
                             op_iface_ctx->log_format ? op_iface_ctx->log_format
                                                      : sc_log_config->log_format,
                             log_level, file, line, function, module, message) == 0) {
@@ -709,7 +707,7 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file, const unsigne
                 }
                 break;
             case SC_LOG_OP_IFACE_SYSLOG:
-                if (SCLogMessageGetBuffer(&tval, 0, op_iface_ctx->type, buffer, sizeof(buffer),
+                if (SCLogMessageGetBuffer(ts, 0, op_iface_ctx->type, buffer, sizeof(buffer),
                             op_iface_ctx->log_format ? op_iface_ctx->log_format
                                                      : sc_log_config->log_format,
                             log_level, file, line, function, module, message) == 0) {

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -662,7 +662,7 @@ bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec)
         EBPFDeleteKey(eb->mapfd, eb->key[1]);
         SCLogDebug("Done delete entry: %u", FLOW_IS_IPV6(f));
     } else {
-        f->lastts.tv_sec = tsec;
+        f->lastts = SCTIME_FROM_SECS(tsec);
         return true;
     }
     return false;

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -170,10 +170,10 @@ static int LuaCallbackPacketPayload(lua_State *luastate)
  *
  *  Places: seconds (number), microseconds (number)
  */
-static int LuaCallbackTimestampPushToStack(lua_State *luastate, const struct timeval *ts)
+static int LuaCallbackTimestampPushToStack(lua_State *luastate, const SCTime_t ts)
 {
-    lua_pushnumber(luastate, (double)ts->tv_sec);
-    lua_pushnumber(luastate, (double)ts->tv_usec);
+    lua_pushnumber(luastate, (double)SCTIME_SECS(ts));
+    lua_pushnumber(luastate, (double)SCTIME_USECS(ts));
     return 2;
 }
 
@@ -188,7 +188,7 @@ static int LuaCallbackTimestampPushToStack(lua_State *luastate, const struct tim
 static int LuaCallbackTimeStringPushToStackFromPacket(lua_State *luastate, const Packet *p)
 {
     char timebuf[64];
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+    CreateTimeString(p->ts, timebuf, sizeof(timebuf));
     lua_pushstring (luastate, timebuf);
     return 1;
 }
@@ -203,7 +203,7 @@ static int LuaCallbackPacketTimestamp(lua_State *luastate)
     if (p == NULL)
         return LuaCallbackError(luastate, "internal error: no packet");
 
-    return LuaCallbackTimestampPushToStack(luastate, &p->ts);
+    return LuaCallbackTimestampPushToStack(luastate, p->ts);
 }
 
 /** \internal
@@ -229,14 +229,13 @@ static int LuaCallbackPacketTimeString(lua_State *luastate)
  * Places: seconds (number), seconds (number), microseconds (number),
  *         microseconds (number)
  */
-static int LuaCallbackFlowTimestampsPushToStack(lua_State *luastate,
-                                                const struct timeval *startts,
-                                                const struct timeval *lastts)
+static int LuaCallbackFlowTimestampsPushToStack(
+        lua_State *luastate, const SCTime_t startts, const SCTime_t lastts)
 {
-    lua_pushnumber(luastate, (double)startts->tv_sec);
-    lua_pushnumber(luastate, (double)lastts->tv_sec);
-    lua_pushnumber(luastate, (double)startts->tv_usec);
-    lua_pushnumber(luastate, (double)lastts->tv_usec);
+    lua_pushnumber(luastate, (double)SCTIME_SECS(startts));
+    lua_pushnumber(luastate, (double)SCTIME_SECS(lastts));
+    lua_pushnumber(luastate, (double)SCTIME_USECS(startts));
+    lua_pushnumber(luastate, (double)SCTIME_USECS(lastts));
     return 4;
 }
 
@@ -251,8 +250,7 @@ static int LuaCallbackFlowTimestamps(lua_State *luastate)
         return LuaCallbackError(luastate, "internal error: no flow");
     }
 
-    return LuaCallbackFlowTimestampsPushToStack(luastate, &flow->startts,
-                                                &flow->lastts);
+    return LuaCallbackFlowTimestampsPushToStack(luastate, flow->startts, flow->lastts);
 }
 
 /** \internal
@@ -266,7 +264,7 @@ static int LuaCallbackFlowTimestamps(lua_State *luastate)
 static int LuaCallbackTimeStringPushToStackFromFlow(lua_State *luastate, const Flow *flow)
 {
     char timebuf[64];
-    CreateTimeString(&flow->startts, timebuf, sizeof(timebuf));
+    CreateTimeString(flow->startts, timebuf, sizeof(timebuf));
     lua_pushstring (luastate, timebuf);
     return 1;
 }

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -108,7 +108,7 @@ static void DoDumpJSON(SCProfileSghDetectCtx *rules_ctx, FILE *fp, const char *n
     }
 
     gettimeofday(&tval, NULL);
-    CreateIsoTimeString(&tval, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(SCTIME_FROM_TIMEVAL(&tval), timebuf, sizeof(timebuf));
     json_object_set_new(js, "timestamp", json_string(timebuf));
 
     for (i = 0; i < rules_ctx->cnt; i++) {

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -299,7 +299,7 @@ static void DumpJson(FILE *fp, SCProfileSummary *summary,
     }
 
     gettimeofday(&tval, NULL);
-    CreateIsoTimeString(&tval, timebuf, sizeof(timebuf));
+    CreateIsoTimeString(SCTIME_FROM_TIMEVAL(&tval), timebuf, sizeof(timebuf));
     json_object_set_new(js, "timestamp", json_string(timebuf));
     json_object_set_new(js, "sort", json_string(sort_desc));
 

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1635,10 +1635,6 @@ static int SCThresholdConfTest09(void)
 
     HostInitConfig(HOST_QUIET);
 
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
 
@@ -1660,7 +1656,7 @@ static int SCThresholdConfTest09(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
     p->alerts.cnt = 0;
     p->action = 0;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
@@ -1675,7 +1671,7 @@ static int SCThresholdConfTest09(void)
     FAIL_IF(p->alerts.cnt != 1 || PacketTestAction(p, ACTION_DROP));
 
     TimeSetIncrementTime(2);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     p->alerts.cnt = 0;
     p->action = 0;
@@ -1683,7 +1679,7 @@ static int SCThresholdConfTest09(void)
     FAIL_IF(p->alerts.cnt != 1 || !(PacketTestAction(p, ACTION_DROP)));
 
     TimeSetIncrementTime(3);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     p->alerts.cnt = 0;
     p->action = 0;
@@ -1691,7 +1687,7 @@ static int SCThresholdConfTest09(void)
     FAIL_IF(p->alerts.cnt != 1 || !(PacketTestAction(p, ACTION_DROP)));
 
     TimeSetIncrementTime(10);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     p->alerts.cnt = 0;
     p->action = 0;
@@ -1719,10 +1715,6 @@ static int SCThresholdConfTest09(void)
 static int SCThresholdConfTest10(void)
 {
     HostInitConfig(HOST_QUIET);
-
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     /* Create two different packets falling to the same rule, and
     *  because count:3, we should drop on match #4.
@@ -1753,7 +1745,7 @@ static int SCThresholdConfTest10(void)
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     p2->ts = p1->ts;
 
     /* All should be alerted, none dropped */
@@ -1777,7 +1769,7 @@ static int SCThresholdConfTest10(void)
     p2->action = 0;
 
     TimeSetIncrementTime(2);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
 
     /* Still dropped because timeout not expired */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
@@ -1786,7 +1778,7 @@ static int SCThresholdConfTest10(void)
     p1->action = 0;
 
     TimeSetIncrementTime(10);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
 
     /* Not dropped because timeout expired */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
@@ -1813,10 +1805,6 @@ static int SCThresholdConfTest10(void)
 static int SCThresholdConfTest11(void)
 {
     HostInitConfig(HOST_QUIET);
-
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
@@ -1847,7 +1835,7 @@ static int SCThresholdConfTest11(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     int alerts10 = 0;
     int alerts11 = 0;
@@ -1875,14 +1863,14 @@ static int SCThresholdConfTest11(void)
     alerts12 += PacketAlertCheck(p, 12);
 
     TimeSetIncrementTime(100);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts10 += PacketAlertCheck(p, 10);
     alerts11 += PacketAlertCheck(p, 11);
 
     TimeSetIncrementTime(10);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts10 += PacketAlertCheck(p, 10);
@@ -1923,10 +1911,6 @@ static int SCThresholdConfTest12(void)
 {
     HostInitConfig(HOST_QUIET);
 
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
 
@@ -1956,7 +1940,7 @@ static int SCThresholdConfTest12(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     int alerts10 = 0;
     int alerts11 = 0;
@@ -1984,14 +1968,14 @@ static int SCThresholdConfTest12(void)
     alerts12 += PacketAlertCheck(p, 12);
 
     TimeSetIncrementTime(100);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts10 += PacketAlertCheck(p, 10);
     alerts11 += PacketAlertCheck(p, 11);
 
     TimeSetIncrementTime(10);
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     alerts10 += PacketAlertCheck(p, 10);
@@ -2090,10 +2074,6 @@ static int SCThresholdConfTest14(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     FAIL_IF_NOT_NULL(g_ut_threshold_fp);
     g_ut_threshold_fp = SCThresholdConfGenerateValidDummyFD11();
     FAIL_IF_NULL(g_ut_threshold_fp);
@@ -2141,10 +2121,6 @@ static int SCThresholdConfTest15(void)
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     Signature *sig = DetectEngineAppendSig(de_ctx,
             "drop tcp any any -> any any (msg:\"suppress test\"; content:\"lalala\"; gid:1; sid:10000;)");
@@ -2194,10 +2170,6 @@ static int SCThresholdConfTest16(void)
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     Signature *sig = DetectEngineAppendSig(de_ctx,
             "drop tcp any any -> any any (msg:\"suppress test\"; gid:1; sid:1000;)");
     FAIL_IF_NULL(sig);
@@ -2244,10 +2216,6 @@ static int SCThresholdConfTest17(void)
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
-
-    struct timeval ts;
-    memset (&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
 
     Signature *sig = DetectEngineAppendSig(de_ctx,
             "drop tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:10000;)");
@@ -2517,10 +2485,6 @@ static int SCThresholdConfTest22(void)
 
     IPPairInitConfig(IPPAIR_QUIET);
 
-    struct timeval ts;
-    memset(&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     /* This packet will cause rate_filter */
     Packet *p1 = UTHBuildPacketSrcDst((uint8_t*)"lalala", 6, IPPROTO_TCP, "172.26.0.1", "172.26.0.10");
     FAIL_IF_NULL(p1);
@@ -2551,7 +2515,7 @@ static int SCThresholdConfTest22(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     p2->ts = p3->ts = p1->ts;
 
     /* All should be alerted, none dropped */
@@ -2570,7 +2534,7 @@ static int SCThresholdConfTest22(void)
     p1->action = p2->action = p3->action = 0;
 
     TimeSetIncrementTime(2);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     p2->ts = p3->ts = p1->ts;
 
     /* p1 still shouldn't be dropped after 2nd alert */
@@ -2581,7 +2545,7 @@ static int SCThresholdConfTest22(void)
     p1->action = 0;
 
     TimeSetIncrementTime(2);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     p2->ts = p3->ts = p1->ts;
 
     /* All should be alerted, only p1 must be dropped  due to rate_filter*/
@@ -2600,7 +2564,7 @@ static int SCThresholdConfTest22(void)
     p1->action = p2->action = p3->action = 0;
 
     TimeSetIncrementTime(7);
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     p2->ts = p3->ts = p1->ts;
 
     /* All should be alerted, none dropped (because timeout expired) */
@@ -2658,10 +2622,6 @@ static int SCThresholdConfTest23(void)
 
     IPPairInitConfig(IPPAIR_QUIET);
 
-    struct timeval ts;
-    memset(&ts, 0, sizeof(struct timeval));
-    TimeGet(&ts);
-
     /* Create two packets between same addresses in opposite direction */
     Packet *p1 = UTHBuildPacketSrcDst((uint8_t*)"lalala", 6, IPPROTO_TCP, "172.26.0.1", "172.26.0.10");
     FAIL_IF_NULL(p1);
@@ -2687,14 +2647,14 @@ static int SCThresholdConfTest23(void)
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
-    TimeGet(&p1->ts);
+    p1->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
     /* First packet should be alerted, not dropped */
     FAIL_IF(PacketTestAction(p1, ACTION_DROP));
     FAIL_IF(PacketAlertCheck(p1, 10) != 1);
 
     TimeSetIncrementTime(2);
-    TimeGet(&p2->ts);
+    p2->ts = TimeGet();
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
 
     /* Second packet should be dropped because it considered as "the same pair"

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -181,7 +181,7 @@ void TimeSetIncrementTime(uint32_t tv_sec)
 {
     SCTime_t ts = TimeGet();
 
-    ts += SCTIME_FROM_SECS(tv_sec);
+    ts = SCTIME_ADD_SECS(ts, tv_sec);
 
     TimeSet(ts);
 }

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -165,7 +165,7 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     if (unlikely(p == NULL))
         return NULL;
 
-    TimeGet(&p->ts);
+    p->ts = TimeGet();
 
     p->src.family = AF_INET6;
     p->dst.family = AF_INET6;
@@ -251,9 +251,7 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
     if (unlikely(p == NULL))
         return NULL;
 
-    struct timeval tv;
-    TimeGet(&tv);
-    COPY_TIMESTAMP(&tv, &p->ts);
+    p->ts = TimeGet();
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;


### PR DESCRIPTION
Continuation of #8378 

Issue: 5718

This commit switches the majority of time handling to a new type -- SCTime_t -- which is a 64 bit container for time:
- 44 bits -- seconds
- 20 bits -- useconds

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5718](https://redmine.openinfosecfoundation.org/issues/5718)

Describe changes:
- Replace packet, thread, flow and other places using `struct timeval` with `SCTime_t`
- SCTime_t values are never passed by reference; always by value
- 64-bit SCTime_t value can represent over 500,000 years.

Updates:
- Applied `clang-format` to `src/flow-util.h` as first commit to clearly show `SCTime_t` differences
- 
#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
