### PR TITLE
pcap-log: fix output filenames when reading from pcap files - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1106,11 +1106,16 @@ static TmEcode PcapLogDataInit(ThreadVars *t, const void *initdata, void **data)
 #endif /* INIT_RING_BUFFER */
     }
 
-    if (pl->mode == LOGMODE_MULTI) {
-        PcapLogOpenFileCtx(td->pcap_log);
-    } else {
-        if (pl->filename == NULL) {
-            PcapLogOpenFileCtx(pl);
+    /* Don't early initialize output files if in a PCAP file mode. */
+    bool is_offline =
+            RunmodeGetCurrent() == RUNMODE_PCAP_FILE || RunmodeGetCurrent() == RUNMODE_UNIX_SOCKET;
+    if (!is_offline) {
+        if (pl->mode == LOGMODE_MULTI) {
+            PcapLogOpenFileCtx(td->pcap_log);
+        } else {
+            if (pl->filename == NULL) {
+                PcapLogOpenFileCtx(pl);
+            }
         }
     }
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1282,7 +1282,7 @@ static int ParseFilename(PcapLogData *pl, const char *filename)
         }
 
         if ((tok == 0) && (pl->mode == LOGMODE_MULTI)) {
-            SCLogError("Invalid filename for multimode. Need at list one %%-sign option");
+            SCLogError("Invalid filename for multimode. Need at least one %%-sign option");
             goto error;
         }
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1396,7 +1396,8 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
                 pl->size_limit = size;
             } else if (pl->size_limit < MIN_LIMIT) {
                 FatalError("Fail to initialize pcap-log output, limit less than "
-                           "allowed minimum.");
+                           "allowed minimum of %d bytes.",
+                        MIN_LIMIT);
             }
         }
     }


### PR DESCRIPTION
Remove early opening of output files if running in an offline mode, as
we don't yet know the timestamp to use.

Prevents the first pcap files being opened with a timestamp of 0,
bringing us back to the same behvaviour of pcap logging in 6.0.

Other commits:
- log-pcap: display mininum limit on error
- log-pcap: fix typo in multi-mode error message

Issue: https://redmine.openinfosecfoundation.org/issues/5374

suricata-verify-pr: 1066
