### PR TITLE
exceptions: ignore midstream-policy if stream.midstream=true - 5765/v1

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -922,7 +922,7 @@ static int StreamTcpPacketIsRetransmission(TcpStream *stream, Packet *p)
  *
  *  \param  tv      Thread Variable containing  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
- *  \param  stt     Strean Thread module registered to handle the stream handling
+ *  \param  stt     Stream Thread module registered to handle the stream handling
  *
  *  \retval 0 ok
  *  \retval -1 error

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -470,6 +470,11 @@ void StreamTcpInitConfig(bool quiet)
     stream_config.reassembly_memcap_policy =
             ExceptionPolicyParse("stream.reassembly.memcap-policy", true);
     stream_config.midstream_policy = ExceptionPolicyParse("stream.midstream-policy", true);
+    if (stream_config.midstream && stream_config.midstream_policy != EXCEPTION_POLICY_IGNORE) {
+        SCLogWarning("stream.midstream_policy setting conflicting with stream.midstream enabled. "
+                     "Ignoring stream.midstream_policy.");
+        stream_config.midstream_policy = EXCEPTION_POLICY_IGNORE;
+    }
 
     if (!quiet) {
         SCLogConfig("stream.\"inline\": %s",


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5765

Describe changes:
- ignore stream.midstream-policy if stream.midstream is enabled

I preferred this solution because it allows for a single point change, right during the configuration check, which felt safer than having to check for conflicting configuration whenever we had to check for midstream enabled. Suri will issue a warning stating that as both are enabled, we're ignoring the exception policy for midstream.

suricata-verify-pr: 1069
https://github.com/OISF/suricata-verify/pull/1069