### PR TITLE
decode-udp:  Allow shorter UDP packets than the remaining payload length v5

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -67,7 +67,6 @@ alert pkthdr any any -> any any (msg:"SURICATA TCP option invalid length"; decod
 alert pkthdr any any -> any any (msg:"SURICATA TCP duplicated option"; decode-event:tcp.opt_duplicate; classtype:protocol-command-decode; sid:2200037; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA UDP packet too small"; decode-event:udp.pkt_too_small; classtype:protocol-command-decode; sid:2200038; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA UDP header length too small"; decode-event:udp.hlen_too_small; classtype:protocol-command-decode; sid:2200039; rev:2;)
-alert pkthdr any any -> any any (msg:"SURICATA UDP invalid header length"; decode-event:udp.hlen_invalid; classtype:protocol-command-decode; sid:2200040; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA SLL packet too small"; decode-event:sll.pkt_too_small; classtype:protocol-command-decode; sid:2200041; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA Ethernet packet too small"; decode-event:ethernet.pkt_too_small; classtype:protocol-command-decode; sid:2200042; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA PPP packet too small"; decode-event:ppp.pkt_too_small; classtype:protocol-command-decode; sid:2200043; rev:2;)

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -56,11 +56,6 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_
         return -1;
     }
 
-    if (unlikely(len != UDP_GET_LEN(p))) {
-        ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_INVALID);
-        return -1;
-    }
-
     SET_UDP_SRC_PORT(p,&p->sp);
     SET_UDP_DST_PORT(p,&p->dp);
 

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -110,6 +110,14 @@ static int DetectEngineEventMatch (DetectEngineThreadCtx *det_ctx,
     SCReturnInt(0);
 }
 
+static bool OutdatedEvent(const char *raw)
+{
+    if (strcmp(raw, "decoder.udp.hlen_invalid") == 0) {
+        return true;
+    }
+    return false;
+}
+
 /**
  * \brief This function is used to parse decoder events options passed via decode-event: keyword
  *
@@ -161,6 +169,16 @@ static DetectEngineEventData *DetectEngineEventParse (const char *rawstr)
     if (de->event == STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA) {
         StreamTcpReassembleConfigEnableOverlapCheck();
     }
+
+    if (OutdatedEvent(rawstr)) {
+        if (SigMatchStrictEnabled(DETECT_DECODE_EVENT)) {
+            SCLogError("decode-event keyword no longer supports event \"%s\"", rawstr);
+            goto error;
+        } else {
+            SCLogWarning("decode-event keyword no longer supports event \"%s\"", rawstr);
+        }
+    }
+
     return de;
 
 error:


### PR DESCRIPTION
If a packet is shorter than IP payload length we no longer flag it as an invalid UDP packet. UDP packet can be therefore shorter than IP payload.

Redmine ticket: #5693

Changes:
- Rebased on the new master
- Changed the way the decode keyword is deprecated

This one was a quickie so I hope it will be ok. 