### PR TITLE
optimization/detect: pattern id assignment is too slow (6.0.x backport)

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -656,6 +656,47 @@ void DetectContentPropagateLimits(Signature *s)
 #undef VALIDATE
 }
 
+static inline bool NeedsAsHex(uint8_t c)
+{
+    if (!isprint(c))
+        return true;
+
+    switch (c) {
+        case '/':
+        case ';':
+        case ':':
+        case '\\':
+        case ' ':
+        case '|':
+        case '"':
+        case '`':
+        case '\'':
+            return true;
+    }
+    return false;
+}
+
+void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len)
+{
+    bool hex = false;
+    for (uint16_t i = 0; i < cd->content_len; i++) {
+        if (NeedsAsHex(cd->content[i])) {
+            char hex_str[4];
+            snprintf(hex_str, sizeof(hex_str), "%s%02X", !hex ? "|" : " ", cd->content[i]);
+            strlcat(str, hex_str, str_len);
+            hex = true;
+        } else {
+            char p_str[3];
+            snprintf(p_str, sizeof(p_str), "%s%c", hex ? "|" : "", cd->content[i]);
+            strlcat(str, p_str, str_len);
+            hex = false;
+        }
+    }
+    if (hex) {
+        strlcat(str, "|", str_len);
+    }
+}
+
 #ifdef UNITTESTS /* UNITTESTS */
 
 static bool TestLastContent(const Signature *s, uint16_t o, uint16_t d)

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -123,4 +123,6 @@ void DetectContentFree(DetectEngineCtx *, void *);
 bool DetectContentPMATCHValidateCallback(const Signature *s);
 void DetectContentPropagateLimits(Signature *s);
 
+void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
+
 #endif /* __DETECT_CONTENT_H__ */

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -672,10 +672,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
     jb_close(js);
 }
 
+static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s);
+
 SCMutex g_rules_analyzer_write_m = SCMUTEX_INITIALIZER;
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 {
     SCEnter();
+
+    EngineAnalysisRulePatterns(de_ctx, s);
 
     RuleAnalyzer ctx = { NULL, NULL, NULL };
 
@@ -894,6 +898,331 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     }
     SCMutexUnlock(&g_rules_analyzer_write_m);
     jb_free(ctx.js);
+    SCReturn;
+}
+
+struct PatternItem {
+    const DetectContentData *cd;
+    int sm_list;
+    uint32_t cnt;
+    uint32_t mpm;
+};
+
+static inline uint32_t ContentFlagsForHash(const DetectContentData *cd)
+{
+    return cd->flags & (DETECT_CONTENT_NOCASE | DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH |
+                               DETECT_CONTENT_NEGATED | DETECT_CONTENT_ENDS_WITH);
+}
+
+/** \internal
+ *  \brief The hash function for Pattern
+ *
+ *  \param ht      Pointer to the hash table.
+ *  \param data    Pointer to the Pattern.
+ *  \param datalen Not used in our case.
+ *
+ *  \retval hash The generated hash value.
+ */
+static uint32_t PatternHashFunc(HashListTable *ht, void *data, uint16_t datalen)
+{
+    struct PatternItem *p = (struct PatternItem *)data;
+    uint32_t hash = p->sm_list + ContentFlagsForHash(p->cd);
+
+    for (uint32_t b = 0; b < p->cd->content_len; b++)
+        hash += p->cd->content[b];
+
+    return hash % ht->array_size;
+}
+
+/**
+ * \brief The Compare function for Pattern
+ *
+ * \param data1 Pointer to the first Pattern.
+ * \param len1  Not used.
+ * \param data2 Pointer to the second Pattern.
+ * \param len2  Not used.
+ *
+ * \retval 1 If the 2 Patterns sent as args match.
+ * \retval 0 If the 2 Patterns sent as args do not match.
+ */
+static char PatternCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)
+{
+    const struct PatternItem *p1 = (struct PatternItem *)data1;
+    const struct PatternItem *p2 = (struct PatternItem *)data2;
+
+    if (p1->sm_list != p2->sm_list)
+        return 0;
+
+    if (ContentFlagsForHash(p1->cd) != ContentFlagsForHash(p2->cd))
+        return 0;
+
+    if (p1->cd->content_len != p2->cd->content_len)
+        return 0;
+
+    if (memcmp(p1->cd->content, p2->cd->content, p1->cd->content_len) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static void PatternFreeFunc(void *ptr)
+{
+    SCFree(ptr);
+}
+
+/**
+ * \brief Initializes the Pattern mpm hash table to be used by the detection
+ *        engine context.
+ *
+ * \param de_ctx Pointer to the detection engine context.
+ *
+ * \retval  0 On success.
+ * \retval -1 On failure.
+ */
+static int PatternInit(DetectEngineCtx *de_ctx)
+{
+    de_ctx->pattern_hash_table =
+            HashListTableInit(4096, PatternHashFunc, PatternCompareFunc, PatternFreeFunc);
+    if (de_ctx->pattern_hash_table == NULL)
+        goto error;
+
+    return 0;
+
+error:
+    return -1;
+}
+
+static inline bool NeedsAsHex(uint8_t c)
+{
+    if (!isprint(c))
+        return true;
+
+    switch (c) {
+        case '/':
+        case ';':
+        case ':':
+        case '\\':
+        case ' ':
+        case '|':
+        case '"':
+        case '`':
+        case '\'':
+            return true;
+    }
+    return false;
+}
+
+static void PatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len)
+{
+    bool hex = false;
+    for (uint16_t i = 0; i < cd->content_len; i++) {
+        if (NeedsAsHex(cd->content[i])) {
+            char hex_str[4];
+            snprintf(hex_str, sizeof(hex_str), "%s%02X", !hex ? "|" : " ", cd->content[i]);
+            strlcat(str, hex_str, str_len);
+            hex = true;
+        } else {
+            char p_str[3];
+            snprintf(p_str, sizeof(p_str), "%s%c", hex ? "|" : "", cd->content[i]);
+            strlcat(str, p_str, str_len);
+            hex = false;
+        }
+    }
+    if (hex) {
+        strlcat(str, "|", str_len);
+    }
+}
+
+void DumpPatterns(DetectEngineCtx *de_ctx)
+{
+    if (de_ctx->buffer_type_map_elements == 0 || de_ctx->pattern_hash_table == NULL)
+        return;
+
+    JsonBuilder *root_jb = jb_new_object();
+    JsonBuilder *arrays[de_ctx->buffer_type_map_elements];
+    memset(&arrays, 0, sizeof(JsonBuilder *) * de_ctx->buffer_type_map_elements);
+
+    jb_open_array(root_jb, "buffers");
+
+    for (HashListTableBucket *htb = HashListTableGetListHead(de_ctx->pattern_hash_table);
+            htb != NULL; htb = HashListTableGetListNext(htb)) {
+        char str[1024] = "";
+        struct PatternItem *p = HashListTableGetListData(htb);
+        PatternPrettyPrint(p->cd, str, sizeof(str));
+
+        JsonBuilder *jb = arrays[p->sm_list];
+        if (arrays[p->sm_list] == NULL) {
+            jb = arrays[p->sm_list] = jb_new_object();
+            const char *name;
+            if (p->sm_list < DETECT_SM_LIST_DYNAMIC_START)
+                name = DetectListToHumanString(p->sm_list);
+            else
+                name = DetectBufferTypeGetNameById(de_ctx, p->sm_list);
+            jb_set_string(jb, "name", name);
+            jb_set_uint(jb, "list_id", p->sm_list);
+
+            jb_open_array(jb, "patterns");
+        }
+
+        jb_start_object(jb);
+        jb_set_string(jb, "pattern", str);
+        jb_set_uint(jb, "patlen", p->cd->content_len);
+        jb_set_uint(jb, "cnt", p->cnt);
+        jb_set_uint(jb, "mpm", p->mpm);
+        jb_open_object(jb, "flags");
+        jb_set_bool(jb, "nocase", p->cd->flags & DETECT_CONTENT_NOCASE);
+        jb_set_bool(jb, "negated", p->cd->flags & DETECT_CONTENT_NEGATED);
+        jb_set_bool(jb, "depth", p->cd->flags & DETECT_CONTENT_DEPTH);
+        jb_set_bool(jb, "offset", p->cd->flags & DETECT_CONTENT_OFFSET);
+        jb_set_bool(jb, "endswith", p->cd->flags & DETECT_CONTENT_ENDS_WITH);
+        jb_close(jb);
+        jb_close(jb);
+    }
+
+    for (uint32_t i = 0; i < de_ctx->buffer_type_map_elements; i++) {
+        JsonBuilder *jb = arrays[i];
+        if (jb == NULL)
+            continue;
+
+        jb_close(jb); // array
+        jb_close(jb); // object
+
+        jb_append_object(root_jb, jb);
+        jb_free(jb);
+    }
+    jb_close(root_jb);
+    jb_close(root_jb);
+
+    const char *filename = "patterns.json";
+    const char *log_dir = ConfigGetLogDirectory();
+    char json_path[PATH_MAX] = "";
+    snprintf(json_path, sizeof(json_path), "%s/%s", log_dir, filename);
+
+    SCMutexLock(&g_rules_analyzer_write_m);
+    FILE *fp = fopen(json_path, "a");
+    if (fp != NULL) {
+        fwrite(jb_ptr(root_jb), jb_len(root_jb), 1, fp);
+        fprintf(fp, "\n");
+        fclose(fp);
+    }
+    SCMutexUnlock(&g_rules_analyzer_write_m);
+    jb_free(root_jb);
+
+    HashListTableFree(de_ctx->pattern_hash_table);
+    de_ctx->pattern_hash_table = NULL;
+}
+
+static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s)
+{
+    SCEnter();
+
+    if (de_ctx->pattern_hash_table == NULL)
+        PatternInit((DetectEngineCtx *)de_ctx); // TODO hack const
+
+    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
+        SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_PMATCH];
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = DETECT_SM_LIST_PMATCH, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = DETECT_SM_LIST_PMATCH;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+
+    const DetectEngineAppInspectionEngine *app = s->app_inspect;
+    for (; app != NULL; app = app->next) {
+        SigMatchData *smd = app->smd;
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = app->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = app->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+    const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
+    for (; pkt != NULL; pkt = pkt->next) {
+        SigMatchData *smd = pkt->smd;
+        do {
+            if (smd == NULL) {
+                BUG_ON(!(pkt->sm_list < DETECT_SM_LIST_DYNAMIC_START));
+                smd = s->sm_arrays[pkt->sm_list];
+            }
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    struct PatternItem lookup = {
+                        .cd = cd, .sm_list = pkt->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    struct PatternItem *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = pkt->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+
     SCReturn;
 }
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -897,6 +897,29 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     SCReturn;
 }
 
+struct PatternItem {
+    const DetectContentData *cd;
+    int sm_list;
+    uint32_t cnt;
+    uint32_t mpm;
+};
+
+static inline uint32_t ContentFlagsForHash(const DetectContentData *cd)
+{
+    return cd->flags & (DETECT_CONTENT_NOCASE | DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH |
+                               DETECT_CONTENT_NEGATED | DETECT_CONTENT_ENDS_WITH);
+}
+
+/** \internal
+ *  \brief The hash function for Pattern
+ *
+ *  \param ht      Pointer to the hash table.
+ *  \param data    Pointer to the Pattern.
+ *  \param datalen Not used in our case.
+ *
+ *  \retval hash The generated hash value.
+ */
+
 void DumpPatterns(DetectEngineCtx *de_ctx)
 {
     if (de_ctx->buffer_type_map_elements == 0 || de_ctx->pattern_hash_table == NULL)
@@ -911,7 +934,7 @@ void DumpPatterns(DetectEngineCtx *de_ctx)
     for (HashListTableBucket *htb = HashListTableGetListHead(de_ctx->pattern_hash_table);
             htb != NULL; htb = HashListTableGetListNext(htb)) {
         char str[1024] = "";
-        DetectPatternTracker *p = HashListTableGetListData(htb);
+        struct PatternItem *p = HashListTableGetListData(htb);
         DetectContentPatternPrettyPrint(p->cd, str, sizeof(str));
 
         JsonBuilder *jb = arrays[p->sm_list];

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -672,14 +672,10 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
     jb_close(js);
 }
 
-static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s);
-
 SCMutex g_rules_analyzer_write_m = SCMUTEX_INITIALIZER;
 void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
 {
     SCEnter();
-
-    EngineAnalysisRulePatterns(de_ctx, s);
 
     RuleAnalyzer ctx = { NULL, NULL, NULL };
 
@@ -901,139 +897,6 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     SCReturn;
 }
 
-struct PatternItem {
-    const DetectContentData *cd;
-    int sm_list;
-    uint32_t cnt;
-    uint32_t mpm;
-};
-
-static inline uint32_t ContentFlagsForHash(const DetectContentData *cd)
-{
-    return cd->flags & (DETECT_CONTENT_NOCASE | DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH |
-                               DETECT_CONTENT_NEGATED | DETECT_CONTENT_ENDS_WITH);
-}
-
-/** \internal
- *  \brief The hash function for Pattern
- *
- *  \param ht      Pointer to the hash table.
- *  \param data    Pointer to the Pattern.
- *  \param datalen Not used in our case.
- *
- *  \retval hash The generated hash value.
- */
-static uint32_t PatternHashFunc(HashListTable *ht, void *data, uint16_t datalen)
-{
-    struct PatternItem *p = (struct PatternItem *)data;
-    uint32_t hash = p->sm_list + ContentFlagsForHash(p->cd);
-
-    for (uint32_t b = 0; b < p->cd->content_len; b++)
-        hash += p->cd->content[b];
-
-    return hash % ht->array_size;
-}
-
-/**
- * \brief The Compare function for Pattern
- *
- * \param data1 Pointer to the first Pattern.
- * \param len1  Not used.
- * \param data2 Pointer to the second Pattern.
- * \param len2  Not used.
- *
- * \retval 1 If the 2 Patterns sent as args match.
- * \retval 0 If the 2 Patterns sent as args do not match.
- */
-static char PatternCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)
-{
-    const struct PatternItem *p1 = (struct PatternItem *)data1;
-    const struct PatternItem *p2 = (struct PatternItem *)data2;
-
-    if (p1->sm_list != p2->sm_list)
-        return 0;
-
-    if (ContentFlagsForHash(p1->cd) != ContentFlagsForHash(p2->cd))
-        return 0;
-
-    if (p1->cd->content_len != p2->cd->content_len)
-        return 0;
-
-    if (memcmp(p1->cd->content, p2->cd->content, p1->cd->content_len) != 0) {
-        return 0;
-    }
-
-    return 1;
-}
-
-static void PatternFreeFunc(void *ptr)
-{
-    SCFree(ptr);
-}
-
-/**
- * \brief Initializes the Pattern mpm hash table to be used by the detection
- *        engine context.
- *
- * \param de_ctx Pointer to the detection engine context.
- *
- * \retval  0 On success.
- * \retval -1 On failure.
- */
-static int PatternInit(DetectEngineCtx *de_ctx)
-{
-    de_ctx->pattern_hash_table =
-            HashListTableInit(4096, PatternHashFunc, PatternCompareFunc, PatternFreeFunc);
-    if (de_ctx->pattern_hash_table == NULL)
-        goto error;
-
-    return 0;
-
-error:
-    return -1;
-}
-
-static inline bool NeedsAsHex(uint8_t c)
-{
-    if (!isprint(c))
-        return true;
-
-    switch (c) {
-        case '/':
-        case ';':
-        case ':':
-        case '\\':
-        case ' ':
-        case '|':
-        case '"':
-        case '`':
-        case '\'':
-            return true;
-    }
-    return false;
-}
-
-static void PatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len)
-{
-    bool hex = false;
-    for (uint16_t i = 0; i < cd->content_len; i++) {
-        if (NeedsAsHex(cd->content[i])) {
-            char hex_str[4];
-            snprintf(hex_str, sizeof(hex_str), "%s%02X", !hex ? "|" : " ", cd->content[i]);
-            strlcat(str, hex_str, str_len);
-            hex = true;
-        } else {
-            char p_str[3];
-            snprintf(p_str, sizeof(p_str), "%s%c", hex ? "|" : "", cd->content[i]);
-            strlcat(str, p_str, str_len);
-            hex = false;
-        }
-    }
-    if (hex) {
-        strlcat(str, "|", str_len);
-    }
-}
-
 void DumpPatterns(DetectEngineCtx *de_ctx)
 {
     if (de_ctx->buffer_type_map_elements == 0 || de_ctx->pattern_hash_table == NULL)
@@ -1048,8 +911,8 @@ void DumpPatterns(DetectEngineCtx *de_ctx)
     for (HashListTableBucket *htb = HashListTableGetListHead(de_ctx->pattern_hash_table);
             htb != NULL; htb = HashListTableGetListNext(htb)) {
         char str[1024] = "";
-        struct PatternItem *p = HashListTableGetListData(htb);
-        PatternPrettyPrint(p->cd, str, sizeof(str));
+        DetectPatternTracker *p = HashListTableGetListData(htb);
+        DetectContentPatternPrettyPrint(p->cd, str, sizeof(str));
 
         JsonBuilder *jb = arrays[p->sm_list];
         if (arrays[p->sm_list] == NULL) {
@@ -1111,119 +974,6 @@ void DumpPatterns(DetectEngineCtx *de_ctx)
 
     HashListTableFree(de_ctx->pattern_hash_table);
     de_ctx->pattern_hash_table = NULL;
-}
-
-static void EngineAnalysisRulePatterns(const DetectEngineCtx *de_ctx, const Signature *s)
-{
-    SCEnter();
-
-    if (de_ctx->pattern_hash_table == NULL)
-        PatternInit((DetectEngineCtx *)de_ctx); // TODO hack const
-
-    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
-        SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_PMATCH];
-        do {
-            switch (smd->type) {
-                case DETECT_CONTENT: {
-                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
-                    struct PatternItem lookup = {
-                        .cd = cd, .sm_list = DETECT_SM_LIST_PMATCH, .cnt = 0, .mpm = 0
-                    };
-                    struct PatternItem *res =
-                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
-                    if (res) {
-                        res->cnt++;
-                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                    } else {
-                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
-                        BUG_ON(add == NULL);
-                        add->cd = cd;
-                        add->sm_list = DETECT_SM_LIST_PMATCH;
-                        add->cnt = 1;
-                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
-                    }
-                    break;
-                }
-            }
-            if (smd->is_last)
-                break;
-            smd++;
-        } while (1);
-    }
-
-    const DetectEngineAppInspectionEngine *app = s->app_inspect;
-    for (; app != NULL; app = app->next) {
-        SigMatchData *smd = app->smd;
-        do {
-            switch (smd->type) {
-                case DETECT_CONTENT: {
-                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
-
-                    struct PatternItem lookup = {
-                        .cd = cd, .sm_list = app->sm_list, .cnt = 0, .mpm = 0
-                    };
-                    struct PatternItem *res =
-                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
-                    if (res) {
-                        res->cnt++;
-                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                    } else {
-                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
-                        BUG_ON(add == NULL);
-                        add->cd = cd;
-                        add->sm_list = app->sm_list;
-                        add->cnt = 1;
-                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
-                    }
-                    break;
-                }
-            }
-            if (smd->is_last)
-                break;
-            smd++;
-        } while (1);
-    }
-    const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
-    for (; pkt != NULL; pkt = pkt->next) {
-        SigMatchData *smd = pkt->smd;
-        do {
-            if (smd == NULL) {
-                BUG_ON(!(pkt->sm_list < DETECT_SM_LIST_DYNAMIC_START));
-                smd = s->sm_arrays[pkt->sm_list];
-            }
-            switch (smd->type) {
-                case DETECT_CONTENT: {
-                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
-
-                    struct PatternItem lookup = {
-                        .cd = cd, .sm_list = pkt->sm_list, .cnt = 0, .mpm = 0
-                    };
-                    struct PatternItem *res =
-                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
-                    if (res) {
-                        res->cnt++;
-                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                    } else {
-                        struct PatternItem *add = SCCalloc(1, sizeof(*add));
-                        BUG_ON(add == NULL);
-                        add->cd = cd;
-                        add->sm_list = pkt->sm_list;
-                        add->cnt = 1;
-                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
-                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
-                    }
-                    break;
-                }
-            }
-            if (smd->is_last)
-                break;
-            smd++;
-        } while (1);
-    }
-
-    SCReturn;
 }
 
 static void EngineAnalysisItemsReset(void)

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1872,6 +1872,7 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
         DetectEnginePktInspectionSetup(s);
 
         if (rule_engine_analysis_set) {
+            EngineAnalysisAddAllRulePatterns(de_ctx, s);
             EngineAnalysisRules2(de_ctx, s);
         }
         /* free lists. Ctx' are xferred to sm_arrays so won't get freed */

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1896,7 +1896,7 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
         s->init_data = NULL;
     }
 
-
+    DumpPatterns(de_ctx);
     SCReturnInt(0);
 }
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -62,6 +62,7 @@
 #include "util-debug.h"
 #include "util-print.h"
 #include "util-validate.h"
+#include "util-hash-string.h"
 
 const char *builtin_mpms[] = {
     "toserver TCP packet",
@@ -1759,14 +1760,133 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
     return 0;
 }
 
-typedef struct DetectFPAndItsId_ {
-    PatIntId id;
-    uint16_t content_len;
-    uint32_t flags;
-    int sm_list;
+static inline uint32_t ContentFlagsForHash(const DetectContentData *cd)
+{
+    return cd->flags & (DETECT_CONTENT_NOCASE | DETECT_CONTENT_OFFSET | DETECT_CONTENT_DEPTH |
+                               DETECT_CONTENT_NEGATED | DETECT_CONTENT_ENDS_WITH);
+}
 
-    uint8_t *content;
-} DetectFPAndItsId;
+/** \internal
+ *  \brief The hash function for Pattern. Hashes pattern after chop is applied.
+ *
+ *  \param ht      Pointer to the hash table.
+ *  \param data    Pointer to the Pattern.
+ *  \param datalen Not used in our case.
+ *
+ *  \retval hash The generated hash value.
+ */
+static uint32_t PatternChopHashFunc(HashListTable *ht, void *data, uint16_t datalen)
+{
+    const DetectPatternTracker *p = (DetectPatternTracker *)data;
+    uint32_t hash = p->sm_list + ContentFlagsForHash(p->cd);
+    uint16_t content_len = p->cd->content_len;
+    const uint8_t *content = p->cd->content;
+    if (p->cd->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) {
+        content += p->cd->fp_chop_offset;
+        content_len = p->cd->fp_chop_len;
+    }
+    hash += StringHashDjb2(content, content_len);
+    return hash % ht->array_size;
+}
+
+/** \internal
+ *  \brief The hash function for Pattern. Ignores chop.
+ *
+ *  \param ht      Pointer to the hash table.
+ *  \param data    Pointer to the Pattern.
+ *  \param datalen Not used in our case.
+ *
+ *  \retval hash The generated hash value.
+ */
+static uint32_t PatternNoChopHashFunc(HashListTable *ht, void *data, uint16_t datalen)
+{
+    const DetectPatternTracker *p = (DetectPatternTracker *)data;
+    uint32_t hash = p->sm_list + ContentFlagsForHash(p->cd);
+    hash += StringHashDjb2(p->cd->content, p->cd->content_len);
+    return hash % ht->array_size;
+}
+
+/**
+ * \brief The Compare function for Pattern. Compares patterns after chop is applied.
+ *
+ * \param data1 Pointer to the first Pattern.
+ * \param len1  Not used.
+ * \param data2 Pointer to the second Pattern.
+ * \param len2  Not used.
+ *
+ * \retval 1 If the 2 Patterns sent as args match.
+ * \retval 0 If the 2 Patterns sent as args do not match.
+ */
+static char PatternChopCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)
+{
+    const DetectPatternTracker *p1 = (DetectPatternTracker *)data1;
+    const DetectPatternTracker *p2 = (DetectPatternTracker *)data2;
+
+    if (p1->sm_list != p2->sm_list)
+        return 0;
+
+    if (ContentFlagsForHash(p1->cd) != ContentFlagsForHash(p2->cd))
+        return 0;
+
+    uint16_t p1_content_len = p1->cd->content_len;
+    uint8_t *p1_content = p1->cd->content;
+    if (p1->cd->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) {
+        p1_content += p1->cd->fp_chop_offset;
+        p1_content_len = p1->cd->fp_chop_len;
+    }
+    uint16_t p2_content_len = p2->cd->content_len;
+    uint8_t *p2_content = p2->cd->content;
+    if (p2->cd->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) {
+        p2_content += p2->cd->fp_chop_offset;
+        p2_content_len = p2->cd->fp_chop_len;
+    }
+
+    if (p1_content_len != p2_content_len)
+        return 0;
+
+    if (memcmp(p1_content, p2_content, p1_content_len) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/**
+ * \brief The Compare function for Pattern. Ignores chop settings
+ *
+ * \param data1 Pointer to the first Pattern.
+ * \param len1  Not used.
+ * \param data2 Pointer to the second Pattern.
+ * \param len2  Not used.
+ *
+ * \retval 1 If the 2 Patterns sent as args match.
+ * \retval 0 If the 2 Patterns sent as args do not match.
+ */
+static char PatternNoChopCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)
+{
+    const DetectPatternTracker *p1 = (DetectPatternTracker *)data1;
+    const DetectPatternTracker *p2 = (DetectPatternTracker *)data2;
+
+    if (p1->sm_list != p2->sm_list)
+        return 0;
+
+    if (ContentFlagsForHash(p1->cd) != ContentFlagsForHash(p2->cd))
+        return 0;
+
+    if (p1->cd->content_len != p2->cd->content_len)
+        return 0;
+
+    if (memcmp(p1->cd->content, p2->cd->content, p1->cd->content_len) != 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+static void PatternFreeFunc(void *ptr)
+{
+    SCFree(ptr);
+}
 
 /**
  * \brief Figure out the FP and their respective content ids for all the
@@ -1779,116 +1899,175 @@ typedef struct DetectFPAndItsId_ {
  */
 int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx)
 {
-    uint32_t struct_total_size = 0;
-    uint32_t content_total_size = 0;
-    Signature *s = NULL;
-
-    /* Count the amount of memory needed to store all the structures
-     * and the content of those structures. This will over estimate the
-     * true size, since duplicates are removed below, but counted here.
-     */
-    for (s = de_ctx->sig_list; s != NULL; s = s->next) {
+    uint32_t cnt = 0;
+    for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
         if (s->flags & SIG_FLAG_PREFILTER)
             continue;
 
         RetrieveFPForSig(de_ctx, s);
         if (s->init_data->mpm_sm != NULL) {
-            DetectContentData *cd = (DetectContentData *)s->init_data->mpm_sm->ctx;
-            struct_total_size += sizeof(DetectFPAndItsId);
-            content_total_size += cd->content_len;
-
             s->flags |= SIG_FLAG_PREFILTER;
+            cnt++;
         }
     }
-    /* no rules */
-    if (struct_total_size + content_total_size == 0)
+    /* no mpm rules */
+    if (cnt == 0)
         return 0;
 
-    /* array hash buffer - I've run out of ideas to name it */
-    uint8_t *ahb = SCMalloc(sizeof(uint8_t) * (struct_total_size + content_total_size));
-    if (unlikely(ahb == NULL))
-        return -1;
-
-    uint8_t *content = NULL;
-    uint16_t content_len = 0;
+    HashListTable *ht =
+            HashListTableInit(4096, PatternChopHashFunc, PatternChopCompareFunc, PatternFreeFunc);
+    BUG_ON(ht == NULL);
     PatIntId max_id = 0;
-    DetectFPAndItsId *struct_offset = (DetectFPAndItsId *)ahb;
-    uint8_t *content_offset = ahb + struct_total_size;
 
-    for (s = de_ctx->sig_list; s != NULL; s = s->next) {
-        if (s->init_data->mpm_sm != NULL) {
-            int sm_list = s->init_data->mpm_sm_list;
-            BUG_ON(sm_list == -1);
+    for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
+        if (s->init_data->mpm_sm == NULL)
+            continue;
 
-            DetectContentData *cd = (DetectContentData *)s->init_data->mpm_sm->ctx;
-            DetectFPAndItsId *dup = (DetectFPAndItsId *)ahb;
-            if (cd->flags & DETECT_CONTENT_FAST_PATTERN_CHOP) {
-                content = cd->content + cd->fp_chop_offset;
-                content_len = cd->fp_chop_len;
-            } else {
-                content = cd->content;
-                content_len = cd->content_len;
-            }
-            uint32_t flags = cd->flags & DETECT_CONTENT_NOCASE;
-            /* Check for content already found on the same list */
-            for (; dup != struct_offset; dup++) {
-                if (dup->content_len != content_len)
-                    continue;
-                if (dup->sm_list != sm_list)
-                    continue;
-                if (dup->flags != flags)
-                    continue;
-                /* Check for pattern matching a duplicate. Use case insensitive matching
-                 * for case insensitive patterns. */
-                if (flags & DETECT_CONTENT_NOCASE) {
-                    if (SCMemcmpLowercase(dup->content, content, content_len) != 0)
-                        continue;
-                } else {
-                    /* Case sensitive matching */
-                    if (SCMemcmp(dup->content, content, content_len) != 0)
-                        continue;
-                }
-                /* Found a match with a previous pattern. */
-                break;
-            }
-            if (dup != struct_offset) {
-                /* Exited for-loop before the end, so found an existing match.
-                 * Use its ID. */
-                cd->id = dup->id;
-                continue;
-            }
+        const int sm_list = s->init_data->mpm_sm_list;
+        BUG_ON(sm_list == -1);
 
-            /* Not found, so new content. Give it a new ID and add it
-             * to the array.  Copy the content at the end of the
-             * content array.
-             */
-            struct_offset->id = max_id++;
-            cd->id = struct_offset->id;
-            struct_offset->content_len = content_len;
-            struct_offset->sm_list = sm_list;
-            struct_offset->content = content_offset;
-            struct_offset->flags = flags;
+        DetectContentData *cd = (DetectContentData *)s->init_data->mpm_sm->ctx;
 
-            content_offset += content_len;
+        DetectPatternTracker lookup = { .cd = cd, .sm_list = sm_list, .cnt = 0, .mpm = 0 };
+        DetectPatternTracker *res = HashListTableLookup(ht, &lookup, 0);
+        if (res) {
+            res->cnt++;
+            res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
 
-            if (flags & DETECT_CONTENT_NOCASE) {
-                /* Need to store case-insensitive patterns as lower case
-                 * because SCMemcmpLowercase() above assumes that all
-                 * patterns are stored lower case so that it doesn't
-                 * need to re-lower its first argument.
-                 */
-                memcpy_tolower(struct_offset->content, content, content_len);
-            } else {
-                memcpy(struct_offset->content, content, content_len);
-            }
+            cd->id = res->cd->id;
+            SCLogDebug("%u: res id %u cnt %u", s->id, res->cd->id, res->cnt);
+        } else {
+            DetectPatternTracker *add = SCCalloc(1, sizeof(*add));
+            BUG_ON(add == NULL);
+            add->cd = cd;
+            add->sm_list = sm_list;
+            add->cnt = 1;
+            add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+            HashListTableAdd(ht, (void *)add, 0);
 
-            struct_offset++;
-        } /* if (s->mpm_sm != NULL) */
-    } /* for */
+            cd->id = max_id++;
+            SCLogDebug("%u: add id %u cnt %u", s->id, add->cd->id, add->cnt);
+        }
+    }
 
     de_ctx->max_fp_id = max_id;
 
-    SCFree(ahb);
+    HashListTableFree(ht);
 
     return 0;
+}
+
+/** \brief add all patterns on our stats hash
+ *  Used to fill the hash later used by DumpPatterns()
+ *  \note sets up the hash table on first call
+ */
+void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *s)
+{
+    if (de_ctx->pattern_hash_table == NULL) {
+        de_ctx->pattern_hash_table = HashListTableInit(
+                4096, PatternNoChopHashFunc, PatternNoChopCompareFunc, PatternFreeFunc);
+        BUG_ON(de_ctx->pattern_hash_table == NULL);
+    }
+    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
+        SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_PMATCH];
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+                    DetectPatternTracker lookup = {
+                        .cd = cd, .sm_list = DETECT_SM_LIST_PMATCH, .cnt = 0, .mpm = 0
+                    };
+                    DetectPatternTracker *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        DetectPatternTracker *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = DETECT_SM_LIST_PMATCH;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+
+    const DetectEngineAppInspectionEngine *app = s->app_inspect;
+    for (; app != NULL; app = app->next) {
+        SigMatchData *smd = app->smd;
+        do {
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    DetectPatternTracker lookup = {
+                        .cd = cd, .sm_list = app->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    DetectPatternTracker *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        DetectPatternTracker *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = app->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
+    const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
+    for (; pkt != NULL; pkt = pkt->next) {
+        SigMatchData *smd = pkt->smd;
+        do {
+            if (smd == NULL) {
+                BUG_ON(!(pkt->sm_list < DETECT_SM_LIST_DYNAMIC_START));
+                smd = s->sm_arrays[pkt->sm_list];
+            }
+            switch (smd->type) {
+                case DETECT_CONTENT: {
+                    const DetectContentData *cd = (const DetectContentData *)smd->ctx;
+
+                    DetectPatternTracker lookup = {
+                        .cd = cd, .sm_list = pkt->sm_list, .cnt = 0, .mpm = 0
+                    };
+                    DetectPatternTracker *res =
+                            HashListTableLookup(de_ctx->pattern_hash_table, &lookup, 0);
+                    if (res) {
+                        res->cnt++;
+                        res->mpm += ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                    } else {
+                        DetectPatternTracker *add = SCCalloc(1, sizeof(*add));
+                        BUG_ON(add == NULL);
+                        add->cd = cd;
+                        add->sm_list = pkt->sm_list;
+                        add->cnt = 1;
+                        add->mpm = ((cd->flags & DETECT_CONTENT_MPM) != 0);
+                        HashListTableAdd(de_ctx->pattern_hash_table, (void *)add, 0);
+                    }
+                    break;
+                }
+            }
+            if (smd->is_last)
+                break;
+            smd++;
+        } while (1);
+    }
 }

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -129,5 +129,7 @@ struct MpmListIdDataArgs {
     void *txv;
 };
 
+void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *s);
+
 #endif /* __DETECT_ENGINE_MPM_H__ */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -652,6 +652,14 @@ typedef struct DetectBufferMpmRegistery_ {
     struct DetectBufferMpmRegistery_ *next;
 } DetectBufferMpmRegistery;
 
+/* helper structure to track pattern stats and assign pattern id's. */
+typedef struct DetectPatternTracker {
+    const struct DetectContentData_ *cd;
+    int sm_list;
+    uint32_t cnt;
+    uint32_t mpm;
+} DetectPatternTracker;
+
 typedef struct DetectReplaceList_ {
     struct DetectContentData_ *cd;
     uint8_t *found;

--- a/src/detect.h
+++ b/src/detect.h
@@ -797,6 +797,7 @@ typedef struct DetectEngineCtx_ {
     HashListTable *sgh_hash_table;
 
     HashListTable *mpm_hash_table;
+    HashListTable *pattern_hash_table;
 
     /* hash table used to cull out duplicate sigs */
     HashListTable *dup_sig_hash_table;
@@ -1512,6 +1513,8 @@ void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e);
 AppLayerDecoderEvents *DetectEngineGetEvents(DetectEngineThreadCtx *det_ctx);
 int DetectEngineGetEventInfo(const char *event_name, int *event_id,
                              AppLayerEventType *event_type);
+
+void DumpPatterns(DetectEngineCtx *de_ctx);
 
 #include "detect-engine-build.h"
 #include "detect-engine-register.h"

--- a/src/util-hash-string.c
+++ b/src/util-hash-string.c
@@ -19,7 +19,7 @@
 #include "util-hash-string.h"
 
 /* djb2 string hashing */
-uint32_t StringHashDjb2(uint8_t *data, uint32_t datalen)
+uint32_t StringHashDjb2(const uint8_t *data, uint32_t datalen)
 {
     uint32_t hash = 5381;
     for (uint32_t i = 0; i < datalen; i++) {
@@ -52,4 +52,3 @@ void StringHashFreeFunc(void *data)
 {
     SCFree(data);
 }
-

--- a/src/util-hash-string.h
+++ b/src/util-hash-string.h
@@ -18,7 +18,7 @@
 #ifndef __UTIL_HASH_STRING_H__
 #define __UTIL_HASH_STRING_H__
 
-uint32_t StringHashDjb2(uint8_t *data, uint32_t datalen);
+uint32_t StringHashDjb2(const uint8_t *data, uint32_t datalen);
 uint32_t StringHashFunc(HashTable *ht, void *data, uint16_t datalen);
 char StringHashCompareFunc(void *data1, uint16_t datalen1,
                            void *data2, uint16_t datalen2);


### PR DESCRIPTION
This PR backports the pattern id optimizations to 6.0.x

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5239](https://redmine.openinfosecfoundation.org/issues/5239)

Describe changes:
- Backport of issue 5232


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
