### PR TITLE
netmap: Fixup issues with v14+ backport

### DIFF
--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -53,7 +53,7 @@
 #include "util-ioctl.h"
 #include "util-byte.h"
 
-#ifdef HAVE_NETMAP
+#if HAVE_NETMAP && USE_NEW_NETMAP_API
 #define NETMAP_WITH_LIBS
 #include <net/netmap_user.h>
 #endif /* HAVE_NETMAP */
@@ -70,14 +70,11 @@ const char *RunModeNetmapGetDefaultMode(void)
 void RunModeIdsNetmapRegister(void)
 {
 #if HAVE_NETMAP
-    SCLogInfo("Using netmap version %d ["
 #if USE_NEW_NETMAP_API
-              "new"
-#else
-              "legacy"
-#endif
+    SCLogInfo("Using netmap version %d"
               " API interfaces]",
             NETMAP_API);
+#endif
     RunModeRegisterNewRunMode(RUNMODE_NETMAP, "single",
             "Single threaded netmap mode",
             RunModeIdsNetmapSingle);
@@ -127,13 +124,15 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
         }
     }
 
+#ifdef USE_NEW_NETMAP_API
     /* we will need the base interface name for later */
     char base_name[IFNAMSIZ];
     strlcpy(base_name, ns->iface, sizeof(base_name));
     if (strlen(base_name) > 0 &&
-            (base_name[strlen(base_name) - 1] == '^' || base_name[strlen(base_name) - 1] == '*')) {
-        base_name[strlen(base_name) - 1] = '\0';
     }
+#else
+    char *base_name = ns->iface;
+#endif
 
     /* prefixed with netmap or vale means it's not a real interface
      * and we don't check offloading. */
@@ -254,6 +253,7 @@ finalize:
         ns->threads = 1;
     }
 
+    SCLogDebug("Setting thread count to %d", ns->threads);
     return 0;
 }
 


### PR DESCRIPTION
This commit reduces the changes associated with adding the v14 api to 6.0.x

During the preparation of this commit, issues in the original backport were corrected

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5744](https://redmine.openinfosecfoundation.org/issues/5744)

Describe changes:
- Failure to release a lock under error conditions
- Typo in an CPP ifdef
- Incorrect target for goto statement in an error handling case.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
