### PR TITLE
ftp: add events for request/response command being too long - v1

### DIFF
--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -7,6 +7,7 @@ dhcp-events.rules \
 dnp3-events.rules \
 dns-events.rules \
 files.rules \
+ftp-events.rules \
 http-events.rules \
 http2-events.rules \
 ipsec-events.rules \

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,34 @@
+# Suricata Reserved SID Allocations
+
+Unless otherwise noted, each component or protocol is allocated 1000
+signature IDs.
+
+## Components
+
+| Component         | Start   | End     |
+| ----------------- | ------- | ------- |
+| Decoder           | 2200000 | 2200999 |
+| Stream            | 2210000 | 2210999 |
+| Generic App-Layer | 2260000 | 2260999 |
+
+## App-Layer Protocols
+
+| Protocol | Start   | End     |
+| -------- | ------- | ------- |
+| SMTP     | 2220000 | 2220999 |
+| HTTP     | 2221000 | 2221999 |
+| NTP      | 2222000 | 2222999 |
+| NFS      | 2223000 | 2223999 |
+| IPsec    | 2224000 | 2224999 |
+| SMB      | 2225000 | 2225999 |
+| Kerberos | 2226000 | 2226999 |
+| DHCP     | 2227000 | 2227999 |
+| SSH      | 2228000 | 2228999 |
+| MQTT     | 2229000 | 2229999 |
+| TLS      | 2230000 | 2230999 |
+| QUIC     | 2231000 | 2231999 |
+| FTP      | 2232000 | 2232999 |
+| DNS      | 2240000 | 2240999 |
+| MODBUS   | 2250000 | 2250999 |
+| DNP3     | 2270000 | 2270999 |
+| HTTP2    | 2290000 | 2290999 |

--- a/rules/ftp-events.rules
+++ b/rules/ftp-events.rules
@@ -1,0 +1,6 @@
+# FTP app-layer event rules
+#
+# SID range start: 2232000
+
+alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -80,7 +80,8 @@ include = [
     "ModbusState",
     "CMark",
     "QuicState",
-    "QuicTransaction"
+    "QuicTransaction",
+    "FtpEvent",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -138,6 +138,7 @@ item_types = ["enums","structs","opaque","functions","constants"]
 "DNSTransaction" = "RSDNSTransaction"
 "JsonT" = "json_t"
 "CLuaState" = "lua_State"
+"Base64ReturnCode" = "SC_BASE64"
 
 #
 # You get the following results:
@@ -165,3 +166,21 @@ exclude = ["libc"]
 #
 # default: []
 features = ["cbindgen"]
+
+# Enum configuration.
+#
+# This will rename Rust enums to work better with C. For example:
+#
+#    enum LzmaStatus {
+#        Ok,
+#        IoError,
+#    }
+#
+#    will become:
+#
+#    typedef enum LzmaStatus {
+#        LZMA_STATUS_OK,
+#        LZMA_STATUS_IO_ERROR,
+#    }
+[enum]
+rename_variants = "QualifiedScreamingSnakeCase"

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -315,25 +315,25 @@ mod test {
     fn test_extract_op_version() {
         let op_version = "<1";
         assert_eq!(
-            Ok((DetectUintMode::DetectUintModeLt, 1)),
+            Ok((DetectUintMode::Lt, 1)),
             extract_op_version(op_version)
         );
 
         let op_version = ">10";
         assert_eq!(
-            Ok((DetectUintMode::DetectUintModeGt, 10)),
+            Ok((DetectUintMode::Gt, 10)),
             extract_op_version(op_version)
         );
 
         let op_version = "=45";
         assert_eq!(
-            Ok((DetectUintMode::DetectUintModeEqual, 45)),
+            Ok((DetectUintMode::Equal, 45)),
             extract_op_version(op_version)
         );
 
         let op_version = "!0";
         assert_eq!(
-            Ok((DetectUintMode::DetectUintModeNe, 0)),
+            Ok((DetectUintMode::Ne, 0)),
             extract_op_version(op_version)
         );
 
@@ -347,7 +347,7 @@ mod test {
     #[test]
     fn test_match_iface_version() {
         let iface_data = DetectUintData::<u16> {
-            mode: DetectUintMode::DetectUintModeEqual,
+            mode: DetectUintMode::Equal,
             arg1: 10,
             arg2: 0,
         };
@@ -374,7 +374,7 @@ mod test {
         let uuid = uuid.map(|uuid| uuid.to_hyphenated().to_string());
         assert_eq!(expected_uuid, uuid);
         let du16 = iface_data.du16.unwrap();
-        assert_eq!(DetectUintMode::DetectUintModeGt, du16.mode);
+        assert_eq!(DetectUintMode::Gt, du16.mode);
         assert_eq!(1, du16.arg1);
 
         let arg = "12345678-1234-1234-1234-123456789ABC,any_frag";
@@ -394,7 +394,7 @@ mod test {
         assert_eq!(expected_uuid, uuid);
         assert_eq!(1, iface_data.any_frag);
         let du16 = iface_data.du16.unwrap();
-        assert_eq!(DetectUintMode::DetectUintModeNe, du16.mode);
+        assert_eq!(DetectUintMode::Ne, du16.mode);
         assert_eq!(10, du16.arg1);
 
         let arg = "12345678-1234-1234-1234-123456789ABC,>1,ay_frag";

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -50,7 +50,7 @@ const DETECT_BYTEMATH_FLAG_REQUIRED: u8 = DETECT_BYTEMATH_FLAG_RESULT
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 // operators: +, -, /, *, <<, >>
 pub enum ByteMathOperator {
-    OperatorNone = 1,
+    None = 1,
     Addition = 2,
     Subtraction = 3,
     Division = 4,
@@ -63,22 +63,22 @@ pub enum ByteMathOperator {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 // endian <big|little|dce>
 pub enum ByteMathEndian {
-    EndianNone = 0,
-    BigEndian = 1,
-    LittleEndian = 2,
-    EndianDCE = 3,
+    None = 0,
+    Big = 1,
+    Little = 2,
+    DCE = 3,
 }
-pub const DETECT_BYTEMATH_ENDIAN_DEFAULT: ByteMathEndian = ByteMathEndian::BigEndian;
+pub const DETECT_BYTEMATH_ENDIAN_DEFAULT: ByteMathEndian = ByteMathEndian::Big;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ByteMathBase {
-    BaseNone = 0,
-    BaseOct = 8,
-    BaseDec = 10,
-    BaseHex = 16,
+    None = 0,
+    Oct = 8,
+    Dec = 10,
+    Hex = 16,
 }
-const BASE_DEFAULT: ByteMathBase = ByteMathBase::BaseDec;
+const BASE_DEFAULT: ByteMathBase = ByteMathBase::Dec;
 
 // Fixed position parameter count: bytes, offset, oper, rvalue, result
 // result is not parsed with the fixed position parameters as it's
@@ -131,7 +131,7 @@ impl Default for DetectByteMathData {
             flags: 0,
             nbytes: 0,
             offset: 0,
-            oper: ByteMathOperator::OperatorNone,
+            oper: ByteMathOperator::None,
             rvalue_str: std::ptr::null_mut(),
             rvalue: 0,
             result: std::ptr::null_mut(),
@@ -154,9 +154,9 @@ impl DetectByteMathData {
 
 fn get_string_value(value: &str) -> Result<ByteMathBase, ()> {
     let res = match value {
-        "hex" => ByteMathBase::BaseHex,
-        "oct" => ByteMathBase::BaseOct,
-        "dec" => ByteMathBase::BaseDec,
+        "hex" => ByteMathBase::Hex,
+        "oct" => ByteMathBase::Oct,
+        "dec" => ByteMathBase::Dec,
         _ => return Err(()),
     };
 
@@ -179,9 +179,9 @@ fn get_oper_value(value: &str) -> Result<ByteMathOperator, ()> {
 
 fn get_endian_value(value: &str) -> Result<ByteMathEndian, ()> {
     let res = match value {
-        "big" => ByteMathEndian::BigEndian,
-        "little" => ByteMathEndian::LittleEndian,
-        "dce" => ByteMathEndian::EndianDCE,
+        "big" => ByteMathEndian::Big,
+        "little" => ByteMathEndian::Little,
+        "dce" => ByteMathEndian::DCE,
         _ => return Err(()),
     };
 
@@ -304,7 +304,7 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
                     return Err(make_error("endianess already set".to_string()));
                 }
                 byte_math.flags |= DETECT_BYTEMATH_FLAG_ENDIAN;
-                byte_math.endian = ByteMathEndian::EndianDCE;
+                byte_math.endian = ByteMathEndian::DCE;
             }
             "string" => {
                 if 0 != (byte_math.flags & DETECT_BYTEMATH_FLAG_STRING) {
@@ -503,8 +503,8 @@ mod tests {
             "myrvalue",
             0,
             "myresult",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::EndianDCE,
+            ByteMathBase::Dec,
+            ByteMathEndian::DCE,
             0,
             DETECT_BYTEMATH_FLAG_RVALUE_VAR
                 | DETECT_BYTEMATH_FLAG_STRING
@@ -519,8 +519,8 @@ mod tests {
             "",
             99,
             "other",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::EndianDCE,
+            ByteMathBase::Dec,
+            ByteMathEndian::DCE,
             0,
             DETECT_BYTEMATH_FLAG_STRING | DETECT_BYTEMATH_FLAG_ENDIAN,
         );
@@ -534,7 +534,7 @@ mod tests {
             0,
             "foo",
             BASE_DEFAULT,
-            ByteMathEndian::BigEndian,
+            ByteMathEndian::Big,
             0,
             DETECT_BYTEMATH_FLAG_RVALUE_VAR,
         );
@@ -548,8 +548,8 @@ mod tests {
             "",
             99,
             "other",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::BigEndian,
+            ByteMathBase::Dec,
+            ByteMathEndian::Big,
             0,
             DETECT_BYTEMATH_FLAG_STRING | DETECT_BYTEMATH_FLAG_ENDIAN,
         );
@@ -565,7 +565,7 @@ mod tests {
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
             endian: DETECT_BYTEMATH_ENDIAN_DEFAULT,
-            base: ByteMathBase::BaseDec,
+            base: ByteMathBase::Dec,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING,
             ..Default::default()
         };
@@ -593,7 +593,7 @@ mod tests {
         }
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING;
-        bmd.base = ByteMathBase::BaseHex;
+        bmd.base = ByteMathBase::Hex;
         match parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex",
         ) {
@@ -605,7 +605,7 @@ mod tests {
             }
         }
 
-        bmd.base = ByteMathBase::BaseOct;
+        bmd.base = ByteMathBase::Oct;
         match parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct",
         ) {
@@ -729,7 +729,7 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteMathEndian::Big,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_BITMASK,
             ..Default::default()
@@ -780,7 +780,7 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteMathEndian::Big,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_ENDIAN,
             ..Default::default()
@@ -797,7 +797,7 @@ mod tests {
             }
         }
 
-        bmd.endian = ByteMathEndian::LittleEndian;
+        bmd.endian = ByteMathEndian::Little;
         match parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian little",
         ) {
@@ -809,7 +809,7 @@ mod tests {
             }
         }
 
-        bmd.endian = ByteMathEndian::EndianDCE;
+        bmd.endian = ByteMathEndian::DCE;
         match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce") {
             Ok((_, val)) => {
                 assert_eq!(val, bmd);
@@ -881,7 +881,7 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteMathEndian::Big,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR,
             ..Default::default()

--- a/rust/src/detect/iprep.rs
+++ b/rust/src/detect/iprep.rs
@@ -29,10 +29,10 @@ use std::str::FromStr;
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, FromPrimitive, Debug)]
 pub enum DetectIPRepDataCmd {
-    IPRepCmdAny = 0,
-    IPRepCmdBoth = 1,
-    IPRepCmdSrc = 2,
-    IPRepCmdDst = 3,
+    Any = 0,
+    Both = 1,
+    Src = 2,
+    Dst = 3,
 }
 
 impl std::str::FromStr for DetectIPRepDataCmd {
@@ -40,10 +40,10 @@ impl std::str::FromStr for DetectIPRepDataCmd {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "any" => Ok(DetectIPRepDataCmd::IPRepCmdAny),
-            "both" => Ok(DetectIPRepDataCmd::IPRepCmdBoth),
-            "src" => Ok(DetectIPRepDataCmd::IPRepCmdSrc),
-            "dst" => Ok(DetectIPRepDataCmd::IPRepCmdDst),
+            "any" => Ok(DetectIPRepDataCmd::Any),
+            "both" => Ok(DetectIPRepDataCmd::Both),
+            "src" => Ok(DetectIPRepDataCmd::Src),
+            "dst" => Ok(DetectIPRepDataCmd::Dst),
             _ => Err(format!(
                 "'{}' is not a valid value for DetectIPRepDataCmd",
                 s

--- a/rust/src/detect/stream_size.rs
+++ b/rust/src/detect/stream_size.rs
@@ -26,22 +26,22 @@ use std::str::FromStr;
 
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, FromPrimitive, Debug)]
-pub enum DetectStreamSizeDataFlags {
-    StreamSizeServer = 1,
-    StreamSizeClient = 2,
-    StreamSizeBoth = 3,
-    StreamSizeEither = 4,
+pub enum DetectStreamSize {
+    Server = 1,
+    Client = 2,
+    Both = 3,
+    Either = 4,
 }
 
-impl std::str::FromStr for DetectStreamSizeDataFlags {
+impl std::str::FromStr for DetectStreamSize {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "server" => Ok(DetectStreamSizeDataFlags::StreamSizeServer),
-            "client" => Ok(DetectStreamSizeDataFlags::StreamSizeClient),
-            "both" => Ok(DetectStreamSizeDataFlags::StreamSizeBoth),
-            "either" => Ok(DetectStreamSizeDataFlags::StreamSizeEither),
+            "server" => Ok(DetectStreamSize::Server),
+            "client" => Ok(DetectStreamSize::Client),
+            "both" => Ok(DetectStreamSize::Both),
+            "either" => Ok(DetectStreamSize::Either),
             _ => Err(format!(
                 "'{}' is not a valid value for DetectStreamSizeDataFlags",
                 s
@@ -53,13 +53,13 @@ impl std::str::FromStr for DetectStreamSizeDataFlags {
 #[derive(Debug)]
 #[repr(C)]
 pub struct DetectStreamSizeData {
-    pub flags: DetectStreamSizeDataFlags,
+    pub flags: DetectStreamSize,
     pub du32: DetectUintData<u32>,
 }
 
 pub fn detect_parse_stream_size(i: &str) -> IResult<&str, DetectStreamSizeData> {
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, flags) = map_res(alpha0, DetectStreamSizeDataFlags::from_str)(i)?;
+    let (i, flags) = map_res(alpha0, DetectStreamSize::from_str)(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = char(',')(i)?;
     let (i, _) = opt(is_a(" "))(i)?;

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -28,13 +28,13 @@ use std::ffi::CStr;
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[repr(u8)]
 pub enum DetectUintMode {
-    DetectUintModeEqual,
-    DetectUintModeLt,
-    DetectUintModeLte,
-    DetectUintModeGt,
-    DetectUintModeGte,
-    DetectUintModeRange,
-    DetectUintModeNe,
+    Equal,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Range,
+    Ne,
 }
 
 #[derive(Debug)]
@@ -65,7 +65,7 @@ pub fn detect_parse_uint_start_equal<T: DetectIntType>(
         DetectUintData {
             arg1,
             arg2: T::min_value(),
-            mode: DetectUintMode::DetectUintModeEqual,
+            mode: DetectUintMode::Equal,
         },
     ))
 }
@@ -85,7 +85,7 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
         DetectUintData {
             arg1,
             arg2,
-            mode: DetectUintMode::DetectUintModeRange,
+            mode: DetectUintMode::Range,
         },
     ))
 }
@@ -107,20 +107,20 @@ fn detect_parse_uint_start_interval_inclusive<T: DetectIntType>(
         DetectUintData {
             arg1: arg1 - T::one(),
             arg2: arg2 + T::one(),
-            mode: DetectUintMode::DetectUintModeRange,
+            mode: DetectUintMode::Range,
         },
     ))
 }
 
 pub fn detect_parse_uint_mode(i: &str) -> IResult<&str, DetectUintMode> {
     let (i, mode) = alt((
-        value(DetectUintMode::DetectUintModeGte, tag(">=")),
-        value(DetectUintMode::DetectUintModeLte, tag("<=")),
-        value(DetectUintMode::DetectUintModeGt, tag(">")),
-        value(DetectUintMode::DetectUintModeLt, tag("<")),
-        value(DetectUintMode::DetectUintModeNe, tag("!=")),
-        value(DetectUintMode::DetectUintModeNe, tag("!")),
-        value(DetectUintMode::DetectUintModeEqual, tag("=")),
+        value(DetectUintMode::Gte, tag(">=")),
+        value(DetectUintMode::Lte, tag("<=")),
+        value(DetectUintMode::Gt, tag(">")),
+        value(DetectUintMode::Lt, tag("<")),
+        value(DetectUintMode::Ne, tag("!=")),
+        value(DetectUintMode::Ne, tag("!")),
+        value(DetectUintMode::Equal, tag("=")),
     ))(i)?;
     return Ok((i, mode));
 }
@@ -131,23 +131,23 @@ fn detect_parse_uint_start_symbol<T: DetectIntType>(i: &str) -> IResult<&str, De
     let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<T>().ok())(i)?;
 
     match mode {
-        DetectUintMode::DetectUintModeNe => {}
-        DetectUintMode::DetectUintModeLt => {
+        DetectUintMode::Ne => {}
+        DetectUintMode::Lt => {
             if arg1 == T::min_value() {
                 return Err(Err::Error(make_error(i, ErrorKind::Verify)));
             }
         }
-        DetectUintMode::DetectUintModeLte => {
+        DetectUintMode::Lte => {
             if arg1 == T::max_value() {
                 return Err(Err::Error(make_error(i, ErrorKind::Verify)));
             }
         }
-        DetectUintMode::DetectUintModeGt => {
+        DetectUintMode::Gt => {
             if arg1 == T::max_value() {
                 return Err(Err::Error(make_error(i, ErrorKind::Verify)));
             }
         }
-        DetectUintMode::DetectUintModeGte => {
+        DetectUintMode::Gte => {
             if arg1 == T::min_value() {
                 return Err(Err::Error(make_error(i, ErrorKind::Verify)));
             }
@@ -169,37 +169,37 @@ fn detect_parse_uint_start_symbol<T: DetectIntType>(i: &str) -> IResult<&str, De
 
 pub fn detect_match_uint<T: DetectIntType>(x: &DetectUintData<T>, val: T) -> bool {
     match x.mode {
-        DetectUintMode::DetectUintModeEqual => {
+        DetectUintMode::Equal => {
             if val == x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeNe => {
+        DetectUintMode::Ne => {
             if val != x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeLt => {
+        DetectUintMode::Lt => {
             if val < x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeLte => {
+        DetectUintMode::Lte => {
             if val <= x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeGt => {
+        DetectUintMode::Gt => {
             if val > x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeGte => {
+        DetectUintMode::Gte => {
             if val >= x.arg1 {
                 return true;
             }
         }
-        DetectUintMode::DetectUintModeRange => {
+        DetectUintMode::Range => {
             if val > x.arg1 && val < x.arg2 {
                 return true;
             }

--- a/rust/src/ffi/base64.rs
+++ b/rust/src/ffi/base64.rs
@@ -19,11 +19,10 @@ use std::os::raw::c_uchar;
 use libc::c_ulong;
 
 #[repr(C)]
-#[allow(non_camel_case_types)]
 pub enum Base64ReturnCode {
-    SC_BASE64_OK = 0,
-    SC_BASE64_INVALID_ARG,
-    SC_BASE64_OVERFLOW,
+    Ok = 0,
+    InvalidArg,
+    Overflow,
 }
 
 /// Base64 encode a buffer.
@@ -39,18 +38,18 @@ pub unsafe extern "C" fn Base64Encode(
     input: *const u8, input_len: c_ulong, output: *mut c_uchar, output_len: *mut c_ulong,
 ) -> Base64ReturnCode {
     if input.is_null() || output.is_null() || output_len.is_null() {
-        return Base64ReturnCode::SC_BASE64_INVALID_ARG;
+        return Base64ReturnCode::InvalidArg;
     }
     let input = std::slice::from_raw_parts(input, input_len as usize);
     let encoded = base64::encode(input);
     if encoded.len() + 1 > *output_len as usize {
-        return Base64ReturnCode::SC_BASE64_OVERFLOW;
+        return Base64ReturnCode::Overflow;
     }
     let output = std::slice::from_raw_parts_mut(&mut *(output as *mut u8), *output_len as usize);
     output[0..encoded.len()].copy_from_slice(encoded.as_bytes());
     output[encoded.len()] = 0;
     *output_len = encoded.len() as c_ulong;
-    Base64ReturnCode::SC_BASE64_OK
+    Base64ReturnCode::Ok
 }
 
 /// Ratio of output bytes to input bytes for Base64 Encoding is 4:3, hence the

--- a/rust/src/ftp/event.rs
+++ b/rust/src/ftp/event.rs
@@ -1,0 +1,48 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::core::AppLayerEventType;
+use std::os::raw::{c_char, c_int};
+
+#[derive(Debug, PartialEq, Eq, AppLayerEvent)]
+#[repr(C)]
+pub enum FtpEvent {
+    RequestCommandTooLong,
+    ResponseCommandTooLong,
+}
+
+/// Wrapper around the Rust generic function for get_event_info.
+///
+/// # Safety
+/// Unsafe as called from C.
+#[no_mangle]
+pub unsafe extern "C" fn ftp_get_event_info(
+    event_name: *const c_char, event_id: *mut c_int, event_type: *mut AppLayerEventType,
+) -> c_int {
+    crate::applayer::get_event_info::<FtpEvent>(event_name, event_id, event_type)
+}
+
+/// Wrapper around the Rust generic function for get_event_info_by_id.
+///
+/// # Safety
+/// Unsafe as called from C.
+#[no_mangle]
+pub unsafe extern "C" fn ftp_get_event_info_by_id(
+    event_id: c_int, event_name: *mut *const c_char, event_type: *mut AppLayerEventType,
+) -> c_int {
+    crate::applayer::get_event_info_by_id::<FtpEvent>(event_id, event_name, event_type) as c_int
+}

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -24,6 +24,8 @@ use std;
 use std::str;
 use std::str::FromStr;
 
+pub mod event;
+
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -866,7 +866,7 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
         data: txdata,
     });
     //we do not expect more data from client
-    tx.state = HTTP2TransactionState::HTTP2StateHalfClosedClient;
+    tx.state = HTTP2TransactionState::HalfClosedClient;
 }
 
 #[no_mangle]

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -930,7 +930,7 @@ mod tests {
                 match ctx.value {
                     Some(ctxval) => {
                         assert_eq!(ctxval.arg1, 42);
-                        assert_eq!(ctxval.mode, DetectUintMode::DetectUintModeRange);
+                        assert_eq!(ctxval.mode, DetectUintMode::Range);
                         assert_eq!(ctxval.arg2, 68);
                     }
                     None => {
@@ -952,7 +952,7 @@ mod tests {
                 match ctx.value {
                     Some(ctxval) => {
                         assert_eq!(ctxval.arg1, 54);
-                        assert_eq!(ctxval.mode, DetectUintMode::DetectUintModeLt);
+                        assert_eq!(ctxval.mode, DetectUintMode::Lt);
                     }
                     None => {
                         panic!("No value");
@@ -973,7 +973,7 @@ mod tests {
                 match ctx.value {
                     Some(ctxval) => {
                         assert_eq!(ctxval.arg1, 76);
-                        assert_eq!(ctxval.mode, DetectUintMode::DetectUintModeGt);
+                        assert_eq!(ctxval.mode, DetectUintMode::Gt);
                     }
                     None => {
                         panic!("No value");

--- a/rust/src/lzma.rs
+++ b/rust/src/lzma.rs
@@ -22,34 +22,34 @@ use std::io::{Cursor, Write};
 /// Propagate lzma crate errors
 #[repr(C)]
 pub enum LzmaStatus {
-    LzmaOk,
-    LzmaIoError,
-    LzmaHeaderTooShortError,
-    LzmaError,
-    LzmaMemoryError,
-    LzmaXzError,
+    Ok,
+    IoError,
+    HeaderTooShortError,
+    Error,
+    MemoryError,
+    XzError,
 }
 
 impl From<Error> for LzmaStatus {
     fn from(e: Error) -> LzmaStatus {
         match e {
-            Error::IoError(_) => LzmaStatus::LzmaIoError,
-            Error::HeaderTooShort(_) => LzmaStatus::LzmaHeaderTooShortError,
+            Error::IoError(_) => LzmaStatus::IoError,
+            Error::HeaderTooShort(_) => LzmaStatus::HeaderTooShortError,
             Error::LzmaError(e) => {
                 if e.contains("exceeded memory limit") {
-                    LzmaStatus::LzmaMemoryError
+                    LzmaStatus::MemoryError
                 } else {
-                    LzmaStatus::LzmaError
+                    LzmaStatus::Error
                 }
             }
-            Error::XzError(_) => LzmaStatus::LzmaXzError,
+            Error::XzError(_) => LzmaStatus::XzError,
         }
     }
 }
 
 impl From<std::io::Error> for LzmaStatus {
     fn from(_e: std::io::Error) -> LzmaStatus {
-        LzmaStatus::LzmaIoError
+        LzmaStatus::IoError
     }
 }
 
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn lzma_decompress(
     match stream.finish() {
         Ok(output) => {
             *output_len = output.position() as usize;
-            LzmaStatus::LzmaOk
+            LzmaStatus::Ok
         }
         Err(e) => e.into(),
     }

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -24,23 +24,22 @@ use std::ptr;
 use std::str::FromStr;
 
 #[derive(FromPrimitive, Debug, Copy, Clone, PartialOrd, PartialEq, Eq)]
-#[allow(non_camel_case_types)]
 #[repr(u8)]
 pub enum MQTTFlagState {
-    MQTT_DONT_CARE = 0,
-    MQTT_MUST_BE_SET = 1,
-    MQTT_CANT_BE_SET = 2,
+    DontCare = 0,
+    MustBeSet = 1,
+    CantBeSet = 2,
 }
 
 #[inline]
 fn check_flag_state(flag_state: MQTTFlagState, flag_value: bool, ok: &mut bool) {
     match flag_state {
-        MQTTFlagState::MQTT_MUST_BE_SET => {
+        MQTTFlagState::MustBeSet => {
             if !flag_value {
                 *ok = false;
             }
         }
-        MQTTFlagState::MQTT_CANT_BE_SET => {
+        MQTTFlagState::CantBeSet => {
             if flag_value {
                 *ok = false;
             }

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -193,7 +193,7 @@ static int SSHParserTest01(void)
     }
 
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string not parsed: ");
         goto end;
     }
@@ -244,7 +244,7 @@ static int SSHParserTest02(void)
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string not parsed: ");
         goto end;
     }
@@ -294,7 +294,7 @@ static int SSHParserTest03(void)
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) == SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) == SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string parsed? It's not a valid string: ");
         goto end;
     }
@@ -346,7 +346,7 @@ static int SSHParserTest04(void)
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string not parsed: ");
         goto end;
     }
@@ -396,7 +396,7 @@ static int SSHParserTest05(void)
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string not parsed: ");
         goto end;
     }
@@ -446,7 +446,7 @@ static int SSHParserTest06(void)
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
 
-    if ( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) == SshStateBannerDone ) {
+    if (rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) == SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Client version string parsed? It's not a valid string: ");
         goto end;
     }
@@ -508,7 +508,8 @@ static int SSHParserTest07(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone );
+    FAIL_IF(rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) !=
+            SSH_CONNECTION_STATE_BANNER_DONE);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER));
 
@@ -559,7 +560,8 @@ static int SSHParserTest08(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) != SshStateBannerDone );
+    FAIL_IF(rs_ssh_tx_get_alstate_progress(tx, STREAM_TOSERVER) !=
+            SSH_CONNECTION_STATE_BANNER_DONE);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER));
 
@@ -609,7 +611,8 @@ static int SSHParserTest09(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone );
+    FAIL_IF(rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) !=
+            SSH_CONNECTION_STATE_BANNER_DONE);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT));
 
@@ -660,7 +663,8 @@ static int SSHParserTest10(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) != SshStateBannerDone );
+    FAIL_IF(rs_ssh_tx_get_alstate_progress(tx, STREAM_TOCLIENT) !=
+            SSH_CONNECTION_STATE_BANNER_DONE);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT));
 
@@ -710,7 +714,7 @@ static int SSHParserTest11(void)
         goto end;
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
+    if (rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_FINISHED) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
@@ -773,7 +777,7 @@ static int SSHParserTest12(void)
         goto end;
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished ) {
+    if (rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_FINISHED) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
@@ -834,7 +838,7 @@ static int SSHParserTest13(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER));
 
@@ -893,7 +897,7 @@ static int SSHParserTest14(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER));
 
@@ -951,7 +955,7 @@ static int SSHParserTest15(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOSERVER));
 
@@ -1007,7 +1011,7 @@ static int SSHParserTest16(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT));
 
@@ -1064,7 +1068,7 @@ static int SSHParserTest17(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", "MySSHClient-0.5.1", tx, STREAM_TOCLIENT));
 
@@ -1131,7 +1135,7 @@ static int SSHParserTest18(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(!(AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_NO_INSPECTION)));
 
@@ -1197,7 +1201,7 @@ static int SSHParserTest19(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     sshbuf3[sizeof(sshbuf3) - 2] = 0;
     FAIL_IF(SSHParserTestUtilCheck("2.0", (char *)sshbuf3, tx, STREAM_TOCLIENT));
@@ -1266,7 +1270,7 @@ static int SSHParserTest20(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", NULL, tx, STREAM_TOCLIENT));
 
@@ -1333,7 +1337,7 @@ static int SSHParserTest21(void)
     void *ssh_state = f->alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
     FAIL_IF(SSHParserTestUtilCheck("2.0", NULL, tx, STREAM_TOCLIENT));
 
@@ -1429,7 +1433,7 @@ static int SSHParserTest22(void)
         void *ssh_state = f->alstate;
         FAIL_IF_NULL(ssh_state);
         void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-        FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SshStateFinished );
+        FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOCLIENT) != SSH_CONNECTION_STATE_FINISHED);
 
         FAIL_IF(SSHParserTestUtilCheck("2.0", "libssh", tx, STREAM_TOCLIENT));
 
@@ -1505,7 +1509,7 @@ static int SSHParserTest24(void)
         goto end;
     }
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    if ( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SshStateBannerDone ) {
+    if (rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) != SSH_CONNECTION_STATE_BANNER_DONE) {
         printf("Didn't detect the msg code of new keys (ciphered data starts): ");
         goto end;
     }
@@ -1546,7 +1550,7 @@ static int SSHParserTest25(void)
     void *ssh_state = f.alstate;
     FAIL_IF_NULL(ssh_state);
     void * tx = rs_ssh_state_get_tx(ssh_state, 0);
-    FAIL_IF( rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) == SshStateBannerDone );
+    FAIL_IF(rs_ssh_tx_get_flags(tx, STREAM_TOSERVER) == SSH_CONNECTION_STATE_BANNER_DONE);
     const uint8_t *dummy = NULL;
     uint32_t dummy_len = 0;
     FAIL_IF (rs_ssh_tx_get_software(tx, &dummy, &dummy_len, STREAM_TOCLIENT) != 0);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -543,12 +543,13 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
 
         /* if we have dce enabled we will have to use the endianness
          * specified by the dce header */
-        if ((bmd->flags & DETECT_BYTEMATH_FLAG_ENDIAN) && endian == (int)EndianDCE &&
+        if ((bmd->flags & DETECT_BYTEMATH_FLAG_ENDIAN) && endian == (int)BYTE_MATH_ENDIAN_DCE &&
                 flags & (DETECT_CI_FLAGS_DCE_LE | DETECT_CI_FLAGS_DCE_BE)) {
 
             /* enable the endianness flag temporarily.  once we are done
              * processing we reset the flags to the original value*/
-            endian |= (uint8_t)((flags & DETECT_CI_FLAGS_DCE_LE) ? LittleEndian : BigEndian);
+            endian |= (uint8_t)((flags & DETECT_CI_FLAGS_DCE_LE) ? BYTE_MATH_ENDIAN_LITTLE
+                                                                 : BYTE_MATH_ENDIAN_BIG);
         }
         uint64_t rvalue;
         if (bmd->flags & DETECT_BYTEMATH_FLAG_RVALUE_VAR) {

--- a/src/detect-engine-prefilter-common.h
+++ b/src/detect-engine-prefilter-common.h
@@ -53,10 +53,10 @@ typedef struct PrefilterPacketU8HashCtx_ {
     SigsArray *array[256];
 } PrefilterPacketU8HashCtx;
 
-#define PREFILTER_U8HASH_MODE_EQ DetectUintModeEqual
-#define PREFILTER_U8HASH_MODE_LT DetectUintModeLt
-#define PREFILTER_U8HASH_MODE_GT DetectUintModeGt
-#define PREFILTER_U8HASH_MODE_RA DetectUintModeRange
+#define PREFILTER_U8HASH_MODE_EQ DETECT_UINT_MODE_EQUAL
+#define PREFILTER_U8HASH_MODE_LT DETECT_UINT_MODE_LT
+#define PREFILTER_U8HASH_MODE_GT DETECT_UINT_MODE_GT
+#define PREFILTER_U8HASH_MODE_RA DETECT_UINT_MODE_RANGE
 
 int PrefilterSetupPacketHeader(DetectEngineCtx *de_ctx,
         SigGroupHead *sgh, int sm_type,

--- a/src/detect-engine-uint.h
+++ b/src/detect-engine-uint.h
@@ -29,13 +29,13 @@
 
 // These definitions are kept to minimize the diff
 // We can run a big sed commit next
-#define DETECT_UINT_GT  DetectUintModeGt
-#define DETECT_UINT_GTE DetectUintModeGte
-#define DETECT_UINT_RA  DetectUintModeRange
-#define DETECT_UINT_EQ  DetectUintModeEqual
-#define DETECT_UINT_NE  DetectUintModeNe
-#define DETECT_UINT_LT  DetectUintModeLt
-#define DETECT_UINT_LTE DetectUintModeLte
+#define DETECT_UINT_GT  DETECT_UINT_MODE_GT
+#define DETECT_UINT_GTE DETECT_UINT_MODE_GTE
+#define DETECT_UINT_RA  DETECT_UINT_MODE_RANGE
+#define DETECT_UINT_EQ  DETECT_UINT_MODE_EQUAL
+#define DETECT_UINT_NE  DETECT_UINT_MODE_NE
+#define DETECT_UINT_LT  DETECT_UINT_MODE_LT
+#define DETECT_UINT_LTE DETECT_UINT_MODE_LTE
 
 typedef DetectUintData_u64 DetectU64Data;
 typedef DetectUintData_u32 DetectU32Data;

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -105,12 +105,10 @@ void DetectFiledataRegister(void)
     DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2,
             PrefilterMpmFiledataRegister, NULL,
             ALPROTO_SMB, 0);
-    DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2,
-            PrefilterMpmFiledataRegister, NULL,
-            ALPROTO_HTTP2, HTTP2StateDataClient);
-    DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2,
-            PrefilterMpmFiledataRegister, NULL,
-            ALPROTO_HTTP2, HTTP2StateDataServer);
+    DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2, PrefilterMpmFiledataRegister,
+            NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
+    DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2, PrefilterMpmFiledataRegister,
+            NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
     DetectAppLayerMpmRegister2(
             "file_data", SIG_FLAG_TOSERVER, 2, PrefilterMpmFiledataRegister, NULL, ALPROTO_NFS, 0);
     DetectAppLayerMpmRegister2(
@@ -139,12 +137,10 @@ void DetectFiledataRegister(void)
     DetectAppLayerInspectEngineRegister2("file_data",
             ALPROTO_SMB, SIG_FLAG_TOCLIENT, 0,
             DetectEngineInspectFiledata, NULL);
-    DetectAppLayerInspectEngineRegister2("file_data",
-            ALPROTO_HTTP2, SIG_FLAG_TOSERVER, HTTP2StateDataClient,
-            DetectEngineInspectFiledata, NULL);
-    DetectAppLayerInspectEngineRegister2("file_data",
-            ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, HTTP2StateDataServer,
-            DetectEngineInspectFiledata, NULL);
+    DetectAppLayerInspectEngineRegister2("file_data", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectFiledata, NULL);
+    DetectAppLayerInspectEngineRegister2("file_data", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectFiledata, NULL);
     DetectAppLayerInspectEngineRegister2(
             "file_data", ALPROTO_NFS, SIG_FLAG_TOSERVER, 0, DetectEngineInspectFiledata, NULL);
     DetectAppLayerInspectEngineRegister2(

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -129,9 +129,9 @@ void DetectFilenameRegister(void)
 
     //this is used by filestore
     DetectAppLayerInspectEngineRegister2("files", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectFileInspectGeneric, NULL);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectFileInspectGeneric, NULL);
     DetectAppLayerInspectEngineRegister2("files", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectFileInspectGeneric, NULL);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectFileInspectGeneric, NULL);
 
     g_file_match_list_id = DetectBufferTypeGetByName("files");
 

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -117,14 +117,15 @@ void DetectHttpCookieRegister(void)
             GetResponseData, ALPROTO_HTTP1, HTP_REQUEST_HEADERS);
 
     DetectAppLayerInspectEngineRegister2("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetRequestData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetRequestData2);
     DetectAppLayerInspectEngineRegister2("http_cookie", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetResponseData2);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric,
+            GetResponseData2);
 
     DetectAppLayerMpmRegister2("http_cookie", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetRequestData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
     DetectAppLayerMpmRegister2("http_cookie", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetResponseData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 
     DetectBufferTypeSetDescriptionByName("http_cookie",
             "http cookie header");

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -231,14 +231,14 @@ void DetectHttpHeaderNamesRegister(void)
 
     /* http2 */
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -449,14 +449,14 @@ void DetectHttpHeaderRegister(void)
             0); /* not used, registered twice: HEADERS/TRAILER */
 
     DetectAppLayerInspectEngineRegister2("http_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerMpmRegister2("http_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectAppLayerInspectEngineRegister2("http_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric, GetBuffer2ForTX);
     DetectAppLayerMpmRegister2("http_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetBuffer2ForTX, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 
     DetectBufferTypeSetDescriptionByName("http_header",
             "http headers");

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -189,25 +189,26 @@ static void DetectHttpHeadersRegisterStub(void)
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
             GetRequestData, ALPROTO_HTTP1, HTP_REQUEST_HEADERS);
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRequestData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetRequestData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
             GetResponseData, ALPROTO_HTTP1, HTP_RESPONSE_HEADERS);
     DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetResponseData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetResponseData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 #endif
 #ifdef KEYWORD_TOSERVER
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_HEADERS, DetectEngineInspectBufferGeneric, GetRequestData);
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetRequestData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetRequestData2);
 #endif
 #ifdef KEYWORD_TOCLIENT
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_HEADERS, DetectEngineInspectBufferGeneric, GetResponseData);
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetResponseData2);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric,
+            GetResponseData2);
 #endif
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -112,10 +112,10 @@ void DetectHttpHHRegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_HEADERS);
 
     DetectAppLayerInspectEngineRegister2("http_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeRegisterValidateCallback("http_host",
             DetectHttpHostValidateCallback);
@@ -147,10 +147,10 @@ void DetectHttpHHRegister(void)
             GetRawData, ALPROTO_HTTP1, HTP_REQUEST_HEADERS);
 
     DetectAppLayerInspectEngineRegister2("http_raw_host", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetRawData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetRawData2);
 
     DetectAppLayerMpmRegister2("http_raw_host", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetRawData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetRawData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeSetDescriptionByName("http_raw_host",
             "http raw host header");

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -104,10 +104,10 @@ void DetectHttpMethodRegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_LINE);
 
     DetectAppLayerInspectEngineRegister2("http_method", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_method", SIG_FLAG_TOSERVER, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeSetDescriptionByName("http_method",
             "http request method");

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -110,14 +110,14 @@ void DetectHttpRawHeaderRegister(void)
             0); /* progress handled in register */
 
     DetectAppLayerInspectEngineRegister2("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
     DetectAppLayerInspectEngineRegister2("http_raw_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_raw_header", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
     DetectAppLayerMpmRegister2("http_raw_header", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 
     DetectBufferTypeSetDescriptionByName("http_raw_header",
             "raw http headers");

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -105,10 +105,10 @@ void DetectHttpStatCodeRegister (void)
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_LINE);
 
     DetectAppLayerInspectEngineRegister2("http_stat_code", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_SERVER, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_stat_code", SIG_FLAG_TOCLIENT, 4, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_SERVER);
 
     DetectBufferTypeSetDescriptionByName("http_stat_code",
             "http response status code");

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -105,10 +105,10 @@ void DetectHttpUARegister(void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_HEADERS);
 
     DetectAppLayerInspectEngineRegister2("http_user_agent", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_user_agent", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeSetDescriptionByName("http_user_agent",
             "http user agent");

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -114,10 +114,10 @@ void DetectHttpUriRegister (void)
             GetData, ALPROTO_HTTP1, HTP_REQUEST_LINE);
 
     DetectAppLayerInspectEngineRegister2("http_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeSetDescriptionByName("http_uri",
             "http request uri");
@@ -153,10 +153,10 @@ void DetectHttpUriRegister (void)
 
     // no difference between raw and decoded uri for HTTP2
     DetectAppLayerInspectEngineRegister2("http_raw_uri", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+            HTTP2_TRANSACTION_STATE_DATA_CLIENT, DetectEngineInspectBufferGeneric, GetData2);
 
     DetectAppLayerMpmRegister2("http_raw_uri", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+            GetData2, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_DATA_CLIENT);
 
     DetectBufferTypeSetDescriptionByName("http_raw_uri",
             "raw http uri");

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -190,17 +190,13 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMpmRegister2("http2_header_name", SIG_FLAG_TOCLIENT, 2,
-                               PrefilterMpmHttp2HeaderNameRegister, NULL,
-                               ALPROTO_HTTP2, HTTP2StateOpen);
-    DetectAppLayerInspectEngineRegister2("http2_header_name",
-                                         ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, HTTP2StateOpen,
-                                         DetectEngineInspectHttp2HeaderName, NULL);
+            PrefilterMpmHttp2HeaderNameRegister, NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_OPEN);
+    DetectAppLayerInspectEngineRegister2("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2_TRANSACTION_STATE_OPEN, DetectEngineInspectHttp2HeaderName, NULL);
     DetectAppLayerMpmRegister2("http2_header_name", SIG_FLAG_TOSERVER, 2,
-                               PrefilterMpmHttp2HeaderNameRegister, NULL,
-                               ALPROTO_HTTP2, HTTP2StateOpen);
-    DetectAppLayerInspectEngineRegister2("http2_header_name",
-                                         ALPROTO_HTTP2, SIG_FLAG_TOSERVER, HTTP2StateOpen,
-                                         DetectEngineInspectHttp2HeaderName, NULL);
+            PrefilterMpmHttp2HeaderNameRegister, NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_OPEN);
+    DetectAppLayerInspectEngineRegister2("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2_TRANSACTION_STATE_OPEN, DetectEngineInspectHttp2HeaderName, NULL);
 
     DetectBufferTypeSetDescriptionByName("http2_header_name",
                                          "HTTP2 header name");
@@ -213,17 +209,13 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADER].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMpmRegister2("http2_header", SIG_FLAG_TOCLIENT, 2,
-                               PrefilterMpmHttp2HeaderRegister, NULL,
-                               ALPROTO_HTTP2, HTTP2StateOpen);
-    DetectAppLayerInspectEngineRegister2("http2_header",
-                                         ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, HTTP2StateOpen,
-                                         DetectEngineInspectHttp2Header, NULL);
+            PrefilterMpmHttp2HeaderRegister, NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_OPEN);
+    DetectAppLayerInspectEngineRegister2("http2_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2_TRANSACTION_STATE_OPEN, DetectEngineInspectHttp2Header, NULL);
     DetectAppLayerMpmRegister2("http2_header", SIG_FLAG_TOSERVER, 2,
-                               PrefilterMpmHttp2HeaderRegister, NULL,
-                               ALPROTO_HTTP2, HTTP2StateOpen);
-    DetectAppLayerInspectEngineRegister2("http2_header",
-                                         ALPROTO_HTTP2, SIG_FLAG_TOSERVER, HTTP2StateOpen,
-                                         DetectEngineInspectHttp2Header, NULL);
+            PrefilterMpmHttp2HeaderRegister, NULL, ALPROTO_HTTP2, HTTP2_TRANSACTION_STATE_OPEN);
+    DetectAppLayerInspectEngineRegister2("http2_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2_TRANSACTION_STATE_OPEN, DetectEngineInspectHttp2Header, NULL);
 
     DetectBufferTypeSetDescriptionByName("http2_header",
                                          "HTTP2 header name and value");

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -156,7 +156,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
     SCLogDebug("rd->cmd %u", rd->cmd);
     switch(rd->cmd) {
-        case IPRepCmdAny:
+        case DETECT_IP_REP_DATA_CMD_ANY:
             val = GetHostRepSrc(p, rd->cat, version);
             if (val == 0)
                 val = SRepCIDRGetIPRepSrc(det_ctx->de_ctx->srepCIDR_ctx, p, rd->cat, version);
@@ -172,7 +172,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
             }
             break;
 
-        case IPRepCmdSrc:
+        case DETECT_IP_REP_DATA_CMD_SRC:
             val = GetHostRepSrc(p, rd->cat, version);
             SCLogDebug("checking src -- val %u (looking for cat %u, val %u)", val, rd->cat,
                     rd->du8.arg1);
@@ -183,7 +183,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
             }
             break;
 
-        case IPRepCmdDst:
+        case DETECT_IP_REP_DATA_CMD_DST:
             SCLogDebug("checking dst");
             val = GetHostRepDst(p, rd->cat, version);
             if (val == 0)
@@ -193,7 +193,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
             }
             break;
 
-        case IPRepCmdBoth:
+        case DETECT_IP_REP_DATA_CMD_BOTH:
             val = GetHostRepSrc(p, rd->cat, version);
             if (val == 0)
                 val = SRepCIDRGetIPRepSrc(det_ctx->de_ctx->srepCIDR_ctx, p, rd->cat, version);

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -128,8 +128,8 @@ static DetectMQTTConnectFlagsData *DetectMQTTConnectFlagsParse(const char *rawst
     de = SCCalloc(1, sizeof(DetectMQTTConnectFlagsData));
     if (unlikely(de == NULL))
         return NULL;
-    de->username = de->password = de->will = MQTT_DONT_CARE;
-    de->will_retain = de->clean_session = MQTT_DONT_CARE;
+    de->username = de->password = de->will = MQTT_FLAG_STATE_DONT_CARE;
+    de->will_retain = de->clean_session = MQTT_FLAG_STATE_DONT_CARE;
 
     char copy[strlen(rawstr)+1];
     strlcpy(copy, rawstr, sizeof(copy));
@@ -144,38 +144,38 @@ static DetectMQTTConnectFlagsData *DetectMQTTConnectFlagsParse(const char *rawst
             goto error;
         }  else {
             int offset = 0;
-            MQTTFlagState fs_to_set = MQTT_MUST_BE_SET;
+            MQTTFlagState fs_to_set = MQTT_FLAG_STATE_MUST_BE_SET;
             if (flagv[0] == '!') {
                 /* negated flag */
                 offset = 1;  /* skip negation operator during comparison */
-                fs_to_set = MQTT_CANT_BE_SET;
+                fs_to_set = MQTT_FLAG_STATE_CANT_BE_SET;
             }
             if (strcmp(flagv+offset, "username") == 0) {
-                if (de->username != MQTT_DONT_CARE) {
+                if (de->username != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }
                 de->username = fs_to_set;
             } else if (strcmp(flagv+offset, "password") == 0) {
-                if (de->password != MQTT_DONT_CARE) {
+                if (de->password != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }
                 de->password = fs_to_set;
             } else if (strcmp(flagv+offset, "will") == 0) {
-                if (de->will != MQTT_DONT_CARE) {
+                if (de->will != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }
                 de->will = fs_to_set;
             } else if (strcmp(flagv+offset, "will_retain") == 0) {
-                if (de->will_retain != MQTT_DONT_CARE) {
+                if (de->will_retain != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }
                 de->will_retain = fs_to_set;
             } else if (strcmp(flagv+offset, "clean_session") == 0) {
-                if (de->clean_session != MQTT_DONT_CARE) {
+                if (de->clean_session != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -123,7 +123,7 @@ static DetectMQTTFlagsData *DetectMQTTFlagsParse(const char *rawstr)
     de = SCCalloc(1, sizeof(DetectMQTTFlagsData));
     if (unlikely(de == NULL))
         return NULL;
-    de->retain = de->dup = MQTT_DONT_CARE;
+    de->retain = de->dup = MQTT_FLAG_STATE_DONT_CARE;
 
     char copy[strlen(rawstr)+1];
     strlcpy(copy, rawstr, sizeof(copy));
@@ -142,20 +142,20 @@ static DetectMQTTFlagsData *DetectMQTTFlagsParse(const char *rawstr)
             goto error;
         }  else {
             int offset = 0;
-            MQTTFlagState fs_to_set = MQTT_MUST_BE_SET;
+            MQTTFlagState fs_to_set = MQTT_FLAG_STATE_MUST_BE_SET;
             if (flagv[0] == '!') {
                 /* negated flag */
                 offset = 1;  /* skip negation operator during comparison */
-                fs_to_set = MQTT_CANT_BE_SET;
+                fs_to_set = MQTT_FLAG_STATE_CANT_BE_SET;
             }
             if (strcmp(flagv+offset, "dup") == 0) {
-                if (de->dup != MQTT_DONT_CARE) {
+                if (de->dup != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }
                 de->dup = fs_to_set;
             } else if (strcmp(flagv+offset, "retain") == 0) {
-                if (de->retain != MQTT_DONT_CARE) {
+                if (de->retain != MQTT_FLAG_STATE_DONT_CARE) {
                     SCLogError("duplicate flag definition: %s", flagv);
                     goto error;
                 }

--- a/src/detect-ssh-hassh-server-string.c
+++ b/src/detect-ssh-hassh-server-string.c
@@ -129,13 +129,10 @@ void DetectSshHasshServerStringRegister(void)
     sigmatch_table[DETECT_AL_SSH_HASSH_SERVER_STRING].Setup = DetectSshHasshServerStringSetup;
     sigmatch_table[DETECT_AL_SSH_HASSH_SERVER_STRING].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
-
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, 
-            PrefilterGenericMpmRegister, GetSshData,
-            ALPROTO_SSH, SshStateBannerDone);
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, 
-            SIG_FLAG_TOCLIENT, SshStateBannerDone, 
-            DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOCLIENT,
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -195,12 +195,10 @@ void DetectSshHasshServerRegister(void)
     sigmatch_table[DETECT_AL_SSH_HASSH_SERVER].Setup = DetectSshHasshServerSetup;
     sigmatch_table[DETECT_AL_SSH_HASSH_SERVER].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, 
-            PrefilterGenericMpmRegister, GetSshData, 
-            ALPROTO_SSH, SshStateBannerDone);
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, 
-            SIG_FLAG_TOCLIENT, SshStateBannerDone, 
-            DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOCLIENT,
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);

--- a/src/detect-ssh-hassh-string.c
+++ b/src/detect-ssh-hassh-string.c
@@ -129,13 +129,10 @@ void DetectSshHasshStringRegister(void)
     sigmatch_table[DETECT_AL_SSH_HASSH_STRING].Setup = DetectSshHasshStringSetup;
     sigmatch_table[DETECT_AL_SSH_HASSH_STRING].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
-
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, 
-            PrefilterGenericMpmRegister, GetSshData, 
-            ALPROTO_SSH, SshStateBannerDone);
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, 
-            SIG_FLAG_TOSERVER, SshStateBannerDone, 
-            DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOSERVER,
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -197,13 +197,10 @@ void DetectSshHasshRegister(void)
     sigmatch_table[DETECT_AL_SSH_HASSH].Setup = DetectSshHasshSetup;
     sigmatch_table[DETECT_AL_SSH_HASSH].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
-
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, 
-            PrefilterGenericMpmRegister, GetSshData, 
-            ALPROTO_SSH, SshStateBannerDone),
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, 
-            SIG_FLAG_TOSERVER, SshStateBannerDone, 
-            DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE),
+            DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOSERVER,
+                    SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);

--- a/src/detect-ssh-proto.c
+++ b/src/detect-ssh-proto.c
@@ -101,20 +101,16 @@ void DetectSshProtocolRegister(void)
     sigmatch_table[DETECT_AL_SSH_PROTOCOL].Setup = DetectSshProtocolSetup;
     sigmatch_table[DETECT_AL_SSH_PROTOCOL].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE),
+            DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
+                    PrefilterGenericMpmRegister, GetSshData, ALPROTO_SSH,
+                    SSH_CONNECTION_STATE_BANNER_DONE),
 
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SshStateBannerDone),
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SshStateBannerDone),
-
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOSERVER, SshStateBannerDone,
-            DetectEngineInspectBufferGeneric, GetSshData);
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOCLIENT, SshStateBannerDone,
-            DetectEngineInspectBufferGeneric, GetSshData);
+            DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOSERVER,
+                    SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOCLIENT,
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -99,9 +99,9 @@ void DetectSshSoftwareVersionRegister(void)
     g_ssh_banner_list_id = DetectBufferTypeRegister("ssh_banner");
 
     DetectAppLayerInspectEngineRegister2("ssh_banner", ALPROTO_SSH, SIG_FLAG_TOSERVER,
-            SshStateBannerDone, DetectEngineInspectGenericList, NULL);
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectGenericList, NULL);
     DetectAppLayerInspectEngineRegister2("ssh_banner", ALPROTO_SSH, SIG_FLAG_TOCLIENT,
-            SshStateBannerDone, DetectEngineInspectGenericList, NULL);
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectGenericList, NULL);
 }
 
 /**

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -102,19 +102,16 @@ void DetectSshSoftwareRegister(void)
     sigmatch_table[DETECT_AL_SSH_SOFTWARE].Setup = DetectSshSoftwareSetup;
     sigmatch_table[DETECT_AL_SSH_SOFTWARE].flags |= SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_NOOPT;
 
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SshStateBannerDone),
-    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetSshData,
-			ALPROTO_SSH, SshStateBannerDone),
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetSshData, ALPROTO_SSH, SSH_CONNECTION_STATE_BANNER_DONE),
+            DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2,
+                    PrefilterGenericMpmRegister, GetSshData, ALPROTO_SSH,
+                    SSH_CONNECTION_STATE_BANNER_DONE),
 
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOSERVER, SshStateBannerDone,
-            DetectEngineInspectBufferGeneric, GetSshData);
-    DetectAppLayerInspectEngineRegister2(BUFFER_NAME,
-            ALPROTO_SSH, SIG_FLAG_TOCLIENT, SshStateBannerDone,
-            DetectEngineInspectBufferGeneric, GetSshData);
+            DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOSERVER,
+                    SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_SSH, SIG_FLAG_TOCLIENT,
+            SSH_CONNECTION_STATE_BANNER_DONE, DetectEngineInspectBufferGeneric, GetSshData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -75,24 +75,24 @@ static int DetectStreamSizeMatchAux(const DetectStreamSizeData *sd, const TcpSes
     uint32_t csdiff = 0;
     uint32_t ssdiff = 0;
 
-    if (sd->flags == StreamSizeServer) {
+    if (sd->flags == DETECT_STREAM_SIZE_SERVER) {
         /* get the server stream size */
         ssdiff = ssn->server.next_seq - ssn->server.isn;
         ret = DetectU32Match(ssdiff, &sd->du32);
 
-    } else if (sd->flags == StreamSizeClient) {
+    } else if (sd->flags == DETECT_STREAM_SIZE_CLIENT) {
         /* get the client stream size */
         csdiff = ssn->client.next_seq - ssn->client.isn;
         ret = DetectU32Match(csdiff, &sd->du32);
 
-    } else if (sd->flags == StreamSizeBoth) {
+    } else if (sd->flags == DETECT_STREAM_SIZE_BOTH) {
         ssdiff = ssn->server.next_seq - ssn->server.isn;
         csdiff = ssn->client.next_seq - ssn->client.isn;
 
         if (DetectU32Match(ssdiff, &sd->du32) && DetectU32Match(csdiff, &sd->du32))
             ret = 1;
 
-    } else if (sd->flags == StreamSizeEither) {
+    } else if (sd->flags == DETECT_STREAM_SIZE_EITHER) {
         ssdiff = ssn->server.next_seq - ssn->server.isn;
         csdiff = ssn->client.next_seq - ssn->client.isn;
 
@@ -244,7 +244,8 @@ static int DetectStreamSizeParseTest01 (void)
     DetectStreamSizeData *sd = NULL;
     sd = rs_detect_stream_size_parse("server,<,6");
     if (sd != NULL) {
-        if (sd->flags & StreamSizeServer && sd->du32.mode == DETECT_UINT_LT && sd->du32.arg1 == 6)
+        if (sd->flags & DETECT_STREAM_SIZE_SERVER && sd->du32.mode == DETECT_UINT_LT &&
+                sd->du32.arg1 == 6)
             result = 1;
         DetectStreamSizeFree(NULL, sd);
     }
@@ -304,7 +305,7 @@ static int DetectStreamSizeParseTest03 (void)
 
     sd = rs_detect_stream_size_parse("client,>,8");
     if (sd != NULL) {
-        if (!(sd->flags & StreamSizeClient)) {
+        if (!(sd->flags & DETECT_STREAM_SIZE_CLIENT)) {
             printf("sd->flags not STREAM_SIZE_CLIENT: ");
             DetectStreamSizeFree(NULL, sd);
             SCFree(p);
@@ -380,7 +381,7 @@ static int DetectStreamSizeParseTest04 (void)
 
     sd = rs_detect_stream_size_parse(" client , > , 8 ");
     if (sd != NULL) {
-        if (!(sd->flags & StreamSizeClient) && sd->du32.mode != DETECT_UINT_GT &&
+        if (!(sd->flags & DETECT_STREAM_SIZE_CLIENT) && sd->du32.mode != DETECT_UINT_GT &&
                 sd->du32.arg1 != 8) {
             SCFree(p);
             return 0;

--- a/src/output-json-http2.c
+++ b/src/output-json-http2.c
@@ -179,6 +179,6 @@ void JsonHttp2LogRegister (void)
 {
     /* also register as child of eve-log */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_TX, "eve-log", MODULE_NAME, "eve-log.http2",
-            OutputHttp2LogInitSub, ALPROTO_HTTP2, JsonHttp2Logger, HTTP2StateClosed,
-            HTTP2StateClosed, JsonHttp2LogThreadInit, JsonHttp2LogThreadDeinit, NULL);
+            OutputHttp2LogInitSub, ALPROTO_HTTP2, JsonHttp2Logger, HTTP2_TRANSACTION_STATE_CLOSED,
+            HTTP2_TRANSACTION_STATE_CLOSED, JsonHttp2LogThreadInit, JsonHttp2LogThreadDeinit, NULL);
 }

--- a/src/util-file-swf-decompression.c
+++ b/src/util-file-swf-decompression.c
@@ -148,28 +148,28 @@ int FileSwfLzmaDecompression(DetectEngineThreadCtx *det_ctx,
             MAX_SWF_DECOMPRESSED_LEN);
 
     switch(ret) {
-        case LzmaOk:
+        case LZMA_STATUS_OK:
             ret = 1;
             break;
-        case LzmaIoError:
+        case LZMA_STATUS_IO_ERROR:
             DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_IO_ERROR);
             ret = 0;
             break;
-        case LzmaHeaderTooShortError:
+        case LZMA_STATUS_HEADER_TOO_SHORT_ERROR:
             DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_HEADER_TOO_SHORT_ERROR);
             ret = 0;
             break;
-        case LzmaError:
+        case LZMA_STATUS_ERROR:
             DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_DECODER_ERROR);
             ret = 0;
             break;
-        case LzmaMemoryError:
+        case LZMA_STATUS_MEMORY_ERROR:
             DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR);
             ret = 0;
             break;
-        case LzmaXzError:
+        case LZMA_STATUS_XZ_ERROR:
             /* We should not see XZ compressed SWF files */
-            DEBUG_VALIDATE_BUG_ON(ret == LzmaXzError);
+            DEBUG_VALIDATE_BUG_ON(ret == LZMA_STATUS_XZ_ERROR);
             DetectEngineSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_XZ_ERROR);
             ret = 0;
             break;


### PR DESCRIPTION
This adds events for when a FTP request or response command is too long
requiring truncation.

I wanted to use the Rust "generics" for the boiler plate of defining app-layer
events, however the way we export enums from Rust to C wasn't very compatible
with the auto-naming of app-layer events into a scheme that fits our current
convention.

To fix this, I modified the cbindgen configuration to do enum naming from
idiomatic Rust names to C style names, which are more to our naming convention
for C enums. As this renamed all export enum fields the commit is quite large.

Once that was done, the FTP events could be added with Rust.

Finally I went looking for SID range documentation in-tree and didn't find any,
and I feel it should be there.

suricata-verify-pr: 1072
