### PR TITLE
detect: config keyword transaction logic fix

### DIFF
--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -476,6 +476,8 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
                 txd->config.log_flags, logger_expectation);
         if (txd->config.log_flags & BIT_U8(CONFIG_TYPE_TX)) {
             SCLogDebug("SKIP tx %p/%"PRIu64, tx, tx_id);
+            // so that AppLayerParserTransactionsCleanup can clean this tx
+            txd->logged.flags |= logger_expectation;
             goto next_tx;
         }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5456

Describe changes:
- detect: checks config keyword in cleanup

Replaces #7665 with new logic : `OutputTxLog` marks the transaction as logged when it skips it because of `config` keyword...