### PR TITLE
dcerpc: store consumed_bytes as i32 (backport-6.0.x)

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -337,7 +337,7 @@ pub struct DCERPCState {
     pub buffer_tc: Vec<u8>,
     pub pad: u8,
     pub padleft: u16,
-    pub bytes_consumed: u16,
+    pub bytes_consumed: i32,
     pub tx_id: u64,
     pub query_completed: bool,
     pub data_needed_for_dir: u8,
@@ -1020,7 +1020,7 @@ impl DCERPCState {
 
         // Check if header data was complete. In case of EoF or incomplete data, wait for more
         // data else return error
-        if self.bytes_consumed < DCERPC_HDR_LEN && input_len > 0 {
+        if self.bytes_consumed < DCERPC_HDR_LEN.into() && input_len > 0 {
             parsed = self.process_header(&buffer);
             if parsed == -1 {
                 self.extend_buffer(buffer, direction);
@@ -1029,7 +1029,7 @@ impl DCERPCState {
             if parsed == -2 {
                 return AppLayerResult::err();
             }
-            self.bytes_consumed += parsed as u16;
+            self.bytes_consumed += parsed;
         }
 
         let fraglen = self.get_hdr_fraglen().unwrap_or(0);
@@ -1041,7 +1041,7 @@ impl DCERPCState {
         } else {
             self.query_completed = true;
         }
-        parsed = self.bytes_consumed as i32;
+        parsed = self.bytes_consumed;
 
         let current_call_id = self.get_hdr_call_id().unwrap_or(0);
 
@@ -1112,7 +1112,7 @@ impl DCERPCState {
                 return AppLayerResult::err();
             }
         }
-        self.bytes_consumed += retval as u16;
+        self.bytes_consumed += retval;
 
         // If the query has been completed, clean the buffer and reset the direction
         if self.query_completed == true {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55277

Describe changes:
- Fixes an unsigned integer overflow in DCERPC

This is the first find of oss-fuzz on fuzzing branch master6 🎊 

Cherry-pick of a commit in master