### PR TITLE
ftp: add events for request/response command being too long - v2

### DIFF
--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -7,6 +7,7 @@ dhcp-events.rules \
 dnp3-events.rules \
 dns-events.rules \
 files.rules \
+ftp-events.rules \
 http-events.rules \
 http2-events.rules \
 ipsec-events.rules \

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,34 @@
+# Suricata Reserved SID Allocations
+
+Unless otherwise noted, each component or protocol is allocated 1000
+signature IDs.
+
+## Components
+
+| Component         | Start   | End     |
+| ----------------- | ------- | ------- |
+| Decoder           | 2200000 | 2200999 |
+| Stream            | 2210000 | 2210999 |
+| Generic App-Layer | 2260000 | 2260999 |
+
+## App-Layer Protocols
+
+| Protocol | Start   | End     |
+| -------- | ------- | ------- |
+| SMTP     | 2220000 | 2220999 |
+| HTTP     | 2221000 | 2221999 |
+| NTP      | 2222000 | 2222999 |
+| NFS      | 2223000 | 2223999 |
+| IPsec    | 2224000 | 2224999 |
+| SMB      | 2225000 | 2225999 |
+| Kerberos | 2226000 | 2226999 |
+| DHCP     | 2227000 | 2227999 |
+| SSH      | 2228000 | 2228999 |
+| MQTT     | 2229000 | 2229999 |
+| TLS      | 2230000 | 2230999 |
+| QUIC     | 2231000 | 2231999 |
+| FTP      | 2232000 | 2232999 |
+| DNS      | 2240000 | 2240999 |
+| MODBUS   | 2250000 | 2250999 |
+| DNP3     | 2270000 | 2270999 |
+| HTTP2    | 2290000 | 2290999 |

--- a/rules/ftp-events.rules
+++ b/rules/ftp-events.rules
@@ -1,0 +1,6 @@
+# FTP app-layer event rules
+#
+# SID range start: 2232000
+
+alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -80,7 +80,8 @@ include = [
     "ModbusState",
     "CMark",
     "QuicState",
-    "QuicTransaction"
+    "QuicTransaction",
+    "FtpEvent",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,12 +32,14 @@ mod applayerframetype;
 ///     MalformedData,
 ///     NotRequest,
 ///     NotResponse,
+///     #[name("reserved_z_flag_set")]
 ///     ZFlagSet,
 /// }
 ///
 /// The enum variants must follow the naming convention of OneTwoThree
-/// for proper conversion to the name used in rules (one_tow_three).
-#[proc_macro_derive(AppLayerEvent)]
+/// for proper conversion to the name used in rules (one_tow_three) or
+/// optionally add a name attribute.
+#[proc_macro_derive(AppLayerEvent, attributes(name))]
 pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
     applayerevent::derive_app_layer_event(input)
 }

--- a/rust/src/ftp/event.rs
+++ b/rust/src/ftp/event.rs
@@ -1,0 +1,50 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::core::AppLayerEventType;
+use std::os::raw::{c_char, c_int};
+
+#[derive(Debug, PartialEq, Eq, AppLayerEvent)]
+#[repr(C)]
+pub enum FtpEvent {
+    #[name("request_command_too_long")]
+    FtpEventRequestCommandTooLong,
+    #[name("response_command_too_long")]
+    FtpEventResponseCommandTooLong,
+}
+
+/// Wrapper around the Rust generic function for get_event_info.
+///
+/// # Safety
+/// Unsafe as called from C.
+#[no_mangle]
+pub unsafe extern "C" fn ftp_get_event_info(
+    event_name: *const c_char, event_id: *mut c_int, event_type: *mut AppLayerEventType,
+) -> c_int {
+    crate::applayer::get_event_info::<FtpEvent>(event_name, event_id, event_type)
+}
+
+/// Wrapper around the Rust generic function for get_event_info_by_id.
+///
+/// # Safety
+/// Unsafe as called from C.
+#[no_mangle]
+pub unsafe extern "C" fn ftp_get_event_info_by_id(
+    event_id: c_int, event_name: *mut *const c_char, event_type: *mut AppLayerEventType,
+) -> c_int {
+    crate::applayer::get_event_info_by_id::<FtpEvent>(event_id, event_name, event_type) as c_int
+}

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -24,6 +24,8 @@ use std;
 use std::str;
 use std::str::FromStr;
 
+pub mod event;
+
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.
 // If either str::from_utf8 or FromStr::from_str fail,

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -340,6 +340,10 @@ static void FTPTransactionFree(FTPTransaction *tx)
         FTPStringFree(str);
     }
 
+    if (tx->tx_data.events) {
+        AppLayerDecoderEventsFreeEvents(&tx->tx_data.events);
+    }
+
     FTPFree(tx, sizeof(*tx));
 }
 
@@ -622,6 +626,10 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
                 state->current_line, state->current_line_len);
         tx->request_truncated = state->current_line_truncated;
 
+        if (tx->request_truncated) {
+            AppLayerDecoderEventsSetEventRaw(&tx->tx_data.events, FtpEventRequestCommandTooLong);
+        }
+
         /* change direction (default to server) so expectation will handle
          * the correct message when expectation will match.
          * For ftp active mode, data connection direction is opposite to
@@ -848,6 +856,10 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
             if (likely(response)) {
                 response->len = CopyCommandLine(&response->str, state->current_line, state->current_line_len);
                 response->truncated = state->current_line_truncated;
+                if (response->truncated) {
+                    AppLayerDecoderEventsSetEventRaw(
+                            &tx->tx_data.events, FtpEventResponseCommandTooLong);
+                }
                 TAILQ_INSERT_TAIL(&tx->response_list, response, next);
             }
         }
@@ -1425,6 +1437,9 @@ void RegisterFTPParsers(void)
 
         AppLayerParserRegisterStateProgressCompletionStatus(
                 ALPROTO_FTPDATA, FTPDATA_STATE_FINISHED, FTPDATA_STATE_FINISHED);
+
+        AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_FTP, ftp_get_event_info);
+        AppLayerParserRegisterGetEventInfoById(IPPROTO_TCP, ALPROTO_FTP, ftp_get_event_info_by_id);
 
         sbcfg.buf_size = 4096;
         sbcfg.Calloc = FTPCalloc;


### PR DESCRIPTION
This adds events for when a FTP request or response command is too long
requiring truncation.

I wanted to use the Rust "generics" for the boiler plate of defining app-layer
events, however the way we export enums from Rust to C wasn't very compatible
with the auto-naming of app-layer events into a scheme that fits our current
convention.

To fix this, I modified the cbindgen configuration to do enum naming from
idiomatic Rust names to C style names, which are more to our naming convention
for C enums. As this renamed all export enum fields the commit is quite large.

Once that was done, the FTP events could be added with Rust.

Finally I went looking for SID range documentation in-tree and didn't find any,
and I feel it should be there.

Previous PR: https://github.com/OISF/suricata/pull/8417

Changes from previous PR:
- Remove enum renaming and associated refactoring
- Allow derive app-layer event names to be specified with a "name" attribute on the enum variants to override the default name transformation.

suricata-verify-pr: 1072