### PR TITLE
Detect stream frames/v27

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5285,6 +5285,9 @@
                 "tc_gap": {
                     "type": "boolean"
                 },
+                "tc_max_regions": {
+                    "type": "integer"
+                },
                 "tcp_flags": {
                     "type": "string"
                 },
@@ -5296,6 +5299,9 @@
                 },
                 "ts_gap": {
                     "type": "boolean"
+                },
+                "ts_max_regions": {
+                    "type": "integer"
                 },
                 "urg": {
                     "type": "boolean"

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -24,6 +24,7 @@ use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
 use crate::core::SC;
 use std::ffi::CStr;
+use crate::core::StreamingBufferConfig;
 
 // Make the AppLayerEvent derive macro available to users importing
 // AppLayerEvent from this module.
@@ -383,6 +384,20 @@ macro_rules! cast_pointer {
     ($ptr:ident, $ty:ty) => ( &mut *($ptr as *mut $ty) );
 }
 
+/// helper for the GetTxFilesFn. Not meant to be embedded as the config
+/// pointer is passed around in the API.
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct AppLayerGetFileState {
+    pub fc: *mut FileContainer,
+    pub cfg: *const StreamingBufferConfig,
+}
+impl AppLayerGetFileState {
+    pub fn err() -> AppLayerGetFileState {
+        AppLayerGetFileState { fc: std::ptr::null_mut(), cfg: std::ptr::null() }
+    }
+}
+
 pub type ParseFn      = unsafe extern "C" fn (flow: *const Flow,
                                        state: *mut c_void,
                                        pstate: *mut c_void,
@@ -399,7 +414,7 @@ pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *
 pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
-pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, u8) -> *mut FileContainer;
+pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, *mut c_void, u8) -> AppLayerGetFileState;
 pub type GetTxIteratorFn    = unsafe extern "C" fn (ipproto: u8, alproto: AppProto,
                                              state: *mut c_void,
                                              min_tx_id: u64,

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -152,6 +152,7 @@ pub enum HttpRangeContainerBlock {}
 pub type SCHttpRangeFreeBlock = extern "C" fn (
         c: *mut HttpRangeContainerBlock);
 pub type SCHTPFileCloseHandleRange = extern "C" fn (
+        sbcfg: &StreamingBufferConfig,
         fc: *mut FileContainer,
         flags: u16,
         c: *mut HttpRangeContainerBlock,
@@ -166,19 +167,23 @@ pub type SCFileOpenFileWithId = extern "C" fn (
         flags: u16) -> i32;
 pub type SCFileCloseFileById = extern "C" fn (
         file_container: &FileContainer,
+        sbcfg: &StreamingBufferConfig,
         track_id: u32,
         data: *const u8, data_len: u32,
         flags: u16) -> i32;
 pub type SCFileAppendDataById = extern "C" fn (
         file_container: &FileContainer,
+        sbcfg: &StreamingBufferConfig,
         track_id: u32,
         data: *const u8, data_len: u32) -> i32;
 pub type SCFileAppendGAPById = extern "C" fn (
         file_container: &FileContainer,
+        sbcfg: &StreamingBufferConfig,
         track_id: u32,
         data: *const u8, data_len: u32) -> i32;
 pub type SCFileContainerRecycle = extern "C" fn (
-        file_container: &FileContainer);
+        file_container: &FileContainer,
+        sbcfg: &StreamingBufferConfig);
 
 // A Suricata context that is passed in from C. This is alternative to
 // using functions from Suricata directly, so they can be wrapped so

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -177,8 +177,6 @@ pub type SCFileAppendGAPById = extern "C" fn (
         file_container: &FileContainer,
         track_id: u32,
         data: *const u8, data_len: u32) -> i32;
-pub type SCFilePrune = extern "C" fn (
-        file_container: &FileContainer);
 pub type SCFileContainerRecycle = extern "C" fn (
         file_container: &FileContainer);
 
@@ -206,7 +204,6 @@ pub struct SuricataContext {
     pub FileAppendData: SCFileAppendDataById,
     pub FileAppendGAP: SCFileAppendGAPById,
     pub FileContainerRecycle: SCFileContainerRecycle,
-    pub FilePrune: SCFilePrune,
 
     pub AppLayerRegisterParser: extern fn(parser: *const crate::applayer::RustParser, alproto: AppProto) -> std::os::raw::c_int,
 }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -54,12 +54,6 @@ pub struct FileContainer {
     tail: * mut c_void,
 }
 
-impl Drop for FileContainer {
-    fn drop(&mut self) {
-        self.free();
-    }
-}
-
 impl Default for FileContainer {
     fn default() -> Self { Self {
         head: ptr::null_mut(),

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -128,14 +128,4 @@ impl FileContainer {
         }
 
     }
-
-    pub fn files_prune(&mut self) {
-        SCLogDebug!("FILECONTAINER: pruning");
-        match unsafe {SC} {
-            None => panic!("BUG no suricata_config"),
-            Some(c) => {
-                (c.FilePrune)(self);
-            }
-        }
-    }
 }

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -62,10 +62,10 @@ impl Default for FileContainer {
 }
 
 impl FileContainer {
-    pub fn free(&mut self) {
+    pub fn free(&mut self, cfg: &'static SuricataFileContext) {
         SCLogDebug!("freeing self");
         if let Some(c) = unsafe {SC} {
-            (c.FileContainerRecycle)(self);
+            (c.FileContainerRecycle)(self, cfg.files_sbcfg);
         }
     }
 
@@ -83,7 +83,7 @@ impl FileContainer {
         }
     }
 
-    pub fn file_append(&mut self, track_id: &u32, data: &[u8], is_gap: bool) -> i32 {
+    pub fn file_append(&mut self, cfg: &'static SuricataFileContext, track_id: &u32, data: &[u8], is_gap: bool) -> i32 {
         SCLogDebug!("FILECONTAINER: append {}", data.len());
         if data.is_empty() {
             return 0
@@ -94,13 +94,13 @@ impl FileContainer {
                 let res = match is_gap {
                     false => {
                         SCLogDebug!("appending file data");
-                        let r = (c.FileAppendData)(self, *track_id,
+                        let r = (c.FileAppendData)(self, cfg.files_sbcfg, *track_id,
                                 data.as_ptr(), data.len() as u32);
                         r
                     },
                     true => {
                         SCLogDebug!("appending GAP");
-                        let r = (c.FileAppendGAP)(self, *track_id,
+                        let r = (c.FileAppendGAP)(self, cfg.files_sbcfg, *track_id,
                                 data.as_ptr(), data.len() as u32);
                         r
                     },
@@ -110,13 +110,13 @@ impl FileContainer {
         }
     }
 
-    pub fn file_close(&mut self, track_id: &u32, flags: u16) -> i32 {
+    pub fn file_close(&mut self, cfg: &'static SuricataFileContext, track_id: &u32, flags: u16) -> i32 {
         SCLogDebug!("FILECONTAINER: CLOSEing");
 
         match unsafe {SC} {
             None => panic!("BUG no suricata_config"),
             Some(c) => {
-                let res = (c.FileCloseFile)(self, *track_id, ptr::null(), 0u32, flags);
+                let res = (c.FileCloseFile)(self, cfg.files_sbcfg, *track_id, ptr::null(), 0u32, flags);
                 res
             }
         }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -364,6 +364,8 @@ impl HTTP2Transaction {
 
 impl Drop for HTTP2Transaction {
     fn drop(&mut self) {
+        self.files.files_ts.free();
+        self.files.files_tc.free();
         self.free();
     }
 }

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1210,14 +1210,15 @@ pub unsafe extern "C" fn rs_http2_tx_get_alstate_progress(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_getfiles(
+    _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void, direction: u8,
-) -> *mut FileContainer {
+) -> AppLayerGetFileState {
     let tx = cast_pointer!(tx, HTTP2Transaction);
-    if direction == Direction::ToClient.into() {
-        &mut tx.files.files_tc as *mut FileContainer
-    } else {
-        &mut tx.files.files_ts as *mut FileContainer
+    let (files, _flags) = tx.files.get(direction.into());
+    if let Some(sfcm) = { SURICATA_HTTP2_FILE_CONFIG } {
+        return AppLayerGetFileState { fc: files, cfg: sfcm.files_sbcfg }
     }
+    AppLayerGetFileState::err()
 }
 
 // Parser name as a C style string.

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -179,17 +179,17 @@ impl HTTP2Transaction {
 
     pub fn free(&mut self) {
         if !self.file_range.is_null() {
-            match unsafe { SC } {
-                None => panic!("BUG no suricata_config"),
-                Some(c) => {
+            if let Some(c) = unsafe { SC } {
+                if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
                     //TODO get a file container instead of NULL
                     (c.HTPFileCloseHandleRange)(
-                        std::ptr::null_mut(),
-                        0,
-                        self.file_range,
-                        std::ptr::null_mut(),
-                        0,
-                    );
+                            sfcm.files_sbcfg,
+                            std::ptr::null_mut(),
+                            0,
+                            self.file_range,
+                            std::ptr::null_mut(),
+                            0,
+                            );
                     (c.HttpRangeFreeBlock)(self.file_range);
                     self.file_range = std::ptr::null_mut();
                 }
@@ -247,7 +247,7 @@ impl HTTP2Transaction {
                 if over {
                     range::http2_range_close(self, Direction::ToClient, decompressed)
                 } else {
-                    range::http2_range_append(self.file_range, decompressed)
+                    range::http2_range_append(sfcm, self.file_range, decompressed)
                 }
             }
             let (files, flags) = self.files.get(Direction::ToClient);
@@ -364,8 +364,10 @@ impl HTTP2Transaction {
 
 impl Drop for HTTP2Transaction {
     fn drop(&mut self) {
-        self.files.files_ts.free();
-        self.files.files_tc.free();
+        if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
+            self.files.files_ts.free(sfcm);
+            self.files.files_tc.free(sfcm);
+        }
         self.free();
     }
 }
@@ -460,10 +462,10 @@ impl HTTP2State {
         // but we need state's file container cf https://redmine.openinfosecfoundation.org/issues/4444
         for tx in &mut self.transactions {
             if !tx.file_range.is_null() {
-                match unsafe { SC } {
-                    None => panic!("BUG no suricata_config"),
-                    Some(c) => {
+                if let Some(c) = unsafe { SC } {
+                    if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
                         (c.HTPFileCloseHandleRange)(
+                            sfcm.files_sbcfg,
                             &mut tx.files.files_tc,
                             0,
                             tx.file_range,
@@ -501,10 +503,10 @@ impl HTTP2State {
                 // this should be in HTTP2Transaction::free
                 // but we need state's file container cf https://redmine.openinfosecfoundation.org/issues/4444
                 if !tx.file_range.is_null() {
-                    match unsafe { SC } {
-                        None => panic!("BUG no suricata_config"),
-                        Some(c) => {
+                    if let Some(c) = unsafe { SC } {
+                        if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
                             (c.HTPFileCloseHandleRange)(
+                                sfcm.files_sbcfg,
                                 &mut tx.files.files_tc,
                                 0,
                                 tx.file_range,

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -131,7 +131,7 @@ pub fn http2_range_open(
         // whole file in one range
         return;
     }
-    let (_, flags) = tx.files.get(dir);
+    let flags = if dir == Direction::ToServer { tx.ft_ts.file_flags } else { tx.ft_tc.file_flags };
     if let Ok((key, index)) = http2_range_key_get(tx) {
         let name = &key[index..];
         tx.file_range = unsafe {
@@ -162,7 +162,11 @@ pub fn http2_range_close(
 ) {
     let added = if let Some(c) = unsafe { SC } {
         if let Some(sfcm) = unsafe { SURICATA_HTTP2_FILE_CONFIG } {
-            let (files, flags) = tx.files.get(dir);
+            let (files, flags) = if dir == Direction::ToServer {
+                (&mut tx.ft_ts.file, tx.ft_ts.file_flags)
+            } else {
+                (&mut tx.ft_tc.file, tx.ft_tc.file_flags)
+            };
             let added = (c.HTPFileCloseHandleRange)(
                     sfcm.files_sbcfg,
                     files,

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -258,6 +258,10 @@ impl Transaction for NFSTransaction {
 
 impl Drop for NFSTransaction {
     fn drop(&mut self) {
+        if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = self.type_data {
+            tdf.files.files_ts.free();
+            tdf.files.files_tc.free();
+        }
         self.free();
     }
 }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -260,8 +260,10 @@ impl Transaction for NFSTransaction {
 impl Drop for NFSTransaction {
     fn drop(&mut self) {
         if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = self.type_data {
-            tdf.files.files_ts.free();
-            tdf.files.files_tc.free();
+            if let Some(sfcm) = unsafe { SURICATA_NFS_FILE_CONFIG } {
+                tdf.files.files_ts.free(sfcm);
+                tdf.files.files_tc.free(sfcm);
+            }
         }
         self.free();
     }
@@ -309,19 +311,27 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
 fn filetracker_trunc(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16)
 {
-    ft.trunc(files, flags);
+    if let Some(sfcm) = unsafe { SURICATA_NFS_FILE_CONFIG } {
+        ft.trunc(sfcm, files, flags);
+    }
 }
 
 pub fn filetracker_close(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16)
 {
-    ft.close(files, flags);
+    if let Some(sfcm) = unsafe { SURICATA_NFS_FILE_CONFIG } {
+        ft.close(sfcm, files, flags);
+    }
 }
 
 fn filetracker_update(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, data: &[u8], gap_size: u32) -> u32
 {
-    ft.update(files, flags, data, gap_size)
+    if let Some(sfcm) = unsafe { SURICATA_NFS_FILE_CONFIG } {
+        ft.update(sfcm, files, flags, data, gap_size)
+    } else {
+        0
+    }
 }
 
 

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -120,10 +120,9 @@ impl NFSState {
                 let file_handle = rd.handle.value.to_vec();
                 if let Some(tx) = self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
                     if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                        let (files, flags) = tdf.files.get(Direction::ToServer);
                         tdf.chunk_count += 1;
                         tdf.file_additional_procs.push(NFSPROC3_COMMIT);
-                        filetracker_close(&mut tdf.file_tracker, files, flags);
+                        filetracker_close(&mut tdf.file_tracker);
                         tdf.file_last_xid = r.hdr.xid;
                         tx.is_last = true;
                         tx.request_done = true;

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -123,7 +123,7 @@ impl NFSState {
                         let (files, flags) = tdf.files.get(Direction::ToServer);
                         tdf.chunk_count += 1;
                         tdf.file_additional_procs.push(NFSPROC3_COMMIT);
-                        tdf.file_tracker.close(files, flags);
+                        filetracker_close(&mut tdf.file_tracker, files, flags);
                         tdf.file_last_xid = r.hdr.xid;
                         tx.is_last = true;
                         tx.request_done = true;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -68,8 +68,7 @@ impl NFSState {
         let found = match self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
             Some(tx) => {
                 if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                    let (files, flags) = tdf.files.get(Direction::ToServer);
-                    filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                    filetracker_newchunk(&mut tdf.file_tracker,
                             &file_name, w.data, w.offset,
                             w.write_len, fill_bytes as u8, is_last, &r.hdr.xid);
                     tdf.chunk_count += 1;
@@ -86,8 +85,7 @@ impl NFSState {
         if !found {
             let tx = self.new_file_tx(&file_handle, &file_name, Direction::ToServer);
             if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                let (files, flags) = tdf.files.get(Direction::ToServer);
-                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                filetracker_newchunk(&mut tdf.file_tracker,
                         &file_name, w.data, w.offset,
                         w.write_len, fill_bytes as u8, is_last, &r.hdr.xid);
                 tx.procedure = NFSPROC4_WRITE;
@@ -117,8 +115,7 @@ impl NFSState {
         let file_handle = fh.to_vec();
         if let Some(tx) = self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
             if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                let (files, flags) = tdf.files.get(Direction::ToServer);
-                filetracker_close(&mut tdf.file_tracker, files, flags);
+                filetracker_close(&mut tdf.file_tracker);
                 tdf.file_last_xid = r.hdr.xid;
                 tx.is_last = true;
                 tx.request_done = true;

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -118,7 +118,7 @@ impl NFSState {
         if let Some(tx) = self.get_file_tx_by_handle(&file_handle, Direction::ToServer) {
             if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                 let (files, flags) = tdf.files.get(Direction::ToServer);
-                tdf.file_tracker.close(files, flags);
+                filetracker_close(&mut tdf.file_tracker, files, flags);
                 tdf.file_last_xid = r.hdr.xid;
                 tx.is_last = true;
                 tx.request_done = true;

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -33,7 +33,7 @@ pub struct SMBTransactionFile {
     /// after a gap, this will be set to a time in the future. If the file
     /// receives no updates before that, it will be considered complete.
     pub post_gap_ts: u64,
-    pub files: Files,
+    //pub files: Files,
 }
 
 impl SMBTransactionFile {
@@ -45,43 +45,39 @@ impl SMBTransactionFile {
     }
 
     pub fn update_file_flags(&mut self, flow_file_flags: u16) {
-        self.files.flags_ts = unsafe { FileFlowFlagsToFlags(flow_file_flags, STREAM_TOSERVER) | FILE_USE_DETECT };
-        self.files.flags_tc = unsafe { FileFlowFlagsToFlags(flow_file_flags, STREAM_TOCLIENT) | FILE_USE_DETECT };
+        let dir_flag = if self.direction == Direction::ToServer { STREAM_TOSERVER } else { STREAM_TOCLIENT };
+        self.file_tracker.file_flags = unsafe { FileFlowFlagsToFlags(flow_file_flags, dir_flag) | FILE_USE_DETECT };
     }
 }
 
 /// little wrapper around the FileTransferTracker::new_chunk method
-pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, name: &[u8], data: &[u8],
+pub fn filetracker_newchunk(ft: &mut FileTransferTracker, name: &[u8], data: &[u8],
         chunk_offset: u64, chunk_size: u32, is_last: bool, xid: &u32)
 {
     if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
-        ft.new_chunk(sfcm, files, flags, name, data, chunk_offset,
+        ft.new_chunk(sfcm, name, data, chunk_offset,
                 chunk_size, 0, is_last, xid);
     }
 }
 
-pub fn filetracker_trunc(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16)
+pub fn filetracker_trunc(ft: &mut FileTransferTracker)
 {
     if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
-        ft.trunc(sfcm, files, flags);
+        ft.trunc(sfcm);
     }
 }
 
-pub fn filetracker_close(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16)
+pub fn filetracker_close(ft: &mut FileTransferTracker)
 {
     if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
-        ft.close(sfcm, files, flags);
+        ft.close(sfcm);
     }
 }
 
-fn filetracker_update(ft: &mut FileTransferTracker, files: &mut FileContainer,
-        flags: u16, data: &[u8], gap_size: u32) -> u32
+fn filetracker_update(ft: &mut FileTransferTracker, data: &[u8], gap_size: u32) -> u32
 {
     if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
-        ft.update(sfcm, files, flags, data, gap_size)
+        ft.update(sfcm, data, gap_size)
     } else {
         0
     }
@@ -204,12 +200,11 @@ impl SMBState {
         let consumed = match self.get_file_tx_by_fuid(&file_handle, direction) {
             Some(tx) => {
                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                    let (files, flags) = tdf.files.get(direction);
                     if ssn_gap {
                         let queued_data = tdf.file_tracker.get_queued_size();
                         if queued_data > 2000000 { // TODO should probably be configurable
                             SCLogDebug!("QUEUED size {} while we've seen GAPs. Truncating file.", queued_data);
-                            filetracker_trunc(&mut tdf.file_tracker, files, flags);
+                            filetracker_trunc(&mut tdf.file_tracker);
                         }
                     }
 
@@ -219,7 +214,7 @@ impl SMBState {
                     }
 
                     let file_data = &data[0..data_to_handle_len];
-                    filetracker_update(&mut tdf.file_tracker, files, flags, file_data, gap_size)
+                    filetracker_update(&mut tdf.file_tracker, file_data, gap_size)
                 } else {
                     0
                 }
@@ -238,9 +233,11 @@ use crate::applayer::AppLayerGetFileState;
 pub unsafe extern "C" fn rs_smb_gettxfiles(_state: *mut std::ffi::c_void, tx: *mut std::ffi::c_void, direction: u8) -> AppLayerGetFileState {
     let tx = cast_pointer!(tx, SMBTransaction);
     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-        let (files, _flags) = tdf.files.get(direction.into());
-        if let Some(sfcm) = { SURICATA_SMB_FILE_CONFIG } {
-            return AppLayerGetFileState { fc: files, cfg: sfcm.files_sbcfg }
+        let tx_dir : u8 = tdf.direction.into();
+        if direction & tx_dir != 0 {
+            if let Some(sfcm) = { SURICATA_SMB_FILE_CONFIG } {
+                return AppLayerGetFileState { fc: &mut tdf.file_tracker.file, cfg: sfcm.files_sbcfg }
+            }
         }
     }
     AppLayerGetFileState::err()

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -64,19 +64,27 @@ pub fn filetracker_newchunk(ft: &mut FileTransferTracker, files: &mut FileContai
 pub fn filetracker_trunc(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16)
 {
-    ft.trunc(files, flags);
+    if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
+        ft.trunc(sfcm, files, flags);
+    }
 }
 
 pub fn filetracker_close(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16)
 {
-    ft.close(files, flags);
+    if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
+        ft.close(sfcm, files, flags);
+    }
 }
 
 fn filetracker_update(ft: &mut FileTransferTracker, files: &mut FileContainer,
         flags: u16, data: &[u8], gap_size: u32) -> u32
 {
-    ft.update(files, flags, data, gap_size)
+    if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
+        ft.update(sfcm, files, flags, data, gap_size)
+    } else {
+        0
+    }
 }
 
 impl SMBState {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -530,8 +530,7 @@ impl Drop for SMBTransaction {
     fn drop(&mut self) {
         if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = self.type_data {
             if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
-                tdf.files.files_ts.free(sfcm);
-                tdf.files.files_tc.free(sfcm);
+                tdf.file_tracker.file.free(sfcm);
             }
         }
         self.free();
@@ -1103,8 +1102,7 @@ impl SMBState {
                     if self.ts > f.post_gap_ts {
                         tx.request_done = true;
                         tx.response_done = true;
-                        let (files, flags) = f.files.get(f.direction);
-                        filetracker_trunc(&mut f.file_tracker, files, flags);
+                        filetracker_trunc(&mut f.file_tracker);
                     } else {
                         post_gap_txs = true;
                     }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -529,8 +529,10 @@ impl SMBTransaction {
 impl Drop for SMBTransaction {
     fn drop(&mut self) {
         if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = self.type_data {
-            tdf.files.files_ts.free();
-            tdf.files.files_tc.free();
+            if let Some(sfcm) = unsafe { SURICATA_SMB_FILE_CONFIG } {
+                tdf.files.files_ts.free(sfcm);
+                tdf.files.files_tc.free(sfcm);
+            }
         }
         self.free();
     }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1098,7 +1098,7 @@ impl SMBState {
                         tx.request_done = true;
                         tx.response_done = true;
                         let (files, flags) = f.files.get(f.direction);
-                        f.file_tracker.trunc(files, flags);
+                        filetracker_trunc(&mut f.file_tracker, files, flags);
                     } else {
                         post_gap_txs = true;
                     }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -528,6 +528,10 @@ impl SMBTransaction {
 
 impl Drop for SMBTransaction {
     fn drop(&mut self) {
+        if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = self.type_data {
+            tdf.files.files_ts.free();
+            tdf.files.files_tc.free();
+        }
         self.free();
     }
 }

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -156,7 +156,7 @@ fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction)
             if !tx.request_done {
                 SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
                 let (files, flags) = tdf.files.get(direction);
-                tdf.file_tracker.close(files, flags);
+                filetracker_close(&mut tdf.file_tracker, files, flags);
                 tx.request_done = true;
                 tx.response_done = true;
                 SCLogDebug!("tx {} is done", tx.id);

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -155,8 +155,7 @@ fn smb1_close_file(state: &mut SMBState, fid: &[u8], direction: Direction)
         if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
             if !tx.request_done {
                 SCLogDebug!("closing file tx {} FID {:?}", tx.id, fid);
-                let (files, flags) = tdf.files.get(direction);
-                filetracker_close(&mut tdf.file_tracker, files, flags);
+                filetracker_close(&mut tdf.file_tracker);
                 tx.request_done = true;
                 tx.response_done = true;
                 SCLogDebug!("tx {} is done", tx.id);
@@ -965,8 +964,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                         if rd.offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        let (files, flags) = tdf.files.get(Direction::ToServer);
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                        filetracker_newchunk(&mut tdf.file_tracker,
                                 &file_name, rd.data, rd.offset,
                                 rd.len, false, &file_id);
                         SCLogDebug!("FID {:?} found at tx {} => {:?}", file_fid, tx.id, tx);
@@ -993,12 +991,10 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                         if rd.offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        let (files, flags) = tdf.files.get(Direction::ToServer);
-                        filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                        filetracker_newchunk(&mut tdf.file_tracker,
                                 &file_name, rd.data, rd.offset,
                                 rd.len, false, &file_id);
                         tdf.share_name = share_name;
-                        SCLogDebug!("files {:?}", files);
                         SCLogDebug!("tdf {:?}", tdf);
                     }
                     tx.vercmd.set_smb1_cmd(SMB1_COMMAND_WRITE_ANDX);
@@ -1063,8 +1059,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                                 if offset < tdf.file_tracker.tracked {
                                     set_event_fileoverlap = true;
                                 }
-                                let (files, flags) = tdf.files.get(Direction::ToClient);
-                                filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                                filetracker_newchunk(&mut tdf.file_tracker,
                                         &file_name, rd.data, offset,
                                         rd.len, false, &file_id);
                             }
@@ -1080,8 +1075,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
                             if offset < tdf.file_tracker.tracked {
                                 set_event_fileoverlap = true;
                             }
-                            let (files, flags) = tdf.files.get(Direction::ToClient);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                            filetracker_newchunk(&mut tdf.file_tracker,
                                     &file_name, rd.data, offset,
                                     rd.len, false, &file_id);
                             tdf.share_name = share_name;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -171,8 +171,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             state.set_event(SMBEvent::ReadQueueCntExceeded);
                             state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
                         } else {
-                            let (files, flags) = tdf.files.get(Direction::ToClient);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                            filetracker_newchunk(&mut tdf.file_tracker,
                                     &tdf.file_name, rd.data, offset,
                                     rd.len, false, &file_id);
                         }
@@ -245,8 +244,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             state.set_event(SMBEvent::ReadQueueCntExceeded);
                             state.set_skip(Direction::ToClient, rd.len, rd.data.len() as u32);
                         } else {
-                            let (files, flags) = tdf.files.get(Direction::ToClient);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                            filetracker_newchunk(&mut tdf.file_tracker,
                                     &file_name, rd.data, offset,
                                     rd.len, false, &file_id);
                         }
@@ -311,8 +309,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             state.set_event(SMBEvent::WriteQueueCntExceeded);
                             state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                         } else {
-                            let (files, flags) = tdf.files.get(Direction::ToServer);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                            filetracker_newchunk(&mut tdf.file_tracker,
                                     &file_name, wr.data, wr.wr_offset,
                                     wr.wr_len, false, &file_id);
                         }
@@ -380,8 +377,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             state.set_event(SMBEvent::WriteQueueCntExceeded);
                             state.set_skip(Direction::ToServer, wr.wr_len, wr.data.len() as u32);
                         } else {
-                            let (files, flags) = tdf.files.get(Direction::ToServer);
-                            filetracker_newchunk(&mut tdf.file_tracker, files, flags,
+                            filetracker_newchunk(&mut tdf.file_tracker,
                                     &file_name, wr.data, wr.wr_offset,
                                     wr.wr_len, false, &file_id);
                         }
@@ -594,8 +590,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         Some(tx) => {
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                                    let (files, flags) = tdf.files.get(Direction::ToServer);
-                                    filetracker_close(&mut tdf.file_tracker, files, flags);
+                                    filetracker_close(&mut tdf.file_tracker);
                                 }
                             }
                             tx.request_done = true;
@@ -609,8 +604,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         Some(tx) => {
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                                    let (files, flags) = tdf.files.get(Direction::ToClient);
-                                    filetracker_close(&mut tdf.file_tracker, files, flags);
+                                    filetracker_close(&mut tdf.file_tracker);
                                 }
                             }
                             tx.request_done = true;
@@ -708,8 +702,7 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                     Some(tx) => {
                         if !tx.request_done {
                             if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
-                                let (files, flags) = tdf.files.get(Direction::ToClient);
-                                filetracker_close(&mut tdf.file_tracker, files, flags);
+                                filetracker_close(&mut tdf.file_tracker);
                             }
                         }
                         tx.set_status(r.nt_status, false);

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -595,7 +595,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                                     let (files, flags) = tdf.files.get(Direction::ToServer);
-                                    tdf.file_tracker.close(files, flags);
+                                    filetracker_close(&mut tdf.file_tracker, files, flags);
                                 }
                             }
                             tx.request_done = true;
@@ -610,7 +610,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                             if !tx.request_done {
                                 if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                                     let (files, flags) = tdf.files.get(Direction::ToClient);
-                                    tdf.file_tracker.close(files, flags);
+                                    filetracker_close(&mut tdf.file_tracker, files, flags);
                                 }
                             }
                             tx.request_done = true;
@@ -709,7 +709,7 @@ pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
                         if !tx.request_done {
                             if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
                                 let (files, flags) = tdf.files.get(Direction::ToClient);
-                                tdf.file_tracker.close(files, flags);
+                                filetracker_close(&mut tdf.file_tracker, files, flags);
                             }
                         }
                         tx.set_status(r.nt_status, false);

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -40,10 +40,10 @@ static void FrameDebug(const char *prefix, const Frames *frames, const Frame *fr
         type_name = AppLayerParserGetFrameNameById(frames->ipproto, frames->alproto, frame->type);
     }
     SCLogDebug("[%s] %p: frame:%p type:%u/%s id:%" PRIi64 " flags:%02x offset:%" PRIu64
-               ", len:%" PRIi64 ", events:%u %u/%u/%u/%u",
+               ", len:%" PRIi64 ", inspect_progress:%" PRIu64 ", events:%u %u/%u/%u/%u",
             prefix, frames, frame, frame->type, type_name, frame->id, frame->flags, frame->offset,
-            frame->len, frame->event_cnt, frame->events[0], frame->events[1], frame->events[2],
-            frame->events[3]);
+            frame->len, frame->inspect_progress, frame->event_cnt, frame->events[0],
+            frame->events[1], frame->events[2], frame->events[3]);
 #endif
 }
 

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -481,6 +481,12 @@ Frame *AppLayerFrameNewByRelativeOffset(Flow *f, const StreamSlice *stream_slice
     }
 
     const uint64_t frame_abs_offset = (uint64_t)frame_start_rel + stream_slice->offset;
+#ifdef DEBUG_VALIDATION
+    const TcpSession *ssn = f->protoctx;
+    const TcpStream *stream = dir == 0 ? &ssn->client : &ssn->server;
+    BUG_ON(stream_slice->offset != STREAM_APP_PROGRESS(stream));
+    BUG_ON(frame_abs_offset > STREAM_APP_PROGRESS(stream) + stream_slice->input_len);
+#endif
     Frame *r = FrameNew(frames, frame_abs_offset, len);
     if (r != NULL) {
         r->type = frame_type;

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -26,7 +26,8 @@
 
 #include "rust.h"
 
-#define FRAME_STREAM_TYPE 255
+/** max 63 to fit the 64 bit per protocol space */
+#define FRAME_STREAM_TYPE 63
 /** always the first frame to be created. TODO but what about protocol upgrades? */
 #define FRAME_STREAM_ID 1
 
@@ -101,5 +102,9 @@ void AppLayerFramesSlide(Flow *f, const uint32_t slide, const uint8_t direction)
 
 FramesContainer *AppLayerFramesGetContainer(Flow *f);
 FramesContainer *AppLayerFramesSetupContainer(Flow *f);
+
+void FrameConfigInit(void);
+void FrameConfigEnableAll(void);
+void FrameConfigEnable(const AppProto p, const uint8_t type);
 
 #endif

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -26,6 +26,10 @@
 
 #include "rust.h"
 
+#define FRAME_STREAM_TYPE 255
+/** always the first frame to be created. TODO but what about protocol upgrades? */
+#define FRAME_STREAM_ID 1
+
 typedef int64_t FrameId;
 
 enum {

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -51,8 +51,8 @@ typedef struct Frame {
     int64_t len;
     int64_t id;
     uint64_t tx_id; /**< tx_id to match this frame. UINT64T_MAX if not used. */
+    uint64_t inspect_progress; /**< inspection tracker relative to the start of the frame */
 } Frame;
-// size 40
 
 #define FRAMES_STATIC_CNT 3
 
@@ -68,13 +68,11 @@ typedef struct Frames {
     AppProto alproto;
 #endif
 } Frames;
-// size 136
 
 typedef struct FramesContainer {
     Frames toserver;
     Frames toclient;
 } FramesContainer;
-// size 272
 
 void FramesFree(Frames *frames);
 void FramesPrune(Flow *f, Packet *p);

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -47,8 +47,7 @@ typedef struct Frame {
     uint8_t event_cnt;
     // TODO one event per frame enough?
     uint8_t events[4];  /**< per frame store for events */
-    int64_t rel_offset; /**< relative offset in the stream on top of Stream::stream_offset (if
-                           negative the start if before the stream data) */
+    uint64_t offset;    /**< offset from the start of the stream */
     int64_t len;
     int64_t id;
     uint64_t tx_id; /**< tx_id to match this frame. UINT64T_MAX if not used. */

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1162,7 +1162,7 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
             SCReturnStruct(APP_LAYER_OK);
         }
         if (input_len != 0) {
-            ret = FileAppendData(ftpdata_state->files, input, input_len);
+            ret = FileAppendData(ftpdata_state->files, &sbcfg, input, input_len);
             if (ret == -2) {
                 ret = 0;
                 SCLogDebug("FileAppendData() - file no longer being extracted");
@@ -1177,7 +1177,7 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
 
     BUG_ON((direction & ftpdata_state->direction) == 0); // should be unreachble
     if (eof) {
-        ret = FileCloseFile(ftpdata_state->files, NULL, 0, flags);
+        ret = FileCloseFile(ftpdata_state->files, &sbcfg, NULL, 0, flags);
         ftpdata_state->state = FTPDATA_STATE_FINISHED;
         SCLogDebug("closed because of eof");
     }
@@ -1235,7 +1235,7 @@ static void FTPDataStateFree(void *s)
         FTPFree(fstate->file_name, fstate->file_len + 1);
     }
 
-    FileContainerFree(fstate->files);
+    FileContainerFree(fstate->files, &sbcfg);
 
     FTPFree(s, sizeof(FtpDataState));
 #ifdef DEBUG

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1284,14 +1284,15 @@ static int FTPDataGetAlstateProgress(void *tx, uint8_t direction)
         return FTPDATA_STATE_FINISHED;
 }
 
-static FileContainer *FTPDataStateGetTxFiles(void *tx, uint8_t direction)
+static AppLayerGetFileState FTPDataStateGetTxFiles(void *_state, void *tx, uint8_t direction)
 {
     FtpDataState *ftpdata_state = (FtpDataState *)tx;
+    AppLayerGetFileState files = { .fc = NULL, .cfg = &sbcfg };
 
-    if (direction != ftpdata_state->direction)
-        SCReturnPtr(NULL, "FileContainer");
+    if (direction == ftpdata_state->direction)
+        files.fc = ftpdata_state->files;
 
-    SCReturnPtr(ftpdata_state->files, "FileContainer");
+    return files;
 }
 
 static void FTPSetMpmState(void)

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -121,7 +121,7 @@ void HtpBodyPrint(HtpBody *body)
  * \param body pointer to the HtpBody holding the list
  * \retval none
  */
-void HtpBodyFree(HtpBody *body)
+void HtpBodyFree(const HTPCfgDir *hcfg, HtpBody *body)
 {
     SCEnter();
 

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -162,15 +162,10 @@ void HtpBodyPrune(HtpState *state, HtpBody *body, int direction)
         SCReturn;
     }
 
-    /* get the configured inspect sizes. Default to response values */
-    uint32_t min_size = state->cfg->response.inspect_min_size;
-    uint32_t window = state->cfg->response.inspect_window;
-
-    if (direction == STREAM_TOSERVER) {
-        min_size = state->cfg->request.inspect_min_size;
-        window = state->cfg->request.inspect_window;
-    }
-
+    const HTPCfgDir *cfg =
+            (direction == STREAM_TOCLIENT) ? &state->cfg->response : &state->cfg->request;
+    uint32_t min_size = cfg->inspect_min_size;
+    uint32_t window = cfg->inspect_window;
     uint64_t max_window = ((min_size > window) ? min_size : window);
     uint64_t in_flight = body->content_len_so_far - body->body_inspected;
 

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -138,7 +138,7 @@ void HtpBodyFree(const HTPCfgDir *hcfg, HtpBody *body)
     }
     body->first = body->last = NULL;
 
-    StreamingBufferFree(body->sb);
+    StreamingBufferFree(body->sb, &hcfg->sbcfg);
 }
 
 /**

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -70,7 +70,7 @@ int HtpBodyAppendChunk(const HTPCfgDir *hcfg, HtpBody *body,
         SCReturnInt(-1);
     }
 
-    if (StreamingBufferAppend(body->sb, &bd->sbseg, data, len) != 0) {
+    if (StreamingBufferAppend(body->sb, &hcfg->sbcfg, &bd->sbseg, data, len) != 0) {
         HTPFree(bd, sizeof(HtpBodyChunk));
         SCReturnInt(-1);
     }

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -33,7 +33,8 @@
 #include "util-streaming-buffer.h"
 #include "util-print.h"
 
-static StreamingBufferConfig default_cfg = { 0, 3072, 1, HTPCalloc, HTPRealloc, HTPFree };
+static StreamingBufferConfig default_cfg = { 0, 3072, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT,
+    HTPCalloc, HTPRealloc, HTPFree };
 
 /**
  * \brief Append a chunk of body to the HtpBody struct

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -187,7 +187,7 @@ void HtpBodyPrune(HtpState *state, HtpBody *body, int direction)
 
     if (left_edge) {
         SCLogDebug("sliding body to offset %"PRIu64, left_edge);
-        StreamingBufferSlideToOffset(body->sb, left_edge);
+        StreamingBufferSlideToOffset(body->sb, &cfg->sbcfg, left_edge);
     }
 
     SCLogDebug("pruning chunks of body %p", body);

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -33,7 +33,7 @@
 #include "util-streaming-buffer.h"
 #include "util-print.h"
 
-static StreamingBufferConfig default_cfg = { 0, 3072, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT,
+static StreamingBufferConfig default_cfg = { 3072, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT,
     HTPCalloc, HTPRealloc, HTPFree };
 
 /**

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -33,7 +33,7 @@
 #include "util-streaming-buffer.h"
 #include "util-print.h"
 
-static StreamingBufferConfig default_cfg = { 0, 3072, HTPCalloc, HTPRealloc, HTPFree };
+static StreamingBufferConfig default_cfg = { 0, 3072, 1, HTPCalloc, HTPRealloc, HTPFree };
 
 /**
  * \brief Append a chunk of body to the HtpBody struct

--- a/src/app-layer-htp-body.h
+++ b/src/app-layer-htp-body.h
@@ -30,7 +30,7 @@
 
 int HtpBodyAppendChunk(const HTPCfgDir *, HtpBody *, const uint8_t *, uint32_t);
 void HtpBodyPrint(HtpBody *);
-void HtpBodyFree(HtpBody *);
+void HtpBodyFree(const HTPCfgDir *, HtpBody *);
 void HtpBodyPrune(HtpState *, HtpBody *, int);
 
 #endif /* __APP_LAYER_HTP_BODY_H__ */

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -31,13 +31,13 @@ int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const ui
         uint64_t, uint8_t);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
         uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
-bool HTPFileCloseHandleRange(
-        FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
-int HTPFileStoreChunk(HtpTxUserData *, const uint8_t *, uint32_t, uint8_t);
+bool HTPFileCloseHandleRange(const StreamingBufferConfig *sbcfg, FileContainer *, const uint16_t,
+        HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+int HTPFileStoreChunk(HtpState *, HtpTxUserData *, const uint8_t *, uint32_t, uint8_t);
 
 int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);
-int HTPFileClose(HtpTxUserData *tx, const uint8_t *data, uint32_t data_len, uint8_t flags,
-        uint8_t direction);
+int HTPFileClose(HtpState *, HtpTxUserData *tx, const uint8_t *data, uint32_t data_len,
+        uint8_t flags, uint8_t direction);
 
 void HTPFileParserRegisterTests(void);
 

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -70,6 +70,8 @@ typedef struct HttpRangeContainerFile {
     uint64_t totalsize;
     /** size of the file after last sync */
     uint64_t lastsize;
+    /** streaming buffer config for files below */
+    const StreamingBufferConfig *sbcfg;
     /** file container, with only one file */
     FileContainer *files;
     /** red and black tree list of ranges which came out of order */
@@ -96,8 +98,10 @@ typedef struct HttpRangeContainerBlock {
     FileContainer *files;
 } HttpRangeContainerBlock;
 
-int HttpRangeAppendData(HttpRangeContainerBlock *c, const uint8_t *data, uint32_t len);
-File *HttpRangeClose(HttpRangeContainerBlock *c, uint16_t flags);
+int HttpRangeAppendData(const StreamingBufferConfig *sbcfg, HttpRangeContainerBlock *c,
+        const uint8_t *data, uint32_t len);
+File *HttpRangeClose(
+        const StreamingBufferConfig *sbcfg, HttpRangeContainerBlock *c, uint16_t flags);
 
 // HttpRangeContainerBlock but trouble with headers inclusion order
 HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, uint32_t keylen,

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2550,16 +2550,14 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
 
     htp_config_register_request_line(cfg_prec->cfg, HTPCallbackRequestLine);
 
-    cfg_prec->request.sbcfg.buf_size = cfg_prec->request.inspect_window ?
-                                       cfg_prec->request.inspect_window : 256;
-    cfg_prec->request.sbcfg.buf_slide = 0;
+    cfg_prec->request.sbcfg.buf_size =
+            cfg_prec->request.inspect_window ? cfg_prec->request.inspect_window : 256;
     cfg_prec->request.sbcfg.Calloc = HTPCalloc;
     cfg_prec->request.sbcfg.Realloc = HTPRealloc;
     cfg_prec->request.sbcfg.Free = HTPFree;
 
-    cfg_prec->response.sbcfg.buf_size = cfg_prec->response.inspect_window ?
-                                        cfg_prec->response.inspect_window : 256;
-    cfg_prec->response.sbcfg.buf_slide = 0;
+    cfg_prec->response.sbcfg.buf_size =
+            cfg_prec->response.inspect_window ? cfg_prec->response.inspect_window : 256;
     cfg_prec->response.sbcfg.Calloc = HTPCalloc;
     cfg_prec->response.sbcfg.Realloc = HTPRealloc;
     cfg_prec->response.sbcfg.Free = HTPFree;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -279,8 +279,6 @@ void RegisterHTPParsers(void);
 void HTPAtExitPrintStats(void);
 void HTPFreeConfig(void);
 
-void HtpBodyPrint(HtpBody *);
-void HtpBodyFree(HtpBody *);
 /* To free the state from unittests using app-layer-htp */
 void HTPStateFree(void *);
 void AppLayerHtpEnableRequestBodyCallback(void);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -149,7 +149,6 @@ typedef struct HTPCfgDir_ {
     uint32_t body_limit;
     uint32_t inspect_min_size;
     uint32_t inspect_window;
-    StreamingBufferConfig sbcfg;
 } HTPCfgDir;
 
 /** Need a linked list in order to keep track of these */

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1293,13 +1293,10 @@ static void HandleStreamFrames(Flow *f, StreamSlice stream_slice, const uint8_t 
         SCLogDebug("EOF closing: frame %p", frame);
         if (frame) {
             /* calculate final frame length */
-            const TcpSession *ssn = f->protoctx;
-            const TcpStream *stream = (direction == 0) ? &ssn->client : &ssn->server;
-            int64_t slice_o =
-                    (int64_t)stream_slice.offset - (int64_t)stream->sb.region.stream_offset;
-            int64_t frame_len = slice_o + ((int64_t)-1 * frame->rel_offset) + (int64_t)input_len;
-            SCLogDebug("%s: EOF frame->rel_offset %" PRIi64 " -> %" PRIi64 ": o %" PRIi64,
-                    AppProtoToString(f->alproto), frame->rel_offset, frame_len, slice_o);
+            int64_t slice_o = (int64_t)stream_slice.offset - (int64_t)frame->offset;
+            int64_t frame_len = slice_o + (int64_t)input_len;
+            SCLogDebug("%s: EOF frame->offset %" PRIu64 " -> %" PRIi64 ": o %" PRIi64,
+                    AppProtoToString(f->alproto), frame->offset, frame_len, slice_o);
             frame->len = frame_len;
         }
     }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -905,10 +905,7 @@ static void AppLayerParserFileTxHousekeeping(
 {
     AppLayerGetFileState files = AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, pkt_dir);
     if (files.fc) {
-        if (trunc) {
-            FileTruncateAllOpenFiles(files.fc);
-        }
-        FilePrune(files.fc);
+        FilesPrune(files.fc, files.cfg, trunc);
     }
 }
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -40,6 +40,8 @@
 #define APP_LAYER_PARSER_EOF_TC                BIT_U16(6)
 #define APP_LAYER_PARSER_TRUNC_TS              BIT_U16(7)
 #define APP_LAYER_PARSER_TRUNC_TC              BIT_U16(8)
+#define APP_LAYER_PARSER_SFRAME_TS             BIT_U16(9)
+#define APP_LAYER_PARSER_SFRAME_TC             BIT_U16(10)
 
 /* Flags for AppLayerParserProtoCtx. */
 #define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U32(0)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -177,8 +177,8 @@ void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto proto,
         void *(*LocalStorageAlloc)(void), void (*LocalStorageFree)(void *));
 // void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
 //     AppLayerDecoderEvents *(*StateGetEvents)(void *) __attribute__((nonnull)));
-void AppLayerParserRegisterGetTxFilesFunc(
-        uint8_t ipproto, AppProto alproto, FileContainer *(*GetTxFiles)(void *, uint8_t));
+void AppLayerParserRegisterGetTxFilesFunc(uint8_t ipproto, AppProto alproto,
+        AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t));
 void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
                          LoggerId (*StateGetTxLogged)(void *, void *),
                          void (*StateSetTxLogged)(void *, void *, LoggerId));
@@ -241,7 +241,8 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
 AppLayerDecoderEvents *AppLayerParserGetDecoderEvents(AppLayerParserState *pstate);
 void AppLayerParserSetDecoderEvents(AppLayerParserState *pstate, AppLayerDecoderEvents *devents);
 AppLayerDecoderEvents *AppLayerParserGetEventsByTx(uint8_t ipproto, AppProto alproto, void *tx);
-FileContainer *AppLayerParserGetTxFiles(const Flow *f, void *tx, const uint8_t direction);
+AppLayerGetFileState AppLayerParserGetTxFiles(
+        const Flow *f, void *state, void *tx, const uint8_t direction);
 int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
                         void *alstate, uint8_t direction);
 uint64_t AppLayerParserGetTxCnt(const Flow *, void *alstate);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -59,7 +59,7 @@ typedef struct AppLayerParser {
     void *(*LocalStorageAlloc)(void);
     void (*LocalStorageFree)(void *);
 
-    FileContainer *(*GetTxFiles)(void *, uint8_t);
+    AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t);
 
     AppLayerGetTxIterTuple (*GetTxIterator)(const uint8_t ipproto,
             const AppProto alproto, void *alstate, uint64_t min_tx_id,

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1691,16 +1691,15 @@ static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
     return tx->done;
 }
 
-static FileContainer *SMTPGetTxFiles(void *txv, uint8_t direction)
+static AppLayerGetFileState SMTPGetTxFiles(void *state, void *txv, uint8_t direction)
 {
+    AppLayerGetFileState files = { .fc = NULL, .cfg = &smtp_config.sbcfg };
     SMTPTransaction *tx = (SMTPTransaction *)txv;
 
-    if (direction & STREAM_TOCLIENT) {
-        SCReturnPtr(NULL, "FileContainer");
-    } else {
-        SCLogDebug("tx->files_ts %p", &tx->files_ts);
-        SCReturnPtr(&tx->files_ts, "FileContainer");
+    if (direction & STREAM_TOSERVER) {
+        files.fc = &tx->files_ts;
     }
+    return files;
 }
 
 static AppLayerTxData *SMTPGetTxData(void *vtx)

--- a/src/detect-engine-file.c
+++ b/src/detect-engine-file.c
@@ -182,13 +182,14 @@ static uint8_t DetectFileInspect(DetectEngineThreadCtx *det_ctx, Flow *f, const 
  */
 uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
-        uint8_t flags, void *_alstate, void *tx, uint64_t tx_id)
+        uint8_t flags, void *alstate, void *tx, uint64_t tx_id)
 {
     SCEnter();
-    DEBUG_VALIDATE_BUG_ON(f->alstate != _alstate);
+    DEBUG_VALIDATE_BUG_ON(f->alstate != alstate);
 
     const uint8_t direction = flags & (STREAM_TOSERVER|STREAM_TOCLIENT);
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, tx, direction);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, tx, direction);
+    FileContainer *ffc = files.fc;
     SCLogDebug("tx %p tx_id %" PRIu64 " ffc %p ffc->head %p sid %u", tx, tx_id, ffc,
             ffc ? ffc->head : NULL, s->id);
     if (ffc == NULL) {

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -95,7 +95,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
     const uint8_t *data = buffer->inspect;
 
     SCLogDebug("mpm'ing buffer:");
-    // SCLogDebug("frame: %p", frame);
+    SCLogDebug("frame: %p", frame);
     // PrintRawDataFp(stdout, data, MIN(32, data_len));
 
     if (data != NULL && data_len >= mpm_ctx->minlen) {
@@ -166,26 +166,30 @@ static InspectionBuffer *DetectFrame2InspectBufferUdp(DetectEngineThreadCtx *det
         const Frames *frames, const Frame *frame, const int list_id, const uint32_t idx,
         const bool first)
 {
-    DEBUG_VALIDATE_BUG_ON(frame->rel_offset >= p->payload_len);
-    if (frame->rel_offset >= p->payload_len)
+    DEBUG_VALIDATE_BUG_ON(frame->offset >= p->payload_len);
+    if (frame->offset >= p->payload_len)
         return NULL;
 
-    int frame_len = frame->len != -1 ? frame->len : p->payload_len - frame->rel_offset;
     uint8_t ci_flags = DETECT_CI_FLAGS_START;
-
-    if (frame->rel_offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->rel_offset;
+    uint32_t frame_len;
+    if (frame->len == -1) {
+        frame_len = p->payload_len - frame->offset;
+    } else {
+        frame_len = (uint32_t)frame->len;
+    }
+    if (frame->offset + frame_len > p->payload_len) {
+        frame_len = p->payload_len - frame->offset;
     } else {
         ci_flags |= DETECT_CI_FLAGS_END;
     }
-    const uint8_t *data = p->payload + frame->rel_offset;
+    const uint8_t *data = p->payload + frame->offset;
     const uint32_t data_len = frame_len;
 
-    SCLogDebug("packet %" PRIu64 " -> frame %p/%" PRIi64 "/%s rel_offset %" PRIi64
+    SCLogDebug("packet %" PRIu64 " -> frame %p/%" PRIi64 "/%s offset %" PRIu64
                " type %u len %" PRIi64,
             p->pcap_cnt, frame, frame->id,
             AppLayerParserGetFrameNameById(p->flow->proto, p->flow->alproto, frame->type),
-            frame->rel_offset, frame->type, frame->len);
+            frame->offset, frame->type, frame->len);
     // PrintRawDataFp(stdout, data, MIN(64,data_len));
 
     InspectionBufferSetupMulti(buffer, transforms, data, data_len);
@@ -200,8 +204,8 @@ struct FrameStreamData {
     const Frame *frame;
     int list_id;
     uint32_t idx;
-    uint64_t frame_data_offset_abs;
-    uint64_t frame_start_offset_abs;
+    uint64_t data_offset;
+    uint64_t frame_offset;
     /** buffer is set if callback was successful */
     InspectionBuffer *buffer;
 };
@@ -210,11 +214,11 @@ static int FrameStreamDataFunc(
         void *cb_data, const uint8_t *input, const uint32_t input_len, const uint64_t offset)
 {
     struct FrameStreamData *fsd = cb_data;
-    SCLogDebug("fsd %p { det_ct:%p, transforms:%p, frame:%p, list_id:%d, idx:%u, "
-               "frame_data_offset_abs:%" PRIu64 ", frame_start_offset_abs:%" PRIu64
+    SCLogDebug("fsd %p { det_ctx:%p, transforms:%p, frame:%p, list_id:%d, idx:%u, "
+               "data_offset:%" PRIu64 ", frame_offset:%" PRIu64
                " }, input: %p, input_len:%u, offset:%" PRIu64,
             fsd, fsd->det_ctx, fsd->transforms, fsd->frame, fsd->list_id, fsd->idx,
-            fsd->frame_data_offset_abs, fsd->frame_start_offset_abs, input, input_len, offset);
+            fsd->data_offset, fsd->frame_offset, input, input_len, offset);
 
     InspectionBuffer *buffer =
             InspectionBufferMultipleForListGet(fsd->det_ctx, fsd->list_id, fsd->idx);
@@ -222,11 +226,12 @@ static int FrameStreamDataFunc(
     SCLogDebug("buffer %p", buffer);
 
     const Frame *frame = fsd->frame;
-    SCLogDebug("frame rel_offset:%" PRIi64, frame->rel_offset);
+    SCLogDebug("frame offset:%" PRIu64, frame->offset);
     const uint8_t *data = input;
     uint8_t ci_flags = 0;
     uint32_t data_len;
-    if (fsd->frame_start_offset_abs == offset) {
+    uint64_t inspect_offset = 0;
+    if (fsd->frame_offset == offset) {
         ci_flags |= DETECT_CI_FLAGS_START;
         SCLogDebug("have frame data start");
 
@@ -240,28 +245,24 @@ static int FrameStreamDataFunc(
             ci_flags |= DETECT_CI_FLAGS_END;
             SCLogDebug("have frame data end");
         }
+        // inspect_offset 0
     } else {
-        BUG_ON(offset < fsd->frame_data_offset_abs);
-
-        uint64_t frame_delta = offset - fsd->frame_start_offset_abs;
-        uint64_t request_delta =
-                offset -
-                fsd->frame_data_offset_abs; // diff between what we requested and what we got
-        BUG_ON(request_delta > frame_delta);
+        BUG_ON(offset < fsd->data_offset);
+        inspect_offset = offset - fsd->frame_offset;
 
         if (frame->len >= 0) {
-            if (frame_delta >= (uint64_t)frame->len) {
+            if (inspect_offset >= (uint64_t)frame->len) {
                 SCLogDebug("data entirely past frame");
                 return 1;
             }
-            uint32_t adjusted_frame_len = (uint32_t)((uint64_t)frame->len - frame_delta);
-            SCLogDebug("frame len after applying offset %" PRIu64 ": %u", frame_delta,
+            uint32_t adjusted_frame_len = (uint32_t)((uint64_t)frame->len - inspect_offset);
+            SCLogDebug("frame len after applying offset %" PRIu64 ": %u", inspect_offset,
                     adjusted_frame_len);
 
             data_len = MIN(adjusted_frame_len, input_len);
             SCLogDebug("usable data len for frame: %u", data_len);
 
-            if ((uint64_t)data_len + frame_delta == (uint64_t)frame->len) {
+            if ((uint64_t)data_len + inspect_offset == (uint64_t)frame->len) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
             }
@@ -271,7 +272,8 @@ static int FrameStreamDataFunc(
     }
     // PrintRawDataFp(stdout, data, data_len);
     InspectionBufferSetupMulti(buffer, fsd->transforms, data, data_len);
-    buffer->inspect_offset = frame->rel_offset < 0 ? -1 * frame->rel_offset : 0; // TODO review/test
+    SCLogDebug("inspect_offset %" PRIu64, inspect_offset);
+    buffer->inspect_offset = inspect_offset;
     buffer->flags = ci_flags;
     fsd->buffer = buffer;
     return 1; // for now only the first chunk
@@ -304,51 +306,20 @@ InspectionBuffer *DetectFrame2InspectBuffer(DetectEngineThreadCtx *det_ctx,
         stream = &ssn->server;
     }
 
-    /*
-        stream:   [s                                           ]
-        frame:          [r               ]
-        progress:        |>p
-            rel_offset: 10, len 100
-            progress: 20
-            avail: 90 (complete)
+    SCLogDebug("frame %" PRIi64 ", len %" PRIi64 ", offset %" PRIu64, frame->id, frame->len,
+            frame->offset);
 
-        stream:   [s            ]
-        frame:          [r               ]
-        progress:        |>p
-            stream: 0, len 59
-            rel_offset: 10, len 100
-            progress: 20
-            avail: 30 (incomplete)
-
-        stream:          [s                                           ]
-        frame:        [r               ]
-        progress:              |>p
-            stream: 0, len 200
-            rel_offset: -30, len 100
-            progress: 20
-            avail: 50 (complete)
-     */
-
-    SCLogDebug("frame %" PRIi64 ", len %" PRIi64 ", rel_offset %" PRIi64, frame->id, frame->len,
-            frame->rel_offset);
-
-    uint64_t offset = STREAM_BASE_OFFSET(stream);
-    if (frame->rel_offset > 0) {
-        offset += (uint64_t)frame->rel_offset;
-    }
-    const int64_t frame_start_abs_offset = frame->rel_offset + (int64_t)STREAM_BASE_OFFSET(stream);
-    BUG_ON(frame_start_abs_offset < 0);
-
+    const uint64_t frame_offset = frame->offset;
     const bool eof = ssn->state == TCP_CLOSED || PKT_IS_PSEUDOPKT(p);
-
     const uint64_t usable = StreamTcpGetUsable(stream, eof);
-    if (usable <= offset)
+    if (usable <= frame_offset)
         return NULL;
+    const uint64_t offset = MAX(STREAM_BASE_OFFSET(stream), frame_offset);
 
-    struct FrameStreamData fsd = { det_ctx, transforms, frame, list_id, idx, offset,
-        (uint64_t)frame_start_abs_offset, NULL };
+    struct FrameStreamData fsd = { det_ctx, transforms, frame, list_id, idx,
+        STREAM_BASE_OFFSET(stream), frame_offset, NULL };
     StreamReassembleForFrame(ssn, stream, FrameStreamDataFunc, &fsd, offset, eof);
-    SCLogDebug("offset %" PRIu64, offset);
+    SCLogDebug("offset %" PRIu64, frame_offset);
     return fsd.buffer;
 }
 
@@ -394,9 +365,9 @@ int DetectEngineInspectFrameBufferGeneric(DetectEngineThreadCtx *det_ctx,
     det_ctx->inspection_recursion_counter = 0;
 #ifdef DEBUG
     const uint8_t ci_flags = buffer->flags;
-    SCLogDebug("frame %p rel_offset %" PRIi64 " type %u len %" PRIi64
+    SCLogDebug("frame %p offset %" PRIu64 " type %u len %" PRIi64
                " ci_flags %02x (start:%s, end:%s)",
-            frame, frame->rel_offset, frame->type, frame->len, ci_flags,
+            frame, frame->offset, frame->type, frame->len, ci_flags,
             (ci_flags & DETECT_CI_FLAGS_START) ? "true" : "false",
             (ci_flags & DETECT_CI_FLAGS_END) ? "true" : "false");
     SCLogDebug("buffer %p offset %" PRIu64 " len %u ci_flags %02x (start:%s, end:%s)", buffer,

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -720,10 +720,11 @@ static int DeStateSigTest03(void)
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(!(PacketAlertCheck(p, 1)));
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
 
-    File *file = files->head;
+    File *file = fc->head;
     FAIL_IF_NULL(file);
 
     FAIL_IF(!(file->flags & FILE_STORE));
@@ -799,9 +800,10 @@ static int DeStateSigTest04(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
 
     FAIL_IF(file->flags & FILE_STORE);
@@ -873,9 +875,10 @@ static int DeStateSigTest05(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF(http_state->state_data.file_flags & FLOWFILE_NO_STORE_TS);
 
@@ -958,9 +961,10 @@ static int DeStateSigTest06(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     /* detect will have set FLOWFILE_NO_STORE_TS, but it won't have had
      * an opportunity to be applied to the file itself yet */
@@ -1045,9 +1049,10 @@ static int DeStateSigTest07(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF(file->flags & FILE_STORE);
 
@@ -1143,9 +1148,10 @@ static int DeStateSigTest08(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF(file->flags & FILE_STORE);
 
@@ -1169,9 +1175,10 @@ static int DeStateSigTest08(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    file = files->head;
+    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    fc = files.fc;
+    FAIL_IF_NULL(fc);
+    file = fc->head;
     FAIL_IF_NULL(file);
     file = file->next;
     FAIL_IF_NULL(file);
@@ -1269,9 +1276,10 @@ static int DeStateSigTest09(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
@@ -1295,9 +1303,10 @@ static int DeStateSigTest09(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    file = files->head;
+    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    fc = files.fc;
+    FAIL_IF_NULL(fc);
+    file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
@@ -1393,9 +1402,10 @@ static int DeStateSigTest10(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    FileContainer *files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    File *file = files->head;
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    FileContainer *fc = files.fc;
+    FAIL_IF_NULL(fc);
+    File *file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 
@@ -1419,9 +1429,10 @@ static int DeStateSigTest10(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
-    FAIL_IF_NULL(files);
-    file = files->head;
+    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    fc = files.fc;
+    FAIL_IF_NULL(fc);
+    file = fc->head;
     FAIL_IF_NULL(file);
     FAIL_IF_NOT(file->flags & FILE_STORE);
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -598,7 +598,8 @@ static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngine
         transforms = engine->v2.transforms;
     }
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
     }
@@ -660,7 +661,8 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;
         for (File *file = ffc->head; file != NULL; file = file->next) {

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -484,7 +484,8 @@ static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngin
         transforms = engine->v2.transforms;
     }
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
     }
@@ -542,7 +543,8 @@ static void PrefilterTxFilemagic(DetectEngineThreadCtx *det_ctx, const void *pec
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;
         for (File *file = ffc->head; file != NULL; file = file->next) {

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -380,7 +380,8 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
         transforms = engine->v2.transforms;
     }
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
     }
@@ -438,7 +439,8 @@ static void PrefilterTxFilename(DetectEngineThreadCtx *det_ctx, const void *pect
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;
         for (File *file = ffc->head; file != NULL; file = file->next) {

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -216,14 +216,16 @@ static int DetectFilestorePostMatch(DetectEngineThreadCtx *det_ctx,
 
     const uint8_t flags = STREAM_FLAGS_FOR_PACKET(p);
     for (uint16_t u = 0; u < det_ctx->filestore_cnt; u++) {
-        AppLayerParserSetStreamDepthFlag(p->flow->proto, p->flow->alproto, FlowGetAppState(p->flow),
-                det_ctx->filestore[u].tx_id, flags);
+        void *alstate = FlowGetAppState(p->flow);
+        AppLayerParserSetStreamDepthFlag(
+                p->flow->proto, p->flow->alproto, alstate, det_ctx->filestore[u].tx_id, flags);
 
-        void *txv = AppLayerParserGetTx(p->flow->proto, p->flow->alproto, FlowGetAppState(p->flow),
-                det_ctx->filestore[u].tx_id);
+        void *txv = AppLayerParserGetTx(
+                p->flow->proto, p->flow->alproto, alstate, det_ctx->filestore[u].tx_id);
         DEBUG_VALIDATE_BUG_ON(txv == NULL);
         if (txv) {
-            FileContainer *ffc_tx = AppLayerParserGetTxFiles(p->flow, txv, flags);
+            AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, alstate, txv, flags);
+            FileContainer *ffc_tx = files.fc;
             DEBUG_VALIDATE_BUG_ON(ffc_tx == NULL);
             if (ffc_tx) {
                 SCLogDebug("u %u txv %p ffc_tx %p file_id %u", u, txv, ffc_tx,

--- a/src/detect-frame.c
+++ b/src/detect-frame.c
@@ -24,6 +24,7 @@
 #include "decode.h"
 #include "detect.h"
 
+#include "app-layer-frames.h"
 #include "app-layer-parser.h"
 
 #include "detect-parse.h"
@@ -106,15 +107,21 @@ static int DetectFrameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *s
 
     const char *frame_str = is_short ? str : val;
     int raw_frame_type = -1;
-    if (is_tcp)
-        raw_frame_type = AppLayerParserGetFrameIdByName(IPPROTO_TCP, keyword_alproto, frame_str);
+    if (is_tcp) {
+        if (strcmp(frame_str, "stream") == 0) {
+            raw_frame_type = FRAME_STREAM_TYPE;
+        } else {
+            raw_frame_type =
+                    AppLayerParserGetFrameIdByName(IPPROTO_TCP, keyword_alproto, frame_str);
+        }
+    }
     if (is_udp && raw_frame_type < 0)
         raw_frame_type = AppLayerParserGetFrameIdByName(IPPROTO_UDP, keyword_alproto, frame_str);
     if (raw_frame_type < 0) {
         SCLogError("unknown frame '%s' for protocol '%s'", frame_str, proto);
         return -1;
     }
-    BUG_ON(raw_frame_type >= UINT8_MAX);
+    BUG_ON(raw_frame_type > UINT8_MAX);
 
     if (is_short) {
         snprintf(buffer_name, sizeof(buffer_name), "%s.%s", AppProtoToString(s->alproto), str);

--- a/src/detect-frame.c
+++ b/src/detect-frame.c
@@ -141,6 +141,7 @@ static int DetectFrameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *s
     if (DetectBufferSetActiveList(s, buffer_id) < 0)
         return -1;
 
+    FrameConfigEnable(keyword_alproto, frame_type);
     return 0;
 }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1096,6 +1096,8 @@ typedef struct DetectEngineThreadCtx_ {
     /** ID of the transaction currently being inspected. */
     uint64_t tx_id;
     int64_t frame_id;
+    uint64_t frame_inspect_progress; /**< used to set Frame::inspect_progress after all inspection
+                                        on a frame is complete. */
     Packet *p;
 
     uint16_t alert_queue_size;

--- a/src/flow.c
+++ b/src/flow.c
@@ -1143,16 +1143,6 @@ int FlowSetProtoFreeFunc (uint8_t proto, void (*Free)(void *))
     return 1;
 }
 
-AppProto FlowGetAppProtocol(const Flow *f)
-{
-    return f->alproto;
-}
-
-void *FlowGetAppState(const Flow *f)
-{
-    return f->alstate;
-}
-
 /**
  *  \brief get 'disruption' flags: GAP/DEPTH/PASS
  *  \param f locked flow

--- a/src/flow.h
+++ b/src/flow.h
@@ -605,6 +605,16 @@ uint16_t FlowGetDestinationPort(Flow *flow);
 
 /** ----- Inline functions ----- */
 
+static inline AppProto FlowGetAppProtocol(const Flow *f)
+{
+    return f->alproto;
+}
+
+static inline void *FlowGetAppState(const Flow *f)
+{
+    return f->alstate;
+}
+
 /** \brief Set the No Packet Inspection Flag without locking the flow.
  *
  * \param f Flow to set the flag in

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -162,7 +162,7 @@ void OutputFiledataLogFfc(ThreadVars *tv, OutputFiledataLoggerThreadData *td, Pa
          * close the logger(s) */
         if (FileDataSize(ff) == ff->content_stored && (file_trunc || file_close)) {
             if (ff->state < FILE_STATE_CLOSED) {
-                FileCloseFilePtr(ff, NULL, 0, FILE_TRUNCATED);
+                ff->state = FILE_STATE_TRUNCATED;
             }
             file_flags |= OUTPUT_FILEDATA_FLAG_CLOSE;
             CallLoggers(tv, store, p, ff, txv, tx_id, NULL, 0, file_flags, dir);
@@ -173,7 +173,7 @@ void OutputFiledataLogFfc(ThreadVars *tv, OutputFiledataLoggerThreadData *td, Pa
         /* if file needs to be closed or truncated, inform
          * loggers */
         if ((file_close || file_trunc) && ff->state < FILE_STATE_CLOSED) {
-            FileCloseFilePtr(ff, NULL, 0, FILE_TRUNCATED);
+            ff->state = FILE_STATE_TRUNCATED;
         }
 
         /* tell the logger we're closing up */

--- a/src/output-filedata.h
+++ b/src/output-filedata.h
@@ -42,7 +42,7 @@ TmEcode OutputFiledataLogThreadInit(ThreadVars *tv, OutputFiledataLoggerThreadDa
 TmEcode OutputFiledataLogThreadDeinit(ThreadVars *tv, OutputFiledataLoggerThreadData *thread_data);
 
 void OutputFiledataLogFfc(ThreadVars *tv, OutputFiledataLoggerThreadData *td, Packet *p,
-        FileContainer *ffc, void *txv, const uint64_t tx_id, AppLayerTxData *txd,
+        AppLayerGetFileState files, void *txv, const uint64_t tx_id, AppLayerTxData *txd,
         const uint8_t call_flags, const bool file_close, const bool file_trunc, const uint8_t dir);
 
 /** filedata logger function pointer type */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -604,7 +604,9 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
     if (p->flow->alstate != NULL) {
         void *tx = AppLayerParserGetTx(p->flow->proto, p->flow->alproto, p->flow->alstate, tx_id);
         if (tx) {
-            ffc = AppLayerParserGetTxFiles(p->flow, tx, direction);
+            AppLayerGetFileState files =
+                    AppLayerParserGetTxFiles(p->flow, p->flow->alstate, tx, direction);
+            ffc = files.fc;
         }
     }
     if (ffc != NULL) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -313,6 +313,9 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
             if (FlowHasGaps(f, STREAM_TOSERVER)) {
                 JB_SET_TRUE(jb, "ts_gap");
             }
+
+            jb_set_uint(jb, "ts_max_regions", ssn->client.sb.max_regions);
+            jb_set_uint(jb, "tc_max_regions", ssn->server.sb.max_regions);
         }
 
         /* Close tcp. */

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -158,8 +158,13 @@ static void FrameAddPayloadTCP(JsonBuilder *js, const TcpStream *stream, const F
     SCLogDebug("frame data_offset %" PRIu64 ", data_len %u frame len %" PRIi64, data_offset,
             sb_data_len, frame->len);
 
-    // TODO update to work with large frames
-    jb_set_bool(js, "complete", ((int64_t)sb_data_len >= frame->len));
+    bool complete = false;
+    if (frame->len > 0) {
+        const uint64_t frame_re = frame->offset + (uint64_t)frame->len;
+        const uint64_t data_re = data_offset + sb_data_len;
+        complete = frame_re <= data_re;
+    }
+    jb_set_bool(js, "complete", complete);
 
     uint32_t data_len = MIN(sb_data_len, 256);
     jb_set_base64(js, "payload", data, data_len);

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -489,6 +489,8 @@ static OutputInitResult JsonFrameLogInitCtxSub(ConfNode *conf, OutputCtx *parent
     output_ctx->data = json_output_ctx;
     output_ctx->DeInit = JsonFrameLogDeInitCtxSub;
 
+    FrameConfigEnableAll();
+
     result.ctx = output_ctx;
     result.ok = true;
     return result;

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -230,7 +230,11 @@ void FrameJsonLogOneFrame(const uint8_t ipproto, const Frame *frame, const Flow 
     DEBUG_VALIDATE_BUG_ON(ipproto != f->proto);
 
     jb_open_object(jb, "frame");
-    jb_set_string(jb, "type", AppLayerParserGetFrameNameById(ipproto, f->alproto, frame->type));
+    if (frame->type == FRAME_STREAM_TYPE) {
+        jb_set_string(jb, "type", "stream");
+    } else {
+        jb_set_string(jb, "type", AppLayerParserGetFrameNameById(ipproto, f->alproto, frame->type));
+    }
     jb_set_uint(jb, "id", frame->id);
     jb_set_string(jb, "direction", PKT_IS_TOSERVER(p) ? "toserver" : "toclient");
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -380,7 +380,7 @@ static void EveHttpLogJSONHeaders(JsonBuilder *js, uint32_t direction, htp_tx_t 
 
 static void BodyPrintableBuffer(JsonBuilder *js, HtpBody *body, const char *key)
 {
-    if (body->sb != NULL && body->sb->buf != NULL) {
+    if (body->sb != NULL && body->sb->region.buf != NULL) {
         uint32_t offset = 0;
         const uint8_t *body_data;
         uint32_t body_data_len;
@@ -418,7 +418,7 @@ void EveHttpLogJSONBodyPrintable(JsonBuilder *js, Flow *f, uint64_t tx_id)
 
 static void BodyBase64Buffer(JsonBuilder *js, HtpBody *body, const char *key)
 {
-    if (body->sb != NULL && body->sb->buf != NULL) {
+    if (body->sb != NULL && body->sb->region.buf != NULL) {
         const uint8_t *body_data;
         uint32_t body_data_len;
         uint64_t body_offset;

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -194,8 +194,8 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
         SCLogDebug("tx: calling files: ffc %p head %p file_close %d file_trunc %d", ffc, ffc->head,
                 file_close, file_trunc);
         if (filedata_td && txd->files_opened > txd->files_stored)
-            OutputFiledataLogFfc(tv, filedata_td, p, ffc, tx, tx_id, txd, packet_dir, file_close,
-                    file_trunc, packet_dir);
+            OutputFiledataLogFfc(tv, filedata_td, p, app_files, tx, tx_id, txd, packet_dir,
+                    file_close, file_trunc, packet_dir);
         if (file_td && txd->files_opened > txd->files_logged)
             OutputFileLogFfc(
                     tv, file_td, p, ffc, tx, tx_id, txd, file_close, file_trunc, packet_dir);
@@ -208,8 +208,8 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
         SCLogDebug("tx: calling for opposing direction files: file_close:%s file_trunc:%s",
                 file_close ? "true" : "false", file_trunc ? "true" : "false");
         if (filedata_td && txd->files_opened > txd->files_stored)
-            OutputFiledataLogFfc(tv, filedata_td, p, ffc_opposing, tx, tx_id, txd, opposing_dir,
-                    file_close, file_trunc, opposing_dir);
+            OutputFiledataLogFfc(tv, filedata_td, p, app_files_opposing, tx, tx_id, txd,
+                    opposing_dir, file_close, file_trunc, opposing_dir);
         if (file_td && txd->files_opened > txd->files_logged)
             OutputFileLogFfc(tv, file_td, p, ffc_opposing, tx, tx_id, txd, file_close, file_trunc,
                     opposing_dir);

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -168,8 +168,12 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
             opposing_dir == STREAM_TOSERVER ? "TOSERVER" : "TOCLIENT", packet_dir_ready,
             opposing_dir_ready);
 
-    FileContainer *ffc = AppLayerParserGetTxFiles(f, tx, packet_dir);
-    FileContainer *ffc_opposing = AppLayerParserGetTxFiles(f, tx, opposing_dir);
+    AppLayerGetFileState app_files =
+            AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, packet_dir);
+    FileContainer *ffc = app_files.fc;
+    AppLayerGetFileState app_files_opposing =
+            AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, opposing_dir);
+    FileContainer *ffc_opposing = app_files_opposing.fc;
 
     /* see if opposing side is finished: if no file support in this direction, of is not
      * files and tx is done for opposing dir. */

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -37,7 +37,6 @@ const SuricataContext suricata_context = {
     FileAppendDataById,
     FileAppendGAPById,
     FileContainerRecycle,
-    FilePrune,
 
     AppLayerRegisterParser,
 };

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -46,19 +46,19 @@ typedef struct SuricataContext_ {
     void (*AppLayerParserTriggerRawStreamReassembly)(Flow *, int direction);
 
     void (*HttpRangeFreeBlock)(HttpRangeContainerBlock *);
-    bool (*HTPFileCloseHandleRange)(
-            FileContainer *, const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
+    bool (*HTPFileCloseHandleRange)(const StreamingBufferConfig *sbcfg, FileContainer *,
+            const uint16_t, HttpRangeContainerBlock *, const uint8_t *, uint32_t);
 
     int (*FileOpenFileWithId)(FileContainer *, const StreamingBufferConfig *,
         uint32_t track_id, const uint8_t *name, uint16_t name_len,
         const uint8_t *data, uint32_t data_len, uint16_t flags);
-    int (*FileCloseFileById)(FileContainer *, uint32_t track_id,
+    int (*FileCloseFileById)(FileContainer *, const StreamingBufferConfig *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len, uint16_t flags);
-    int (*FileAppendDataById)(FileContainer *, uint32_t track_id,
+    int (*FileAppendDataById)(FileContainer *, const StreamingBufferConfig *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
-    int (*FileAppendGAPById)(FileContainer *, uint32_t track_id,
+    int (*FileAppendGAPById)(FileContainer *, const StreamingBufferConfig *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
-    void (*FileContainerRecycle)(FileContainer *ffc);
+    void (*FileContainerRecycle)(FileContainer *ffc, const StreamingBufferConfig *);
 
     int (*AppLayerRegisterParser)(const struct AppLayerParser *p, AppProto alproto);
 

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -59,7 +59,6 @@ typedef struct SuricataContext_ {
     int (*FileAppendGAPById)(FileContainer *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
     void (*FileContainerRecycle)(FileContainer *ffc);
-    void (*FilePrune)(FileContainer *ffc);
 
     int (*AppLayerRegisterParser)(const struct AppLayerParser *p, AppProto alproto);
 

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -936,7 +936,7 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
         if (!(ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED)) {
             AppLayerFramesSlide(f, slide, flags & (STREAM_TOSERVER | STREAM_TOCLIENT));
         }
-        StreamingBufferSlideToOffset(&stream->sb, left_edge);
+        StreamingBufferSlideToOffset(&stream->sb, &stream_config.sbcnf, left_edge);
         stream->base_seq += slide;
 
         if (slide <= stream->app_progress_rel) {

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -816,7 +816,7 @@ static inline uint64_t GetLeftEdge(Flow *f, TcpSession *ssn, TcpStream *stream)
         left_edge = app_le;
         SCLogDebug("left_edge %" PRIu64 ", using only app:%" PRIu64, left_edge, app_le);
     } else {
-        left_edge = STREAM_BASE_OFFSET(stream) + stream->sb.buf_offset;
+        left_edge = StreamingBufferGetConsecutiveDataRightEdge(&stream->sb);
         SCLogDebug("no app & raw: left_edge %"PRIu64" (full stream)", left_edge);
     }
 

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -96,8 +96,8 @@ static inline int InsertSegmentDataCustom(TcpStream *stream, TcpSegment *seg, ui
         SCReturnInt(0);
     }
 
-    int ret = StreamingBufferInsertAt(
-            &stream->sb, &seg->sbseg, data + data_offset, data_len - data_offset, stream_offset);
+    int ret = StreamingBufferInsertAt(&stream->sb, &stream_config.sbcnf, &seg->sbseg,
+            data + data_offset, data_len - data_offset, stream_offset);
     if (ret != 0) {
         /* StreamingBufferInsertAt can return -2 only if the offset is wrong, which should be
          * impossible in this path. */

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -914,7 +914,7 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
         SCLogDebug("ssn %p / stream %p: reassembly depth reached, "
                  "STREAMTCP_STREAM_FLAG_NOREASSEMBLY set", ssn, stream);
         StreamTcpReturnStreamSegments(stream);
-        StreamingBufferClear(&stream->sb);
+        StreamingBufferClear(&stream->sb, &stream_config.sbcnf);
         return;
 
     } else if ((ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) &&
@@ -923,7 +923,7 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
                  "STREAMTCP_STREAM_FLAG_NOREASSEMBLY set", ssn, stream);
         stream->flags |= STREAMTCP_STREAM_FLAG_NOREASSEMBLY;
         StreamTcpReturnStreamSegments(stream);
-        StreamingBufferClear(&stream->sb);
+        StreamingBufferClear(&stream->sb, &stream_config.sbcnf);
         return;
     }
 

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -100,8 +100,8 @@ RB_PROTOTYPE(TCPSEG, TcpSegment, rb, TcpSegmentCompare);
  * Only use if STREAM_HAS_SEEN_DATA is true. */
 #define STREAM_SEQ_RIGHT_EDGE(stream)   (stream)->segs_right_edge
 #define STREAM_RIGHT_EDGE(stream)       (STREAM_BASE_OFFSET((stream)) + (STREAM_SEQ_RIGHT_EDGE((stream)) - (stream)->base_seq))
-/* return true if we have seen data segments. */
-#define STREAM_HAS_SEEN_DATA(stream)    (!RB_EMPTY(&(stream)->sb.sbb_tree) || (stream)->sb.stream_offset || (stream)->sb.buf_offset)
+/* return true if we have seen data. */
+#define STREAM_HAS_SEEN_DATA(stream) StreamingBufferHasData(&(stream)->sb)
 
 typedef struct TcpStream_ {
     uint16_t flags:12;              /**< Flag specific to the stream e.g. Timestamp */

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -140,7 +140,7 @@ typedef struct TcpStream_ {
     struct TCPSACK sack_tree;       /**< red back tree of TCP SACK records. */
 } TcpStream;
 
-#define STREAM_BASE_OFFSET(stream)  ((stream)->sb.stream_offset)
+#define STREAM_BASE_OFFSET(stream)  ((stream)->sb.region.stream_offset)
 #define STREAM_APP_PROGRESS(stream) (STREAM_BASE_OFFSET((stream)) + (stream)->app_progress_rel)
 #define STREAM_RAW_PROGRESS(stream) (STREAM_BASE_OFFSET((stream)) + (stream)->raw_progress_rel)
 #define STREAM_LOG_PROGRESS(stream) (STREAM_BASE_OFFSET((stream)) + (stream)->log_progress_rel)

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -484,7 +484,22 @@ static int StreamTcpReassemblyConfig(bool quiet)
         StreamTcpReassembleConfigEnableOverlapCheck();
     }
 
+    uint16_t max_regions = 8;
+    ConfNode *mr = ConfGetNode("stream.reassembly.max-regions");
+    if (mr) {
+        uint16_t max_r = 0;
+        if (StringParseUint16(&max_r, 10, (uint16_t)strlen(mr->val), mr->val) < 0) {
+            SCLogError("max-regions %s is invalid", mr->val);
+            return -1;
+        }
+        max_regions = max_r;
+    }
+    if (!quiet)
+        SCLogConfig("stream.reassembly \"max-regions\": %u", max_regions);
+
+    stream_config.prealloc_segments = segment_prealloc;
     stream_config.sbcnf.buf_size = 2048;
+    stream_config.sbcnf.max_regions = max_regions;
     stream_config.sbcnf.Calloc = ReassembleCalloc;
     stream_config.sbcnf.Realloc = StreamTcpReassembleRealloc;
     stream_config.sbcnf.Free = ReassembleFree;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -911,20 +911,24 @@ uint8_t StreamNeedsReassembly(const TcpSession *ssn, uint8_t direction)
         // raw is dead
         use_raw = 0;
     }
-
-    const uint64_t right_edge = StreamingBufferGetConsecutiveDataRightEdge(&stream->sb);
-    SCLogDebug("%s: app %"PRIu64" (use: %s), raw %"PRIu64" (use: %s). Stream right edge: %"PRIu64,
-            dirstr,
-            STREAM_APP_PROGRESS(stream), use_app ? "yes" : "no",
-            STREAM_RAW_PROGRESS(stream), use_raw ? "yes" : "no",
-            right_edge);
     if (use_raw) {
+        const uint64_t right_edge =
+                STREAM_BASE_OFFSET(stream) + stream->segs_right_edge - stream->base_seq;
+        SCLogDebug("%s: app %" PRIu64 " (use: %s), raw %" PRIu64
+                   " (use: %s). Stream right edge: %" PRIu64,
+                dirstr, STREAM_APP_PROGRESS(stream), use_app ? "yes" : "no",
+                STREAM_RAW_PROGRESS(stream), use_raw ? "yes" : "no", right_edge);
         if (right_edge > STREAM_RAW_PROGRESS(stream)) {
             SCLogDebug("%s: STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION", dirstr);
             return STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION;
         }
     }
     if (use_app) {
+        const uint64_t right_edge = StreamingBufferGetConsecutiveDataRightEdge(&stream->sb);
+        SCLogDebug("%s: app %" PRIu64 " (use: %s), raw %" PRIu64
+                   " (use: %s). Stream right edge: %" PRIu64,
+                dirstr, STREAM_APP_PROGRESS(stream), use_app ? "yes" : "no",
+                STREAM_RAW_PROGRESS(stream), use_raw ? "yes" : "no", right_edge);
         if (right_edge > STREAM_APP_PROGRESS(stream)) {
             SCLogDebug("%s: STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION", dirstr);
             return STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -500,6 +500,7 @@ static int StreamTcpReassemblyConfig(bool quiet)
     stream_config.prealloc_segments = segment_prealloc;
     stream_config.sbcnf.buf_size = 2048;
     stream_config.sbcnf.max_regions = max_regions;
+    stream_config.sbcnf.region_gap = STREAMING_BUFFER_REGION_GAP_DEFAULT;
     stream_config.sbcnf.Calloc = ReassembleCalloc;
     stream_config.sbcnf.Realloc = StreamTcpReassembleRealloc;
     stream_config.sbcnf.Free = ReassembleFree;

--- a/src/stream-tcp-util.c
+++ b/src/stream-tcp-util.c
@@ -63,7 +63,7 @@ void StreamTcpUTSetupSession(TcpSession *ssn)
 {
     memset(ssn, 0x00, sizeof(TcpSession));
 
-    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER(&stream_config.sbcnf);
+    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER;
     ssn->client.sb = x;
     ssn->server.sb = x;
 }
@@ -84,7 +84,7 @@ void StreamTcpUTSetupStream(TcpStream *s, uint32_t isn)
     STREAMTCP_SET_RA_BASE_SEQ(s, isn);
     s->base_seq = isn+1;
 
-    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER(&stream_config.sbcnf);
+    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER;
     s->sb = x;
 }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -200,7 +200,7 @@ void StreamTcpStreamCleanup(TcpStream *stream)
     if (stream != NULL) {
         StreamTcpSackFreeList(stream);
         StreamTcpReturnStreamSegments(stream);
-        StreamingBufferClear(&stream->sb);
+        StreamingBufferClear(&stream->sb, &stream_config.sbcnf);
     }
 }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -735,7 +735,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         ssn->server.flags = stream_config.stream_init_flags;
         ssn->client.flags = stream_config.stream_init_flags;
 
-        StreamingBuffer x = STREAMING_BUFFER_INITIALIZER(&stream_config.sbcnf);
+        StreamingBuffer x = STREAMING_BUFFER_INITIALIZER;
         ssn->client.sb = x;
         ssn->server.sb = x;
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -336,6 +336,7 @@ void GlobalsInitPreConfig(void)
     SupportFastPatternForSigMatchTypes();
     SCThresholdConfGlobalInit();
     SCProtoNameInit();
+    FrameConfigInit();
 }
 
 static void GlobalsDestroy(SCInstance *suri)

--- a/src/tests/stream-tcp-list.c
+++ b/src/tests/stream-tcp-list.c
@@ -28,9 +28,8 @@
 
 static int VALIDATE(TcpStream *stream, uint8_t *data, uint32_t data_len)
 {
-    if (StreamingBufferCompareRawData(&stream->sb,
-                data, data_len) == 0)
-    {
+    // HACK: these tests should be updated to check the SBB blocks
+    if (memcmp(stream->sb.region.buf, data, data_len) != 0) {
         SCReturnInt(0);
     }
     SCLogInfo("OK");

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -412,7 +412,7 @@ static int FilePruneFile(File *file, const StreamingBufferConfig *cfg)
     }
 
     if (left_edge) {
-        StreamingBufferSlideToOffset(file->sb, left_edge);
+        StreamingBufferSlideToOffset(file->sb, cfg, left_edge);
     }
 
     SCReturnInt(0);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -659,7 +659,7 @@ static int AppendData(
         const StreamingBufferConfig *sbcfg, File *file, const uint8_t *data, uint32_t data_len)
 {
     SCLogDebug("file %p data_len %u", file, data_len);
-    if (StreamingBufferAppendNoTrack(file->sb, data, data_len) != 0) {
+    if (StreamingBufferAppendNoTrack(file->sb, sbcfg, data, data_len) != 0) {
         SCLogDebug("file %p StreamingBufferAppendNoTrack failed", file);
         SCReturnInt(-1);
     }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -593,7 +593,7 @@ static void FileFree(File *ff, const StreamingBufferConfig *sbcfg)
         SCFree(ff->magic);
 #endif
     if (ff->sb != NULL) {
-        StreamingBufferFree(ff->sb);
+        StreamingBufferFree(ff->sb, sbcfg);
     }
 
     if (ff->md5_ctx)

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -323,9 +323,9 @@ static int FileMagicSize(void)
 uint64_t FileDataSize(const File *file)
 {
     if (file != NULL && file->sb != NULL) {
-        SCLogDebug("returning %"PRIu64,
-                file->sb->stream_offset + file->sb->buf_offset);
-        return file->sb->stream_offset + file->sb->buf_offset;
+        const uint64_t size = StreamingBufferGetConsecutiveDataRightEdge(file->sb);
+        SCLogDebug("returning %" PRIu64, size);
+        return size;
     }
     SCLogDebug("returning 0 (default)");
     return 0;
@@ -392,12 +392,13 @@ static int FilePruneFile(File *file)
         /* if file has inspect window and min size set, we
          * do some house keeping here */
         if (file->inspect_window != 0 && file->inspect_min_size != 0) {
+            const uint64_t file_offset = StreamingBufferGetOffset(file->sb);
             uint32_t window = file->inspect_window;
-            if (file->sb->stream_offset == 0)
+            if (file_offset == 0)
                 window = MAX(window, file->inspect_min_size);
 
             uint64_t file_size = FileDataSize(file);
-            uint64_t data_size = file_size - file->sb->stream_offset;
+            uint64_t data_size = file_size - file_offset;
 
             SCLogDebug("window %"PRIu32", file_size %"PRIu64", data_size %"PRIu64,
                     window, file_size, data_size);

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -116,9 +116,9 @@ typedef struct FileContainer_ {
 } FileContainer;
 
 FileContainer *FileContainerAlloc(void);
-void FileContainerFree(FileContainer *);
+void FileContainerFree(FileContainer *, const StreamingBufferConfig *cfg);
 
-void FileContainerRecycle(FileContainer *);
+void FileContainerRecycle(FileContainer *, const StreamingBufferConfig *cfg);
 
 void FileContainerAdd(FileContainer *, File *);
 
@@ -157,11 +157,11 @@ int FileOpenFileWithId(FileContainer *, const StreamingBufferConfig *,
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileCloseFile(FileContainer *, const uint8_t *data, uint32_t data_len,
-        uint16_t flags);
-int FileCloseFileById(FileContainer *, uint32_t track_id,
+int FileCloseFile(FileContainer *, const StreamingBufferConfig *sbcfg, const uint8_t *data,
+        uint32_t data_len, uint16_t flags);
+int FileCloseFileById(FileContainer *, const StreamingBufferConfig *sbcfg, uint32_t track_id,
         const uint8_t *data, uint32_t data_len, uint16_t flags);
-int FileCloseFilePtr(File *ff, const uint8_t *data,
+int FileCloseFilePtr(File *ff, const StreamingBufferConfig *sbcfg, const uint8_t *data,
         uint32_t data_len, uint16_t flags);
 
 /**
@@ -175,10 +175,11 @@ int FileCloseFilePtr(File *ff, const uint8_t *data,
  *  \retval 0 ok
  *  \retval -1 error
  */
-int FileAppendData(FileContainer *, const uint8_t *data, uint32_t data_len);
-int FileAppendDataById(FileContainer *, uint32_t track_id,
+int FileAppendData(FileContainer *, const StreamingBufferConfig *sbcfg, const uint8_t *data,
+        uint32_t data_len);
+int FileAppendDataById(FileContainer *, const StreamingBufferConfig *sbcfg, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
-int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
+int FileAppendGAPById(FileContainer *ffc, const StreamingBufferConfig *sbcfg, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 
 void FileSetInspectSizes(File *file, const uint32_t win, const uint32_t min);
@@ -213,7 +214,6 @@ int FileStore(File *);
 void FileDisableStoringForTransaction(Flow *f, const uint8_t direction, void *tx, uint64_t tx_id);
 
 void FlowFileDisableStoringForTransaction(struct Flow_ *f, uint64_t tx_id);
-void FilePrune(FileContainer *ffc);
 
 void FileForceFilestoreEnable(void);
 int FileForceFilestore(void);
@@ -240,8 +240,6 @@ void FileForceTrackingEnable(void);
 
 void FileStoreFileById(FileContainer *fc, uint32_t);
 
-void FileTruncateAllOpenFiles(FileContainer *);
-
 uint64_t FileDataSize(const File *file);
 uint64_t FileTrackedSize(const File *file);
 
@@ -253,5 +251,7 @@ void FilePrintFlags(const File *file);
 #else
 #define FilePrintFlags(file)
 #endif
+
+void FilesPrune(FileContainer *fc, const StreamingBufferConfig *sbcfg, const bool trunc);
 
 #endif /* __UTIL_FILE_H__ */

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -1299,9 +1299,8 @@ static StreamingBufferRegion *BufferInsertAtRegion(StreamingBuffer *sb, const ui
  *  \return -1 on memory allocation errors
  *  \return negative value on other errors
  */
-int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
-                            const uint8_t *data, uint32_t data_len,
-                            uint64_t offset)
+int StreamingBufferInsertAt(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
+        StreamingBufferSegment *seg, const uint8_t *data, uint32_t data_len, uint64_t offset)
 {
     BUG_ON(seg == NULL);
     DEBUG_VALIDATE_BUG_ON(offset < sb->region.stream_offset);
@@ -1708,7 +1707,7 @@ static int StreamingBufferTest03(void)
     StreamingBufferSegment seg1;
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 8);
     FAIL_IF(seg1.stream_offset != 0);
@@ -1723,7 +1722,7 @@ static int StreamingBufferTest03(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 22);
     FAIL_IF(seg3.stream_offset != 8);
@@ -1764,7 +1763,7 @@ static int StreamingBufferTest04(void)
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     FAIL_IF(!RB_EMPTY(&sb->sbb_tree));
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 8);
     FAIL_IF(seg1.stream_offset != 0);
@@ -1788,7 +1787,7 @@ static int StreamingBufferTest04(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 22);
     FAIL_IF(seg3.stream_offset != 8);
@@ -1811,7 +1810,7 @@ static int StreamingBufferTest04(void)
 
     /* far ahead of curve: */
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"XYZ", 3, 124) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"XYZ", 3, 124) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 22);
     FAIL_IF(sb->region.buf_size != 128);
@@ -1854,28 +1853,28 @@ static int StreamingBufferTest06(void)
     StreamingBufferSegment seg1;
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"A", 1) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"C", 1, 2) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"C", 1, 2) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
     StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -1887,7 +1886,7 @@ static int StreamingBufferTest06(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
     sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -1910,30 +1909,30 @@ static int StreamingBufferTest07(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg1, (const uint8_t *)"B", 1, 1) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg1, (const uint8_t *)"B", 1, 1) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
     StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -1945,7 +1944,7 @@ static int StreamingBufferTest07(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
     sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -1968,30 +1967,30 @@ static int StreamingBufferTest08(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg1, (const uint8_t *)"B", 1, 1) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg1, (const uint8_t *)"B", 1, 1) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"F", 1, 5) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"H", 1, 7) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
     StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -2026,30 +2025,30 @@ static int StreamingBufferTest09(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg1, (const uint8_t *)"B", 1, 1) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg1, (const uint8_t *)"B", 1, 1) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 2);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"H", 1, 7) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 3);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"F", 1, 5) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"F", 1, 5) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 4);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg5;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg5, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
     StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -2061,7 +2060,7 @@ static int StreamingBufferTest09(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg6, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
     sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -2084,32 +2083,32 @@ static int StreamingBufferTest10(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg1, (const uint8_t *)"A", 1, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg1, (const uint8_t *)"A", 1, 0) != 0);
     Dump(sb);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"D", 1, 3) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"D", 1, 3) != 0);
     Dump(sb);
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"H", 1, 7) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg3, (const uint8_t *)"H", 1, 7) != 0);
     Dump(sb);
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 3);
 
     StreamingBufferSegment seg4;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"B", 1, 1) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg4, (const uint8_t *)"B", 1, 1) != 0);
     Dump(sb);
     StreamingBufferSegment seg5;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg5, (const uint8_t *)"C", 1, 2) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg5, (const uint8_t *)"C", 1, 2) != 0);
     Dump(sb);
     StreamingBufferSegment seg6;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg6, (const uint8_t *)"G", 1, 6) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg6, (const uint8_t *)"G", 1, 6) != 0);
     Dump(sb);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 6);
 
     StreamingBufferSegment seg7;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg7, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg7, (const uint8_t *)"ABCDEFGHIJ", 10, 0) != 0);
     Dump(sb);
     StreamingBufferBlock *sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);
@@ -2120,7 +2119,7 @@ static int StreamingBufferTest10(void)
     FAIL_IF_NOT(sb->sbb_size == 10);
 
     StreamingBufferSegment seg8;
-    FAIL_IF(StreamingBufferInsertAt(sb, &seg8, (const uint8_t *)"abcdefghij", 10, 0) != 0);
+    FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg8, (const uint8_t *)"abcdefghij", 10, 0) != 0);
     Dump(sb);
     sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -829,7 +829,8 @@ void StreamingBufferSlideToOffset(
 
 #define DATA_FITS(sb, len) ((sb)->region.buf_offset + (len) <= (sb)->region.buf_size)
 
-StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint8_t *data, uint32_t data_len)
+StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,
+        const StreamingBufferConfig *cfg, const uint8_t *data, uint32_t data_len)
 {
     if (sb->region.buf == NULL) {
         if (InitBuffer(sb) == -1)

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -867,17 +867,6 @@ void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset)
     BUG_ON(sb->region.stream_offset < offset);
 }
 
-void StreamingBufferSlide(StreamingBuffer *sb, uint32_t slide)
-{
-    SCLogDebug("slide with %" PRIu32, slide);
-    uint32_t size = sb->region.buf_offset - slide;
-    SCLogDebug("sliding %u forward, size of original buffer left after slide %u", slide, size);
-    memmove(sb->region.buf, sb->region.buf + slide, size);
-    sb->region.stream_offset += slide;
-    sb->region.buf_offset = size;
-    SBBPrune(sb);
-}
-
 #define DATA_FITS(sb, len) ((sb)->region.buf_offset + (len) <= (sb)->region.buf_size)
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint8_t *data, uint32_t data_len)
@@ -1726,7 +1715,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlide(sb, 6);
+    StreamingBufferSlideToOffset(sb, 6);
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
@@ -1745,7 +1734,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlide(sb, 6);
+    StreamingBufferSlideToOffset(sb, 12);
     FAIL_IF(!StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));
@@ -1799,7 +1788,7 @@ static int StreamingBufferTest03(void)
     FAIL_IF_NOT(sb->sbb_size == 22);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlide(sb, 10);
+    StreamingBufferSlideToOffset(sb, 10);
     FAIL_IF(!StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -103,6 +103,12 @@ StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlo
 
 static inline StreamingBufferRegion *InitBufferRegion(StreamingBuffer *sb, const uint32_t min_size)
 {
+    if (sb->regions == USHRT_MAX ||
+            (sb->cfg->max_regions != 0 && sb->regions >= sb->cfg->max_regions)) {
+        SCLogDebug("max regions reached");
+        return NULL;
+    }
+
     StreamingBufferRegion *aux_r = CALLOC(sb->cfg, 1, sizeof(*aux_r));
     if (aux_r == NULL)
         return NULL;
@@ -115,8 +121,6 @@ static inline StreamingBufferRegion *InitBufferRegion(StreamingBuffer *sb, const
     aux_r->buf_size = MAX(sb->cfg->buf_size, min_size);
     sb->regions++;
     sb->max_regions = MAX(sb->regions, sb->max_regions);
-
-    BUG_ON(sb->regions > 100);
     return aux_r;
 }
 
@@ -1703,7 +1707,7 @@ static void DumpSegment(StreamingBuffer *sb, StreamingBufferSegment *seg)
 
 static int StreamingBufferTest02(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1759,7 +1763,7 @@ static int StreamingBufferTest02(void)
 
 static int StreamingBufferTest03(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1814,7 +1818,7 @@ static int StreamingBufferTest03(void)
 
 static int StreamingBufferTest04(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1905,7 +1909,7 @@ static int StreamingBufferTest04(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest06(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1963,7 +1967,7 @@ static int StreamingBufferTest06(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest07(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2021,7 +2025,7 @@ static int StreamingBufferTest07(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest08(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2079,7 +2083,7 @@ static int StreamingBufferTest08(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest09(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2137,7 +2141,7 @@ static int StreamingBufferTest09(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest10(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -650,7 +650,7 @@ static inline bool RegionContainsOffset(const StreamingBufferRegion *r, const ui
  *     - no shift
  */
 static inline void StreamingBufferSlideToOffsetWithRegions(
-        StreamingBuffer *sb, const uint64_t slide_offset)
+        StreamingBuffer *sb, const StreamingBufferConfig *cfg, const uint64_t slide_offset)
 {
     ListRegions(sb);
     BUG_ON(slide_offset == sb->region.stream_offset);
@@ -760,7 +760,8 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
  *  \brief slide to absolute offset
  *  \todo if sliding beyond window, we could perhaps reset?
  */
-void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset)
+void StreamingBufferSlideToOffset(
+        StreamingBuffer *sb, const StreamingBufferConfig *cfg, uint64_t offset)
 {
     SCLogDebug("sliding to offset %" PRIu64, offset);
     ListRegions(sb);
@@ -769,7 +770,7 @@ void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset)
 #endif
 
     if (sb->region.next) {
-        StreamingBufferSlideToOffsetWithRegions(sb, offset);
+        StreamingBufferSlideToOffsetWithRegions(sb, cfg, offset);
         SBBPrune(sb);
         SCLogDebug("post SBBPrune");
         ListRegions(sb);
@@ -1664,7 +1665,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlideToOffset(sb, 6);
+    StreamingBufferSlideToOffset(sb, &cfg, 6);
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
@@ -1683,7 +1684,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlideToOffset(sb, 12);
+    StreamingBufferSlideToOffset(sb, &cfg, 12);
     FAIL_IF(!StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));
@@ -1737,7 +1738,7 @@ static int StreamingBufferTest03(void)
     FAIL_IF_NOT(sb->sbb_size == 22);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferSlideToOffset(sb, 10);
+    StreamingBufferSlideToOffset(sb, &cfg, 10);
     FAIL_IF(!StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg3));

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2016 Open Information Security Foundation
+/* Copyright (C) 2015-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -21,6 +21,11 @@
 #include "util-print.h"
 #include "util-validate.h"
 #include "util-debug.h"
+
+static void ListRegions(StreamingBuffer *sb);
+#define REGION_MAX_GAP 250000
+
+#define DUMP_REGIONS 0 // set to 1 to dump a visual representation of the regions list and sbb tree.
 
 /**
  * \file
@@ -45,8 +50,7 @@ RB_GENERATE(SBB, StreamingBufferBlock, rb, SBBCompare);
 
 int SBBCompare(struct StreamingBufferBlock *a, struct StreamingBufferBlock *b)
 {
-    SCLogDebug("a %"PRIu64" len %u, b %"PRIu64" len %u",
-            a->offset, a->len, b->offset, b->len);
+    SCLogDebug("a %" PRIu64 " len %u, b %" PRIu64 " len %u", a->offset, a->len, b->offset, b->len);
 
     if (a->offset > b->offset)
         SCReturnInt(1);
@@ -77,12 +81,12 @@ static inline int InclusiveCompare(StreamingBufferBlock *lookup, StreamingBuffer
 
 StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlock *elm)
 {
-    SCLogDebug("looking up %"PRIu64, elm->offset);
+    SCLogDebug("looking up %" PRIu64, elm->offset);
 
     struct StreamingBufferBlock *tmp = RB_ROOT(head);
     struct StreamingBufferBlock *res = NULL;
     while (tmp) {
-        SCLogDebug("compare with %"PRIu64"/%u", tmp->offset, tmp->len);
+        SCLogDebug("compare with %" PRIu64 "/%u", tmp->offset, tmp->len);
         const int comp = InclusiveCompare(elm, tmp);
         SCLogDebug("compare result: %d", comp);
         if (comp < 0) {
@@ -97,14 +101,32 @@ StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlo
     return res;
 }
 
+static inline StreamingBufferRegion *InitBufferRegion(StreamingBuffer *sb, const uint32_t min_size)
+{
+    StreamingBufferRegion *aux_r = CALLOC(sb->cfg, 1, sizeof(*aux_r));
+    if (aux_r == NULL)
+        return NULL;
+
+    aux_r->buf = CALLOC(sb->cfg, 1, MAX(sb->cfg->buf_size, min_size));
+    if (aux_r->buf == NULL) {
+        FREE(sb->cfg, aux_r, sizeof(*aux_r));
+        return NULL;
+    }
+    aux_r->buf_size = MAX(sb->cfg->buf_size, min_size);
+    sb->regions++;
+    sb->max_regions = MAX(sb->regions, sb->max_regions);
+
+    BUG_ON(sb->regions > 100);
+    return aux_r;
+}
 
 static inline int InitBuffer(StreamingBuffer *sb)
 {
-    sb->buf = CALLOC(sb->cfg, 1, sb->cfg->buf_size);
-    if (sb->buf == NULL) {
+    sb->region.buf = CALLOC(sb->cfg, 1, sb->cfg->buf_size);
+    if (sb->region.buf == NULL) {
         return -1;
     }
-    sb->buf_size = sb->cfg->buf_size;
+    sb->region.buf_size = sb->cfg->buf_size;
     return 0;
 }
 
@@ -112,8 +134,9 @@ StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg)
 {
     StreamingBuffer *sb = CALLOC(cfg, 1, sizeof(StreamingBuffer));
     if (sb != NULL) {
-        sb->buf_size = cfg->buf_size;
+        sb->region.buf_size = cfg->buf_size;
         sb->cfg = cfg;
+        sb->regions = sb->max_regions = 1;
 
         if (cfg->buf_size > 0) {
             if (InitBuffer(sb) == 0) {
@@ -131,13 +154,23 @@ StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg)
 void StreamingBufferClear(StreamingBuffer *sb)
 {
     if (sb != NULL) {
-        SCLogDebug("sb->buf_size %u max %u", sb->buf_size, sb->buf_size_max);
+        SCLogDebug("sb->region.buf_size %u max %u", sb->region.buf_size, sb->buf_size_max);
 
         SBBFree(sb);
-        if (sb->buf != NULL) {
-            FREE(sb->cfg, sb->buf, sb->buf_size);
-            sb->buf = NULL;
+        ListRegions(sb);
+        if (sb->region.buf != NULL) {
+            FREE(sb->cfg, sb->region.buf, sb->region.buf_size);
+            sb->region.buf = NULL;
         }
+
+        for (StreamingBufferRegion *r = sb->region.next; r != NULL;) {
+            StreamingBufferRegion *next = r->next;
+            FREE(sb->cfg, r->buf, r->buf_size);
+            FREE(sb->cfg, r, sizeof(*r));
+            r = next;
+        }
+        sb->region.next = NULL;
+        sb->regions = sb->max_regions = 1;
     }
 }
 
@@ -154,11 +187,11 @@ static void SBBPrintList(StreamingBuffer *sb)
 {
     StreamingBufferBlock *sbb = NULL;
     RB_FOREACH(sbb, SBB, &sb->sbb_tree) {
-        SCLogDebug("sbb: offset %"PRIu64", len %u", sbb->offset, sbb->len);
+        SCLogDebug("sbb: offset %" PRIu64 ", len %u", sbb->offset, sbb->len);
         StreamingBufferBlock *next = SBB_RB_NEXT(sbb);
         if (next) {
             if ((sbb->offset + sbb->len) != next->offset) {
-                SCLogDebug("gap: offset %"PRIu64", len %"PRIu64, (sbb->offset + sbb->len),
+                SCLogDebug("gap: offset %" PRIu64 ", len %" PRIu64, (sbb->offset + sbb->len),
                         next->offset - (sbb->offset + sbb->len));
             }
         }
@@ -170,26 +203,26 @@ static void SBBPrintList(StreamingBuffer *sb)
  *
  * [block][gap][block]
  **/
-static void SBBInit(StreamingBuffer *sb,
-                    uint32_t rel_offset, uint32_t data_len)
+static void SBBInit(
+        StreamingBuffer *sb, StreamingBufferRegion *region, uint32_t rel_offset, uint32_t data_len)
 {
     DEBUG_VALIDATE_BUG_ON(!RB_EMPTY(&sb->sbb_tree));
-    DEBUG_VALIDATE_BUG_ON(sb->buf_offset > sb->stream_offset + rel_offset);
+    DEBUG_VALIDATE_BUG_ON(region->buf_offset > region->stream_offset + rel_offset);
 
     /* need to set up 2: existing data block and new data block */
     StreamingBufferBlock *sbb = CALLOC(sb->cfg, 1, sizeof(*sbb));
     if (sbb == NULL) {
         return;
     }
-    sbb->offset = sb->stream_offset;
-    sbb->len = sb->buf_offset;
+    sbb->offset = sb->region.stream_offset;
+    sbb->len = sb->region.buf_offset;
 
     StreamingBufferBlock *sbb2 = CALLOC(sb->cfg, 1, sizeof(*sbb2));
     if (sbb2 == NULL) {
         FREE(sb->cfg, sbb, sizeof(*sbb));
         return;
     }
-    sbb2->offset = sb->stream_offset + rel_offset;
+    sbb2->offset = region->stream_offset + rel_offset;
     sbb2->len = data_len;
 
     sb->head = sbb;
@@ -197,8 +230,8 @@ static void SBBInit(StreamingBuffer *sb,
     SBB_RB_INSERT(&sb->sbb_tree, sbb);
     SBB_RB_INSERT(&sb->sbb_tree, sbb2);
 
-    SCLogDebug("sbb1 %"PRIu64", len %u, sbb2 %"PRIu64", len %u",
-            sbb->offset, sbb->len, sbb2->offset, sbb2->len);
+    SCLogDebug("sbb1 %" PRIu64 ", len %u, sbb2 %" PRIu64 ", len %u", sbb->offset, sbb->len,
+            sbb2->offset, sbb2->len);
 #ifdef DEBUG
     SBBPrintList(sb);
 #endif
@@ -209,8 +242,8 @@ static void SBBInit(StreamingBuffer *sb,
  *
  * [gap][block]
  **/
-static void SBBInitLeadingGap(StreamingBuffer *sb,
-                              uint64_t offset, uint32_t data_len)
+static void SBBInitLeadingGap(
+        StreamingBuffer *sb, StreamingBufferRegion *region, uint64_t offset, uint32_t data_len)
 {
     DEBUG_VALIDATE_BUG_ON(!RB_EMPTY(&sb->sbb_tree));
 
@@ -224,14 +257,13 @@ static void SBBInitLeadingGap(StreamingBuffer *sb,
     sb->sbb_size = sbb->len;
     SBB_RB_INSERT(&sb->sbb_tree, sbb);
 
-    SCLogDebug("sbb %"PRIu64", len %u",
-            sbb->offset, sbb->len);
+    SCLogDebug("sbb %" PRIu64 ", len %u", sbb->offset, sbb->len);
 #ifdef DEBUG
     SBBPrintList(sb);
 #endif
 }
 
-static inline void ConsolidateFwd(StreamingBuffer *sb,
+static inline void ConsolidateFwd(StreamingBuffer *sb, StreamingBufferRegion *region,
         struct SBB *tree, StreamingBufferBlock *sa)
 {
     uint64_t sa_re = sa->offset + sa->len;
@@ -241,13 +273,14 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
             continue;
 
         const uint64_t tr_re = tr->offset + tr->len;
-        SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u re %"PRIu64,
-                tr, tr->offset, tr->len, tr_re);
+        SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u re %" PRIu64, tr, tr->offset, tr->len, tr_re);
 
-        if (sa_re < tr->offset)
+        if (sa_re < tr->offset) {
+            SCLogDebug("entirely before: %" PRIu64 " < %" PRIu64, sa_re, tr->offset);
             break; // entirely before
+        }
 
-        /*
+        /* new block (sa) entirely eclipsed by in tree block (tr)
             sa:     [   ]
             tr: [           ]
             sa:     [   ]
@@ -260,28 +293,43 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
             sa->len = tr->len;
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
-            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED2", tr, tr->offset, tr->len);
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u REMOVED ECLIPSED (sa overlapped by tr)", tr,
+                    tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
-        /*
-            sa: [         ]
-            tr: [         ]
-            sa: [         ]
-            tr:    [      ]
-            sa: [         ]
-            tr:    [   ]
-        */
+            /* new block (sa) entire eclipses in tree block (tr)
+                sa: [         ]
+                tr: [         ]
+                sa: [         ]
+                tr:    [      ]
+                sa: [         ]
+                tr:    [   ]
+            */
         } else if (sa->offset <= tr->offset && sa_re >= tr_re) {
-            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED", tr, tr->offset, tr->len);
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u REMOVED ECLIPSED (tr overlapped by sa)", tr,
+                    tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
             sb->sbb_size -= tr->len;
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
-        /*
-            sa: [         ]
-            tr:      [         ]
-            sa: [       ]
-            tr:         [       ]
-        */
+
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64 " bo %u sz %u", sa,
+                    sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                    region->buf_size);
+            if (sa->offset == region->stream_offset &&
+                    sa_re > (region->stream_offset + region->buf_offset)) {
+                BUG_ON(sa_re < region->stream_offset);
+                region->buf_offset = sa_re - region->stream_offset;
+                SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
+                           " bo %u sz %u BUF_OFFSET UPDATED",
+                        sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                        region->buf_size);
+            }
+            /* new block (sa) extended by in tree block (tr)
+                sa: [         ]
+                tr:      [         ]
+                sa: [       ]
+                tr:         [       ]
+            */
         } else if (sa->offset < tr->offset && // starts before
                    sa_re >= tr->offset && sa_re < tr_re) // ends inside
         {
@@ -289,15 +337,28 @@ static inline void ConsolidateFwd(StreamingBuffer *sb,
             uint32_t combined_len = sa->len + tr->len;
             sa->len = tr_re - sa->offset;
             sa_re = sa->offset + sa->len;
-            SCLogDebug("-> (fwd) tr %p %"PRIu64"/%u REMOVED MERGED", tr, tr->offset, tr->len);
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u REMOVED MERGED", tr, tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
             sb->sbb_size -= (combined_len - sa->len); // remove what we added twice
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u RESULT", sa, sa->offset, sa->len);
+            SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64 " bo %u sz %u", sa,
+                    sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                    region->buf_size);
+            if (sa->offset == region->stream_offset &&
+                    sa_re > (region->stream_offset + region->buf_offset)) {
+                BUG_ON(sa_re < region->stream_offset);
+                region->buf_offset = sa_re - region->stream_offset;
+                SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
+                           " bo %u sz %u BUF_OFFSET UPDATED",
+                        sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                        region->buf_size);
+            }
         }
     }
 }
 
-static inline void ConsolidateBackward(StreamingBuffer *sb,
+static inline void ConsolidateBackward(StreamingBuffer *sb, StreamingBufferRegion *region,
         struct SBB *tree, StreamingBufferBlock *sa)
 {
     uint64_t sa_re = sa->offset + sa->len;
@@ -306,22 +367,12 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
         if (sa == tr)
             continue;
         const uint64_t tr_re = tr->offset + tr->len;
-        SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u", tr, tr->offset, tr->len);
+        SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u", tr, tr->offset, tr->len);
 
         if (sa->offset > tr_re)
             break; // entirely after
 
-        if (sa->offset >= tr->offset && sa_re <= tr_re) {
-            sb->sbb_size -= sa->len; // sa entirely eclipsed so remove double accounting
-            sa->len = tr->len;
-            sa->offset = tr->offset;
-            sa_re = sa->offset + sa->len;
-            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED2", tr, tr->offset, tr->len);
-            if (sb->head == tr)
-                sb->head = sa;
-            SBB_RB_REMOVE(tree, tr);
-            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
-        /*
+        /* new block (sa) entirely eclipsed by in tree block (tr)
             sa: [         ]
             tr: [         ]
             sa:    [      ]
@@ -329,69 +380,123 @@ static inline void ConsolidateBackward(StreamingBuffer *sb,
             sa:    [   ]
             tr: [         ]
         */
+        if (sa->offset >= tr->offset && sa_re <= tr_re) {
+            sb->sbb_size -= sa->len; // sa entirely eclipsed so remove double accounting
+            sa->len = tr->len;
+            sa->offset = tr->offset;
+            sa_re = sa->offset + sa->len;
+            SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u REMOVED ECLIPSED (sa overlapped by tr)", tr,
+                    tr->offset, tr->len);
+            if (sb->head == tr)
+                sb->head = sa;
+            SBB_RB_REMOVE(tree, tr);
+            FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+            /* new block (sa) entire eclipses in tree block (tr)
+                sa: [         ]
+                tr:    [      ]
+                sa: [         ]
+                tr: [      ]
+                sa: [         ]
+                tr:    [    ]
+            */
         } else if (sa->offset <= tr->offset && sa_re >= tr_re) {
-            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED ECLIPSED", tr, tr->offset, tr->len);
+            SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u REMOVED ECLIPSED (tr overlapped by sa)", tr,
+                    tr->offset, tr->len);
             if (sb->head == tr)
                 sb->head = sa;
             SBB_RB_REMOVE(tree, tr);
             sb->sbb_size -= tr->len; // tr entirely eclipsed so remove double accounting
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
-        /*
-            sa:     [   ]
-            tr: [   ]
-            sa:    [    ]
-            tr: [   ]
-        */
+
+            SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64 " bo %u sz %u", sa,
+                    sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                    region->buf_size);
+
+            if (sa->offset == region->stream_offset &&
+                    sa_re > (region->stream_offset + region->buf_offset)) {
+                BUG_ON(sa_re < region->stream_offset);
+                region->buf_offset = sa_re - region->stream_offset;
+                SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
+                           " bo %u sz %u BUF_OFFSET UPDATED",
+                        sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                        region->buf_size);
+            }
+
+            /* new block (sa) extends in tree block (tr)
+                sa:     [   ]
+                tr: [   ]
+                sa:    [    ]
+                tr: [   ]
+            */
         } else if (sa->offset > tr->offset && sa_re > tr_re && sa->offset <= tr_re) {
             // merge. sb->sbb_size includes both so we need to adjust that too.
             uint32_t combined_len = sa->len + tr->len;
             sa->len = sa_re - tr->offset;
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
-            SCLogDebug("-> (bwd) tr %p %"PRIu64"/%u REMOVED MERGED", tr, tr->offset, tr->len);
+            SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u REMOVED MERGED", tr, tr->offset, tr->len);
             if (sb->head == tr)
                 sb->head = sa;
             SBB_RB_REMOVE(tree, tr);
             sb->sbb_size -= (combined_len - sa->len); // remove what we added twice
             FREE(sb->cfg, tr, sizeof(StreamingBufferBlock));
+
+            SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64 " bo %u sz %u", sa,
+                    sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                    region->buf_size);
+            if (sa->offset == region->stream_offset &&
+                    sa_re > (region->stream_offset + region->buf_offset)) {
+                BUG_ON(sa_re < region->stream_offset);
+                region->buf_offset = sa_re - region->stream_offset;
+                SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
+                           " bo %u sz %u BUF_OFFSET UPDATED",
+                        sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
+                        region->buf_size);
+            }
         }
     }
 }
 
-static int Insert(StreamingBuffer *sb, struct SBB *tree,
-        uint32_t rel_offset, uint32_t len)
+/** \internal
+ *  \param region the region that holds the new data
+ */
+static int SBBUpdate(
+        StreamingBuffer *sb, StreamingBufferRegion *region, uint32_t rel_offset, uint32_t len)
 {
+    struct SBB *tree = &sb->sbb_tree;
     SCLogDebug("* inserting: %u/%u", rel_offset, len);
 
     StreamingBufferBlock *sbb = CALLOC(sb->cfg, 1, sizeof(*sbb));
     if (sbb == NULL)
         return -1;
-    sbb->offset = sb->stream_offset + rel_offset;
+    sbb->offset = region->stream_offset + rel_offset;
     sbb->len = len;
+
     StreamingBufferBlock *res = SBB_RB_INSERT(tree, sbb);
     if (res) {
         // exact overlap
-        SCLogDebug("* insert failed: exact match in tree with %p %"PRIu64"/%u", res, res->offset, res->len);
+        SCLogDebug("* insert failed: exact match in tree with %p %" PRIu64 "/%u", res, res->offset,
+                res->len);
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
         return 0;
     }
     sb->sbb_size += len; // may adjust based on consolidation below
+
+    /* handle backwards and forwards overlaps */
     if (SBB_RB_PREV(sbb) == NULL) {
         sb->head = sbb;
     } else {
-        ConsolidateBackward(sb, tree, sbb);
+        ConsolidateBackward(sb, region, tree, sbb);
     }
-    ConsolidateFwd(sb, tree, sbb);
+    ConsolidateFwd(sb, region, tree, sbb);
 #ifdef DEBUG
     SBBPrintList(sb);
 #endif
+    if (sbb->offset == sb->region.stream_offset) {
+        SCLogDebug("insert at head");
+        sb->region.buf_offset = sbb->len;
+    }
     return 0;
-}
-
-static void SBBUpdate(StreamingBuffer *sb,
-                      uint32_t rel_offset, uint32_t data_len)
-{
-    Insert(sb, &sb->sbb_tree, rel_offset, data_len);
 }
 
 static void SBBFree(StreamingBuffer *sb)
@@ -407,27 +512,41 @@ static void SBBFree(StreamingBuffer *sb)
 
 static void SBBPrune(StreamingBuffer *sb)
 {
-    SCLogDebug("pruning %p to %"PRIu64, sb, sb->stream_offset);
+    SCLogDebug("pruning %p to %" PRIu64, sb, sb->region.stream_offset);
     StreamingBufferBlock *sbb = NULL, *safe = NULL;
     RB_FOREACH_SAFE(sbb, SBB, &sb->sbb_tree, safe) {
         /* completely beyond window, we're done */
-        if (sbb->offset >= sb->stream_offset) {
+        if (sbb->offset >= sb->region.stream_offset) {
             sb->head = sbb;
+            if (sbb->offset == sb->region.stream_offset) {
+                SCLogDebug("set buf_offset?");
+                if (sbb->offset == sb->region.stream_offset) {
+                    SCLogDebug("set buf_offset to first sbb len %u", sbb->len);
+                    BUG_ON(sbb->len > sb->region.buf_size);
+                    sb->region.buf_offset = sbb->len;
+                }
+            }
             break;
         }
 
         /* partly before, partly beyond. Adjust */
-        if (sbb->offset < sb->stream_offset &&
-            sbb->offset + sbb->len > sb->stream_offset) {
-            uint32_t shrink_by = sb->stream_offset - sbb->offset;
+        if (sbb->offset < sb->region.stream_offset &&
+                sbb->offset + sbb->len > sb->region.stream_offset) {
+            uint32_t shrink_by = sb->region.stream_offset - sbb->offset;
             DEBUG_VALIDATE_BUG_ON(shrink_by > sbb->len);
             if (sbb->len >= shrink_by) {
                 sbb->len -=  shrink_by;
                 sbb->offset += shrink_by;
                 sb->sbb_size -= shrink_by;
-                DEBUG_VALIDATE_BUG_ON(sbb->offset != sb->stream_offset);
+                SCLogDebug("shrunk by %u", shrink_by);
+                DEBUG_VALIDATE_BUG_ON(sbb->offset != sb->region.stream_offset);
             }
             sb->head = sbb;
+            if (sbb->offset == sb->region.stream_offset) {
+                SCLogDebug("set buf_offset to first sbb len %u", sbb->len);
+                BUG_ON(sbb->len > sb->region.buf_size);
+                sb->region.buf_offset = sbb->len;
+            }
             break;
         }
 
@@ -435,21 +554,24 @@ static void SBBPrune(StreamingBuffer *sb)
         /* either we set it again for the next sbb, or there isn't any */
         sb->head = NULL;
         sb->sbb_size -= sbb->len;
-        SCLogDebug("sb %p removed %p %"PRIu64", %u", sb, sbb, sbb->offset, sbb->len);
+        SCLogDebug("sb %p removed %p %" PRIu64 ", %u", sb, sbb, sbb->offset, sbb->len);
         FREE(sb->cfg, sbb, sizeof(StreamingBufferBlock));
     }
+#ifdef DEBUG
+    SBBPrintList(sb);
+#endif
 }
 
 static thread_local bool g2s_warn_once = false;
 
-static int WARN_UNUSED
-GrowToSize(StreamingBuffer *sb, uint32_t size)
+static inline int WARN_UNUSED GrowRegionToSize(
+        StreamingBuffer *sb, StreamingBufferRegion *region, const uint32_t size)
 {
-    DEBUG_VALIDATE_BUG_ON(sb->buf_size > BIT_U32(30));
+    DEBUG_VALIDATE_BUG_ON(region->buf_size > BIT_U32(30));
     if (size > BIT_U32(30)) { // 1GiB
         if (!g2s_warn_once) {
-            SCLogWarning(
-                    "StreamingBuffer::GrowToSize() tried to alloc %u bytes, exceeds limit of %lu",
+            SCLogWarning("StreamingBuffer::GrowRegionToSize() tried to alloc %u bytes, exceeds "
+                         "limit of %lu",
                     size, BIT_U32(30));
             g2s_warn_once = true;
         }
@@ -461,25 +583,30 @@ GrowToSize(StreamingBuffer *sb, uint32_t size)
     uint32_t base = size - x;
     uint32_t grow = base + sb->cfg->buf_size;
 
-    void *ptr = REALLOC(sb->cfg, sb->buf, sb->buf_size, grow);
-    if (ptr == NULL)
+    void *ptr = REALLOC(sb->cfg, region->buf, region->buf_size, grow);
+    if (ptr == NULL) {
         return -1;
-
+    }
     /* for safe printing and general caution, lets memset the
      * new data to 0 */
-    size_t diff = grow - sb->buf_size;
-    void *new_mem = ((char *)ptr) + sb->buf_size;
+    size_t diff = grow - region->buf_size;
+    void *new_mem = ((char *)ptr) + region->buf_size;
     memset(new_mem, 0, diff);
 
-    sb->buf = ptr;
-    sb->buf_size = grow;
+    region->buf = ptr;
+    region->buf_size = grow;
     SCLogDebug("grown buffer to %u", grow);
 #ifdef DEBUG
-    if (sb->buf_size > sb->buf_size_max) {
-        sb->buf_size_max = sb->buf_size;
+    if (region->buf_size > sb->buf_size_max) {
+        sb->buf_size_max = region->buf_size;
     }
 #endif
     return 0;
+}
+
+static int WARN_UNUSED GrowToSize(StreamingBuffer *sb, uint32_t size)
+{
+    return GrowRegionToSize(sb, &sb->region, size);
 }
 
 static thread_local bool grow_warn_once = false;
@@ -491,8 +618,8 @@ static thread_local bool grow_warn_once = false;
  */
 static int WARN_UNUSED Grow(StreamingBuffer *sb)
 {
-    DEBUG_VALIDATE_BUG_ON(sb->buf_size > BIT_U32(30));
-    uint32_t grow = sb->buf_size * 2;
+    DEBUG_VALIDATE_BUG_ON(sb->region.buf_size > BIT_U32(30));
+    uint32_t grow = sb->region.buf_size * 2;
     if (grow > BIT_U32(30)) { // 1GiB
         if (!grow_warn_once) {
             SCLogWarning("StreamingBuffer::Grow() tried to alloc %u bytes, exceeds limit of %lu",
@@ -502,25 +629,169 @@ static int WARN_UNUSED Grow(StreamingBuffer *sb)
         return -1;
     }
 
-    void *ptr = REALLOC(sb->cfg, sb->buf, sb->buf_size, grow);
+    void *ptr = REALLOC(sb->cfg, sb->region.buf, sb->region.buf_size, grow);
     if (ptr == NULL)
         return -1;
 
     /* for safe printing and general caution, lets memset the
      * new data to 0 */
-    size_t diff = grow - sb->buf_size;
-    void *new_mem = ((char *)ptr) + sb->buf_size;
+    size_t diff = grow - sb->region.buf_size;
+    void *new_mem = ((char *)ptr) + sb->region.buf_size;
     memset(new_mem, 0, diff);
 
-    sb->buf = ptr;
-    sb->buf_size = grow;
+    sb->region.buf = ptr;
+    sb->region.buf_size = grow;
     SCLogDebug("grown buffer to %u", grow);
 #ifdef DEBUG
-    if (sb->buf_size > sb->buf_size_max) {
-        sb->buf_size_max = sb->buf_size;
+    if (sb->region.buf_size > sb->buf_size_max) {
+        sb->buf_size_max = sb->region.buf_size;
     }
 #endif
     return 0;
+}
+
+static inline bool RegionBeforeOffset(const StreamingBufferRegion *r, const uint64_t o)
+{
+    return (r->stream_offset + r->buf_size <= o);
+}
+
+static inline bool RegionContainsOffset(const StreamingBufferRegion *r, const uint64_t o)
+{
+    return (o >= r->stream_offset && (r->stream_offset + r->buf_size) >= o);
+}
+
+/** \internal
+ *  \brief slide to offset for regions
+ *
+ *
+ *     [ main ] [ gap ] [ aux ] [ gap ] [ aux ]
+ *                 ^
+ *     - main reset to 0
+ *
+ *
+ *     [ main ] [ gap ] [ aux ] [ gap ] [ aux ]
+ *         ^
+ *     - main shift
+ *
+ *     [ main ] [ gap ] [ aux ] [ gap ] [ aux ]
+ *                          ^
+ *     - main reset
+ *     - move aux into main
+ *     - free aux
+ *     - shift
+ *
+ *     [ main ] [ gap ] [ aux ] [ gap ] [ aux ]
+ *                      ^
+ *     - main reset
+ *     - move aux into main
+ *     - free aux
+ *     - no shift
+ */
+static inline void StreamingBufferSlideToOffsetWithRegions(
+        StreamingBuffer *sb, const uint64_t slide_offset)
+{
+    ListRegions(sb);
+    BUG_ON(slide_offset == sb->region.stream_offset);
+
+    SCLogDebug("slide_offset %" PRIu64, slide_offset);
+    SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", sb->region.stream_offset,
+            sb->region.buf, sb->region.buf_size, sb->region.buf_offset);
+
+    StreamingBufferRegion *to_shift = NULL;
+    const bool main_is_oow = RegionBeforeOffset(&sb->region, slide_offset);
+    if (main_is_oow) {
+        SCLogDebug("main_is_oow");
+        if (sb->region.buf != NULL) {
+            SCLogDebug("clearing main");
+            FREE(sb->cfg, sb->region.buf, sb->region.buf_size);
+            sb->region.buf = NULL;
+            sb->region.buf_size = 0;
+            sb->region.buf_offset = 0;
+            sb->region.stream_offset = slide_offset;
+        } else {
+            sb->region.stream_offset = slide_offset;
+        }
+
+        /* remove regions that are out of window & select the region to
+         * become the new main */
+        StreamingBufferRegion *prev = &sb->region;
+        for (StreamingBufferRegion *r = sb->region.next; r != NULL;) {
+            SCLogDebug("r %p so %" PRIu64 ", re %" PRIu64, r, r->stream_offset,
+                    r->stream_offset + r->buf_offset);
+            StreamingBufferRegion *next = r->next;
+            if (RegionBeforeOffset(r, slide_offset)) {
+                SCLogDebug("r %p so %" PRIu64 ", re %" PRIu64 " -> before", r, r->stream_offset,
+                        r->stream_offset + r->buf_offset);
+                BUG_ON(r == &sb->region);
+                prev->next = next;
+
+                FREE(sb->cfg, r->buf, r->buf_size);
+                FREE(sb->cfg, r, sizeof(*r));
+                sb->regions--;
+                BUG_ON(sb->regions == 0);
+            } else if (RegionContainsOffset(r, slide_offset)) {
+                SCLogDebug("r %p so %" PRIu64 ", re %" PRIu64 " -> within", r, r->stream_offset,
+                        r->stream_offset + r->buf_offset);
+                /* remove from list, we will xfer contents to main below */
+                prev->next = next;
+                to_shift = r;
+                break;
+            } else {
+                SCLogDebug("r %p so %" PRIu64 ", re %" PRIu64 " -> post", r, r->stream_offset,
+                        r->stream_offset + r->buf_offset);
+                /* implied beyond slide offset */
+                BUG_ON(r->stream_offset < slide_offset);
+                break;
+            }
+            r = next;
+        }
+        SCLogDebug("to_shift %p", to_shift);
+    } else {
+        to_shift = &sb->region;
+        SCLogDebug("shift start region %p", to_shift);
+    }
+
+    // this region is main, or will xfer its buffer to main
+    if (to_shift) {
+        SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", to_shift->stream_offset,
+                to_shift->buf, to_shift->buf_size, to_shift->buf_offset);
+        if (to_shift != &sb->region) {
+            BUG_ON(sb->region.buf != NULL);
+
+            sb->region.buf = to_shift->buf;
+            sb->region.stream_offset = to_shift->stream_offset;
+            sb->region.buf_offset = to_shift->buf_offset;
+            sb->region.buf_size = to_shift->buf_size;
+            sb->region.next = to_shift->next;
+
+            FREE(sb->cfg, to_shift, sizeof(*to_shift));
+            to_shift = &sb->region;
+            sb->regions--;
+            BUG_ON(sb->regions == 0);
+        }
+
+        // Do the shift. If new region is exactly at the slide offset we can skip this.
+        BUG_ON(to_shift->stream_offset > slide_offset);
+        const uint32_t s = slide_offset - to_shift->stream_offset;
+        if (s > 0) {
+            const uint32_t new_size = to_shift->buf_size - s;
+            SCLogDebug("s %u new_size %u", s, new_size);
+            memmove(to_shift->buf, to_shift->buf + s, new_size);
+            void *ptr = REALLOC(sb->cfg, to_shift->buf, to_shift->buf_size, new_size);
+            BUG_ON(ptr == NULL); // TODO
+            to_shift->buf = ptr;
+            to_shift->buf_size = new_size;
+            if (s < to_shift->buf_offset)
+                to_shift->buf_offset -= s;
+            else
+                to_shift->buf_offset = 0;
+            to_shift->stream_offset = slide_offset;
+        }
+    }
+
+    SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", sb->region.stream_offset,
+            sb->region.buf, sb->region.buf_size, sb->region.buf_offset);
+    SCLogDebug("end of slide");
 }
 
 /**
@@ -529,41 +800,92 @@ static int WARN_UNUSED Grow(StreamingBuffer *sb)
  */
 void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset)
 {
-    if (offset > sb->stream_offset &&
-        offset <= sb->stream_offset + sb->buf_offset)
-    {
-        uint32_t slide = offset - sb->stream_offset;
-        uint32_t size = sb->buf_offset - slide;
-        SCLogDebug("sliding %u forward, size of original buffer left after slide %u", slide, size);
-        memmove(sb->buf, sb->buf+slide, size);
-        sb->stream_offset += slide;
-        sb->buf_offset = size;
+    SCLogDebug("sliding to offset %" PRIu64, offset);
+    ListRegions(sb);
+#ifdef DEBUG
+    SBBPrintList(sb);
+#endif
+
+    if (sb->region.next) {
+        StreamingBufferSlideToOffsetWithRegions(sb, offset);
+        SBBPrune(sb);
+        SCLogDebug("post SBBPrune");
+        ListRegions(sb);
+#ifdef DEBUG
+        SBBPrintList(sb);
+#endif
+        BUG_ON(sb->region.buf != NULL && sb->region.buf_size == 0);
+        BUG_ON(sb->region.buf_offset > sb->region.buf_size);
+        BUG_ON(offset > sb->region.stream_offset);
+        BUG_ON(sb->head && sb->head->offset == sb->region.stream_offset &&
+                sb->head->len > sb->region.buf_offset);
+        BUG_ON(sb->region.stream_offset < offset);
+        return;
+    }
+
+    if (offset > sb->region.stream_offset) {
+        const uint32_t slide = offset - sb->region.stream_offset;
+        if (sb->head != NULL) {
+            /* have sbb's, so can't rely on buf_offset for the slide */
+            if (slide < sb->region.buf_size) {
+                const uint32_t size = sb->region.buf_size - slide;
+                SCLogDebug("sliding %u forward, size of original buffer left after slide %u", slide,
+                        size);
+                memmove(sb->region.buf, sb->region.buf + slide, size);
+                if (sb->region.buf_offset > slide) {
+                    sb->region.buf_offset -= slide;
+                } else {
+                    sb->region.buf_offset = 0;
+                }
+            } else {
+                sb->region.buf_offset = 0;
+            }
+            sb->region.stream_offset = offset;
+        } else {
+            /* no sbb's, so we can use buf_offset */
+            if (offset <= sb->region.stream_offset + sb->region.buf_offset) {
+                const uint32_t size = sb->region.buf_offset - slide;
+                SCLogDebug("sliding %u forward, size of original buffer left after slide %u", slide,
+                        size);
+                memmove(sb->region.buf, sb->region.buf + slide, size);
+                sb->region.stream_offset = offset;
+                sb->region.buf_offset = size;
+            } else {
+                /* moved past all data */
+                sb->region.stream_offset = offset;
+                sb->region.buf_offset = 0;
+            }
+        }
         SBBPrune(sb);
     }
+#ifdef DEBUG
+    SBBPrintList(sb);
+#endif
+    BUG_ON(sb->region.stream_offset < offset);
 }
 
 void StreamingBufferSlide(StreamingBuffer *sb, uint32_t slide)
 {
-    uint32_t size = sb->buf_offset - slide;
+    SCLogDebug("slide with %" PRIu32, slide);
+    uint32_t size = sb->region.buf_offset - slide;
     SCLogDebug("sliding %u forward, size of original buffer left after slide %u", slide, size);
-    memmove(sb->buf, sb->buf+slide, size);
-    sb->stream_offset += slide;
-    sb->buf_offset = size;
+    memmove(sb->region.buf, sb->region.buf + slide, size);
+    sb->region.stream_offset += slide;
+    sb->region.buf_offset = size;
     SBBPrune(sb);
 }
 
-#define DATA_FITS(sb, len) \
-    ((sb)->buf_offset + (len) <= (sb)->buf_size)
+#define DATA_FITS(sb, len) ((sb)->region.buf_offset + (len) <= (sb)->region.buf_size)
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint8_t *data, uint32_t data_len)
 {
-    if (sb->buf == NULL) {
+    if (sb->region.buf == NULL) {
         if (InitBuffer(sb) == -1)
             return NULL;
     }
 
     if (!DATA_FITS(sb, data_len)) {
-        if (sb->buf_size == 0) {
+        if (sb->region.buf_size == 0) {
             if (GrowToSize(sb, data_len) != 0)
                 return NULL;
         } else {
@@ -578,14 +900,14 @@ StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint
 
     StreamingBufferSegment *seg = CALLOC(sb->cfg, 1, sizeof(StreamingBufferSegment));
     if (seg != NULL) {
-        memcpy(sb->buf + sb->buf_offset, data, data_len);
-        seg->stream_offset = sb->stream_offset + sb->buf_offset;
+        memcpy(sb->region.buf + sb->region.buf_offset, data, data_len);
+        seg->stream_offset = sb->region.stream_offset + sb->region.buf_offset;
         seg->segment_len = data_len;
-        uint32_t rel_offset = sb->buf_offset;
-        sb->buf_offset += data_len;
+        uint32_t rel_offset = sb->region.buf_offset;
+        sb->region.buf_offset += data_len;
 
         if (!RB_EMPTY(&sb->sbb_tree)) {
-            SBBUpdate(sb, rel_offset, data_len);
+            SBBUpdate(sb, &sb->region, rel_offset, data_len);
         }
         return seg;
     }
@@ -597,13 +919,13 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
 {
     BUG_ON(seg == NULL);
 
-    if (sb->buf == NULL) {
+    if (sb->region.buf == NULL) {
         if (InitBuffer(sb) == -1)
             return -1;
     }
 
     if (!DATA_FITS(sb, data_len)) {
-        if (sb->buf_size == 0) {
+        if (sb->region.buf_size == 0) {
             if (GrowToSize(sb, data_len) != 0)
                 return -1;
         } else {
@@ -616,14 +938,14 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
     }
     DEBUG_VALIDATE_BUG_ON(!DATA_FITS(sb, data_len));
 
-    memcpy(sb->buf + sb->buf_offset, data, data_len);
-    seg->stream_offset = sb->stream_offset + sb->buf_offset;
+    memcpy(sb->region.buf + sb->region.buf_offset, data, data_len);
+    seg->stream_offset = sb->region.stream_offset + sb->region.buf_offset;
     seg->segment_len = data_len;
-    uint32_t rel_offset = sb->buf_offset;
-    sb->buf_offset += data_len;
+    uint32_t rel_offset = sb->region.buf_offset;
+    sb->region.buf_offset += data_len;
 
     if (!RB_EMPTY(&sb->sbb_tree)) {
-        SBBUpdate(sb, rel_offset, data_len);
+        SBBUpdate(sb, &sb->region, rel_offset, data_len);
     }
     return 0;
 }
@@ -634,13 +956,13 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
 int StreamingBufferAppendNoTrack(StreamingBuffer *sb,
                                  const uint8_t *data, uint32_t data_len)
 {
-    if (sb->buf == NULL) {
+    if (sb->region.buf == NULL) {
         if (InitBuffer(sb) == -1)
             return -1;
     }
 
     if (!DATA_FITS(sb, data_len)) {
-        if (sb->buf_size == 0) {
+        if (sb->region.buf_size == 0) {
             if (GrowToSize(sb, data_len) != 0)
                 return -1;
         } else {
@@ -653,18 +975,380 @@ int StreamingBufferAppendNoTrack(StreamingBuffer *sb,
     }
     DEBUG_VALIDATE_BUG_ON(!DATA_FITS(sb, data_len));
 
-    memcpy(sb->buf + sb->buf_offset, data, data_len);
-    uint32_t rel_offset = sb->buf_offset;
-    sb->buf_offset += data_len;
+    memcpy(sb->region.buf + sb->region.buf_offset, data, data_len);
+    uint32_t rel_offset = sb->region.buf_offset;
+    sb->region.buf_offset += data_len;
 
     if (!RB_EMPTY(&sb->sbb_tree)) {
-        SBBUpdate(sb, rel_offset, data_len);
+        SBBUpdate(sb, &sb->region, rel_offset, data_len);
     }
     return 0;
 }
 
-#define DATA_FITS_AT_OFFSET(sb, len, offset) \
-    ((offset) + (len) <= (sb)->buf_size)
+#define DATA_FITS_AT_OFFSET(region, len, offset) ((offset) + (len) <= (region)->buf_size)
+
+#if defined(DEBUG) || defined(DEBUG_VALIDATION)
+static void Validate(const StreamingBuffer *sb)
+{
+    bool bail = false;
+    uint32_t cnt = 0;
+    for (const StreamingBufferRegion *r = &sb->region; r != NULL; r = r->next) {
+        cnt++;
+        if (r->next) {
+            bail |= ((r->stream_offset + r->buf_size) > r->next->stream_offset);
+        }
+
+        bail |= (r->buf != NULL && r->buf_size == 0);
+        bail |= (r->buf_offset > r->buf_size);
+    }
+    // leading gap, so buf_offset should be 0?
+    if (sb->head && sb->head->offset > sb->region.stream_offset) {
+        SCLogDebug("leading gap of size %" PRIu64, sb->head->offset - sb->region.stream_offset);
+        BUG_ON(sb->region.buf_offset != 0);
+    }
+
+    if (sb->head && sb->head->offset == sb->region.stream_offset) {
+        BUG_ON(sb->head->len > sb->region.buf_offset);
+        BUG_ON(sb->head->len < sb->region.buf_offset);
+    }
+    BUG_ON(sb->regions != cnt);
+    BUG_ON(bail);
+}
+#endif
+
+static void ListRegions(StreamingBuffer *sb)
+{
+    if (sb->cfg == NULL)
+        return;
+#ifdef DEBUG
+#if DUMP_REGIONS == 1
+    uint32_t cnt = 0;
+    for (StreamingBufferRegion *r = &sb->region; r != NULL; r = r->next) {
+        cnt++;
+        char gap[64] = "";
+        if (r->next) {
+            snprintf(gap, sizeof(gap), "[ gap:%" PRIu64 " ]",
+                    r->next->stream_offset - (r->stream_offset + r->buf_size));
+        }
+
+        printf("[ %s offset:%" PRIu64 " size:%u offset:%u ]%s", r == &sb->region ? "main" : "aux",
+                r->stream_offset, r->buf_size, r->buf_offset, gap);
+    }
+    printf("(max %u, cnt %u, sb->regions %u)\n", sb->max_regions, cnt, sb->regions);
+    bool at_least_one = false;
+    uint64_t last_re = sb->region.stream_offset;
+    StreamingBufferBlock *sbb = NULL;
+    RB_FOREACH(sbb, SBB, &sb->sbb_tree)
+    {
+        if (last_re != sbb->offset) {
+            printf("[ gap:%" PRIu64 " ]", sbb->offset - last_re);
+        }
+        printf("[ sbb offset:%" PRIu64 " len:%u ]", sbb->offset, sbb->len);
+        at_least_one = true;
+        last_re = sbb->offset + sbb->len;
+    }
+    if (at_least_one)
+        printf("\n");
+#endif
+#endif
+#if defined(DEBUG) || defined(DEBUG_VALIDATION)
+    Validate(sb);
+#endif
+}
+
+/** \interal
+ *  \brief does data region intersect with list region 'r'
+ *  Takes the max gap into account.
+ */
+static inline bool RegionsIntersect(const StreamingBuffer *sb, const StreamingBufferRegion *r,
+        const uint64_t offset, const uint32_t len)
+{
+    const uint64_t re = offset + len;
+
+    /* create the data range for the region, adding the max gap */
+    const uint64_t reg_o =
+            r->stream_offset > REGION_MAX_GAP ? (r->stream_offset - REGION_MAX_GAP) : 0;
+    const uint64_t reg_re = r->stream_offset + r->buf_size + REGION_MAX_GAP;
+    SCLogDebug("r %p: %" PRIu64 "/%" PRIu64 " - adjusted %" PRIu64 "/%" PRIu64, r, r->stream_offset,
+            r->stream_offset + r->buf_size, reg_o, reg_re);
+    /* check if data range intersects with region range */
+    if (offset >= reg_o && offset <= reg_re) {
+        SCLogDebug("r %p is in-scope", r);
+        return true;
+    }
+    if (re >= reg_o && re <= reg_re) {
+        SCLogDebug("r %p is in-scope: %" PRIu64 " >= %" PRIu64 " && %" PRIu64 " <= %" PRIu64, r, re,
+                reg_o, re, reg_re);
+        return true;
+    }
+    SCLogDebug("r %p is out of scope: %" PRIu64 "/%" PRIu64, r, offset, re);
+    return false;
+}
+
+/** \internal
+ *  \brief find the first region for merging.
+ */
+static StreamingBufferRegion *FindFirstRegionForOffset(const StreamingBuffer *sb,
+        StreamingBufferRegion *r, const uint64_t offset, const uint32_t len)
+{
+    const uint64_t data_re = offset + len;
+    SCLogDebug("looking for first region matching %" PRIu64 "/%" PRIu64, offset, data_re);
+
+    for (; r != NULL; r = r->next) {
+        if (RegionsIntersect(sb, r, offset, data_re) == true)
+            return r;
+    }
+    return NULL;
+}
+
+static StreamingBufferRegion *FindLargestRegionForOffset(const StreamingBuffer *sb,
+        StreamingBufferRegion *r, const uint64_t offset, const uint32_t len)
+{
+    const uint64_t data_re = offset + len;
+    SCLogDebug("starting at %p/%" PRIu64 ", offset %" PRIu64 ", data_re %" PRIu64, r,
+            r->stream_offset, offset, data_re);
+    StreamingBufferRegion *candidate = r;
+    for (; r != NULL; r = r->next) {
+#ifdef DEBUG
+        const uint64_t reg_re = r->stream_offset + r->buf_size;
+        SCLogDebug("checking: %p/%" PRIu64 "/%" PRIu64 ", offset %" PRIu64 "/%" PRIu64, r,
+                r->stream_offset, reg_re, offset, data_re);
+#endif
+        if (!RegionsIntersect(sb, r, offset, data_re))
+            return candidate;
+
+        if (candidate == NULL) {
+            candidate = r;
+            SCLogDebug("candidate %p", candidate);
+        } else if (r->buf_size > candidate->buf_size) {
+            SCLogDebug("candidate %p as size %u > %u", candidate, r->buf_size, candidate->buf_size);
+            candidate = r;
+        }
+    }
+    return candidate;
+}
+
+static StreamingBufferRegion *FindRightEdge(const StreamingBuffer *sb, StreamingBufferRegion *r,
+        const uint64_t offset, const uint32_t len)
+{
+    const uint64_t data_re = offset + len;
+    StreamingBufferRegion *candidate = r;
+    for (; r != NULL; r = r->next) {
+        if (!RegionsIntersect(sb, r, offset, data_re)) {
+            SCLogDebug("r %p is out of scope: %" PRIu64 "/%u", r, offset, len);
+            return candidate;
+        }
+        candidate = r;
+    }
+    return candidate;
+}
+
+/** \internal
+ *  \brief process insert by consolidating the affected regions into one
+ */
+static StreamingBufferRegion *BufferInsertAtRegionConsolidate(StreamingBuffer *sb,
+        StreamingBufferRegion *dst, StreamingBufferRegion *src_start,
+        StreamingBufferRegion *src_end, const uint64_t data_offset, const uint32_t data_len)
+{
+    const uint64_t data_re = data_offset + data_len;
+    SCLogDebug("sb %p dst %p src_start %p src_end %p data_offset %" PRIu64
+               "/data_len %u/data_re %" PRIu64,
+            sb, dst, src_start, src_end, data_offset, data_len, data_re);
+
+    // 1. determine size for dst.
+    const uint64_t dst_offset = MIN(src_start->stream_offset, data_offset);
+    DEBUG_VALIDATE_BUG_ON(dst_offset < sb->region.stream_offset);
+    const uint64_t dst_re = MAX((src_end->stream_offset + src_end->buf_size), data_re);
+    const uint32_t dst_size = dst_re - dst_offset;
+    SCLogDebug("dst_offset %" PRIu64 ", dst_re %" PRIu64 ", dst_size %u", dst_offset, dst_re,
+            dst_size);
+
+    // 2. resize dst
+    const uint32_t old_size = dst->buf_size;
+    const uint32_t dst_copy_offset = dst->stream_offset - dst_offset;
+#ifdef DEBUG
+    const uint32_t old_offset = dst->buf_offset;
+    SCLogDebug("old_size %u, old_offset %u, dst_copy_offset %u", old_size, old_offset,
+            dst_copy_offset);
+#endif
+    if (GrowRegionToSize(sb, dst, dst_size) != 0)
+        return NULL;
+    SCLogDebug("resized to %u", dst_size);
+    if (dst_copy_offset != 0)
+        memmove(dst->buf + dst_copy_offset, dst->buf, old_size);
+    dst->stream_offset = dst_offset;
+
+    uint32_t new_offset = src_start->buf_offset;
+    if (data_offset == src_start->stream_offset + src_start->buf_offset) {
+        new_offset += data_len;
+    }
+
+    bool start_is_main = false;
+    StreamingBufferRegion *prev = NULL;
+    if (src_start == &sb->region) {
+        DEBUG_VALIDATE_BUG_ON(src_start->stream_offset != dst_offset);
+
+        start_is_main = true;
+        SCLogDebug("src_start is main region");
+        if (src_start != dst)
+            memcpy(dst->buf, src_start->buf, src_start->buf_offset);
+        if (src_start == src_end) {
+            SCLogDebug("src_start == src_end == main, we're done");
+            BUG_ON(src_start != dst);
+            return src_start;
+        }
+        prev = src_start;
+        src_start = src_start->next; // skip in the loop below
+    }
+
+    // 3. copy all regions from src_start to dst_start into the new region
+    for (StreamingBufferRegion *r = src_start; r != NULL;) {
+        SCLogDebug("r %p %" PRIu64 ", offset %u, len %u, %s, last %s", r, r->stream_offset,
+                r->buf_offset, r->buf_size, r == &sb->region ? "main" : "aux",
+                BOOL2STR(r == src_end));
+        // skip dst
+        if (r == dst) {
+            SCLogDebug("skipping r %p as it is 'dst'", r);
+            if (r == src_end)
+                break;
+            prev = r;
+            r = r->next;
+            continue;
+        }
+        const uint32_t target_offset = r->stream_offset - dst_offset;
+        SCLogDebug("r %p: target_offset %u", r, target_offset);
+        memcpy(dst->buf + target_offset, r->buf, r->buf_size);
+
+        StreamingBufferRegion *next = r->next;
+        FREE(sb->cfg, r->buf, r->buf_size);
+        FREE(sb->cfg, r, sizeof(*r));
+        sb->regions--;
+        BUG_ON(sb->regions == 0);
+        if (prev != NULL) {
+            SCLogDebug("setting prev %p next to %p (was %p)", prev, next, prev->next);
+            prev->next = next;
+        } else {
+            SCLogDebug("no prev yet");
+        }
+
+        if (r == src_end)
+            break;
+
+        prev = r;
+        r = next;
+    }
+
+    /* special handling of main region being the start, but not the
+     * region we expand. In this case we'll have main and dst. We will
+     * move the buffer from dst into main and free dst. */
+    if (start_is_main && dst != &sb->region) {
+        BUG_ON(sb->region.next != dst);
+        SCLogDebug("start_is_main && dst != main region");
+        FREE(sb->cfg, sb->region.buf, sb->region.buf_size);
+        sb->region.buf = dst->buf;
+        sb->region.buf_size = dst->buf_size;
+        sb->region.buf_offset = new_offset;
+        SCLogDebug("sb->region.buf_offset set to %u", sb->region.buf_offset);
+        sb->region.next = dst->next;
+        FREE(sb->cfg, dst, sizeof(*dst));
+        dst = &sb->region;
+        sb->regions--;
+        BUG_ON(sb->regions == 0);
+    } else {
+        SCLogDebug("dst: %p next %p", dst, dst->next);
+    }
+
+    SCLogDebug("returning dst %p stream_offset %" PRIu64 " buf_offset %u buf_size %u", dst,
+            dst->stream_offset, dst->buf_offset, dst->buf_size);
+    return dst;
+}
+
+static StreamingBufferRegion *BufferInsertAtRegionDo(
+        StreamingBuffer *sb, const uint64_t offset, const uint32_t len)
+{
+    SCLogDebug("offset %" PRIu64 ", len %u", offset, len);
+    StreamingBufferRegion *start = FindFirstRegionForOffset(sb, &sb->region, offset, len);
+    if (start) {
+        SCLogDebug("start region %p/%" PRIu64 "/%u", start, start->stream_offset, start->buf_size);
+        StreamingBufferRegion *big = FindLargestRegionForOffset(sb, start, offset, len);
+        DEBUG_VALIDATE_BUG_ON(big == NULL);
+        if (big == NULL)
+            return NULL;
+        SCLogDebug("big region %p/%" PRIu64 "/%u", big, big->stream_offset, big->buf_size);
+        StreamingBufferRegion *end = FindRightEdge(sb, big, offset, len);
+        DEBUG_VALIDATE_BUG_ON(end == NULL);
+        if (end == NULL)
+            return NULL;
+        SCLogDebug("end region %p/%" PRIu64 "/%u", end, end->stream_offset, end->buf_size);
+        StreamingBufferRegion *ret =
+                BufferInsertAtRegionConsolidate(sb, big, start, end, offset, len);
+        return ret;
+    } else {
+        /* if there was no region we can use we add a new region and insert it */
+        StreamingBufferRegion *append = &sb->region;
+        for (StreamingBufferRegion *r = append; r != NULL; r = r->next) {
+            if (r->stream_offset > offset) {
+                break;
+            } else {
+                append = r;
+            }
+        }
+
+        SCLogDebug("no matching region found, append to %p (%s)", append,
+                append == &sb->region ? "main" : "aux");
+        StreamingBufferRegion *add = InitBufferRegion(sb, len);
+        if (add == NULL)
+            return NULL;
+        add->stream_offset = offset;
+        add->next = append->next;
+        append->next = add;
+        SCLogDebug("new region %p offset %" PRIu64, add, add->stream_offset);
+        return add;
+    }
+}
+
+/** \internal
+ *  \brief return the region to put the new data in
+ *
+ *  Will find an existing region, expand it if needed. If no existing region exists or is
+ *  a good fit, it will try to set up a new region. If the region then overlaps or gets
+ *  too close to the next, merge them.
+ */
+static StreamingBufferRegion *BufferInsertAtRegion(StreamingBuffer *sb, const uint8_t *data,
+        const uint32_t data_len, const uint64_t data_offset)
+{
+    SCLogDebug("data_offset %" PRIu64 ", data_len %u, re %" PRIu64, data_offset, data_len,
+            data_offset + data_len);
+    ListRegions(sb);
+
+    if (RegionsIntersect(sb, &sb->region, data_offset, data_len)) {
+        SCLogDebug("data_offset %" PRIu64 ", data_len %u intersects with main region (next %p)",
+                data_offset, data_len, sb->region.next);
+        if (sb->region.next == NULL ||
+                !RegionsIntersect(sb, sb->region.next, data_offset, data_len)) {
+            SCLogDebug(
+                    "data_offset %" PRIu64
+                    ", data_len %u intersects with main region, no next or way before next region",
+                    data_offset, data_len);
+            if (sb->region.buf == NULL)
+                if (InitBuffer(sb) == -1) // TODO init with size
+                    return NULL;
+            return &sb->region;
+        }
+    } else if (sb->region.next == NULL) {
+        StreamingBufferRegion *aux_r = sb->region.next = InitBufferRegion(sb, data_len);
+        if (aux_r == NULL)
+            return NULL;
+        aux_r->stream_offset = data_offset;
+        DEBUG_VALIDATE_BUG_ON(data_len > aux_r->buf_size);
+        SCLogDebug("created new region %p with offset %" PRIu64 ", size %u", aux_r,
+                aux_r->stream_offset, aux_r->buf_size);
+        return aux_r;
+    }
+    StreamingBufferRegion *blob = BufferInsertAtRegionDo(sb, data_offset, data_len);
+    SCLogDebug("blob %p (%s)", blob, blob == &sb->region ? "main" : "aux");
+    return blob;
+}
 
 /**
  *  \param offset offset relative to StreamingBuffer::stream_offset
@@ -678,59 +1362,106 @@ int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
                             uint64_t offset)
 {
     BUG_ON(seg == NULL);
-    DEBUG_VALIDATE_BUG_ON(offset < sb->stream_offset);
-    if (offset < sb->stream_offset)
+    DEBUG_VALIDATE_BUG_ON(offset < sb->region.stream_offset);
+    if (offset < sb->region.stream_offset)
         return -2;
 
-    if (sb->buf == NULL) {
-        if (InitBuffer(sb) == -1)
-            return -1;
+    StreamingBufferRegion *region = BufferInsertAtRegion(sb, data, data_len, offset);
+    if (region == NULL) {
+        return -1;
     }
 
-    uint32_t rel_offset = offset - sb->stream_offset;
-    if (!DATA_FITS_AT_OFFSET(sb, data_len, rel_offset)) {
+    const bool region_is_main = region == &sb->region;
+
+    SCLogDebug("inserting %" PRIu64 "/%u using %s region %p", offset, data_len,
+            region == &sb->region ? "main" : "aux", region);
+
+    uint32_t rel_offset = offset - region->stream_offset;
+    if (!DATA_FITS_AT_OFFSET(region, data_len, rel_offset)) {
         if (GrowToSize(sb, (rel_offset + data_len)) != 0)
             return -1;
     }
-    DEBUG_VALIDATE_BUG_ON(!DATA_FITS_AT_OFFSET(sb, data_len, rel_offset));
+    DEBUG_VALIDATE_BUG_ON(!DATA_FITS_AT_OFFSET(region, data_len, rel_offset));
 
-    memcpy(sb->buf + rel_offset, data, data_len);
+    SCLogDebug("offset %" PRIu64 " data_len %u, rel_offset %u into region offset %" PRIu64
+               ", buf_offset %u, buf_size %u",
+            offset, data_len, rel_offset, region->stream_offset, region->buf_offset,
+            region->buf_size);
+    memcpy(region->buf + rel_offset, data, data_len);
     seg->stream_offset = offset;
     seg->segment_len = data_len;
 
-    SCLogDebug("rel_offset %u sb->stream_offset %"PRIu64", buf_offset %u",
-            rel_offset, sb->stream_offset, sb->buf_offset);
+    SCLogDebug("rel_offset %u region->stream_offset %" PRIu64 ", buf_offset %u", rel_offset,
+            region->stream_offset, sb->region.buf_offset);
 
     if (RB_EMPTY(&sb->sbb_tree)) {
         SCLogDebug("empty sbb list");
 
-        if (sb->stream_offset == offset) {
-            SCLogDebug("empty sbb list: block exactly what was expected, fall through");
-            /* empty list, data is exactly what is expected (append),
-             * so do nothing */
-        } else if ((rel_offset + data_len) <= sb->buf_offset) {
-            SCLogDebug("empty sbb list: block is within existing region");
+        if (region_is_main) {
+            if (sb->region.stream_offset == offset) {
+                SCLogDebug("empty sbb list: block exactly what was expected, fall through");
+                /* empty list, data is exactly what is expected (append),
+                 * so do nothing.
+                 * Update buf_offset if needed, but in case of overlaps it might be beyond us. */
+                sb->region.buf_offset = MAX(sb->region.buf_offset, rel_offset + data_len);
+            } else if ((rel_offset + data_len) <= sb->region.buf_offset) {
+                SCLogDebug("empty sbb list: block is within existing main data region");
+            } else {
+                if (sb->region.buf_offset && rel_offset == sb->region.buf_offset) {
+                    SCLogDebug("exactly at expected offset");
+                    // nothing to do
+                    sb->region.buf_offset = rel_offset + data_len;
+
+                } else if (rel_offset < sb->region.buf_offset) {
+                    // nothing to do
+
+                    SCLogDebug("before expected offset: %u < sb->region.buf_offset %u", rel_offset,
+                            sb->region.buf_offset);
+                    if (rel_offset + data_len > sb->region.buf_offset) {
+                        SCLogDebug("before expected offset, ends after: %u < sb->region.buf_offset "
+                                   "%u, %u > %u",
+                                rel_offset, sb->region.buf_offset, rel_offset + data_len,
+                                sb->region.buf_offset);
+                        sb->region.buf_offset = rel_offset + data_len;
+                    }
+
+                } else if (sb->region.buf_offset) {
+                    SCLogDebug("beyond expected offset: SBBInit");
+                    /* existing data, but there is a gap between us */
+                    SBBInit(sb, region, rel_offset, data_len);
+                } else {
+                    /* gap before data in empty list */
+                    SCLogDebug("empty sbb list: invoking SBBInitLeadingGap");
+                    SBBInitLeadingGap(sb, region, offset, data_len);
+                }
+            }
         } else {
-            if (sb->buf_offset && rel_offset == sb->buf_offset) {
-                // nothing to do
-            } else if (rel_offset < sb->buf_offset) {
-                // nothing to do
-            } else if (sb->buf_offset) {
+            if (sb->region.buf_offset) {
                 /* existing data, but there is a gap between us */
-                SBBInit(sb, rel_offset, data_len);
+                SCLogDebug("empty sbb list, no data in main: use SBBInit");
+                SBBInit(sb, region, rel_offset, data_len);
             } else {
                 /* gap before data in empty list */
                 SCLogDebug("empty sbb list: invoking SBBInitLeadingGap");
-                SBBInitLeadingGap(sb, offset, data_len);
+                SBBInitLeadingGap(sb, region, offset, data_len);
+            }
+            if (rel_offset == region->buf_offset) {
+                SCLogDebug("pre region->buf_offset %u", region->buf_offset);
+                region->buf_offset = rel_offset + data_len;
+                SCLogDebug("post region->buf_offset %u", region->buf_offset);
             }
         }
     } else {
+        SCLogDebug("updating sbb tree");
         /* already have blocks, so append new block based on new data */
-        SBBUpdate(sb, rel_offset, data_len);
+        SBBUpdate(sb, region, rel_offset, data_len);
     }
+    BUG_ON(!region_is_main && sb->head == NULL);
 
-    if (rel_offset + data_len > sb->buf_offset)
-        sb->buf_offset = rel_offset + data_len;
+    ListRegions(sb);
+    if (RB_EMPTY(&sb->sbb_tree)) {
+        BUG_ON(offset + data_len > sb->region.stream_offset + sb->region.buf_offset);
+    }
 
     return 0;
 }
@@ -738,12 +1469,32 @@ int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
 int StreamingBufferSegmentIsBeforeWindow(const StreamingBuffer *sb,
                                          const StreamingBufferSegment *seg)
 {
-    if (seg->stream_offset < sb->stream_offset) {
-        if (seg->stream_offset + seg->segment_len <= sb->stream_offset) {
+    if (seg->stream_offset < sb->region.stream_offset) {
+        if (seg->stream_offset + seg->segment_len <= sb->region.stream_offset) {
             return 1;
         }
     }
     return 0;
+}
+
+static inline const StreamingBufferRegion *GetRegionForOffset(
+        const StreamingBuffer *sb, const uint64_t offset)
+{
+    if (sb == NULL)
+        return NULL;
+    if (sb->region.next == NULL) {
+        return &sb->region;
+    }
+    if (offset >= sb->region.stream_offset &&
+            offset < (sb->region.stream_offset + sb->region.buf_size)) {
+        return &sb->region;
+    }
+    for (const StreamingBufferRegion *r = sb->region.next; r != NULL; r = r->next) {
+        if (offset >= r->stream_offset && offset < (r->stream_offset + r->buf_size)) {
+            return r;
+        }
+    }
+    return NULL;
 }
 
 /** \brief get the data for one SBB */
@@ -751,20 +1502,28 @@ void StreamingBufferSBBGetData(const StreamingBuffer *sb,
                                const StreamingBufferBlock *sbb,
                                const uint8_t **data, uint32_t *data_len)
 {
-    if (sbb->offset >= sb->stream_offset) {
-        uint64_t offset = sbb->offset - sb->stream_offset;
-        *data = sb->buf + offset;
-        if (offset + sbb->len > sb->buf_offset)
-            *data_len = sb->buf_offset - offset;
-        else
+    ListRegions((StreamingBuffer *)sb);
+    const StreamingBufferRegion *region = GetRegionForOffset(sb, sbb->offset);
+    SCLogDebug("first find our region (offset %" PRIu64 ") -> %p", sbb->offset, region);
+    if (region) {
+        SCLogDebug("region %p found %" PRIu64 "/%u/%u", region, region->stream_offset,
+                region->buf_size, region->buf_offset);
+        if (sbb->offset >= region->stream_offset) {
+            SCLogDebug("1");
+            uint64_t offset = sbb->offset - region->stream_offset;
+            *data = region->buf + offset;
+            BUG_ON(offset + sbb->len > region->buf_size);
             *data_len = sbb->len;
-        return;
-    } else {
-        uint64_t offset = sb->stream_offset - sbb->offset;
-        if (offset < sbb->len) {
-            *data = sb->buf;
-            *data_len = sbb->len - offset;
             return;
+        } else {
+            SCLogDebug("2");
+            uint64_t offset = region->stream_offset - sbb->offset;
+            if (offset < sbb->len) {
+                *data = region->buf;
+                *data_len = sbb->len - offset;
+                return;
+            }
+            SCLogDebug("3");
         }
     }
     *data = NULL;
@@ -778,22 +1537,31 @@ void StreamingBufferSBBGetDataAtOffset(const StreamingBuffer *sb,
                                        const uint8_t **data, uint32_t *data_len,
                                        uint64_t offset)
 {
-    if (offset >= sbb->offset && offset < (sbb->offset + sbb->len)) {
+    /* validate that we are looking for a offset within the sbb */
+    DEBUG_VALIDATE_BUG_ON(!(offset >= sbb->offset && offset < (sbb->offset + sbb->len)));
+    if (!(offset >= sbb->offset && offset < (sbb->offset + sbb->len))) {
+        *data = NULL;
+        *data_len = 0;
+        return;
+    }
+
+    const StreamingBufferRegion *region = GetRegionForOffset(sb, offset);
+    if (region) {
         uint32_t sbblen = sbb->len - (offset - sbb->offset);
 
-        if (offset >= sb->stream_offset) {
-            uint64_t data_offset = offset - sb->stream_offset;
-            *data = sb->buf + data_offset;
-            if (data_offset + sbblen > sb->buf_size)
-                *data_len = sb->buf_size - data_offset;
+        if (offset >= region->stream_offset) {
+            uint64_t data_offset = offset - region->stream_offset;
+            *data = region->buf + data_offset;
+            if (data_offset + sbblen > region->buf_size)
+                *data_len = region->buf_size - data_offset;
             else
                 *data_len = sbblen;
             BUG_ON(*data_len > sbblen);
             return;
         } else {
-            uint64_t data_offset = sb->stream_offset - sbb->offset;
+            uint64_t data_offset = region->stream_offset - sbb->offset;
             if (data_offset < sbblen) {
-                *data = sb->buf;
+                *data = region->buf;
                 *data_len = sbblen - data_offset;
                 BUG_ON(*data_len > sbblen);
                 return;
@@ -810,20 +1578,23 @@ void StreamingBufferSegmentGetData(const StreamingBuffer *sb,
                                    const StreamingBufferSegment *seg,
                                    const uint8_t **data, uint32_t *data_len)
 {
-    if (likely(sb->buf)) {
-        if (seg->stream_offset >= sb->stream_offset) {
-            uint64_t offset = seg->stream_offset - sb->stream_offset;
-            *data = sb->buf + offset;
-            if (offset + seg->segment_len > sb->buf_size)
-                *data_len = sb->buf_size - offset;
+    const StreamingBufferRegion *region = GetRegionForOffset(sb, seg->stream_offset);
+    if (region) {
+        if (seg->stream_offset >= region->stream_offset) {
+            uint64_t offset = seg->stream_offset - region->stream_offset;
+            *data = region->buf + offset;
+            if (offset + seg->segment_len > region->buf_size)
+                *data_len = region->buf_size - offset;
             else
                 *data_len = seg->segment_len;
+            SCLogDebug("*data_len %u", *data_len);
             return;
         } else {
-            uint64_t offset = sb->stream_offset - seg->stream_offset;
+            uint64_t offset = region->stream_offset - seg->stream_offset;
             if (offset < seg->segment_len) {
-                *data = sb->buf;
+                *data = region->buf;
                 *data_len = seg->segment_len - offset;
+                SCLogDebug("*data_len %u", *data_len);
                 return;
             }
         }
@@ -857,10 +1628,10 @@ int StreamingBufferGetData(const StreamingBuffer *sb,
         const uint8_t **data, uint32_t *data_len,
         uint64_t *stream_offset)
 {
-    if (sb != NULL && sb->buf != NULL) {
-        *data = sb->buf;
-        *data_len = sb->buf_offset;
-        *stream_offset = sb->stream_offset;
+    if (sb != NULL && sb->region.buf != NULL) {
+        *data = sb->region.buf;
+        *data_len = sb->region.buf_offset;
+        *stream_offset = sb->region.stream_offset;
         return 1;
     } else {
         *data = NULL;
@@ -874,13 +1645,12 @@ int StreamingBufferGetDataAtOffset (const StreamingBuffer *sb,
         const uint8_t **data, uint32_t *data_len,
         uint64_t offset)
 {
-    if (sb != NULL && sb->buf != NULL &&
-            offset >= sb->stream_offset &&
-            offset < (sb->stream_offset + sb->buf_offset))
-    {
-        uint32_t skip = offset - sb->stream_offset;
-        *data = sb->buf + skip;
-        *data_len = sb->buf_offset - skip;
+    const StreamingBufferRegion *region = GetRegionForOffset(sb, offset);
+    if (region != NULL && region->buf != NULL && offset >= region->stream_offset &&
+            offset < (region->stream_offset + region->buf_offset)) {
+        uint32_t skip = offset - region->stream_offset;
+        *data = region->buf + skip;
+        *data_len = region->buf_offset - skip;
         return 1;
     } else {
         *data = NULL;
@@ -907,7 +1677,7 @@ int StreamingBufferCompareRawData(const StreamingBuffer *sb,
     {
         return 1;
     }
-    SCLogDebug("sbdata_len %u, offset %"PRIu64, sbdata_len, offset);
+    SCLogDebug("sbdata_len %u, offset %" PRIu64, sbdata_len, offset);
     printf("got:\n");
     PrintRawDataFp(stdout, sbdata,sbdata_len);
     printf("wanted:\n");
@@ -918,7 +1688,7 @@ int StreamingBufferCompareRawData(const StreamingBuffer *sb,
 #ifdef UNITTESTS
 static void Dump(StreamingBuffer *sb)
 {
-    PrintRawDataFp(stdout, sb->buf, sb->buf_offset);
+    PrintRawDataFp(stdout, sb->region.buf, sb->region.buf_offset);
 }
 
 static void DumpSegment(StreamingBuffer *sb, StreamingBufferSegment *seg)
@@ -941,8 +1711,8 @@ static int StreamingBufferTest02(void)
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferAppend(sb, &seg2, (const uint8_t *)"01234567", 8) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 16);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 16);
     FAIL_IF(seg1.stream_offset != 0);
     FAIL_IF(seg2.stream_offset != 8);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
@@ -959,8 +1729,8 @@ static int StreamingBufferTest02(void)
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferAppend(sb, &seg3, (const uint8_t *)"QWERTY", 6) != 0);
-    FAIL_IF(sb->stream_offset != 6);
-    FAIL_IF(sb->buf_offset != 16);
+    FAIL_IF(sb->region.stream_offset != 6);
+    FAIL_IF(sb->region.buf_offset != 16);
     FAIL_IF(seg3.stream_offset != 16);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
@@ -997,8 +1767,8 @@ static int StreamingBufferTest03(void)
     FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 22);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 8);
     FAIL_IF(seg1.stream_offset != 0);
     FAIL_IF(seg2.stream_offset != 14);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
@@ -1012,8 +1782,8 @@ static int StreamingBufferTest03(void)
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 22);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 22);
     FAIL_IF(seg3.stream_offset != 8);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
@@ -1053,8 +1823,8 @@ static int StreamingBufferTest04(void)
     FAIL_IF(!RB_EMPTY(&sb->sbb_tree));
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 22);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 8);
     FAIL_IF(seg1.stream_offset != 0);
     FAIL_IF(seg2.stream_offset != 14);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
@@ -1077,8 +1847,8 @@ static int StreamingBufferTest04(void)
 
     StreamingBufferSegment seg3;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg3, (const uint8_t *)"QWERTY", 6, 8) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 22);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 22);
     FAIL_IF(seg3.stream_offset != 8);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));
@@ -1100,9 +1870,9 @@ static int StreamingBufferTest04(void)
     /* far ahead of curve: */
     StreamingBufferSegment seg4;
     FAIL_IF(StreamingBufferInsertAt(sb, &seg4, (const uint8_t *)"XYZ", 3, 124) != 0);
-    FAIL_IF(sb->stream_offset != 0);
-    FAIL_IF(sb->buf_offset != 127);
-    FAIL_IF(sb->buf_size != 128);
+    FAIL_IF(sb->region.stream_offset != 0);
+    FAIL_IF(sb->region.buf_offset != 22);
+    FAIL_IF(sb->region.buf_size != 128);
     FAIL_IF(seg4.stream_offset != 124);
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg1));
     FAIL_IF(StreamingBufferSegmentIsBeforeWindow(sb,&seg2));

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -863,8 +863,8 @@ StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb, const uint
     return NULL;
 }
 
-int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
-                          const uint8_t *data, uint32_t data_len)
+int StreamingBufferAppend(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
+        StreamingBufferSegment *seg, const uint8_t *data, uint32_t data_len)
 {
     BUG_ON(seg == NULL);
 
@@ -1650,9 +1650,9 @@ static int StreamingBufferTest02(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     StreamingBufferSegment seg2;
-    FAIL_IF(StreamingBufferAppend(sb, &seg2, (const uint8_t *)"01234567", 8) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg2, (const uint8_t *)"01234567", 8) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
     FAIL_IF(sb->region.buf_offset != 16);
     FAIL_IF(seg1.stream_offset != 0);
@@ -1670,7 +1670,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg3;
-    FAIL_IF(StreamingBufferAppend(sb, &seg3, (const uint8_t *)"QWERTY", 6) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg3, (const uint8_t *)"QWERTY", 6) != 0);
     FAIL_IF(sb->region.stream_offset != 6);
     FAIL_IF(sb->region.buf_offset != 16);
     FAIL_IF(seg3.stream_offset != 16);
@@ -1706,7 +1706,7 @@ static int StreamingBufferTest03(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
     FAIL_IF(sb->region.stream_offset != 0);
@@ -1761,7 +1761,7 @@ static int StreamingBufferTest04(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg1, (const uint8_t *)"ABCDEFGH", 8) != 0);
     FAIL_IF(!RB_EMPTY(&sb->sbb_tree));
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"01234567", 8, 14) != 0);
@@ -1852,7 +1852,7 @@ static int StreamingBufferTest06(void)
     FAIL_IF(sb == NULL);
 
     StreamingBufferSegment seg1;
-    FAIL_IF(StreamingBufferAppend(sb, &seg1, (const uint8_t *)"A", 1) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg1, (const uint8_t *)"A", 1) != 0);
     StreamingBufferSegment seg2;
     FAIL_IF(StreamingBufferInsertAt(sb, &cfg, &seg2, (const uint8_t *)"C", 1, 2) != 0);
     Dump(sb);
@@ -2003,7 +2003,7 @@ static int StreamingBufferTest08(void)
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
     StreamingBufferSegment seg6;
-    FAIL_IF(StreamingBufferAppend(sb, &seg6, (const uint8_t *)"abcdefghij", 10) != 0);
+    FAIL_IF(StreamingBufferAppend(sb, &cfg, &seg6, (const uint8_t *)"abcdefghij", 10) != 0);
     Dump(sb);
     sbb1 = RB_MIN(SBB, &sb->sbb_tree);
     FAIL_IF_NULL(sbb1);

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -898,8 +898,8 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
 /**
  *  \brief add data w/o tracking a segment
  */
-int StreamingBufferAppendNoTrack(StreamingBuffer *sb,
-                                 const uint8_t *data, uint32_t data_len)
+int StreamingBufferAppendNoTrack(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
+        const uint8_t *data, uint32_t data_len)
 {
     if (sb->region.buf == NULL) {
         if (InitBuffer(sb) == -1)

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -23,7 +23,6 @@
 #include "util-debug.h"
 
 static void ListRegions(StreamingBuffer *sb);
-#define REGION_MAX_GAP 250000
 
 #define DUMP_REGIONS 0 // set to 1 to dump a visual representation of the regions list and sbb tree.
 
@@ -1071,8 +1070,8 @@ static inline bool RegionsIntersect(const StreamingBuffer *sb, const StreamingBu
 
     /* create the data range for the region, adding the max gap */
     const uint64_t reg_o =
-            r->stream_offset > REGION_MAX_GAP ? (r->stream_offset - REGION_MAX_GAP) : 0;
-    const uint64_t reg_re = r->stream_offset + r->buf_size + REGION_MAX_GAP;
+            r->stream_offset > sb->cfg->region_gap ? (r->stream_offset - sb->cfg->region_gap) : 0;
+    const uint64_t reg_re = r->stream_offset + r->buf_size + sb->cfg->region_gap;
     SCLogDebug("r %p: %" PRIu64 "/%" PRIu64 " - adjusted %" PRIu64 "/%" PRIu64, r, r->stream_offset,
             r->stream_offset + r->buf_size, reg_o, reg_re);
     /* check if data range intersects with region range */
@@ -1707,7 +1706,7 @@ static void DumpSegment(StreamingBuffer *sb, StreamingBufferSegment *seg)
 
 static int StreamingBufferTest02(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1763,7 +1762,7 @@ static int StreamingBufferTest02(void)
 
 static int StreamingBufferTest03(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1818,7 +1817,7 @@ static int StreamingBufferTest03(void)
 
 static int StreamingBufferTest04(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1909,7 +1908,7 @@ static int StreamingBufferTest04(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest06(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1967,7 +1966,7 @@ static int StreamingBufferTest06(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest07(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2025,7 +2024,7 @@ static int StreamingBufferTest07(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest08(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2083,7 +2082,7 @@ static int StreamingBufferTest08(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest09(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2141,7 +2140,7 @@ static int StreamingBufferTest09(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest10(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -1706,7 +1706,7 @@ static void DumpSegment(StreamingBuffer *sb, StreamingBufferSegment *seg)
 
 static int StreamingBufferTest02(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1762,7 +1762,7 @@ static int StreamingBufferTest02(void)
 
 static int StreamingBufferTest03(void)
 {
-    StreamingBufferConfig cfg = { 8, 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 24, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1817,7 +1817,7 @@ static int StreamingBufferTest03(void)
 
 static int StreamingBufferTest04(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1908,7 +1908,7 @@ static int StreamingBufferTest04(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest06(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -1966,7 +1966,7 @@ static int StreamingBufferTest06(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest07(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2024,7 +2024,7 @@ static int StreamingBufferTest07(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest08(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2082,7 +2082,7 @@ static int StreamingBufferTest08(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest09(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 
@@ -2140,7 +2140,7 @@ static int StreamingBufferTest09(void)
 /** \test lots of gaps in block list */
 static int StreamingBufferTest10(void)
 {
-    StreamingBufferConfig cfg = { 8, 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
+    StreamingBufferConfig cfg = { 16, 1, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL };
     StreamingBuffer *sb = StreamingBufferInit(&cfg);
     FAIL_IF(sb == NULL);
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -177,7 +177,7 @@ void StreamingBufferClear(StreamingBuffer *sb)
     }
 }
 
-void StreamingBufferFree(StreamingBuffer *sb)
+void StreamingBufferFree(StreamingBuffer *sb, const StreamingBufferConfig *cfg)
 {
     if (sb != NULL) {
         StreamingBufferClear(sb);
@@ -1696,7 +1696,7 @@ static int StreamingBufferTest02(void)
     FAIL_IF_NOT_NULL(sb->head);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -1751,7 +1751,7 @@ static int StreamingBufferTest03(void)
     FAIL_IF_NOT(sb->sbb_size == 12);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -1841,7 +1841,7 @@ static int StreamingBufferTest04(void)
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,&seg3,(const uint8_t *)"QWERTY", 6));
     FAIL_IF(!StreamingBufferSegmentCompareRawData(sb,&seg4,(const uint8_t *)"XYZ", 3));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -1899,7 +1899,7 @@ static int StreamingBufferTest06(void)
     FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -1957,7 +1957,7 @@ static int StreamingBufferTest07(void)
     FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -2015,7 +2015,7 @@ static int StreamingBufferTest08(void)
     FAIL_IF_NOT(sb->sbb_size == 20);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -2073,7 +2073,7 @@ static int StreamingBufferTest09(void)
     FAIL_IF_NOT(sb->sbb_size == 10);
     FAIL_IF_NOT(sb->head == RB_MIN(SBB, &sb->sbb_tree));
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 
@@ -2132,7 +2132,7 @@ static int StreamingBufferTest10(void)
     FAIL_IF_NULL(sb->head);
     FAIL_IF_NOT(sb->sbb_size == 10);
 
-    StreamingBufferFree(sb);
+    StreamingBufferFree(sb, &cfg);
     PASS;
 }
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -154,7 +154,7 @@ StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg)
     return NULL;
 }
 
-void StreamingBufferClear(StreamingBuffer *sb)
+void StreamingBufferClear(StreamingBuffer *sb, const StreamingBufferConfig *cfg)
 {
     if (sb != NULL) {
         SCLogDebug("sb->region.buf_size %u max %u", sb->region.buf_size, sb->buf_size_max);
@@ -180,7 +180,7 @@ void StreamingBufferClear(StreamingBuffer *sb)
 void StreamingBufferFree(StreamingBuffer *sb, const StreamingBufferConfig *cfg)
 {
     if (sb != NULL) {
-        StreamingBufferClear(sb);
+        StreamingBufferClear(sb, cfg);
         FREE(sb->cfg, sb, sizeof(StreamingBuffer));
     }
 }

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -157,7 +157,7 @@ typedef struct StreamingBufferSegment_ {
 } __attribute__((__packed__)) StreamingBufferSegment;
 
 StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg);
-void StreamingBufferClear(StreamingBuffer *sb);
+void StreamingBufferClear(StreamingBuffer *sb, const StreamingBufferConfig *cfg);
 void StreamingBufferFree(StreamingBuffer *sb, const StreamingBufferConfig *cfg);
 
 void StreamingBufferSlideToOffset(

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -160,7 +160,6 @@ StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg);
 void StreamingBufferClear(StreamingBuffer *sb);
 void StreamingBufferFree(StreamingBuffer *sb);
 
-void StreamingBufferSlide(StreamingBuffer *sb, uint32_t slide);
 void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset);
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -166,7 +166,7 @@ StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
-int StreamingBufferAppendNoTrack(StreamingBuffer *sb,
+int StreamingBufferAppendNoTrack(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
                              const uint8_t *data, uint32_t data_len,

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -61,10 +61,13 @@
 
 #include "tree.h"
 
+#define STREAMING_BUFFER_REGION_GAP_DEFAULT 262144
+
 typedef struct StreamingBufferConfig_ {
     uint32_t buf_slide;
     uint32_t buf_size;
     uint16_t max_regions; /**< max concurrent memory regions. 0 means no limit. */
+    uint32_t region_gap;  /**< max gap size before a new region will be created. */
     void *(*Calloc)(size_t n, size_t size);
     void *(*Realloc)(void *ptr, size_t orig_size, size_t size);
     void (*Free)(void *ptr, size_t size);
@@ -72,7 +75,7 @@ typedef struct StreamingBufferConfig_ {
 
 #define STREAMING_BUFFER_CONFIG_INITIALIZER                                                        \
     {                                                                                              \
-        0, 0, 0, NULL, NULL, NULL,                                                                 \
+        0, 0, 0, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL,                            \
     }
 
 #define STREAMING_BUFFER_REGION_INIT                                                               \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -74,7 +74,7 @@ typedef struct StreamingBufferConfig_ {
 
 #define STREAMING_BUFFER_CONFIG_INITIALIZER                                                        \
     {                                                                                              \
-        0, 0, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL,                               \
+        2048, 8, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL,                            \
     }
 
 #define STREAMING_BUFFER_REGION_INIT                                                               \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -160,7 +160,8 @@ StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg);
 void StreamingBufferClear(StreamingBuffer *sb);
 void StreamingBufferFree(StreamingBuffer *sb);
 
-void StreamingBufferSlideToOffset(StreamingBuffer *sb, uint64_t offset);
+void StreamingBufferSlideToOffset(
+        StreamingBuffer *sb, const StreamingBufferConfig *cfg, uint64_t offset);
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -64,6 +64,7 @@
 typedef struct StreamingBufferConfig_ {
     uint32_t buf_slide;
     uint32_t buf_size;
+    uint16_t max_regions; /**< max concurrent memory regions. 0 means no limit. */
     void *(*Calloc)(size_t n, size_t size);
     void *(*Realloc)(void *ptr, size_t orig_size, size_t size);
     void (*Free)(void *ptr, size_t size);
@@ -71,7 +72,7 @@ typedef struct StreamingBufferConfig_ {
 
 #define STREAMING_BUFFER_CONFIG_INITIALIZER                                                        \
     {                                                                                              \
-        0, 0, NULL, NULL, NULL,                                                                    \
+        0, 0, 0, NULL, NULL, NULL,                                                                 \
     }
 
 #define STREAMING_BUFFER_REGION_INIT                                                               \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -164,7 +164,7 @@ void StreamingBufferSlideToOffset(
         StreamingBuffer *sb, const StreamingBufferConfig *cfg, uint64_t offset);
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,
-        const uint8_t *data, uint32_t data_len) WARN_UNUSED;
+        const StreamingBufferConfig *cfg, const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferAppend(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
         StreamingBufferSegment *seg, const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferAppendNoTrack(StreamingBuffer *sb, const StreamingBufferConfig *cfg,

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -107,7 +107,6 @@ RB_PROTOTYPE(SBB, StreamingBufferBlock, rb, SBBCompare);
 StreamingBufferBlock *SBB_RB_FIND_INCLUSIVE(struct SBB *head, StreamingBufferBlock *elm);
 
 typedef struct StreamingBuffer_ {
-    const StreamingBufferConfig *cfg;
     StreamingBufferRegion region;
     struct SBB sbb_tree;    /**< red black tree of Stream Buffer Blocks */
     StreamingBufferBlock *head; /**< head, should always be the same as RB_MIN */
@@ -136,9 +135,8 @@ static inline uint64_t StreamingBufferGetOffset(const StreamingBuffer *sb)
 }
 
 #ifndef DEBUG
-#define STREAMING_BUFFER_INITIALIZER(cfg)                                                          \
+#define STREAMING_BUFFER_INITIALIZER                                                               \
     {                                                                                              \
-        (cfg),                                                                                     \
         STREAMING_BUFFER_REGION_INIT,                                                              \
         { NULL },                                                                                  \
         NULL,                                                                                      \
@@ -147,8 +145,7 @@ static inline uint64_t StreamingBufferGetOffset(const StreamingBuffer *sb)
         1,                                                                                         \
     };
 #else
-#define STREAMING_BUFFER_INITIALIZER(cfg)                                                          \
-    { (cfg), STREAMING_BUFFER_REGION_INIT, { NULL }, NULL, 0, 1, 1, 0 };
+#define STREAMING_BUFFER_INITIALIZER { STREAMING_BUFFER_REGION_INIT, { NULL }, NULL, 0, 1, 1, 0 };
 #endif
 
 typedef struct StreamingBufferSegment_ {

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -158,7 +158,7 @@ typedef struct StreamingBufferSegment_ {
 
 StreamingBuffer *StreamingBufferInit(const StreamingBufferConfig *cfg);
 void StreamingBufferClear(StreamingBuffer *sb);
-void StreamingBufferFree(StreamingBuffer *sb);
+void StreamingBufferFree(StreamingBuffer *sb, const StreamingBufferConfig *cfg);
 
 void StreamingBufferSlideToOffset(
         StreamingBuffer *sb, const StreamingBufferConfig *cfg, uint64_t offset);

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -168,9 +168,9 @@ int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferAppendNoTrack(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
-int StreamingBufferInsertAt(StreamingBuffer *sb, StreamingBufferSegment *seg,
-                             const uint8_t *data, uint32_t data_len,
-                             uint64_t offset) WARN_UNUSED;
+int StreamingBufferInsertAt(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
+        StreamingBufferSegment *seg, const uint8_t *data, uint32_t data_len,
+        uint64_t offset) WARN_UNUSED;
 
 void StreamingBufferSegmentGetData(const StreamingBuffer *sb,
                                    const StreamingBufferSegment *seg,

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -64,7 +64,6 @@
 #define STREAMING_BUFFER_REGION_GAP_DEFAULT 262144
 
 typedef struct StreamingBufferConfig_ {
-    uint32_t buf_slide;
     uint32_t buf_size;
     uint16_t max_regions; /**< max concurrent memory regions. 0 means no limit. */
     uint32_t region_gap;  /**< max gap size before a new region will be created. */
@@ -75,7 +74,7 @@ typedef struct StreamingBufferConfig_ {
 
 #define STREAMING_BUFFER_CONFIG_INITIALIZER                                                        \
     {                                                                                              \
-        0, 0, 0, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL,                            \
+        0, 0, STREAMING_BUFFER_REGION_GAP_DEFAULT, NULL, NULL, NULL,                               \
     }
 
 #define STREAMING_BUFFER_REGION_INIT                                                               \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -106,6 +106,21 @@ typedef struct StreamingBuffer_ {
 #endif
 } StreamingBuffer;
 
+static inline bool StreamingBufferHasData(const StreamingBuffer *sb)
+{
+    return (sb->stream_offset || sb->buf_offset || !RB_EMPTY(&sb->sbb_tree));
+}
+
+static inline uint64_t StreamingBufferGetConsecutiveDataRightEdge(const StreamingBuffer *sb)
+{
+    return sb->stream_offset + sb->buf_offset;
+}
+
+static inline uint64_t StreamingBufferGetOffset(const StreamingBuffer *sb)
+{
+    return sb->stream_offset;
+}
+
 #ifndef DEBUG
 #define STREAMING_BUFFER_INITIALIZER(cfg)                                                          \
     {                                                                                              \

--- a/src/util-streaming-buffer.h
+++ b/src/util-streaming-buffer.h
@@ -165,8 +165,8 @@ void StreamingBufferSlideToOffset(
 
 StreamingBufferSegment *StreamingBufferAppendRaw(StreamingBuffer *sb,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
-int StreamingBufferAppend(StreamingBuffer *sb, StreamingBufferSegment *seg,
-        const uint8_t *data, uint32_t data_len) WARN_UNUSED;
+int StreamingBufferAppend(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
+        StreamingBufferSegment *seg, const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferAppendNoTrack(StreamingBuffer *sb, const StreamingBufferConfig *cfg,
         const uint8_t *data, uint32_t data_len) WARN_UNUSED;
 int StreamingBufferInsertAt(StreamingBuffer *sb, const StreamingBufferConfig *cfg,

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -557,7 +557,7 @@ int UTHAddSessionToFlow(Flow *f,
     TcpSession *ssn = SCCalloc(1, sizeof(*ssn));
     FAIL_IF_NULL(ssn);
 
-    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER(&stream_config.sbcnf);
+    StreamingBuffer x = STREAMING_BUFFER_INITIALIZER;
     ssn->client.sb = x;
     ssn->server.sb = x;
 

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -542,7 +542,7 @@ int UTHAddStreamToFlow(Flow *f, int direction,
 
     StreamingBufferSegment seg;
     TcpStream *stream = direction == 0 ? &ssn->client : &ssn->server;
-    int r = StreamingBufferAppend(&stream->sb, &seg, data, data_len);
+    int r = StreamingBufferAppend(&stream->sb, &stream_config.sbcnf, &seg, data, data_len);
     FAIL_IF_NOT(r == 0);
     stream->last_ack += data_len;
     return 1;


### PR DESCRIPTION
Stream and frame updates:
- more efficient handling of lossy streams
- update to streaming api to no longer store cfg per File/Body/Stream, but pass it through the API
- simplification of file tracking rust, by putting FileContainer in FileTransferTracker
- add "stream" frames
- improve frame detection logic
- frames are now optional, if not used they are not tracked

suricata-verify-pr: 1067