### PR TITLE
exceptions: ignore midstream-policy if stream.midstream=true (6.0.x backports) - v1

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -474,9 +474,15 @@ void StreamTcpInitConfig(char quiet)
     stream_config.ssn_memcap_policy = ExceptionPolicyParse("stream.memcap-policy", true);
     stream_config.reassembly_memcap_policy =
             ExceptionPolicyParse("stream.reassembly.memcap-policy", true);
-    stream_config.midstream_policy = ExceptionPolicyParse("stream.midstream-policy", true);
     SCLogConfig("memcap-policy: %u/%u", stream_config.ssn_memcap_policy,
             stream_config.reassembly_memcap_policy);
+    stream_config.midstream_policy = ExceptionPolicyParse("stream.midstream-policy", true);
+    if (stream_config.midstream && stream_config.midstream_policy != EXCEPTION_POLICY_IGNORE) {
+        SCLogWarning(SC_WARN_COMPATIBILITY,
+                "stream.midstream_policy setting conflicting with stream.midstream enabled. "
+                "Ignoring stream.midstream_policy.");
+        stream_config.midstream_policy = EXCEPTION_POLICY_IGNORE;
+    }
 
     if (!quiet) {
         SCLogConfig("stream.\"inline\": %s",

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -920,7 +920,7 @@ static int StreamTcpPacketIsRetransmission(TcpStream *stream, Packet *p)
  *
  *  \param  tv      Thread Variable containig  input/output queue, cpu affinity
  *  \param  p       Packet which has to be handled in this TCP state.
- *  \param  stt     Strean Thread module registered to handle the stream handling
+ *  \param  stt     Stream Thread module registered to handle the stream handling
  *
  *  \retval 0 ok
  *  \retval -1 error


### PR DESCRIPTION

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/5765
- https://redmine.openinfosecfoundation.org/issues/5806

Describe changes:
- ignore the exception policy for midstream flows if `stream.midstream=true` in the configuration
