### PR TITLE
log-pcap: fix inverse logic error

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1104,8 +1104,9 @@ static TmEcode PcapLogDataInit(ThreadVars *t, const void *initdata, void **data)
 #endif /* INIT_RING_BUFFER */
     }
 
-    /* Don't early initialize output files if in a PCAP file mode. */
-    if (IsRunModeOffline(RunmodeGetCurrent())) {
+    /* Don't early initialize output files if in a PCAP file (offline)
+     * mode. */
+    if (!IsRunModeOffline(RunmodeGetCurrent())) {
         if (pl->mode == LOGMODE_MULTI) {
             PcapLogOpenFileCtx(td->pcap_log);
         } else {


### PR DESCRIPTION
We shouldn't early initialize when *offline*.  Instead this accidentally
delayed initializing when if an online mode, however its likely not to
have been noticed as delaying initializing in online mode is supported
as well.

suricata-verify-pr: 1066
