### PR TITLE
config: allow fully qualified overrides - v1

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -56,15 +56,15 @@ static ConfNode *root_backup = NULL;
  * This function exits on memory failure as creating configuration
  * nodes is usually part of application initialization.
  *
+ * \param parent The node to use as the parent
  * \param name The name of the configuration node to get.
  * \param final Flag to set created nodes as final or not.
  *
  * \retval The existing configuration node if it exists, or a newly
  *   created node for the provided name.  On error, NULL will be returned.
  */
-static ConfNode *ConfGetNodeOrCreate(const char *name, int final)
+ConfNode *ConfNodeGetNodeOrCreate(ConfNode *parent, const char *name, int final)
 {
-    ConfNode *parent = root;
     ConfNode *node = NULL;
     char node_name[NODE_NAME_MAX];
     char *key;
@@ -103,6 +103,15 @@ static ConfNode *ConfGetNodeOrCreate(const char *name, int final)
 
 end:
     return node;
+}
+
+/**
+ * \brief Wrapper function for ConfNodeGetNodeOrCreate that operates
+ *     on the current root node.
+ */
+static ConfNode *ConfGetNodeOrCreate(const char *name, int final)
+{
+    return ConfNodeGetNodeOrCreate(root, name, final);
 }
 
 /**

--- a/src/conf.h
+++ b/src/conf.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -97,5 +97,5 @@ int ConfNodeIsSequence(const ConfNode *node);
 ConfNode *ConfSetIfaceNode(const char *ifaces_node_name, const char *iface);
 int ConfSetRootAndDefaultNodes(
         const char *ifaces_node_name, const char *iface, ConfNode **if_root, ConfNode **if_default);
-
+ConfNode *ConfNodeGetNodeOrCreate(ConfNode *parent, const char *name, int final);
 #endif /* ! __CONF_H__ */


### PR DESCRIPTION
Allow configuration parameters to be overrided usually a fully
qualified name such as:

vars.address-groups.HOME_NET: "7.1.2.0/24"

In configuration files (including "include" files).  This allows the
overriding of a specific value deeply nested in the configuration
without having to redefine the complete top-layer object.

Ticket: https://redmine.openinfosecfoundation.org/issues/4783

suricata-verify-pr: 1087
