### PR TITLE
dcerpc: config limit for maximum number of live transactions

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1722,7 +1722,7 @@ incompatible with ``decode-mime``. If both are enabled,
 Maximum transactions
 ~~~~~~~~~~~~~~~~~~~~
 
-MQTT, FTP, PostgreSQL, SMB and NFS have each a `max-tx` parameter that can be customized.
+MQTT, FTP, PostgreSQL, SMB, DCERPC and NFS have each a `max-tx` parameter that can be customized.
 `max-tx` refers to the maximum number of live transactions for each flow.
 An app-layer event `protocol.too_many_transactions` is triggered when this value is reached.
 The point of this parameter is to find a balance between the completeness of analysis

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -900,6 +900,8 @@ app-layer:
       # max-tx: 1024
     dcerpc:
       enabled: yes
+      # Maximum number of live DCERPC transactions per flow
+      # max-tx: 1024
     ftp:
       enabled: yes
       # memcap: 64mb


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5779

Describe changes:
- dcerpc: config limit for maximum number of live transactions
