### PR TITLE
Nfs read 5812 v1 (master-6.0.x)

### DIFF
--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -79,7 +79,7 @@ named!(pub parse_nfs2_reply_read<NfsReplyRead>,
             status: be_u32
         >>  attr_blob: take!(68)
         >>  data_len: be_u32
-        >>  data_contents: rest
+        >>  data_contents: take!(data_len)
         >> (
             NfsReplyRead {
                 status,

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -16,6 +16,7 @@
 #define HEADER_LEN 6
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+int LLVMFuzzerInitialize(int *argc, char ***argv);
 
 AppLayerParserThreadCtx *alp_tctx = NULL;
 
@@ -34,6 +35,30 @@ AppLayerParserThreadCtx *alp_tctx = NULL;
 const uint8_t separator[] = {0x01, 0xD5, 0xCA, 0x7A};
 SCInstance surifuzz;
 uint64_t forceLayer = 0;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+    char *target_suffix = strrchr((*argv)[0], '_');
+    if (target_suffix != NULL) {
+        AppProto applayer = StringToAppProto(target_suffix + 1);
+        if (applayer != ALPROTO_UNKNOWN) {
+            forceLayer = applayer;
+            printf("Forcing %s=%" PRIu64 "\n", AppProtoToString(forceLayer), forceLayer);
+            return 0;
+        }
+    }
+    // else
+    const char *forceLayerStr = getenv("FUZZ_APPLAYER");
+    if (forceLayerStr) {
+        if (ByteExtractStringUint64(&forceLayer, 10, 0, forceLayerStr) < 0) {
+            forceLayer = 0;
+            printf("Invalid numeric value for FUZZ_APPLAYER environment variable");
+        } else {
+            printf("Forcing %s\n", AppProtoToString(forceLayer));
+        }
+    }
+    return 0;
+}
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -68,15 +93,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
         PostConfLoadedSetup(&surifuzz);
         alp_tctx = AppLayerParserThreadCtxAlloc();
-        const char* forceLayerStr = getenv("FUZZ_APPLAYER");
-        if (forceLayerStr) {
-            if (ByteExtractStringUint64(&forceLayer, 10, 0, forceLayerStr) < 0) {
-                forceLayer = 0;
-                printf("Invalid numeric value for FUZZ_APPLAYER environment variable");
-            } else {
-                printf("Forcing %s\n", AppProtoToString(forceLayer));
-            }
-        }
     }
 
     if (data[0] >= ALPROTO_MAX) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5812

Describe changes:
- Improve nfs2 read by limiting data read (not taking into account padding)
- fuzz: cherry-pick commit to have separate targets for the different app-layers (based on the name of the target, not only an environment variable)
