### PR TITLE
rfb: remove duplicate logging of depth - v1

### DIFF
--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -102,7 +102,6 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.set_uint("red_shift", tc_server_init.pixel_format.red_shift as u64)?;
         js.set_uint("green_shift", tc_server_init.pixel_format.green_shift as u64)?;
         js.set_uint("blue_shift", tc_server_init.pixel_format.blue_shift as u64)?;
-        js.set_uint("depth", tc_server_init.pixel_format.depth as u64)?;
         js.close()?;
 
         js.close()?;


### PR DESCRIPTION
The "depth" field in the "pixel_format" object was being logged twice.

Ticket: https://redmine.openinfosecfoundation.org/issues/5813
