### PR TITLE
test: do not output non ascii character (backport-6.0.x)

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -165,8 +165,10 @@ int DetectContentDataParse(
                         // SCLogDebug("space as part of binary string");
                     }
                     else if (str[i] != ',') {
-                        SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid hex code in "
-                                    "content - %s, hex %c. Invalidating signature.", str, str[i]);
+                        SCLogError(SC_ERR_INVALID_SIGNATURE,
+                                "Invalid hex code in "
+                                "content - %s, hex %c. Invalidating signature.",
+                                contentstr, str[i]);
                         goto error;
                     }
                 } else if (escape) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5601

Describe changes:
- backport of https://github.com/OISF/suricata/pull/8325

Cherry-pick adapted for clang-format and `SCLogError` not using a category anymore in 7

suricata-verify-pr: 939
https://github.com/OISF/suricata-verify/pull/939