### PR TITLE
eve: remove duplicate fields from json - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -38,6 +38,8 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-latest
     steps:
+      - name: Dumping github context for debugging
+        run: echo '${{ toJSON(github) }}'
       - run: sudo apt update && sudo apt -y install jq curl
       - name: Parse repo and branch information
         env:
@@ -48,6 +50,9 @@ jobs:
         run: |
           if test "${PR_HREF}"; then
               body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
+
+              echo "Parsing branch and PR info from:"
+              echo "${body}"
 
               libhtp_repo=$(echo "${body}" | awk '/^libhtp-repo/ { print $2 }')
               libhtp_branch=$(echo "${body}" | awk '/^libhtp-branch/ { print $2 }')
@@ -60,6 +65,8 @@ jobs:
               sv_repo=$(echo "${body}" | awk '/^suricata-verify-repo/ { print $2 }')
               sv_branch=$(echo "${body}" | awk '/^suricata-verify-branch/ { print $2 }')
               sv_pr=$(echo "${body}" | awk '/^suricata-verify-pr/ { print $2 }')
+          else
+              echo "PR_HREF is empty"
           fi
           echo "libhtp_repo=${libhtp_repo:-${DEFAULT_LIBHTP_REPO}}" >> $GITHUB_ENV
           echo "libhtp_branch=${libhtp_branch:-${DEFAULT_LIBHTP_BRANCH}}" >> $GITHUB_ENV

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,6 +72,17 @@ jobs:
           echo "sv_repo=${sv_repo:-${DEFAULT_SV_REPO}}" >> $GITHUB_ENV
           echo "sv_branch=${sv_branch:-${DEFAULT_SV_BRANCH}}" >> $GITHUB_ENV
           echo "sv_pr=${sv_pr:-${DEFAULT_SV_PR}}" >> $GITHUB_ENV
+      - name: Annotate output
+        run: |
+          echo "::notice:: LIBHTP_REPO=${libhtp_repo}"
+          echo "::notice:: LIBHTP_BRANCH=${libhtp_branch}"
+          echo "::notice:: LIBHTP_PR=${libhtp_pr}"
+          echo "::notice:: SU_REPO=${su_repo}"
+          echo "::notice:: SU_BRANCH=${su_branch}"
+          echo "::notice:: SU_PR=${su_pr}"
+          echo "::notice:: SV_REPO=${sv_repo}"
+          echo "::notice:: SV_BRANCH=${sv_branch}"
+          echo "::notice:: SV_PR=${sv_pr}"
       - name: Fetching libhtp
         run: |
           git clone --depth 1 ${libhtp_repo} -b ${libhtp_branch} libhtp

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3533,19 +3533,6 @@
                         "response": {
                             "type": "string"
                         },
-                        "interface": {
-                            "type": "object",
-                            "optional": true,
-                            "properties": {
-                                "uuid": {
-                                    "type": "string"
-                                },
-                                "version": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "interfaces": {
                             "type": "array",
                             "minItems": 1,

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -102,7 +102,6 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.set_uint("red_shift", tc_server_init.pixel_format.red_shift as u64)?;
         js.set_uint("green_shift", tc_server_init.pixel_format.green_shift as u64)?;
         js.set_uint("blue_shift", tc_server_init.pixel_format.blue_shift as u64)?;
-        js.set_uint("depth", tc_server_init.pixel_format.depth as u64)?;
         js.close()?;
 
         js.close()?;

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -260,8 +260,6 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
             }
         },
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
-            jsb.set_uint("tree_id", x.tree_id as u64)?;
-
             let share_name = String::from_utf8_lossy(&x.share_name);
             if x.is_pipe {
                 jsb.set_string("named_pipe", &share_name)?;


### PR DESCRIPTION
Fixes for the following duplicate JSON field tickets:
- https://redmine.openinfosecfoundation.org/issues/5813
- https://redmine.openinfosecfoundation.org/issues/5814
- https://redmine.openinfosecfoundation.org/issues/5811

The RFB one (5813) was trival.  5814 and 5811 (SMB) need review.

Also includes a commit to github-ci to better highlight what suricata-verify pr
among other variables are being used.

Commits:
- smb: remove duplicate tree_id logging
- eve: remove dcerpc.interface from schema
- smb: fix duplicate interface logging
- rfb: remove duplicate logging of depth
- github-ci: annotate job with s-v info

suricata-verify-pr: 1083
