### PR TITLE
rust: fix more lints from newer rust - v1

### DIFF
--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+#![allow(clippy::uninlined_format_args)]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -42,7 +42,7 @@ impl DHCPLogger {
             let code = option.code;
             #[allow(clippy::single_match)]
             match &option.option {
-                &DHCPOptionWrapper::Generic(ref option) => {
+                DHCPOptionWrapper::Generic(option) => {
                     #[allow(clippy::single_match)]
                     match code {
                         DHCP_OPT_TYPE => {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -255,10 +255,10 @@ impl DNSTransaction {
 
     /// Get the DNS transactions ID (not the internal tracking ID).
     pub fn tx_id(&self) -> u16 {
-        if let &Some(ref request) = &self.request {
+        if let Some(request) = &self.request {
             return request.header.tx_id;
         }
-        if let &Some(ref response) = &self.response {
+        if let Some(response) = &self.response {
             return response.header.tx_id;
         }
 
@@ -269,7 +269,7 @@ impl DNSTransaction {
     /// Get the reply code of the transaction. Note that this will
     /// also return 0 if there is no reply.
     pub fn rcode(&self) -> u16 {
-        if let &Some(ref response) = &self.response {
+        if let Some(response) = &self.response {
             return response.header.flags & 0x000f;
         }
         return 0;
@@ -865,7 +865,7 @@ export_state_data_get!(rs_dns_get_state_data, DNSState);
 pub unsafe extern "C" fn rs_dns_tx_get_query_name(
     tx: &mut DNSTransaction, i: u32, buf: *mut *const u8, len: *mut u32,
 ) -> u8 {
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if !query.name.is_empty() {
@@ -898,7 +898,7 @@ pub extern "C" fn rs_dns_tx_get_response_flags(tx: &mut DNSTransaction) -> u16 {
 pub unsafe extern "C" fn rs_dns_tx_get_query_rrtype(
     tx: &mut DNSTransaction, i: u16, rrtype: *mut u16,
 ) -> u8 {
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         if (i as usize) < request.queries.len() {
             let query = &request.queries[i as usize];
             if !query.name.is_empty() {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -611,7 +611,7 @@ fn dns_log_query(
     tx: &mut DNSTransaction, i: u16, flags: u64, jb: &mut JsonBuilder,
 ) -> Result<bool, JsonError> {
     let index = i as usize;
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         if index < request.queries.len() {
             let query = &request.queries[index];
             if dns_log_rrtype_enabled(query.rrtype, flags) {
@@ -651,7 +651,7 @@ pub extern "C" fn rs_dns_log_json_query(
 pub extern "C" fn rs_dns_log_json_answer(
     tx: &mut DNSTransaction, flags: u64, js: &mut JsonBuilder,
 ) -> bool {
-    if let &Some(ref response) = &tx.response {
+    if let Some(response) = &tx.response {
         for query in &response.queries {
             if dns_log_rrtype_enabled(query.rrtype, flags) {
                 return dns_log_json_answer(js, response, flags).is_ok();
@@ -663,7 +663,7 @@ pub extern "C" fn rs_dns_log_json_answer(
 
 #[no_mangle]
 pub extern "C" fn rs_dns_do_log_answer(tx: &mut DNSTransaction, flags: u64) -> bool {
-    if let &Some(ref response) = &tx.response {
+    if let Some(response) = &tx.response {
         for query in &response.queries {
             if dns_log_rrtype_enabled(query.rrtype, flags) {
                 return true;

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -32,12 +32,12 @@ pub extern "C" fn rs_dns_lua_get_tx_id(clua: &mut CLuaState, tx: &mut DNSTransac
 pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
     let lua = LuaState { lua: clua };
 
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         if let Some(query) = request.queries.first() {
             lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
-    } else if let &Some(ref response) = &tx.response {
+    } else if let Some(response) = &tx.response {
         if let Some(query) = response.queries.first() {
             lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
@@ -74,7 +74,7 @@ pub extern "C" fn rs_dns_lua_get_query_table(
 
     // We first look in the request for queries. However, if there is
     // no request, check the response for queries.
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         for query in &request.queries {
             lua.pushinteger(i);
             i += 1;
@@ -91,7 +91,7 @@ pub extern "C" fn rs_dns_lua_get_query_table(
 
             lua.settable(-3);
         }
-    } else if let &Some(ref response) = &tx.response {
+    } else if let Some(response) = &tx.response {
         for query in &response.queries {
             lua.pushinteger(i);
             i += 1;
@@ -127,7 +127,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(
     // table even in the absence of any authorities.
     lua.newtable();
 
-    if let &Some(ref response) = &tx.response {
+    if let Some(response) = &tx.response {
         for answer in &response.answers {
             lua.pushinteger(i);
             i += 1;
@@ -206,7 +206,7 @@ pub extern "C" fn rs_dns_lua_get_authority_table(
     // table even in the absence of any authorities.
     lua.newtable();
 
-    if let &Some(ref response) = &tx.response {
+    if let Some(response) = &tx.response {
         for answer in &response.authorities {
             lua.pushinteger(i);
             i += 1;

--- a/rust/src/ike/parser.rs
+++ b/rust/src/ike/parser.rs
@@ -537,8 +537,8 @@ impl fmt::Display for IsakmpPayloadType {
     }
 }
 
-pub fn parse_payload<'a>(
-    payload_type: u8, data: &'a [u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
+pub fn parse_payload(
+    payload_type: u8, data: &[u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
     key_exchange: &mut Vec<u8>, nonce: &mut Vec<u8>, transforms: &mut Vec<Vec<SaAttribute>>,
     vendor_ids: &mut Vec<String>, payload_types: &mut HashSet<u8>,
 ) -> Result<(), ()> {
@@ -611,8 +611,8 @@ pub fn parse_payload<'a>(
     }
 }
 
-fn parse_proposal_payload<'a>(
-    data: &'a [u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
+fn parse_proposal_payload(
+    data: &[u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
     key_exchange: &mut Vec<u8>, nonce: &mut Vec<u8>, transforms: &mut Vec<Vec<SaAttribute>>,
     vendor_ids: &mut Vec<String>, payload_types: &mut HashSet<u8>,
 ) -> Result<(), ()> {
@@ -658,8 +658,8 @@ fn parse_proposal_payload<'a>(
     }
 }
 
-fn parse_security_association_payload<'a>(
-    data: &'a [u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
+fn parse_security_association_payload(
+    data: &[u8], data_length: u16, domain_of_interpretation: &mut Option<u32>,
     key_exchange: &mut Vec<u8>, nonce: &mut Vec<u8>, transforms: &mut Vec<Vec<SaAttribute>>,
     vendor_ids: &mut Vec<String>, payload_types: &mut HashSet<u8>,
 ) -> Result<(), ()> {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,7 @@
 // Allow these patterns as its a style we like.
 #![allow(clippy::needless_return)]
 #![allow(clippy::let_and_return)]
+#![allow(clippy::uninlined_format_args)]
 
 // We find this makes sense at time.
 #![allow(clippy::module_inception)]

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -672,7 +672,7 @@ impl NFSState {
         }
     }
 
-    pub fn process_request_record_lookup<'b>(&mut self, r: &RpcPacket<'b>, xidmap: &mut NFSRequestXidMap) {
+    pub fn process_request_record_lookup(&mut self, r: &RpcPacket, xidmap: &mut NFSRequestXidMap) {
         match parse_nfs3_request_lookup(r.prog_data) {
             Ok((_, lookup)) => {
                 SCLogDebug!("LOOKUP {:?}", lookup);
@@ -698,7 +698,7 @@ impl NFSState {
     }
 
     /// complete request record
-    fn process_request_record<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcPacket<'b>) {
+    fn process_request_record(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcPacket) {
         SCLogDebug!("REQUEST {} procedure {} ({}) blob size {}",
                 r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
 
@@ -845,7 +845,7 @@ impl NFSState {
         return self.process_write_record(r, w);
     }
 
-    fn process_reply_record<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcReplyPacket<'b>) -> u32 {
+    fn process_reply_record(&mut self, flow: *const Flow, stream_slice: &StreamSlice, r: &RpcReplyPacket) -> u32 {
         let mut xidmap;
         match self.requestmap.remove(&r.hdr.xid) {
             Some(p) => { xidmap = p; },

--- a/rust/src/nfs/nfs2.rs
+++ b/rust/src/nfs/nfs2.rs
@@ -27,7 +27,7 @@ use nom7::number::streaming::be_u32;
 
 impl NFSState {
     /// complete request record
-    pub fn process_request_record_v2<'b>(&mut self, r: &RpcPacket<'b>) {
+    pub fn process_request_record_v2(&mut self, r: &RpcPacket) {
         SCLogDebug!("NFSv2: REQUEST {} procedure {} ({}) blob size {}",
                 r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
 
@@ -92,7 +92,7 @@ impl NFSState {
         self.requestmap.insert(r.hdr.xid, xidmap);
     }
 
-    pub fn process_reply_record_v2<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &NFSRequestXidMap) {
+    pub fn process_reply_record_v2(&mut self, r: &RpcReplyPacket, xidmap: &NFSRequestXidMap) {
         let mut nfs_status = 0;
         let resp_handle = Vec::new();
 

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -29,7 +29,7 @@ use nom7::number::streaming::be_u32;
 
 impl NFSState {
     /// complete NFS3 request record
-    pub fn process_request_record_v3<'b>(&mut self, r: &RpcPacket<'b>) {
+    pub fn process_request_record_v3(&mut self, r: &RpcPacket) {
         SCLogDebug!("REQUEST {} procedure {} ({}) blob size {}",
                 r.hdr.xid, r.procedure, self.requestmap.len(), r.prog_data.len());
 
@@ -186,7 +186,7 @@ impl NFSState {
         self.requestmap.insert(r.hdr.xid, xidmap);
     }
 
-    pub fn process_reply_record_v3<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &mut NFSRequestXidMap) {
+    pub fn process_reply_record_v3(&mut self, r: &RpcReplyPacket, xidmap: &mut NFSRequestXidMap) {
         let mut nfs_status = 0;
         let mut resp_handle = Vec::new();
 

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -321,7 +321,7 @@ impl NFSState {
                     SCLogDebug!("READDIRv4: status {} eof {}", _s, rd.eof);
                     
                     for d in &rd.listing {
-                        if let &Some(ref _d) = d {
+                        if let Some(_d) = d {
                             SCLogDebug!("READDIRv4: dir {}", String::from_utf8_lossy(_d.name));
                         }
                     }

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -320,6 +320,7 @@ impl NFSState {
                 Nfs4ResponseContent::ReadDir(_s, Some(ref rd)) => {
                     SCLogDebug!("READDIRv4: status {} eof {}", _s, rd.eof);
                     
+                    #[allow(clippy::manual_flatten)]
                     for d in &rd.listing {
                         if let Some(_d) = d {
                             SCLogDebug!("READDIRv4: dir {}", String::from_utf8_lossy(_d.name));

--- a/rust/src/nfs/nfs4.rs
+++ b/rust/src/nfs/nfs4.rs
@@ -124,8 +124,8 @@ impl NFSState {
         }
     }
 
-    fn new_tx_v4<'b>(
-        &mut self, r: &RpcPacket<'b>, xidmap: &NFSRequestXidMap, procedure: u32,
+    fn new_tx_v4(
+        &mut self, r: &RpcPacket, xidmap: &NFSRequestXidMap, procedure: u32,
         _aux_opcodes: &[u32],
     ) {
         let mut tx = self.new_tx();
@@ -238,7 +238,7 @@ impl NFSState {
     }
 
     /// complete request record
-    pub fn process_request_record_v4<'b>(&mut self, r: &RpcPacket<'b>) {
+    pub fn process_request_record_v4(&mut self, r: &RpcPacket) {
         SCLogDebug!(
             "NFSv4 REQUEST {} procedure {} ({}) blob size {}",
             r.hdr.xid,
@@ -381,8 +381,8 @@ impl NFSState {
         }
     }
 
-    pub fn process_reply_record_v4<'b>(
-        &mut self, r: &RpcReplyPacket<'b>, xidmap: &mut NFSRequestXidMap,
+    pub fn process_reply_record_v4(
+        &mut self, r: &RpcReplyPacket, xidmap: &mut NFSRequestXidMap,
     ) {
         if xidmap.procedure == NFSPROC4_COMPOUND {
             let mut data = r.prog_data;

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -28,7 +28,7 @@ pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.set_uint("tx_id", tx.tx_id)?;
-    if let &Some(ref request) = &tx.request {
+    if let Some(request) = &tx.request {
         js.set_object("request", &log_request(request, flags)?)?;
     } else if tx.responses.is_empty() {
         SCLogDebug!("Suricata created an empty PGSQL transaction");

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -439,11 +439,11 @@ fn dcerpc_response_handle(tx: &mut SMBTransaction,
 
 /// Handle DCERPC reply record. Called for READ, TRANS, IOCTL
 ///
-pub fn smb_read_dcerpc_record<'b>(state: &mut SMBState,
+pub fn smb_read_dcerpc_record(state: &mut SMBState,
         vercmd: SMBVerCmdStat,
         hdr: SMBCommonHdr,
         guid: &[u8],
-        indata: &'b [u8]) -> bool
+        indata: &[u8]) -> bool
 {
     let (_, ntstatus) = vercmd.get_ntstatus();
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1267,7 +1267,7 @@ impl SMBState {
     }
 
     /// return bytes consumed
-    pub fn parse_tcp_data_ts_partial<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &'b[u8]) -> usize
+    pub fn parse_tcp_data_ts_partial(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8]) -> usize
     {
         SCLogDebug!("incomplete of size {}", input.len());
         if input.len() < 512 {
@@ -1595,7 +1595,7 @@ impl SMBState {
     }
 
     /// return bytes consumed
-    pub fn parse_tcp_data_tc_partial<'b>(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &'b[u8]) -> usize
+    pub fn parse_tcp_data_tc_partial(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8]) -> usize
     {
         SCLogDebug!("incomplete of size {}", input.len());
         if input.len() < 512 {

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -182,7 +182,7 @@ fn smb1_command_is_andx(c: u8) -> bool {
     }
 }
 
-fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command: u8, andx_offset: &mut usize) {
+fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
     let mut events : Vec<SMBEvent> = Vec::new();
     let mut no_response_expected = false;
 
@@ -580,7 +580,7 @@ fn smb1_request_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command:
     }
 }
 
-pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
+pub fn smb1_request_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
     SCLogDebug!("record: command {}: record {:?}", r.command, r);
 
     let mut andx_offset = SMB1_HEADER_SIZE;
@@ -606,7 +606,7 @@ pub fn smb1_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
     0
 }
 
-fn smb1_response_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command: u8, andx_offset: &mut usize) {
+fn smb1_response_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, andx_offset: &mut usize) {
     SCLogDebug!("record: command {} status {} -> {:?}", r.command, r.nt_status, r);
 
     let key_ssn_id = r.ssn_id;
@@ -822,7 +822,7 @@ fn smb1_response_record_one<'b>(state: &mut SMBState, r: &SmbRecord<'b>, command
     }
 }
 
-pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 {
+pub fn smb1_response_record(state: &mut SMBState, r: &SmbRecord) -> u32 {
     let mut andx_offset = SMB1_HEADER_SIZE;
     let mut command = r.command;
     loop {
@@ -846,7 +846,7 @@ pub fn smb1_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>) -> u32 
     0
 }
 
-pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
+pub fn smb1_trans_request_record(state: &mut SMBState, r: &SmbRecord)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -885,7 +885,7 @@ pub fn smb1_trans_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
     smb1_request_record_generic(state, r, events);
 }
 
-pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
+pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -932,7 +932,7 @@ pub fn smb1_trans_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>)
 }
 
 /// Handle WRITE, WRITE_ANDX, WRITE_AND_CLOSE request records
-pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, andx_offset: usize, command: u8)
+pub fn smb1_write_request_record(state: &mut SMBState, r: &SmbRecord, andx_offset: usize, command: u8)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -1019,7 +1019,7 @@ pub fn smb1_write_request_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
     smb1_request_record_generic(state, r, events);
 }
 
-pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, andx_offset: usize)
+pub fn smb1_read_response_record(state: &mut SMBState, r: &SmbRecord, andx_offset: usize)
 {
     let mut events : Vec<SMBEvent> = Vec::new();
 
@@ -1111,7 +1111,7 @@ pub fn smb1_read_response_record<'b>(state: &mut SMBState, r: &SmbRecord<'b>, an
 /// create a tx for a command / response pair if we're
 /// configured to do so, or if this is a tx especially
 /// for setting an event.
-fn smb1_request_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, events: Vec<SMBEvent>) {
+fn smb1_request_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
     if smb1_create_new_tx(r.command) || !events.is_empty() {
         let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
         let tx = state.new_generic_tx(1, r.command as u16, tx_key);
@@ -1122,7 +1122,7 @@ fn smb1_request_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, even
 /// update or create a tx for a command / reponse pair based
 /// on the response. We only create a tx for the response side
 /// if we didn't already update a tx, and we have to set events
-fn smb1_response_record_generic<'b>(state: &mut SMBState, r: &SmbRecord<'b>, events: Vec<SMBEvent>) {
+fn smb1_response_record_generic(state: &mut SMBState, r: &SmbRecord, events: Vec<SMBEvent>) {
     let tx_key = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
     if let Some(tx) = state.get_generic_tx(1, r.command as u16, &tx_key) {
         tx.request_done = true;

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -331,7 +331,7 @@ pub fn parse_smb_trans_request_record_data(i: &[u8],
     Ok((i, req))
 }
 
-pub fn parse_smb_trans_request_record<'a, 'b>(i: &'a[u8], r: &SmbRecord<'b>)
+pub fn parse_smb_trans_request_record<'a>(i: &'a[u8], r: &SmbRecord)
     -> IResult<&'a[u8], SmbRecordTransRequest<'a>, SmbError>
 {
     let (rem, (params, pipe)) = parse_smb_trans_request_record_params(i)?;

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -101,7 +101,7 @@ fn smb2_create_new_tx(cmd: u16) -> bool {
     }
 }
 
-fn smb2_read_response_record_generic<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+fn smb2_read_response_record_generic(state: &mut SMBState, r: &Smb2Record)
 {
     if smb2_create_new_tx(r.command) {
         let tx_hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_GENERICTX);
@@ -113,7 +113,7 @@ fn smb2_read_response_record_generic<'b>(state: &mut SMBState, r: &Smb2Record<'b
     }
 }
 
-pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_READ_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_READ_QUEUE_CNT };
@@ -264,7 +264,7 @@ pub fn smb2_read_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record)
 {
     let max_queue_size = unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE };
     let max_queue_cnt = unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT };
@@ -396,7 +396,7 @@ pub fn smb2_write_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_request_record(state: &mut SMBState, r: &Smb2Record)
 {
     SCLogDebug!("SMBv2 request record, command {} tree {} session {}",
             &smb2_command_string(r.command), r.tree_id, r.session_id);
@@ -638,7 +638,7 @@ pub fn smb2_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
     }
 }
 
-pub fn smb2_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
 {
     SCLogDebug!("SMBv2 response record, command {} status {} tree {} session {} message {}",
             &smb2_command_string(r.command), r.nt_status,

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -57,7 +57,7 @@ impl SMBState {
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_ioctl_request_record(state: &mut SMBState, r: &Smb2Record)
 {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_request_ioctl(r.data) {
@@ -86,7 +86,7 @@ pub fn smb2_ioctl_request_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
 }
 
 // IOCTL responses ASYNC don't set the tree id
-pub fn smb2_ioctl_response_record<'b>(state: &mut SMBState, r: &Smb2Record<'b>)
+pub fn smb2_ioctl_response_record(state: &mut SMBState, r: &Smb2Record)
 {
     let hdr = SMBCommonHdr::from2(r, SMBHDR_TYPE_HEADER);
     match parse_smb2_response_ioctl(r.data) {


### PR DESCRIPTION
- rust: allow uninlined_format_args
- rust: fix needless borrows of references
- rust: remove explicit lifetimes where not needed
- rust: suppress specific manual_flatten list
