### PR TITLE
tls: fix date logging for dates before 1970

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5368,10 +5368,10 @@
                             "type": "string"
                         },
                         "notafter": {
-                            "type": "string"
+                            "$ref": "#/$defs/tls_date"
                         },
                         "notbefore": {
-                            "type": "string"
+                            "$ref": "#/$defs/tls_date"
                         },
                         "serial": {
                             "type": "string"
@@ -5392,10 +5392,10 @@
                     "type": "string"
                 },
                 "notafter": {
-                    "type": "string"
+                    "$ref": "#/$defs/tls_date"
                 },
                 "notbefore": {
-                    "type": "string"
+                    "$ref": "#/$defs/tls_date"
                 },
                 "serial": {
                     "type": "string"
@@ -5513,6 +5513,11 @@
                 }
             },
             "additionalProperties": false
+        },
+        "tls_date": {
+            "$comment": "Definition for TLS date formats",
+            "type": "string",
+            "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
         }
     }
 }

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -49,29 +49,6 @@ pub unsafe extern "C" fn SCSha256Finalize(hasher: &mut SCSha256, out: *mut u8, l
     finalize(hasher.0, out, len);
 }
 
-/// C function to finalize the Sha256 hasher to a hex string.
-///
-/// Notes:
-/// - There is probably room for optimization here, by iterating the result and writing
-///   the output directly to the output buffer.
-///
-/// But even given the notes, this appears to be faster than the equivalent that we
-/// did in C using NSS.
-#[no_mangle]
-pub unsafe extern "C" fn SCSha256FinalizeToHex(hasher: &mut SCSha256, out: *mut c_char, len: u32) {
-    let out = &mut *(out as *mut u8);
-    let hasher: Box<SCSha256> = Box::from_raw(hasher);
-    let result = hasher.0.finalize();
-    let hex = format!("{:x}", &result);
-    let output = std::slice::from_raw_parts_mut(out, len as usize);
-
-    // This will panic if the sizes differ.
-    output[0..len as usize - 1].copy_from_slice(hex.as_bytes());
-
-    // Terminate the string.
-    output[output.len() - 1] = 0;
-}
-
 /// Free an unfinalized Sha256 context.
 #[no_mangle]
 pub unsafe extern "C" fn SCSha256Free(hasher: &mut SCSha256) {
@@ -157,24 +134,6 @@ pub unsafe extern "C" fn SCMd5Update(hasher: &mut SCMd5, bytes: *const u8, len: 
 pub unsafe extern "C" fn SCMd5Finalize(hasher: &mut SCMd5, out: *mut u8, len: u32) {
     let hasher: Box<SCMd5> = Box::from_raw(hasher);
     finalize(hasher.0, out, len);
-}
-
-/// Finalize MD5 context to a hex string.
-///
-/// Consumes the hash context and cannot be re-used.
-#[no_mangle]
-pub unsafe extern "C" fn SCMd5FinalizeToHex(hasher: &mut SCMd5, out: *mut c_char, len: u32) {
-    let out = &mut *(out as *mut u8);
-    let hasher: Box<SCMd5> = Box::from_raw(hasher);
-    let result = hasher.0.finalize();
-    let hex = format!("{:x}", &result);
-    let output = std::slice::from_raw_parts_mut(out, len as usize);
-
-    // This will panic if the sizes differ.
-    output[0..len as usize - 1].copy_from_slice(hex.as_bytes());
-
-    // Terminate the string.
-    output[output.len() - 1] = 0;
 }
 
 /// Free an unfinalized Sha1 context.

--- a/rust/src/ffi/hashing.rs
+++ b/rust/src/ffi/hashing.rs
@@ -156,18 +156,10 @@ pub unsafe extern "C" fn SCMd5HashBuffer(buf: *const u8, buf_len: u32, out: *mut
 pub unsafe extern "C" fn SCMd5HashBufferToHex(
     buf: *const u8, buf_len: u32, out: *mut c_char, len: u32,
 ) {
-    let out = &mut *(out as *mut u8);
-    let output = std::slice::from_raw_parts_mut(out, len as usize);
     let data = std::slice::from_raw_parts(buf, buf_len as usize);
-    // let output = std::slice::from_raw_parts_mut(out, len as usize);
     let hash = Md5::new().chain(data).finalize();
     let hex = format!("{:x}", &hash);
-
-    // This will panic if the sizes differ.
-    output[0..len as usize - 1].copy_from_slice(hex.as_bytes());
-
-    // Terminate the string.
-    output[output.len() - 1] = 0;
+    crate::ffi::strings::copy_to_c_char(hex, out, len as usize);
 }
 
 // Functions that are generic over Digest. For the most part the C bindings are

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod hashing;
 pub mod base64;
+pub mod strings;

--- a/rust/src/ffi/strings.rs
+++ b/rust/src/ffi/strings.rs
@@ -1,0 +1,43 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+/// FFI utility function to copy a Rust string to a C string buffer.
+///
+/// Return true on success. On error, false will be returned.
+///
+/// An error will be returned if the provided string cannot be
+/// converted to a C string (for example, it contains NULs), or if the
+/// provided buffer is not large enough.
+///
+/// # Safety
+///
+/// Unsafe as this depends on the caller providing valid buf and size
+/// parameters.
+pub unsafe fn copy_to_c_char(src: String, buf: *mut c_char, size: usize) -> bool {
+    if let Ok(src) = CString::new(src) {
+        let src = src.as_bytes_with_nul();
+        if size >= src.len() {
+            let buf = std::slice::from_raw_parts_mut(buf as *mut u8, size);
+            buf[0..src.len()].copy_from_slice(src);
+            return true;
+        }
+    }
+    false
+}

--- a/rust/src/x509/log.rs
+++ b/rust/src/x509/log.rs
@@ -1,0 +1,40 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::jsonbuilder::JsonBuilder;
+use crate::x509::time::format_timestamp;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+/// Helper function to log a TLS timestamp from C to JSON with the
+/// provided key. The format of the timestamp is ISO 8601 timestamp
+/// with no sub-second or offset information as UTC is assumed.
+///
+/// # Safety
+///
+/// FFI function that dereferences pointers from C.
+#[no_mangle]
+pub unsafe extern "C" fn sc_x509_log_timestamp(
+    jb: &mut JsonBuilder, key: *const c_char, timestamp: i64,
+) -> bool {
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        if let Ok(timestamp) = format_timestamp(timestamp) {
+            return jb.set_string(key, &timestamp).is_ok();
+        }
+    }
+    false
+}

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -22,6 +22,8 @@ use nom7::Err;
 use std;
 use std::os::raw::c_char;
 use x509_parser::prelude::*;
+mod time;
+mod log;
 
 #[repr(u32)]
 pub enum X509DecodeError {

--- a/rust/src/x509/time.rs
+++ b/rust/src/x509/time.rs
@@ -1,0 +1,72 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+use time::macros::format_description;
+
+/// Format a timestamp in an ISO format suitable for TLS logging.
+///
+/// Negative timestamp values are used for dates prior to 1970.
+pub fn format_timestamp(timestamp: i64) -> Result<String, time::error::Error> {
+    let format = format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");
+    let ts = time::OffsetDateTime::from_unix_timestamp(timestamp)?;
+    let formatted = ts.format(&format)?;
+    Ok(formatted)
+}
+
+/// Format a x509 ISO timestamp into the provided C buffer.
+///
+/// Returns false if an error occurs, otherwise true is returned if
+/// the timestamp is properly formatted into the provided buffer.
+///
+/// # Safety
+///
+/// Access buffers from C that are expected to be valid.
+#[no_mangle]
+pub unsafe extern "C" fn sc_x509_format_timestamp(
+    timestamp: i64, buf: *mut c_char, size: usize,
+) -> bool {
+    let ctimestamp = match format_timestamp(timestamp) {
+        Ok(ts) => match CString::new(ts) {
+            Ok(ts) => ts,
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+    let bytes = ctimestamp.as_bytes_with_nul();
+
+    if size < bytes.len() {
+        false
+    } else {
+        // Convert buf into a slice we can copy into.
+        let buf = std::slice::from_raw_parts_mut(buf as *mut u8, size);
+        buf[0..bytes.len()].copy_from_slice(bytes);
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_format_timestamp() {
+        assert_eq!("1969-12-31T00:00:00", format_timestamp(-86400).unwrap());
+        assert_eq!("2038-12-31T00:10:03", format_timestamp(2177367003).unwrap());
+    }
+}

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -521,8 +521,6 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
     /* only store fields from the first certificate in the chain */
     if (certn == 0 && connp->cert0_subject == NULL && connp->cert0_issuerdn == NULL &&
             connp->cert0_serial == NULL) {
-        int64_t not_before, not_after;
-
         x509 = rs_x509_decode(input, cert_len, &err_code);
         if (x509 == NULL) {
             TlsDecodeHSCertificateErrSetEvent(ssl_state, err_code);
@@ -550,13 +548,11 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
         }
         connp->cert0_serial = str;
 
-        rc = rs_x509_get_validity(x509, &not_before, &not_after);
+        rc = rs_x509_get_validity(x509, &connp->cert0_not_before, &connp->cert0_not_after);
         if (rc != 0) {
             err_code = ERR_EXTRACT_VALIDITY;
             goto error;
         }
-        connp->cert0_not_before = (time_t)not_before;
-        connp->cert0_not_after = (time_t)not_after;
 
         rs_x509_free(x509);
         x509 = NULL;

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -252,8 +252,8 @@ typedef struct SSLStateConnp_ {
     char *cert0_subject;
     char *cert0_issuerdn;
     char *cert0_serial;
-    time_t cert0_not_before;
-    time_t cert0_not_after;
+    int64_t cert0_not_before;
+    int64_t cert0_not_after;
     char *cert0_fingerprint;
 
     /* ssl server name indication extension */

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -290,12 +290,12 @@ static void LogTlsLogVersion(MemBuffer *buffer, uint16_t version)
     MemBufferWriteString(buffer, "VERSION='%s'", ssl_version);
 }
 
-static void LogTlsLogDate(MemBuffer *buffer, const char *title, time_t *date)
+static void LogTlsLogDate(MemBuffer *buffer, const char *title, int64_t *date)
 {
     char timebuf[64] = {0};
-    const SCTime_t ts = SCTIME_FROM_SECS(*date);
-    CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-    MemBufferWriteString(buffer, "%s='%s'", title, timebuf);
+    if (sc_x509_format_timestamp(*date, timebuf, sizeof(timebuf))) {
+        MemBufferWriteString(buffer, "%s='%s'", title, timebuf);
+    }
 }
 
 static void LogTlsLogString(MemBuffer *buffer, const char *title,

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -168,20 +168,14 @@ static void JsonTlsLogVersion(JsonBuilder *js, SSLState *ssl_state)
 static void JsonTlsLogNotBefore(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_before != 0) {
-        char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_before);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-        jb_set_string(js, "notbefore", timebuf);
+        sc_x509_log_timestamp(js, "notbefore", ssl_state->server_connp.cert0_not_before);
     }
 }
 
 static void JsonTlsLogNotAfter(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_after != 0) {
-        char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_after);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-        jb_set_string(js, "notafter", timebuf);
+        sc_x509_log_timestamp(js, "notafter", ssl_state->server_connp.cert0_not_after);
     }
 }
 


### PR DESCRIPTION
The Rust time crate used by the x509-parser crate represents dates before 1970
as negative numbers which do not surive the conversion to SCTime_t and
formatting with the current time formatting functions.
    
Instead of fixing our formatting functions to handle such dates, create a Rust
function for logging TLS dates directly to JSON using the time crate that
handles such dates properly.

Ticket: https://redmine.openinfosecfoundation.org/issues/5817

suricata-verify-pr: 1089
