### PR TITLE
draft: Backport/bug/5793 udp invalid event v1

### DIFF
--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -57,8 +57,8 @@ static int DecodeUDPPacket(ThreadVars *t, Packet *p, const uint8_t *pkt, uint16_
     }
 
     if (unlikely(len != UDP_GET_LEN(p))) {
+        // packet can still be valid, keeping for consistency with decoder.udp.hlen_invalid event
         ENGINE_SET_INVALID_EVENT(p, UDP_HLEN_INVALID);
-        return -1;
     }
 
     SET_UDP_SRC_PORT(p,&p->sp);

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -110,6 +110,14 @@ static int DetectEngineEventMatch (DetectEngineThreadCtx *det_ctx,
     SCReturnInt(0);
 }
 
+static bool OutdatedEvent(const char *raw)
+{
+    if (strcmp(raw, "decoder.udp.hlen_invalid") == 0) {
+        return true;
+    }
+    return false;
+}
+
 /**
  * \brief This function is used to parse decoder events options passed via decode-event: keyword
  *
@@ -163,6 +171,12 @@ static DetectEngineEventData *DetectEngineEventParse (const char *rawstr)
     if (de->event == STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA) {
         StreamTcpReassembleConfigEnableOverlapCheck();
     }
+
+    if (OutdatedEvent(rawstr)) {
+        SCLogWarning(
+                SC_WARN_DEPRECATED, "decode-event keyword no longer supports event \"%s\"", rawstr);
+    }
+
     return de;
 
 error:


### PR DESCRIPTION
If the packet is shorter than IP payload length we no longer flag it as an invalid UDP packet. UDP packet can be therefore shorter than IP payload. Keyword "udp.hlen_invalid" became outdated as we no longer flag short UDP packets as invalid. The keyword's evaluation remains the same.

Inspired by commit: d18e52ed93e996bc0335d4a100b2ac7f12b3848d

Redmine ticket: #5793

suricata-verify-pr: 1078
