### PR TITLE
tls: log time string that can be before 1970

### DIFF
--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -18,7 +18,25 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
 #[no_mangle]
 pub unsafe extern "C" fn rs_check_utf8(val: *const c_char) -> bool {
     CStr::from_ptr(val).to_str().is_ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_tls_create_utc_iso_time_string(
+    nsecs: i64, buffer: *mut u8, buffer_len: usize,
+) {
+    let mut slice = std::slice::from_raw_parts_mut(buffer, buffer_len);
+    // format moves slice forward, so we keep original one.
+    let oslice = std::slice::from_raw_parts_mut(buffer, buffer_len);
+    let t = OffsetDateTime::from_unix_timestamp(nsecs).unwrap();
+    let n = t.format_into(&mut slice, &Rfc3339).unwrap();
+    // remove final Z for time offset.
+    if n > 0 {
+        oslice[n - 1] = 0;
+    }
 }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -169,8 +169,8 @@ static void JsonTlsLogNotBefore(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_before != 0) {
         char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_before);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
+        rs_tls_create_utc_iso_time_string((int64_t)ssl_state->server_connp.cert0_not_before,
+                (uint8_t *)timebuf, sizeof(timebuf));
         jb_set_string(js, "notbefore", timebuf);
     }
 }
@@ -179,8 +179,8 @@ static void JsonTlsLogNotAfter(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_after != 0) {
         char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_after);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
+        rs_tls_create_utc_iso_time_string((int64_t)ssl_state->server_connp.cert0_not_after,
+                (uint8_t *)timebuf, sizeof(timebuf));
         jb_set_string(js, "notafter", timebuf);
     }
 }
@@ -301,14 +301,14 @@ static void JsonTlsLogClientCert(
     }
     if (connp->cert0_not_before != 0) {
         char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(connp->cert0_not_before);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
+        rs_tls_create_utc_iso_time_string(
+                (int64_t)connp->cert0_not_before, (uint8_t *)timebuf, sizeof(timebuf));
         jb_set_string(js, "notbefore", timebuf);
     }
     if (connp->cert0_not_after != 0) {
         char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(connp->cert0_not_after);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
+        rs_tls_create_utc_iso_time_string(
+                (int64_t)connp->cert0_not_after, (uint8_t *)timebuf, sizeof(timebuf));
         jb_set_string(js, "notafter", timebuf);
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3253
https://redmine.openinfosecfoundation.org/issues/5718

Describe changes:
- Make TLS be able to correctly log timestamps before 1970

suricata-verify-pr: 1090

Replaces #8471 by removing final `Z` (corresponding to the timezone/offset) in the time string