### PR TITLE
config: check return value of dotted override

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -304,6 +304,10 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
 
                     if (strchr(value, '.') != NULL) {
                         node = ConfNodeGetNodeOrCreate(parent, value, 0);
+                        if (node == NULL) {
+                            /* Error message already logged. */
+                            goto fail;
+                        }
                     } else {
                         ConfNode *existing = ConfNodeLookupChild(parent, value);
                         if (existing != NULL) {


### PR DESCRIPTION
Fixes commit fbb0d2b0f4ccc873b74ec5db97c08cfa8a9ce251.

Getting to used to forced return value checks in Rust I guess.
