### PR TITLE
pfring/time: Address sign mismatch warnings

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -347,7 +347,7 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
     Packet *p = NULL;
     struct pfring_pkthdr hdr;
     TmSlot *s = (TmSlot *)slot;
-    time_t last_dump = 0;
+    SCTime_t last_dump = SCTIME_INITIALIZER;
     u_int buffer_size;
     u_char *pkt_buffer;
 

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -47,6 +47,12 @@ typedef struct {
         (t).secs = 0;                                                                              \
         (t).usecs = 0;                                                                             \
     }
+
+#define SCTIME_INITIALIZER                                                                         \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = 0, .usecs = 0                                                                      \
+    }
 #define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)


### PR DESCRIPTION
This PR addresses a build-time warning re: the SCTime_t type and its usage in PF-ring
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5818](https://redmine.openinfosecfoundation.org/issues/5818)

Describe changes:
- Add initializer for SCTime types
- Correct sign mismatch in PFr-ing packet acquisition logic


#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
