### PR TITLE
next/20230129/v3.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -38,6 +38,8 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-latest
     steps:
+      - name: Dumping github context for debugging
+        run: echo '${{ toJSON(github) }}'
       - run: sudo apt update && sudo apt -y install jq curl
       - name: Parse repo and branch information
         env:
@@ -48,6 +50,9 @@ jobs:
         run: |
           if test "${PR_HREF}"; then
               body=$(curl -s "${PR_HREF}" | jq -r .body | tr -d '\r')
+
+              echo "Parsing branch and PR info from:"
+              echo "${body}"
 
               libhtp_repo=$(echo "${body}" | awk '/^libhtp-repo/ { print $2 }')
               libhtp_branch=$(echo "${body}" | awk '/^libhtp-branch/ { print $2 }')
@@ -60,6 +65,8 @@ jobs:
               sv_repo=$(echo "${body}" | awk '/^suricata-verify-repo/ { print $2 }')
               sv_branch=$(echo "${body}" | awk '/^suricata-verify-branch/ { print $2 }')
               sv_pr=$(echo "${body}" | awk '/^suricata-verify-pr/ { print $2 }')
+          else
+              echo "PR_HREF is empty"
           fi
           echo "libhtp_repo=${libhtp_repo:-${DEFAULT_LIBHTP_REPO}}" >> $GITHUB_ENV
           echo "libhtp_branch=${libhtp_branch:-${DEFAULT_LIBHTP_BRANCH}}" >> $GITHUB_ENV

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -72,6 +72,17 @@ jobs:
           echo "sv_repo=${sv_repo:-${DEFAULT_SV_REPO}}" >> $GITHUB_ENV
           echo "sv_branch=${sv_branch:-${DEFAULT_SV_BRANCH}}" >> $GITHUB_ENV
           echo "sv_pr=${sv_pr:-${DEFAULT_SV_PR}}" >> $GITHUB_ENV
+      - name: Annotate output
+        run: |
+          echo "::notice:: LIBHTP_REPO=${libhtp_repo}"
+          echo "::notice:: LIBHTP_BRANCH=${libhtp_branch}"
+          echo "::notice:: LIBHTP_PR=${libhtp_pr}"
+          echo "::notice:: SU_REPO=${su_repo}"
+          echo "::notice:: SU_BRANCH=${su_branch}"
+          echo "::notice:: SU_PR=${su_pr}"
+          echo "::notice:: SV_REPO=${sv_repo}"
+          echo "::notice:: SV_BRANCH=${sv_branch}"
+          echo "::notice:: SV_PR=${sv_pr}"
       - name: Fetching libhtp
         run: |
           git clone --depth 1 ${libhtp_repo} -b ${libhtp_branch} libhtp

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,7 @@ jobs:
       - run: |
           diff=$(git diff)
           if [ "${diff}" ]; then
+              echo "${diff}"
               echo "::error ::Clippy --fix made changes, please fix"
               exit 1
           fi

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3533,19 +3533,6 @@
                         "response": {
                             "type": "string"
                         },
-                        "interface": {
-                            "type": "object",
-                            "optional": true,
-                            "properties": {
-                                "uuid": {
-                                    "type": "string"
-                                },
-                                "version": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "interfaces": {
                             "type": "array",
                             "minItems": 1,

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5374,10 +5374,10 @@
                             "type": "string"
                         },
                         "notafter": {
-                            "type": "string"
+                            "$ref": "#/$defs/tls_date"
                         },
                         "notbefore": {
-                            "type": "string"
+                            "$ref": "#/$defs/tls_date"
                         },
                         "serial": {
                             "type": "string"
@@ -5398,10 +5398,10 @@
                     "type": "string"
                 },
                 "notafter": {
-                    "type": "string"
+                    "$ref": "#/$defs/tls_date"
                 },
                 "notbefore": {
-                    "type": "string"
+                    "$ref": "#/$defs/tls_date"
                 },
                 "serial": {
                     "type": "string"
@@ -5519,6 +5519,11 @@
                 }
             },
             "additionalProperties": false
+        },
+        "tls_date": {
+            "$comment": "Definition for TLS date formats",
+            "type": "string",
+            "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
         }
     }
 }

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod hashing;
 pub mod base64;
+pub mod strings;

--- a/rust/src/ffi/strings.rs
+++ b/rust/src/ffi/strings.rs
@@ -1,0 +1,84 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+/// FFI utility function to copy a Rust string to a C string buffer.
+///
+/// Return true on success. On error, false will be returned.
+///
+/// An error will be returned if the provided string cannot be
+/// converted to a C string (for example, it contains NULs), or if the
+/// provided buffer is not large enough.
+///
+/// # Safety
+///
+/// Unsafe as this depends on the caller providing valid buf and size
+/// parameters.
+pub unsafe fn copy_to_c_char(src: String, buf: *mut c_char, size: usize) -> bool {
+    if let Ok(src) = CString::new(src) {
+        let src = src.as_bytes_with_nul();
+        if size >= src.len() {
+            let buf = std::slice::from_raw_parts_mut(buf as *mut u8, size);
+            buf[0..src.len()].copy_from_slice(src);
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_copy_to_c_char() {
+        unsafe {
+            const INPUT: &str = "1234567890";
+            let buf = [0_i8; INPUT.len() + 1];
+            assert!(copy_to_c_char(
+                INPUT.to_string(),
+                buf.as_ptr() as *mut c_char,
+                buf.len()
+            ));
+            // Note that while CStr::from_ptr is documented to take a
+            // *const i8, on Arm/Arm64 it actually takes a *const
+            // u8. So cast it c_char which is an alias for the correct
+            // type depending on the arch.
+            let output = std::ffi::CStr::from_ptr(buf.as_ptr() as *const c_char)
+                .to_str()
+                .unwrap();
+            assert_eq!(INPUT, output);
+        };
+    }
+
+    // Test `copy_to_c_char` with too short of an output buffer to
+    // make sure false is returned.
+    #[test]
+    fn test_copy_to_c_char_short_output() {
+        unsafe {
+            const INPUT: &str = "1234567890";
+            let buf = [0_i8; INPUT.len()];
+            assert!(!copy_to_c_char(
+                INPUT.to_string(),
+                buf.as_ptr() as *mut c_char,
+                buf.len()
+            ));
+        };
+    }
+}

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -102,7 +102,6 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.set_uint("red_shift", tc_server_init.pixel_format.red_shift as u64)?;
         js.set_uint("green_shift", tc_server_init.pixel_format.green_shift as u64)?;
         js.set_uint("blue_shift", tc_server_init.pixel_format.blue_shift as u64)?;
-        js.set_uint("depth", tc_server_init.pixel_format.depth as u64)?;
         js.close()?;
 
         js.close()?;

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -260,8 +260,6 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
             }
         },
         Some(SMBTransactionTypeData::TREECONNECT(ref x)) => {
-            jsb.set_uint("tree_id", x.tree_id as u64)?;
-
             let share_name = String::from_utf8_lossy(&x.share_name);
             if x.is_pipe {
                 jsb.set_string("named_pipe", &share_name)?;

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -337,9 +337,18 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
                         jsb.set_uint("stub_data_size", x.stub_data_ts.len() as u64)?;
                         jsb.close()?;
                         if let Some(ref ifaces) = state.dcerpc_ifaces {
-                            for i in ifaces {
-                                if i.context_id == x.context_id {
-                                    jsb.open_object("interface")?;
+                            // First filter the interfaces to those
+                            // with the context_id we want to log to
+                            // avoid creating an empty "interfaces"
+                            // array.
+                            let mut ifaces = ifaces
+                                .iter()
+                                .filter(|i| i.context_id == x.context_id)
+                                .peekable();
+                            if ifaces.peek().is_some() {
+                                jsb.open_array("interfaces")?;
+                                for i in ifaces {
+                                    jsb.start_object()?;
                                     let ifstr = uuid::Uuid::from_slice(&i.uuid);
                                     let ifstr = ifstr.map(|ifstr| ifstr.to_hyphenated().to_string()).unwrap();
                                     jsb.set_string("uuid", &ifstr)?;
@@ -347,6 +356,7 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
                                     jsb.set_string("version", &vstr)?;
                                     jsb.close()?;
                                 }
+                                jsb.close()?;
                             }
                         }
                     },

--- a/rust/src/x509/log.rs
+++ b/rust/src/x509/log.rs
@@ -1,0 +1,40 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::jsonbuilder::JsonBuilder;
+use crate::x509::time::format_timestamp;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+/// Helper function to log a TLS timestamp from C to JSON with the
+/// provided key. The format of the timestamp is ISO 8601 timestamp
+/// with no sub-second or offset information as UTC is assumed.
+///
+/// # Safety
+///
+/// FFI function that dereferences pointers from C.
+#[no_mangle]
+pub unsafe extern "C" fn sc_x509_log_timestamp(
+    jb: &mut JsonBuilder, key: *const c_char, timestamp: i64,
+) -> bool {
+    if let Ok(key) = CStr::from_ptr(key).to_str() {
+        if let Ok(timestamp) = format_timestamp(timestamp) {
+            return jb.set_string(key, &timestamp).is_ok();
+        }
+    }
+    false
+}

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -22,6 +22,8 @@ use nom7::Err;
 use std;
 use std::os::raw::c_char;
 use x509_parser::prelude::*;
+mod time;
+mod log;
 
 #[repr(u32)]
 pub enum X509DecodeError {

--- a/rust/src/x509/time.rs
+++ b/rust/src/x509/time.rs
@@ -1,0 +1,72 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+use time::macros::format_description;
+
+/// Format a timestamp in an ISO format suitable for TLS logging.
+///
+/// Negative timestamp values are used for dates prior to 1970.
+pub fn format_timestamp(timestamp: i64) -> Result<String, time::error::Error> {
+    let format = format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");
+    let ts = time::OffsetDateTime::from_unix_timestamp(timestamp)?;
+    let formatted = ts.format(&format)?;
+    Ok(formatted)
+}
+
+/// Format a x509 ISO timestamp into the provided C buffer.
+///
+/// Returns false if an error occurs, otherwise true is returned if
+/// the timestamp is properly formatted into the provided buffer.
+///
+/// # Safety
+///
+/// Access buffers from C that are expected to be valid.
+#[no_mangle]
+pub unsafe extern "C" fn sc_x509_format_timestamp(
+    timestamp: i64, buf: *mut c_char, size: usize,
+) -> bool {
+    let ctimestamp = match format_timestamp(timestamp) {
+        Ok(ts) => match CString::new(ts) {
+            Ok(ts) => ts,
+            Err(_) => return false,
+        },
+        Err(_) => return false,
+    };
+    let bytes = ctimestamp.as_bytes_with_nul();
+
+    if size < bytes.len() {
+        false
+    } else {
+        // Convert buf into a slice we can copy into.
+        let buf = std::slice::from_raw_parts_mut(buf as *mut u8, size);
+        buf[0..bytes.len()].copy_from_slice(bytes);
+        true
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_format_timestamp() {
+        assert_eq!("1969-12-31T00:00:00", format_timestamp(-86400).unwrap());
+        assert_eq!("2038-12-31T00:10:03", format_timestamp(2177367003).unwrap());
+    }
+}

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -521,8 +521,6 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
     /* only store fields from the first certificate in the chain */
     if (certn == 0 && connp->cert0_subject == NULL && connp->cert0_issuerdn == NULL &&
             connp->cert0_serial == NULL) {
-        int64_t not_before, not_after;
-
         x509 = rs_x509_decode(input, cert_len, &err_code);
         if (x509 == NULL) {
             TlsDecodeHSCertificateErrSetEvent(ssl_state, err_code);
@@ -550,13 +548,11 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
         }
         connp->cert0_serial = str;
 
-        rc = rs_x509_get_validity(x509, &not_before, &not_after);
+        rc = rs_x509_get_validity(x509, &connp->cert0_not_before, &connp->cert0_not_after);
         if (rc != 0) {
             err_code = ERR_EXTRACT_VALIDITY;
             goto error;
         }
-        connp->cert0_not_before = (time_t)not_before;
-        connp->cert0_not_after = (time_t)not_after;
 
         rs_x509_free(x509);
         x509 = NULL;

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -252,8 +252,8 @@ typedef struct SSLStateConnp_ {
     char *cert0_subject;
     char *cert0_issuerdn;
     char *cert0_serial;
-    time_t cert0_not_before;
-    time_t cert0_not_after;
+    int64_t cert0_not_before;
+    int64_t cert0_not_after;
     char *cert0_fingerprint;
 
     /* ssl server name indication extension */

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -290,12 +290,12 @@ static void LogTlsLogVersion(MemBuffer *buffer, uint16_t version)
     MemBufferWriteString(buffer, "VERSION='%s'", ssl_version);
 }
 
-static void LogTlsLogDate(MemBuffer *buffer, const char *title, time_t *date)
+static void LogTlsLogDate(MemBuffer *buffer, const char *title, int64_t *date)
 {
     char timebuf[64] = {0};
-    const SCTime_t ts = SCTIME_FROM_SECS(*date);
-    CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-    MemBufferWriteString(buffer, "%s='%s'", title, timebuf);
+    if (sc_x509_format_timestamp(*date, timebuf, sizeof(timebuf))) {
+        MemBufferWriteString(buffer, "%s='%s'", title, timebuf);
+    }
 }
 
 static void LogTlsLogString(MemBuffer *buffer, const char *title,

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -168,20 +168,14 @@ static void JsonTlsLogVersion(JsonBuilder *js, SSLState *ssl_state)
 static void JsonTlsLogNotBefore(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_before != 0) {
-        char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_before);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-        jb_set_string(js, "notbefore", timebuf);
+        sc_x509_log_timestamp(js, "notbefore", ssl_state->server_connp.cert0_not_before);
     }
 }
 
 static void JsonTlsLogNotAfter(JsonBuilder *js, SSLState *ssl_state)
 {
     if (ssl_state->server_connp.cert0_not_after != 0) {
-        char timebuf[64];
-        SCTime_t ts = SCTIME_FROM_SECS(ssl_state->server_connp.cert0_not_after);
-        CreateUtcIsoTimeString(ts, timebuf, sizeof(timebuf));
-        jb_set_string(js, "notafter", timebuf);
+        sc_x509_log_timestamp(js, "notafter", ssl_state->server_connp.cert0_not_after);
     }
 }
 


### PR DESCRIPTION
Staging:
- #8484 
- #8483

Fix for c_char/i8 on Arm.

Fixes issue where CStr::from_ptr takes an i8 on x86_64, but a u8 on arm/arm64.
Instead cast it to c_char which is aliased correctly depending on the target
arch.
