### PR TITLE
smb: fix wrong endian conversion when parse NTLM Negotiate Flags - V4

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1210,37 +1210,31 @@ NTLMSSP fields
 * "domain" (string): the Windows domain.
 * "user" (string): the user.
 * "host" (string): the host.
+* "version" (string): the version of client.
 
 Example::
 
-    "ntlmssp": {
-      "domain": "VNET3",
-      "user": "administrator",
-      "host": "BLU"
-    }
-
+  "ntlmssp": {
+      "domain": "CONTOSO",
+      "user": "Administrator",
+      "host": "SERVER01",
+      "version": "6.0 build 6001 rev 15"
+  }
 More complete example::
 
   "smb": {
     "id": 3,
-    "dialect": "NT LM 0.12",
-    "command": "SMB1_COMMAND_SESSION_SETUP_ANDX",
+    "dialect": "2.02",
+    "command": "SMB2_COMMAND_SESSION_SETUP",
     "status": "STATUS_SUCCESS",
     "status_code": "0x0",
-    "session_id": 2048,
+    "session_id": 4398046511109,
     "tree_id": 0,
     "ntlmssp": {
-      "domain": "VNET3",
-      "user": "administrator",
-      "host": "BLU"
-    },
-    "request": {
-      "native_os": "Unix",
-      "native_lm": "Samba 3.9.0-SVN-build-11572"
-    },
-    "response": {
-      "native_os": "Windows (TM) Code Name \"Longhorn\" Ultimate 5231",
-      "native_lm": "Windows (TM) Code Name \"Longhorn\" Ultimate 6.0"
+      "domain": "CONTOSO",
+      "user": "Administrator",
+      "host": "SERVER01",
+      "version": "6.0 build 6001 rev 15"
     }
   }
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3614,6 +3614,13 @@
                         },
                         "user": {
                             "type": "string"
+                        },
+                        "version": {
+                            "type": "string",
+                            "optional": true
+                        },
+                        "warning": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -72,6 +72,7 @@ fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError
     Ok((rem, d))
 }
 
+#[derive(Debug, PartialEq)]
 pub struct SpnegoRequest {
     pub krb: Option<Kerberos5Ticket>,
     pub ntlmssp: Option<NtlmsspData>,
@@ -227,5 +228,33 @@ pub fn parse_secblob(blob: &[u8]) -> Option<SpnegoRequest>
                 None => { None },
             }
         },
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_parse_secblob() {
+        // smb2.security_blob
+        let blob = hex::decode("a18202313082022da0030a0101a28202100482020c4e544c4d5353500003000000180018009c00000048014801b40000001e001e005800000008000800760000001e001e007e00000010001000fc010000158288e20a005a290000000fc6107a73184fb65fe684f6a1641464be4400450053004b0054004f0050002d0032004100450046004d003700470075007300650072004400450053004b0054004f0050002d0032004100450046004d003700470000000000000000000000000000000000000000000000000028a0c9f4e792c408913d2878feaa9a22010100000000000078a7ed218527d2010cf876f08a0b3bfa0000000002001e004400450053004b0054004f0050002d00560031004600410030005500510001001e004400450053004b0054004f0050002d00560031004600410030005500510004001e004400450053004b0054004f0050002d00560031004600410030005500510003001e004400450053004b0054004f0050002d0056003100460041003000550051000700080078a7ed218527d20106000400020000000800300030000000000000000100000000200000ad865b6d08a95d0e76a94e2ca013ab3f69c4fd945cca01b277700fd2b305ca010a001000000000000000000000000000000000000900280063006900660073002f003100390032002e003100360038002e003100390039002e003100330033000000000000000000000000005858824ec4a47b3b42ad3132ab84a5c3a31204100100000092302d756840453f00000000").unwrap();
+        let result = parse_secblob(&blob);
+        assert_eq!(
+            result,
+            Some(SpnegoRequest {
+                krb: None,
+                ntlmssp: Some(NtlmsspData {
+                    host: b"DESKTOP-2AEFM7G".to_vec(),
+                    user: b"user".to_vec(),
+                    domain: b"DESKTOP-2AEFM7G".to_vec(),
+                    version: Some(NTLMSSPVersion {
+                        ver_major: 10,
+                        ver_minor: 0,
+                        ver_build: 10586,
+                        ver_ntlm_rev: 15,
+                    },),
+                    warning: false,
+                }),
+            })
+        );
     }
 }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine ticket: [5783](https://redmine.openinfosecfoundation.org/issues/5783)

Previous PR: https://github.com/OISF/suricata/pull/8449

Changes from last PR:
- fix commit message
- update the user guide

Signed-off-by: Lancer Cheng b1tg@protonmail.ch

suricata-verify-pr: 1105
https://github.com/OISF/suricata-verify/pull/1105

