### PR TITLE
Update base64-keywords.rst

### DIFF
--- a/doc/userguide/rules/base64-keywords.rst
+++ b/doc/userguide/rules/base64-keywords.rst
@@ -18,7 +18,7 @@ The ``bytes`` option specifies how many bytes Suricata should decode and make av
 The decoding will stop at the end of the buffer.
 
 The ``offset`` option specifies how many bytes Suricata should skip before decoding.
-Bytes are skipped relative to the start of the payload buffer if the ``relative`` is not set.
+Bytes are skipped relative to the start of the payload buffer if the ``relative`` is set.
 
 The ``relative`` option makes the decoding start relative to the previous content match. Default behavior is to start at the beginning of the buffer.
 This option makes ``offset`` skip bytes relative to the previous match.


### PR DESCRIPTION
"The offset option specifies how many bytes Suricata should skip before decoding. Bytes are skipped relative to the start of the payload buffer if the relative is not set."  Here "is not set" may be modified to  "is set". Need to confirm.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
