### PR TITLE
log: Stop if log initialization fails at startup

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -734,7 +734,7 @@ static void RunModeInitializeEveOutput(ConfNode *conf, OutputCtx *parent_ctx)
                 OutputInitResult result =
                     sub_module->InitSubFunc(sub_output_config, parent_ctx);
                 if (!result.ok || result.ctx == NULL) {
-                    continue;
+                    FatalError("unable to initialize sub-module %s", subname);
                 }
 
                 AddOutputToFreeList(sub_module, result.ctx);


### PR DESCRIPTION
Issue: 5836

This commit modifies Suricata to fail if log initialization errors occur during startup.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5836](https://redmine.openinfosecfoundation.org/issues/5836)

Describe changes:
- If output initialization fails during startup, stop Suricata with an error message

suricata-verify-pr: 1114
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
