### PR TITLE
stream: set event on bad timestamp on syn_sent state

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1468,8 +1468,10 @@ static int StreamTcpPacketStateSynSent(ThreadVars *tv, Packet *p,
                "toclient":"toserver");
 
     /* check for bad responses */
-    if (StateSynSentValidateTimestamp(ssn, p) == false)
+    if (StateSynSentValidateTimestamp(ssn, p) == false) {
+        StreamTcpSetEvent(p, STREAM_PKT_INVALID_TIMESTAMP);
         return -1;
+    }
 
     /* RST */
     if (p->tcph->th_flags & TH_RST) {


### PR DESCRIPTION
(cherry picked from commit fc376f81455ebfd487a0de2f8a14884be073b8ac)

suricata-verify-pr: 1119