### PR TITLE
doc: set correct src and dest ports for inline IDS iptables rules

### DIFF
--- a/doc/userguide/setting-up-ipsinline-for-linux.rst
+++ b/doc/userguide/setting-up-ipsinline-for-linux.rst
@@ -79,8 +79,8 @@ In this case, Suricata checks just TCP traffic.
 
 ::
 
-  sudo iptables -I INPUT -p tcp --sport 80  -j NFQUEUE
-  sudo iptables -I OUTPUT -p tcp --dport 80 -j NFQUEUE
+  sudo iptables -I INPUT -p tcp --dport 80  -j NFQUEUE
+  sudo iptables -I OUTPUT -p tcp --sport 80 -j NFQUEUE
 
 In this example, Suricata checks all input and output on port 80.
 


### PR DESCRIPTION
Swap sport and dport cause they're wrong

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
