### PR TITLE
log: Stop if log initialization fails at startup

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1017,7 +1017,7 @@ static int LogFileTypePrepare(
     else if (log_filetype == LOGFILE_TYPE_PLUGIN) {
         if (json_ctx->file_ctx->threaded) {
             /* Prepare for threaded log output. */
-            if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx, 1)) {
+            if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx)) {
                 return -1;
             }
         }

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -734,7 +734,7 @@ static void RunModeInitializeEveOutput(ConfNode *conf, OutputCtx *parent_ctx)
                 OutputInitResult result =
                     sub_module->InitSubFunc(sub_output_config, parent_ctx);
                 if (!result.ok || result.ctx == NULL) {
-                    continue;
+                    FatalError("unable to initialize sub-module %s", subname);
                 }
 
                 AddOutputToFreeList(sub_module, result.ctx);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -48,17 +48,16 @@ typedef struct SyslogSetup_ {
     int alert_syslog_level;
 } SyslogSetup;
 
-typedef struct ThreadSlotHashEntry_ {
+typedef struct ThreadLogFileHashEntry {
     uint64_t thread_id;
-    int slot; /* table slot */
-} ThreadSlotHashEntry;
+    int slot_number; /* slot identifier -- for plugins */
+    bool isopen;
+    struct LogFileCtx_ *ctx;
+} ThreadLogFileHashEntry;
 
 struct LogFileCtx_;
 typedef struct LogThreadedFileCtx_ {
     SCMutex mutex;
-    int slot_count;                /* Allocated slot count */
-    struct LogFileCtx_ **lf_slots; /* Slots */
-    int last_slot;                 /* Last slot allocated */
     HashTable *ht;
     char *append;
 } LogThreadedFileCtx;
@@ -98,7 +97,7 @@ typedef struct LogFileCtx_ {
     /** When threaded, track of the parent and thread id */
     bool threaded;
     struct LogFileCtx_ *parent;
-    int slot;
+    ThreadLogFileHashEntry *entry;
 
     /** the type of file */
     enum LogFileType type;
@@ -178,7 +177,6 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
-bool SCLogOpenThreadedFile(
-        const char *log_path, const char *append, LogFileCtx *parent_ctx, int slot_count);
+bool SCLogOpenThreadedFile(const char *log_path, const char *append, LogFileCtx *parent_ctx);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */


### PR DESCRIPTION
Based on #8519 

Issue: 5836

This commit modifies Suricata to fail if log initialization errors occur during startup.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5836](https://redmine.openinfosecfoundation.org/issues/5836)

Describe changes:
- If output initialization fails during startup, stop Suricata with an error message
- Remove thread slot lacking structure and consolidate tracking info with the hash table entry.

Updates
- Removed slot tracking structure and consolidated tracking information with each hash table entry.

suricata-verify-pr: 1114
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
