### PR TITLE
Parse DNSSEC-related flags in DNS messages

### DIFF
--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -67,3 +67,51 @@ DNS query on the wire (snippet)::
 ``dns.query`` buffer::
 
     mail.google.com
+
+dns.ad
+----------
+
+This keyword matches on the **authentic data (AD) bit** found in the DNS header flags.
+Values can be ``yes``, ``true``, ``no`` or ``false``.
+
+Syntax
+~~~~~~
+
+::
+
+   dns.ad:[yes | true | no | false];
+
+Examples
+~~~~~~~~
+
+Match on DNS requests and responses with **ad** set::
+
+  dns.ad:true;
+
+Match on DNS requests and responses with **ad** unset::
+
+  dns.ad:false;
+
+dns.cd
+----------
+
+This keyword matches on the **checking disabled (CD) bit** found in DNS request header flags.
+Values can be ``yes``, ``true``, ``no`` or ``false``.
+
+Syntax
+~~~~~~
+
+::
+
+   dns.cd:[yes | true | no | false];
+
+Examples
+~~~~~~~~
+
+Match on DNS requests with **cd** set::
+
+  dns.cd:true;
+
+Match on DNS requests with **cd** unset::
+
+  dns.cd:false;

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -989,6 +989,14 @@
                     "description": "DNS opcode as an integer",
                     "type": "integer"
                 },
+                "ad": {
+                    "description": "DNSSEC Authentic Data bit",
+                    "type": "boolean"
+                },
+                "cd": {
+                    "description": "DNSSEC Check Disabled bit",
+                    "type": "boolean"
+                },
                 "answers": {
                     "type": "array",
                     "minItems": 1,
@@ -1110,6 +1118,14 @@
                             "opcode": {
                                 "description": "DNS opcode as an integer",
                                 "type": "integer"
+                            },
+                            "ad": {
+                                "description": "DNSSEC Authentic Data bit",
+                                "type": "boolean"
+                            },
+                            "cd": {
+                                "description": "DNSSEC Check Disabled bit",
+                                "type": "boolean"
                             }
                         },
                         "additionalProperties": false
@@ -1151,6 +1167,14 @@
                         "opcode": {
                             "description": "DNS opcode as an integer",
                             "type": "integer"
+                        },
+                        "ad": {
+                            "description": "DNSSEC Authentic Data bit",
+                            "type": "boolean"
+                        },
+                        "cd": {
+                            "description": "DNSSEC Check Disabled bit",
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -415,7 +415,7 @@ impl DNSState {
                 self.transactions.push_back(tx);
 
                 if z_flag {
-                    SCLogDebug!("Z-flag set on DNS response");
+                    SCLogDebug!("Z-flag set on DNS request");
                     self.set_event(DNSEvent::ZFlagSet);
                 }
 

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -505,6 +505,9 @@ fn dns_log_json_answer(
     if header.flags & 0x0040 != 0 {
         js.set_bool("z", true)?;
     }
+    if header.flags & 0x0020 != 0 {
+        js.set_bool("ad", true)?;
+    }
 
     let opcode = ((header.flags >> 11) & 0xf) as u8;
     js.set_uint("opcode", opcode as u64)?;
@@ -622,6 +625,12 @@ fn dns_log_query(
                 jb.set_uint("tx_id", tx.id - 1)?;
                 if request.header.flags & 0x0040 != 0 {
                     jb.set_bool("z", true)?;
+                }
+                if request.header.flags & 0x0020 != 0 {
+                    jb.set_bool("ad", true)?;
+                }
+                if request.header.flags & 0x0010 != 0 {
+                    jb.set_bool("cd", true)?;
                 }
                 let opcode = ((request.header.flags >> 11) & 0xf) as u8;
                 jb.set_uint("opcode", opcode as u64)?;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: N/A

Describe changes:
Parse DNSSEC-related DNS header flags, making them available in logs.

The Authentic Data (AD) and Checking Disabled (CD) flags are used by DNSSEC resolvers and servers to communicate desired and effective resolution behavior. These flags are defined in RFC 2535 and the usage of them is further clarified in RFC 6840.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
