### PR TITLE
output: fix logic error

### DIFF
--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -119,7 +119,7 @@ int OutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto,
         OutputTxLogger *t = list[alproto];
         while (t->next)
             t = t->next;
-        if (t->id * 2 > UINT32_MAX) {
+        if (t->id * 2ULL > UINT32_MAX) {
             FatalError("Too many loggers registered.");
         }
         op->id = t->id * 2;


### PR DESCRIPTION
 The logical error may have been made
 here. Comparison with the upper  bound of the variable type does not make
 sense. It may be worth adding  the cast of one of the multiplication operands
 to the 64-bit type for  avoiding overflow

Found by Security Code with Svace static analyzer
Bug: [#5789](https://redmine.openinfosecfoundation.org/issues/5789)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5789

Describe changes:
- Added cast to ULL one of the operands of multiplication for avoiding overflow

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
