### PR TITLE
pfring/time: Address sign mismatch warnings

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -231,7 +231,9 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
 
     /* PF_RING may fail to set timestamp */
     if (h->ts.tv_sec == 0) {
-        gettimeofday((struct timeval *)&h->ts, NULL);
+        struct timeval tmp_ts;
+        gettimeofday(&tmp_ts, NULL);
+        h->ts = tmp_ts;
     }
 
     p->ts = SCTIME_FROM_TIMEVAL(&h->ts);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -347,7 +347,7 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
     Packet *p = NULL;
     struct pfring_pkthdr hdr;
     TmSlot *s = (TmSlot *)slot;
-    time_t last_dump = 0;
+    SCTime_t last_dump = SCTIME_INITIALIZER;
     u_int buffer_size;
     u_char *pkt_buffer;
 
@@ -422,9 +422,9 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
             }
 
             /* Trigger one dump of stats every second */
-            if (SCTIME_SECS(p->ts) != last_dump) {
+            if (SCTIME_CMP_NEQ(p->ts, last_dump)) {
                 PfringDumpCounters(ptv);
-                last_dump = SCTIME_SECS(p->ts);
+                last_dump = p->ts;
             }
         } else if (unlikely(r == 0)) {
             if (suricata_ctl_flags & SURICATA_STOP) {

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -47,6 +47,12 @@ typedef struct {
         (t).secs = 0;                                                                              \
         (t).usecs = 0;                                                                             \
     }
+
+#define SCTIME_INITIALIZER                                                                         \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = 0, .usecs = 0                                                                      \
+    }
 #define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
@@ -83,6 +89,7 @@ typedef struct {
 #define SCTIME_CMP_GT(a, b)  SCTIME_CMP((a), (b), >)
 #define SCTIME_CMP_LT(a, b)  SCTIME_CMP((a), (b), <)
 #define SCTIME_CMP_LTE(a, b) SCTIME_CMP((a), (b), <=)
+#define SCTIME_CMP_NEQ(a, b) SCTIME_CMP((a), (b), !=)
 
 void TimeInit(void);
 void TimeDeinit(void);


### PR DESCRIPTION
Continuation of #8487 

This PR addresses a build-time warning re: the SCTime_t type and its usage in PF-ring
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5818](https://redmine.openinfosecfoundation.org/issues/5818)

Describe changes:
- Add initializer for SCTime types
- Correct sign mismatch in PFr-ing packet acquisition logic

Updates
- Address packet structure member usage
- Fix issues with sign mismatch change.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
