### PR TITLE
log: Display netmap api message during debug.

### DIFF
--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -71,8 +71,8 @@ void RunModeIdsNetmapRegister(void)
 {
 #if HAVE_NETMAP
 #if USE_NEW_NETMAP_API
-    SCLogInfo("Using netmap version %d"
-              " API interfaces]",
+    SCLogDebug("Using netmap version %d"
+               " API interfaces]",
             NETMAP_API);
 #endif
     RunModeRegisterNewRunMode(RUNMODE_NETMAP, "single",


### PR DESCRIPTION
This MR changes the level associated with the message displayed when registering the netmap module.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5879](https://redmine.openinfosecfoundation.org/issues/5879)

Describe changes:
- Change registration time message to debug (was info)

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
