### PR TITLE
[draft] Rewrite suricatasc in Rust - v0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2566,7 +2566,7 @@ jobs:
   windows-msys2-mingw64-libpcap:
     name: Windows MSYS2 MINGW64 (libpcap)
     runs-on: windows-latest
-    needs: [prepare-deps]
+    needs: [prepare-deps, almalinux-8]
     defaults:
       run:
         shell: msys2 {0}
@@ -2576,27 +2576,23 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.5.3
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
           update: true
           install: git mingw-w64-x86_64-toolchain automake1.16 automake-wrapper autoconf libtool libyaml-devel pcre2-devel jansson-devel make mingw-w64-x86_64-libyaml mingw-w64-x86_64-pcre2 mingw-w64-x86_64-rust mingw-w64-x86_64-jansson unzip p7zip python-setuptools mingw-w64-x86_64-python-yaml mingw-w64-x86_64-jq mingw-w64-x86_64-libxml2 libpcap-devel mingw-w64-x86_64-libpcap
-      # hack: install our own cbindgen system wide as we can't get the
-      # preinstalled one to be picked up by configure
-      - name: cbindgen
-        run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
-      - run: tar xf prep/libhtp.tar.gz
-      - run: tar xf prep/suricata-update.tar.gz
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: dist
+      - run: tar xvf suricata-*.tar.gz --strip-components=1
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Build
         run: |
-          ./autogen.sh
           CFLAGS="-ggdb -Werror" ./configure --enable-unittests --enable-gccprotect --disable-gccmarch-native --disable-shared --with-libpcap-includes=/npcap/Include --with-libpcap-libraries=/npcap/Lib/x64
           make -j3
       - name: Run

--- a/configure.ac
+++ b/configure.ac
@@ -2590,6 +2590,8 @@ AC_SUBST(enable_non_bundled_htp)
 AM_CONDITIONAL([BUILD_SHARED_LIBRARY], [test "x$enable_shared" = "xyes"] && [test "x$can_build_shared_library" = "xyes"])
 
 AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.lock rust/Cargo.toml rust/derive/Cargo.toml rust/.cargo/config)
+AC_CONFIG_FILES(rust/client/Makefile rust/client/Cargo.toml)
+AC_CONFIG_FILES(rust/suricatasc/Makefile rust/suricatasc/Cargo.toml)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)
 AC_CONFIG_FILES(rules/Makefile doc/Makefile doc/userguide/Makefile)
 AC_CONFIG_FILES(contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -2591,6 +2591,7 @@ AM_CONDITIONAL([BUILD_SHARED_LIBRARY], [test "x$enable_shared" = "xyes"] && [tes
 
 AC_CONFIG_FILES(Makefile src/Makefile rust/Makefile rust/Cargo.lock rust/Cargo.toml rust/derive/Cargo.toml rust/.cargo/config)
 AC_CONFIG_FILES(rust/client/Makefile rust/client/Cargo.toml)
+AC_CONFIG_FILES(rust/suricatactl/Makefile rust/suricatactl/Cargo.toml)
 AC_CONFIG_FILES(rust/suricatasc/Makefile rust/suricatasc/Cargo.toml)
 AC_CONFIG_FILES(qa/Makefile qa/coccinelle/Makefile)
 AC_CONFIG_FILES(rules/Makefile doc/Makefile doc/userguide/Makefile)

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -11,8 +11,6 @@ LIBS =	\
 		suricata/sc/suricatasc.py \
 		suricatasc/__init__.py
 
-BINS =		suricatactl
-
 EXTRA_DIST = $(LIBS) bin suricata/config/defaults.py
 
 if HAVE_PYTHON
@@ -22,20 +20,13 @@ install-exec-local:
 	install -d -m 0755 "$(DESTDIR)$(prefix)/lib/suricata/python/suricata/ctl"
 	install -d -m 0755 "$(DESTDIR)$(prefix)/lib/suricata/python/suricata/sc"
 	install -d -m 0755 "$(DESTDIR)$(prefix)/lib/suricata/python/suricatasc"
-	install -d -m 0755 "$(DESTDIR)$(prefix)/bin"
 	for src in $(LIBS); do \
 		install -m 0644 $(srcdir)/$$src "$(DESTDIR)$(prefix)/lib/suricata/python/$$src"; \
 	done
 	install suricata/config/defaults.py \
 		"$(DESTDIR)$(prefix)/lib/suricata/python/suricata/config/defaults.py"
-	for bin in $(BINS); do \
-		cat "$(srcdir)/bin/$$bin" | \
-		    sed -e "1 s,.*,#"'!'" ${HAVE_PYTHON}," > "${DESTDIR}$(bindir)/$$bin"; \
-		chmod 0755 "$(DESTDIR)$(bindir)/$$bin"; \
-	done
 
 uninstall-local:
-	rm -f $(DESTDIR)$(bindir)/suricatactl
 	rm -rf $(DESTDIR)$(prefix)/lib/suricata/python
 
 clean-local:

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -11,9 +11,7 @@ LIBS =	\
 		suricata/sc/suricatasc.py \
 		suricatasc/__init__.py
 
-BINS =	\
-		suricatasc \
-		suricatactl
+BINS =		suricatactl
 
 EXTRA_DIST = $(LIBS) bin suricata/config/defaults.py
 
@@ -38,7 +36,6 @@ install-exec-local:
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/suricatactl
-	rm -f $(DESTDIR)$(bindir)/suricatasc
 	rm -rf $(DESTDIR)$(prefix)/lib/suricata/python
 
 clean-local:

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -8,9 +8,14 @@ members = [
     ".",
     "derive",
     "client",
+    "suricatactl",
     "suricatasc",
 ]
-default-members = [".", "suricatasc"]
+default-members = [
+    ".",
+    "suricatactl",
+    "suricatasc",
+]
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -4,7 +4,13 @@ version = "@PACKAGE_VERSION@"
 edition = "2021"
 
 [workspace]
-members = [".", "./derive"]
+members = [
+    ".",
+    "derive",
+    "client",
+    "suricatasc",
+]
+default-members = [".", "suricatasc"]
 
 [lib]
 crate-type = ["staticlib", "rlib"]
@@ -23,7 +29,7 @@ debug-validate = []
 
 [dependencies]
 nom7 = { version="7.0", package="nom" }
-bitflags = "~1.2.1"
+bitflags = "~1.3.2"
 byteorder = "~1.4.2"
 uuid = "~0.8.2"
 crc = "~1.8.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,8 +1,13 @@
+SUBDIRS =	client \
+		suricatasc
+
 EXTRA_DIST =	src derive \
 		.cargo/config.in \
 		cbindgen.toml \
 		dist/rust-bindings.h \
-		vendor
+		vendor \
+		client \
+		suricatasc
 
 if !DEBUG
 RELEASE = --release
@@ -30,13 +35,13 @@ endif
 
 all-local: Cargo.toml
 if HAVE_CYGPATH
-	@rustup_home@ \
+	@rustup_home@ LOCALSTATEDIR=$(e_localstatedir) \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(e_rustdir)/target" \
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
-	@rustup_home@ \
+	@rustup_home@ LOCALSTATEDIR=$(e_localstatedir) \
 		CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
@@ -52,12 +57,17 @@ endif
 	fi
 	$(MAKE) gen/rust-bindings.h
 
+install-exec-local:
+	install -d -m 0755 "$(DESTDIR)$(bindir)"
+	install -m 0755 $(RUST_SURICATA_LIBDIR)/suricatasc "$(DESTDIR)$(bindir)/suricatasc"
+
 install-library:
 	$(MKDIR_P) "$(DESTDIR)$(libdir)"
 	$(INSTALL_DATA) $(RUST_SURICATA_LIB) "$(DESTDIR)$(libdir)"
 
 uninstall-local:
 	rm -f "$(DESTDIR)$(libdir)/$(RUST_SURICATA_LIBNAME)"
+	rm -f "$(DESTDIR)$(bindir)/suricatasc"
 
 clean-local:
 	rm -rf target

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS =	client \
+		suricatactl \
 		suricatasc
 
 EXTRA_DIST =	src derive \
@@ -7,6 +8,7 @@ EXTRA_DIST =	src derive \
 		dist/rust-bindings.h \
 		vendor \
 		client \
+		suricatactl \
 		suricatasc
 
 if !DEBUG
@@ -60,6 +62,7 @@ endif
 install-exec-local:
 	install -d -m 0755 "$(DESTDIR)$(bindir)"
 	install -m 0755 $(RUST_SURICATA_LIBDIR)/suricatasc "$(DESTDIR)$(bindir)/suricatasc"
+	install -m 0755 $(RUST_SURICATA_LIBDIR)/suricatactl "$(DESTDIR)$(bindir)/suricatactl"
 
 install-library:
 	$(MKDIR_P) "$(DESTDIR)$(libdir)"
@@ -68,6 +71,7 @@ install-library:
 uninstall-local:
 	rm -f "$(DESTDIR)$(libdir)/$(RUST_SURICATA_LIBNAME)"
 	rm -f "$(DESTDIR)$(bindir)/suricatasc"
+	rm -f "$(DESTDIR)$(bindir)/suricatactl"
 
 clean-local:
 	rm -rf target

--- a/rust/client/Cargo.toml.in
+++ b/rust/client/Cargo.toml.in
@@ -1,0 +1,16 @@
+[package]
+name = "suricata-client"
+version = "@PACKAGE_VERSION@"
+edition = "2021"
+license = "MIT"
+description = "Suricata socket control client library"
+
+[lib]
+path = "@e_rustdir@/client/src/lib.rs"
+
+[dependencies]
+thiserror = { version = "1.0.38" }
+
+# Serde pinned for Rust 1.63.0
+serde = { version = "=1.0.152", default_features = false, features = ["derive"] }
+serde_json = { version = "=1.0.93", default_features = false, features = ["preserve_order"] }

--- a/rust/client/LICENSE-MIT
+++ b/rust/client/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (C) 2023 Open Information Security Foundation
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rust/client/Makefile.am
+++ b/rust/client/Makefile.am
@@ -1,0 +1,1 @@
+all-local: Cargo.toml

--- a/rust/client/README.md
+++ b/rust/client/README.md
@@ -1,0 +1,7 @@
+# suricata-client
+
+This is a Rust library that implements a client for the Suricata
+control socket.
+
+This is a blocking client with minimal dependencies to keep the size
+of the vendored sources down.

--- a/rust/client/examples/iface-list.rs
+++ b/rust/client/examples/iface-list.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: MIT
+
+/// This example connects to the Suricata control socket and requests
+/// the interface list.
+use serde_json::json;
+use suricata_client::unix::Client;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+
+    let filename = if let Some(filename) = args.get(1) {
+        filename
+    } else {
+        "/run/suricata/suricata-command.socket"
+    };
+    dbg!(filename);
+
+    let mut client = Client::connect(filename, false)?;
+    client.send(&json!({"command": "iface-list"}))?;
+    let response = client.read()?;
+    dbg!(response);
+    Ok(())
+}

--- a/rust/client/src/lib.rs
+++ b/rust/client/src/lib.rs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: MIT
+
+#[cfg(not(target_os = "windows"))]
+pub mod unix;

--- a/rust/client/src/unix.rs
+++ b/rust/client/src/unix.rs
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: MIT
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("ioerror: `{0}`")]
+    IoError(#[from] std::io::Error),
+    #[error("serde error: `{0}`")]
+    DeserializeError(#[from] serde_json::Error),
+    #[error("connection closed")]
+    Closed,
+}
+
+pub struct Client {
+    socket: UnixStream,
+
+    // If set, the client will print to stdout the messages sent and
+    // received. Primarily useful when running with the interactive
+    // client in verbose mode.
+    verbose: bool,
+}
+
+impl Client {
+    pub fn connect<T: AsRef<str>>(filename: T, verbose: bool) -> Result<Self, ClientError> {
+        let filename = filename.as_ref().to_string();
+        let socket = UnixStream::connect(filename)?;
+        let mut client = Self { socket, verbose };
+        client.handshake()?;
+        Ok(client)
+    }
+
+    fn handshake(&mut self) -> Result<(), ClientError> {
+        self.send(&json!({"version": "0.2"}))?;
+        self.read().map(serde_json::from_value::<Response>)??;
+        Ok(())
+    }
+
+    pub fn send<T>(&mut self, msg: &T) -> Result<(), std::io::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut encoded = serde_json::to_string(&msg)?;
+        if self.verbose {
+            println!("SND: {}", &encoded);
+        }
+        encoded.push('\n');
+        self.socket.write_all(encoded.as_bytes())?;
+        Ok(())
+    }
+
+    /// Read a line of data from the client.
+    ///
+    /// An empty line means the server has disconnected.
+    pub fn read_line(&self) -> Result<String, ClientError> {
+        let mut reader = BufReader::new(&self.socket);
+        let mut response = String::new();
+        reader.read_line(&mut response)?;
+        if self.verbose {
+            println!("RCV: {}", response.trim_end());
+        }
+        Ok(response)
+    }
+
+    pub fn read(&self) -> Result<serde_json::Value, ClientError> {
+        let line = self.read_line()?;
+        if line.is_empty() {
+            return Err(ClientError::Closed);
+        }
+        let decoded = serde_json::from_str(&line)?;
+        Ok(decoded)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Response {
+    #[serde(rename = "return")]
+    pub status: String,
+    #[serde(default)]
+    pub message: serde_json::Value,
+}

--- a/rust/suricatactl/Cargo.toml.in
+++ b/rust/suricatactl/Cargo.toml.in
@@ -1,0 +1,21 @@
+[package]
+name = "suricatactl"
+version = "@PACKAGE_VERSION@"
+edition = "2021"
+license = "GPL-2.0-only"
+
+[[bin]]
+name = "suricatactl"
+path = "@e_rustdir@/suricatactl/src/main.rs"
+
+[dependencies]
+regex = "~1.5.5"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+# 4.0 is the newest version that builds with Rust 1.63.0.
+clap = { version = "~4.0.0", features = ["derive"] }
+
+# This dependency is not used directly, but we have to pin this back
+# to 0.3.0 for Rust 1.63.0.
+clap_lex = "=0.3.0"

--- a/rust/suricatactl/Makefile.am
+++ b/rust/suricatactl/Makefile.am
@@ -1,0 +1,1 @@
+all-local: Cargo.toml

--- a/rust/suricatactl/src/filestore/mod.rs
+++ b/rust/suricatactl/src/filestore/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+pub(crate) mod prune;

--- a/rust/suricatactl/src/filestore/prune.rs
+++ b/rust/suricatactl/src/filestore/prune.rs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+use std::path::{Path, PathBuf};
+use tracing::{debug, error, info};
+
+use crate::FilestorePruneArgs;
+
+pub(crate) fn prune(args: FilestorePruneArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let age = parse_age(&args.age)?;
+    info!("Pruning files older than {} seconds", age);
+
+    let mut total_bytes = 0;
+    let mut file_count = 0;
+
+    let mut stack = vec![PathBuf::from(&args.directory)];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                match FileInfo::from_path(&path) {
+                    Ok(info) => {
+                        if info.age > age {
+                            debug!("Deleting {:?}", path);
+                            file_count += 1;
+                            total_bytes += info.size;
+                            if !args.dry_run {
+                                if let Err(err) = std::fs::remove_file(&path) {
+                                    error!("Failed to delete {}: {}", path.display(), err);
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error!(
+                            "Failed to get last modified time of file {}: {}",
+                            path.display(),
+                            err
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    info!("Removed {} files; {} bytes", file_count, total_bytes);
+
+    Ok(())
+}
+
+struct FileInfo {
+    age: u64,
+    size: u64,
+}
+
+impl FileInfo {
+    fn from_path(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let metadata = path.metadata()?;
+        let age = metadata.modified()?.elapsed()?.as_secs();
+        Ok(Self {
+            age,
+            size: metadata.len(),
+        })
+    }
+}
+
+/// Given input like "1s", "1m", "1h" or "1d" return the number of
+/// seconds
+fn parse_age(age: &str) -> Result<u64, String> {
+    // Use a regex to separate the value from the unit.
+    let re = regex::Regex::new(r"^(\d+)([smhd])$").unwrap();
+    let caps = re.captures(age).ok_or_else(|| {
+        format!(
+            "Invalid age: {}. Must be a number followed by one of s, m, h, d",
+            age
+        )
+    })?;
+    let value = caps
+        .get(1)
+        .unwrap()
+        .as_str()
+        .parse::<u64>()
+        .map_err(|e| format!("Invalid age: {}: {}", age, e))?;
+    let unit = caps.get(2).unwrap().as_str();
+
+    match unit {
+        "s" => Ok(value),
+        "m" => Ok(value * 60),
+        "h" => Ok(value * 60 * 60),
+        "d" => Ok(value * 60 * 60 * 24),
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_age() {
+        assert!(parse_age("1").is_err());
+        assert!(parse_age("s").is_err());
+        assert!(parse_age("1a").is_err());
+
+        // Valid tests
+        assert_eq!(parse_age("1s").unwrap(), 1);
+        assert_eq!(parse_age("3s").unwrap(), 3);
+        assert_eq!(parse_age("1m").unwrap(), 60);
+        assert_eq!(parse_age("3m").unwrap(), 180);
+        assert_eq!(parse_age("3h").unwrap(), 10800);
+        assert_eq!(parse_age("1d").unwrap(), 86400);
+        assert_eq!(parse_age("3d").unwrap(), 86400 * 3);
+    }
+}

--- a/rust/suricatactl/src/main.rs
+++ b/rust/suricatactl/src/main.rs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+use clap::Parser;
+use clap::Subcommand;
+use tracing::Level;
+
+mod filestore;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    #[arg(long, short, global = true, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    #[arg(
+        long,
+        short,
+        global = true,
+        help = "Quiet mode, only warnings and errors will be logged"
+    )]
+    quiet: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Filestore management commands
+    Filestore(FilestoreCommand),
+}
+
+#[derive(Parser, Debug)]
+struct FilestoreCommand {
+    #[command(subcommand)]
+    command: FilestoreCommands,
+}
+
+#[derive(Subcommand, Debug)]
+enum FilestoreCommands {
+    /// Remove files by age
+    Prune(FilestorePruneArgs),
+}
+
+#[derive(Parser, Debug)]
+struct FilestorePruneArgs {
+    #[arg(long, short = 'n', help = "only print what would happen")]
+    dry_run: bool,
+    #[arg(long, short, help = "file-store directory")]
+    directory: String,
+    #[arg(long, help = "prune files older than age, units: s, m, h, d")]
+    age: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let log_level = if cli.quiet {
+        Level::WARN
+    } else if cli.verbose > 0 {
+        Level::DEBUG
+    } else {
+        Level::INFO
+    };
+    tracing_subscriber::fmt().with_max_level(log_level).init();
+
+    match cli.command {
+        Commands::Filestore(filestore) => match filestore.command {
+            FilestoreCommands::Prune(args) => crate::filestore::prune::prune(args),
+        },
+    }
+}

--- a/rust/suricatasc/Cargo.toml.in
+++ b/rust/suricatasc/Cargo.toml.in
@@ -1,0 +1,22 @@
+[package]
+name = "suricatasc"
+version = "@PACKAGE_VERSION@"
+edition = "2021"
+license = "GPL-2.0-only"
+description = "Suricata socket control program"
+readme = "README.md"
+
+[[bin]]
+name = "suricatasc"
+path = "@e_rustdir@/suricatasc/src/main.rs"
+
+[dependencies]
+getopts = "0.2.21"
+rustyline = { version = "12.0.0" }
+rustyline-derive = { version = "0.9.0" }
+thiserror = { version = "1.0.40" }
+suricata-client = { path = "../client" }
+
+# Serde pinned for Rust 1.63.0
+serde = { version = "=1.0.152", default_features = false, features = ["derive"] }
+serde_json = { version = "=1.0.93", default_features = false, features = ["preserve_order"] }

--- a/rust/suricatasc/LICENSE
+++ b/rust/suricatasc/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/rust/suricatasc/Makefile.am
+++ b/rust/suricatasc/Makefile.am
@@ -1,0 +1,1 @@
+all-local: Cargo.toml

--- a/rust/suricatasc/README.md
+++ b/rust/suricatasc/README.md
@@ -1,0 +1,3 @@
+# suricatasc
+
+A replacement `suricatasc` written in Rust.

--- a/rust/suricatasc/src/main.rs
+++ b/rust/suricatasc/src/main.rs
@@ -1,0 +1,12 @@
+#[cfg(not(target_os = "windows"))]
+mod unix;
+
+#[cfg(not(target_os = "windows"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    crate::unix::main::main()
+}
+
+#[cfg(target_os = "windows")]
+fn main () {
+    println!("suricatasc is not supported on Windows");
+}

--- a/rust/suricatasc/src/unix/commands.rs
+++ b/rust/suricatasc/src/unix/commands.rs
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+use serde::Deserialize;
+use serde_json::json;
+use std::{collections::HashMap, str::FromStr};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CommandParseError {
+    #[error("Unknown command {0}")]
+    UnknownCommand(String),
+    #[error("`{0}`")]
+    Other(String),
+}
+
+#[derive(Debug, Copy, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArgType {
+    String,
+    Number,
+    Bool,
+}
+
+#[derive(Clone)]
+pub struct Commands {
+    /// The list of parsed command the client knows about.
+    pub commands: HashMap<String, Vec<Argument>>,
+
+    /// A list of commands from the server. This is used to:
+    /// - augment the list of known commands
+    /// - error out on commands not given by Suricata as not all
+    ///   command are valid in all running modes.
+    server_commands: Vec<String>,
+}
+
+impl Commands {
+    pub fn new(server_commands: Vec<String>) -> Self {
+        let mut commands = command_defs().unwrap();
+        for command in &server_commands {
+            if !commands.contains_key(command) {
+                commands.insert(command.to_string(), vec![]);
+            }
+        }
+        Self {
+            commands,
+            server_commands,
+        }
+    }
+
+    pub fn get(&self, command: &str) -> Option<&Vec<Argument>> {
+        self.commands.get(command)
+    }
+
+    pub fn is_valid(&self, command: &str) -> bool {
+        self.server_commands.iter().any(|c| c == command)
+    }
+}
+
+pub struct CommandParser<'a> {
+    pub commands: &'a Commands,
+}
+
+impl<'a> CommandParser<'a> {
+    pub fn new(commands: &'a Commands) -> Self {
+        Self { commands }
+    }
+
+    pub fn parse(&self, input: &str) -> Result<serde_json::Value, CommandParseError> {
+        let parts: Vec<&str> = input.split(' ').map(|s| s.trim()).collect();
+        if parts.is_empty() {
+            return Err(CommandParseError::Other("No command provided".to_string()));
+        }
+        let command = parts[0];
+        let args = &parts[1..];
+
+        let spec = self
+            .commands
+            .get(command)
+            .ok_or(CommandParseError::UnknownCommand(command.to_string()))?;
+
+        if !self.commands.is_valid(command) {
+            return Err(CommandParseError::Other(
+                "Command not valid for current Suricata running-mode".to_string(),
+            ));
+        }
+
+        // Calculate the number of required arguments for better error reporting.
+        let required = spec.iter().filter(|e| e.required).count();
+
+        let mut json_args = HashMap::new();
+        for (i, spec) in spec.iter().enumerate() {
+            if let Some(arg) = args.get(i) {
+                let val = match spec.datatype {
+                    ArgType::String => serde_json::Value::String(arg.to_string()),
+                    ArgType::Bool => match *arg {
+                        "true" | "1" => true.into(),
+                        "false" | "0" => false.into(),
+                        _ => {
+                            return Err(CommandParseError::Other(format!(
+                                "Bad argument: value is not a boolean: {}",
+                                arg
+                            )));
+                        }
+                    },
+                    ArgType::Number => {
+                        let number = serde_json::Number::from_str(arg).map_err(|_| {
+                            CommandParseError::Other(format!("Bad argument: not a number: {}", arg))
+                        })?;
+                        serde_json::Value::Number(number)
+                    }
+                };
+                json_args.insert(&spec.name, val);
+            } else if spec.required {
+                return Err(CommandParseError::Other(format!(
+                    "Missing arguments: expected at least {}",
+                    required
+                )));
+            }
+        }
+
+        let mut message = json!({ "command": command });
+        if !json_args.is_empty() {
+            message["arguments"] = json!(json_args);
+        }
+
+        Ok(message)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Argument {
+    pub name: String,
+    pub required: bool,
+    #[serde(rename = "type")]
+    pub datatype: ArgType,
+    pub value: Option<serde_json::Value>,
+}
+
+fn command_defs() -> Result<HashMap<String, Vec<Argument>>, serde_json::Error> {
+    #[rustfmt::skip]
+    let defs = json!({
+	"shutdown": [],
+	"quit": [],
+	"pcap-file-number": [],
+	"pcap-file-list": [],
+	"pcap-file-processed": [],
+	"pcap-interrupt": [],
+	"iface-list": [],
+	"pcap-file": [
+            {
+		"name": "filename",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "output-dir",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "tenant",
+		"type": "number",
+		"required": false,
+            },
+            {
+		"name": "continuous",
+		"required": false,
+		"type": "bool",
+            },
+            {
+		"name": "delete-when-done",
+		"required": false,
+		"type": "bool",
+            },
+	],
+	"pcap-file-continuous": [
+            {
+		"name": "filename",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "output-dir",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "continuous",
+		"required": true,
+		"type": "bool",
+		"value": true,
+            },
+            {
+		"name": "tenant",
+		"type": "number",
+		"required": false,
+            },
+            {
+		"name": "delete-when-done",
+		"required": false,
+		"type": "bool",
+            },
+	],
+	"iface-stat": [
+            {
+		"name": "iface",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"conf-get": [
+            {
+		"name": "variable",
+		"required": true,
+		"type": "string",
+            }
+	],
+	"unregister-tenant-handler": [
+            {
+		"name": "id",
+		"type": "number",
+		"required": true,
+            },
+            {
+		"name": "htype",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "hargs",
+		"type": "number",
+		"required": false,
+            },
+	],
+	"register-tenant-handler": [
+            {
+		"name": "id",
+		"type": "number",
+		"required": true,
+            },
+            {
+		"name": "htype",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "hargs",
+		"type": "number",
+		"required": false,
+            },
+	],
+	"unregister-tenant": [
+            {
+		"name": "id",
+		"type": "number",
+		"required": true,
+            },
+	],
+	"register-tenant": [
+            {
+		"name": "id",
+		"type": "number",
+		"required": true,
+            },
+            {
+		"name": "filename",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"reload-tenant": [
+            {
+		"name": "id",
+		"type": "number",
+		"required": true,
+            },
+            {
+		"name": "filename",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"add-hostbit": [
+            {
+		"name": "ipaddress",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "hostbit",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "expire",
+		"type": "number",
+		"required": true,
+            },
+	],
+	"remove-hostbit": [
+            {
+		"name": "ipaddress",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "hostbit",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"list-hostbit": [
+            {
+		"name": "ipaddress",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"memcap-set": [
+            {
+		"name": "config",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "memcap",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"memcap-show": [
+            {
+		"name": "config",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"dataset-add": [
+            {
+		"name": "setname",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "settype",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "datavalue",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"dataset-remove": [
+            {
+		"name": "setname",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "settype",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "datavalue",
+		"required": true,
+		"type": "string",
+            },
+	],
+	"get-flow-stats-by-id": [
+            {
+		"name": "flow_id",
+		"type": "number",
+		"required": true,
+            },
+	],
+	"dataset-clear": [
+            {
+		"name": "setname",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "settype",
+		"required": true,
+		"type": "string",
+            }
+	],
+	"dataset-lookup": [
+            {
+		"name": "setname",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "settype",
+		"required": true,
+		"type": "string",
+            },
+            {
+		"name": "datavalue",
+		"required": true,
+		"type": "string",
+            },
+	],
+    });
+    serde_json::from_value(defs)
+}

--- a/rust/suricatasc/src/unix/main.rs
+++ b/rust/suricatasc/src/unix/main.rs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+use crate::unix::commands::Commands;
+use crate::unix::rustyprompt::RustyPrompt;
+use crate::unix::commands::CommandParser;
+use serde_json::json;
+use suricata_client::unix::{Client, ClientError, Response};
+
+const DEFAULT_SC_PATH: &str = "/var/run/suricata/suricata-command.socket";
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let localstatedir = option_env!("LOCALSTATEDIR");
+    let args: Vec<String> = std::env::args().collect();
+    let mut opts = getopts::Options::new();
+    opts.optflag("v", "verbose", "Verbose output");
+    opts.optflag("h", "help", "Print this help menu");
+    opts.optopt("c", "command", "Execute command and return JSON", "COMMAND");
+    let matches = opts.parse(&args[1..])?;
+    if matches.opt_present("h") {
+        let brief = format!("Usage: {} [OPTIONS]", &args[0]);
+        print!("{}", opts.usage(&brief));
+        return Ok(());
+    }
+
+    let socket_filename = if let Some(filename) = matches.free.get(0) {
+	filename.to_string()
+    } else if let Some(localstatedir) = localstatedir {
+	format!("{localstatedir}/suricata-command.socket")
+    } else {
+	DEFAULT_SC_PATH.to_string()
+    };
+
+    let verbose = matches.opt_present("v");
+    if verbose {
+        println!("Using Suricata command socket: {}", &socket_filename);
+    }
+
+    let client = match Client::connect(&socket_filename, verbose) {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("Unable to connect socket to {}: {}", &socket_filename, err);
+            std::process::exit(1);
+        }
+    };
+
+    if let Some(command) = matches.opt_str("c") {
+        run_batch_command(client, &command)
+    } else {
+        run_interactive(client)
+    }
+}
+
+fn run_interactive(mut client: Client) -> Result<(), Box<dyn std::error::Error>> {
+    client.send(&json!({"command": "command-list"}))?;
+    let response = client.read()?;
+    let server_commands: Vec<String> =
+        serde_json::from_value(response["message"]["commands"].clone())?;
+    println!("Command list: {}, quit", server_commands.join(", "));
+    let commands = Commands::new(server_commands);
+    let command_parser = CommandParser::new(&commands);
+    let mut prompt = RustyPrompt::new(commands.clone());
+
+    while let Some(line) = prompt.readline() {
+        if line.starts_with("quit") {
+            break;
+        }
+        match command_parser.parse(&line) {
+            Ok(command) => {
+                match interactive_request_response(&mut client, &command) {
+                    Ok(response) => {
+                        let response: Response = serde_json::from_value(response).unwrap();
+                        if response.status == "OK" {
+                            println!("Success:");
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&response.message).unwrap()
+                            );
+                        } else {
+                            println!("Error:");
+                            println!("{}", serde_json::to_string(&response.message).unwrap());
+                        }
+                    }
+                    Err(err) => {
+                        println!("{}", err);
+                    }
+                }
+            }
+            Err(err) => {
+                println!("{}", err);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_batch_command(mut client: Client, command: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let commands = Commands::new(vec![]);
+    let command_parser = CommandParser::new(&commands);
+    let command = command_parser.parse(command)?;
+    client.send(&command)?;
+    let response = client.read()?;
+    println!("{}", serde_json::to_string(&response)?);
+    Ok(())
+}
+
+fn interactive_request_response(
+    client: &mut Client, msg: &serde_json::Value,
+) -> Result<serde_json::Value, ClientError> {
+    client.send(msg)?;
+    let response = client.read()?;
+    Ok(response)
+}

--- a/rust/suricatasc/src/unix/mod.rs
+++ b/rust/suricatasc/src/unix/mod.rs
@@ -1,0 +1,3 @@
+pub mod main;
+pub mod commands;
+pub mod rustyprompt;

--- a/rust/suricatasc/src/unix/rustyprompt.rs
+++ b/rust/suricatasc/src/unix/rustyprompt.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: Copyright 2023 Open Information Security Foundation
+// SPDX-License-Identifier: GPL-2.0-only
+
+// A prompt built on Rustyline.
+
+use crate::unix::commands::Commands;
+use rustyline::completion::Completer;
+use rustyline::completion::Pair;
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::history::DefaultHistory;
+use rustyline::validate::{self, MatchingBracketValidator, Validator};
+use rustyline::Context;
+use rustyline::{CompletionType, Config, EditMode, Editor};
+use rustyline_derive::Helper;
+
+#[derive(Helper)]
+struct PromptHelper {
+    commands: Commands,
+    validator: MatchingBracketValidator,
+}
+
+impl PromptHelper {
+    fn new(commands: Commands) -> Self {
+        Self {
+            validator: MatchingBracketValidator::new(),
+            commands,
+        }
+    }
+}
+
+impl Hinter for PromptHelper {
+    type Hint = String;
+
+    fn hint(&self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<String> {
+        None
+    }
+}
+
+impl Highlighter for PromptHelper {}
+
+impl Validator for PromptHelper {
+    fn validate(
+        &self, ctx: &mut validate::ValidationContext,
+    ) -> rustyline::Result<validate::ValidationResult> {
+        self.validator.validate(ctx)
+    }
+
+    fn validate_while_typing(&self) -> bool {
+        self.validator.validate_while_typing()
+    }
+}
+
+impl Completer for PromptHelper {
+    type Candidate = Pair;
+    fn complete(
+        &self, line: &str, _pos: usize, _ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Pair>), ReadlineError> {
+        let mut pairs = vec![];
+        if line.is_empty() {
+            for command in &self.commands.commands {
+                pairs.push(Pair {
+                    display: command.0.to_string(),
+                    replacement: command.0.to_string(),
+                })
+            }
+            return Ok((pairs.len(), pairs));
+        }
+
+        let parts: Vec<&str> = line.split(' ').collect();
+        if parts.len() == 1 {
+            // We're still completing the command name.
+            for name in self.commands.commands.keys() {
+                if name.starts_with(parts[0]) {
+                    pairs.push(Pair {
+                        display: name.to_string(),
+                        replacement: name.to_string(),
+                    })
+                }
+            }
+        }
+
+        Ok((0, pairs))
+    }
+}
+
+pub struct RustyPrompt {
+    rl: Editor<PromptHelper, DefaultHistory>,
+}
+
+impl RustyPrompt {
+    pub fn new(commands: Commands) -> Self {
+        let config = Config::builder()
+            .history_ignore_space(true)
+            .completion_type(CompletionType::List)
+            .edit_mode(EditMode::Emacs)
+            .build();
+        let helper = PromptHelper::new(commands);
+        let mut rl = Editor::with_config(config).unwrap();
+        rl.set_helper(Some(helper));
+        Self { rl }
+    }
+
+    pub fn readline(&mut self) -> Option<String> {
+        loop {
+            let prompt = ">>> ";
+            let readline = self.rl.readline(prompt);
+            match readline {
+                Ok(line) => {
+                    self.rl.add_history_entry(line.as_str()).unwrap();
+                    return Some(line);
+                }
+                Err(ReadlineError::Interrupted) => {
+                    return None;
+                }
+                Err(ReadlineError::Eof) => {
+                    return None;
+                }
+                _ => {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a reimplementation of suricatasc I've been sitting on for about a year
as I didn't get around to fixing the Windows compilation issue (now fixed).

What I don't like is how the vendor size has grown due to the Rust
reedline-like lib, "rustyline" pulling in all sorts of Windows crates as it's
cross platform.  We could just delete those and we don't build the full
suricatasc tool on Windows yet due to unix sockets being required.

This aims to be 100% compatible with the current Python "suricatasc".

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6287
