### PR TITLE
nflog/time: Fixup timestamp handling

### DIFF
--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -178,13 +178,13 @@ static int NFLOGCallback(struct nflog_g_handle *gh, struct nfgenmsg *msg,
     } else if (ret == -1)
         SET_PKT_LEN(p, 0);
 
-    ret = nflog_get_timestamp(nfa, &p->ts);
+    struct timeval tv;
+    ret = nflog_get_timestamp(nfa, &tv);
     if (ret != 0) {
-        struct timeval tv;
-        memset(&tv, 0, sizeof(struct timeval));
+        memset(&tv, 0, sizeof(tv));
         gettimeofday(&tv, NULL);
-        p->ts = SCTIME_FROM_TIMEVAL(&tv);
     }
+    p->ts = SCTIME_FROM_TIMEVAL(&tv);
 
     p->datalink = DLT_RAW;
 


### PR DESCRIPTION
Issue: 5818

This commit corrects the timestamp handling for the packet to work with the SCTime_t struct.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5818](https://redmine.openinfosecfoundation.org/issues/5818)

Describe changes:
- Use `timeval` for the nflog call an then convert to a `SCTime_t`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
