### PR TITLE
smb/ntlmssp:the negotiate flags num is little endian

### DIFF
--- a/rust/src/smb/ntlmssp_records.rs
+++ b/rust/src/smb/ntlmssp_records.rs
@@ -69,7 +69,7 @@ pub struct NTLMSSPAuthRecord<'a> {
 }
 
 fn parse_ntlm_auth_nego_flags(i: &[u8]) -> IResult<&[u8], (u32, u8, u8)> {
-    bits(tuple((take_bits(25u8), take_bits(1u8), take_bits(6u32))))(i)
+    bits(tuple((take_bits(30u32), take_bits(1u8), take_bits(1u8))))(i)
 }
 
 const NTLMSSP_IDTYPE_LEN: usize = 12;


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/5783

To get the 6th bit of integer, have to pass 3*8+6 bits in memory。I have tested in master-5.0.x, it's looks like:
    let (i, nego_flags) = bits!(i, tuple!(take_bits!(u32, 30),take_bits!(u8,1),take_bits!(u8,1)))?;

Signed-off-by: tianjinshan tianjinshan@gmail.com
