### PR TITLE
[draft] app-layer: mark unidirectional transactions with a direction - v1

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -122,6 +122,10 @@ pub struct AppLayerTxData {
     /// STREAM_TOSERVER|STREAM_TOCLIENT: files possible in both dirs
     pub file_tx: u8,
 
+    /// The direction of the transaction. 0 for transactions that are
+    /// made up of request and replies.
+    direction: u8,
+
     /// detection engine flags for use by detection engine
     detect_flags_ts: u64,
     detect_flags_tc: u64,
@@ -157,6 +161,7 @@ impl AppLayerTxData {
             files_stored: 0,
             file_flags: 0,
             file_tx: 0,
+	    direction: 0,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
             de_state: std::ptr::null_mut(),

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1127,8 +1127,9 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
     if (unlikely(IS_DISRUPTED(flags))) {
         r = StateGetProgressCompletionStatus(alproto, flags);
     } else {
-        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
-            StateGetProgress(alstate, flags);
+        uint8_t direction = flags & (STREAM_TOCLIENT | STREAM_TOSERVER);
+        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetProgress(
+                alstate, direction);
     }
     SCReturnInt(r);
 }


### PR DESCRIPTION
This PR pulls in a commit from @regit that cleans the flow flags to just to
direction before passing to StateGetProgress is that is what parsers are
inspecting.

Then at the app-layer, mark each unidirectional transaction with its direction
so its not considered for inspection in the other direction, which may cause it
to be disposed of too early.

Issue: https://redmine.openinfosecfoundation.org/issues/4759 (and others)

suricata-verify-pr: 1140
