### PR TITLE
util/base64: don't reset decoded bytes in RFC4648

### DIFF
--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -118,10 +118,10 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
             /* Invalid character found, so decoding fails */
             if (src[i] != '=') {
                 valid = false;
-                if (mode != BASE64_MODE_RELAX) {
+                ecode = BASE64_ECODE_ERR;
+                if (mode == BASE64_MODE_RFC2045) {
                     *decoded_bytes = 0;
                 }
-                ecode = BASE64_ECODE_ERR;
                 break;
             }
             padding++;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5885

suricata-verify-pr: 1141