### PR TITLE
jsonschema: do not enforce keys for alert metadata

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -264,7 +264,7 @@
                             }
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": true
                 },
                 "source": {
                     "type": "object",


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- relax json schema for alert metadata

suricata-verify-pr: 1051

Replaces #8445 with remaining commit about schema made simpler (and needed by S-V test)