### PR TITLE
detect: bytemath do not left shift more than 64

### DIFF
--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -168,7 +168,11 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *sm
             val *= rvalue;
             break;
         case LeftShift:
-            val <<= rvalue;
+            if (rvalue < 64) {
+                val <<= rvalue;
+            } else {
+                val = 0;
+            }
             break;
         case RightShift:
             val >>= rvalue;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5900

Describe changes:
- Fix UBSAN report about undefined left shift in `DetectByteMathDoMatch`

cc @jlucovsky 