### PR TITLE
output/eve: add 'verdict' field to 'alert' and 'drop' events - v7

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -89,22 +89,16 @@ generated the event.
 Event type: Alert
 -----------------
 
-Field action
-~~~~~~~~~~~~
+This field contains data about a signature that matched, such as
+``signature_id`` (``sid`` in the rule) and the ``signature`` (``msg`` in the
+rule).
 
-Possible values: "allowed" and "blocked".
-
-Example:
-
-::
-
-
-  "action":"allowed"
-
-Action is set to "allowed" unless a rule used the "drop" action and Suricata is in IPS mode, or when the rule used the "reject" action. It is important to note that this does not necessarily indicate the final verdict for a given packet or flow, since one packet may match on several rules.
-
-It can also contain information about Source and Target of the attack in the alert.source and alert.target field if target keyword is used in
+It can also contain information about Source and Target of the attack in the
+``alert.source`` and ``alert.target`` field if target keyword is used in
 the signature.
+
+This event will also have the ``pcap_cnt`` field, when running in pcap mode, to
+indicate which packet triggered the signature.
 
 ::
 
@@ -147,6 +141,22 @@ the signature.
     }
   },
 
+Field action
+~~~~~~~~~~~~
+
+Possible values: "allowed" and "blocked".
+
+Example:
+
+::
+
+  "action":"allowed"
+
+Action is set to "allowed" unless a rule used the "drop" action and Suricata is
+in IPS mode, or when the rule used the "reject" action. It is important to note
+that this does not necessarily indicate the final verdict for a given packet or
+flow, since one packet may match on several rules.
+
 Verdict Field
 ~~~~~~~~~~~~~
 
@@ -155,7 +165,6 @@ Possible values are "accept", "drop" or "reject".
 Example:
 
 ::
-
 
   "verdict":"drop"
 

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -92,7 +92,7 @@ Event type: Alert
 Field action
 ~~~~~~~~~~~~
 
-Possible values: "allowed" and "blocked"
+Possible values: "allowed" and "blocked".
 
 Example:
 
@@ -101,7 +101,7 @@ Example:
 
   "action":"allowed"
 
-Action is set to "allowed" unless a rule used the "drop" action and Suricata is in IPS mode, or when the rule used the "reject" action.
+Action is set to "allowed" unless a rule used the "drop" action and Suricata is in IPS mode, or when the rule used the "reject" action. It is important to note that this does not necessarily indicate the final verdict for a given packet or flow, since one packet may match on several rules.
 
 It can also contain information about Source and Target of the attack in the alert.source and alert.target field if target keyword is used in
 the signature.
@@ -146,6 +146,22 @@ the signature.
       ]
     }
   },
+
+Verdict Field
+~~~~~~~~~~~~~
+
+Possible values are "accept", "drop" or "reject".
+
+Example:
+
+::
+
+
+  "verdict":"drop"
+
+Verdict is the final action that will be applied to a given packet, based on all
+the signatures triggered by it. In IPS mode, all values are possible. In IDS
+mode, verdict is only present if its value is "reject".
 
 Pcap Field
 ~~~~~~~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -264,6 +264,19 @@ enabled, then the log gets more verbose.
 
 By using ``custom`` it is possible to select which TLS fields to log.
 
+Drops
+~~~~~
+
+Drops are event types logged when the engine drops a packet.
+
+Config::
+
+    - drop:
+        alerts: yes      # log alerts that caused drops
+        flows: all       # start or all: 'start' logs only a single drop
+                         # per flow direction. All logs each dropped pkt.
+
+
 Date modifiers in filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -94,6 +94,9 @@
             "type": "string",
             "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+[+\\-]\\d+$"
         },
+        "verdict": {
+            "type": "string"
+        },
         "direction": {
             "type": "string"
         },

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.c
+++ b/src/decode.c
@@ -819,6 +819,24 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
     return NULL;
 }
 
+/** \brief Decide Packet's final verdict based on packet action, return it as a string */
+const char *PacketActionVerdictToString(const Packet *p)
+{
+    /* Reject is valid in both IDS and IPS */
+    if (PacketCheckAction(p, ACTION_REJECT_ANY)) {
+        return "reject";
+    } else if (EngineModeIsIPS()) {
+        /* Verdicts will be reject, drop, or accept */
+        if (PacketCheckAction(p, ACTION_DROP)) {
+            return "drop";
+        }
+        return "accept";
+    }
+
+    /* If we're in IDS mode and action isn't reject, we won't log verdict */
+    return NULL;
+}
+
 /* TODO drop reason stats! */
 void CaptureStatsUpdate(ThreadVars *tv, CaptureStats *s, const Packet *p)
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.h
+++ b/src/decode.h
@@ -840,6 +840,7 @@ void DecodeThreadVarsFree(ThreadVars *, DecodeThreadVars *);
 void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p);
 const char *PacketDropReasonToString(enum PacketDropReason r);
+const char *PacketActionVerdictToString(const Packet *p);
 
 /* decoder functions */
 int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2022 Open Information Security Foundation
+/* Copyright (C) 2013-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -828,12 +828,16 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             jb_set_string(jb, "capture_file", pcap_filename);
         }
 
+        const char *verdict = PacketActionVerdictToString(p);
+        if (verdict != NULL) {
+            jb_set_string(jb, "verdict", verdict);
+        }
+
         OutputJsonBuilderBuffer(jb, aft->ctx);
         jb_free(jb);
     }
 
-    if ((p->flags & PKT_HAS_TAG) && (json_output_ctx->flags &
-            LOG_JSON_TAGGED_PACKETS)) {
+    if ((p->flags & PKT_HAS_TAG) && (json_output_ctx->flags & LOG_JSON_TAGGED_PACKETS)) {
         JsonBuilder *packetjs =
                 CreateEveHeader(p, LOG_DIR_PACKET, "packet", NULL, json_output_ctx->eve_ctx);
         if (unlikely(packetjs != NULL)) {

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2014 Open Information Security Foundation
+/* Copyright (C) 2013-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -28,6 +28,8 @@
 #define __OUTPUT_JSON_ALERT_H__
 
 void JsonAlertLogRegister(void);
+void DropAlertJsonHeader(
+        const Packet *p, const PacketAlert *pa, JsonBuilder *js, JsonAddrInfo *addr);
 void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuilder *js,
         uint16_t flags, JsonAddrInfo *addr, char *xff_buffer);
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -82,7 +82,7 @@ static int g_droplog_flows_start = 1;
  * \param tv    Pointer the current thread variables
  * \param p     Pointer the packet which is being logged
  *
- * \return return TM_EODE_OK on success
+ * \return return TM_ECODE_OK on success
  */
 static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 {
@@ -203,7 +203,7 @@ static TmEcode JsonDropLogThreadInit(ThreadVars *t, const void *initdata, void *
         goto error_exit;
     }
 
-    /** Use the Ouptut Context (file pointer and mutex) */
+    /** Use the Output Context (file pointer and mutex) */
     aft->drop_ctx = ((OutputCtx *)initdata)->data;
     aft->ctx = CreateEveThreadCtx(t, aft->drop_ctx->eve_ctx);
     if (!aft->ctx) {
@@ -309,7 +309,7 @@ static OutputInitResult JsonDropLogInitCtxSub(ConfNode *conf, OutputCtx *parent_
  * \param data  Pointer to the droplog struct
  * \param p     Pointer the packet which is being logged
  *
- * \retval 0 on succes
+ * \retval 0 on success
  */
 static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -158,6 +158,9 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     /* Close drop. */
     jb_close(js);
 
+    const char *verdict = PacketActionVerdictToString(p);
+    jb_set_string(js, "verdict", verdict);
+
     if (aft->drop_ctx->flags & LOG_DROP_ALERTS) {
         int logged = 0;
         int i;

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -172,7 +172,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
                ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
             {
-                AlertJsonHeader(NULL, p, pa, js, 0, &addr, NULL);
+                DropAlertJsonHeader(p, pa, js, &addr);
                 logged = 1;
                 break;
             }
@@ -180,7 +180,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
         if (logged == 0) {
             if (p->alerts.drop.action != 0) {
                 const PacketAlert *pa = &p->alerts.drop;
-                AlertJsonHeader(NULL, p, pa, js, 0, &addr, NULL);
+                DropAlertJsonHeader(p, pa, js, &addr);
             }
         }
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -52,6 +52,9 @@
 #include "output.h"
 #include "output-json.h"
 
+#include "packet.h"
+#include "action-globals.h"
+
 #include "util-byte.h"
 #include "util-privs.h"
 #include "util-print.h"

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -168,6 +168,9 @@ outputs:
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
             tagged-packets: yes
+            # Enable logging of the alert's action. Possible values are
+            # "allowed" or "blocked" (for 'drop' or 'reject' rules). Default: yes
+            # action: no
         # app layer frames
         - frame:
             # disabled by default as this is very verbose.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5464

Previous PR: https://github.com/OISF/suricata/pull/8559

Changes from last PR:
- remove global variable for saving info on `alert.action` setting
- incorporate other feedback from previous PR
 
suricata-verify-pr: 1145
https://github.com/OISF/suricata-verify/pull/1145