### PR TITLE
github-ci: Add Netmap build to GH actions v3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1606,6 +1606,94 @@ jobs:
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ LDFLAGS="-fsanitize=address" ./configure --enable-fuzztargets --disable-shared
       - run: AFL_HARDEN=1 make -j2
 
+  ubuntu-22-04-netmap-build:
+    name: Ubuntu 22.04 (Netmap build)
+    needs: [prepare-deps, prepare-cbindgen]
+    runs-on: ubuntu-22.04
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Install dependencies
+        run: |
+            sudo apt update
+            sudo apt -y install \
+                  libpcre2-dev \
+                  build-essential \
+                  autoconf \
+                  automake \
+                  cargo \
+                  git \
+                  jq \
+                  libtool \
+                  libpcap-dev \
+                  libnet1-dev \
+                  libyaml-0-2 \
+                  libyaml-dev \
+                  libcap-ng-dev \
+                  libcap-ng0 \
+                  libmagic-dev \
+                  libnetfilter-queue-dev \
+                  libnetfilter-queue1 \
+                  libnfnetlink-dev \
+                  libnfnetlink0 \
+                  libhiredis-dev \
+                  libjansson-dev \
+                  libevent-dev \
+                  libevent-pthreads-2.1-7 \
+                  libjansson-dev \
+                  libpython2.7 \
+                  make \
+                  parallel \
+                  python3-yaml \
+                  rustc \
+                  software-properties-common \
+                  zlib1g \
+                  zlib1g-dev \
+                  exuberant-ctags
+
+      - name: Install Netmap dependencies
+        run: |
+          sudo apt -y install \
+                build-essential \
+                git \
+                linux-headers-$(uname -r)
+
+      - name: Checkout Netmap repository
+        uses: actions/checkout@v3
+        with:
+          repository: luigirizzo/netmap
+          # gets cloned to $GITHUB_WORKSPACE/netmap/
+          path: netmap/
+
+      - name: Compile and install Netmap
+        run: |
+          cd $GITHUB_WORKSPACE/netmap/LINUX
+          ./configure --no-drivers
+          make -j2
+          sudo make install
+
+      - uses: actions/checkout@v3.3.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - name: Setup cbindgen
+        run: |
+          mkdir -p $HOME/.cargo/bin
+          cp prep/cbindgen $HOME/.cargo/bin
+          chmod 755 $HOME/.cargo/bin/cbindgen
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-netmap
+      - run: make -j2
+      - run: ./src/suricata --build-info | grep -E "Netmap support:\s+yes"
+
   ubuntu-22-04-dpdk-build:
     name: Ubuntu 22.04 (DPDK Build)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Follow-up of #8595
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5803) ticket:

Describe changes:
- prefixed job name
- grepping build info for Netmap support