### PR TITLE
smtp: sync in-code defaults with configuration file - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1338,7 +1338,10 @@
                 },
                 "has_exe_url": {
                     "type": "boolean"
-                }
+                },
+		"message_id": {
+		    "type": "string"
+		}
             },
             "additionalProperties": false
         },

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -242,8 +242,23 @@ SCEnumCharMap smtp_reply_map[ ] = {
 };
 
 /* Create SMTP config structure */
-SMTPConfig smtp_config = { false, { false, false, false, NULL, false, false, 0 }, 0, 0, 0, false,
-    STREAMING_BUFFER_CONFIG_INITIALIZER };
+SMTPConfig smtp_config = {
+    .decode_mime = true,
+    {
+            .decode_base64 = true,
+            .decode_quoted_printable = true,
+            .extract_urls = true,
+            .extract_urls_schemes = NULL,
+            .log_url_scheme = false,
+            .body_md5 = false,
+            .header_value_depth = 0,
+    },
+    .content_limit = FILEDATA_CONTENT_LIMIT,
+    .content_inspect_min_size = FILEDATA_CONTENT_INSPECT_MIN_SIZE,
+    .content_inspect_window = FILEDATA_CONTENT_INSPECT_WINDOW,
+    .raw_extraction = SMTP_RAW_EXTRACTION_DEFAULT_VALUE,
+    STREAMING_BUFFER_CONFIG_INITIALIZER,
+};
 
 static SMTPString *SMTPStringAlloc(void);
 
@@ -362,10 +377,6 @@ static void SMTPConfigure(void) {
 
     /* Pass mime config data to MimeDec API */
     MimeDecSetConfig(&smtp_config.mime_config);
-
-    smtp_config.content_limit = FILEDATA_CONTENT_LIMIT;
-    smtp_config.content_inspect_window = FILEDATA_CONTENT_INSPECT_WINDOW;
-    smtp_config.content_inspect_min_size = FILEDATA_CONTENT_INSPECT_MIN_SIZE;
 
     ConfNode *t = ConfGetNode("app-layer.protocols.smtp.inspected-tracker");
     ConfNode *p = NULL;

--- a/src/conf.c
+++ b/src/conf.c
@@ -492,6 +492,11 @@ int ConfGetBool(const char *name, int *val)
     return 1;
 }
 
+/**
+ * Get a boolean value from the provided ConfNode.
+ *
+ * \retval 1 If the value exists, 0 if not.
+ */
 int ConfGetChildValueBool(const ConfNode *base, const char *name, int *val)
 {
     const char *strval = NULL;


### PR DESCRIPTION
Currently the default suricata.yaml sets some values that do not
reflect the default values in the code. As most users are probably
using a default suricata.yaml, make the code have the same defaults as
in suricata.yaml:

- mime.decode-mime: false -> true
- mime.decode-base64: false -> true
- mime.decode-quoted-printable: false -> true
- mime.extract-urls: false -> true

I guess the question is if its OK for a simple configuration of:

```
app-layer:
  protocols:
    smtp:
      enabled: yes
```

to acquire these new defaults.

Ticket: https://redmine.openinfosecfoundation.org/issues/5823
