### PR TITLE
dns: remove unused events field from state

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -403,8 +403,6 @@ pub struct DNSState {
     // Transactions.
     pub transactions: Vec<DNSTransaction>,
 
-    pub events: u16,
-
     config: Option<ConfigTracker>,
 
     gap: bool,
@@ -416,7 +414,6 @@ impl DNSState {
         return DNSState{
             tx_id: 0,
             transactions: Vec::new(),
-            events: 0,
             config: None,
             gap: false,
         };
@@ -426,7 +423,6 @@ impl DNSState {
         return DNSState{
             tx_id: 0,
             transactions: Vec::new(),
-            events: 0,
             config: None,
             gap: false,
         };
@@ -496,7 +492,6 @@ impl DNSState {
         let tx = &mut self.transactions[len - 1];
         core::sc_app_layer_decoder_events_set_event_raw(&mut tx.events,
                                                         event as u8);
-        self.events += 1;
     }
 
     pub fn parse_request(&mut self, input: &[u8]) -> bool {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5906

Describe changes:
- remove unused overflowing field in rust dns : backport of commit 26dc70648c2b840ae7b56c88162f129c06ef03fd 
