### PR TITLE
app-layer: mark unidirectional transactions with a direction - v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -18,7 +18,7 @@
 //! Parser registration functions and common interface
 
 use std;
-use crate::core::{self,DetectEngineState,Flow,AppLayerEventType,AppProto};
+use crate::core::{self,DetectEngineState,Flow,AppLayerEventType,AppProto,Direction};
 use crate::filecontainer::FileContainer;
 use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
@@ -178,6 +178,14 @@ impl AppLayerTxData {
         if (self.file_flags & state_flags) != state_flags {
             SCLogDebug!("updating tx file_flags {:04x} with state flags {:04x}", self.file_flags, state_flags);
             self.file_flags |= state_flags;
+        }
+    }
+
+    pub fn set_inspect_direction(&mut self, direction: Direction) {
+        if direction == Direction::ToClient {
+            self.detect_flags_ts |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+        } else {
+            self.detect_flags_tc |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
         }
     }
 }
@@ -473,6 +481,8 @@ pub const APP_LAYER_PARSER_TRUNC_TC : u16 = BIT_U16!(8);
 
 pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = BIT_U32!(0);
 pub const APP_LAYER_PARSER_OPT_UNIDIR_TXS: u32 = BIT_U32!(1);
+
+pub const APP_LAYER_TX_SKIP_INSPECT_FLAG: u64 = BIT_U64!(62);
 
 pub type AppLayerGetTxIteratorFn = unsafe extern "C" fn (ipproto: u8,
                                                   alproto: AppProto,

--- a/rust/src/bittorrent_dht/bittorrent_dht.rs
+++ b/rust/src/bittorrent_dht/bittorrent_dht.rs
@@ -19,7 +19,7 @@ use crate::applayer::{self, *};
 use crate::bittorrent_dht::parser::{
     parse_bittorrent_dht_packet, BitTorrentDHTError, BitTorrentDHTRequest, BitTorrentDHTResponse,
 };
-use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_UDP};
+use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN, IPPROTO_UDP, Direction};
 use std::ffi::CString;
 use std::os::raw::c_char;
 
@@ -46,8 +46,11 @@ pub struct BitTorrentDHTTransaction {
 }
 
 impl BitTorrentDHTTransaction {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(direction: Direction) -> Self {
+	Self {
+	    tx_data: AppLayerTxData::for_direction(direction),
+	    ..Default::default()
+	}
     }
 
     /// Set an event on the transaction
@@ -77,11 +80,10 @@ impl BitTorrentDHTState {
         self.transactions.iter().find(|&tx| tx.tx_id == tx_id + 1)
     }
 
-    fn new_tx(&mut self, _direction: crate::core::Direction) -> BitTorrentDHTTransaction {
-        let mut tx = BitTorrentDHTTransaction::default();
+    fn new_tx(&mut self, direction: Direction) -> BitTorrentDHTTransaction {
+        let mut tx = BitTorrentDHTTransaction::new(direction);
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
-        tx.tx_data.set_inspect_direction(_direction);
         return tx;
     }
 

--- a/rust/src/bittorrent_dht/parser.rs
+++ b/rust/src/bittorrent_dht/parser.rs
@@ -446,6 +446,7 @@ pub fn parse_bittorrent_dht_packet(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::Direction;
     use test_case::test_case;
 
     #[test_case(
@@ -576,7 +577,7 @@ mod tests {
         expected_error: Option<BitTorrentDHTError>, expected_transaction_id: Vec<u8>,
         expected_client_version: Option<Vec<u8>>,
     ) {
-        let mut tx = BitTorrentDHTTransaction::new();
+        let mut tx = BitTorrentDHTTransaction::new(Direction::ToServer);
         parse_bittorrent_dht_packet(encoded, &mut tx).unwrap();
         assert_eq!(request_type, tx.request_type);
         assert_eq!(expected_request, tx.request);
@@ -637,7 +638,7 @@ mod tests {
         "test parse bittorrent dht packet err 10"
     )]
     fn test_parse_bittorrent_dht_packet_err(encoded: &[u8], expected_error: &str) {
-        let mut tx = BitTorrentDHTTransaction::new();
+        let mut tx = BitTorrentDHTTransaction::new(Direction::ToServer);
         let err = parse_bittorrent_dht_packet(encoded, &mut tx).unwrap_err();
         assert_eq!(expected_error, err.to_string());
     }

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -49,6 +49,18 @@ pub enum Direction {
     ToClient = 0x08,
 }
 
+impl Direction {
+    /// Return true if the direction is to server.
+    pub fn is_to_server(&self) -> bool {
+	matches!(self, Self::ToServer)
+    }
+
+    /// Return true if the direction is to client.
+    pub fn is_to_client(&self) -> bool {
+	matches!(self, Self::ToClient)
+    }
+}
+
 impl Default for Direction {
     fn default() -> Self { Direction::ToServer }
 }
@@ -313,5 +325,19 @@ impl Flow {
     /// Return flow ports
     pub fn get_ports(&self) -> (u16, u16) {
         unsafe { (FlowGetSourcePort(self), FlowGetDestinationPort(self)) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_direction() {
+	assert!(Direction::ToServer.is_to_server());
+	assert!(!Direction::ToServer.is_to_client());
+
+	assert!(Direction::ToClient.is_to_client());
+	assert!(!Direction::ToClient.is_to_server());
     }
 }

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -38,7 +38,6 @@ pub const STREAM_TOCLIENT: u8 = 0x08;
 pub const STREAM_GAP:      u8 = 0x10;
 pub const STREAM_DEPTH:    u8 = 0x20;
 pub const STREAM_MIDSTREAM:u8 = 0x40;
-pub const STREAM_FLUSH:    u8 = 0x80;
 pub const DIR_BOTH:        u8 = 0b0000_1100;
 const DIR_TOSERVER:        u8 = 0b0000_0100;
 const DIR_TOCLIENT:        u8 = 0b0000_1000;

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -412,6 +412,7 @@ impl DNSState {
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
+                tx.tx_data.set_inspect_direction(Direction::ToServer);
                 self.transactions.push_back(tx);
 
                 if z_flag {
@@ -490,6 +491,7 @@ impl DNSState {
                     }
                 }
                 tx.response = Some(response);
+                tx.tx_data.set_inspect_direction(Direction::ToClient);
                 self.transactions.push_back(tx);
 
                 if z_flag {

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -123,8 +123,12 @@ impl Transaction for IKETransaction {
 }
 
 impl IKETransaction {
-    pub fn new() -> Self {
-        Default::default()
+    pub fn new(direction: Direction) -> Self {
+	Self {
+	    direction,
+	    tx_data: applayer::AppLayerTxData::for_direction(direction),
+	    ..Default::default()
+	}
     }
 
     /// Set an event.
@@ -170,8 +174,8 @@ impl IKEState {
         self.transactions.iter_mut().find(|tx| tx.tx_id == tx_id + 1)
     }
 
-    pub fn new_tx(&mut self) -> IKETransaction {
-        let mut tx = IKETransaction::new();
+    pub fn new_tx(&mut self, direction: Direction) -> IKETransaction {
+        let mut tx = IKETransaction::new(direction);
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
         return tx;

--- a/rust/src/ike/ike.rs
+++ b/rust/src/ike/ike.rs
@@ -113,7 +113,7 @@ pub struct IKETransaction {
     pub errors: u32,
 
     logged: LoggerFlags,
-    tx_data: applayer::AppLayerTxData,
+    pub tx_data: applayer::AppLayerTxData,
 }
 
 impl Transaction for IKETransaction {

--- a/rust/src/ike/ikev1.rs
+++ b/rust/src/ike/ikev1.rs
@@ -74,11 +74,9 @@ pub struct Ikev1Container {
 pub fn handle_ikev1(
     state: &mut IKEState, current: &[u8], isakmp_header: IsakmpHeader, direction: Direction,
 ) -> AppLayerResult {
-    let mut tx = state.new_tx();
+    let mut tx = state.new_tx(direction);
 
     tx.ike_version = 1;
-    tx.direction = direction;
-    tx.tx_data.set_inspect_direction(direction);
     tx.hdr.spi_initiator = format!("{:016x}", isakmp_header.init_spi);
     tx.hdr.spi_responder = format!("{:016x}", isakmp_header.resp_spi);
     tx.hdr.maj_ver = isakmp_header.maj_ver;

--- a/rust/src/ike/ikev1.rs
+++ b/rust/src/ike/ikev1.rs
@@ -78,6 +78,7 @@ pub fn handle_ikev1(
 
     tx.ike_version = 1;
     tx.direction = direction;
+    tx.tx_data.set_inspect_direction(direction);
     tx.hdr.spi_initiator = format!("{:016x}", isakmp_header.init_spi);
     tx.hdr.spi_responder = format!("{:016x}", isakmp_header.resp_spi);
     tx.hdr.maj_ver = isakmp_header.maj_ver;

--- a/rust/src/ike/ikev2.rs
+++ b/rust/src/ike/ikev2.rs
@@ -117,6 +117,7 @@ pub fn handle_ikev2(
     tx.ike_version = 2;
     // use init_spi as transaction identifier
     // tx.xid = hdr.init_spi; todo is this used somewhere?
+    tx.tx_data.set_inspect_direction(direction);
     tx.hdr.ikev2_header = hdr.clone();
     tx.hdr.spi_initiator = format!("{:016x}", isakmp_header.init_spi);
     tx.hdr.spi_responder = format!("{:016x}", isakmp_header.resp_spi);

--- a/rust/src/ike/ikev2.rs
+++ b/rust/src/ike/ikev2.rs
@@ -113,11 +113,10 @@ pub fn handle_ikev2(
         length: isakmp_header.length,
     };
 
-    let mut tx = state.new_tx();
+    let mut tx = state.new_tx(direction);
     tx.ike_version = 2;
     // use init_spi as transaction identifier
     // tx.xid = hdr.init_spi; todo is this used somewhere?
-    tx.tx_data.set_inspect_direction(direction);
     tx.hdr.ikev2_header = hdr.clone();
     tx.hdr.spi_initiator = format!("{:016x}", isakmp_header.init_spi);
     tx.hdr.spi_responder = format!("{:016x}", isakmp_header.resp_spi);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -240,7 +240,7 @@ impl KRB5State {
 
 impl KRB5Transaction {
     pub fn new(id: u64) -> KRB5Transaction {
-        KRB5Transaction{
+        let mut krbtx = KRB5Transaction{
             msg_type: MessageType(0),
             cname: None,
             realm: None,
@@ -250,7 +250,9 @@ impl KRB5Transaction {
             error_code: None,
             id,
             tx_data: applayer::AppLayerTxData::new(),
-        }
+        };
+        krbtx.tx_data.set_inspect_direction(Direction::ToClient);
+        return krbtx;
     }
 }
 

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -393,6 +393,7 @@ mod test {
     use crate::mqtt::mqtt::MQTTTransaction;
     use crate::mqtt::mqtt_message::*;
     use crate::mqtt::parser::FixedHeader;
+    use crate::core::Direction;
     use std;
 
     #[test]
@@ -410,7 +411,7 @@ mod test {
                 topics: vec!["foo".to_string(), "baar".to_string()],
                 properties: None,
             }),
-        });
+        }, Direction::ToServer);
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::UNSUBSCRIBE,
@@ -471,7 +472,7 @@ mod test {
                 ],
                 properties: None,
             }),
-        });
+        }, Direction::ToServer);
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::SUBSCRIBE,

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -180,8 +180,10 @@ impl MQTTState {
         tx.tx_id = self.tx_id;
         if toclient {
             tx.toclient = true;
+            tx.tx_data.set_inspect_direction(Direction::ToClient);
         } else {
             tx.toserver = true;
+            tx.tx_data.set_inspect_direction(Direction::ToServer);
         }
         if self.transactions.len() > unsafe { MQTT_MAX_TX } {
             let mut index = self.tx_index_completed;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -2075,7 +2075,7 @@ pub unsafe extern "C" fn rs_nfs_udp_register_parser() {
         get_tx_data: rs_nfs_get_tx_data,
         get_state_data: rs_nfs_get_state_data,
         apply_tx_config: None,
-        flags: APP_LAYER_PARSER_OPT_UNIDIR_TXS,
+        flags: 0,
         truncate: None,
         get_frame_id_by_name: Some(NFSFrameType::ffi_id_from_name),
         get_frame_name_by_id: Some(NFSFrameType::ffi_name_from_id),

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -86,7 +86,7 @@ impl SIPState {
         self.transactions.clear();
     }
 
-    fn new_tx(&mut self) -> SIPTransaction {
+    fn new_tx(&mut self, _direction: crate::core::Direction) -> SIPTransaction {
         self.tx_id += 1;
         SIPTransaction::new(self.tx_id)
     }
@@ -127,7 +127,7 @@ impl SIPState {
         match sip_parse_request(input) {
             Ok((_, request)) => {
                 sip_frames_ts(flow, &stream_slice, &request);
-                let mut tx = self.new_tx();
+                let mut tx = self.new_tx(crate::core::Direction::ToServer);
                 tx.request = Some(request);
                 if let Ok((_, req_line)) = sip_take_line(input) {
                     tx.request_line = req_line;
@@ -155,7 +155,7 @@ impl SIPState {
         match sip_parse_response(input) {
             Ok((_, response)) => {
                 sip_frames_tc(flow, &stream_slice, &response);
-                let mut tx = self.new_tx();
+                let mut tx = self.new_tx(crate::core::Direction::ToClient);
                 tx.response = Some(response);
                 if let Ok((_, resp_line)) = sip_take_line(input) {
                     tx.response_line = resp_line;

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -204,11 +204,9 @@ impl<'a> SNMPState<'a> {
         self.transactions.clear();
     }
 
-    fn new_tx(&mut self, _direction: Direction) -> SNMPTransaction<'a> {
+    fn new_tx(&mut self, direction: Direction) -> SNMPTransaction<'a> {
         self.tx_id += 1;
-        let mut tx = SNMPTransaction::new(self.version, self.tx_id);
-        tx.tx_data.set_inspect_direction(_direction);
-        tx
+        SNMPTransaction::new(direction, self.version, self.tx_id)
     }
 
     fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SNMPTransaction> {
@@ -237,7 +235,7 @@ impl<'a> SNMPState<'a> {
 }
 
 impl<'a> SNMPTransaction<'a> {
-    pub fn new(version: u32, id: u64) -> SNMPTransaction<'a> {
+    pub fn new(direction: Direction, version: u32, id: u64) -> SNMPTransaction<'a> {
         SNMPTransaction {
             version,
             info: None,
@@ -245,7 +243,7 @@ impl<'a> SNMPTransaction<'a> {
             usm: None,
             encrypted: false,
             id,
-            tx_data: applayer::AppLayerTxData::new(),
+            tx_data: applayer::AppLayerTxData::for_direction(direction),
         }
     }
 }

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -499,6 +499,11 @@ static DNP3Transaction *DNP3TxAlloc(DNP3State *dnp3, bool request)
     tx->dnp3 = dnp3;
     tx->tx_num = dnp3->transaction_max;
     tx->is_request = request;
+    if (tx->is_request) {
+        tx->tx_data.detect_flags_tc |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+    } else {
+        tx->tx_data.detect_flags_ts |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+    }
     TAILQ_INIT(&tx->objects);
     TAILQ_INSERT_TAIL(&dnp3->tx_list, tx, next);
 
@@ -1423,31 +1428,8 @@ static int DNP3GetAlstateProgress(void *tx, uint8_t direction)
         SCReturnInt(1);
     }
 
-    /* This is a unidirectional protocol.
-     *
-     * If progress is being checked in the TOSERVER (request)
-     * direction, always return complete if the message is not a
-     * request, as there will never be replies on transactions created
-     * in the TOSERVER direction.
-     *
-     * Like wise, if progress is being checked in the TOCLIENT
-     * direction, requests will never be seen. So always return
-     * complete if the transaction is not a reply.
-     *
-     * Otherwise, if TOSERVER and transaction is a request, return
-     * complete if the transaction is complete. And if TOCLIENT and
-     * transaction is a response, return complete if the transaction
-     * is complete.
-     */
-    if (direction & STREAM_TOSERVER) {
-        if (!dnp3tx->is_request || dnp3tx->complete) {
-            retval = 1;
-        }
-    } else if (direction & STREAM_TOCLIENT) {
-        if (dnp3tx->is_request || dnp3tx->complete) {
-            retval = 1;
-        }
-    }
+    if (dnp3tx->complete)
+        retval = 1;
 
     SCReturnInt(retval);
 }
@@ -1579,12 +1561,9 @@ void RegisterDNP3Parsers(void)
         AppLayerParserRegisterTxDataFunc(IPPROTO_TCP, ALPROTO_DNP3,
             DNP3GetTxData);
         AppLayerParserRegisterStateDataFunc(IPPROTO_TCP, ALPROTO_DNP3, DNP3GetStateData);
-#if 0
-        /* While this parser is now fully unidirectional. setting this
-         * flag breaks detection at this time. */
+
         AppLayerParserRegisterOptionFlags(
                 IPPROTO_TCP, ALPROTO_DNP3, APP_LAYER_PARSER_OPT_UNIDIR_TXS);
-#endif
     }
     else {
         SCLogConfig("Parser disabled for protocol %s. "

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -299,7 +299,7 @@ static void ENIPStateTransactionFree(void *state, uint64_t tx_id)
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstate,
-        StreamSlice stream_slice, void *local_data)
+        StreamSlice stream_slice, void *local_data, uint8_t direction)
 {
     SCEnter();
     ENIPState *enip = (ENIPState *) state;
@@ -326,6 +326,11 @@ static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstat
         if (tx == NULL)
             SCReturnStruct(APP_LAYER_OK);
 
+        if (direction == STREAM_TOCLIENT)
+            tx->tx_data.detect_flags_ts |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+        else
+            tx->tx_data.detect_flags_tc |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+
         SCLogDebug("ENIPParse input len %d", input_len);
         DecodeENIPPDU(input, input_len, tx);
         uint32_t pkt_len = tx->header.length + sizeof(ENIPEncapHdr);
@@ -348,6 +353,18 @@ static AppLayerResult ENIPParse(Flow *f, void *state, AppLayerParserState *pstat
     }
 
     SCReturnStruct(APP_LAYER_OK);
+}
+
+static AppLayerResult ENIPParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
+        StreamSlice stream_slice, void *local_data)
+{
+    return ENIPParse(f, state, pstate, stream_slice, local_data, STREAM_TOSERVER);
+}
+
+static AppLayerResult ENIPParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+        StreamSlice stream_slice, void *local_data)
+{
+    return ENIPParse(f, state, pstate, stream_slice, local_data, STREAM_TOCLIENT);
 }
 
 #define ENIP_LEN_REGISTER_SESSION 4 // protocol u16, options u16
@@ -491,10 +508,8 @@ void RegisterENIPUDPParsers(void)
 
     if (AppLayerParserConfParserEnabled("udp", proto_name))
     {
-        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_ENIP,
-                STREAM_TOSERVER, ENIPParse);
-        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_ENIP,
-                STREAM_TOCLIENT, ENIPParse);
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_ENIP, STREAM_TOSERVER, ENIPParseRequest);
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_ENIP, STREAM_TOCLIENT, ENIPParseResponse);
 
         AppLayerParserRegisterStateFuncs(IPPROTO_UDP, ALPROTO_ENIP,
                 ENIPStateAlloc, ENIPStateFree);
@@ -566,10 +581,8 @@ void RegisterENIPTCPParsers(void)
 
     if (AppLayerParserConfParserEnabled("tcp", proto_name))
     {
-        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_ENIP,
-                STREAM_TOSERVER, ENIPParse);
-        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_ENIP,
-                STREAM_TOCLIENT, ENIPParse);
+        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_ENIP, STREAM_TOSERVER, ENIPParseRequest);
+        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_ENIP, STREAM_TOCLIENT, ENIPParseResponse);
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_ENIP,
                 ENIPStateAlloc, ENIPStateFree);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1127,8 +1127,9 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
     if (unlikely(IS_DISRUPTED(flags))) {
         r = StateGetProgressCompletionStatus(alproto, flags);
     } else {
-        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
-            StateGetProgress(alstate, flags);
+        uint8_t direction = flags & (STREAM_TOCLIENT | STREAM_TOSERVER);
+        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetProgress(
+                alstate, direction);
     }
     SCReturnInt(r);
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -66,7 +66,6 @@
 #define APP_LAYER_TX_RESERVED12_FLAG BIT_U64(59)
 #define APP_LAYER_TX_RESERVED13_FLAG BIT_U64(60)
 #define APP_LAYER_TX_RESERVED14_FLAG BIT_U64(61)
-#define APP_LAYER_TX_RESERVED15_FLAG BIT_U64(62)
 
 #define APP_LAYER_TX_RESERVED_FLAGS                                                                \
     (APP_LAYER_TX_RESERVED1_FLAG | APP_LAYER_TX_RESERVED2_FLAG | APP_LAYER_TX_RESERVED3_FLAG |     \
@@ -75,8 +74,10 @@
             APP_LAYER_TX_RESERVED8_FLAG | APP_LAYER_TX_RESERVED9_FLAG |                            \
             APP_LAYER_TX_RESERVED10_FLAG | APP_LAYER_TX_RESERVED11_FLAG |                          \
             APP_LAYER_TX_RESERVED12_FLAG | APP_LAYER_TX_RESERVED13_FLAG |                          \
-            APP_LAYER_TX_RESERVED14_FLAG | APP_LAYER_TX_RESERVED15_FLAG)
+            APP_LAYER_TX_RESERVED14_FLAG)
 
+/** should inspection be skipped in that direction */
+#define APP_LAYER_TX_SKIP_INSPECT_FLAG BIT_U64(62)
 /** is tx fully inspected? */
 #define APP_LAYER_TX_INSPECTED_FLAG             BIT_U64(63)
 /** other 63 bits are for tracking which prefilter engine is already

--- a/src/detect.c
+++ b/src/detect.c
@@ -898,7 +898,6 @@ static DetectRunScratchpad DetectRunSetup(
             if (p->proto == IPPROTO_TCP && pflow->protoctx &&
                     StreamReassembleRawHasDataReady(pflow->protoctx, p)) {
                 p->flags |= PKT_DETECT_HAS_STREAMDATA;
-                flow_flags |= STREAM_FLUSH;
             }
             SCLogDebug("alproto %u", alproto);
         } else {
@@ -1078,12 +1077,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     bool mpm_before_progress = false;   // is mpm engine before progress?
     bool mpm_in_progress = false;       // is mpm engine in a buffer we will revisit?
 
-    /* see if we want to pass on the FLUSH flag */
-    if ((s->flags & SIG_FLAG_FLUSH) == 0)
-        flow_flags &=~ STREAM_FLUSH;
-
     TRACE_SID_TXS(s->id, tx, "starting %s", direction ? "toclient" : "toserver");
-    TRACE_SID_TXS(s->id, tx, "FLUSH? %s", (flow_flags & STREAM_FLUSH)?"true":"false");
 
     /* for a new inspection we inspect pkt header and packet matches */
     if (likely(stored_flags == NULL)) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1256,6 +1256,22 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         DetectTransaction no_tx = { NULL, 0, NULL, NULL, 0, 0, 0, 0, 0, };
         return no_tx;
     }
+    if (detect_flags & APP_LAYER_TX_SKIP_INSPECT_FLAG) {
+        SCLogDebug("%" PRIu64 " tx should not be inspected in direction %s. Flags %016" PRIx64,
+                tx_id, flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
+        DetectTransaction no_tx = {
+            NULL,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+        };
+        return no_tx;
+    }
 
     const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
     const int dir_int = (flow_flags & STREAM_TOSERVER) ? 0 : 1;


### PR DESCRIPTION
This PR builds on work from @regit but changes the API a little to make it more
clear that unidirectional transactions are being created.

Previous PR: https://github.com/OISF/suricata/pull/8578

Issue: https://redmine.openinfosecfoundation.org/issues/4759 (and others)

suricata-verify-pr: 1140
