### PR TITLE
 nfq: fix potential NULL deref

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -569,10 +569,6 @@ static TmEcode NFQInitThread(NFQThreadVars *t, uint32_t queue_maxlen)
     struct timeval tv;
     int opt;
     NFQQueueVars *q = NFQGetQueue(t->nfq_index);
-    if (q == NULL) {
-        SCLogError("no queue for given index");
-        return TM_ECODE_FAILED;
-    }
     SCLogDebug("opening library handle");
     q->h = nfq_open();
     if (q->h == NULL) {
@@ -915,13 +911,10 @@ int NFQParseAndRegisterQueues(const char *queues)
  *  \param number idx of the queue in our array
  *
  *  \retval ptr pointer to the NFQThreadVars at index
- *  \retval NULL on error
  */
 void *NFQGetQueue(int number)
 {
-    if (unlikely(number < 0 || number >= receive_queue_num || g_nfq_q == NULL))
-        return NULL;
-
+    BUG_ON(number < 0 || number >= receive_queue_num || g_nfq_q == NULL);
     return (void *)&g_nfq_q[number];
 }
 


### PR DESCRIPTION
 Added some asserts statements for NFQGetQueue so that
 it is not possible to return NULL.
 Also deleted useless check of returned value of
 NFQGetQueue() in NFQInitThread()
 Found by Security Code with Svace static analyzer
Signed-off-by: Maxim Korotkov <m.korotkov@securitycode.ru>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6385

Describe changes:
- added check of ptr and added return error code if check is fail

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
