### PR TITLE
nfq: Ensure packet release function set

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -532,6 +532,9 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     if (nfq_config.bypass_mask) {
         p->BypassPacketsFlow = NFQBypassCallback;
     }
+
+    p->ReleasePacket = NFQReleasePacket;
+
     ret = NFQSetupPkt(p, qh, (void *)nfa);
     if (ret == -1) {
 #ifdef COUNTERS
@@ -547,8 +550,6 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
         TmqhOutputPacketpool(tv, p);
         return 0;
     }
-
-    p->ReleasePacket = NFQReleasePacket;
 
 #ifdef COUNTERS
     NFQQueueVars *q = NFQGetQueue(ntv->nfq_index);

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1077,7 +1077,7 @@ static inline void UpdateCounters(NFQQueueVars *t, const Packet *p)
 TmEcode NFQSetVerdict(Packet *p)
 {
     int iter = 0;
-    /* we could also have a direct pointer but we need to have a ref counf in this case */
+    /* we could also have a direct pointer but we need to have a ref count in this case */
     NFQQueueVars *t = g_nfq_q + p->nfq_v.nfq_index;
 
     p->nfq_v.verdicted = 1;


### PR DESCRIPTION
This PR ensures that early error returns in `NFQCallBack` will have the packet's release function pointer set.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5916](https://redmine.openinfosecfoundation.org/issues/5916)

Describe changes:
- Set packet's `ReleasePacket` earlier for early error paths.

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
