### PR TITLE
flow/manager: fix prealloc unhandled division by 0 - v1

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -814,7 +814,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         if (ts_ms >= next_run_ms) {
             if (ftd->instance == 0) {
                 const uint32_t sq_len = FlowSpareGetPoolSize();
-                const uint32_t spare_perc = sq_len * 100 / flow_config.prealloc;
+                const uint32_t spare_perc = sq_len * 100 / MAX(flow_config.prealloc, 1);
                 /* see if we still have enough spare flows */
                 if (spare_perc < 90 || spare_perc > 110) {
                     FlowSparePoolUpdate(sq_len);


### PR DESCRIPTION
If flow.prealloc was set to zero in our yaml config, this would lead to Suri erroring out.

Bug #5919

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5919

Describe changes:
- ensure we won't use flow.prealloc value if it's set to zero (use 1 instead)