### PR TITLE
source-xf-xdp: update for deprecated function in libbpf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1369,6 +1369,10 @@
         # Are all required libs installed, yes=HAVE_AF_XDP
         AS_IF([test "x$enable_af_xdp" = "xyes"],
             AC_DEFINE([HAVE_AF_XDP],[1],[AF_XDP support is available]))
+
+        # bpf_get_link_xpd_id has been removed in the most recent
+        # versions of libbpf.
+        AC_CHECK_FUNCS([bpf_xdp_query_id])
     ])
 
   # DPDK support

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -493,10 +493,17 @@ static TmEcode AFXDPSocketCreation(AFXDPThreadVars *ptv)
     }
 
     /* Has the eBPF program successfully bound? */
+#ifdef HAVE_BPF_XDP_QUERY_ID
+    if (bpf_xdp_query_id(ptv->ifindex, ptv->xsk.cfg.xdp_flags, &ptv->prog_id)) {
+        SCLogError("Failed to attach eBPF program to interface: %s", ptv->livedev->dev);
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+#else
     if (bpf_get_link_xdp_id(ptv->ifindex, &ptv->prog_id, ptv->xsk.cfg.xdp_flags)) {
         SCLogError("Failed to attach eBPF program to interface: %s", ptv->livedev->dev);
         SCReturnInt(TM_ECODE_FAILED);
     }
+#endif
 
     SCReturnInt(TM_ECODE_OK);
 }


### PR DESCRIPTION
libbpf 0.8 deprecates bpf_get_link_xpd_id, and 1.0 removes it. Add
./configure check to see if this method is available and use it if so,
otherwise use the deprecated method which is not available on older
but still supported Linux distributions.

Ticket: https://redmine.openinfosecfoundation.org/issues/5924
