### PR TITLE
exception/policy: use pkt action if no flow support - v1

### DIFF
--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -150,10 +150,24 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support
         }
 
         if (!support_flow) {
-            if (policy == EXCEPTION_POLICY_DROP_FLOW || policy == EXCEPTION_POLICY_PASS_FLOW ||
-                    policy == EXCEPTION_POLICY_BYPASS_FLOW) {
-                SCLogWarning("flow actions not supported for %s, defaulting to \"ignore\"", option);
-                policy = EXCEPTION_POLICY_NOT_SET;
+            switch (policy) {
+                case EXCEPTION_POLICY_DROP_FLOW:
+                    SCLogWarning("flow actions not supported for %s, defaulting to \"drop-packet\"",
+                            option);
+                    policy = EXCEPTION_POLICY_DROP_PACKET;
+                    break;
+                case EXCEPTION_POLICY_PASS_FLOW:
+                    SCLogWarning("flow actions not supported for %s, defaulting to \"pass-packet\"",
+                            option);
+                    policy = EXCEPTION_POLICY_PASS_PACKET;
+                    break;
+                case EXCEPTION_POLICY_BYPASS_FLOW:
+                    SCLogWarning(
+                            "flow actions not supported for %s, defaulting to \"ignore\"", option);
+                    policy = EXCEPTION_POLICY_NOT_SET;
+                    break;
+                default:
+                    /* do nothing, these are the ones that bring issues */
             }
         }
 


### PR DESCRIPTION
Defrag memcap and flow memcap do not support flow action for the exception policies, as there is no flow when the exception condition is hit. In such cases, the exception policy must be considered for the packet only, when that makes sense, or should be ignored, in case of `bypass`.

Bug #TBD

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
didn't create one yet, as not confirmed it's a bug

Describe changes:
- Add checks to `ExceptionPolicyParse` to ensure that if an exception policy with flow action is selected when that's not valid, we'll fall back to packet actions, when possible.

suricata-verify-pr: 1155
https://github.com/OISF/suricata-verify/pull/1155