### PR TITLE
conf: deprecate duplicate includes - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -377,6 +377,11 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
         }
         else if (event.type == YAML_MAPPING_START_EVENT) {
             SCLogDebug("event.type=YAML_MAPPING_START_EVENT; state=%d", state);
+            if (state == CONF_INCLUDE) {
+                SCLogError("Include fields cannot be a mapping: line %zu", parser->mark.line);
+                retval = -1;
+                goto fail;
+            }
             if (inseq) {
                 char sequence_node_name[DEFAULT_NAME_LEN];
                 snprintf(sequence_node_name, DEFAULT_NAME_LEN, "%d", seq_idx++);

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -175,6 +175,7 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
     int seq_idx = 0;
     int retval = 0;
     int was_empty = -1;
+    int include_count = 0;
 
     if (rlevel++ > RECURSION_LIMIT) {
         SCLogError("Recursion limit reached while parsing "
@@ -296,6 +297,12 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
 
                     if (strcmp(value, "include") == 0) {
                         state = CONF_INCLUDE;
+                        if (++include_count > 1) {
+                            SCLogWarning("Multipline \"include\" fields at the same level are "
+                                         "deprecated and will not work in Suricata 8, please move "
+                                         "to an array of include files: line: %zu",
+                                    parser->mark.line);
+                        }
                         goto next;
                     }
 

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -48,7 +48,7 @@ static int mangle_errors = 0;
 
 static char *conf_dirname = NULL;
 
-static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel);
+static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel, int state);
 
 /* Configuration processing states. */
 enum conf_state {
@@ -142,7 +142,7 @@ int ConfYamlHandleInclude(ConfNode *parent, const char *filename)
 
     yaml_parser_set_input_file(&parser, file);
 
-    if (ConfYamlParse(&parser, parent, 0, 0) != 0) {
+    if (ConfYamlParse(&parser, parent, 0, 0, 0) != 0) {
         SCLogError("Failed to include configuration file %s", filename);
         goto done;
     }
@@ -166,14 +166,12 @@ done:
  *
  * \retval 0 on success, -1 on failure.
  */
-static int
-ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
+static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel, int state)
 {
     ConfNode *node = parent;
     yaml_event_t event;
     memset(&event, 0, sizeof(event));
     int done = 0;
-    int state = 0;
     int seq_idx = 0;
     int retval = 0;
     int was_empty = -1;
@@ -235,6 +233,13 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
             }
 
             if (inseq) {
+                if (state == CONF_INCLUDE) {
+                    SCLogInfo("Including configuration file %s.", value);
+                    if (ConfYamlHandleInclude(parent, value) != 0) {
+                        goto fail;
+                    }
+                    goto next;
+                }
                 char sequence_node_name[DEFAULT_NAME_LEN];
                 snprintf(sequence_node_name, DEFAULT_NAME_LEN, "%d", seq_idx++);
                 ConfNode *seq_node = NULL;
@@ -360,7 +365,8 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
         }
         else if (event.type == YAML_SEQUENCE_START_EVENT) {
             SCLogDebug("event.type=YAML_SEQUENCE_START_EVENT; state=%d", state);
-            if (ConfYamlParse(parser, node, 1, rlevel) != 0)
+            if (ConfYamlParse(parser, node, 1, rlevel, state == CONF_INCLUDE ? CONF_INCLUDE : 0) !=
+                    0)
                 goto fail;
             node->is_seq = 1;
             state = CONF_KEY;
@@ -396,11 +402,11 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
                 }
                 seq_node->is_seq = 1;
                 TAILQ_INSERT_TAIL(&node->head, seq_node, next);
-                if (ConfYamlParse(parser, seq_node, 0, rlevel) != 0)
+                if (ConfYamlParse(parser, seq_node, 0, rlevel, 0) != 0)
                     goto fail;
             }
             else {
-                if (ConfYamlParse(parser, node, inseq, rlevel) != 0)
+                if (ConfYamlParse(parser, node, inseq, rlevel, 0) != 0)
                     goto fail;
             }
             state = CONF_KEY;
@@ -477,7 +483,7 @@ ConfYamlLoadFile(const char *filename)
     }
 
     yaml_parser_set_input_file(&parser, infile);
-    ret = ConfYamlParse(&parser, root, 0, 0);
+    ret = ConfYamlParse(&parser, root, 0, 0, 0);
     yaml_parser_delete(&parser);
     fclose(infile);
 
@@ -499,7 +505,7 @@ ConfYamlLoadString(const char *string, size_t len)
         exit(EXIT_FAILURE);
     }
     yaml_parser_set_input_string(&parser, (const unsigned char *)string, len);
-    ret = ConfYamlParse(&parser, root, 0, 0);
+    ret = ConfYamlParse(&parser, root, 0, 0, 0);
     yaml_parser_delete(&parser);
 
     return ret;
@@ -565,7 +571,7 @@ ConfYamlLoadFileWithPrefix(const char *filename, const char *prefix)
         }
     }
     yaml_parser_set_input_file(&parser, infile);
-    ret = ConfYamlParse(&parser, root, 0, 0);
+    ret = ConfYamlParse(&parser, root, 0, 0, 0);
     yaml_parser_delete(&parser);
     fclose(infile);
 


### PR DESCRIPTION
Deprecates duplicate "include" keyword at the same level in a configuration
file by displaying a warnings.

Adds support for "include" to be an array.

The following will now output an error:

```
include: one.yaml
include: two.yaml
```

The following will not be processed as you might expect it to:

```
include:
  - one.yaml
  - two.yaml
```

and s asimple include will continue to work:

```
include: one.yaml
```
