### PR TITLE
nfq: Ensure packet release function set 

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -100,7 +100,7 @@ static TmEcode NoNFQSupportExit(ThreadVars *tv, const void *initdata, void **dat
 extern int max_pending_packets;
 
 #define MAX_ALREADY_TREATED 5
-#define NFQ_VERDICT_RETRY_TIME 3
+#define NFQ_VERDICT_RETRY_COUNT 3
 static int already_seen_warning;
 static int runmode_workers;
 
@@ -315,7 +315,7 @@ static void NFQVerdictCacheFlush(NFQQueueVars *t)
             ret = nfq_set_verdict_batch(t->qh,
                                         t->verdict_cache.packet_id,
                                         t->verdict_cache.verdict);
-    } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_TIME));
+    } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_COUNT));
 
     if (ret < 0) {
         SCLogWarning("nfq_set_verdict_batch failed: %s", strerror(errno));
@@ -428,7 +428,7 @@ static int NFQSetupPkt (Packet *p, struct nfq_q_handle *qh, void *data)
             already_seen_warning++;
             do {
                 ret = nfq_set_verdict(qh, p->nfq_v.id, NF_ACCEPT, 0, NULL);
-            } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_TIME));
+            } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_COUNT));
             if (ret < 0) {
                 SCLogWarning(
                         "nfq_set_verdict of %p failed %" PRId32 ": %s", p, ret, strerror(errno));
@@ -1175,7 +1175,7 @@ TmEcode NFQSetVerdict(Packet *p)
 #endif /* HAVE_NFQ_SET_VERDICT2 */
                 break;
         }
-    } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_TIME));
+    } while ((ret < 0) && (iter++ < NFQ_VERDICT_RETRY_COUNT));
 
     NFQMutexUnlock(t);
 

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2019 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1077,7 +1077,7 @@ static inline void UpdateCounters(NFQQueueVars *t, const Packet *p)
 TmEcode NFQSetVerdict(Packet *p)
 {
     int iter = 0;
-    /* we could also have a direct pointer but we need to have a ref counf in this case */
+    /* we could also have a direct pointer but we need to have a ref count in this case */
     NFQQueueVars *t = g_nfq_q + p->nfq_v.nfq_index;
 
     p->nfq_v.verdicted = 1;


### PR DESCRIPTION
Continuation of #8608 

This PR ensures that early error returns in `NFQCallBack` will have the packet's release function pointer set.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5916](https://redmine.openinfosecfoundation.org/issues/5916)

Describe changes:
- Set packet's `ReleasePacket` earlier for early error paths.

Updates:
- Moved setting of `ReleasePacket` to `NFQSetupPkt`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
