### PR TITLE
 conf: deprecate duplicate includes - v2

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -379,6 +379,11 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
         }
         else if (event.type == YAML_MAPPING_START_EVENT) {
             SCLogDebug("event.type=YAML_MAPPING_START_EVENT; state=%d", state);
+            if (state == CONF_INCLUDE) {
+                SCLogError("Include fields cannot be a mapping: line %zu", parser->mark.line);
+                retval = -1;
+                goto fail;
+            }
             if (inseq) {
                 char sequence_node_name[DEFAULT_NAME_LEN];
                 snprintf(sequence_node_name, DEFAULT_NAME_LEN, "%d", seq_idx++);

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -175,6 +175,7 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
     int seq_idx = 0;
     int retval = 0;
     int was_empty = -1;
+    int include_count = 0;
 
     if (rlevel++ > RECURSION_LIMIT) {
         SCLogError("Recursion limit reached while parsing "
@@ -298,6 +299,12 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
 
                     if (strcmp(value, "include") == 0) {
                         state = CONF_INCLUDE;
+                        if (++include_count > 1) {
+                            SCLogWarning("Multipline \"include\" fields at the same level are "
+                                         "deprecated and will not work in Suricata 8, please move "
+                                         "to an array of include files: line: %zu",
+                                    parser->mark.line);
+                        }
                         goto next;
                     }
 


### PR DESCRIPTION
Deprecates duplicate "include" keyword at the same level in a configuration
file by displaying a warnings.

Adds support for "include" to be an array.

The following will now output an error:

```
include: one.yaml
include: two.yaml
```

The following will not be processed as you might expect it to:

```
include:
  - one.yaml
  - two.yaml
```

and s asimple include will continue to work:

```
include: one.yaml
```

Previous PR: #8627

Changes from previous PR:
- [cifuzz] Don't attempt to include null value as file
