### PR TITLE
flow/manager: fix prealloc unhandled division by 0 (60x backports) - v1

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -901,11 +901,11 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             if (emerg == true) {
                 SCLogDebug("flow_sparse_q.len = %"PRIu32" prealloc: %"PRIu32
                         "flow_spare_q status: %"PRIu32"%% flows at the queue",
-                        len, flow_config.prealloc, len * 100 / flow_config.prealloc);
+                        len, flow_config.prealloc, len * 100 / MAX(flow_config.prealloc, 1));
 
             /* only if we have pruned this "emergency_recovery" percentage
              * of flows, we will unset the emergency bit */
-            if (len * 100 / flow_config.prealloc > flow_config.emergency_recovery) {
+            if (len * 100 / MAX(flow_config.prealloc, 1) > flow_config.emergency_recovery) {
                 emerg_over_cnt++;
             } else {
                 emerg_over_cnt = 0;
@@ -923,7 +923,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                           " FLOW_EMERGENCY bit (ts.tv_sec: %"PRIuMAX", "
                           "ts.tv_usec:%"PRIuMAX") flow_spare_q status(): %"PRIu32
                           "%% flows at the queue", (uintmax_t)ts.tv_sec,
-                          (uintmax_t)ts.tv_usec, len * 100 / flow_config.prealloc);
+                          (uintmax_t)ts.tv_usec, len * 100 / MAX(flow_config.prealloc, 1));
 
                 StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
             }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -899,17 +899,17 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             uint32_t len = FlowSpareGetPoolSize();
             StatsSetUI64(th_v, ftd->cnt.flow_mgr_spare, (uint64_t)len);
             if (emerg == true) {
-                SCLogDebug("flow_sparse_q.len = %"PRIu32" prealloc: %"PRIu32
-                        "flow_spare_q status: %"PRIu32"%% flows at the queue",
+                SCLogDebug("flow_sparse_q.len = %" PRIu32 " prealloc: %" PRIu32
+                           "flow_spare_q status: %" PRIu32 "%% flows at the queue",
                         len, flow_config.prealloc, len * 100 / MAX(flow_config.prealloc, 1));
 
-            /* only if we have pruned this "emergency_recovery" percentage
-             * of flows, we will unset the emergency bit */
-            if (len * 100 / MAX(flow_config.prealloc, 1) > flow_config.emergency_recovery) {
-                emerg_over_cnt++;
-            } else {
-                emerg_over_cnt = 0;
-            }
+                /* only if we have pruned this "emergency_recovery" percentage
+                 * of flows, we will unset the emergency bit */
+                if (len * 100 / MAX(flow_config.prealloc, 1) > flow_config.emergency_recovery) {
+                    emerg_over_cnt++;
+                } else {
+                    emerg_over_cnt = 0;
+                }
 
             if (emerg_over_cnt >= 30) {
                 SC_ATOMIC_AND(flow_flags, ~FLOW_EMERGENCY);
@@ -920,10 +920,11 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 emerg_over_cnt = 0;
                 hash_pass_iter = 0;
                 SCLogNotice("Flow emergency mode over, back to normal... unsetting"
-                          " FLOW_EMERGENCY bit (ts.tv_sec: %"PRIuMAX", "
-                          "ts.tv_usec:%"PRIuMAX") flow_spare_q status(): %"PRIu32
-                          "%% flows at the queue", (uintmax_t)ts.tv_sec,
-                          (uintmax_t)ts.tv_usec, len * 100 / MAX(flow_config.prealloc, 1));
+                            " FLOW_EMERGENCY bit (ts.tv_sec: %" PRIuMAX ", "
+                            "ts.tv_usec:%" PRIuMAX ") flow_spare_q status(): %" PRIu32
+                            "%% flows at the queue",
+                        (uintmax_t)ts.tv_sec, (uintmax_t)ts.tv_usec,
+                        len * 100 / MAX(flow_config.prealloc, 1));
 
                 StatsIncr(th_v, ftd->cnt.flow_emerg_mode_over);
             }

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -822,7 +822,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         if (ts_ms >= next_run_ms) {
             if (ftd->instance == 0) {
                 const uint32_t sq_len = FlowSpareGetPoolSize();
-                const uint32_t spare_perc = sq_len * 100 / flow_config.prealloc;
+                const uint32_t spare_perc = sq_len * 100 / MAX(flow_config.prealloc, 1);
                 /* see if we still have enough spare flows */
                 if (spare_perc < 90 || spare_perc > 110) {
                     FlowSparePoolUpdate(sq_len);


### PR DESCRIPTION
https://github.com/OISF/suricata/pull/8616
and
https://github.com/OISF/suricata/pull/8628
backports

plus clang formatting fixes

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5946