### PR TITLE
detect: bytemath do not left shift more than 64 (backport6)

### DIFF
--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -226,7 +226,11 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *sm
             val *= rvalue;
             break;
         case DETECT_BYTEMATH_OPERATOR_LSHIFT:
-            val <<= rvalue;
+            if (rvalue < 64) {
+                val <<= rvalue;
+            } else {
+                val = 0;
+            }
             break;
         case DETECT_BYTEMATH_OPERATOR_RSHIFT:
             val >>= rvalue;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5903

Describe changes:
- Backport of #8594 
