### PR TITLE
detect: bump detect engine version for tenant reload (backport6)

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4264,6 +4264,8 @@ int DetectEngineMTApply(void)
 
     /* walk free list, freeing the old_de_ctx */
     DetectEnginePruneFreeList();
+    // needed for VarNameStoreFree
+    DetectEngineBumpVersion();
 
     SCLogDebug("old_de_ctx should have been freed");
     return 0;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5951

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/8611
