### PR TITLE
http: complete multipart until request.body-limit

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1446,6 +1446,16 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
             if (chunks_buffer_len > expected_boundary_end_len) {
                 const uint8_t *filedata = chunks_buffer;
                 uint32_t filedata_len = chunks_buffer_len - expected_boundary_len;
+                for (; filedata_len < chunks_buffer_len; filedata_len++) {
+                    // take as much as we can until the beginning of a new line
+                    if (chunks_buffer[filedata_len] == '\r') {
+                        if (filedata_len + 1 == expected_boundary_len ||
+                                chunks_buffer[filedata_len + 1] == '\n') {
+                            break;
+                        }
+                    }
+                }
+
 #ifdef PRINT
                 printf("FILEDATA (part) START: \n");
                 PrintRawDataFp(stdout, filedata, filedata_len);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5952

- http: complete multipart until request.body-limit

This illustrates the QA SURI_TLPW1_files_sha256 differences from https://github.com/OISF/suricata/pull/8450

https://github.com/OISF/suricata/pull/8450 is right for hash 0adad78526c1b9c35f349a2cc7014c458aa87adcb9ec86f052fd8a9a80584e39 and master is wrong because being zealous with the limit `request.body_limit` and taking less bytes than it can

I propose we merge this first, do the QA rebase, and then rebase https://github.com/OISF/suricata/pull/8450 to check SURI_TLPW1_files_sha256 again

Replaces #8510 with rebase and commit reword with redmine ticket reference

suricata-verify-pr: 1109
https://github.com/OISF/suricata-verify/pull/1109