### PR TITLE
runmodes: Determine engine's copy-mode as early as possible

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2554,6 +2554,10 @@ int PostConfLoadedSetup(SCInstance *suri)
         SCReturnInt(TM_ECODE_FAILED);
     }
 #endif
+    /* set engine mode if L2 IPS */
+    if (PostDeviceFinalizedSetup(suri) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
 
     /* load the pattern matchers */
     MpmTableSetup();
@@ -2720,11 +2724,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     DecodeGlobalConfig();
 
     LiveDeviceFinalize();
-
-    /* set engine mode if L2 IPS */
-    if (PostDeviceFinalizedSetup(suri) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
 
     /* hostmode depends on engine mode being set */
     PostConfLoadedSetupHostMode();


### PR DESCRIPTION
Configuration and behavior of HTP app layer depends on the copy mode of Suricata engine. Copy mode was set after the app layer setup. Decision of engine's copy mode operation is now made earlier.

Ticket: #5934

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5934) ticket:

Describe changes:
- engine mode decision is executed earlier