### PR TITLE
Draft: Backport/bug/5934 determining engine mode v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2602,6 +2602,11 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
+    /* set engine mode if L2 IPS */
+    if (PostDeviceFinalizedSetup(suri) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
     AppLayerSetup();
 
     /* Suricata will use this umask if provided. By default it will use the
@@ -2720,11 +2725,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     DecodeGlobalConfig();
 
     LiveDeviceFinalize();
-
-    /* set engine mode if L2 IPS */
-    if (PostDeviceFinalizedSetup(suri) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
 
     /* hostmode depends on engine mode being set */
     PostConfLoadedSetupHostMode();


### PR DESCRIPTION
Follow-up of #8643

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5934) ticket:

Describe changes:
- postpone the function call - picked the wrong commit for the previous version...