### PR TITLE
Backport/bug/5934 determining engine mode v3

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -719,7 +719,7 @@ static int AFPConfigGeThreadsCount(void *conf)
 
 int AFPRunModeIsIPS(void)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceNameCount();
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -736,7 +736,7 @@ int AFPRunModeIsIPS(void)
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceNameName(ldev);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -768,7 +768,7 @@ int AFPRunModeIsIPS(void)
                 "AF_PACKET using both IPS and TAP/IDS mode, this will not "
                 "be allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceNameName(ldev);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -377,7 +377,7 @@ static int NetmapConfigGeThreadsCount(void *conf)
 
 int NetmapRunModeIsIPS(void)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceNameCount();
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -394,7 +394,7 @@ int NetmapRunModeIsIPS(void)
     if_default = ConfNodeLookupKeyValue(netmap_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceNameName(ldev);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -426,7 +426,7 @@ int NetmapRunModeIsIPS(void)
                 "Netmap using both IPS and TAP/IDS mode, this will not be "
                 "allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceNameName(ldev);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -248,6 +248,12 @@ int SuriHasSigFile(void)
 
 int EngineModeIsIPS(void)
 {
+#ifdef DEBUG
+    static enum EngineMode prev_engine_mode = ENGINE_MODE_UNKNOWN;
+    BUG_ON((prev_engine_mode != ENGINE_MODE_UNKNOWN) && (g_engine_mode != prev_engine_mode));
+    prev_engine_mode = g_engine_mode; // engine mode can not change since the first query
+#endif
+
     return (g_engine_mode == ENGINE_MODE_IPS);
 }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2456,10 +2456,8 @@ void PostConfLoadedDetectSetup(SCInstance *suri)
     }
 }
 
-static int PostDeviceFinalizedSetup(SCInstance *suri)
+static void RunModeEngineIsIPS(SCInstance *suri)
 {
-    SCEnter();
-
 #ifdef HAVE_AF_PACKET
     if (suri->run_mode == RUNMODE_AFP_DEV) {
         if (AFPRunModeIsIPS()) {
@@ -2476,8 +2474,6 @@ static int PostDeviceFinalizedSetup(SCInstance *suri)
         }
     }
 #endif
-
-    SCReturnInt(TM_ECODE_OK);
 }
 
 static void PostConfLoadedSetupHostMode(void)
@@ -2602,6 +2598,9 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
+    /* set engine mode if L2 IPS */
+    RunModeEngineIsIPS(suri);
+
     AppLayerSetup();
 
     /* Suricata will use this umask if provided. By default it will use the
@@ -2720,11 +2719,6 @@ int PostConfLoadedSetup(SCInstance *suri)
     DecodeGlobalConfig();
 
     LiveDeviceFinalize();
-
-    /* set engine mode if L2 IPS */
-    if (PostDeviceFinalizedSetup(suri) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
 
     /* hostmode depends on engine mode being set */
     PostConfLoadedSetupHostMode();

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -100,6 +100,7 @@ enum {
 
 /* Engine is acting as */
 enum EngineMode {
+    ENGINE_MODE_UNKNOWN,
     ENGINE_MODE_IDS,
     ENGINE_MODE_IPS,
 };


### PR DESCRIPTION
Follow-up of #8645 
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5934) ticket:

Changes:
- in how runmode is determined
- bug test for runmode changing during the Suricata startup

I do not think adding a SV test is viable as for the test we would need to setup an actual AFP/Netmap setup where the check for incorrectly set runmode mode would be run. (`--simulate-ips` doesn't really help here as it explicitly enables IPS mode. In the AFP/Netmap case it was checked from config but after libhtp was initialized)

I've been able to verify manually that prior to the fix, Suricata kept buffering the reassembled stream (IDS mode) and would only output an alert after some (flow) timeout (or Suricata shutdown). After the fix, Suricata properly behaves as in IPS inline mode where the alert was generated right after the packet containing the specified pattern.