### PR TITLE
6.0.x - app-layer: mark unidirectional transactions with a direction - v1

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -18,7 +18,7 @@
 //! Parser registration functions and common interface
 
 use std;
-use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto};
+use crate::core::{DetectEngineState,Flow,AppLayerEventType,AppLayerDecoderEvents,AppProto, STREAM_TOCLIENT};
 use crate::filecontainer::FileContainer;
 use crate::applayer;
 use std::os::raw::{c_void,c_char,c_int};
@@ -84,6 +84,14 @@ impl AppLayerTxData {
     }
     pub fn incr_files_opened(&mut self) {
         self.files_opened += 1;
+    }
+
+    pub fn set_inspect_direction(&mut self, direction: u8) {
+        if direction == STREAM_TOCLIENT {
+            self.detect_flags_ts |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+        } else {
+            self.detect_flags_tc |= APP_LAYER_TX_SKIP_INSPECT_FLAG;
+        }
     }
 }
 
@@ -321,6 +329,7 @@ pub const APP_LAYER_PARSER_BYPASS_READY : u8 = BIT_U8!(4);
 
 pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = BIT_U32!(0);
 pub const APP_LAYER_PARSER_OPT_UNIDIR_TXS: u32 = BIT_U32!(1);
+pub const APP_LAYER_TX_SKIP_INSPECT_FLAG: u64 = BIT_U64!(62);
 
 pub type AppLayerGetTxIteratorFn = extern "C" fn (ipproto: u8,
                                                   alproto: AppProto,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -24,6 +24,8 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::applayer::*;
+use crate::core::STREAM_TOCLIENT;
+use crate::core::STREAM_TOSERVER;
 use crate::core::{self, AppProto, ALPROTO_UNKNOWN, IPPROTO_UDP, IPPROTO_TCP};
 use crate::dns::parser;
 
@@ -512,6 +514,7 @@ impl DNSState {
 
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
+                tx.tx_data.set_inspect_direction(STREAM_TOSERVER);
                 self.transactions.push(tx);
 
                 if z_flag {
@@ -556,6 +559,7 @@ impl DNSState {
                     }
                 }
                 tx.response = Some(response);
+                tx.tx_data.set_inspect_direction(STREAM_TOCLIENT);
                 self.transactions.push(tx);
 
                 if z_flag {

--- a/rust/src/ikev2/ikev2.rs
+++ b/rust/src/ikev2/ikev2.rs
@@ -153,6 +153,7 @@ impl IKEV2State {
                 }
                 let mut tx = self.new_tx();
                 // use init_spi as transaction identifier
+		tx.tx_data.set_inspect_direction(direction);
                 tx.xid = hdr.init_spi;
                 tx.hdr = (*hdr).clone();
                 self.transactions.push(tx);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -228,7 +228,7 @@ impl KRB5State {
 
 impl KRB5Transaction {
     pub fn new(id: u64) -> KRB5Transaction {
-        KRB5Transaction{
+        let mut krbtx = KRB5Transaction{
             msg_type: MessageType(0),
             cname: None,
             realm: None,
@@ -239,7 +239,9 @@ impl KRB5Transaction {
             de_state: None,
             events: std::ptr::null_mut(),
             tx_data: applayer::AppLayerTxData::new(),
-        }
+        };
+        krbtx.tx_data.set_inspect_direction(STREAM_TOCLIENT);
+        return krbtx;
     }
 }
 

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -21,6 +21,8 @@ use super::mqtt_message::*;
 use super::parser::*;
 use crate::applayer::{self, LoggerFlags};
 use crate::applayer::*;
+use crate::core::STREAM_TOCLIENT;
+use crate::core::STREAM_TOSERVER;
 use crate::core::{self, AppProto, Flow, ALPROTO_FAILED, ALPROTO_UNKNOWN, IPPROTO_TCP};
 use num_traits::FromPrimitive;
 use crate::conf::conf_get;
@@ -183,8 +185,10 @@ impl MQTTState {
         tx.tx_id = self.tx_id;
         if toclient {
             tx.toclient = true;
+            tx.tx_data.set_inspect_direction(STREAM_TOCLIENT);
         } else {
             tx.toserver = true;
+            tx.tx_data.set_inspect_direction(STREAM_TOSERVER);
         }
         if self.transactions.len() > unsafe { MQTT_MAX_TX } {
             let mut index = self.tx_index_completed;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1073,8 +1073,9 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
         r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
             StateGetProgressCompletionStatus(flags);
     } else {
-        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
-            StateGetProgress(alstate, flags);
+        uint8_t direction = flags & (STREAM_TOCLIENT | STREAM_TOSERVER);
+        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetProgress(
+                alstate, direction);
     }
     SCReturnInt(r);
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -49,6 +49,7 @@
 
 /* applies to DetectFlags uint64_t field */
 
+#define APP_LAYER_TX_SKIP_INSPECT_FLAG BIT_U64(62)
 /** is tx fully inspected? */
 #define APP_LAYER_TX_INSPECTED_FLAG             BIT_U64(63)
 /** other 63 bits are for tracking which prefilter engine is already

--- a/src/detect.c
+++ b/src/detect.c
@@ -1242,6 +1242,22 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         DetectTransaction no_tx = { NULL, 0, NULL, NULL, 0, 0, 0, 0, 0, };
         return no_tx;
     }
+    if (detect_flags & APP_LAYER_TX_SKIP_INSPECT_FLAG) {
+        SCLogDebug("%" PRIu64 " tx should not be inspected in direction %s. Flags %016" PRIx64,
+                tx_id, flow_flags & STREAM_TOSERVER ? "toserver" : "toclient", detect_flags);
+        DetectTransaction no_tx = {
+            NULL,
+            0,
+            NULL,
+            NULL,
+            0,
+            0,
+            0,
+            0,
+            0,
+        };
+        return no_tx;
+    }
 
     const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
     const int dir_int = (flow_flags & STREAM_TOSERVER) ? 0 : 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -880,7 +880,6 @@ static DetectRunScratchpad DetectRunSetup(
             if (p->proto == IPPROTO_TCP && pflow->protoctx &&
                     StreamReassembleRawHasDataReady(pflow->protoctx, p)) {
                 p->flags |= PKT_DETECT_HAS_STREAMDATA;
-                flow_flags |= STREAM_FLUSH;
             }
             SCLogDebug("alproto %u", alproto);
         } else {
@@ -1059,12 +1058,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     bool mpm_before_progress = false;   // is mpm engine before progress?
     bool mpm_in_progress = false;       // is mpm engine in a buffer we will revisit?
 
-    /* see if we want to pass on the FLUSH flag */
-    if ((s->flags & SIG_FLAG_FLUSH) == 0)
-        flow_flags &=~ STREAM_FLUSH;
-
     TRACE_SID_TXS(s->id, tx, "starting %s", direction ? "toclient" : "toserver");
-    TRACE_SID_TXS(s->id, tx, "FLUSH? %s", (flow_flags & STREAM_FLUSH)?"true":"false");
 
     /* for a new inspection we inspect pkt header and packet matches */
     if (likely(stored_flags == NULL)) {


### PR DESCRIPTION
A backport of https://github.com/OISF/suricata/pull/8601.

Just the minimum, doesn't backport the API ergonomics patch.

Ticket:  https://redmine.openinfosecfoundation.org/issues/4759

suricata-verify-pr: 1140
