### PR TITLE
Backport/bug/5934 determining engine mode v6

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -157,14 +157,6 @@ static void *ParseAFPConfig(const char *iface)
     aconf->ebpf_t_config.cpus_count = UtilCpuGetNumProcessorsConfigured();
 #endif
 
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            aconf->bpf_filter = bpf_filter;
-            SCLogConfig("Going to use command-line provided bpf filter '%s'",
-                       aconf->bpf_filter);
-        }
-    }
-
     /* Find initial node */
     af_packet_node = ConfGetNode("af-packet");
     if (af_packet_node == NULL) {
@@ -372,11 +364,18 @@ static void *ParseAFPConfig(const char *iface)
 
     /*load af_packet bpf filter*/
     /* command line value has precedence */
-    if (ConfGet("bpf-filter", &bpf_filter) != 1) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                aconf->bpf_filter = bpf_filter;
-                SCLogConfig("Going to use bpf filter %s", aconf->bpf_filter);
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            aconf->bpf_filter = bpf_filter;
+            SCLogConfig("Going to use command-line provided bpf filter '%s'", aconf->bpf_filter);
+        }
+    } else { // reading from the file
+        if (aconf->bpf_filter == NULL) {
+            if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+                if (strlen(bpf_filter) > 0) {
+                    aconf->bpf_filter = bpf_filter;
+                    SCLogConfig("Going to use file provided bpf filter '%s'", aconf->bpf_filter);
+                }
             }
         }
     }

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -718,7 +718,7 @@ static int AFPConfigGeThreadsCount(void *conf)
 
 int AFPRunModeIsIPS(void)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceNameCount();
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -735,7 +735,7 @@ int AFPRunModeIsIPS(void)
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceNameName(ldev);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -767,7 +767,7 @@ int AFPRunModeIsIPS(void)
                 "AF_PACKET using both IPS and TAP/IDS mode, this will not "
                 "be allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceNameName(ldev);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -142,15 +142,6 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
         ns->real = true;
     }
 
-    const char *bpf_filter = NULL;
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            ns->bpf_filter = bpf_filter;
-            SCLogInfo("Going to use command-line provided bpf filter '%s'",
-                    ns->bpf_filter);
-        }
-    }
-
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("Unable to find netmap config for "
                 "interface \"%s\" or \"default\", using default values",
@@ -183,11 +174,19 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
 
     /* load netmap bpf filter */
     /* command line value has precedence */
-    if (ns->bpf_filter == NULL) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                ns->bpf_filter = bpf_filter;
-                SCLogInfo("Going to use bpf filter %s", ns->bpf_filter);
+    const char *bpf_filter = NULL;
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            ns->bpf_filter = bpf_filter;
+            SCLogInfo("Going to use command-line provided bpf filter '%s'", ns->bpf_filter);
+        }
+    } else { // reading from the file
+        if (ns->bpf_filter == NULL) {
+            if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+                if (strlen(bpf_filter) > 0) {
+                    ns->bpf_filter = bpf_filter;
+                    SCLogInfo("Going to use file provided bpf filter %s", ns->bpf_filter);
+                }
             }
         }
     }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -376,7 +376,7 @@ static int NetmapConfigGeThreadsCount(void *conf)
 
 int NetmapRunModeIsIPS(void)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceNameCount();
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -393,7 +393,7 @@ int NetmapRunModeIsIPS(void)
     if_default = ConfNodeLookupKeyValue(netmap_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        const char *live_dev = LiveGetDeviceName(ldev);
+        const char *live_dev = LiveGetDeviceNameName(ldev);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -425,7 +425,7 @@ int NetmapRunModeIsIPS(void)
                 "Netmap using both IPS and TAP/IDS mode, this will not be "
                 "allowed in Suricata 8 due to undefined behavior. See ticket #5588.");
         for (ldev = 0; ldev < nlive; ldev++) {
-            const char *live_dev = LiveGetDeviceName(ldev);
+            const char *live_dev = LiveGetDeviceNameName(ldev);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -319,26 +319,29 @@ static void *ParsePfringConfig(const char *iface)
         if (strlen(bpf_filter) > 0) {
             pfconf->bpf_filter = SCStrdup(bpf_filter);
             if (unlikely(pfconf->bpf_filter == NULL)) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                           "Can't allocate BPF filter string");
+                SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate BPF filter string");
             } else {
-                SCLogDebug("Going to use command-line provided bpf filter %s",
-                           pfconf->bpf_filter);
+                SCLogConfig("Going to use command-line provided bpf filter %s", pfconf->bpf_filter);
             }
         }
     } else {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                pfconf->bpf_filter = SCStrdup(bpf_filter);
-                if (unlikely(pfconf->bpf_filter == NULL)) {
-                    SCLogError(SC_ERR_MEM_ALLOC,
-                               "Can't allocate BPF filter string");
-                } else {
-                    SCLogDebug("Going to use bpf filter %s",
-                               pfconf->bpf_filter);
+        if (pfconf->bpf_filter == NULL) {
+            if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+                if (strlen(bpf_filter) > 0) {
+                    pfconf->bpf_filter = SCStrdup(bpf_filter);
+                    if (unlikely(pfconf->bpf_filter == NULL)) {
+                        SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate BPF filter string");
+                    } else {
+                        SCLogConfig("Going to use file provided bpf filter %s", pfconf->bpf_filter);
+                    }
                 }
             }
         }
+    }
+
+    if (pfconf->bpf_filter != NULL && EngineModeIsIPS()) {
+        FatalError(SC_ERR_NOT_SUPPORTED,
+                "BPF filter not available in IPS mode. Use firewall filtering if possible.");
     }
 
     if (ConfGet("pfring.cluster-type", &tmpctype) == 1) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -471,13 +471,6 @@ static int SetBpfString(int argc, char *argv[])
     if (bpf_len == 0)
         return TM_ECODE_OK;
 
-    if (EngineModeIsIPS()) {
-        SCLogError(SC_ERR_NOT_SUPPORTED,
-                   "BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-        return TM_ECODE_FAILED;
-    }
-
     bpf_filter = SCMalloc(bpf_len);
     if (unlikely(bpf_filter == NULL))
         return TM_ECODE_OK;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -100,12 +100,14 @@ enum {
 
 /* Engine is acting as */
 enum EngineMode {
+    ENGINE_MODE_UNKNOWN,
     ENGINE_MODE_IDS,
     ENGINE_MODE_IPS,
 };
 
 void EngineModeSetIPS(void);
 void EngineModeSetIDS(void);
+int EngineModeIsUnknown(void);
 int EngineModeIsIPS(void);
 int EngineModeIsIDS(void);
 

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -194,6 +194,7 @@ uint32_t UtRunTests(const char *regex_arg)
     int ret = 0, rcomp = 0;
     int ov[MAX_SUBSTRINGS];
 
+    EngineModeSetIDS();
     StreamTcpInitMemuse();
     StreamTcpReassembleInitMemuse();
 


### PR DESCRIPTION
Follow-up of #8649 

https://redmine.openinfosecfoundation.org/issues/5934
https://redmine.openinfosecfoundation.org/issues/5958

Describe changes:
- new engine mode - unknown - to determine when the engine mode is queried uninitialized
- bpf evaluates IPS mode later on - AF_PACKET and NETMAP permits usage of BPF filters in IPS mode, PF-RING prohibits the usage
- refactor BPF checks in individual capture interfaces 
