### PR TITLE
app-layer-dnp3: Fix build for big endian

### DIFF
--- a/src/app-layer-dnp3.h
+++ b/src/app-layer-dnp3.h
@@ -19,6 +19,9 @@
 #define __APP_LAYER_DNP3_H__
 
 #include "rust.h"
+#if __BYTE_ORDER == __BIG_ENDIAN
+#include "util-byte.h"
+#endif
 
 /**
  * The maximum size of a DNP3 link PDU.


### PR DESCRIPTION
Add missing include of util-byte.h for big endian targets that need SCByteSwap(16|32|64) for DNP3_SWAP(16|32|64).

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [✓] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

No redmine ticket due to simplicity of fix.

Describe changes:
Fix build error for implicit declaration of function 'SCByteSwap(16|32|64)' in app-layer-dnp3.h for big-endian targets.