### PR TITLE
exception/policy: add stats counters - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5225,6 +5225,9 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "type": "integer"
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4747,6 +4747,9 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "integer"
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5174,6 +5174,9 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "type": "integer"
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -348,7 +348,9 @@
                 "response": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["id"],
+                    "required": [
+                        "id"
+                    ],
                     "properties": {
                         "id": {
                             "type": "string"
@@ -361,10 +363,10 @@
                                     "type": "object",
                                     "additionalProperties": false,
                                     "required": [
-					"id",
-					"ip",
-					"port"
-				    ],
+                                        "id",
+                                        "ip",
+                                        "port"
+                                    ],
                                     "properties": {
                                         "id": {
                                             "type": "string"
@@ -385,10 +387,10 @@
                                 "type": "object",
                                 "additionalProperties": false,
                                 "required": [
-				    "id",
-				    "ip",
-				    "port"
-				],
+                                    "id",
+                                    "ip",
+                                    "port"
+                                ],
                                 "properties": {
                                     "id": {
                                         "type": "string"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4877,6 +4877,9 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "integer"
+                        },
                         "memuse": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1341,9 +1341,9 @@
                 "has_exe_url": {
                     "type": "boolean"
                 },
-		"message_id": {
-		    "type": "string"
-		}
+                "message_id": {
+                    "type": "string"
+                }
             },
             "additionalProperties": false
         },
@@ -1490,6 +1490,9 @@
                 },
                 "dest_port": {
                     "type": "integer"
+                },
+                "emergency": {
+                    "type": "boolean"
                 },
                 "end": {
                     "type": "string"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5192,6 +5192,9 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "type": "integer"
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5460,6 +5460,9 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "type": "integer"
                 }
             },
             "additionalProperties": false

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -476,7 +476,7 @@ static int TCPProtoDetect(ThreadVars *tv,
          *
          * \todo We need to figure out a more robust solution for this,
          *       as this can lead to easy evasion tactics, where the
-         *       attackeer can first send some dummy data in the wrong
+         *       attacker can first send some dummy data in the wrong
          *       direction first to mislead our proto detection process.
          *       While doing this we need to update the parsers as well,
          *       since the parsers must be robust to see such wrong

--- a/src/decode.c
+++ b/src/decode.c
@@ -587,16 +587,10 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);
-    dtv->counter_defrag_ipv4_reassembled =
-        StatsRegisterCounter("defrag.ipv4.reassembled", tv);
-    dtv->counter_defrag_ipv4_timeouts =
-        StatsRegisterCounter("defrag.ipv4.timeouts", tv);
+    dtv->counter_defrag_ipv4_reassembled = StatsRegisterCounter("defrag.ipv4.reassembled", tv);
     dtv->counter_defrag_ipv6_fragments =
         StatsRegisterCounter("defrag.ipv6.fragments", tv);
-    dtv->counter_defrag_ipv6_reassembled =
-        StatsRegisterCounter("defrag.ipv6.reassembled", tv);
-    dtv->counter_defrag_ipv6_timeouts =
-        StatsRegisterCounter("defrag.ipv6.timeouts", tv);
+    dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -564,6 +564,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    dtv->counter_flow_memcap_exc_policy = StatsRegisterCounter("flow.memcap_exception_policy", tv);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -593,6 +593,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+    dtv->counter_defrag_memcap_exc_policy =
+            StatsRegisterCounter("defrag.memcap_exception_policy", tv);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.h
+++ b/src/decode.h
@@ -713,6 +713,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    uint16_t counter_defrag_memcap_exc_policy;
 
     uint16_t counter_flow_memcap;
     uint16_t counter_flow_memcap_exc_policy;

--- a/src/decode.h
+++ b/src/decode.h
@@ -710,10 +710,8 @@ typedef struct DecodeThreadVars_
     /** frag stats - defrag runs in the context of the decoder. */
     uint16_t counter_defrag_ipv4_fragments;
     uint16_t counter_defrag_ipv4_reassembled;
-    uint16_t counter_defrag_ipv4_timeouts;
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
-    uint16_t counter_defrag_ipv6_timeouts;
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;

--- a/src/decode.h
+++ b/src/decode.h
@@ -717,6 +717,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    uint16_t counter_flow_memcap_exc_policy;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -469,7 +469,7 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *  Get a new defrag tracker. We're checking memcap first and will try to make room
  *  if the memcap is reached.
  *
- *  \retval dt *LOCKED* tracker on succes, NULL on error.
+ *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
 static DefragTracker *DefragTrackerGetNew(Packet *p)
 {
@@ -518,7 +518,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
     } else {
         /* tracker has been recycled before it went into the spare queue */
 
-        /* tracker is initialized (recylced) but *unlocked* */
+        /* tracker is initialized (recycled) but *unlocked* */
     }
 
     (void) SC_ATOMIC_ADD(defragtracker_counter, 1);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1041,8 +1041,10 @@ Defrag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 
     /* return a locked tracker or NULL */
     tracker = DefragGetTracker(tv, dtv, p);
-    if (tracker == NULL)
+    if (tracker == NULL) {
+        StatsIncr(tv, dtv->counter_defrag_max_hit);
         return NULL;
+    }
 
     Packet *rp = DefragInsertFrag(tv, dtv, tracker, p);
     DefragTrackerRelease(tracker);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1043,6 +1043,8 @@ Defrag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
     tracker = DefragGetTracker(tv, dtv, p);
     if (tracker == NULL) {
         StatsIncr(tv, dtv->counter_defrag_max_hit);
+        /* currently, whenever tracker is NULL, ExceptionPolicyApply has been called */
+        StatsIncr(tv, dtv->counter_defrag_memcap_exc_policy);
         return NULL;
     }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -621,6 +621,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
+        NoFlowHandleIPS(p);
         return NULL;
     }
 #endif

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -614,7 +614,8 @@ static inline void NoFlowHandleIPS(Packet *p)
  *  \param tv thread vars
  *  \param fls lookup support vars
  *
- *  \retval f *LOCKED* flow on succes, NULL on error.
+ *  \retval f *LOCKED* flow on success, NULL on error or if we should not create
+ *  a new flow.
  */
 static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
@@ -679,7 +680,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     } else {
         /* flow has been recycled before it went into the spare queue */
 
-        /* flow is initialized (recylced) but *unlocked* */
+        /* flow is initialized (recycled) but *unlocked* */
     }
 
     FLOWLOCK_WRLOCK(f);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -623,6 +623,9 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
         NoFlowHandleIPS(p);
+        StatsIncr(tv, fls->dtv->counter_flow_memcap);
+        // TODO increase exception policy stats ONLY if not set to ignore!!
+        StatsIncr(tv, fls->dtv->counter_flow_memcap_exc_policy);
         return NULL;
     }
 #endif
@@ -648,6 +651,15 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
             f = FlowGetUsedFlow(tv, fls->dtv, p->ts);
             if (f == NULL) {
                 NoFlowHandleIPS(p);
+#ifdef UNITTESTS
+                if (tv != NULL && fls->dtv != NULL) {
+#endif
+                    StatsIncr(tv, fls->dtv->counter_flow_memcap);
+                    // TODO increase exception policy stats ONLY if not set to ignore!!
+                    StatsIncr(tv, fls->dtv->counter_flow_memcap_exc_policy);
+#ifdef UNITTESTS
+                }
+#endif
                 return NULL;
             }
 #ifdef UNITTESTS
@@ -673,6 +685,8 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
             }
 #endif
             NoFlowHandleIPS(p);
+            // TODO increase exception policy stats ONLY if not set to ignore!!
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_exc_policy);
             return NULL;
         }
 

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -2033,6 +2033,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
                     p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StatsIncr(tv, ra_ctx->counter_tcp_reass_exc_policy);
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -63,6 +63,8 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    uint16_t counter_tcp_reass_exc_policy;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -963,6 +963,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_FIN) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StatsIncr(tv, stt->counter_tcp_midstream_exc_policy);
 
         if (!stream_config.midstream || p->payload_len == 0) {
             StreamTcpSetEvent(p, STREAM_FIN_BUT_NO_SESSION);
@@ -1060,6 +1061,7 @@ static int StreamTcpPacketStateNone(
     } else if ((p->tcph->th_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StatsIncr(tv, stt->counter_tcp_midstream_exc_policy);
 
         if (!stream_config.midstream && !stream_config.async_oneside) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -1233,6 +1235,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_ACK) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StatsIncr(tv, stt->counter_tcp_midstream_exc_policy);
 
         if (!stream_config.midstream) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -5782,6 +5785,8 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_synack = StatsRegisterCounter("tcp.synack", tv);
     stt->counter_tcp_rst = StatsRegisterCounter("tcp.rst", tv);
     stt->counter_tcp_midstream_pickups = StatsRegisterCounter("tcp.midstream_pickups", tv);
+    stt->counter_tcp_midstream_exc_policy =
+            StatsRegisterCounter("tcp.midstream_exception_policy", tv);
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", tv);
     stt->counter_tcp_ack_unseen_data = StatsRegisterCounter("tcp.ack_unseen_data", tv);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5787,6 +5787,8 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+    stt->ra_ctx->counter_tcp_reass_exc_policy =
+            StatsRegisterCounter("tcp.reassembly_exception_policy", tv);
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -746,6 +746,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_exc_policy);
             return NULL;
         }
 #endif
@@ -753,6 +754,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_exc_policy);
             return NULL;
         }
 
@@ -5770,6 +5772,8 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    stt->counter_tcp_ssn_memcap_exc_policy =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy", tv);
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -105,7 +105,7 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_midstream_pickups;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
-    /** ack for unseed data */
+    /** ack for unseen data */
     uint16_t counter_tcp_ack_unseen_data;
 
     /** tcp reassembly thread data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -104,6 +104,7 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_rst;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    uint16_t counter_tcp_midstream_exc_policy;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseen data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -85,6 +85,7 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    uint16_t counter_tcp_ssn_memcap_exc_policy;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5816

Describe changes:
- defrag: remove unused counters
- defrag: reintroduce usage of counter for memcap hit
- exception/policy: add stats counters
- exception/policy: make work for simulated flow memcap
- schema: add exception policy counters and flow.emergency
- fix typos & update copyright years

Considerations: 
- I'm not sure if this is the right/best approach, as in many cases it seems that we're just replicating the stats for the exception conditions themselves - in which case maybe documenting them would be a solution?
- A case in which it would make these don't feel so similar would be if when we have `ignore` we didn't add to the counters. - In which case an analyst would have to check the complementary stats to have access to the info (so in any case I'd say we should document them).
- I'm considering taking a different approach, in which we have `ExceptionPolicyCounters` with all counters there, and then we trigger their increase from within `ExceptionPolicyApply`.

Output examples:
compact:
`stats.flow.memcap_exception_policy: 0`
`stats.tcp.ssn_memcap_exception_policy: 0`
`stats.tcp.midstream_exception_policy: 0`
`stats.tcp.reassembly_exception_policy: 0`
`stats.defrag.memcap_exception_policy: 0`
`stats.app_layer.error.http.exception_policy: 0`
(app_layer ones are somewhat different, as they're per protocol)

`flow:`
```json
 "flow": {
    "memcap": 0,
    "memcap_exception_policy": 0,
    "total": 1,
    "active": 0,
    "tcp": 0,
    "udp": 0,
    "icmpv4": 1,
    "icmpv6": 0,
    "tcp_reuse": 0,
    "get_used": 0,
    "get_used_eval": 0,
    "get_used_eval_reject": 0,
    "get_used_eval_busy": 0,
    "get_used_failed": 0,
    "wrk": {
      "spare_sync_avg": 100,
      "spare_sync": 1,
      "spare_sync_incomplete": 0,
      "spare_sync_empty": 0,
      "flows_evicted_needs_work": 0,
      "flows_evicted_pkt_inject": 0,
      "flows_evicted": 0,
      "flows_injected": 0,
      "flows_injected_max": 0
    },
```
`stream:`
```json
"tcp": {
    "active_sessions": 0,
    "sessions": 0,
    "ssn_memcap_drop": 0,
    "ssn_from_cache": 0,
    "ssn_from_pool": 0,
    "ssn_memcap_exception_policy": 0,
    "pseudo": 0,
    "pseudo_failed": 0,
    "invalid_checksum": 0,
    "no_flow": 0,
    "syn": 0,
    "synack": 0,
    "rst": 0,
    "midstream_pickups": 0,
    "midstream_exception_policy": 0,
    "pkt_on_wrong_thread": 0,
    "ack_unseen_data": 0,
    "segment_memcap_drop": 0,
    "reassembly_exception_policy": 0,
    "segment_from_cache": 0,
    "segment_from_pool": 0,
    "stream_depth_reached": 0,
    "reassembly_gap": 0,
    "overlap": 0,
    "overlap_diff_data": 0,
    "insert_data_normal_fail": 0,
    "insert_data_overlap_fail": 0,
    "memuse": 7667712,
    "reassembly_memuse": 1376256
  },
```
`defrag:`
```json
  "defrag": {
    "ipv4": {
      "fragments": 2,
      "reassembled": 0
    },
    "ipv6": {
      "fragments": 0,
      "reassembled": 0
    },
    "max_frag_hits": 1,
    "memcap_exception_policy": 1
  },
```
`app_layer:`
```json
 "app_layer": {
    "error": {
      "http": {
        "gap": 0,
        "alloc": 0,
        "parser": 0,
        "internal": 0,
        "exception_policy": 0
      },
```

suricata-verify-pr: 1160
https://github.com/OISF/suricata-verify/pull/1160