### PR TITLE
draft: policy: postpone setting of policy after determining engine mode v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2677,9 +2677,9 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
-    SetMasterExceptionPolicy();
-
     LiveDeviceFinalize(); // must be after EBPF extension registration
+
+    SetMasterExceptionPolicy();
 
     RunModeEngineIsIPS(
             suricata.run_mode, suricata.runmode_custom_mode, suricata.capture_plugin_name);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5960) ticket:

Describe changes:
- moved evaluation of exception policy prior to the setting of engine mode to make sure that the failing IPS test from #8668 is related to the IPS mode setting and not to finalizing LiveDevices. The expected outcome is passing the test which is in fact incorrect (and the pipeline baseline should be adjusted).