### PR TITLE
http: fix multipart completion

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1449,7 +1449,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 for (; filedata_len < chunks_buffer_len; filedata_len++) {
                     // take as much as we can until the beginning of a new line
                     if (chunks_buffer[filedata_len] == '\r') {
-                        if (filedata_len + 1 == expected_boundary_len ||
+                        if (filedata_len + 1 == chunks_buffer_len ||
                                 chunks_buffer[filedata_len + 1] == '\n') {
                             break;
                         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5952

- http: complete multipart until request.body-limit

Fixes https://github.com/OISF/suricata/pull/8641

Makes #8661 simpler, to check for the right length against overflow

suricata-verify-pr: 1109
https://github.com/OISF/suricata-verify/pull/1109