### PR TITLE
Engine mode fixes v1 

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -244,14 +244,6 @@ static void *ParseAFPConfig(const char *iface)
     aconf->ebpf_t_config.cpus_count = UtilCpuGetNumProcessorsConfigured();
 #endif
 
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            aconf->bpf_filter = bpf_filter;
-            SCLogConfig(
-                    "%s: using command-line provided bpf filter '%s'", iface, aconf->bpf_filter);
-        }
-    }
-
     /* Find initial node */
     af_packet_node = ConfGetNode("af-packet");
     if (af_packet_node == NULL) {
@@ -437,11 +429,19 @@ static void *ParseAFPConfig(const char *iface)
 
     /*load af_packet bpf filter*/
     /* command line value has precedence */
-    if (ConfGet("bpf-filter", &bpf_filter) != 1) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                aconf->bpf_filter = bpf_filter;
-                SCLogConfig("%s: bpf filter %s", iface, aconf->bpf_filter);
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            aconf->bpf_filter = bpf_filter;
+            SCLogConfig(
+                    "%s: using command-line provided bpf filter '%s'", iface, aconf->bpf_filter);
+        }
+    } else { // reading from the file
+        if (aconf->bpf_filter == NULL) {
+            if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+                if (strlen(bpf_filter) > 0) {
+                    aconf->bpf_filter = bpf_filter;
+                    SCLogConfig("%s: using file provided bpf filter %s", iface, aconf->bpf_filter);
+                }
             }
         }
     }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -205,14 +205,6 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
         ns->real = true;
     }
 
-    const char *bpf_filter = NULL;
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            ns->bpf_filter = bpf_filter;
-            SCLogInfo("%s: using command-line provided bpf filter '%s'", iface, ns->bpf_filter);
-        }
-    }
-
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("%s: unable to find netmap config for interface \"%s\" or \"default\", using "
                   "default values",
@@ -244,11 +236,19 @@ static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
 
     /* load netmap bpf filter */
     /* command line value has precedence */
-    if (ns->bpf_filter == NULL) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                ns->bpf_filter = bpf_filter;
-                SCLogInfo("%s: using bpf filter %s", iface, ns->bpf_filter);
+    const char *bpf_filter = NULL;
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            ns->bpf_filter = bpf_filter;
+            SCLogInfo("%s: using command-line provided bpf filter '%s'", iface, ns->bpf_filter);
+        }
+    } else { // reading from the file
+        if (ns->bpf_filter == NULL) {
+            if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+                if (strlen(bpf_filter) > 0) {
+                    ns->bpf_filter = bpf_filter;
+                    SCLogInfo("%s: using file provided bpf filter %s", iface, ns->bpf_filter);
+                }
             }
         }
     }

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -323,22 +323,26 @@ static void *ParsePfringConfig(const char *iface)
             if (unlikely(pfconf->bpf_filter == NULL)) {
                 SCLogError("Can't allocate BPF filter string");
             } else {
-                SCLogDebug("Going to use command-line provided bpf filter %s",
-                           pfconf->bpf_filter);
+                SCLogConfig("%s: using to use command-line provided bpf filter %s", pfconf->iface,
+                        pfconf->bpf_filter);
             }
         }
-    } else {
+    } else if (pfconf->bpf_filter == NULL) {
         if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
             if (strlen(bpf_filter) > 0) {
                 pfconf->bpf_filter = SCStrdup(bpf_filter);
                 if (unlikely(pfconf->bpf_filter == NULL)) {
                     SCLogError("Can't allocate BPF filter string");
                 } else {
-                    SCLogDebug("Going to use bpf filter %s",
-                               pfconf->bpf_filter);
+                    SCLogConfig("%s: using file provided bpf filter %s", pfconf->iface,
+                            pfconf->bpf_filter);
                 }
             }
         }
+    }
+
+    if (pfconf->bpf_filter != NULL && EngineModeIsIPS()) {
+        FatalError("BPF filter not available in IPS mode. Use firewall filtering if possible.");
     }
 
     if (ConfGet("pfring.cluster-type", &tmpctype) == 1) {

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -232,6 +232,7 @@ void RunUnittests(int list_unittests, const char *regex_arg)
 #ifdef UNITTESTS
     /* Initializations for global vars, queues, etc (memsets, mutex init..) */
     GlobalsInitPreConfig();
+    EngineModeSetIDS();
 
 #ifdef HAVE_LUAJIT
     if (LuajitSetupStatesPool() != 0) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -456,15 +456,9 @@ static int SetBpfString(int argc, char *argv[])
     if (bpf_len == 0)
         return TM_ECODE_OK;
 
-    if (EngineModeIsIPS()) {
-        SCLogError("BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-        return TM_ECODE_FAILED;
-    }
-
     bpf_filter = SCMalloc(bpf_len);
     if (unlikely(bpf_filter == NULL))
-        return TM_ECODE_OK;
+        return TM_ECODE_FAILED;
     memset(bpf_filter, 0x00, bpf_len);
 
     tmpindex = optind;
@@ -501,11 +495,6 @@ static void SetBpfStringFromFile(char *filename)
 #endif /* OS_WIN32 */
     FILE *fp = NULL;
     size_t nm = 0;
-
-    if (EngineModeIsIPS()) {
-        FatalError("BPF filter not available in IPS mode."
-                   " Use firewall filtering if possible.");
-    }
 
     fp = fopen(filename, "r");
     if (fp == NULL) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2666,12 +2666,12 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
-    SetMasterExceptionPolicy();
-
     LiveDeviceFinalize(); // must be after EBPF extension registration
 
     RunModeEngineIsIPS(
             suricata.run_mode, suricata.runmode_custom_mode, suricata.capture_plugin_name);
+
+    SetMasterExceptionPolicy();
 
     AppLayerSetup();
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -168,7 +168,7 @@ int run_mode = RUNMODE_UNKNOWN;
 
 /** Engine mode: inline (ENGINE_MODE_IPS) or just
   * detection mode (ENGINE_MODE_IDS by default) */
-static enum EngineMode g_engine_mode = ENGINE_MODE_IDS;
+static enum EngineMode g_engine_mode = ENGINE_MODE_UNKNOWN;
 
 /** Host mode: set if box is sniffing only
  * or is a router */
@@ -208,13 +208,24 @@ int SuriHasSigFile(void)
     return (suricata.sig_file != NULL);
 }
 
+int EngineModeIsUnknown(void)
+{
+    return (g_engine_mode == ENGINE_MODE_UNKNOWN);
+}
+
 int EngineModeIsIPS(void)
 {
+#ifdef DEBUG
+    BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
+#endif
     return (g_engine_mode == ENGINE_MODE_IPS);
 }
 
 int EngineModeIsIDS(void)
 {
+#ifdef DEBUG
+    BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
+#endif
     return (g_engine_mode == ENGINE_MODE_IDS);
 }
 
@@ -2670,6 +2681,11 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     RunModeEngineIsIPS(
             suricata.run_mode, suricata.runmode_custom_mode, suricata.capture_plugin_name);
+
+    if (EngineModeIsUnknown()) { // if still uninitialized the set the default
+        SCLogInfo("Setting engine mode to IDS mode by default");
+        EngineModeSetIDS();
+    }
 
     SetMasterExceptionPolicy();
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -99,12 +99,14 @@ enum {
 
 /* Engine is acting as */
 enum EngineMode {
+    ENGINE_MODE_UNKNOWN,
     ENGINE_MODE_IDS,
     ENGINE_MODE_IPS,
 };
 
 void EngineModeSetIPS(void);
 void EngineModeSetIDS(void);
+int EngineModeIsUnknown(void);
 int EngineModeIsIPS(void);
 int EngineModeIsIDS(void);
 


### PR DESCRIPTION
PR is a collection of:
- Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5957) ticket.
- Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5959) ticket.
- Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5960) ticket.

PR fixes determination of engine mode. The main problem is that some parts of Suricata queries the state of the engine mode before it is determined. They are given the default engine mode state (IDS) while later Suricata determined IPS behavior. This then led to unwanted behavior in IPS mode. 

BPF contained this issue but hasn't really affected Suricata. However, the policy settings did affect Suricata run in IPS mode. This has been tested in PRs #8668 and #8671. #8687 has moved the policy setting only after DeviceFinalization but still before engine mode evaluation. This PR has not triggered different behavior in the pipeline run. #8668 has moved the policy setting after the engine mode evaluation and the behavior of Suricata in IPS mode changed. The bug is also highlighted with the addition of unknown/uninitialized engine mode in combination with the BUG_ON macro.

IPS behavior deviation is expected and I suggest baseline adjustment.