### PR TITLE
all: remove unused literals

### DIFF
--- a/src/app-layer-dnp3.h
+++ b/src/app-layer-dnp3.h
@@ -23,10 +23,6 @@
 #include "util-byte.h"
 #endif
 
-/**
- * The maximum size of a DNP3 link PDU.
- */
-#define DNP3_MAX_LINK_PDU_LEN 292
 
 /* DNP3 application request function codes. */
 #define DNP3_APP_FC_CONFIRM                0x00

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -98,22 +98,6 @@ extern const FtpCommand FtpCommands[FTP_COMMAND_MAX + 1];
 
 typedef uint32_t FtpRequestCommandArgOfs;
 
-typedef uint16_t FtpResponseCode;
-
-enum {
-    FTP_FIELD_NONE = 0,
-
-    FTP_FIELD_REQUEST_LINE,
-    FTP_FIELD_REQUEST_COMMAND,
-    FTP_FIELD_REQUEST_ARGS,
-
-    FTP_FIELD_RESPONSE_LINE,
-    FTP_FIELD_REPONSE_CODE,
-
-    /* must be last */
-    FTP_FIELD_MAX,
-};
-
 /** used to hold the line state when we have fragmentation. */
 typedef struct FtpLineState_ {
     /** used to indicate if the current_line buffer is a malloced buffer.  We
@@ -173,8 +157,6 @@ typedef struct FtpState_ {
     uint8_t *port_line;
 
     uint16_t dyn_port;
-    /* specifies which loggers are done logging */
-    uint32_t logged;
 
     AppLayerStateData state_data;
 } FtpState;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -195,9 +195,7 @@ typedef struct HtpBody_ {
     uint64_t body_inspected;
 } HtpBody;
 
-#define HTP_CONTENTTYPE_SET     BIT_U8(0)    /**< We have the content type */
 #define HTP_BOUNDARY_SET        BIT_U8(1)    /**< We have a boundary string */
-#define HTP_BOUNDARY_OPEN       BIT_U8(2)    /**< We have a boundary string */
 #define HTP_FILENAME_SET        BIT_U8(3)    /**< filename is registered in the flow */
 #define HTP_DONTSTORE           BIT_U8(4)    /**< not storing this file */
 #define HTP_STREAM_DEPTH_SET    BIT_U8(5)    /**< stream-depth is set */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -182,9 +182,6 @@ void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto proto,
 //     AppLayerDecoderEvents *(*StateGetEvents)(void *) __attribute__((nonnull)));
 void AppLayerParserRegisterGetTxFilesFunc(uint8_t ipproto, AppProto alproto,
         AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t));
-void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
-                         LoggerId (*StateGetTxLogged)(void *, void *),
-                         void (*StateSetTxLogged)(void *, void *, LoggerId));
 void AppLayerParserRegisterLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserRegisterLoggerBits(uint8_t ipproto, AppProto alproto, LoggerId bits);
 void AppLayerParserRegisterTruncateFunc(uint8_t ipproto, AppProto alproto,

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -241,7 +241,6 @@ typedef struct SSLStateConnp_ {
     uint8_t content_type;
 
     uint8_t handshake_type;
-    uint32_t handshake_length;
 
     /* the no of bytes processed in the currently parsed record */
     uint32_t bytes_processed;

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -80,15 +80,12 @@
 #define ICMP6_DST_UNREACH_NOROUTE       0 /* no route to destination */
 #define ICMP6_DST_UNREACH_ADMIN         1 /* communication with destination */
                                           /* administratively prohibited */
-#define ICMP6_DST_UNREACH_BEYONDSCOPE   2 /* beyond scope of source address */
-#define ICMP6_DST_UNREACH_ADDR          3 /* address unreachable */
 #define ICMP6_DST_UNREACH_NOPORT        4 /* bad port */
 #define ICMP6_DST_UNREACH_FAILEDPOLICY  5 /* Source address failed ingress/egress policy */
 #define ICMP6_DST_UNREACH_REJECTROUTE   6 /* Reject route to destination */
 
 
 /** Time Exceeded Message (type=3) Code: */
-#define ICMP6_TIME_EXCEED_TRANSIT     0 /* Hop Limit == 0 in transit */
 #define ICMP6_TIME_EXCEED_REASSEMBLY  1 /* Reassembly time out */
 
 /** Parameter Problem Message (type=4) Code: */

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -125,7 +125,6 @@ typedef struct DefragTracker_ {
 
 void DefragInit(void);
 void DefragDestroy(void);
-void DefragReload(void); /**< use only in unittests */
 
 uint8_t DefragGetOsPolicy(Packet *);
 void DefragTrackerFreeFrags(DefragTracker *);

--- a/src/detect-http-stat-msg.h
+++ b/src/detect-http-stat-msg.h
@@ -25,8 +25,6 @@
 #define	_DETECT_HTTP_STAT_MSG_H
 
 /* prototypes */
-int DetectHttpStatMsgMatch (ThreadVars *, DetectEngineThreadCtx *, Flow *,
-                            uint8_t , void *, Signature *, SigMatch *);
 void DetectHttpStatMsgRegister(void);
 
 #endif	/* _DETECT_HTTP_STAT_MSG_H */

--- a/src/detect.h
+++ b/src/detect.h
@@ -861,8 +861,6 @@ typedef struct DetectEngineCtx_ {
 
     /* conf parameter that limits the length of the http request body inspected */
     int hcbd_buffer_limit;
-    /* conf parameter that limits the length of the http response body inspected */
-    int hsbd_buffer_limit;
 
     /* array containing all sgh's in use so we can loop
      * through it in Stage4. */

--- a/src/flow.h
+++ b/src/flow.h
@@ -199,14 +199,6 @@ typedef struct AppLayerParserState_ AppLayerParserState;
         (a)->addr_data32[3] = 0;                                  \
     } while (0)
 
-/* clear the address structure by setting all fields to 0 */
-#define FLOW_CLEAR_ADDR(a) do {  \
-        (a)->addr_data32[0] = 0; \
-        (a)->addr_data32[1] = 0; \
-        (a)->addr_data32[2] = 0; \
-        (a)->addr_data32[3] = 0; \
-    } while (0)
-
 /* Set the IPv6 addressesinto the Addrs of the Packet.
  * Make sure p->ip6h is initialized and validated. */
 #define FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, a) do {   \
@@ -327,8 +319,6 @@ typedef struct FlowAddress_ {
 #define addr_data32 address.address_un_data32
 #define addr_data16 address.address_un_data16
 #define addr_data8  address.address_un_data8
-
-typedef unsigned short FlowRefCount;
 
 typedef unsigned short FlowStateType;
 

--- a/src/output-json-anomaly.h
+++ b/src/output-json-anomaly.h
@@ -28,8 +28,6 @@
 #define __OUTPUT_JSON_ANOMALY_H__
 
 void JsonAnomalyLogRegister(void);
-void AnomalyJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, json_t *js,
-                     uint16_t flags);
 
 #endif /* __OUTPUT_JSON_ALERT_H__ */
 

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -32,7 +32,6 @@
 #define B64_BLOCK           4
 
 typedef enum {
-    BASE64_MODE_RELAX,
     /* If the following strings were to be passed to the decoder with RFC2045 mode,
      * the results would be as follows. See the unittest B64TestVectorsRFC2045 in
      * src/util-base64.c

--- a/src/util-config.h
+++ b/src/util-config.h
@@ -25,7 +25,6 @@
 #define __UTIL_CONFIG_H__
 
 enum ConfigAction {
-    CONFIG_ACTION_UNSET = 0,
     CONFIG_ACTION_SET = 1,
 };
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Remove unused literals

`grep -o -E '\w+' src/*.h | cut -d: -f2- | sort -u -f | while read i; do echo -n "$i"; git grep "$i" | wc -l;  done > lol.txt`
Then `cat lol.txt | awk ' $2==1 {print $1}' | grep -v "_$"`

Then manual inspection

Draft because there are many more to remove...