### PR TITLE
http2: faster when reducing dynamic headers size

### DIFF
--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -564,13 +564,16 @@ fn http2_parse_headers_block_dynamic_size<'a>(
     if (maxsize2 as usize) < dyn_headers.max_size {
         //dyn_headers.max_size is updated later with all headers
         //may evict entries
-        while dyn_headers.current_size > (maxsize2 as usize) && dyn_headers.table.len() > 0 {
+        let mut toremove = 0;
+        while dyn_headers.current_size > (maxsize2 as usize) && toremove < dyn_headers.table.len() {
             // we check dyn_headers.table as we may be in best effort
             // because the previous maxsize was too big for us to retain all the headers
-            dyn_headers.current_size -=
-                32 + dyn_headers.table[0].name.len() + dyn_headers.table[0].value.len();
-            dyn_headers.table.remove(0);
+            dyn_headers.current_size -= 32
+                + dyn_headers.table[toremove].name.len()
+                + dyn_headers.table[toremove].value.len();
+            toremove += 1;
         }
+        dyn_headers.table.drain(0..toremove);
     }
     return Ok((
         i3,


### PR DESCRIPTION
avoid quadratic complexity from removing the first element and copying all the contents a big number fo times.

Ticket: #5909
(cherry picked from commit 9adb59bcdb61a06792bec1bee468a900ad5118f5)

Rebased #8692