### PR TITLE
rust/sip: register parser for tcp v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3827,7 +3827,10 @@
                                 "rfb": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
-                                "sip": {
+                                "sip_udp": {
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "sip_tcp": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "smb": {
@@ -3944,7 +3947,10 @@
                                 "rfb": {
                                     "type": "integer"
                                 },
-                                "sip": {
+                                "sip_udp": {
+                                    "type": "integer"
+                                },
+                                "sip_tcp": {
                                     "type": "integer"
                                 },
                                 "smb": {
@@ -4055,7 +4061,10 @@
                                 "rfb": {
                                     "type": "integer"
                                 },
-                                "sip": {
+                                "sip_udp": {
+                                    "type": "integer"
+                                },
+                                "sip_tcp": {
                                     "type": "integer"
                                 },
                                 "smb": {

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-// written by Giuseppe Longo <giuseppe@glono.it>
+// written by Giuseppe Longo <giuseppe@glongo.it>
 
 use nom7::bytes::streaming::{take, take_while, take_while1};
 use nom7::character::streaming::{char, crlf};
@@ -65,7 +65,7 @@ pub enum Method {
 
 #[inline]
 fn is_token_char(b: u8) -> bool {
-    is_alphanumeric(b) || b"!%'*+-._`".contains(&b)
+    is_alphanumeric(b) || b"!%'*+-._`;=@".contains(&b)
 }
 
 #[inline]

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -20,7 +20,7 @@
 use crate::frames::*;
 use crate::applayer::{self, *};
 use crate::core;
-use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN};
+use crate::core::{AppProto, Flow, ALPROTO_UNKNOWN, ALPROTO_FAILED};
 use crate::sip::parser::*;
 use nom7::Err;
 use std;
@@ -86,9 +86,9 @@ impl SIPState {
         self.transactions.clear();
     }
 
-    fn new_tx(&mut self, _direction: crate::core::Direction) -> SIPTransaction {
+    fn new_tx(&mut self, direction: crate::core::Direction) -> SIPTransaction {
         self.tx_id += 1;
-        SIPTransaction::new(self.tx_id)
+        SIPTransaction::new(self.tx_id, direction)
     }
 
     fn get_tx_by_id(&mut self, tx_id: u64) -> Option<&SIPTransaction> {
@@ -112,6 +112,15 @@ impl SIPState {
         }
     }
 
+    fn append_request(&mut self, input: &[u8], request: Request) {
+        let mut tx = self.new_tx(crate::core::Direction::ToServer);
+        tx.request = Some(request);
+        if let Ok((_, req_line)) = sip_take_line(input) {
+            tx.request_line = req_line;
+        }
+        self.transactions.push(tx);
+    }
+
     // app-layer-frame-documentation tag start: parse_request
     fn parse_request(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
         let input = stream_slice.as_slice();
@@ -127,12 +136,7 @@ impl SIPState {
         match sip_parse_request(input) {
             Ok((_, request)) => {
                 sip_frames_ts(flow, &stream_slice, &request);
-                let mut tx = self.new_tx(crate::core::Direction::ToServer);
-                tx.request = Some(request);
-                if let Ok((_, req_line)) = sip_take_line(input) {
-                    tx.request_line = req_line;
-                }
-                self.transactions.push(tx);
+                self.append_request(input, request);
                 return true;
             }
             // app-layer-frame-documentation tag end: parse_request
@@ -147,6 +151,55 @@ impl SIPState {
         }
     }
 
+    fn parse_request_tcp(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+        if input.is_empty() {
+            return AppLayerResult::ok();
+        }
+        let _pdu = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            SIPFrameType::Pdu as u8,
+        );
+        SCLogDebug!("ts: pdu {:?}", _pdu);
+
+        match sip_parse_request(input) {
+            Ok((_, request)) => {
+                sip_frames_ts(flow, &stream_slice, &request);
+                self.append_request(input, request);
+            }
+            Err(Err::Incomplete(_needed)) => {
+                let consumed = input.len();
+                let needed_estimation = input.len() + 1;
+                SCLogDebug!(
+                    "Needed: {:?}, estimated needed: {:?}",
+                    _needed,
+                    needed_estimation
+                );
+                self.set_event(SIPEvent::IncompleteData);
+                return AppLayerResult::incomplete(consumed as u32, needed_estimation as u32);
+            }
+            Err(_) => {
+                self.set_event(SIPEvent::InvalidData);
+                return AppLayerResult::err();
+            }
+        }
+
+        // input fully consumed.
+        return AppLayerResult::ok();
+    }
+
+    fn append_response(&mut self, input: &[u8], response: Response) {
+        let mut tx = self.new_tx(crate::core::Direction::ToClient);
+        tx.response = Some(response);
+        if let Ok((_, resp_line)) = sip_take_line(input) {
+            tx.response_line = resp_line;
+        }
+        self.transactions.push(tx);
+    }
+
     fn parse_response(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
         let input = stream_slice.as_slice();
         let _pdu = Frame::new(flow, &stream_slice, input, input.len() as i64, SIPFrameType::Pdu as u8);
@@ -155,12 +208,7 @@ impl SIPState {
         match sip_parse_response(input) {
             Ok((_, response)) => {
                 sip_frames_tc(flow, &stream_slice, &response);
-                let mut tx = self.new_tx(crate::core::Direction::ToClient);
-                tx.response = Some(response);
-                if let Ok((_, resp_line)) = sip_take_line(input) {
-                    tx.response_line = resp_line;
-                }
-                self.transactions.push(tx);
+                self.append_response(input, response);
                 return true;
             }
             Err(Err::Incomplete(_)) => {
@@ -173,17 +221,57 @@ impl SIPState {
             }
         }
     }
+
+    fn parse_response_tcp(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+        if input.is_empty() {
+            return AppLayerResult::ok();
+        }
+        let _pdu = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            SIPFrameType::Pdu as u8,
+        );
+        SCLogDebug!("tc: pdu {:?}", _pdu);
+
+        match sip_parse_response(input) {
+            Ok((_, response)) => {
+                sip_frames_tc(flow, &stream_slice, &response);
+                self.append_response(input, response);
+            }
+            Err(Err::Incomplete(_needed)) => {
+                let consumed = input.len();
+                let needed_estimation = input.len() + 1;
+                SCLogDebug!(
+                    "Needed: {:?}, estimated needed: {:?}",
+                    _needed,
+                    needed_estimation
+                );
+                self.set_event(SIPEvent::IncompleteData);
+                return AppLayerResult::incomplete(consumed as u32, needed_estimation as u32);
+            }
+            Err(_) => {
+                self.set_event(SIPEvent::InvalidData);
+                return AppLayerResult::err();
+            }
+        }
+
+        // input fully consumed.
+        return AppLayerResult::ok();
+    }
 }
 
 impl SIPTransaction {
-    pub fn new(id: u64) -> SIPTransaction {
+    pub fn new(id: u64, direction: crate::core::Direction) -> SIPTransaction {
         SIPTransaction {
             id,
             request: None,
             response: None,
             request_line: None,
             response_line: None,
-            tx_data: applayer::AppLayerTxData::new(),
+            tx_data: applayer::AppLayerTxData::for_direction(direction),
         }
     }
 }
@@ -299,6 +387,31 @@ pub unsafe extern "C" fn rs_sip_probing_parser_ts(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_sip_probing_parser_tcp_ts(
+    _flow: *const Flow,
+    _direction: u8,
+    input: *const u8,
+    input_len: u32,
+    _rdir: *mut u8,
+) -> AppProto {
+    if input_len >= 3 && !input.is_null() {
+        let buf = build_slice!(input, input_len as usize);
+        match sip_parse_request(buf) {
+            Ok((_, _request)) => {
+                return ALPROTO_SIP;
+            }
+            Err(Err::Incomplete(_)) => {
+                return ALPROTO_UNKNOWN;
+            }
+            Err(_e) => {
+                return ALPROTO_FAILED;
+            }
+        }
+    }
+    return ALPROTO_UNKNOWN;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_sip_probing_parser_tc(
     _flow: *const Flow,
     _direction: u8,
@@ -309,6 +422,31 @@ pub unsafe extern "C" fn rs_sip_probing_parser_tc(
     let buf = build_slice!(input, input_len as usize);
     if sip_parse_response(buf).is_ok() {
         return ALPROTO_SIP;
+    }
+    return ALPROTO_UNKNOWN;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_sip_probing_parser_tcp_tc(
+    _flow: *const Flow,
+    _direction: u8,
+    input: *const u8,
+    input_len: u32,
+    _rdir: *mut u8,
+) -> AppProto {
+    if input_len >= 3 && !input.is_null() {
+        let buf = build_slice!(input, input_len as usize);
+        match sip_parse_response(buf) {
+            Ok((_, _response)) => {
+                return ALPROTO_SIP;
+            }
+            Err(Err::Incomplete(_)) => {
+                return ALPROTO_UNKNOWN;
+            }
+            Err(_e) => {
+                return ALPROTO_FAILED;
+            }
+        }
     }
     return ALPROTO_UNKNOWN;
 }
@@ -326,6 +464,26 @@ pub unsafe extern "C" fn rs_sip_parse_request(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_sip_parse_request_tcp(
+    flow: *const core::Flow,
+    state: *mut std::os::raw::c_void,
+    pstate: *mut std::os::raw::c_void,
+    stream_slice: StreamSlice,
+    _data: *const std::os::raw::c_void,
+) -> AppLayerResult {
+    if stream_slice.is_empty() {
+        if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS) > 0 {
+            return AppLayerResult::ok();
+        } else {
+            return AppLayerResult::err();
+        }
+    }
+
+    let state = cast_pointer!(state, SIPState);
+    state.parse_request_tcp(flow, stream_slice)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_sip_parse_response(
     flow: *const core::Flow,
     state: *mut std::os::raw::c_void,
@@ -337,6 +495,18 @@ pub unsafe extern "C" fn rs_sip_parse_response(
     state.parse_response(flow, stream_slice).into()
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn rs_sip_parse_response_tcp(
+    flow: *const core::Flow,
+    state: *mut std::os::raw::c_void,
+    _pstate: *mut std::os::raw::c_void,
+    stream_slice: StreamSlice,
+    _data: *const std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, SIPState);
+    state.parse_response_tcp(flow, stream_slice)
+}
+
 export_tx_data_get!(rs_sip_get_tx_data, SIPTransaction);
 export_state_data_get!(rs_sip_get_state_data, SIPState);
 
@@ -345,7 +515,7 @@ const PARSER_NAME: &[u8] = b"sip\0";
 #[no_mangle]
 pub unsafe extern "C" fn rs_sip_register_parser() {
     let default_port = CString::new("[5060,5061]").unwrap();
-    let parser = RustParser {
+    let mut parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),
         ipproto: core::IPPROTO_UDP,
@@ -387,5 +557,24 @@ pub unsafe extern "C" fn rs_sip_register_parser() {
         }
     } else {
         SCLogDebug!("Protocol detecter and parser disabled for SIP/UDP.");
+    }
+
+
+    // register TCP parser
+    parser.ipproto = core::IPPROTO_TCP;
+    parser.probe_ts = Some(rs_sip_probing_parser_tcp_ts);
+    parser.probe_tc = Some(rs_sip_probing_parser_tcp_tc);
+    parser.parse_ts = rs_sip_parse_request_tcp;
+    parser.parse_tc = rs_sip_parse_response_tcp;
+
+    let ip_proto_str = CString::new("tcp").unwrap();
+    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
+        ALPROTO_SIP = alproto;
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    } else {
+        SCLogDebug!("Protocol detector and parser disabled for SIP/TCP.");
     }
 }

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -65,7 +65,7 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     SIPTransaction *siptx = tx;
     OutputJsonThreadCtx *thread = thread_data;
 
-    JsonBuilder *js = CreateEveHeader((Packet *)p, LOG_DIR_PACKET, "sip", NULL, thread->ctx);
+    JsonBuilder *js = CreateEveHeader((Packet *)p, LOG_DIR_FLOW, "sip", NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
@@ -88,6 +88,7 @@ static OutputInitResult OutputSIPLogInitSub(ConfNode *conf,
     OutputCtx *parent_ctx)
 {
     AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_SIP);
+    AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_SIP);
     return OutputJsonLogInitSub(conf, parent_ctx);
 }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -50,7 +50,7 @@ vars:
     GENEVE_PORTS: 6081
     VXLAN_PORTS: 4789
     TEREDO_PORTS: 3544
-
+    SIP_PORTS: "[5060, 5061]"
 ##
 ## Step 2: Select outputs to enable
 ##


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3351

Previous PR: https://github.com/OISF/suricata/pull/5034

Describe changes:
The main purpose of this patch is to register sip parser to work over tcp protocol, taking care of handling data before calling the request/response parsers.

In addition, the following minor fixes/improvements are made:

- Accept characters that are not allowed atm
- Register logger to log sip messages coming over tcp
- Define SIP_PORTS var to be used within rules
- Update JSON schema
- Set direction for tx_data

#suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/1171
suricata-verify-pr: 1171