### PR TITLE
flow: make exc policy work w/ simulated flowmemcap - v1

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -621,6 +621,8 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
+        NoFlowHandleIPS(p);
+        StatsIncr(tv, fls->dtv->counter_flow_memcap);
         return NULL;
     }
 #endif


### PR DESCRIPTION
Exception policy wouldn't be applied if we were in the context of a simulated flow memcap hit.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5998

Describe changes:
- add a call to `ExceptionPolicyApply` when we trigger the simulated flow memcap via command-line

suricata-verify-pr: 1175
https://github.com/OISF/suricata-verify/pull/1175
