### PR TITLE
pf-ring: Support inner mode cluster types 

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2085,6 +2085,9 @@ type value; in a round robin manner or a per flow manner that are part
 of the same cluster. All traffic for pf_ring will be load balanced across
 acquisition threads of the same cluster id.
 
+The "inner" flow means that the traffic will be load balanced based on
+address tuple after the outer vlan has been removed.
+
 +----------------------------+--------------------------------------------------+
 | Cluster Type               | Value                                            |
 +============================+==================================================+
@@ -2109,9 +2112,9 @@ of the same flow to the same thread. The flows itself will be
 distributed to the threads in a round-robin manner.
 
 If your deployment has VLANs, the cluster types with "inner" will use the innermost
-tuple for distribution.
+address tuple for distribution.
 
-Round-robin is not recommended with Suricata.
+The default cluster type is ``cluster_flow``; the ``cluster_round_robin`` is not recommended with Suricata.
 
 ::
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2080,10 +2080,27 @@ is making use of clusters with the same id.
   cluster-id: 99
 
 Pf_ring can load balance traffic using pf_ring-clusters. All traffic
-for pf_ring can be load balanced in one of two ways, in a round robin
-manner or a per flow manner that are part of the same cluster. All
-traffic for pf_ring will be load balanced across acquisition threads
-of the same cluster id.
+for pf_ring can be load balanced according to the configured cluster
+type value; in a round robin manner or a per flow manner that are part
+of the same cluster. All traffic for pf_ring will be load balanced across
+acquisition threads of the same cluster id.
+
++----------------------------+--------------------------------------------------+
+| Cluster Type               | Value                                            |
++============================+==================================================+
+| cluster_flow               | src ip, src_port, dst ip, dst port, proto, vlan  |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow         | src ip, src port, dst ip, dst port, proto, vlan  |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_2_tuple | src ip, dst ip                                   |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_4_tuple | src ip, src port, dst ip, dst port               |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_5_tuple | src ip, src port, dst ip, dst port, proto        |
++----------------------------+--------------------------------------------------+
+| cluster_round_robin        | not recommended                                  |
++----------------------------+--------------------------------------------------+
+
 
 The cluster_round_robin manner is a way of distributing packets one at
 a time to each thread (like distributing playing cards to fellow
@@ -2091,9 +2108,14 @@ players). The cluster_flow manner is a way of distributing all packets
 of the same flow to the same thread. The flows itself will be
 distributed to the threads in a round-robin manner.
 
+If your deployment has VLANs, the cluster types with "inner" will use the innermost
+tuple for distribution.
+
+Round-robin is not recommended with Suricata.
+
 ::
 
-   cluster-type: cluster_round_robin
+   cluster-type: cluster_inner_flow_5_tuple
 
 .. _suricata-yaml-nfq:
 

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -367,6 +367,21 @@ static void *ParsePfringConfig(const char *iface)
             SCLogInfo("Using flow cluster mode for PF_RING (iface %s)",
                     pfconf->iface);
             pfconf->ctype = CLUSTER_FLOW;
+        } else if (strcmp(tmpctype, "cluster_inner_flow") == 0) {
+            SCLogInfo("Using flow cluster mode inner mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_2_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 2 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_2_TUPLE;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_4_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 4 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_4_TUPLE;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_5_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 5 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_5_TUPLE;
         } else {
             SCLogError("invalid cluster-type %s", tmpctype);
             SCFree(pfconf);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -96,7 +96,7 @@ static void *OldParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    cluster_type default_ctype = CLUSTER_FLOW;
 
     if (unlikely(pfconf == NULL)) {
         return NULL;
@@ -202,7 +202,7 @@ static void *ParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    cluster_type default_ctype = CLUSTER_FLOW;
     int getctype = 0;
     const char *bpf_filter = NULL;
     int bool_val;
@@ -360,7 +360,8 @@ static void *ParsePfringConfig(const char *iface)
 
     if (getctype) {
         if (strcmp(tmpctype, "cluster_round_robin") == 0) {
-            SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)",
+            SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)."
+                      " This mode is not recommended.",
                     pfconf->iface);
             pfconf->ctype = CLUSTER_ROUND_ROBIN;
         } else if (strcmp(tmpctype, "cluster_flow") == 0) {

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -85,7 +85,7 @@ static void PfringDerefConfig(void *conf)
  * to thread or to reparse the file for each thread (and thus have
  * new structure.
  *
- * If old config system is used, then return the smae parameters
+ * If old config system is used, then return the same parameters
  * value for each interface.
  *
  * \return a PfringIfaceConfig corresponding to the interface name

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -138,7 +138,7 @@ static void *OldParsePfringConfig(const char *iface)
     (void) SC_ATOMIC_ADD(pfconf->ref, pfconf->threads);
 
     if (strncmp(pfconf->iface, "zc", 2) == 0) {
-        SCLogInfo("ZC interface detected, not setting cluster-id");
+        SCLogInfo("%s: ZC interface detected, not setting cluster-id", pfconf->iface);
     }
     else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
         SCLogInfo("DNA interface detected, not setting cluster-id");
@@ -156,20 +156,17 @@ static void *OldParsePfringConfig(const char *iface)
     }
 
     if (strncmp(pfconf->iface, "zc", 2) == 0) {
-        SCLogInfo("ZC interface detected, not setting cluster type for PF_RING (iface %s)",
-                pfconf->iface);
+        SCLogInfo("%s: ZC interface detected, not setting cluster type for PF_RING", pfconf->iface);
     } else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
-        SCLogInfo("DNA interface detected, not setting cluster type for PF_RING (iface %s)",
-                pfconf->iface);
+        SCLogInfo(
+                "%s: DNA interface detected, not setting cluster type for PF_RING", pfconf->iface);
     } else if (ConfGet("pfring.cluster-type", &tmpctype) != 1) {
         SCLogError("Could not get cluster-type from config");
     } else if (strcmp(tmpctype, "cluster_round_robin") == 0) {
-        SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)",
-                pfconf->iface);
+        SCLogInfo("%s: Using round-robin cluster mode for PF_RING", pfconf->iface);
         pfconf->ctype = (cluster_type)tmpctype;
     } else if (strcmp(tmpctype, "cluster_flow") == 0) {
-        SCLogInfo("Using flow cluster mode for PF_RING (iface %s)",
-                pfconf->iface);
+        SCLogInfo("%s: Using flow cluster mode for PF_RING", pfconf->iface);
         pfconf->ctype = (cluster_type)tmpctype;
     } else {
         SCLogError("invalid cluster-type %s", tmpctype);
@@ -296,10 +293,10 @@ static void *ParsePfringConfig(const char *iface)
     } else {
 
         if (strncmp(pfconf->iface, "zc", 2) == 0) {
-            SCLogInfo("ZC interface detected, not setting cluster-id for PF_RING (iface %s)",
-                    pfconf->iface);
+            SCLogInfo(
+                    "%s: ZC interface detected, not setting cluster-id for PF_RING", pfconf->iface);
         } else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
-            SCLogInfo("DNA interface detected, not setting cluster-id for PF_RING (iface %s)",
+            SCLogInfo("%s: DNA interface detected, not setting cluster-id for PF_RING",
                     pfconf->iface);
         } else if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-id", &tmpclusterid) != 1) {
             SCLogError("Could not get cluster-id from config");
@@ -346,10 +343,10 @@ static void *ParsePfringConfig(const char *iface)
         getctype = 1;
     } else {
         if (strncmp(pfconf->iface, "zc", 2) == 0) {
-            SCLogInfo("ZC interface detected, not setting cluster type for PF_RING (iface %s)",
+            SCLogInfo("%s: ZC interface detected, not setting cluster type for PF_RING",
                     pfconf->iface);
         } else if ((pfconf->threads == 1) && (strncmp(pfconf->iface, "dna", 3) == 0)) {
-            SCLogInfo("DNA interface detected, not setting cluster type for PF_RING (iface %s)",
+            SCLogInfo("%s: DNA interface detected, not setting cluster type for PF_RING",
                     pfconf->iface);
         } else if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-type", &tmpctype) != 1) {
             SCLogError("Could not get cluster-type from config");
@@ -360,28 +357,24 @@ static void *ParsePfringConfig(const char *iface)
 
     if (getctype) {
         if (strcmp(tmpctype, "cluster_round_robin") == 0) {
-            SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)."
+            SCLogInfo("%s: Using round-robin cluster mode for PF_RING."
                       " This mode is not recommended.",
                     pfconf->iface);
             pfconf->ctype = CLUSTER_ROUND_ROBIN;
         } else if (strcmp(tmpctype, "cluster_flow") == 0) {
-            SCLogInfo("Using flow cluster mode for PF_RING (iface %s)",
-                    pfconf->iface);
+            SCLogInfo("%s: Using flow cluster mode for PF_RING", pfconf->iface);
             pfconf->ctype = CLUSTER_FLOW;
         } else if (strcmp(tmpctype, "cluster_inner_flow") == 0) {
-            SCLogInfo("Using flow cluster mode inner mode for PF_RING (iface %s)", pfconf->iface);
+            SCLogInfo("%s: Using flow cluster mode inner mode for PF_RING", pfconf->iface);
             pfconf->ctype = CLUSTER_INNER_FLOW;
         } else if (strcmp(tmpctype, "cluster_inner_flow_2_tuple") == 0) {
-            SCLogInfo(
-                    "Using flow cluster inner 2 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            SCLogInfo("%s: Using flow cluster inner 2 tuple mode for PF_RING", pfconf->iface);
             pfconf->ctype = CLUSTER_INNER_FLOW_2_TUPLE;
         } else if (strcmp(tmpctype, "cluster_inner_flow_4_tuple") == 0) {
-            SCLogInfo(
-                    "Using flow cluster inner 4 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            SCLogInfo("%s: Using flow cluster inner 4 tuple mode for PF_RING", pfconf->iface);
             pfconf->ctype = CLUSTER_INNER_FLOW_4_TUPLE;
         } else if (strcmp(tmpctype, "cluster_inner_flow_5_tuple") == 0) {
-            SCLogInfo(
-                    "Using flow cluster inner 5 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            SCLogInfo("%s: Using flow cluster inner 5 tuple mode for PF_RING", pfconf->iface);
             pfconf->ctype = CLUSTER_INNER_FLOW_5_TUPLE;
         } else {
             SCLogError("invalid cluster-type %s", tmpctype);
@@ -399,14 +392,15 @@ static void *ParsePfringConfig(const char *iface)
         } else if (strcmp(tmpctype, "rx-only") == 0) {
             pfconf->checksum_mode = CHECKSUM_VALIDATION_RXONLY;
         } else {
-            SCLogError("Invalid value for checksum-checks for %s", pfconf->iface);
+            SCLogError("%s: Invalid value for checksum-checks", pfconf->iface);
         }
     }
 
     if (ConfGetChildValueBoolWithDefault(if_root, if_default, "bypass", &bool_val) == 1) {
         if (bool_val) {
 #ifdef HAVE_PF_RING_FLOW_OFFLOAD
-            SCLogConfig("Enabling bypass support in PF_RING for iface %s (if supported by underlying hw)", pfconf->iface);
+            SCLogConfig("%s: Enabling bypass support in PF_RING (if supported by underlying hw)",
+                    pfconf->iface);
             pfconf->flags |= PFRING_CONF_FLAGS_BYPASS;
 #else
             SCLogError("Bypass is not supported by this Pfring version, please upgrade");

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -157,7 +157,7 @@ struct PfringThreadVars_
 };
 
 /**
- * \brief Registration Function for RecievePfring.
+ * \brief Registration Function for ReceivePfring.
  * \todo Unit tests are needed for this module.
  */
 void TmModuleReceivePfringRegister (void)
@@ -330,9 +330,9 @@ static int PfringBypassCallback(Packet *p)
 #endif
 
 /**
- * \brief Recieves packets from an interface via libpfring.
+ * \brief Receives packets from an interface via libpfring.
  *
- *  This function recieves packets from an interface and passes
+ *  This function receives packets from an interface and passes
  *  the packet on to the pfring callback function.
  *
  * \param tv pointer to ThreadVars
@@ -473,9 +473,9 @@ TmEcode PfringBreakLoop(ThreadVars *tv, void *data)
 }
 
 /**
- * \brief Init function for RecievePfring.
+ * \brief Init function for ReceivePfring.
  *
- * This is a setup function for recieving packets
+ * This is a setup function for receiving packets
  * via libpfring.
  *
  * \param tv pointer to ThreadVars
@@ -627,7 +627,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
 #endif
 
     /* If kernel is older than 3.0, VLAN is not stripped so we don't
-     * get the info from packt extended header but we will use a standard
+     * get the info from packet extended header but we will use a standard
      * parsing */
     ptv->vlan_in_ext_header = 1;
     if (! SCKernelVersionIsAtLeast(3, 0)) {
@@ -745,7 +745,7 @@ TmEcode DecodePfring(ThreadVars *tv, Packet *p, void *data)
  * \brief This an Init function for DecodePfring
  *
  * \param tv pointer to ThreadVars
- * \param initdata pointer to initilization data.
+ * \param initdata pointer to initialization data.
  * \param data pointer that gets cast into PfringThreadVars for ptv
  * \retval TM_ECODE_OK is returned on success
  * \retval TM_ECODE_FAILED is returned on error

--- a/src/source-pfring.h
+++ b/src/source-pfring.h
@@ -69,8 +69,16 @@ void TmModuleDecodePfringRegister (void);
 int PfringConfGetThreads(void);
 void PfringLoadConfig(void);
 
-/* We don't have to use an enum that sucks in our code */
+/*
+ * We don't have to use an enum that sucks in our code
+ * these values must match with cluster_type in the kernel
+ * include file pf_ring.h
+ */
 #define CLUSTER_FLOW 0
 #define CLUSTER_ROUND_ROBIN 1
 #define CLUSTER_FLOW_5_TUPLE 4
+#define CLUSTER_INNER_FLOW         6
+#define CLUSTER_INNER_FLOW_2_TUPLE 7
+#define CLUSTER_INNER_FLOW_4_TUPLE 8
+#define CLUSTER_INNER_FLOW_5_TUPLE 9
 #endif /* __SOURCE_PFRING_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1953,7 +1953,13 @@ pfring:
     cluster-id: 99
 
     # Default PF_RING cluster type. PF_RING can load balance per flow.
-    # Possible values are cluster_flow or cluster_round_robin.
+    # Possible values are:
+    # - cluster_flow:               6-tuple: <src ip, src_port, dst ip, dst port, proto, vlan>
+    # - cluster_inner_flow:         6-tuple: <src ip, src port, dst ip, dst port, proto, vlan>
+    # - cluster_inner_flow_2_tuple: 2-tuple: <src ip,           dst ip                       >
+    # - cluster_inner_flow_4_tuple: 4-tuple: <src ip, src port, dst ip, dst port             >
+    # - cluster_inner_flow_5_tuple: 5-tuple: <src ip, src port, dst ip, dst port, proto      >
+    # - cluster_round_robin (NOT RECOMMENDED)
     cluster-type: cluster_flow
 
     # bpf filter for this interface


### PR DESCRIPTION
Continuation fo #8731 

Add support for addition PF_RING cluster types that use the inner tuple for flow distribution.

See [PF_RING kernel documentation](https://www.ntop.org/guides/pf_ring/api/pfring_k.html#_CPPv412cluster_type) for the cluster type supported by the PF_RING kernel module.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5975](https://redmine.openinfosecfoundation.org/issues/5975)

Describe changes:
- Briefly describe inner
- Modify message format to follow style used with AF_PACKET so messages including the interface name follow the format `<interface-name>: <message-string>`

#suricata-verify-pr:
#suricata-verify-repo:
#suricata-verify-branch:
#suricata-update-pr:
#suricata-update-repo:
#suricata-update-branch:
#libhtp-pr:
#libhtp-repo:
#libhtp-branch:
