### PR TITLE
exception/policy: add stats counters - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4745,6 +4745,32 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {
@@ -4902,8 +4928,7 @@
                                 {
                                     "$ref": "#/$defs/reject"
                                 }
-                            ],
-                            "additionalProperties": "false"
+                            ]
                         },
                         "memuse": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3855,7 +3855,7 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": true
                         },
                         "flow": {
                             "type": "object",
@@ -5593,6 +5593,32 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/drop_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/drop_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/bypass"
+                        },
+                        {
+                            "$ref": "#/$defs/ignore"
+                        },
+                        {
+                            "$ref": "#/$defs/reject"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5214,6 +5214,32 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -348,7 +348,9 @@
                 "response": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["id"],
+                    "required": [
+                        "id"
+                    ],
                     "properties": {
                         "id": {
                             "type": "string"
@@ -361,10 +363,10 @@
                                     "type": "object",
                                     "additionalProperties": false,
                                     "required": [
-					"id",
-					"ip",
-					"port"
-				    ],
+                                        "id",
+                                        "ip",
+                                        "port"
+                                    ],
                                     "properties": {
                                         "id": {
                                             "type": "string"
@@ -385,10 +387,10 @@
                                 "type": "object",
                                 "additionalProperties": false,
                                 "required": [
-				    "id",
-				    "ip",
-				    "port"
-				],
+                                    "id",
+                                    "ip",
+                                    "port"
+                                ],
                                 "properties": {
                                     "id": {
                                         "type": "string"
@@ -1339,9 +1341,9 @@
                 "has_exe_url": {
                     "type": "boolean"
                 },
-		"message_id": {
-		    "type": "string"
-		}
+                "message_id": {
+                    "type": "string"
+                }
             },
             "additionalProperties": false
         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5196,6 +5196,32 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1489,6 +1489,9 @@
                 "dest_port": {
                     "type": "integer"
                 },
+                "emergency": {
+                    "type": "boolean"
+                },
                 "end": {
                     "type": "string"
                 },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5270,6 +5270,32 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4878,6 +4878,33 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ],
+                            "additionalProperties": "false"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5471,6 +5498,27 @@
             "$comment": "Definition for TLS date formats",
             "type": "string",
             "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+        },
+        "drop_flow": {
+            "type": "object"
+        },
+        "drop_packet": {
+            "type": "object"
+        },
+        "pass_flow": {
+            "type": "object"
+        },
+        "pass_packet": {
+            "type": "object"
+        },
+        "bypass": {
+            "type": "object"
+        },
+        "ignore": {
+            "type": "object"
+        },
+        "reject": {
+            "type": "object"
         }
     }
 }

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -80,6 +80,13 @@ typedef struct AppLayerCounterNames_ {
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
     char alloc_error[MAX_COUNTER_SIZE];
+    char eps_error_ignore[MAX_COUNTER_SIZE];
+    char eps_error_reject[MAX_COUNTER_SIZE];
+    char eps_error_bypass[MAX_COUNTER_SIZE];
+    char eps_error_pass_flow[MAX_COUNTER_SIZE];
+    char eps_error_pass_packet[MAX_COUNTER_SIZE];
+    char eps_error_drop_flow[MAX_COUNTER_SIZE];
+    char eps_error_drop_packet[MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
@@ -89,6 +96,13 @@ typedef struct AppLayerCounters_ {
     uint16_t parser_error_id;
     uint16_t internal_error_id;
     uint16_t alloc_error_id;
+    uint16_t eps_error_ignore_id;
+    uint16_t eps_error_reject_id;
+    uint16_t eps_error_bypass_id;
+    uint16_t eps_error_pass_flow_id;
+    uint16_t eps_error_pass_packet_id;
+    uint16_t eps_error_drop_flow_id;
+    uint16_t eps_error_drop_packet_id;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
@@ -154,6 +168,38 @@ void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f)
 void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
 {
     const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum ExceptionPolicy policy)
+{
+    uint16_t id;
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_ignore_id;
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_reject_id;
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_bypass_id;
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_drop_flow_id;
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_drop_packet_id;
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_pass_packet_id;
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_pass_flow_id;
+            break;
+    }
+
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -627,6 +673,7 @@ static int TCPProtoDetect(ThreadVars *tv,
     SCReturnInt(0);
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -696,6 +743,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         StreamTcpUpdateAppLayerProgress(ssn, direction, data_len);
         if (r < 0) {
             ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+            AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
             SCReturnInt(-1);
         }
         goto end;
@@ -781,6 +829,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 if (r < 0) {
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+                    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
                     SCReturnInt(-1);
                 }
             }
@@ -921,6 +970,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     }
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+        AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
         SCReturnInt(-1);
     }
 
@@ -1095,6 +1145,33 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_ignore,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_ignore),
+                            "%s%s%s.exception_policy.ignore", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_reject),
+                            "%s%s%s.exception_policy.reject", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_bypass),
+                            "%s%s%s.exception_policy.bypass", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_flow),
+                            "%s%s%s.exception_policy.pass_flow", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s%s.exception_policy.pass_packet", estr, alproto_str,
+                            ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_flow),
+                            "%s%s%s.exception_policy.drop_flow", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_packet),
+                            "%s%s%s.exception_policy.drop_packet", estr, alproto_str,
+                            ipproto_suffix);
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1117,6 +1194,31 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s.internal", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_ignore,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_ignore),
+                            "%s%s.exception_policy.ignore", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_reject),
+                            "%s%s.exception_policy.reject", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_bypass),
+                            "%s%s.exception_policy.bypass", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_flow),
+                            "%s%s.exception_policy.pass_flow", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s.exception_policy.pass_packet", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_flow),
+                            "%s%s.exception_policy.drop_flow", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s.exception_policy.drop_packet", estr, alproto_str);
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1160,6 +1262,28 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
                         applayer_counter_names[ipproto_map][alproto].parser_error, tv);
                 applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
                         applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_ignore_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_ignore, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_reject_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_reject, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_bypass_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_bypass, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_pass_flow_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_pass_packet_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_drop_flow_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_drop_packet_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                                tv);
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -510,7 +510,7 @@ static int TCPProtoDetect(ThreadVars *tv,
          *
          * \todo We need to figure out a more robust solution for this,
          *       as this can lead to easy evasion tactics, where the
-         *       attackeer can first send some dummy data in the wrong
+         *       attacker can first send some dummy data in the wrong
          *       direction first to mislead our proto detection process.
          *       While doing this we need to update the parsers as well,
          *       since the parsers must be robust to see such wrong

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.c
+++ b/src/decode.c
@@ -607,6 +607,21 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+    /* Counters for Exception Policy Defrag values */
+    dtv->counter_defrag_memcap_eps_ignore =
+            StatsRegisterCounter("defrag.memcap_exception_policy.ignore", tv);
+    dtv->counter_defrag_memcap_eps_reject =
+            StatsRegisterCounter("defrag.memcap_exception_policy.reject", tv);
+    dtv->counter_defrag_memcap_eps_bypass =
+            StatsRegisterCounter("defrag.memcap_exception_policy.bypass", tv);
+    dtv->counter_defrag_memcap_eps_pass_flow =
+            StatsRegisterCounter("defrag.memcap_exception_policy.pass_flow", tv);
+    dtv->counter_defrag_memcap_eps_pass_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_defrag_memcap_eps_drop_flow =
+            StatsRegisterCounter("defrag.memcap_exception_policy.drop_flow", tv);
+    dtv->counter_defrag_memcap_eps_drop_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.drop_packet", tv);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.c
+++ b/src/decode.c
@@ -601,16 +601,10 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);
-    dtv->counter_defrag_ipv4_reassembled =
-        StatsRegisterCounter("defrag.ipv4.reassembled", tv);
-    dtv->counter_defrag_ipv4_timeouts =
-        StatsRegisterCounter("defrag.ipv4.timeouts", tv);
+    dtv->counter_defrag_ipv4_reassembled = StatsRegisterCounter("defrag.ipv4.reassembled", tv);
     dtv->counter_defrag_ipv6_fragments =
         StatsRegisterCounter("defrag.ipv6.fragments", tv);
-    dtv->counter_defrag_ipv6_reassembled =
-        StatsRegisterCounter("defrag.ipv6.reassembled", tv);
-    dtv->counter_defrag_ipv6_timeouts =
-        StatsRegisterCounter("defrag.ipv6.timeouts", tv);
+    dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -564,6 +564,21 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    /* Register stats counters for all exception policy values */
+    dtv->counter_flow_memcap_eps_ignore =
+            StatsRegisterCounter("flow.memcap_exception_policy.ignore", tv);
+    dtv->counter_flow_memcap_eps_reject =
+            StatsRegisterCounter("flow.memcap_exception_policy.reject", tv);
+    dtv->counter_flow_memcap_eps_bypass =
+            StatsRegisterCounter("flow.memcap_exception_policy.bypass", tv);
+    dtv->counter_flow_memcap_eps_pass_flow =
+            StatsRegisterCounter("flow.memcap_exception_policy.pass_flow", tv);
+    dtv->counter_flow_memcap_eps_pass_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_flow_memcap_eps_drop_flow =
+            StatsRegisterCounter("flow.memcap_exception_policy.drop_flow", tv);
+    dtv->counter_flow_memcap_eps_drop_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.drop_packet", tv);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.h
+++ b/src/decode.h
@@ -713,6 +713,13 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    uint16_t counter_defrag_memcap_eps_ignore;
+    uint16_t counter_defrag_memcap_eps_reject;
+    uint16_t counter_defrag_memcap_eps_bypass;
+    uint16_t counter_defrag_memcap_eps_pass_flow;
+    uint16_t counter_defrag_memcap_eps_pass_packet;
+    uint16_t counter_defrag_memcap_eps_drop_flow;
+    uint16_t counter_defrag_memcap_eps_drop_packet;
 
     uint16_t counter_flow_memcap;
     uint16_t counter_flow_memcap_eps_ignore;

--- a/src/decode.h
+++ b/src/decode.h
@@ -717,6 +717,13 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    uint16_t counter_flow_memcap_eps_ignore;
+    uint16_t counter_flow_memcap_eps_reject;
+    uint16_t counter_flow_memcap_eps_bypass;
+    uint16_t counter_flow_memcap_eps_pass_flow;
+    uint16_t counter_flow_memcap_eps_pass_packet;
+    uint16_t counter_flow_memcap_eps_drop_flow;
+    uint16_t counter_flow_memcap_eps_drop_packet;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/decode.h
+++ b/src/decode.h
@@ -710,10 +710,8 @@ typedef struct DecodeThreadVars_
     /** frag stats - defrag runs in the context of the decoder. */
     uint16_t counter_defrag_ipv4_fragments;
     uint16_t counter_defrag_ipv4_reassembled;
-    uint16_t counter_defrag_ipv4_timeouts;
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
-    uint16_t counter_defrag_ipv6_timeouts;
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -497,7 +497,7 @@ static void DefragExceptionPolicyStatsIncr(
  *  Get a new defrag tracker. We're checking memcap first and will try to make room
  *  if the memcap is reached.
  *
- *  \retval dt *LOCKED* tracker on succes, NULL on error.
+ *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
 static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
@@ -549,7 +549,7 @@ static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv,
     } else {
         /* tracker has been recycled before it went into the spare queue */
 
-        /* tracker is initialized (recylced) but *unlocked* */
+        /* tracker is initialized (recycled) but *unlocked* */
     }
 
     (void) SC_ATOMIC_ADD(defragtracker_counter, 1);

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -463,6 +463,34 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
     return CMP_DEFRAGTRACKER(t, p, id);
 }
 
+static void DefragExceptionPolicyStatsIncr(
+        ThreadVars *tv, DecodeThreadVars *dtv, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_pass_flow);
+            break;
+    }
+}
+
 /**
  *  \brief Get a new defrag tracker
  *
@@ -471,12 +499,13 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *
  *  \retval dt *LOCKED* tracker on succes, NULL on error.
  */
-static DefragTracker *DefragTrackerGetNew(Packet *p)
+static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
 #ifdef DEBUG
     if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
         SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
         ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+        DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
         return NULL;
     }
 #endif
@@ -501,6 +530,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerGetUsedDefragTracker();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -510,6 +540,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerAlloc();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -534,7 +565,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
  *
  * returns a *LOCKED* tracker or NULL
  */
-DefragTracker *DefragGetTrackerFromHash (Packet *p)
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     DefragTracker *dt = NULL;
 
@@ -546,7 +577,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
 
     /* see if the bucket already has a tracker */
     if (hb->head == NULL) {
-        dt = DefragTrackerGetNew(p);
+        dt = DefragTrackerGetNew(tv, dtv, p);
         if (dt == NULL) {
             DRLOCK_UNLOCK(hb);
             return NULL;
@@ -575,7 +606,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
             dt = dt->hnext;
 
             if (dt == NULL) {
-                dt = pdt->hnext = DefragTrackerGetNew(p);
+                dt = pdt->hnext = DefragTrackerGetNew(tv, dtv, p);
                 if (dt == NULL) {
                     DRLOCK_UNLOCK(hb);
                     return NULL;

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -95,7 +95,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1041,8 +1041,10 @@ Defrag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 
     /* return a locked tracker or NULL */
     tracker = DefragGetTracker(tv, dtv, p);
-    if (tracker == NULL)
+    if (tracker == NULL) {
+        StatsIncr(tv, dtv->counter_defrag_max_hit);
         return NULL;
+    }
 
     Packet *rp = DefragInsertFrag(tv, dtv, tracker, p);
     DefragTrackerRelease(tracker);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -991,7 +991,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -642,7 +642,8 @@ static void FlowExceptionPolicyStatsIncr(
  *  \param tv thread vars
  *  \param fls lookup support vars
  *
- *  \retval f *LOCKED* flow on succes, NULL on error.
+ *  \retval f *LOCKED* flow on success, NULL on error or if we should not create
+ *  a new flow.
  */
 static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {
@@ -718,7 +719,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     } else {
         /* flow has been recycled before it went into the spare queue */
 
-        /* flow is initialized (recylced) but *unlocked* */
+        /* flow is initialized (recycled) but *unlocked* */
     }
 
     FLOWLOCK_WRLOCK(f);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -621,6 +621,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
+        NoFlowHandleIPS(p);
         return NULL;
     }
 #endif

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -63,6 +63,14 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    uint16_t counter_tcp_reas_eps_ignore;
+    uint16_t counter_tcp_reas_eps_reject;
+    uint16_t counter_tcp_reas_eps_bypass;
+    uint16_t counter_tcp_reas_eps_pass_flow;
+    uint16_t counter_tcp_reas_eps_pass_packet;
+    uint16_t counter_tcp_reas_eps_drop_flow;
+    uint16_t counter_tcp_reas_eps_drop_packet;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5795,6 +5795,20 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_ignore =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.ignore", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_reject =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.reject", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_bypass =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.bypass", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_packet", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_packet", tv);
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -707,6 +707,34 @@ void StreamTcpFreeConfig(bool quiet)
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
 }
 
+static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_pass_flow);
+            break;
+    }
+}
+
 /** \internal
  *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
@@ -746,6 +774,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 #endif
@@ -753,6 +782,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 
@@ -5778,6 +5808,20 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    stt->counter_tcp_ssn_memcap_eps_ignore =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.ignore", tv);
+    stt->counter_tcp_ssn_memcap_eps_reject =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.reject", tv);
+    stt->counter_tcp_ssn_memcap_eps_bypass =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.bypass", tv);
+    stt->counter_tcp_ssn_memcap_eps_pass_flow =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.pass_flow", tv);
+    stt->counter_tcp_ssn_memcap_eps_pass_packet =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.pass_packet", tv);
+    stt->counter_tcp_ssn_memcap_eps_drop_flow =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.drop_flow", tv);
+    stt->counter_tcp_ssn_memcap_eps_drop_packet =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.drop_packet", tv);
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -938,6 +938,34 @@ static inline void StreamTcpCloseSsnWithReset(Packet *p, TcpSession *ssn)
             "TCP_CLOSED", ssn, StreamTcpStateAsString(ssn->state));
 }
 
+static void StreamTcpMidstreamExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_midstream_eps_pass_flow);
+            break;
+    }
+}
+
 static int StreamTcpPacketIsRetransmission(TcpStream *stream, Packet *p)
 {
     if (p->payload_len == 0)
@@ -991,6 +1019,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_FIN) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream || p->payload_len == 0) {
             StreamTcpSetEvent(p, STREAM_FIN_BUT_NO_SESSION);
@@ -1088,6 +1117,7 @@ static int StreamTcpPacketStateNone(
     } else if ((p->tcph->th_flags & (TH_SYN | TH_ACK)) == (TH_SYN | TH_ACK)) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream && !stream_config.async_oneside) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -1261,6 +1291,7 @@ static int StreamTcpPacketStateNone(
     } else if (p->tcph->th_flags & TH_ACK) {
         /* Drop reason will only be used if midstream policy is set to fail closed */
         ExceptionPolicyApply(p, stream_config.midstream_policy, PKT_DROP_REASON_STREAM_MIDSTREAM);
+        StreamTcpMidstreamExceptionPolicyStatsIncr(tv, stt, stream_config.midstream_policy);
 
         if (!stream_config.midstream) {
             SCLogDebug("Midstream not enabled, so won't pick up a session");
@@ -5830,6 +5861,20 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_synack = StatsRegisterCounter("tcp.synack", tv);
     stt->counter_tcp_rst = StatsRegisterCounter("tcp.rst", tv);
     stt->counter_tcp_midstream_pickups = StatsRegisterCounter("tcp.midstream_pickups", tv);
+    stt->counter_tcp_midstream_eps_ignore =
+            StatsRegisterCounter("tcp.midstream_exception_policy.ignore", tv);
+    stt->counter_tcp_midstream_eps_reject =
+            StatsRegisterCounter("tcp.midstream_exception_policy.reject", tv);
+    stt->counter_tcp_midstream_eps_bypass =
+            StatsRegisterCounter("tcp.midstream_exception_policy.bypass", tv);
+    stt->counter_tcp_midstream_eps_pass_flow =
+            StatsRegisterCounter("tcp.midstream_exception_policy.pass_flow", tv);
+    stt->counter_tcp_midstream_eps_pass_packet =
+            StatsRegisterCounter("tcp.midstream_exception_policy.pass_packet", tv);
+    stt->counter_tcp_midstream_eps_drop_flow =
+            StatsRegisterCounter("tcp.midstream_exception_policy.drop_flow", tv);
+    stt->counter_tcp_midstream_eps_drop_packet =
+            StatsRegisterCounter("tcp.midstream_exception_policy.drop_packet", tv);
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", tv);
     stt->counter_tcp_ack_unseen_data = StatsRegisterCounter("tcp.ack_unseen_data", tv);
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -85,6 +85,14 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    uint16_t counter_tcp_ssn_memcap_eps_ignore;
+    uint16_t counter_tcp_ssn_memcap_eps_reject;
+    uint16_t counter_tcp_ssn_memcap_eps_bypass;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_packet;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_packet;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -111,6 +111,14 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_rst;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    uint16_t counter_tcp_midstream_eps_ignore;
+    uint16_t counter_tcp_midstream_eps_reject;
+    uint16_t counter_tcp_midstream_eps_bypass;
+    uint16_t counter_tcp_midstream_eps_pass_flow;
+    uint16_t counter_tcp_midstream_eps_pass_packet;
+    uint16_t counter_tcp_midstream_eps_drop_flow;
+    uint16_t counter_tcp_midstream_eps_drop_packet;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseed data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -121,7 +121,7 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_midstream_eps_drop_packet;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
-    /** ack for unseed data */
+    /** ack for unseen data */
     uint16_t counter_tcp_ack_unseen_data;
 
     /** tcp reassembly thread data */

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5816

Previous PR: #8658 

Includes commit from https://github.com/OISF/suricata/pull/8733, to keep work complete.

Describe changes:
- register stats counters for all exception policies

TODO:
- better align stats.log - as the new counters size character is longer than what we currently have in the stats
- update the `json.schema` to include delta counters.

Considerations:
- Should we not output the registers that are zero, for the counters that are `0`?
Overall, Victor would like to have @jasonish input on the stats event verbosity. `app_layer` is especially long, since we have all values per enabled protocol.

The approach suggested [here](https://redmine.openinfosecfoundation.org/issues/5816#note-5) would be less verbose, but more complex to implement, given how the code is organized.

Output examples:
`app_layer`:
```json
 "app_layer": {
    "error": {
      "http": {
          "exception_policy": {
            "ignore": 0,
            "reject": 0,
            "bypass": 0,
            "pass_flow": 0,
            "drop_packet": 0,
            "drop_flow": 0
          }
       }
    }
}
```
`flow`:
```json
 "flow": {
    "memcap": 0,
     "memcap_exception_policy": {
        "ignore": 0,
        "reject": 0,
        "bypass": 0,
        "pass_flow": 0,
        "pass_packet": 0,
        "drop_flow": 0,
        "drop_packet": 1
  },
    "total": 1,
    "active": 0,
    "tcp": 0,
    "udp": 0,
    "icmpv4": 1,
    "icmpv6": 0,
    "tcp_reuse": 0,
    "get_used": 0,
    "get_used_eval": 0,
    "get_used_eval_reject": 0,
    "get_used_eval_busy": 0,
    "get_used_failed": 0,
    "wrk": {
      "spare_sync_avg": 100,
      "spare_sync": 1,
      "spare_sync_incomplete": 0,
      "spare_sync_empty": 0,
      "flows_evicted_needs_work": 0,
      "flows_evicted_pkt_inject": 0,
      "flows_evicted": 0,
      "flows_injected": 0,
      "flows_injected_max": 0
    },
```

suricata-verify-pr: 1178
https://github.com/OISF/suricata-verify/pull/1178