### PR TITLE
rust: update der-parser, snmp-parser - v2

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -10,29 +10,30 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
-version = "0.3.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "aes"
-version = "0.6.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if",
  "cipher",
+ "cpufeatures",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.8.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -40,26 +41,6 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
- "opaque-debug",
 ]
 
 [[package]]
@@ -114,7 +95,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
@@ -126,7 +107,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -208,27 +189,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crc"
@@ -260,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -327,7 +302,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -356,7 +331,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
  "synstructure",
@@ -374,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -384,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -395,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -481,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "lzma-rs"
@@ -563,7 +538,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -702,7 +677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -771,11 +746,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cpuid-bool",
+ "cfg-if",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -807,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -829,7 +805,7 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
 ]
 
 [[package]]
@@ -926,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "770d921f325c749e0b9099b97edda6b2914e22339b37569d8eb5a90d55e47bcf"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -945,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 
 [[package]]
 name = "sha1"
@@ -979,11 +955,11 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "snmp-parser"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7f0b0216476fe1afa2dbcabea4e2a8e2ed3c1389d6208f37f242aa07a8407a"
+checksum = "773a26ad6742636f4259e7cc32262efb31feabd56bc34f0b2f28de9801aa24b3"
 dependencies = [
- "der-parser 6.0.1",
+ "asn1-rs",
  "nom 7.1.3",
  "rusticata-macros",
  "thiserror",
@@ -1007,6 +983,7 @@ version = "7.0.0-rc2-dev"
 dependencies = [
  "aes",
  "aes-gcm",
+ "asn1-rs",
  "base64",
  "bendy",
  "bitflags",
@@ -1050,7 +1027,7 @@ name = "suricata-derive"
 version = "7.0.0-rc2-dev"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
 ]
@@ -1072,18 +1049,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.4"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -1094,7 +1071,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
@@ -1107,7 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956044ef122917dde830c19dec5f76d0670329fde4104836d62ebcb14f4865f1"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
  "syn 1.0.109",
  "version_check",
@@ -1128,9 +1105,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.52",
+ "proc-macro2 1.0.56",
  "quote 1.0.26",
- "syn 2.0.4",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -991,6 +991,7 @@ dependencies = [
  "byteorder",
  "crc",
  "der-parser 6.0.1",
+ "der-parser 8.2.0",
  "digest",
  "flate2",
  "hex",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -45,7 +45,7 @@ der-parser = "~6.0"
 kerberos-parser = "~0.7.1"
 ntp-parser = "~0.6.0"
 ipsec-parser = "~0.7.0"
-snmp-parser = "~0.8.0"
+snmp-parser = "~0.9.0"
 tls-parser = "~0.11.0"
 x509-parser = "~0.14.0"
 libc = "~0.2.82"
@@ -58,6 +58,7 @@ lazy_static = "~1.4.0"
 base64 = "~0.13.0"
 time = "=0.3.13"
 bendy = { version = "~0.3.3", default-features = false }
+asn1-rs = { version = "~0.5.2" }
 
 suricata-derive = { path = "./derive" }
 

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -41,8 +41,12 @@ aes-gcm = "~0.9.4"
 
 sawp-modbus = "~0.11.0"
 sawp = "~0.11.0"
-der-parser = "~6.0"
-kerberos-parser = "~0.7.1"
+der-parser = "~8.2.0"
+kerberos-parser = { version = "~0.7.1", default_features = false }
+
+# Kerberos parsing still depends on der-parser 6.0.1.
+der-parser6 = { package = "der-parser", version = "~6.0.1", default_features = false }
+
 ntp-parser = "~0.6.0"
 ipsec-parser = "~0.7.0"
 snmp-parser = "~0.9.0"

--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-use der_parser::ber::{parse_ber_recursive, BerObject, BerObjectContent, BerTag};
+use der_parser::ber::{parse_ber_recursive, BerObject, BerObjectContent, Tag};
 use nom7::Err;
 use std::convert::TryFrom;
 
@@ -86,7 +86,7 @@ impl<'a> Asn1<'a> {
     fn check_object(obj: &BerObject, ad: &DetectAsn1Data) -> Option<Asn1Check> {
         // get length
         // Note that if length is indefinite (BER), this will return None
-        let len = obj.header.len.primitive().ok()?;
+        let len = obj.header.length().definite().ok()?;
         // oversize_length will check if a node has a length greater than
         // the user supplied length
         if let Some(oversize_length) = ad.oversize_length {
@@ -101,7 +101,7 @@ impl<'a> Asn1<'a> {
         // to ignore is greater than the length decoded (in bits)
         if ad.bitstring_overflow
             && (obj.header.is_universal()
-                && obj.header.tag == BerTag::BitString
+                && obj.header.tag() == Tag::BitString
                 && obj.header.is_primitive())
         {
             if let BerObjectContent::BitString(bits, _v) = &obj.content {
@@ -118,7 +118,7 @@ impl<'a> Asn1<'a> {
         // and the buffer is greater than 256, the array is overflown
         if ad.double_overflow
             && (obj.header.is_universal()
-                && obj.header.tag == BerTag::RealType
+                && obj.header.tag() == Tag::RealType
                 && obj.header.is_primitive())
         {
             if let Ok(data) = obj.content.as_slice() {

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -18,9 +18,9 @@
 use nom7::IResult;
 use nom7::error::{ErrorKind, ParseError};
 use nom7::number::streaming::le_u16;
-use der_parser;
-use der_parser::der::parse_der_oid;
-use der_parser::error::BerError;
+use der_parser6;
+use der_parser6::der::parse_der_oid;
+use der_parser6::error::BerError;
 use kerberos_parser::krb5::{ApReq, PrincipalName, Realm};
 use kerberos_parser::krb5_parser::parse_ap_req;
 
@@ -56,7 +56,7 @@ pub struct Kerberos5Ticket {
 
 fn parse_kerberos5_request_do(blob: &[u8]) -> IResult<&[u8], ApReq, SecBlobError>
 {
-    let (_,b) = der_parser::parse_der(blob).map_err(nom7::Err::convert)?;
+    let (_,b) = der_parser6::parse_der(blob).map_err(nom7::Err::convert)?;
     let blob = b.as_slice().or(
         Err(nom7::Err::Error(SecBlobError::KrbFmtError))
     )?;

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -22,7 +22,7 @@ use std::ffi::CString;
 use nom7::{Err, IResult};
 use nom7::number::streaming::be_u32;
 use der_parser::der::der_read_element_header;
-use der_parser::ber::BerClass;
+use der_parser::ber::Class;
 use kerberos_parser::krb5_parser;
 use kerberos_parser::krb5::{EncryptionType,ErrorCode,MessageType,PrincipalName,Realm};
 use crate::applayer::{self, *};
@@ -129,8 +129,8 @@ impl KRB5State {
         match der_read_element_header(i) {
             Ok((_rem,hdr)) => {
                 // Kerberos messages start with an APPLICATION header
-                if hdr.class != BerClass::Application { return 0; }
-                match hdr.tag.0 {
+                if hdr.class() != Class::Application { return 0; }
+                match hdr.tag().0 {
                     10 => {
                         self.req_id = 10;
                     },
@@ -190,7 +190,7 @@ impl KRB5State {
                         };
                         self.req_id = 0;
                     },
-                    _ => { SCLogDebug!("unknown/unsupported tag {}", hdr.tag); },
+                    _ => { SCLogDebug!("unknown/unsupported tag {}", hdr.tag()); },
                 }
                 0
             },
@@ -338,9 +338,9 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
     match der_read_element_header(slice) {
         Ok((rem, ref hdr)) => {
             // Kerberos messages start with an APPLICATION header
-            if hdr.class != BerClass::Application { return ALPROTO_FAILED; }
+            if hdr.class() != Class::Application { return ALPROTO_FAILED; }
             // Tag number should be <= 30
-            if hdr.tag.0 > 30 { return ALPROTO_FAILED; }
+            if hdr.tag().0 > 30 { return ALPROTO_FAILED; }
             // Kerberos messages contain sequences
             if rem.is_empty() || rem[0] != 0x30 { return ALPROTO_FAILED; }
             // Check kerberos version

--- a/rust/src/smb/auth.rs
+++ b/rust/src/smb/auth.rs
@@ -21,12 +21,12 @@ use crate::smb::ntlmssp_records::*;
 use crate::smb::smb::*;
 
 use nom7::{Err, IResult};
-use der_parser::ber::BerObjectContent;
-use der_parser::der::{parse_der_oid, parse_der_sequence};
+use der_parser6::ber::BerObjectContent;
+use der_parser6::der::{parse_der_oid, parse_der_sequence};
 
 fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
 {
-    let (rem, base_o) = der_parser::parse_der(blob).map_err(Err::convert)?;
+    let (rem, base_o) = der_parser6::parse_der(blob).map_err(Err::convert)?;
     SCLogDebug!("parse_secblob_get_spnego: base_o {:?}", base_o);
     let d = match base_o.content.as_slice() {
         Err(_) => { return Err(Err::Error(SecBlobError::NotSpNego)); },
@@ -59,7 +59,7 @@ fn parse_secblob_get_spnego(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
 
 fn parse_secblob_spnego_start(blob: &[u8]) -> IResult<&[u8], &[u8], SecBlobError>
 {
-    let (rem, o) = der_parser::parse_der(blob).map_err(Err::convert)?;
+    let (rem, o) = der_parser6::parse_der(blob).map_err(Err::convert)?;
     let d = match o.content.as_slice() {
         Ok(d) => {
             SCLogDebug!("d: next data len {}",d.len());
@@ -96,7 +96,7 @@ fn parse_secblob_spnego(blob: &[u8]) -> Option<SpnegoRequest>
             Ok(s) => s,
             _ => { continue; },
         };
-        let o = match der_parser::parse_der(n) {
+        let o = match der_parser6::parse_der(n) {
             Ok((_,x)) => x,
             _ => { continue; },
         };

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -23,9 +23,9 @@ use crate::applayer::{self, *};
 use std;
 use std::ffi::CString;
 
+use asn1_rs::Oid;
 use der_parser::ber::BerObjectContent;
 use der_parser::der::parse_der_sequence;
-use der_parser::oid::Oid;
 use nom7::{Err, IResult};
 use nom7::error::{ErrorKind, make_error};
 


### PR DESCRIPTION
- rust: update snmp-parser to 0.9.0
- rust: update der-parser to 8.2.0

Tickets:
- https://redmine.openinfosecfoundation.org/issues/5991
- https://redmine.openinfosecfoundation.org/issues/5992
