### PR TITLE
rust: fix clippy lint for assert - v1

### DIFF
--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -306,15 +306,15 @@ mod tests {
     #[test]
     fn test_memval_erroneous_val() {
         let s = "5eb";
-        assert_eq!(true, get_memval(s).is_err());
+        assert!(get_memval(s).is_err());
 
         let s = "5 1kb";
-        assert_eq!(true, get_memval(s).is_err());
+        assert!(get_memval(s).is_err());
 
         let s = "61k b";
-        assert_eq!(true, get_memval(s).is_err());
+        assert!(get_memval(s).is_err());
 
         let s = "8 8 k b";
-        assert_eq!(true, get_memval(s).is_err());
+        assert!(get_memval(s).is_err());
     }
 }

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1869,7 +1869,7 @@ mod tests {
         assert_eq!(9, tx.opnum);
         assert_eq!(1, tx.first_request_seen);
         assert_eq!(1000, tx.stub_data_buffer_ts.len());
-        assert_eq!(true, tx.stub_data_buffer_reset_ts);
+        assert!(tx.stub_data_buffer_reset_ts);
     }
 
     #[test]

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -338,7 +338,7 @@ mod test {
         );
 
         let op_version = "@1";
-        assert_eq!(true, extract_op_version(op_version).is_err());
+        assert!(extract_op_version(op_version).is_err());
 
         let op_version = "";
         assert_eq!(Err(()), extract_op_version(op_version));
@@ -352,10 +352,10 @@ mod test {
             arg2: 0,
         };
         let version: u16 = 10;
-        assert_eq!(true, detect_match_uint(&iface_data, version));
+        assert!(detect_match_uint(&iface_data, version));
 
         let version: u16 = 2;
-        assert_eq!(false, detect_match_uint(&iface_data, version));
+        assert!(!detect_match_uint(&iface_data, version));
     }
 
     #[test]
@@ -399,39 +399,39 @@ mod test {
 
         let arg = "12345678-1234-1234-1234-123456789ABC,>1,ay_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-1234-12345679ABC,>1,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-134-123456789ABC,>1,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-123-124-1234-123456789ABC,>1,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "1234568-1234-1234-1234-123456789ABC,>1,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-1234-123456789ABC,>65536,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-1234-123456789ABC,>=0,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-1234-123456789ABC,<0,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
 
         let arg = "12345678-1234-1234-1234-123456789ABC,>65535,any_frag";
         let iface_data = parse_iface_data(arg);
-        assert_eq!(iface_data.is_err(), true);
+        assert!(iface_data.is_err());
     }
 
     #[test]
@@ -474,10 +474,10 @@ mod test {
 
         let arg = "12,26,62,61,6513--";
         let opnum_data = parse_opnum_data(arg);
-        assert_eq!(true, opnum_data.is_err());
+        assert!(opnum_data.is_err());
 
         let arg = "12-14,12,121,62-8";
         let opnum_data = parse_opnum_data(arg);
-        assert_eq!(true, opnum_data.is_err());
+        assert!(opnum_data.is_err());
     }
 }

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -620,22 +620,19 @@ mod tests {
 
     #[test]
     fn test_parser_string_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string decimal"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hexadecimal"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string octal"
             )
@@ -646,73 +643,61 @@ mod tests {
     #[test]
     // bytes must be between 1 and 10; when combined with rshift/lshift, must be 4 or less
     fn test_parser_bytes_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 0, offset 3933, oper +, rvalue myrvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 11, offset 3933, oper +, rvalue myrvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 5, offset 3933, oper >>, rvalue myrvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 5, offset 3933, oper <<, rvalue myrvalue, result foo").is_err()
         );
     }
 
     #[test]
     fn test_parser_bitmask_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x")
                 .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask x12345678"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask X12345678"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x123456789012"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0q")
                 .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask maple"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0xGHIJKLMN"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask #*#*@-"
             )
@@ -833,15 +818,13 @@ mod tests {
 
     #[test]
     fn test_parser_endian_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian bigger"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian smaller"
             )
@@ -849,22 +832,19 @@ mod tests {
         );
 
         // endianess can only be specified once
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big, dce"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, endian big"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, dce"
             )
@@ -946,28 +926,22 @@ mod tests {
 
     #[test]
     fn test_parser_oper_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper !, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper ^, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper <>, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper ><, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper <, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper >, rvalue myvalue, result foo").is_err()
         );
     }
@@ -1017,8 +991,7 @@ mod tests {
 
     #[test]
     fn test_parser_rvalue_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967296, result foo").is_err()
         );
     }
@@ -1061,89 +1034,77 @@ mod tests {
     #[test]
     // offset: numeric values must be between -65535 and 65535
     fn test_parser_offset_invalid() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset -70000, oper *, rvalue myvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 70000, oper +, rvalue myvalue, result foo").is_err()
         );
     }
 
     #[test]
     fn test_parser_incomplete_args() {
-        assert_eq!(true, parse_bytemath("").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0, oper <<").is_err());
+        assert!(parse_bytemath("").is_err());
+        assert!(parse_bytemath("bytes 4").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper <<").is_err());
     }
 
     #[test]
     fn test_parser_missing_required() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("endian big, offset 3933, oper +, rvalue myrvalue, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, endian big, oper +, rvalue myrvalue, result foo,").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 3933, endian big, rvalue myrvalue, result foo")
                 .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 3933, oper +, endian big, result foo").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, endian big").is_err()
         );
     }
 
     #[test]
     fn test_parser_invalid_args() {
-        assert_eq!(true, parse_bytemath("monkey banana").is_err());
-        assert_eq!(true, parse_bytemath("bytes nan").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset nan").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0, three 3, four 4, five 5, six 6, seven 7, eight 8, nine 9, ten 10, eleven 11").is_err());
-        assert_eq!(
-            true,
+        assert!(parse_bytemath("monkey banana").is_err());
+        assert!(parse_bytemath("bytes nan").is_err());
+        assert!(parse_bytemath("bytes 4, offset nan").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, three 3, four 4, five 5, six 6, seven 7, eight 8, nine 9, ten 10, eleven 11").is_err());
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper ><, rvalue myrvalue").is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, endian endian").is_err()
         );
     }
     #[test]
     fn test_parser_multiple() {
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 0, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
             )
             .is_err()
         );
-        assert_eq!(
-            true,
+        assert!(
             parse_bytemath(
                 "bytes 4, offset 0, oper +, oper +, rvalue myrvalue, result myresult, endian big"
             )
             .is_err()
         );
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, rvalue myrvalue, result myresult, endian big").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, result myresult, endian big").is_err());
-        assert_eq!(true, parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big, endian big").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, rvalue myrvalue, result myresult, endian big").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, result myresult, endian big").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big, endian big").is_err());
     }
 }

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -156,48 +156,44 @@ mod test {
 
     #[test]
     fn test_match_opcode() {
-        assert_eq!(
+        assert!(
             match_opcode(
                 &DetectDnsOpcode {
                     negate: false,
                     opcode: 0,
                 },
                 0b0000_0000_0000_0000,
-            ),
-            true
+            )
         );
 
-        assert_eq!(
-            match_opcode(
+        assert!(
+            !match_opcode(
                 &DetectDnsOpcode {
                     negate: true,
                     opcode: 0,
                 },
                 0b0000_0000_0000_0000,
-            ),
-            false
+            )
         );
 
-        assert_eq!(
+        assert!(
             match_opcode(
                 &DetectDnsOpcode {
                     negate: false,
                     opcode: 4,
                 },
                 0b0010_0000_0000_0000,
-            ),
-            true
+            )
         );
 
-        assert_eq!(
-            match_opcode(
+        assert!(
+            !match_opcode(
                 &DetectDnsOpcode {
                     negate: true,
                     opcode: 4,
                 },
                 0b0010_0000_0000_0000,
-            ),
-            false
+            )
         );
     }
 }

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -279,7 +279,7 @@ mod tests {
             Ok((rem, ctx)) => {
                 match ctx {
                     DetectKrb5TicketEncryptionData::WEAK(w) => {
-                        assert_eq!(w, true);
+                        assert!(w);
                     }
                     _ => {
                         panic!("Result should have been weak.");
@@ -296,7 +296,7 @@ mod tests {
             Ok((rem, ctx)) => {
                 match ctx {
                     DetectKrb5TicketEncryptionData::WEAK(w) => {
-                        assert_eq!(w, false);
+                        assert!(!w);
                     }
                     _ => {
                         panic!("Result should have been weak.");
@@ -313,9 +313,9 @@ mod tests {
             Ok((rem, ctx)) => {
                 match ctx {
                     DetectKrb5TicketEncryptionData::LIST(l) => {
-                        assert_eq!(l.positive[EncryptionType::DES_CBC_CRC.0 as usize], true);
-                        assert_eq!(l.negative[128], true);
-                        assert_eq!(l.positive[2], true);
+                        assert!(l.positive[EncryptionType::DES_CBC_CRC.0 as usize]);
+                        assert!(l.negative[128]);
+                        assert!(l.positive[2]);
                         assert_eq!(l.other.len(), 1);
                         assert_eq!(l.other[0], EncryptionType(257));
                     }

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -764,9 +764,9 @@ mod tests {
         match result {
             Ok((remainder, message)) => {
                 assert_eq!(message.message_type, MQTTTypeCode::PUBLISH);
-                assert_eq!(message.dup_flag, false);
+                assert!(!message.dup_flag);
                 assert_eq!(message.qos_level, 0);
-                assert_eq!(message.retain, false);
+                assert!(!message.retain);
                 assert_eq!(message.remaining_length, 35767);
                 assert_eq!(remainder.len(), 17);
             }
@@ -823,12 +823,12 @@ mod tests {
             Ok((remainder, message)) => {
                 assert_eq!(message.protocol_string, "MQTT");
                 assert_eq!(message.protocol_version, 5);
-                assert_eq!(message.username_flag, true);
-                assert_eq!(message.password_flag, true);
-                assert_eq!(message.will_retain, false);
+                assert!(message.username_flag);
+                assert!(message.password_flag);
+                assert!(!message.will_retain);
                 assert_eq!(message.will_qos, 0);
-                assert_eq!(message.will_flag, false);
-                assert_eq!(message.clean_session, true);
+                assert!(!message.will_flag);
+                assert!(message.clean_session);
                 assert_eq!(message.keepalive, 60);
                 assert_eq!(remainder.len(), 0);
             }
@@ -869,7 +869,7 @@ mod tests {
                     MQTTProperty::ASSIGNED_CLIENT_IDENTIFIER(client_identifier.to_string())
                 );
                 assert_eq!(message.return_code, 0);
-                assert_eq!(message.session_present, false);
+                assert!(!message.session_present);
                 assert_eq!(remainder.len(), 0);
             }
 
@@ -1118,9 +1118,9 @@ mod tests {
         match result {
             Ok((remainder, message)) => {
                 assert_eq!(message.header.message_type, MQTTTypeCode::CONNECT);
-                assert_eq!(message.header.dup_flag, false);
+                assert!(!message.header.dup_flag);
                 assert_eq!(message.header.qos_level, 0);
-                assert_eq!(message.header.retain, false);
+                assert!(!message.header.retain);
                 assert_eq!(remainder.len(), 49);
             }
 

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -200,7 +200,7 @@ mod tests {
                 assert_eq!(response.attr_follows, 1);
                 assert_eq!(response.attr_blob.len(), 68);
                 assert_eq!(response.count, response.data_len);
-                assert_eq!(response.eof, false);
+                assert!(!response.eof);
                 assert_eq!(response.data_len, 11);
                 assert_eq!(response.data, &buf[76..87]);
             }

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -991,7 +991,7 @@ mod tests {
                 assert_eq!(reply.attr_follows, 1);
                 assert_eq!(reply.attr_blob.len(), 84);
                 assert_eq!(reply.count, 11);
-                assert_eq!(reply.eof, true);
+                assert!(reply.eof);
                 assert_eq!(reply.data_len, 11);
                 assert_eq!(reply.data, "the b file\n".as_bytes());
             }

--- a/rust/src/nfs/nfs4_records.rs
+++ b/rust/src/nfs/nfs4_records.rs
@@ -1900,7 +1900,7 @@ mod tests {
         assert_eq!(res_entry1.name, "data".as_bytes());
 
         let (_, res_rd) = nfs4_res_readdir_ok(&buf[8..]).unwrap();
-        assert_eq!(res_rd.eof, true);
+        assert!(res_rd.eof);
         assert_eq!(res_rd.listing, [Some(res_entry0), Some(res_entry1)]);
 
         let (_, response) = nfs4_res_readdir(&buf[4..]).unwrap();

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -517,25 +517,25 @@ mod tests {
     #[test]
     fn test_probe_rdp() {
         let buf: &[u8] = &[0x03, 0x00];
-        assert_eq!(true, probe_rdp(buf));
+        assert!(probe_rdp(buf));
     }
 
     #[test]
     fn test_probe_rdp_other() {
         let buf: &[u8] = &[0x04, 0x00];
-        assert_eq!(false, probe_rdp(buf));
+        assert!(!probe_rdp(buf));
     }
 
     #[test]
     fn test_probe_tls_handshake() {
         let buf: &[u8] = &[0x16, 0x00];
-        assert_eq!(true, probe_tls_handshake(buf));
+        assert!(probe_tls_handshake(buf));
     }
 
     #[test]
     fn test_probe_tls_handshake_other() {
         let buf: &[u8] = &[0x17, 0x00];
-        assert_eq!(false, probe_tls_handshake(buf));
+        assert!(!probe_tls_handshake(buf));
     }
 
     #[test]
@@ -614,8 +614,8 @@ mod tests {
         assert_eq!(2, state.transactions.len());
         assert_eq!(1, state.transactions[0].id);
         assert_eq!(2, state.transactions[1].id);
-        assert_eq!(false, state.tls_parsing);
-        assert_eq!(false, state.bypass_parsing);
+        assert!(!state.tls_parsing);
+        assert!(!state.bypass_parsing);
     }
 
     #[test]

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -116,10 +116,10 @@ mod tests {
                 assert_ne!(p.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
 
                 // this packet had an acceptable length, we don't need more
-                assert_eq!(p.needs_more(), false);
+                assert!(!p.needs_more());
 
                 // does this really look like smb?
-                assert_eq!(p.is_smb(), true);
+                assert!(p.is_smb());
 
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);
@@ -159,11 +159,11 @@ mod tests {
                 assert_ne!(p_not_smb.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
 
                 // this packet had an acceptable length, we don't need more
-                assert_eq!(p_not_smb.needs_more(), false);
+                assert!(!p_not_smb.needs_more());
 
                 // this packet doesn't have the SMB keyword
                 // is_smb must be false
-                assert_eq!(p_not_smb.is_smb(), false);
+                assert!(!p_not_smb.is_smb());
 
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);
@@ -200,10 +200,10 @@ mod tests {
                 assert_ne!(p.message_type, NBSS_MSGTYPE_KEEP_ALIVE);
 
                 // this packet had an acceptable length, we don't need more
-                assert_eq!(p.needs_more(), false);
+                assert!(!p.needs_more());
 
                 // does this really look like smb?
-                assert_eq!(p.is_smb(), true);
+                assert!(p.is_smb());
 
                 // there should be nothing left
                 assert_eq!(remainder.len(), 0);


### PR DESCRIPTION
Fix done automatically by clippy --fix
