### PR TITLE
detect: fix break loop for timeout based rule reload - v1

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2278,8 +2278,14 @@ retry:
         if (SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) == 1) {
             SCLogDebug("new_det_ctx - %p used by detect engine", new_det_ctx[i]);
             threads_done++;
-        } else if (detect_tvs[i]->break_loop) {
-            TmThreadsCaptureBreakLoop(detect_tvs[i]);
+        } else {
+            /* If the capture method supports it, BreakLoop, otherwise
+               rely on the capture method's receive timeout. */
+            if (detect_tvs[i]->break_loop) {
+                TmThreadsCaptureBreakLoop(detect_tvs[i]);
+            } else {
+                TmThreadsSetFlag(detect_tvs[i], THV_CAPTURE_INJECT_PKT);
+            }
         }
     }
     if (threads_done < no_of_detect_tvs) {

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -253,6 +253,10 @@ static inline void TmThreadsCaptureHandleTimeout(ThreadVars *tv, Packet *p)
         tv->tmqh_out(tv, p);
 }
 
+/**
+ * Note: Only ever called if tv->break_loop is true and
+ *   tm->PktAcqBreakLoop is set.
+ */
 static inline void TmThreadsCaptureBreakLoop(ThreadVars *tv)
 {
     if (unlikely(!tv->break_loop))
@@ -265,12 +269,9 @@ static inline void TmThreadsCaptureBreakLoop(ThreadVars *tv)
     TmSlot *s = tv->tm_slots;
     TmModule *tm = TmModuleGetById(s->tm_id);
     if (tm->flags & TM_FLAG_RECEIVE_TM) {
-        /* if the method supports it, BreakLoop. Otherwise we rely on
-         * the capture method's recv timeout */
         if (tm->PktAcqLoop && tm->PktAcqBreakLoop) {
             tm->PktAcqBreakLoop(tv, SC_ATOMIC_GET(s->slot_data));
         }
-        TmThreadsSetFlag(tv, THV_CAPTURE_INJECT_PKT);
     }
 }
 


### PR DESCRIPTION
As part of 6d8b50b748844e9de6010cde5a6b139148c0e937, the settings of
THV_CAPTURE_INJECT_PKT ended up in a location unreachable by capture
methods that did not have PktAcqBreakLoop. Refactor so this flag is
set outside of TmThreadsCaptureBreakLoop for such capture methods like
AF_PACKET.

This fixes the case where read threads won't "break" for rule reloads
until packets are seen.

Ticket: https://redmine.openinfosecfoundation.org/issues/6021
