### PR TITLE
App layer cleanup v1

### DIFF
--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -210,16 +210,6 @@ def logger_patch_suricata_yaml_in(proto):
 
     open(filename, "w").write(output.getvalue())
 
-def logger_patch_suricata_common_h(proto):
-    filename = "src/suricata-common.h"
-    print("Patching %s." % (filename))
-    output = io.StringIO()
-    with open(filename) as infile:
-        for line in infile:
-            if line.find("LOGGER_JSON_TEMPLATE,") > -1:
-                output.write(line.replace("TEMPLATE", proto.upper()))
-            output.write(line)
-    open(filename, "w").write(output.getvalue())
 
 def logger_patch_output_c(proto):
     filename = "src/output.c"
@@ -227,9 +217,9 @@ def logger_patch_output_c(proto):
     output = io.StringIO()
     inlines = open(filename).readlines()
     for i, line in enumerate(inlines):
-        if line.find("output-json-template.h") > -1:
+        if line.find("output-json-template-rust.h") > -1:
             output.write(line.replace("template", proto.lower()))
-        if line.find("/* Template JSON logger.") > -1:
+        if line.find("/* Template Rust JSON logger.") > -1:
             output.write(inlines[i].replace("Template", proto))
             output.write(inlines[i+1].replace("Template", proto))
         output.write(line)
@@ -260,16 +250,6 @@ def logger_patch_makefile_am(protoname):
             output.write(line)
     open(filename, "w").write(output.getvalue())
 
-def logger_patch_util_profiling_c(proto):
-    filename = "src/util-profiling.c"
-    print("Patching %s." % (filename))
-    output = io.StringIO()
-    with open(filename) as infile:
-        for line in infile:
-            if line.find("(LOGGER_JSON_TEMPLATE);") > -1:
-                output.write(line.replace("TEMPLATE", proto.upper()))
-            output.write(line)
-    open(filename, "w").write(output.getvalue())
 
 def detect_copy_templates(proto, buffername):
     lower = proto.lower()
@@ -432,10 +412,8 @@ def main():
         logger_copy_templates(proto)
         patch_rust_applayer_mod_rs(proto)
         logger_patch_makefile_am(proto)
-        logger_patch_suricata_common_h(proto)
         logger_patch_output_c(proto)
         logger_patch_suricata_yaml_in(proto)
-        logger_patch_util_profiling_c(proto)
 
     if detect:
         if not proto_exists(proto):

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -158,18 +158,6 @@ def patch_app_layer_protos_c(protoname):
         output.write(line)
     open(filename, "w").write(output.getvalue())
 
-def patch_app_layer_detect_proto_c(proto):
-    filename = "src/app-layer-detect-proto.c"
-    print("Patching %s." % (filename))
-    output = io.StringIO()
-    inlines = open(filename).readlines()
-    for i, line in enumerate(inlines):
-        if line.find("== ALPROTO_TEMPLATE)") > -1:
-            output.write(inlines[i].replace("TEMPLATE", proto.upper()))
-            output.write(inlines[i+1].replace("TEMPLATE", proto.upper()))
-        output.write(line)
-    open(filename, "w").write(output.getvalue())
-
 def patch_app_layer_parser_c(proto):
     filename = "src/app-layer-parser.c"
     print("Patching %s." % (filename))
@@ -435,7 +423,6 @@ def main():
         patch_rust_lib_rs(proto)
         patch_app_layer_protos_h(proto)
         patch_app_layer_protos_c(proto)
-        patch_app_layer_detect_proto_c(proto)
         patch_app_layer_parser_c(proto)
         patch_suricata_yaml_in(proto)
 

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -860,69 +860,7 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                 pp_pe = pp_port->dp;
                 for ( ; pp_pe != NULL; pp_pe = pp_pe->next) {
 
-                    if (pp_pe->alproto == ALPROTO_HTTP1)
-                        printf("            alproto: ALPROTO_HTTP1\n");
-                    else if (pp_pe->alproto == ALPROTO_FTP)
-                        printf("            alproto: ALPROTO_FTP\n");
-                    else if (pp_pe->alproto == ALPROTO_FTPDATA)
-                        printf("            alproto: ALPROTO_FTPDATA\n");
-                    else if (pp_pe->alproto == ALPROTO_SMTP)
-                        printf("            alproto: ALPROTO_SMTP\n");
-                    else if (pp_pe->alproto == ALPROTO_TLS)
-                        printf("            alproto: ALPROTO_TLS\n");
-                    else if (pp_pe->alproto == ALPROTO_SSH)
-                        printf("            alproto: ALPROTO_SSH\n");
-                    else if (pp_pe->alproto == ALPROTO_IMAP)
-                        printf("            alproto: ALPROTO_IMAP\n");
-                    else if (pp_pe->alproto == ALPROTO_JABBER)
-                        printf("            alproto: ALPROTO_JABBER\n");
-                    else if (pp_pe->alproto == ALPROTO_SMB)
-                        printf("            alproto: ALPROTO_SMB\n");
-                    else if (pp_pe->alproto == ALPROTO_DCERPC)
-                        printf("            alproto: ALPROTO_DCERPC\n");
-                    else if (pp_pe->alproto == ALPROTO_IRC)
-                        printf("            alproto: ALPROTO_IRC\n");
-                    else if (pp_pe->alproto == ALPROTO_DNS)
-                        printf("            alproto: ALPROTO_DNS\n");
-                    else if (pp_pe->alproto == ALPROTO_MODBUS)
-                        printf("            alproto: ALPROTO_MODBUS\n");
-                    else if (pp_pe->alproto == ALPROTO_ENIP)
-                        printf("            alproto: ALPROTO_ENIP\n");
-                    else if (pp_pe->alproto == ALPROTO_NFS)
-                        printf("            alproto: ALPROTO_NFS\n");
-                    else if (pp_pe->alproto == ALPROTO_NTP)
-                        printf("            alproto: ALPROTO_NTP\n");
-                    else if (pp_pe->alproto == ALPROTO_TFTP)
-                        printf("            alproto: ALPROTO_TFTP\n");
-                    else if (pp_pe->alproto == ALPROTO_IKE)
-                        printf("            alproto: ALPROTO_IKE\n");
-                    else if (pp_pe->alproto == ALPROTO_KRB5)
-                        printf("            alproto: ALPROTO_KRB5\n");
-                    else if (pp_pe->alproto == ALPROTO_DHCP)
-                        printf("            alproto: ALPROTO_DHCP\n");
-                    else if (pp_pe->alproto == ALPROTO_QUIC)
-                        printf("            alproto: ALPROTO_QUIC\n");
-                    else if (pp_pe->alproto == ALPROTO_SNMP)
-                        printf("            alproto: ALPROTO_SNMP\n");
-                    else if (pp_pe->alproto == ALPROTO_SIP)
-                        printf("            alproto: ALPROTO_SIP\n");
-                    else if (pp_pe->alproto == ALPROTO_TEMPLATE)
-                        printf("            alproto: ALPROTO_TEMPLATE\n");
-                    else if (pp_pe->alproto == ALPROTO_RFB)
-                        printf("            alproto: ALPROTO_RFB\n");
-                    else if (pp_pe->alproto == ALPROTO_MQTT)
-                        printf("            alproto: ALPROTO_MQTT\n");
-                    else if (pp_pe->alproto == ALPROTO_PGSQL)
-                        printf("            alproto: ALPROTO_PGSQL\n");
-                    else if (pp_pe->alproto == ALPROTO_TELNET)
-                        printf("            alproto: ALPROTO_TELNET\n");
-                    else if (pp_pe->alproto == ALPROTO_DNP3)
-                        printf("            alproto: ALPROTO_DNP3\n");
-                    else if (pp_pe->alproto == ALPROTO_BITTORRENT_DHT)
-                        printf("            alproto: ALPROTO_BITTORRENT_DHT\n");
-                    else
-                        printf("impossible\n");
-
+                    printf("            alproto: %s\n", AppProtoToString(pp_pe->alproto));
                     printf("            port: %"PRIu16 "\n", pp_pe->port);
                     printf("            mask: %"PRIu32 "\n", pp_pe->alproto_mask);
                     printf("            min_depth: %"PRIu32 "\n", pp_pe->min_depth);
@@ -943,69 +881,7 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
             pp_pe = pp_port->sp;
             for ( ; pp_pe != NULL; pp_pe = pp_pe->next) {
 
-                if (pp_pe->alproto == ALPROTO_HTTP1)
-                    printf("            alproto: ALPROTO_HTTP1\n");
-                else if (pp_pe->alproto == ALPROTO_FTP)
-                    printf("            alproto: ALPROTO_FTP\n");
-                else if (pp_pe->alproto == ALPROTO_FTPDATA)
-                    printf("            alproto: ALPROTO_FTPDATA\n");
-                else if (pp_pe->alproto == ALPROTO_SMTP)
-                    printf("            alproto: ALPROTO_SMTP\n");
-                else if (pp_pe->alproto == ALPROTO_TLS)
-                    printf("            alproto: ALPROTO_TLS\n");
-                else if (pp_pe->alproto == ALPROTO_SSH)
-                    printf("            alproto: ALPROTO_SSH\n");
-                else if (pp_pe->alproto == ALPROTO_IMAP)
-                    printf("            alproto: ALPROTO_IMAP\n");
-                else if (pp_pe->alproto == ALPROTO_JABBER)
-                    printf("            alproto: ALPROTO_JABBER\n");
-                else if (pp_pe->alproto == ALPROTO_SMB)
-                    printf("            alproto: ALPROTO_SMB\n");
-                else if (pp_pe->alproto == ALPROTO_DCERPC)
-                    printf("            alproto: ALPROTO_DCERPC\n");
-                else if (pp_pe->alproto == ALPROTO_IRC)
-                    printf("            alproto: ALPROTO_IRC\n");
-                else if (pp_pe->alproto == ALPROTO_DNS)
-                    printf("            alproto: ALPROTO_DNS\n");
-                else if (pp_pe->alproto == ALPROTO_MODBUS)
-                    printf("            alproto: ALPROTO_MODBUS\n");
-                else if (pp_pe->alproto == ALPROTO_ENIP)
-                    printf("            alproto: ALPROTO_ENIP\n");
-                else if (pp_pe->alproto == ALPROTO_NFS)
-                    printf("            alproto: ALPROTO_NFS\n");
-                else if (pp_pe->alproto == ALPROTO_NTP)
-                    printf("            alproto: ALPROTO_NTP\n");
-                else if (pp_pe->alproto == ALPROTO_TFTP)
-                    printf("            alproto: ALPROTO_TFTP\n");
-                else if (pp_pe->alproto == ALPROTO_IKE)
-                    printf("            alproto: ALPROTO_IKE\n");
-                else if (pp_pe->alproto == ALPROTO_KRB5)
-                    printf("            alproto: ALPROTO_KRB5\n");
-                else if (pp_pe->alproto == ALPROTO_QUIC)
-                    printf("            alproto: ALPROTO_QUIC\n");
-                else if (pp_pe->alproto == ALPROTO_DHCP)
-                    printf("            alproto: ALPROTO_DHCP\n");
-                else if (pp_pe->alproto == ALPROTO_SNMP)
-                    printf("            alproto: ALPROTO_SNMP\n");
-                else if (pp_pe->alproto == ALPROTO_SIP)
-                    printf("            alproto: ALPROTO_SIP\n");
-                else if (pp_pe->alproto == ALPROTO_TEMPLATE)
-                    printf("            alproto: ALPROTO_TEMPLATE\n");
-                else if (pp_pe->alproto == ALPROTO_RFB)
-                    printf("            alproto: ALPROTO_RFB\n");
-                else if (pp_pe->alproto == ALPROTO_MQTT)
-                    printf("            alproto: ALPROTO_MQTT\n");
-                else if (pp_pe->alproto == ALPROTO_PGSQL)
-                    printf("            alproto: ALPROTO_PGSQL\n");
-                else if (pp_pe->alproto == ALPROTO_TELNET)
-                    printf("            alproto: ALPROTO_TELNET\n");
-                else if (pp_pe->alproto == ALPROTO_DNP3)
-                    printf("            alproto: ALPROTO_DNP3\n");
-                else if (pp_pe->alproto == ALPROTO_BITTORRENT_DHT)
-                    printf("            alproto: ALPROTO_BITTORRENT_DHT\n");
-                else
-                    printf("impossible\n");
-
+                printf("            alproto: %s\n", AppProtoToString(pp_pe->alproto));
                 printf("            port: %"PRIu16 "\n", pp_pe->port);
                 printf("            mask: %"PRIu32 "\n", pp_pe->alproto_mask);
                 printf("            min_depth: %"PRIu32 "\n", pp_pe->min_depth);

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -25,122 +25,52 @@
 #include "suricata-common.h"
 #include "app-layer-protos.h"
 
-#define CASE_CODE(E)  case E: return #E
+const char *AppProtoStrings[ALPROTO_MAX] = {
+    "unknown",        // ALPROTO_UNKNOWN,
+    "http",           // ALPROTO_HTTP1
+    "ftp",            // ALPROTO_FTP
+    "smtp",           // ALPROTO_SMTP
+    "tls",            // ALPROTO_TLS
+    "ssh",            // ALPROTO_SSH
+    "imap",           // ALPROTO_IMAP
+    "jabber",         // ALPROTO_JABBER
+    "smb",            // ALPROTO_SMB
+    "dcerpc",         // ALPROTO_DCERPC
+    "irc",            // ALPROTO_IRC
+    "dns",            // ALPROTO_DNS
+    "modbus",         // ALPROTO_MODBUS
+    "enip",           // ALPROTO_ENIP
+    "dnp3",           // ALPROTO_DNP3
+    "nfs",            // ALPROTO_NFS
+    "ntp",            // ALPROTO_NTP
+    "ftp-data",       // ALPROTO_FTPDATA
+    "tftp",           // ALPROTO_TFTP
+    "ike",            // ALPROTO_IKE
+    "krb5",           // ALPROTO_KRB5
+    "quic",           // ALPROTO_QUIC
+    "dhcp",           // ALPROTO_DHCP
+    "snmp",           // ALPROTO_SNMP
+    "sip",            // ALPROTO_SIP
+    "rfb",            // ALPROTO_RFB
+    "mqtt",           // ALPROTO_MQTT
+    "pgsql",          // ALPROTO_PGSQL
+    "telnet",         // ALPROTO_TELNET
+    "template",       // ALPROTO_TEMPLATE
+    "rdp",            // ALPROTO_RDP
+    "http2",          // ALPROTO_HTTP2
+    "bittorrent-dht", // ALPROTO_BITTORRENT_DHT
+    "http_any",       // ALPROTO_HTTP
+    "failed",         // ALPROTO_FAILED
+#ifdef UNITTESTS
+    "test", // ALPROTO_TEST
+#endif
+};
 
 const char *AppProtoToString(AppProto alproto)
 {
     const char *proto_name = NULL;
-    enum AppProtoEnum proto = alproto;
-
-    switch (proto) {
-        case ALPROTO_HTTP1:
-            proto_name = "http";
-            break;
-        case ALPROTO_FTP:
-            proto_name = "ftp";
-            break;
-        case ALPROTO_SMTP:
-            proto_name = "smtp";
-            break;
-        case ALPROTO_TLS:
-            proto_name = "tls";
-            break;
-        case ALPROTO_SSH:
-            proto_name = "ssh";
-            break;
-        case ALPROTO_IMAP:
-            proto_name = "imap";
-            break;
-        case ALPROTO_JABBER:
-            proto_name = "jabber";
-            break;
-        case ALPROTO_SMB:
-            proto_name = "smb";
-            break;
-        case ALPROTO_DCERPC:
-            proto_name = "dcerpc";
-            break;
-        case ALPROTO_IRC:
-            proto_name = "irc";
-            break;
-        case ALPROTO_DNS:
-            proto_name = "dns";
-            break;
-        case ALPROTO_MODBUS:
-            proto_name = "modbus";
-            break;
-        case ALPROTO_ENIP:
-            proto_name = "enip";
-            break;
-        case ALPROTO_DNP3:
-            proto_name = "dnp3";
-            break;
-        case ALPROTO_NFS:
-            proto_name = "nfs";
-            break;
-        case ALPROTO_NTP:
-            proto_name = "ntp";
-            break;
-        case ALPROTO_FTPDATA:
-            proto_name = "ftp-data";
-            break;
-        case ALPROTO_TFTP:
-            proto_name = "tftp";
-            break;
-        case ALPROTO_IKE:
-            proto_name = "ike";
-            break;
-        case ALPROTO_KRB5:
-            proto_name = "krb5";
-            break;
-        case ALPROTO_QUIC:
-            proto_name = "quic";
-            break;
-        case ALPROTO_DHCP:
-            proto_name = "dhcp";
-            break;
-        case ALPROTO_SNMP:
-            proto_name = "snmp";
-            break;
-        case ALPROTO_SIP:
-            proto_name = "sip";
-            break;
-        case ALPROTO_RFB:
-            proto_name = "rfb";
-	    break;
-        case ALPROTO_MQTT:
-            proto_name = "mqtt";
-            break;
-        case ALPROTO_PGSQL:
-            proto_name = "pgsql";
-            break;
-        case ALPROTO_TELNET:
-            proto_name = "telnet";
-            break;
-        case ALPROTO_TEMPLATE:
-            proto_name = "template";
-            break;
-        case ALPROTO_RDP:
-            proto_name = "rdp";
-            break;
-        case ALPROTO_HTTP2:
-            proto_name = "http2";
-            break;
-        case ALPROTO_HTTP:
-            proto_name = "http_any";
-            break;
-        case ALPROTO_BITTORRENT_DHT:
-            proto_name = "bittorrent-dht";
-            break;
-        case ALPROTO_FAILED:
-            proto_name = "failed";
-            break;
-#ifdef UNITTESTS
-        case ALPROTO_TEST:
-#endif
-        case ALPROTO_MAX:
-        case ALPROTO_UNKNOWN:
-            break;
+    if (alproto < sizeof(AppProtoStrings) / sizeof(const char *)) {
+        proto_name = AppProtoStrings[alproto];
     }
 
     return proto_name;
@@ -151,74 +81,11 @@ AppProto StringToAppProto(const char *proto_name)
     if (proto_name == NULL)
         return ALPROTO_UNKNOWN;
 
-    if (strcmp(proto_name, "http") == 0)
-        return ALPROTO_HTTP;
-    if (strcmp(proto_name, "http1") == 0)
-        return ALPROTO_HTTP1;
-    if (strcmp(proto_name, "ftp") == 0)
-        return ALPROTO_FTP;
-    if (strcmp(proto_name, "ftp-data") == 0)
-        return ALPROTO_FTPDATA;
-    if (strcmp(proto_name, "tftp") == 0)
-        return ALPROTO_TFTP;
-    if (strcmp(proto_name, "smtp") == 0)
-        return ALPROTO_SMTP;
-    if (strcmp(proto_name, "tls") == 0)
-        return ALPROTO_TLS;
-    if (strcmp(proto_name, "ssh") == 0)
-        return ALPROTO_SSH;
-    if (strcmp(proto_name, "imap") == 0)
-        return ALPROTO_IMAP;
-    if (strcmp(proto_name, "jabber") == 0)
-        return ALPROTO_JABBER;
-    if (strcmp(proto_name, "smb") == 0)
-        return ALPROTO_SMB;
-    if (strcmp(proto_name, "dcerpc") == 0)
-        return ALPROTO_DCERPC;
-    if (strcmp(proto_name, "irc") == 0)
-        return ALPROTO_IRC;
-    if (strcmp(proto_name, "dns") == 0)
-        return ALPROTO_DNS;
-    if (strcmp(proto_name, "modbus") == 0)
-        return ALPROTO_MODBUS;
-    if (strcmp(proto_name, "enip") == 0)
-        return ALPROTO_ENIP;
-    if (strcmp(proto_name, "dnp3") == 0)
-        return ALPROTO_DNP3;
-    if (strcmp(proto_name, "nfs") == 0)
-        return ALPROTO_NFS;
-    if (strcmp(proto_name, "ntp") == 0)
-        return ALPROTO_NTP;
-    if (strcmp(proto_name, "ike") == 0)
-        return ALPROTO_IKE;
-    if (strcmp(proto_name, "krb5") == 0)
-        return ALPROTO_KRB5;
-    if (strcmp(proto_name, "quic") == 0)
-        return ALPROTO_QUIC;
-    if (strcmp(proto_name, "dhcp") == 0)
-        return ALPROTO_DHCP;
-    if (strcmp(proto_name, "snmp") == 0)
-        return ALPROTO_SNMP;
-    if (strcmp(proto_name, "sip") == 0)
-        return ALPROTO_SIP;
-    if (strcmp(proto_name, "rfb") == 0)
-        return ALPROTO_RFB;
-    if (strcmp(proto_name, "mqtt") == 0)
-        return ALPROTO_MQTT;
-    if (strcmp(proto_name, "pgsql") == 0)
-        return ALPROTO_PGSQL;
-    if (strcmp(proto_name, "telnet") == 0)
-        return ALPROTO_TELNET;
-    if (strcmp(proto_name, "template") == 0)
-        return ALPROTO_TEMPLATE;
-    if (strcmp(proto_name, "rdp") == 0)
-        return ALPROTO_RDP;
-    if (strcmp(proto_name, "http2") == 0)
-        return ALPROTO_HTTP2;
-    if (strcmp(proto_name, "bittorrent-dht") == 0)
-        return ALPROTO_BITTORRENT_DHT;
-    if (strcmp(proto_name, "failed") == 0)
-        return ALPROTO_FAILED;
+    // We could use a Multi Pattern Matcher
+    for (size_t i = 0; i < sizeof(AppProtoStrings) / sizeof(const char *); i++) {
+        if (strcmp(proto_name, AppProtoStrings[i]) == 0)
+            return ((AppProto)i);
+    }
 
     return ALPROTO_UNKNOWN;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, preliminary work for https://redmine.openinfosecfoundation.org/issues/5053 and app-layer plugins

Describe changes:
- debug: use function `AppProtoToString` instead of recoding it twice
- fix setup-app-layer.py and remove unused code
- app-layer: use an array for app-layer proto strings

By the way, there is also output-json-alert.c that should be patched by setup-app-layer.py
But I plan for a bigger simplification of the transaction logging code, basically adding an array indexed by app-layer proto and having the name (of the json object), and the logging function (which takes a transaction pointer, a jsonbuilder pointer, maybe some other stuff for some protocols like state, flags... and returning a bool) 
Then we can use it in both `JsonGenericLogger` and `AlertAddAppLayer`
