### PR TITLE
detect: allow 0-sized non-NULL buffers to match

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -118,7 +118,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
         SCReturnInt(0);
     }
 
-    if (smd == NULL || buffer_len == 0) {
+    // we want the ability to match on bsize: 0
+    if (smd == NULL || buffer == NULL) {
         KEYWORD_PROFILING_END(det_ctx, smd->type, 0);
         SCReturnInt(0);
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6025

Describe changes:
- detect: allow 0-sized non-NULL buffers to match

```
SV_BRANCH=pr/1189
```
https://github.com/OISF/suricata-verify/pull/1189
