### PR TITLE
af-packet: Ignore outgoing packets on loopback interfaces - v3

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -327,6 +327,9 @@ typedef struct AFPThreadVars_
 
     int promisc;
 
+    /* bitmask of ignored ssl_pkttypes */
+    uint32_t pkttype_filter_mask;
+
     int down_count;
 
     uint16_t cluster_id;
@@ -854,6 +857,25 @@ static inline int AFPReadFromRingWaitForPacket(AFPThreadVars *ptv)
 }
 
 /**
+ * \brief AF packet frame ignore logic
+ *
+ * Given a sockaddr_ll of a frame, use the pkttype_filter_mask to decide if the
+ * frame should be ignored. Protect from undefined behavior if there's ever
+ * a sll_pkttype that would shift by too much. At this point, only outgoing
+ * packets (4) are ignored. The highest value in if_linux.h is PACKET_KERNEL (7),
+ * this extra check is being overly cautious.
+ *
+ * \retval true if the frame should be ignored
+ */
+static inline bool AFPShouldIgnoreFrame(AFPThreadVars *ptv, const struct sockaddr_ll *sll)
+{
+    if (unlikely(sll->sll_pkttype > 31))
+        return false;
+
+    return (ptv->pkttype_filter_mask & BIT_U32(sll->sll_pkttype)) != 0;
+}
+
+/**
  * \brief AF packet read function for ring
  *
  * This function fills
@@ -897,6 +919,12 @@ static int AFPReadFromRing(AFPThreadVars *ptv)
             h.h2->tp_status = TP_STATUS_KERNEL;
             goto next_frame;
         }
+
+        const struct sockaddr_ll *sll =
+                (const struct sockaddr_ll *)((uint8_t *)h.h2 +
+                                             TPACKET_ALIGN(sizeof(struct tpacket2_hdr)));
+        if (unlikely(AFPShouldIgnoreFrame(ptv, sll)))
+            goto next_frame;
 
         Packet *p = PacketGetFromQueueOrAlloc();
         if (p == NULL) {
@@ -990,6 +1018,12 @@ static inline int AFPWalkBlock(AFPThreadVars *ptv, struct tpacket_block_desc *pb
     uint8_t *ppd = (uint8_t *)pbd + pbd->hdr.bh1.offset_to_first_pkt;
 
     for (int i = 0; i < num_pkts; ++i) {
+        const struct sockaddr_ll *sll =
+                (const struct sockaddr_ll *)(ppd + TPACKET_ALIGN(sizeof(struct tpacket3_hdr)));
+        if (unlikely(AFPShouldIgnoreFrame(ptv, sll))) {
+            ppd = ppd + ((struct tpacket3_hdr *)ppd)->tp_next_offset;
+            continue;
+        }
         int ret = AFPParsePacketV3(ptv, pbd, (struct tpacket3_hdr *)ppd);
         switch (ret) {
             case AFP_READ_OK:
@@ -1876,6 +1910,10 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
         ret = AFP_RECOVERABLE_ERROR;
         goto socket_err;
     }
+
+    /* ignore outgoing packets on loopback interfaces */
+    if (if_flags & IFF_LOOPBACK)
+        ptv->pkttype_filter_mask |= BIT_U32(PACKET_OUTGOING);
 
     if (ptv->promisc != 0) {
         /* Force promiscuous mode */


### PR DESCRIPTION
Replaces #8752 

* simplified AFPShouldIgnoreFrame() bit fiddling
* squashed formatting fixup

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5955

Describe changes:

When reading a loopback interface, packets are received twice: Once as outgoing packets and once as incoming packets.

Libpcap ignores outgoing packets. With current versions of Suricata, sniffing a single http://localhost:80 request over lo using the af-packet source minimally shows two syn packets, two synacks and twice as many packets in the stats entries than you'd expect when running tcpdump or Wireshark.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
