### PR TITLE
Draft changes for issue 4145

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -67,9 +67,19 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
         flags = FileFlowFlagsToFlags(tx->tx_data.file_flags, STREAM_TOSERVER);
     }
 
+    flags |= FILE_USE_DETECT;
+
     if (FileOpenFileWithId(files, &htp_sbcfg, s->file_track_id++, filename, filename_len, data,
                 data_len, flags) != 0) {
         retval = -1;
+    } else {
+        const HTPCfgDir *cfg;
+        if (direction & STREAM_TOCLIENT) {
+            cfg = &s->cfg->response;
+        } else {
+            cfg = &s->cfg->request;
+        }
+        FileSetInspectSizes(files->tail, cfg->inspect_window, cfg->inspect_min_size);
     }
 
     tx->tx_data.files_opened++;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1766,9 +1766,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
      * we check for tx->response_line in case of junk
      * interpreted as body before response line
      */
-    if (!(htud->tcflags & HTP_FILENAME_SET) &&
-        (tx->response_line != NULL || tx->is_protocol_0_9))
-    {
+    if (!(htud->tcflags & HTP_FILENAME_SET)) {
         SCLogDebug("setting up file name");
 
         uint8_t *filename = NULL;
@@ -1818,9 +1816,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 htud->tcflags &= ~HTP_DONTSTORE;
             }
         }
-    }
-    else if (tx->response_line != NULL || tx->is_protocol_0_9)
-    {
+    } else {
         /* otherwise, just store the data */
 
         if (!(htud->tcflags & HTP_DONTSTORE)) {

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -87,9 +87,8 @@ static int g_mpm_list_cnt[DETECT_BUFFER_MPM_TYPE_SIZE] = { 0, 0, 0 };
  *  \note to be used at start up / registration only. Errors are fatal.
  */
 void DetectAppLayerMpmRegister2(const char *name, int direction, int priority,
-        int (*PrefilterRegister)(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
-                const DetectBufferMpmRegistry *mpm_reg, int list_id),
-        InspectionBufferGetDataPtr GetData, AppProto alproto, int tx_min_progress)
+        PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
+        AppProto alproto, int tx_min_progress)
 {
     SCLogDebug("registering %s/%d/%d/%p/%p/%u/%d", name, direction, priority,
             PrefilterRegister, GetData, alproto, tx_min_progress);

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -75,6 +75,9 @@ MpmStore *MpmStorePrepareBuffer(DetectEngineCtx *de_ctx, SigGroupHead *sgh, enum
  */
 int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx);
 
+typedef int (*PrefilterRegisterFunc)(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
+        const DetectBufferMpmRegistry *mpm_reg, int list_id);
+
 /** \brief register an app layer keyword for mpm
  *  \param name buffer name
  *  \param direction SIG_FLAG_TOSERVER or SIG_FLAG_TOCLIENT
@@ -88,17 +91,14 @@ int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx);
  *        If both are needed, register the keyword twice.
  */
 void DetectAppLayerMpmRegister2(const char *name, int direction, int priority,
-        int (*PrefilterRegister)(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
-                const DetectBufferMpmRegistry *mpm_reg, int list_id),
-        InspectionBufferGetDataPtr GetData, AppProto alproto, int tx_min_progress);
+        PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
+        AppProto alproto, int tx_min_progress);
 void DetectAppLayerMpmRegisterByParentId(
         DetectEngineCtx *de_ctx,
         const int id, const int parent_id,
         DetectEngineTransforms *transforms);
 
-void DetectPktMpmRegister(const char *name, int priority,
-        int (*PrefilterRegister)(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
-                const DetectBufferMpmRegistry *mpm_reg, int list_id),
+void DetectPktMpmRegister(const char *name, int priority, PrefilterRegisterFunc PrefilterRegister,
         InspectionBufferGetPktDataPtr GetData);
 void DetectPktMpmRegisterByParentId(DetectEngineCtx *de_ctx,
         const int id, const int parent_id,

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -448,6 +448,14 @@ int SigTableList(const char *keyword)
     return TM_ECODE_DONE;
 }
 
+static void DetectFileHandlerRegister(void)
+{
+    for (int i = 0; i < DETECT_TBLSIZE; i++) {
+        if (filehandler_table[i].name)
+            DetectFileRegisterFileProtocols(&filehandler_table[i]);
+    }
+}
+
 void SigTableSetup(void)
 {
     memset(sigmatch_table, 0, sizeof(sigmatch_table));
@@ -690,6 +698,8 @@ void SigTableSetup(void)
     DetectTransformPcrexformRegister();
     DetectTransformUrlDecodeRegister();
     DetectTransformXorRegister();
+
+    DetectFileHandlerRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -60,19 +60,9 @@ static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
                                         Signature *s);
 static int g_file_data_buffer_id = 0;
 
-static inline HtpBody *GetResponseBody(htp_tx_t *tx);
-
-/* HTTP */
-static int PrefilterMpmHTTPFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
-        MpmCtx *mpm_ctx, const DetectBufferMpmRegistry *mpm_reg, int list_id);
-
 /* file API */
 int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistry *mpm_reg, int list_id);
-
-static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
-        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);
 
 /**
  * \brief Registration function for keyword: file_data
@@ -89,28 +79,12 @@ void DetectFiledataRegister(void)
 #endif
     sigmatch_table[DETECT_FILE_DATA].flags = SIGMATCH_NOOPT;
 
-    for (int i = 0; file_protos_ts[i].alproto != ALPROTO_UNKNOWN; i++) {
-        DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOSERVER, 2, PrefilterMpmFiledataRegister,
-                NULL, file_protos_ts[i].alproto, file_protos_ts[i].progress);
-        DetectAppLayerInspectEngineRegister2("file_data", file_protos_ts[i].alproto,
-                SIG_FLAG_TOSERVER, file_protos_ts[i].progress, DetectEngineInspectFiledata, NULL);
-    }
-    for (int i = 0; file_protos_tc[i].alproto != ALPROTO_UNKNOWN; i++) {
-        if (file_protos_tc[i].alproto == ALPROTO_HTTP1) {
-            // special case for HTTP1
-            DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2,
-                    PrefilterMpmHTTPFiledataRegister, NULL, ALPROTO_HTTP1, HTP_RESPONSE_BODY);
-            DetectAppLayerInspectEngineRegister2("file_data", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
-                    HTP_RESPONSE_BODY, DetectEngineInspectBufferHttpBody, NULL);
-            continue;
-        }
-        DetectAppLayerMpmRegister2("file_data", SIG_FLAG_TOCLIENT, 2, PrefilterMpmFiledataRegister,
-                NULL, file_protos_tc[i].alproto, file_protos_tc[i].progress);
-        DetectAppLayerInspectEngineRegister2("file_data", file_protos_tc[i].alproto,
-                SIG_FLAG_TOCLIENT, file_protos_tc[i].progress, DetectEngineInspectFiledata, NULL);
-    }
-    DetectBufferTypeRegisterSetupCallback("file_data",
-            DetectFiledataSetupCallback);
+    filehandler_table[DETECT_FILE_DATA].name = "file_data";
+    filehandler_table[DETECT_FILE_DATA].priority = 2;
+    filehandler_table[DETECT_FILE_DATA].PrefilterFn = PrefilterMpmFiledataRegister;
+    filehandler_table[DETECT_FILE_DATA].Callback = DetectEngineInspectFiledata;
+
+    DetectBufferTypeRegisterSetupCallback("file_data", DetectFiledataSetupCallback);
 
     DetectBufferTypeSetDescriptionByName("file_data", "data from tracked files");
     DetectBufferTypeSupportsMultiInstance("file_data");
@@ -197,235 +171,6 @@ static void PrefilterMpmFiledataFree(void *ptr)
     SCFree(ptr);
 }
 
-/* HTTP based detection */
-
-static inline HtpBody *GetResponseBody(htp_tx_t *tx)
-{
-    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
-    if (htud == NULL) {
-        SCLogDebug("no htud");
-        return NULL;
-    }
-
-    return &htud->response_body;
-}
-
-static inline InspectionBuffer *HttpServerBodyXformsGetDataCallback(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, const int list_id, InspectionBuffer *base_buffer)
-{
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect != NULL)
-        return buffer;
-
-    InspectionBufferSetup(det_ctx, list_id, buffer, base_buffer->inspect, base_buffer->inspect_len);
-    buffer->inspect_offset = base_buffer->inspect_offset;
-    InspectionBufferApplyTransforms(buffer, transforms);
-    SCLogDebug("xformed buffer %p size %u", buffer, buffer->inspect_len);
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
-static InspectionBuffer *HttpServerBodyGetDataCallback(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, const int base_id)
-{
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, base_id);
-    if (base_id != list_id && buffer->inspect != NULL)
-        return HttpServerBodyXformsGetDataCallback(det_ctx, transforms, list_id, buffer);
-    else if (buffer->inspect != NULL)
-        return buffer;
-
-    htp_tx_t *tx = txv;
-    HtpState *htp_state = f->alstate;
-    const uint8_t flags = flow_flags;
-
-    HtpBody *body = GetResponseBody(tx);
-    if (body == NULL) {
-        return NULL;
-    }
-
-    /* no new data */
-    if (body->body_inspected == body->content_len_so_far) {
-        SCLogDebug("no new data");
-        return NULL;
-    }
-
-    HtpBodyChunk *cur = body->first;
-    if (cur == NULL) {
-        SCLogDebug("No http chunks to inspect for this transaction");
-        return NULL;
-    }
-
-    SCLogDebug("response.body_limit %u response_body.content_len_so_far %" PRIu64
-               ", response.inspect_min_size %" PRIu32 ", EOF %s, progress > body? %s",
-            htp_state->cfg->response.body_limit, body->content_len_so_far,
-            htp_state->cfg->response.inspect_min_size, flags & STREAM_EOF ? "true" : "false",
-            (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) >
-                    HTP_RESPONSE_BODY)
-                    ? "true"
-                    : "false");
-
-    if (!htp_state->cfg->http_body_inline) {
-        /* inspect the body if the transfer is complete or we have hit
-        * our body size limit */
-        if ((htp_state->cfg->response.body_limit == 0 ||
-                    body->content_len_so_far < htp_state->cfg->response.body_limit) &&
-                body->content_len_so_far < htp_state->cfg->response.inspect_min_size &&
-                !(AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) >
-                        HTP_RESPONSE_BODY) &&
-                !(flags & STREAM_EOF)) {
-            SCLogDebug("we still haven't seen the entire response body.  "
-                       "Let's defer body inspection till we see the "
-                       "entire body.");
-            return NULL;
-        }
-    }
-
-    /* get the inspect buffer
-     *
-     * make sure that we have at least the configured inspect_win size.
-     * If we have more, take at least 1/4 of the inspect win size before
-     * the new data.
-     */
-    uint64_t offset = 0;
-    if (body->body_inspected > htp_state->cfg->response.inspect_min_size) {
-        BUG_ON(body->content_len_so_far < body->body_inspected);
-        uint64_t inspect_win = body->content_len_so_far - body->body_inspected;
-        SCLogDebug("inspect_win %"PRIu64, inspect_win);
-        if (inspect_win < htp_state->cfg->response.inspect_window) {
-            uint64_t inspect_short = htp_state->cfg->response.inspect_window - inspect_win;
-            if (body->body_inspected < inspect_short)
-                offset = 0;
-            else
-                offset = body->body_inspected - inspect_short;
-        } else {
-            offset = body->body_inspected - (htp_state->cfg->response.inspect_window / 4);
-        }
-    }
-
-    const uint8_t *data;
-    uint32_t data_len;
-
-    StreamingBufferGetDataAtOffset(body->sb,
-            &data, &data_len, offset);
-    InspectionBufferSetup(det_ctx, base_id, buffer, data, data_len);
-    buffer->inspect_offset = offset;
-    body->body_inspected = body->content_len_so_far;
-    SCLogDebug("body->body_inspected now: %" PRIu64, body->body_inspected);
-
-    /* built-in 'transformation' */
-    if (htp_state->cfg->swf_decompression_enabled) {
-        int swf_file_type = FileIsSwfFile(data, data_len);
-        if (swf_file_type == FILE_SWF_ZLIB_COMPRESSION ||
-            swf_file_type == FILE_SWF_LZMA_COMPRESSION)
-        {
-            (void)FileSwfDecompression(data, data_len,
-                                       det_ctx,
-                                       buffer,
-                                       htp_state->cfg->swf_compression_type,
-                                       htp_state->cfg->swf_decompress_depth,
-                                       htp_state->cfg->swf_compress_depth);
-        }
-    }
-
-    if (base_id != list_id) {
-        buffer = HttpServerBodyXformsGetDataCallback(det_ctx, transforms, list_id, buffer);
-    }
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
-static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
-        DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
-        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id)
-{
-    bool eof =
-            (AppLayerParserGetStateProgress(f->proto, f->alproto, txv, flags) > engine->progress);
-    const InspectionBuffer *buffer = HttpServerBodyGetDataCallback(
-            det_ctx, engine->v2.transforms, f, flags, txv, engine->sm_list, engine->sm_list_base);
-    if (buffer == NULL || buffer->inspect == NULL) {
-        return eof ? DETECT_ENGINE_INSPECT_SIG_CANT_MATCH : DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
-    }
-
-    const uint32_t data_len = buffer->inspect_len;
-    const uint8_t *data = buffer->inspect;
-    const uint64_t offset = buffer->inspect_offset;
-
-    uint8_t ci_flags = eof ? DETECT_CI_FLAGS_END : 0;
-    ci_flags |= (offset == 0 ? DETECT_CI_FLAGS_START : 0);
-    ci_flags |= buffer->flags;
-
-    det_ctx->discontinue_matching = 0;
-    det_ctx->buffer_offset = 0;
-    det_ctx->inspection_recursion_counter = 0;
-
-    /* Inspect all the uricontents fetched on each
-     * transaction at the app layer */
-    int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
-            data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
-    if (r == 1) {
-        return DETECT_ENGINE_INSPECT_SIG_MATCH;
-    }
-
-    if (flags & STREAM_TOSERVER) {
-        if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, txv, flags) >
-                HTP_REQUEST_BODY)
-            return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
-    } else {
-        if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, txv, flags) >
-                HTP_RESPONSE_BODY)
-            return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
-    }
-    return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
-}
-
-/** \brief Filedata Filedata Mpm prefilter callback
- *
- *  \param det_ctx detection engine thread ctx
- *  \param pectx inspection context
- *  \param p packet to inspect
- *  \param f flow to inspect
- *  \param txv tx to inspect
- *  \param idx transaction id
- *  \param flags STREAM_* flags including direction
- */
-static void PrefilterTxHTTPFiledata(DetectEngineThreadCtx *det_ctx, const void *pectx, Packet *p,
-        Flow *f, void *txv, const uint64_t idx, const AppLayerTxData *_txd, const uint8_t flags)
-{
-    SCEnter();
-
-    const PrefilterMpmFiledata *ctx = (const PrefilterMpmFiledata *)pectx;
-    const MpmCtx *mpm_ctx = ctx->mpm_ctx;
-    const int list_id = ctx->list_id;
-
-    InspectionBuffer *buffer = HttpServerBodyGetDataCallback(
-            det_ctx, ctx->transforms, f, flags, txv, list_id, ctx->base_list_id);
-    if (buffer == NULL)
-        return;
-
-    if (buffer->inspect_len >= mpm_ctx->minlen) {
-        (void)mpm_table[mpm_ctx->mpm_type].Search(
-                mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
-        PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
-    }
-}
-
-static int PrefilterMpmHTTPFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
-        MpmCtx *mpm_ctx, const DetectBufferMpmRegistry *mpm_reg, int list_id)
-{
-    PrefilterMpmFiledata *pectx = SCCalloc(1, sizeof(*pectx));
-    if (pectx == NULL)
-        return -1;
-    pectx->list_id = list_id;
-    pectx->base_list_id = mpm_reg->sm_list_base;
-    SCLogDebug("list_id %d base_list_id %d", list_id, pectx->base_list_id);
-    pectx->mpm_ctx = mpm_ctx;
-    pectx->transforms = &mpm_reg->transforms;
-
-    return PrefilterAppendTxEngine(de_ctx, sgh, PrefilterTxHTTPFiledata, mpm_reg->app_v2.alproto,
-            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterMpmFiledataFree, mpm_reg->pname);
-}
-
 /* file API based inspection */
 
 static inline InspectionBuffer *FiledataWithXformsGetDataCallback(DetectEngineThreadCtx *det_ctx,
@@ -450,7 +195,7 @@ static inline InspectionBuffer *FiledataWithXformsGetDataCallback(DetectEngineTh
 
 static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, uint8_t flow_flags, File *cur_file,
-        const int list_id, const int base_id, int local_file_id)
+        const int list_id, const int base_id, int local_file_id, void *txv)
 {
     SCEnter();
     SCLogDebug("starting: list_id %d base_id %d", list_id, base_id);
@@ -472,9 +217,8 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
     const uint64_t file_size = FileDataSize(cur_file);
     const DetectEngineCtx *de_ctx = det_ctx->de_ctx;
     const uint32_t content_limit = de_ctx->filedata_config[f->alproto].content_limit;
-    const uint32_t content_inspect_min_size = de_ctx->filedata_config[f->alproto].content_inspect_min_size;
-    // TODO this is unused, is that right?
-    //const uint32_t content_inspect_window = de_ctx->filedata_config[f->alproto].content_inspect_window;
+    const uint32_t content_inspect_min_size =
+            de_ctx->filedata_config[f->alproto].content_inspect_min_size;
 
     SCLogDebug("[list %d] content_limit %u, content_inspect_min_size %u", list_id, content_limit,
             content_inspect_min_size);
@@ -485,40 +229,121 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
     /* no new data */
     if (cur_file->content_inspected == file_size) {
         SCLogDebug("no new data");
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
+        goto empty_return;
     }
 
     if (file_size == 0) {
         SCLogDebug("no data to inspect for this transaction");
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
+        goto empty_return;
     }
 
-    if ((content_limit == 0 || file_size < content_limit) &&
-        file_size < content_inspect_min_size &&
-        !(flow_flags & STREAM_EOF) && !(cur_file->state > FILE_STATE_OPENED)) {
-        SCLogDebug("we still haven't seen the entire content. "
-                   "Let's defer content inspection till we see the "
-                   "entire content.");
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
+    uint64_t offset = 0;
+    if (f->alproto == ALPROTO_HTTP1) {
+
+        htp_tx_t *tx = txv;
+        HtpState *htp_state = f->alstate;
+
+        SCLogDebug("response.body_limit %u file_size %" PRIu64
+                   ", cur_file->inspect_min_size %" PRIu32 ", EOF %s, progress > body? %s",
+                htp_state->cfg->response.body_limit, file_size, cur_file->inspect_min_size,
+                flow_flags & STREAM_EOF ? "true" : "false",
+                (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flow_flags) >
+                        HTP_RESPONSE_BODY)
+                        ? "true"
+                        : "false");
+
+        if (!htp_state->cfg->http_body_inline) {
+            /* inspect the body if the transfer is complete or we have hit
+             * our body size limit */
+            if ((htp_state->cfg->response.body_limit == 0 ||
+                        file_size < htp_state->cfg->response.body_limit) &&
+                    file_size < cur_file->inspect_min_size &&
+                    !(AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flow_flags) >
+                            HTP_RESPONSE_BODY) &&
+                    !(flow_flags & STREAM_EOF)) {
+                SCLogDebug("we still haven't seen the entire response body.  "
+                           "Let's defer body inspection till we see the "
+                           "entire body.");
+                goto empty_return;
+            }
+            SCLogDebug("inline and we're continuing");
+        }
+
+        /* get the inspect buffer
+         *
+         * make sure that we have at least the configured inspect_win size.
+         * If we have more, take at least 1/4 of the inspect win size before
+         * the new data.
+         */
+        SCLogDebug("file_size %ld cur_file->content_inspected %ld cur_file->inspect_min_size %d",
+                file_size, cur_file->content_inspected, cur_file->inspect_min_size);
+        if (cur_file->content_inspected > cur_file->inspect_min_size) {
+            BUG_ON(file_size < cur_file->content_inspected);
+            uint64_t inspect_win = file_size - cur_file->content_inspected;
+            SCLogDebug("inspect_win %" PRIu64 " cur_file->inspect_window: %d", inspect_win,
+                    cur_file->inspect_window);
+            if (inspect_win < cur_file->inspect_window) {
+                uint64_t inspect_short = cur_file->inspect_window - inspect_win;
+                if (cur_file->content_inspected >= inspect_short) {
+                    offset = cur_file->content_inspected - inspect_short;
+                    SCLogDebug("%ld = file_size[%ld] - inspect_short[%ld]", offset, file_size,
+                            inspect_short);
+                }
+            } else {
+                offset = file_size - (cur_file->inspect_window / 4);
+                SCLogDebug("%ld = file_size - (cur_file->inspect_window / 4", offset);
+            }
+            SCLogDebug("content_inspected %ld, offset %ld", cur_file->content_inspected, offset);
+            offset = MIN(cur_file->content_inspected, offset);
+        } else {
+            offset = cur_file->content_inspected;
+        }
+
+    } else {
+        if ((content_limit == 0 || file_size < content_limit) &&
+                file_size < content_inspect_min_size && !(flow_flags & STREAM_EOF) &&
+                !(cur_file->state > FILE_STATE_OPENED)) {
+            SCLogDebug("we still haven't seen the entire content. "
+                       "Let's defer content inspection till we see the "
+                       "entire content. We've seen %ld and need at least %d",
+                    file_size, content_inspect_min_size);
+            goto empty_return;
+        }
+        offset = cur_file->content_inspected;
     }
 
     const uint8_t *data;
     uint32_t data_len;
 
-    StreamingBufferGetDataAtOffset(cur_file->sb,
-            &data, &data_len,
-            cur_file->content_inspected);
+    SCLogDebug("Fetching data at offset: %ld", offset);
+    StreamingBufferGetDataAtOffset(cur_file->sb, &data, &data_len, offset);
+    /* update inspected tracker */
+    buffer->inspect_offset = offset;
+    //cur_file->content_inspected = offset + data_len;
+    SCLogDebug("content inspected: %" PRIu64, cur_file->content_inspected);
+
     InspectionBufferSetupMulti(buffer, NULL, data, data_len);
     SCLogDebug("[list %d] [before] buffer offset %" PRIu64 "; buffer len %" PRIu32
                "; data_len %" PRIu32 "; file_size %" PRIu64,
             list_id, buffer->inspect_offset, buffer->inspect_len, data_len, file_size);
-    buffer->inspect_offset = cur_file->content_inspected;
 
-    /* update inspected tracker */
-    cur_file->content_inspected = buffer->inspect_len + buffer->inspect_offset;
+    if (f->alproto == ALPROTO_HTTP1 && flow_flags & STREAM_TOCLIENT) {
+        HtpState *htp_state = f->alstate;
+        /* built-in 'transformation' */
+        if (htp_state->cfg->swf_decompression_enabled) {
+            int swf_file_type = FileIsSwfFile(data, data_len);
+            if (swf_file_type == FILE_SWF_ZLIB_COMPRESSION ||
+                    swf_file_type == FILE_SWF_LZMA_COMPRESSION) {
+                SCLogDebug("decompressing ...");
+                (void)FileSwfDecompression(data, data_len, det_ctx, buffer,
+                        htp_state->cfg->swf_compression_type, htp_state->cfg->swf_decompress_depth,
+                        htp_state->cfg->swf_compress_depth);
+                SCLogDebug("uncompressed buffer %p size %u; buf: \"%s\"", buffer,
+                        buffer->inspect_len, (char *)buffer->inspect);
+            }
+        }
+    }
+
     SCLogDebug("content inspected: %" PRIu64, cur_file->content_inspected);
 
     /* get buffer for the list id if it is different from the base id */
@@ -527,19 +352,20 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
         InspectionBuffer *tbuffer = FiledataWithXformsGetDataCallback(
                 det_ctx, transforms, list_id, local_file_id, buffer);
         SCReturnPtr(tbuffer, "InspectionBuffer");
-    } else {
-        SCLogDebug("regular buffer %p size %u", buffer, buffer->inspect_len);
-        SCReturnPtr(buffer, "InspectionBuffer");
     }
+    SCLogDebug("regular buffer %p size %ld; buf: \"%.*s\"", buffer, cur_file->content_inspected,
+            buffer->inspect_len, (char *)buffer->inspect);
+    SCReturnPtr(buffer, "InspectionBuffer");
+
+empty_return:
+    InspectionBufferSetupMultiEmpty(buffer);
+    return NULL;
 }
 
 uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id)
 {
-    int r = 0;
-    int match = 0;
-
     const DetectEngineTransforms *transforms = NULL;
     if (!engine->mpm) {
         transforms = engine->v2.transforms;
@@ -551,11 +377,12 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
     }
 
+    bool match = false;
     int local_file_id = 0;
     File *file = ffc->head;
     for (; file != NULL; file = file->next) {
         InspectionBuffer *buffer = FiledataGetDataCallback(det_ctx, transforms, f, flags, file,
-                engine->sm_list, engine->sm_list_base, local_file_id);
+                engine->sm_list, engine->sm_list_base, local_file_id, txv);
         if (buffer == NULL)
             continue;
 
@@ -573,14 +400,13 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
                                               buffer->inspect_len,
                                               buffer->inspect_offset, ciflags,
                                               DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
-        if (match == 1) {
-            r = 1;
+        if (match) {
             break;
         }
         local_file_id++;
     }
 
-    if (r == 1)
+    if (match)
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     else
         return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
@@ -614,7 +440,7 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
         int local_file_id = 0;
         for (File *file = ffc->head; file != NULL; file = file->next) {
             InspectionBuffer *buffer = FiledataGetDataCallback(det_ctx, ctx->transforms, f, flags,
-                    file, list_id, ctx->base_list_id, local_file_id);
+                    file, list_id, ctx->base_list_id, local_file_id, txv);
             if (buffer == NULL)
                 continue;
 

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -54,6 +54,7 @@
 
 #include "stream-tcp.h"
 
+#include "detect-file-data.h"
 #include "detect-filemagic.h"
 
 #include "conf.h"
@@ -134,27 +135,14 @@ void DetectFilemagicRegister(void)
     sigmatch_table[DETECT_FILE_MAGIC].Setup = DetectFilemagicSetupSticky;
     sigmatch_table[DETECT_FILE_MAGIC].flags = SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
 
+    filehandler_table[DETECT_FILE_MAGIC].name = "file.magic",
+    filehandler_table[DETECT_FILE_MAGIC].priority = 2;
+    filehandler_table[DETECT_FILE_MAGIC].PrefilterFn = PrefilterMpmFilemagicRegister;
+    filehandler_table[DETECT_FILE_MAGIC].Callback = DetectEngineInspectFilemagic;
+
     g_file_match_list_id = DetectBufferTypeRegister("files");
 
-    for (int i = 0; file_protos_ts[i].alproto != ALPROTO_UNKNOWN; i++) {
-        DetectAppLayerInspectEngineRegister2("file.magic", file_protos_ts[i].alproto,
-                SIG_FLAG_TOSERVER, file_protos_ts[i].progress, DetectEngineInspectFilemagic, NULL);
-
-        DetectAppLayerMpmRegister2("file.magic", SIG_FLAG_TOSERVER, 2,
-                PrefilterMpmFilemagicRegister, NULL, file_protos_ts[i].alproto,
-                file_protos_ts[i].progress);
-    }
-    for (int i = 0; file_protos_tc[i].alproto != ALPROTO_UNKNOWN; i++) {
-        DetectAppLayerInspectEngineRegister2("file.magic", file_protos_tc[i].alproto,
-                SIG_FLAG_TOCLIENT, file_protos_tc[i].progress, DetectEngineInspectFilemagic, NULL);
-
-        DetectAppLayerMpmRegister2("file.magic", SIG_FLAG_TOCLIENT, 2,
-                PrefilterMpmFilemagicRegister, NULL, file_protos_tc[i].alproto,
-                file_protos_tc[i].progress);
-    }
-
-    DetectBufferTypeSetDescriptionByName("file.magic",
-            "file magic");
+    DetectBufferTypeSetDescriptionByName("file.magic", "file magic");
     DetectBufferTypeSupportsMultiInstance("file.magic");
 
     g_file_magic_buffer_id = DetectBufferTypeGetByName("file.magic");

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -28,8 +28,6 @@
 #include "decode.h"
 
 #include "detect.h"
-#include "detect-parse.h"
-#include "detect-content.h"
 
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
@@ -37,6 +35,10 @@
 #include "detect-engine-file.h"
 #include "detect-engine-prefilter.h"
 #include "detect-engine-content-inspection.h"
+
+#include "detect-parse.h"
+#include "detect-content.h"
+#include "detect-file-data.h"
 
 #include "flow.h"
 #include "flow-var.h"
@@ -103,45 +105,23 @@ void DetectFilenameRegister(void)
     sigmatch_table[DETECT_FILE_NAME].Setup = DetectFilenameSetupSticky;
     sigmatch_table[DETECT_FILE_NAME].flags = SIGMATCH_NOOPT|SIGMATCH_INFO_STICKY_BUFFER;
 
-    // this is required by filestore, and filesize
-    for (int i = 0; file_protos_ts[i].alproto != ALPROTO_UNKNOWN; i++) {
-        DetectAppLayerInspectEngineRegister2("files", file_protos_ts[i].alproto, SIG_FLAG_TOSERVER,
-                file_protos_ts[i].progress, DetectFileInspectGeneric, NULL);
-    }
-    for (int i = 0; file_protos_tc[i].alproto != ALPROTO_UNKNOWN; i++) {
-        DetectAppLayerInspectEngineRegister2("files", file_protos_tc[i].alproto, SIG_FLAG_TOCLIENT,
-                file_protos_tc[i].progress, DetectFileInspectGeneric, NULL);
-    }
-    g_file_match_list_id = DetectBufferTypeGetByName("files");
+    DetectBufferTypeSetDescriptionByName("file.name", "http user agent");
 
-    for (int i = 0; file_protos_ts[i].alproto != ALPROTO_UNKNOWN; i++) {
-        if (file_protos_ts[i].alproto == ALPROTO_HTTP2) {
-            // no filename on HTTP2 files
-            continue;
-        }
-        DetectAppLayerInspectEngineRegister2("file.name", file_protos_ts[i].alproto,
-                SIG_FLAG_TOSERVER, file_protos_ts[i].progress, DetectEngineInspectFilename, NULL);
+    g_file_match_list_id = DetectBufferTypeRegister("files");
+    g_file_name_buffer_id = DetectBufferTypeRegister("file.name");
 
-        DetectAppLayerMpmRegister2("file.name", SIG_FLAG_TOSERVER, 2, PrefilterMpmFilenameRegister,
-                NULL, file_protos_ts[i].alproto, file_protos_ts[i].progress);
-    }
-    for (int i = 0; file_protos_tc[i].alproto != ALPROTO_UNKNOWN; i++) {
-        if (file_protos_tc[i].alproto == ALPROTO_HTTP2) {
-            // no filename on HTTP2 files
-            continue;
-        }
-        DetectAppLayerInspectEngineRegister2("file.name", file_protos_tc[i].alproto,
-                SIG_FLAG_TOCLIENT, file_protos_tc[i].progress, DetectEngineInspectFilename, NULL);
+    SCLogDebug("registering filename rule option");
+    filehandler_table[DETECT_FILENAME].name = "files";
+    filehandler_table[DETECT_FILENAME].priority = 0;
+    filehandler_table[DETECT_FILENAME].PrefilterFn = NULL;
+    filehandler_table[DETECT_FILENAME].Callback = DetectFileInspectGeneric;
 
-        DetectAppLayerMpmRegister2("file.name", SIG_FLAG_TOCLIENT, 2, PrefilterMpmFilenameRegister,
-                NULL, file_protos_tc[i].alproto, file_protos_tc[i].progress);
-    }
+    filehandler_table[DETECT_FILE_NAME].name = "file.name";
+    filehandler_table[DETECT_FILE_NAME].priority = 2;
+    filehandler_table[DETECT_FILE_NAME].PrefilterFn = PrefilterMpmFilenameRegister;
+    filehandler_table[DETECT_FILE_NAME].Callback = DetectEngineInspectFilename;
 
-    DetectBufferTypeSetDescriptionByName("file.name", "file name");
     DetectBufferTypeSupportsMultiInstance("file.name");
-
-    g_file_name_buffer_id = DetectBufferTypeGetByName("file.name");
-	SCLogDebug("registering filename rule option");
     return;
 }
 

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -25,6 +25,24 @@
 #define __DETECT_PARSE_H__
 
 #include "detect.h"
+#include "detect-engine-mpm.h"
+
+/* File handler registration */
+#define MAX_DETECT_ALPROTO_CNT 10
+typedef struct DetectFileHandlerTableElmt_ {
+    const char *name;
+    int priority;
+    PrefilterRegisterFunc PrefilterFn;
+    InspectEngineFuncPtr2 Callback;
+    InspectionBufferGetDataPtr GetData;
+    int al_protocols[MAX_DETECT_ALPROTO_CNT];
+    int tx_progress;
+    int progress;
+} DetectFileHandlerTableElmt;
+void DetectFileRegisterFileProtocols(DetectFileHandlerTableElmt *entry);
+
+/* File registration table */
+extern DetectFileHandlerTableElmt filehandler_table[DETECT_TBLSIZE];
 
 /** Flags to indicate if the Signature parsing must be done
 *   switching the source and dest (for ip addresses and ports)
@@ -104,4 +122,3 @@ int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UC
         PCRE2_SIZE *bufflen);
 
 #endif /* __DETECT_PARSE_H__ */
-

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -1770,6 +1770,10 @@ int StreamingBufferGetDataAtOffset (const StreamingBuffer *sb,
         uint64_t offset)
 {
     const StreamingBufferRegion *region = GetRegionForOffset(sb, offset);
+#if 0
+    SCLogNotice("offset %ld, region available: [%ld - %ld]", offset, region->stream_offset,
+           region->stream_offset + region->buf_offset);
+#endif
     if (region != NULL && region->buf != NULL && offset >= region->stream_offset &&
             offset < (region->stream_offset + region->buf_offset)) {
         uint32_t skip = offset - region->stream_offset;


### PR DESCRIPTION
This commit is *draft* and demonstrates an approach to common registrations for file data.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4145](https://redmine.openinfosecfoundation.org/issues/4145)

Describe changes:
- Build on 4141 use common handling for all file based detection

With changes:
```
$ hyperfine -m3 'sudo rm -rf /tmp/ll/* && ./src/suricata -c suricata.yaml -l /tmp/ll -S ~/suricata.rules -r ~/TLP_WHITE-smb-16kfiles-no-close.pcap --set outputs.1.eve-log.threaded=true'
Benchmark 1: sudo rm -rf /tmp/ll/* && ./src/suricata -c suricata.yaml -l /tmp/ll -S ~/suricata.rules -r ~/TLP_WHITE-smb-16kfiles-no-close.pcap --set outputs.1.eve-log.threaded=true
  Time (mean ± σ):     1506.882 s ± 30.635 s    [User: 1522.916 s, System: 65.111 s]
  Range (min … max):   1476.483 s … 1537.747 s    3 runs
  ```

Comparative numbers from `master`:
```
$ hyperfine -m3 'sudo rm -rf /tmp/ll/* && ./src/suricata -c suricata.yaml -l /tmp/ll -S ~/suricata.rules -r ~/TLP_WHITE-smb-16kfiles-no-close.pcap --set outputs.1.eve-log.threaded=true'
Benchmark 1: sudo rm -rf /tmp/ll/* && ./src/suricata -c suricata.yaml -l /tmp/ll -S ~/suricata.rules -r ~/TLP_WHITE-smb-16kfiles-no-close.pcap --set outputs.1.eve-log.threaded=true
  Time (mean ± σ):     1555.037 s ± 25.689 s    [User: 1577.058 s, System: 62.196 s]
  Range (min … max):   1528.016 s … 1579.144 s    3 runs
  ```
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=pr/389
```
