### PR TITLE
flow: fix exception policy w/ simulated flow memcap (6.0.x backports) - v1

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -541,6 +541,8 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     const bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 #ifdef DEBUG
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
+        NoFlowHandleIPS(p);
+        StatsIncr(tv, fls->dtv->counter_flow_memcap);
         return NULL;
     }
 #endif


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
back port - https://redmine.openinfosecfoundation.org/issues/5999
original - https://redmine.openinfosecfoundation.org/issues/5998


Describe changes:
- ensure that the exception policy for flowmemcap also works when we're using the command-line option to simulate said memcap
- since the flowmemcap is happening, also increase related stats counter there

```
SV_REPO=
SV_BRANCH=pr/1191
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
