### PR TITLE
detect: fix break loop for timeout based rule reload - v3

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2278,7 +2278,7 @@ retry:
         if (SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) == 1) {
             SCLogDebug("new_det_ctx - %p used by detect engine", new_det_ctx[i]);
             threads_done++;
-        } else if (detect_tvs[i]->break_loop) {
+        } else {
             TmThreadsCaptureBreakLoop(detect_tvs[i]);
         }
     }

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -255,9 +255,6 @@ static inline void TmThreadsCaptureHandleTimeout(ThreadVars *tv, Packet *p)
 
 static inline void TmThreadsCaptureBreakLoop(ThreadVars *tv)
 {
-    if (unlikely(!tv->break_loop))
-        return;
-
     if ((tv->tmm_flags & TM_FLAG_RECEIVE_TM) == 0) {
         return;
     }


### PR DESCRIPTION
Previous PR:
- https://github.com/OISF/suricata/pull/8768

Changes from PR:
- Use cleaner/simpler fix as commented on by @tugtugtug
  (https://github.com/OISF/suricata/pull/8765#discussion_r1179264941)

As part of 6d8b50b748844e9de6010cde5a6b139148c0e937, the settings of
THV_CAPTURE_INJECT_PKT ended up in a location unreachable by capture
methods that did not have PktAcqBreakLoop.

Instead, always call TmThreadsCaptureBreakLoop which handles the logic
for how the read loop should be broken.

This fixes the case where read threads won't "break" for rule reloads
until packets are seen.

Ticket: https://redmine.openinfosecfoundation.org/issues/6021
