### PR TITLE
log/file: Reduce log file flush frequency, if configured.

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -30,6 +30,12 @@ Output types::
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
+      # Control for calls to flush file contents:
+      # - 0 Flush after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -279,7 +285,7 @@ The example above adds epoch time to the filename. All the date modifiers from t
 C library should be supported. See the man page for ``strftime`` for all supported
 modifiers.
 
-.. _output_eve_rotate:
+.. _output_eve_threaded:
 
 Threaded file output
 ~~~~~~~~~~~~~~~~~~~~
@@ -300,6 +306,32 @@ the aggregate of each file's contents must be treated together.
 This example will cause each Suricata thread to write to its own "eve.json" file. Filenames are constructed
 by adding a unique identifier to the filename.  For example, ``eve.7.json``.
 
+
+.. _output_eve_flush:
+
+Flushing file contents
+--~~~~~~~~~~~~~~~~~~~~
+
+By default, Suricata will call ``flush`` each time the file is written. ``flush-threshold``
+can be set to a byte-count to reduce the number of ``fflush`` calls. When non-zero, ``fflush`` is called
+when the bytes written to the file are equal to or exceed the value; subsequent calls to ``fflush`` occur.
+
+Reducing the number of ``fflush`` calls can reduce write overhead at the expense of risk of leaving
+up to ``flush-threshold`` bytes unbuffered/unwritten should Suricata unexpectedly terminate.
+
+The default value is ``0``.
+
+::
+
+   outputs:
+     - eve-log:
+         filename: eve.json
+         flush-threshold: 1024
+
+This example will cause Suricata to call ``fflush`` every time 1024 bytes have been written to ``eve.json``.
+
+
+.. _output_eve_rotate:
 
 Rotate log file
 ~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -7,6 +7,12 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json
       #threaded: false
+      # Control for calls to flush file contents:
+      # - 0 Flush contents after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/detect.h
+++ b/src/detect.h
@@ -307,9 +307,7 @@ typedef struct IPOnlyCIDRItem_ {
 /** \brief Used to start a pointer to SigMatch context
  * Should never be dereferenced without casting to something else.
  */
-typedef struct SigMatchCtx_ {
-    int foo;
-} SigMatchCtx;
+typedef void SigMatchCtx;
 
 /** \brief a single match condition for a signature */
 typedef struct SigMatch_ {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -88,6 +88,10 @@ typedef struct LogFileCtx_ {
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
 
+    /* use locked/nolocked versions */
+    void (*ClearError)(FILE *fp);
+    int (*Flush)(FILE *fp);
+
     LogFilePluginCtx plugin;
 
     /** It will be locked if the log/alert
@@ -160,6 +164,16 @@ typedef struct LogFileCtx_ {
     uint64_t dropped;
 
     uint64_t output_errors;
+
+    /* For reducing fflush() calls.
+     * A flush threshold can be applied -- the default value is 0 -- and calls
+     * to fflush() will occur if the threshold is 0 or the bytes written exceed
+     * the threshold
+     */
+    uint64_t flush_threshold;
+    uint64_t bytes_since_last_flush;
+    uint64_t flush_count;
+    ;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -95,6 +95,12 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
+      # Control for calls to flush file contents:
+      # - 0 Flush contents after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"


### PR DESCRIPTION
This PR provides a configurable way to reduce the number of times an output file is flushed.

By default, output files will continue to be flushed after each write. When a flush-threshold is configured, files will be flushed every `flush-threshold` bytes; the byte count since the last write is tracked and when it reaches or exceeds the threshold, the file will be flushed.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3449](https://redmine.openinfosecfoundation.org/issues/3449)

Describe changes:
- Refactor write/clearerror logic to remove duplication
- Add `flush-threshold` config setting to control `fflush` frequency
- When a threshold exists, track flush count and display (as perf) when output file is closed.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
