### PR TITLE
6.0.x backport: Add support for 'inner' PF_RING clustering modes

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1914,10 +1914,27 @@ is making use of clusters with the same id.
   cluster-id: 99
 
 Pf_ring can load balance traffic using pf_ring-clusters. All traffic
-for pf_ring can be load balanced in one of two ways, in a round robin
-manner or a per flow manner that are part of the same cluster. All
-traffic for pf_ring will be load balanced across acquisition threads
-of the same cluster id.
+for pf_ring can be load balanced according to the configured cluster
+type value; in a round robin manner or a per flow manner that are part
+of the same cluster. All traffic for pf_ring will be load balanced across
+acquisition threads of the same cluster id.
+
++----------------------------+--------------------------------------------------+
+| Cluster Type               | Value                                            |
++============================+==================================================+
+| cluster_flow               | src ip, src_port, dst ip, dst port, proto, vlan  |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow         | src ip, src port, dst ip, dst port, proto, vlan  |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_2_tuple | src ip, dst ip                                   |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_4_tuple | src ip, src port, dst ip, dst port               |
++----------------------------+--------------------------------------------------+
+| cluster_inner_flow_5_tuple | src ip, src port, dst ip, dst port, proto        |
++----------------------------+--------------------------------------------------+
+| cluster_round_robin        | not recommended                                  |
++----------------------------+--------------------------------------------------+
+
 
 The cluster_round_robin manner is a way of distributing packets one at
 a time to each thread (like distributing playing cards to fellow
@@ -1925,9 +1942,14 @@ players). The cluster_flow manner is a way of distributing all packets
 of the same flow to the same thread. The flows itself will be
 distributed to the threads in a round-robin manner.
 
+If your deployment has VLANs, the cluster types with "inner" will use the innermost
+tuple for distribution.
+
+Round-robin is not recommended with Suricata.
+
 ::
 
-   cluster-type: cluster_round_robin
+   cluster-type: cluster_inner_flow_5_tuple
 
 .. _suricata-yaml-nfq:
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1919,6 +1919,9 @@ type value; in a round robin manner or a per flow manner that are part
 of the same cluster. All traffic for pf_ring will be load balanced across
 acquisition threads of the same cluster id.
 
+The "inner" flow means that the traffic will be load balanced based on
+address tuple after the outer vlan has been removed.
+
 +----------------------------+--------------------------------------------------+
 | Cluster Type               | Value                                            |
 +============================+==================================================+
@@ -1943,9 +1946,9 @@ of the same flow to the same thread. The flows itself will be
 distributed to the threads in a round-robin manner.
 
 If your deployment has VLANs, the cluster types with "inner" will use the innermost
-tuple for distribution.
+address tuple for distribution.
 
-Round-robin is not recommended with Suricata.
+The default cluster type is ``cluster_flow``; the ``cluster_round_robin`` is not recommended with Suricata.
 
 ::
 

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -87,7 +87,7 @@ static void PfringDerefConfig(void *conf)
  * to thread or to reparse the file for each thread (and thus have
  * new structure.
  *
- * If old config system is used, then return the smae parameters
+ * If old config system is used, then return the same parameters
  * value for each interface.
  *
  * \return a PfringIfaceConfig corresponding to the interface name

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -368,6 +368,21 @@ static void *ParsePfringConfig(const char *iface)
             SCLogInfo("Using flow cluster mode for PF_RING (iface %s)",
                     pfconf->iface);
             pfconf->ctype = CLUSTER_FLOW;
+        } else if (strcmp(tmpctype, "cluster_inner_flow") == 0) {
+            SCLogInfo("Using flow cluster mode inner mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_2_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 2 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_2_TUPLE;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_4_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 4 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_4_TUPLE;
+        } else if (strcmp(tmpctype, "cluster_inner_flow_5_tuple") == 0) {
+            SCLogInfo(
+                    "Using flow cluster inner 5 tuple mode for PF_RING (iface %s)", pfconf->iface);
+            pfconf->ctype = CLUSTER_INNER_FLOW_5_TUPLE;
         } else {
             SCLogError(SC_ERR_INVALID_CLUSTER_TYPE,
                        "invalid cluster-type %s",

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -98,7 +98,7 @@ static void *OldParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    cluster_type default_ctype = CLUSTER_FLOW;
 
     if (unlikely(pfconf == NULL)) {
         return NULL;
@@ -202,7 +202,7 @@ static void *ParsePfringConfig(const char *iface)
     PfringIfaceConfig *pfconf = SCMalloc(sizeof(*pfconf));
     const char *tmpclusterid;
     const char *tmpctype = NULL;
-    cluster_type default_ctype = CLUSTER_ROUND_ROBIN;
+    cluster_type default_ctype = CLUSTER_FLOW;
     int getctype = 0;
     const char *bpf_filter = NULL;
     int bool_val;
@@ -361,7 +361,8 @@ static void *ParsePfringConfig(const char *iface)
 
     if (getctype) {
         if (strcmp(tmpctype, "cluster_round_robin") == 0) {
-            SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)",
+            SCLogInfo("Using round-robin cluster mode for PF_RING (iface %s)."
+                      " This mode is not recommended.",
                     pfconf->iface);
             pfconf->ctype = CLUSTER_ROUND_ROBIN;
         } else if (strcmp(tmpctype, "cluster_flow") == 0) {

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -229,7 +229,9 @@ static inline void PfringProcessPacket(void *user, struct pfring_pkthdr *h, Pack
 
     /* PF_RING may fail to set timestamp */
     if (h->ts.tv_sec == 0) {
-        gettimeofday((struct timeval *)&h->ts, NULL);
+        struct timeval tmp_ts;
+        gettimeofday(&tmp_ts, NULL);
+        h->ts = tmp_ts;
     }
 
     p->ts.tv_sec = h->ts.tv_sec;

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -155,7 +155,7 @@ struct PfringThreadVars_
 };
 
 /**
- * \brief Registration Function for RecievePfring.
+ * \brief Registration Function for ReceivePfring.
  * \todo Unit tests are needed for this module.
  */
 void TmModuleReceivePfringRegister (void)
@@ -327,9 +327,9 @@ static int PfringBypassCallback(Packet *p)
 #endif
 
 /**
- * \brief Recieves packets from an interface via libpfring.
+ * \brief Receives packets from an interface via libpfring.
  *
- *  This function recieves packets from an interface and passes
+ *  This function receives packets from an interface and passes
  *  the packet on to the pfring callback function.
  *
  * \param tv pointer to ThreadVars
@@ -466,9 +466,9 @@ TmEcode PfringBreakLoop(ThreadVars *tv, void *data)
 }
 
 /**
- * \brief Init function for RecievePfring.
+ * \brief Init function for ReceivePfring.
  *
- * This is a setup function for recieving packets
+ * This is a setup function for receiving packets
  * via libpfring.
  *
  * \param tv pointer to ThreadVars
@@ -622,7 +622,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
 #endif
 
     /* If kernel is older than 3.0, VLAN is not stripped so we don't
-     * get the info from packt extended header but we will use a standard
+     * get the info from packet extended header but we will use a standard
      * parsing */
     ptv->vlan_in_ext_header = 1;
     if (! SCKernelVersionIsAtLeast(3, 0)) {
@@ -737,7 +737,7 @@ TmEcode DecodePfring(ThreadVars *tv, Packet *p, void *data)
  * \brief This an Init function for DecodePfring
  *
  * \param tv pointer to ThreadVars
- * \param initdata pointer to initilization data.
+ * \param initdata pointer to initialization data.
  * \param data pointer that gets cast into PfringThreadVars for ptv
  * \retval TM_ECODE_OK is returned on success
  * \retval TM_ECODE_FAILED is returned on error

--- a/src/source-pfring.h
+++ b/src/source-pfring.h
@@ -69,8 +69,16 @@ void TmModuleDecodePfringRegister (void);
 int PfringConfGetThreads(void);
 void PfringLoadConfig(void);
 
-/* We don't have to use an enum that sucks in our code */
+/*
+ * We don't have to use an enum that sucks in our code
+ * these values must match with cluster_type in the kernel
+ * include file pf_ring.h
+ */
 #define CLUSTER_FLOW 0
 #define CLUSTER_ROUND_ROBIN 1
 #define CLUSTER_FLOW_5_TUPLE 4
+#define CLUSTER_INNER_FLOW         6
+#define CLUSTER_INNER_FLOW_2_TUPLE 7
+#define CLUSTER_INNER_FLOW_4_TUPLE 8
+#define CLUSTER_INNER_FLOW_5_TUPLE 9
 #endif /* __SOURCE_PFRING_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1765,7 +1765,13 @@ pfring:
     cluster-id: 99
 
     # Default PF_RING cluster type. PF_RING can load balance per flow.
-    # Possible values are cluster_flow or cluster_round_robin.
+    # Possible values are:
+    # - cluster_flow:               6-tuple: <src ip, src_port, dst ip, dst port, proto, vlan>
+    # - cluster_inner_flow:         6-tuple: <src ip, src port, dst ip, dst port, proto, vlan>
+    # - cluster_inner_flow_2_tuple: 2-tuple: <src ip,           dst ip                       >
+    # - cluster_inner_flow_4_tuple: 4-tuple: <src ip, src port, dst ip, dst port             >
+    # - cluster_inner_flow_5_tuple: 5-tuple: <src ip, src port, dst ip, dst port, proto      >
+    # - cluster_round_robin (NOT RECOMMENDED)
     cluster-type: cluster_flow
 
     # bpf filter for this interface


### PR DESCRIPTION
Continuation of #8803 

PF_RING backports to 6.0.x

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets: 
- [5996](https://redmine.openinfosecfoundation.org/issues/5996)
- [6034](https://redmine.openinfosecfoundation.org/issues/6034)

Describe changes:
- Fixes from [5975](https://redmine.openinfosecfoundation.org/issues/5975)
- Fixes from [6034](https://redmine.openinfosecfoundation.org/issues/6034)

Updates
- Removed commit that changed log message prefix to the interface name.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
