### PR TITLE
capture: use uint16_t for max_pending_packets

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -59,7 +59,7 @@
 #include "source-af-packet.h"
 #include "util-bpf.h"
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 const char *RunModeAFPGetDefaultMode(void)
 {

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -50,7 +50,7 @@
 #include "suricata.h"
 #include "util-bpf.h"
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 const char *RunModeNetmapGetDefaultMode(void)
 {

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -278,7 +278,7 @@ void RunUnittests(int list_unittests, const char *regex_arg)
         UtListTests(regex_arg);
     } else {
         /* global packet pool */
-        extern intmax_t max_pending_packets;
+        extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -118,7 +118,7 @@ struct bpf_program {
 
 #endif /* HAVE_AF_PACKET */
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 #ifndef HAVE_AF_PACKET
 

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -89,7 +89,7 @@ NoErfDagSupportExit(ThreadVars *tv, const void *initdata, void **data)
 /* Number of bytes per loop to process before fetching more data. */
 #define BYTES_PER_LOOP (4 * 1024 * 1024) /* 4 MB */
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 typedef struct ErfDagThreadVars_ {
     ThreadVars *tv;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -102,7 +102,7 @@ TmEcode NoIPFWSupportExit(ThreadVars *tv, const void *initdata, void **data)
 
 #include "action-globals.h"
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 /**
  * \brief Structure to hold thread specific variables.

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -79,7 +79,7 @@ TmEcode NoNapatechSupportExit(ThreadVars *tv, const void *initdata, void **data)
 #include <numa.h>
 #include <nt.h>
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 typedef struct NapatechThreadVars_
 {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -97,7 +97,7 @@ static TmEcode NoNFQSupportExit(ThreadVars *tv, const void *initdata, void **dat
 
 #else /* we do have NFQ support */
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 #define MAX_ALREADY_TREATED 5
 #define NFQ_VERDICT_RETRY_COUNT 3

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -31,7 +31,7 @@
 #include "source-pcap-file.h"
 #include "util-exception-policy.h"
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
 
 static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -32,7 +32,7 @@
 #include "runmode-unix-socket.h"
 #include "suricata.h"
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 PcapFileGlobalVars pcap_g;
 
 /**

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -57,7 +57,7 @@ TmEcode DecodePfringThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodePfring(ThreadVars *, Packet *, void *);
 TmEcode DecodePfringThreadDeinit(ThreadVars *tv, void *data);
 
-extern intmax_t max_pending_packets;
+extern uint16_t max_pending_packets;
 
 #ifndef HAVE_PFRING
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -176,7 +176,7 @@ static enum EngineMode g_engine_mode = ENGINE_MODE_UNKNOWN;
 uint8_t host_mode = SURI_HOST_IS_SNIFFER_ONLY;
 
 /** Maximum packets to simultaneously process. */
-intmax_t max_pending_packets;
+uint16_t max_pending_packets;
 
 /** global indicating if detection is enabled */
 int g_detect_disabled = 0;
@@ -2426,16 +2426,19 @@ static int ConfigGetCaptureValue(SCInstance *suri)
 {
     /* Pull the max pending packets from the config, if not found fall
      * back on a sane default. */
-    if (ConfGetInt("max-pending-packets", &max_pending_packets) != 1)
-        max_pending_packets = DEFAULT_MAX_PENDING_PACKETS;
-    if (max_pending_packets >= 65535) {
-        SCLogError("Maximum max-pending-packets setting is 65534. "
+    intmax_t tmp_max_pending_packets;
+    if (ConfGetInt("max-pending-packets", &tmp_max_pending_packets) != 1)
+        tmp_max_pending_packets = DEFAULT_MAX_PENDING_PACKETS;
+    if (tmp_max_pending_packets < 1 || tmp_max_pending_packets >= UINT16_MAX) {
+        SCLogError("Maximum max-pending-packets setting is 65534 and must be greater than 0. "
                    "Please check %s for errors",
                 suri->conf_filename);
         return TM_ECODE_FAILED;
+    } else {
+        max_pending_packets = (uint16_t)tmp_max_pending_packets;
     }
 
-    SCLogDebug("Max pending packets set to %"PRIiMAX, max_pending_packets);
+    SCLogDebug("Max pending packets set to %" PRIu16, max_pending_packets);
 
     /* Pull the default packet size from the config, if not found fall
      * back on a sane default. */

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -77,7 +77,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_DECODEPCAPFILE].ThreadInit(tv, NULL, (void **) &dtv);
         (void)SC_ATOMIC_SET(tv->tm_slots->slot_next->slot_data, dtv);
 
-        extern intmax_t max_pending_packets;
+        extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
 

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -96,7 +96,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern intmax_t max_pending_packets;
+        extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         if (DetectEngineReload(&surifuzz) < 0) {

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -89,7 +89,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern intmax_t max_pending_packets;
+        extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         initialized = 1;

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -115,7 +115,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern intmax_t max_pending_packets;
+        extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         initialized = 1;

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -283,7 +283,7 @@ void PacketPoolInitEmpty(void)
 
 void PacketPoolInit(void)
 {
-    extern intmax_t max_pending_packets;
+    extern uint16_t max_pending_packets;
 
     PktPool *my_pool = GetThreadPacketPool();
 
@@ -499,8 +499,8 @@ void TmqhReleasePacketsToPacketPool(PacketQueue *pq)
  */
 void PacketPoolPostRunmodes(void)
 {
-    extern intmax_t max_pending_packets;
-    intmax_t pending_packets = max_pending_packets;
+    extern uint16_t max_pending_packets;
+    uint16_t pending_packets = max_pending_packets;
     if (pending_packets < RESERVED_PACKETS) {
         FatalError("'max-pending-packets' setting "
                    "must be at least %d",


### PR DESCRIPTION
Use a fixed type of max_pending_packets instead of intmax_t which can differ based on the platform/standard library.

Should also prevent lints about possible arithmetic overflow.
