### PR TITLE
Zer1t0 fix/krb5 msg type v5

### DIFF
--- a/doc/userguide/rules/kerberos-keywords.rst
+++ b/doc/userguide/rules/kerberos-keywords.rst
@@ -4,25 +4,31 @@ Kerberos Keywords
 krb5_msg_type
 -------------
 
-Kerberos message type (integer).
-
-Values are defined in RFC4120. Common values are
+This keyword allows to match the Kerberos messages by its type (integer).
+It is possible to specify the following values defined in RFC4120:
 
 * 10 (AS-REQ)
 * 11 (AS-REP)
 * 12 (TGS-REQ)
 * 13 (TGS-REP)
-* 14 (AP-REQ)
-* 15 (AP-REP)
 * 30 (ERROR)
 
 Syntax::
 
  krb5_msg_type:<number>
 
-Signature example::
+Signature examples::
 
  alert krb5 any any -> any any (msg:"Kerberos 5 AS-REQ message"; krb5_msg_type:10; sid:3; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 AS-REP message"; krb5_msg_type:11; sid:4; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 TGS-REQ message"; krb5_msg_type:12; sid:5; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 TGS-REP message"; krb5_msg_type:13; sid:6; rev:1;)
+ alert krb5 any any -> any any (msg:"Kerberos 5 ERROR message"; krb5_msg_type:30; sid:7; rev:1;)
+
+
+.. note:: AP-REQ and AP-REP are not currently supported since those messages
+          are embedded in other application protocols.
+
 
 krb5_cname
 ----------

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -132,6 +132,16 @@ impl KRB5State {
                 if hdr.class() != Class::Application { return 0; }
                 match hdr.tag().0 {
                     10 => {
+                        let req = krb5_parser::parse_as_req(i);
+                        if let Ok((_,kdc_req)) = req {
+                            let mut tx = self.new_tx(direction);
+                            tx.msg_type = MessageType::KRB_AS_REQ;
+                            tx.cname = kdc_req.req_body.cname;
+                            tx.realm = Some(kdc_req.req_body.realm);
+                            tx.sname = kdc_req.req_body.sname;
+                            tx.etype = None;
+                            self.transactions.push(tx);
+                        };
                         self.req_id = 10;
                     },
                     11 => {
@@ -152,6 +162,16 @@ impl KRB5State {
                         self.req_id = 0;
                     },
                     12 => {
+                        let req = krb5_parser::parse_tgs_req(i);
+                        if let Ok((_,kdc_req)) = req {
+                            let mut tx = self.new_tx(direction);
+                            tx.msg_type = MessageType::KRB_TGS_REQ;
+                            tx.cname = kdc_req.req_body.cname;
+                            tx.realm = Some(kdc_req.req_body.realm);
+                            tx.sname = kdc_req.req_body.sname;
+                            tx.etype = None;
+                            self.transactions.push(tx);
+                        };
                         self.req_id = 12;
                     },
                     13 => {

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -201,7 +201,7 @@ impl KRB5State {
                         let res = krb5_parser::parse_krb_error(i);
                         if let Ok((_,error)) = res {
                             let mut tx = self.new_tx(direction);
-                            tx.msg_type = MessageType(self.req_id as u32);
+                            tx.msg_type = MessageType::KRB_ERROR;
                             tx.cname = error.cname;
                             tx.realm = error.crealm;
                             tx.sname = Some(error.sname);

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -24,8 +24,15 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<
 {
     match tx.error_code {
         Some(c) => {
-            jsb.set_string("msg_type", "KRB_ERROR")?;
-            jsb.set_string("failed_request", &format!("{:?}", tx.msg_type))?;
+            jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?;
+            if let Some(req_type) = tx.req_type {
+                jsb.set_string("failed_request", &format!("{:?}", req_type))?;
+            } else {
+                // In case we capture the response but not the request
+                // we can't know the failed request type, since it could be
+                // AS-REQ or TGS-REQ
+                jsb.set_string("failed_request", "UNKNOWN")?;
+            }
             jsb.set_string("error_code", &format!("{:?}", c))?;
         },
         None    => { jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?; },


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4529

Describe changes:

The problem is that the krb5_msg_type doesn't trigger properly for:
- AS-REQ (krb5_msg_type: 10): This rule matches the KRB-ERROR message that follows an AS-REQ, which is not the expected behaviour. 
- TGS-REQ (krb5_msg_type: 12): Same behaviour as AS-REQ.
-  KRB-ERROR (krb5_msg_type: 30) It's not triggered at all.

To solve the problem the following actions were taken in `KRB5State.parse`:
- Add transaction when parsing AS-REQ message
- Add transaction when parsing TGS-REQ message
- Change the message type of KRB-ERROR to MessageType::KRB_ERROR
Rebase of https://github.com/OISF/suricata/pull/7335 with fixed compilation for #8819


```
SV_BRANCH=pr/1194
```
https://github.com/OISF/suricata-verify/pull/1194
