### PR TITLE
schema: add port to target and source objects

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -271,6 +271,9 @@
                     "properties": {
                         "ip": {
                             "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false
@@ -280,6 +283,9 @@
                     "properties": {
                         "ip": {
                             "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
Rebase of https://github.com/OISF/suricata/pull/7792:
- removal of change to tags, not sure why this is needed
- the additionalProperties already is set to true in master
- S-V test modified to excercise the port in source and target

```
SV_REPO=
SV_BRANCH=pr/1193
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
