### PR TITLE
napatech: fix timestamp and flag

### DIFF
--- a/src/source-napatech.h
+++ b/src/source-napatech.h
@@ -30,6 +30,7 @@ void TmModuleNapatechDecodeRegister(void);
 
 #ifdef HAVE_NAPATECH
 #include <nt.h>
+#include "runmode-napatech.h"
 
 struct NapatechStreamDevConf
 {

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -643,6 +643,7 @@ static void *NapatechStatsLoop(void *arg)
     }
 
     TmThreadsSetFlag(tv, THV_INIT_DONE);
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv, THV_KILL)) {
             SCLogDebug("NapatechStatsLoop THV_KILL detected");
@@ -1027,6 +1028,7 @@ static void *NapatechBufMonitorLoop(void *arg)
     }
 
     TmThreadsSetFlag(tv, THV_INIT_DONE);
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv, THV_KILL)) {
             SCLogDebug("NapatechBufMonitorLoop THV_KILL detected");


### PR DESCRIPTION
Describe changes:
- fix function call in source-napatech.c
- set the flag for thread in util-napatech.c

These changes have been tested on suricata-7.0.0-rc1 only.

Please note that the linker parameter has not been fixed.
