### PR TITLE
file/data: Use file inspection logic for HTTP(1) 

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -66,6 +66,8 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
         flags = FileFlowFlagsToFlags(tx->tx_data.file_flags, STREAM_TOSERVER);
     }
 
+    flags |= FILE_USE_DETECT;
+
     if (FileOpenFileWithId(files, &htp_sbcfg, s->file_track_id++, filename, filename_len, data,
                 data_len, flags) != 0) {
         retval = -1;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1745,9 +1745,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
      * we check for tx->response_line in case of junk
      * interpreted as body before response line
      */
-    if (!(htud->tcflags & HTP_FILENAME_SET) &&
-        (tx->response_line != NULL || tx->is_protocol_0_9))
-    {
+    if (!(htud->tcflags & HTP_FILENAME_SET)) {
         SCLogDebug("setting up file name");
 
         uint8_t *filename = NULL;
@@ -1797,9 +1795,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
                 htud->tcflags &= ~HTP_DONTSTORE;
             }
         }
-    }
-    else if (tx->response_line != NULL || tx->is_protocol_0_9)
-    {
+    } else {
         /* otherwise, just store the data */
 
         if (!(htud->tcflags & HTP_DONTSTORE)) {

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -59,8 +59,6 @@ static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
                                         Signature *s);
 static int g_file_data_buffer_id = 0;
 
-static inline HtpBody *GetResponseBody(htp_tx_t *tx);
-
 /* file API */
 static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
@@ -242,19 +240,6 @@ typedef struct PrefilterMpmFiledata {
 static void PrefilterMpmFiledataFree(void *ptr)
 {
     SCFree(ptr);
-}
-
-/* HTTP based detection */
-
-static inline HtpBody *GetResponseBody(htp_tx_t *tx)
-{
-    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
-    if (htud == NULL) {
-        SCLogDebug("no htud");
-        return NULL;
-    }
-
-    return &htud->response_body;
 }
 
 /* file API based inspection */


### PR DESCRIPTION
Continuation of #8786

This PR removes the custom response-body based inspection logic and replaces it with the file data logic used by HTTP2, smb, nfs, etc.

This PR depends on https://github.com/OISF/libhtp/pull/387 by @catenacyber 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4141](https://redmine.openinfosecfoundation.org/issues/4141)

Describe changes:
- Use file data functions for handling HTTP1 inspection (instead of response-body based)
-  Add `FILE_USE_DETECT` for content-inspected tracking

Updates:
- Rebase

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=pr/389
```
