### PR TITLE
(draft) jsonbuilder: better handling of memory allocation errors - v1

### DIFF
--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -399,7 +399,7 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
 
 /// Log SOA section fields.
 fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_string_from_bytes("mname", &soa.mname)?;
     js.set_string_from_bytes("rname", &soa.rname)?;
@@ -415,7 +415,7 @@ fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
 
 /// Log SSHFP section fields.
 fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     let mut hex = Vec::new();
     for byte in &sshfp.fingerprint {
@@ -432,7 +432,7 @@ fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
 
 /// Log SRV section fields.
 fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_uint("priority", srv.priority as u64)?;
     js.set_uint("weight", srv.weight as u64)?;
@@ -444,7 +444,7 @@ fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
 }
 
 fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
-    let mut jsa = JsonBuilder::new_object();
+    let mut jsa = JsonBuilder::try_new_object()?;
 
     jsa.set_string_from_bytes("rrname", &answer.name)?;
     jsa.set_string("rrtype", &dns_rrtype_string(answer.rrtype))?;
@@ -516,7 +516,7 @@ fn dns_log_json_answer(
     js.set_string("rcode", &dns_rcode_string(header.flags))?;
 
     if !response.answers.is_empty() {
-        let mut js_answers = JsonBuilder::new_array();
+        let mut js_answers = JsonBuilder::try_new_array()?;
 
         // For grouped answers we use a HashMap keyed by the rrtype.
         let mut answer_types = HashMap::new();
@@ -527,7 +527,7 @@ fn dns_log_json_answer(
                 match &answer.data {
                     DNSRData::A(addr) | DNSRData::AAAA(addr) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string(&dns_print_addr(addr))?;
@@ -540,7 +540,7 @@ fn dns_log_json_answer(
                     | DNSRData::NULL(bytes)
                     | DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string_from_bytes(bytes)?;
@@ -548,7 +548,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SOA(soa) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_soa(soa)?)?;
@@ -556,7 +556,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SSHFP(sshfp) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_sshfp(sshfp)?)?;
@@ -564,7 +564,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SRV(srv) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_srv(srv)?)?;

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -159,7 +159,7 @@ impl JsonBuilder {
             State::None => {
                 debug_validate_fail!("invalid state");
                 Err(JsonError::InvalidState)
-            },
+            }
         }
     }
 
@@ -334,7 +334,7 @@ impl JsonBuilder {
             State::ArrayFirst => {
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -345,7 +345,7 @@ impl JsonBuilder {
                 self.buf.push(',');
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -522,7 +522,7 @@ impl JsonBuilder {
         self.buf.push_str(key);
         self.buf.push_str("\":\"");
         for i in 0..val.len() {
-            self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+            self.buf.push(HEX[(val[i] >> 4) as usize] as char);
             self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
         }
         self.buf.push('"');

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -138,6 +138,26 @@ impl JsonBuilder {
         })
     }
 
+    /// A wrapper around String::push that pre-allocates data return
+    /// an error if unable to.
+    pub fn push(&mut self, ch: char) -> Result<&mut Self, JsonError> {
+        if self.buf.capacity() == self.buf.len() {
+            self.buf.try_reserve(INIT_SIZE)?;
+        }
+        self.buf.push(ch);
+        Ok(self)
+    }
+
+    /// A wrapper around String::push_str that pre-allocates data
+    /// return an error if unable to.
+    pub fn push_str(&mut self, s: &str) -> Result<&mut Self, JsonError> {
+        if self.buf.capacity() < self.buf.len() + s.len() {
+            self.buf.try_reserve(INIT_SIZE)?;
+        }
+        self.buf.push_str(s);
+        Ok(self)
+    }
+
     // Reset the builder to its initial state, without losing
     // the current capacity.
     pub fn reset(&mut self) {
@@ -158,12 +178,12 @@ impl JsonBuilder {
     pub fn close(&mut self) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectFirst | State::ObjectNth => {
-                self.buf.push('}');
+                self.push('}')?;
                 self.pop_state();
                 Ok(self)
             }
             State::ArrayFirst | State::ArrayNth => {
-                self.buf.push(']');
+                self.push(']')?;
                 self.pop_state();
                 Ok(self)
             }
@@ -225,19 +245,19 @@ impl JsonBuilder {
     pub fn open_object(&mut self, key: &str) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectFirst => {
-                self.buf.push('"');
+                self.push('"')?;
                 self.set_state(State::ObjectNth);
             }
             State::ObjectNth => {
-                self.buf.push_str(",\"");
+                self.push_str(",\"")?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push_str(key);
-        self.buf.push_str("\":{");
+        self.push_str(key)?;
+        self.push_str("\":{")?;
         self.push_state(State::ObjectFirst);
         Ok(self)
     }
@@ -251,14 +271,14 @@ impl JsonBuilder {
         match self.current_state() {
             State::ArrayFirst => {}
             State::ArrayNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('{');
+        self.push('{')?;
         self.set_state(State::ArrayNth);
         self.push_state(State::ObjectFirst);
         Ok(self)
@@ -273,16 +293,16 @@ impl JsonBuilder {
         match self.current_state() {
             State::ObjectFirst => {}
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":[");
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":[")?;
         self.set_state(State::ObjectNth);
         self.push_state(State::ArrayFirst);
         Ok(self)
@@ -297,7 +317,7 @@ impl JsonBuilder {
                 Ok(self)
             }
             State::ArrayNth => {
-                self.buf.push(',');
+                self.push(',')?;
                 self.encode_string(val)?;
                 Ok(self)
             }
@@ -311,7 +331,7 @@ impl JsonBuilder {
     pub fn append_string_from_bytes(&mut self, val: &[u8]) -> Result<&mut Self, JsonError> {
         match std::str::from_utf8(val) {
             Ok(s) => self.append_string(s),
-            Err(_) => self.append_string(&string_from_bytes(val)),
+            Err(_) => self.append_string(&try_string_from_bytes(val)?),
         }
     }
 
@@ -319,17 +339,17 @@ impl JsonBuilder {
     pub fn append_base64(&mut self, val: &[u8]) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ArrayFirst => {
-                self.buf.push('"');
+                self.push('"')?;
                 base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
-                self.buf.push('"');
+                self.push('"')?;
                 self.set_state(State::ArrayNth);
                 Ok(self)
             }
             State::ArrayNth => {
-                self.buf.push(',');
-                self.buf.push('"');
+                self.push(',')?;
+                self.push('"')?;
                 base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
-                self.buf.push('"');
+                self.push('"')?;
                 Ok(self)
             }
             _ => {
@@ -343,23 +363,23 @@ impl JsonBuilder {
     pub fn append_hex(&mut self, val: &[u8]) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ArrayFirst => {
-                self.buf.push('"');
+                self.push('"')?;
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
-                    self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
+                    self.push(HEX[(val[i] >> 4) as usize] as char)?;
+                    self.push(HEX[(val[i] & 0xf) as usize] as char)?;
                 }
-                self.buf.push('"');
+                self.push('"')?;
                 self.set_state(State::ArrayNth);
                 Ok(self)
             }
             State::ArrayNth => {
-                self.buf.push(',');
-                self.buf.push('"');
+                self.push(',')?;
+                self.push('"')?;
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
-                    self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
+                    self.push(HEX[(val[i] >> 4) as usize] as char)?;
+                    self.push(HEX[(val[i] & 0xf) as usize] as char)?;
                 }
-                self.buf.push('"');
+                self.push('"')?;
                 Ok(self)
             }
             _ => {
@@ -376,7 +396,7 @@ impl JsonBuilder {
                 self.set_state(State::ArrayNth);
             }
             State::ArrayNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
@@ -393,21 +413,21 @@ impl JsonBuilder {
                 self.set_state(State::ArrayNth);
             }
             State::ArrayNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push_str(&val.to_string());
+        self.push_str(&val.to_string())?;
         Ok(self)
     }
 
     pub fn set_object(&mut self, key: &str, js: &JsonBuilder) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -417,10 +437,10 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":");
-        self.buf.push_str(&js.buf);
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":")?;
+        self.push_str(&js.buf)?;
         Ok(self)
     }
 
@@ -434,14 +454,14 @@ impl JsonBuilder {
                 self.set_state(State::ArrayNth);
             }
             State::ArrayNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             _ => {
                 debug_validate_fail!("invalid state");
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push_str(&js.buf);
+        self.push_str(&js.buf)?;
         Ok(self)
     }
 
@@ -450,7 +470,7 @@ impl JsonBuilder {
     pub fn set_string(&mut self, key: &str, val: &str) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -460,9 +480,9 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":");
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":")?;
         self.encode_string(val)?;
         Ok(self)
     }
@@ -470,7 +490,7 @@ impl JsonBuilder {
     pub fn set_formatted(&mut self, formatted: &str) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -480,7 +500,7 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push_str(formatted);
+        self.push_str(formatted)?;
         Ok(self)
     }
 
@@ -488,7 +508,7 @@ impl JsonBuilder {
     pub fn set_string_from_bytes(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
         match std::str::from_utf8(val) {
             Ok(s) => self.set_string(key, s),
-            Err(_) => self.set_string(key, &string_from_bytes(val)),
+            Err(_) => self.set_string(key, &try_string_from_bytes(val)?),
         }
     }
 
@@ -496,7 +516,7 @@ impl JsonBuilder {
     pub fn set_base64(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -506,11 +526,11 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":\"");
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":\"")?;
         base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
-        self.buf.push('"');
+        self.push('"')?;
 
         Ok(self)
     }
@@ -519,7 +539,7 @@ impl JsonBuilder {
     pub fn set_hex(&mut self, key: &str, val: &[u8]) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -529,14 +549,14 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":\"");
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":\"")?;
         for i in 0..val.len() {
-            self.buf.push(HEX[(val[i] >> 4) as usize] as char);
-            self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
+            self.push(HEX[(val[i] >> 4) as usize] as char)?;
+            self.push(HEX[(val[i] & 0xf) as usize] as char)?;
         }
-        self.buf.push('"');
+        self.push('"')?;
 
         Ok(self)
     }
@@ -545,7 +565,7 @@ impl JsonBuilder {
     pub fn set_uint(&mut self, key: &str, val: u64) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -555,17 +575,17 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":");
-        self.buf.push_str(&val.to_string());
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":")?;
+        self.push_str(&val.to_string())?;
         Ok(self)
     }
 
     pub fn set_float(&mut self, key: &str, val: f64) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -575,17 +595,17 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
-        self.buf.push_str("\":");
-        self.buf.push_str(&val.to_string());
+        self.push('"')?;
+        self.push_str(key)?;
+        self.push_str("\":")?;
+        self.push_str(&val.to_string())?;
         Ok(self)
     }
 
     pub fn set_bool(&mut self, key: &str, val: bool) -> Result<&mut Self, JsonError> {
         match self.current_state() {
             State::ObjectNth => {
-                self.buf.push(',');
+                self.push(',')?;
             }
             State::ObjectFirst => {
                 self.set_state(State::ObjectNth);
@@ -595,12 +615,12 @@ impl JsonBuilder {
                 return Err(JsonError::InvalidState);
             }
         }
-        self.buf.push('"');
-        self.buf.push_str(key);
+        self.push('"')?;
+        self.push_str(key)?;
         if val {
-            self.buf.push_str("\":true");
+            self.push_str("\":true")?;
         } else {
-            self.buf.push_str("\":false");
+            self.push_str("\":false")?;
         }
         Ok(self)
     }
@@ -613,6 +633,8 @@ impl JsonBuilder {
     ///
     /// The string is encoded into an intermediate vector as its faster
     /// than building onto the buffer.
+    ///
+    /// TODO: Allocate memory in a fallible way.
     #[inline(always)]
     fn encode_string(&mut self, val: &str) -> Result<(), JsonError> {
         let mut buf = vec![0; val.len() * 2 + 2];
@@ -653,7 +675,7 @@ impl JsonBuilder {
         offset += 1;
         match std::str::from_utf8(&buf[0..offset]) {
             Ok(s) => {
-                self.buf.push_str(s);
+                self.push_str(s)?;
             }
             Err(err) => {
                 let error = format!(
@@ -662,7 +684,7 @@ impl JsonBuilder {
                     &buf[0..offset],
                     val.as_bytes(),
                 );
-                self.buf.push_str(&error);
+                self.push_str(&error)?;
             }
         }
         Ok(())
@@ -672,8 +694,13 @@ impl JsonBuilder {
 /// A Suricata specific function to create a string from bytes when UTF-8 decoding fails.
 ///
 /// For bytes over 0x0f, we encode as hex like "\xf2".
-fn string_from_bytes(input: &[u8]) -> String {
-    let mut out = String::with_capacity(input.len());
+fn try_string_from_bytes(input: &[u8]) -> Result<String, JsonError> {
+    let mut out = String::new();
+
+    // Allocate enough data to handle the worst case scenario of every
+    // byte needing to be presented as a byte.
+    out.try_reserve(input.len() * 4)?;
+
     for b in input.iter() {
         if *b < 128 {
             out.push(*b as char);
@@ -681,7 +708,7 @@ fn string_from_bytes(input: &[u8]) -> String {
             out.push_str(&format!("\\x{:02x}", *b));
         }
     }
-    return out;
+    return Ok(out);
 }
 
 #[no_mangle]
@@ -1164,7 +1191,7 @@ mod test {
 
         for i in 1..1000 {
             let mut s = Vec::new();
-	    s.resize(i, 0x41);
+            s.resize(i, 0x41);
             let mut jb = JsonBuilder::try_new_array().unwrap();
             jb.append_string_from_bytes(&s)?;
         }

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -46,7 +46,7 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
 }
 
 fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
     match req {
         PgsqlFEMessage::StartupMessage(StartupPacket {
             length: _,
@@ -108,7 +108,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
 }
 
 fn log_response_object(tx: &PgsqlTransaction) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     let mut array_open = false;
     for response in &tx.responses {
         if let PgsqlBEMessage::ParameterStatus(msg) = response {
@@ -268,7 +268,7 @@ fn log_error_notice_field_types(
 }
 
 fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     // User is a mandatory field in a pgsql message
     jb.set_string_from_bytes("user", &params.user.value)?;
     if let Some(parameters) = &params.optional_params {
@@ -284,7 +284,7 @@ fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder
 }
 
 fn log_pgsql_param(param: &PgsqlParameter) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     jb.set_string_from_bytes(param.name.to_str(), &param.value)?;
     jb.close()?;
     Ok(jb)


### PR DESCRIPTION
Wrap (most) growth of the internal buffer in methods that first try to reserve
the required data and return a Result if unable to do so. The idea being we
return error on memory failures rather than panic/abort.

Ticket: https://redmine.openinfosecfoundation.org/issues/6057
