### PR TITLE
6.0.x: Fix ReadTheDocs building - v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,13 @@ version: 2
 
 formats: all
 
-python:
-  version: "3.8"
+# Use an image with modern OpenSSL.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
+python:
   # Use an empty install section to avoid RTD from picking up a non-python
   # requirements.txt file.
   install: []


### PR DESCRIPTION
Alternate fix to https://github.com/OISF/suricata/pull/8843 by using an Ubuntu
22.04 image with updated OpenSSL.
