### PR TITLE
datasets: bugfix to load ip types from yaml

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -949,6 +949,29 @@ int DatasetsInit(void)
                 }
                 SCLogDebug("dataset %s: id %u type %s", set_name, dset->id, set_type->val);
                 dset->from_yaml = true;
+
+	    } else if (strcmp(set_type->val, "ipv4") == 0) {
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_IPV4, save, load,
+                        memcap > 0 ? memcap : default_memcap,
+                        hashsize > 0 ? hashsize : default_hashsize);
+                if (dset == NULL) {
+                    FatalErrorOnInit("failed to setup dataset for %s", set_name);
+                    continue;
+                }
+                SCLogDebug("dataset %s: id %u type %s", set_name, dset->id, set_type->val);
+                dset->from_yaml = true;
+
+            } else if (strcmp(set_type->val, "ip") == 0) {
+                Dataset *dset = DatasetGet(set_name, DATASET_TYPE_IPV6, save, load,
+                        memcap > 0 ? memcap : default_memcap,
+                        hashsize > 0 ? hashsize : default_hashsize);
+                if (dset == NULL) {
+                    FatalErrorOnInit("failed to setup dataset for %s", set_name);
+                    continue;
+                }
+                SCLogDebug("dataset %s: id %u type %s", set_name, dset->id, set_type->val);
+                dset->from_yaml = true;
+
             }
 
             list_pos++;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6060

Describe changes:
- I was playing around with datasets today and was having some troubling get ipv4 and ip types initialized from suricata.yaml.
- I took a look at the some work done and noticed that in DatasetsInit() the addition of ipv4 and ip dataset types wasn't included. 
- Adding these changes in resolved the issue for me and I was able to work with ipv4 and ip datasets as expected. 
