### PR TITLE
github-ci: new author check - v13

### DIFF
--- a/.github/workflows/authors-done.yml
+++ b/.github/workflows/authors-done.yml
@@ -1,0 +1,52 @@
+name: New Authors Report
+
+on:
+  workflow_run:
+    workflows: [New Authors Check]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Author check is complete"
+
+      - name: Download artifact new authors
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "new-authors";
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/new-authors.zip`, Buffer.from(download.data));
+      - run: unzip new-authors.zip
+      - run: |
+          if test -s new-authors.txt; then
+            echo new_authors=yes >> $GITHUB_ENV
+          fi
+      - name: Comment on PR
+        if: ${{ env.new_authors == 'yes' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number = Number(fs.readFileSync('./pr-number.txt'));
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: 'NOTE: This PR may contain new authors'
+            });

--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -1,0 +1,46 @@
+name: New Authors Check
+
+on:
+  pull_request:
+
+jobs:
+  check-id:
+    name: New Author Check
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt -y install git
+      - run: git clone https://github.com/${{ github.repository }}
+      - run: git remote add author ${{ github.event.pull_request.head.repo.html_url }}
+        working-directory: suricata
+      - run: git fetch author
+        working-directory: suricata
+      - run: git checkout author/${{ github.event.pull_request.head.ref }}
+        working-directory: suricata
+      - name: Export known authors from master branch
+        run: git log --format="%an <%ae>" origin/master | sort | uniq > ../authors.txt
+        working-directory: suricata
+      - name: Export authors from new commits
+        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > ../commit-authors.txt
+        working-directory: suricata
+      - name: Check new authors
+        run: |
+          touch new-authors.txt
+          while read -r author; do
+             echo "Checking author: ${author}"
+             if ! grep -q "^${author}\$" authors.txt; then
+                 echo "ERROR: ${author} NOT FOUND"
+                 echo "::warning ::New author found: ${author}"
+                 echo "${author}" >> new-authors.txt
+                 echo has_new_authors="yes" >> $GITHUB_ENV
+             fi
+          done < commit-authors.txt
+      - run: mkdir new-authors
+      - run: cp new-authors.txt new-authors
+      - run: echo ${{ github.event.number }} > new-authors/pr-number.txt
+      - run: ls -l
+      - name: Upload new authors
+        uses: actions/upload-artifact@v3
+        with:
+          name: new-authors
+          path: new-authors
+


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/8844

For a pull request, compare the authors of the commits to the known authors in
the master branch and upload these as an artifact.

Using a workflow_run, check if this file is non-zero and if so, add a comment
to the pull request.

This can-not be demonstrated in the scope of a pull request, as
".github/workflows/authors-done.yml" needs to exist in the repo's default
branch for security reasons.

This allow the author check to not fail, but get a comment about new authors.

Example: https://github.com/jasonish/suricata/pull/177#issuecomment-1540941268
