### PR TITLE
jsonbuilder: attempt to handle memory allocation errors - v2

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -59,7 +59,7 @@ sha1 = "~0.10.5"
 md-5 = "~0.10.1"
 regex = "~1.5.5"
 lazy_static = "~1.4.0"
-base64 = "~0.13.0"
+base64 = "~0.21.0"
 bendy = { version = "~0.3.3", default-features = false }
 asn1-rs = { version = "~0.5.2" }
 

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -399,7 +399,7 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
 
 /// Log SOA section fields.
 fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_string_from_bytes("mname", &soa.mname)?;
     js.set_string_from_bytes("rname", &soa.rname)?;
@@ -415,7 +415,7 @@ fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
 
 /// Log SSHFP section fields.
 fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     let mut hex = Vec::new();
     for byte in &sshfp.fingerprint {
@@ -432,7 +432,7 @@ fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
 
 /// Log SRV section fields.
 fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_uint("priority", srv.priority as u64)?;
     js.set_uint("weight", srv.weight as u64)?;
@@ -444,7 +444,7 @@ fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
 }
 
 fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
-    let mut jsa = JsonBuilder::new_object();
+    let mut jsa = JsonBuilder::try_new_object()?;
 
     jsa.set_string_from_bytes("rrname", &answer.name)?;
     jsa.set_string("rrtype", &dns_rrtype_string(answer.rrtype))?;
@@ -516,7 +516,7 @@ fn dns_log_json_answer(
     js.set_string("rcode", &dns_rcode_string(header.flags))?;
 
     if !response.answers.is_empty() {
-        let mut js_answers = JsonBuilder::new_array();
+        let mut js_answers = JsonBuilder::try_new_array()?;
 
         // For grouped answers we use a HashMap keyed by the rrtype.
         let mut answer_types = HashMap::new();
@@ -527,7 +527,7 @@ fn dns_log_json_answer(
                 match &answer.data {
                     DNSRData::A(addr) | DNSRData::AAAA(addr) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string(&dns_print_addr(addr))?;
@@ -540,7 +540,7 @@ fn dns_log_json_answer(
                     | DNSRData::NULL(bytes)
                     | DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string_from_bytes(bytes)?;
@@ -548,7 +548,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SOA(soa) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_soa(soa)?)?;
@@ -556,7 +556,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SSHFP(sshfp) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_sshfp(sshfp)?)?;
@@ -564,7 +564,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SRV(srv) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_srv(srv)?)?;

--- a/rust/src/ffi/base64.rs
+++ b/rust/src/ffi/base64.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,6 +15,7 @@
  * 02110-1301, USA.
  */
 
+use base64::Engine;
 use std::os::raw::c_uchar;
 use libc::c_ulong;
 
@@ -42,7 +43,7 @@ pub unsafe extern "C" fn Base64Encode(
         return Base64ReturnCode::SC_BASE64_INVALID_ARG;
     }
     let input = std::slice::from_raw_parts(input, input_len as usize);
-    let encoded = base64::encode(input);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(input);
     if encoded.len() + 1 > *output_len as usize {
         return Base64ReturnCode::SC_BASE64_OVERFLOW;
     }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -886,7 +886,8 @@ pub unsafe extern "C" fn rs_http2_tx_set_uri(
 }
 
 fn http2_tx_set_settings(state: &mut HTTP2State, input: &[u8]) {
-    match base64::decode(input) {
+    use base64::Engine;
+    match base64::engine::general_purpose::STANDARD.decode(input) {
         Ok(dec) => {
             if dec.len() % 6 != 0 {
                 state.set_event(HTTP2Event::InvalidHTTP1Settings);

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -17,6 +17,7 @@
 
 #![allow(clippy::missing_safety_doc)]
 
+use base64::Engine;
 use std::cmp::max;
 use std::collections::TryReserveError;
 use std::ffi::CStr;
@@ -704,7 +705,7 @@ impl JsonBuilder {
         if self.buf.capacity() < self.buf.len() + val.len() * 2 {
             self.buf.try_reserve(val.len() * 2)?;
         }
-        base64::encode_config_buf(val, base64::STANDARD, &mut self.buf);
+        base64::engine::general_purpose::STANDARD.encode_string(val, &mut self.buf);
         Ok(self)
     }
 }

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -159,7 +159,7 @@ impl JsonBuilder {
             State::None => {
                 debug_validate_fail!("invalid state");
                 Err(JsonError::InvalidState)
-            },
+            }
         }
     }
 
@@ -334,7 +334,7 @@ impl JsonBuilder {
             State::ArrayFirst => {
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -345,7 +345,7 @@ impl JsonBuilder {
                 self.buf.push(',');
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -522,7 +522,7 @@ impl JsonBuilder {
         self.buf.push_str(key);
         self.buf.push_str("\":\"");
         for i in 0..val.len() {
-            self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+            self.buf.push(HEX[(val[i] >> 4) as usize] as char);
             self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
         }
         self.buf.push('"');

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -46,7 +46,7 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
 }
 
 fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
     match req {
         PgsqlFEMessage::StartupMessage(StartupPacket {
             length: _,
@@ -108,7 +108,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
 }
 
 fn log_response_object(tx: &PgsqlTransaction) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     let mut array_open = false;
     for response in &tx.responses {
         if let PgsqlBEMessage::ParameterStatus(msg) = response {
@@ -268,7 +268,7 @@ fn log_error_notice_field_types(
 }
 
 fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     // User is a mandatory field in a pgsql message
     jb.set_string_from_bytes("user", &params.user.value)?;
     if let Some(parameters) = &params.optional_params {
@@ -284,7 +284,7 @@ fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder
 }
 
 fn log_pgsql_param(param: &PgsqlParameter) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     jb.set_string_from_bytes(param.name.to_str(), &param.value)?;
     jb.close()?;
     Ok(jb)


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/8847
Ticket: https://redmine.openinfosecfoundation.org/issues/6057

Attempt to handle all "normal" memory allocation errors in JsonBuilder where
the Rust APIs allow us. This primarily means growing the underlying String
buffer as data is added.

As the JsonBuilder already used a Result for most methods, most users of
JsonBuilder already handle errors.

Changes from last PR:
- I think this is complete now.

Things to investigate:
- Box::new failing. This might not be catchable. Box::try_new is an
  experimental API that will allow us to handle this better.
