### PR TITLE
napatech: minor fixes in the Napatech code

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -26,6 +26,7 @@
  *
  */
 #include "suricata-common.h"
+#include "action-globals.h"
 #include "decode.h"
 #include "packet.h"
 #include "suricata.h"
@@ -39,6 +40,7 @@
 #include "tmqh-packetpool.h"
 #include "util-napatech.h"
 #include "source-napatech.h"
+#include "runmode-napatech.h"
 
 #ifndef HAVE_NAPATECH
 
@@ -740,22 +742,22 @@ static void RecommendNUMAConfig(SCLogLevel log_level)
     }
 
     if (set_cpu_affinity) {
-        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__,
+        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech",
                 "Minimum host buffers that should be defined in ntservice.ini:");
 
-        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "   NUMA Node 0: %d",
+        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech", "   NUMA Node 0: %d",
                 (SC_ATOMIC_GET(numa0_count)));
 
         if (numa_max_node() >= 1)
-            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__,
+            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech",
                     "   NUMA Node 1: %d ", (SC_ATOMIC_GET(numa1_count)));
 
         if (numa_max_node() >= 2)
-            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__,
+            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech",
                     "   NUMA Node 2: %d ", (SC_ATOMIC_GET(numa2_count)));
 
         if (numa_max_node() >= 3)
-            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__,
+            SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech",
                     "   NUMA Node 3: %d ", (SC_ATOMIC_GET(numa3_count)));
 
         snprintf(string0, 16, "[%d, 16, 0]", SC_ATOMIC_GET(numa0_count));
@@ -766,7 +768,7 @@ static void RecommendNUMAConfig(SCLogLevel log_level)
         snprintf(string3, 16, (numa_max_node() >= 3 ? ",[%d, 16, 3]" : ""),
                 SC_ATOMIC_GET(numa3_count));
 
-        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__,
+        SCLog(log_level, __FILE__, __FUNCTION__, __LINE__, "napatech",
                 "E.g.: HostBuffersRx=%s%s%s%s", string0, string1, string2,
                 string3);
     } else if (log_level == SC_LOG_ERROR) {
@@ -948,24 +950,29 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
          */
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
-                p->ts = SCTIME_FROM_SECS(pkt_ts / 100000000);
-                p->ts += SCTIME_FROM_USECS(
-                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
+                p->ts = (SCTime_t){
+                    .secs = pkt_ts / 100000000,
+                    .usecs = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0)
+                };
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
-                p->ts = SCTIME_FROM_SECS(pkt_ts >> 32);
-                p->ts += SCTIME_FROM_USECS(pkt_ts & 0xFFFFFFFF);
+                p->ts = (SCTime_t){
+                    .secs = pkt_ts >> 32,
+                    .usecs = pkt_ts & 0xFFFFFFFF
+                };
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
-                p->ts = SCTIME_FROM_SECS(pkt_ts >> 32);
-                p->ts += SCTIME_FROM_USECS(
-                        ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0));
+                p->ts = (SCTime_t){
+                    .secs = pkt_ts >> 32,
+                    .usecs = ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0)
+                };
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
-                p->ts = SCTIME_FROM_SECS((pkt_ts / 100000000) - 11644473600);
-                p->ts += SCTIME_FROM_USECS(
-                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
+                p->ts = (SCTime_t){
+                    .secs = (pkt_ts / 100000000) - 11644473600,
+                    .usecs = ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0)
+                };
                 break;
             default:
                 SCLogError("Packet from Napatech Stream: %u does not have a supported timestamp "

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -33,6 +33,7 @@
 #include "tm-threads.h"
 #include "util-napatech.h"
 #include "source-napatech.h"
+#include "runmode-napatech.h"
 
 #ifdef NAPATECH_ENABLE_BYPASS
 
@@ -643,6 +644,7 @@ static void *NapatechStatsLoop(void *arg)
     }
 
     TmThreadsSetFlag(tv, THV_INIT_DONE);
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv, THV_KILL)) {
             SCLogDebug("NapatechStatsLoop THV_KILL detected");
@@ -1027,6 +1029,7 @@ static void *NapatechBufMonitorLoop(void *arg)
     }
 
     TmThreadsSetFlag(tv, THV_INIT_DONE);
+    TmThreadsSetFlag(tv, THV_RUNNING);
     while (1) {
         if (TmThreadsCheckFlag(tv, THV_KILL)) {
             SCLogDebug("NapatechBufMonitorLoop THV_KILL detected");
@@ -1454,14 +1457,18 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
             if (strchr(port->val, '-')) {
                 stream_spec = CONFIG_SPECIFIER_RANGE;
 
-                ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val);
-                ByteExtractStringUint8(&ports_spec.second[iteration], 10, 0, strchr(port->val, '-')+1);
+                if (ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val) == -1) {
+                    SCLogWarning("Invalid value in napatech.ports specification in conf file.");
+                };
+
+                if (ByteExtractStringUint8(&ports_spec.second[iteration], 10, 0, strchr(port->val, '-')+1) == -1) {
+                    SCLogWarning("Invalid value in napatech.ports specification in conf file.");
+                };
 
                 if (ports_spec.first[iteration] == ports_spec.second[iteration]) {
                     if (is_inline) {
-                        FatalError(
-                                "Error with napatech.ports in conf file.  When running in inline "
-                                "mode the two ports specifying a segment must be different.");
+                        FatalError("Error with napatech.ports in conf file.  When running in inline "
+                                   "mode the two ports specifying a segment must be different.");
                     } else {
                         /* SPAN port configuration */
                         is_span_port[ports_spec.first[iteration]] = 1;
@@ -1533,8 +1540,14 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
                 }
                 stream_spec = CONFIG_SPECIFIER_RANGE;
 
-                ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val);
-                ByteExtractStringUint8(&ports_spec.second[iteration], 10, 0, strchr(port->val, '-') + 1);
+                if (ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val) == -1) {
+                    SCLogWarning("Invalid value in napatech.ports specification in conf file.");
+                };
+
+                if (ByteExtractStringUint8(&ports_spec.second[iteration], 10, 0, strchr(port->val, '-')+1) == -1) {
+                    SCLogWarning("Invalid value in napatech.ports specification in conf file.");
+                };
+
                 snprintf(ports_spec.str, sizeof (ports_spec.str), "(%d..%d)", ports_spec.first[iteration], ports_spec.second[iteration]);
             } else {
                 /* check that the sting in the config file is correctly specified */
@@ -1544,7 +1557,9 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
                 }
                 stream_spec = CONFIG_SPECIFIER_INDIVIDUAL;
 
-                ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val);
+                if (ByteExtractStringUint8(&ports_spec.first[iteration], 10, 0, port->val) == -1) {
+                    SCLogError("Invalid value in napatech.ports specification in conf file.");
+                };
 
                 /* Determine the ports to use on the NTPL assign statement*/
                 if (iteration == 0) {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Added 'module' argument to the SCLog() functions used by source-napatech.c
- Set SCTime_t structure from the HW timestamps
- Added return value check for ByteExtractStringUint8() calls
- Set THV_RUNNING flag for the TmThreads 

Replaces [#8802](https://github.com/OISF/suricata/pull/8802)