### PR TITLE
dataset: Address compile-time error

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1631,10 +1631,10 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
             return DatasetOpIPv4(set, (uint8_t *)&in.s_addr, 4);
         }
         case DATASET_TYPE_IPV6: {
-            struct in_addr in;
+            struct in6_addr in;
             if (inet_pton(AF_INET6, string, &in) != 1)
                 return -2;
-            return DatasetOpIPv6(set, (uint8_t *)&in.s_addr, 16);
+            return DatasetOpIPv6(set, (uint8_t *)&in.s6_addr, 16);
         }
     }
     return -1;


### PR DESCRIPTION
This commit fixes an issue with using a `in_addr` when an IPv6 structure should be used.


Describe changes:
- Use IPv6 `in6_addr` instead of IPv4 `in_addr`
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
