### PR TITLE
Detect http2 4067 v5

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -142,6 +142,7 @@ pub struct HTTP2Transaction {
     //temporary escaped header for detection
     //must be attached to transaction for memory management (be freed at the right time)
     pub escaped: Vec<Vec<u8>>,
+    pub req_line: Vec<u8>,
 }
 
 impl Transaction for HTTP2Transaction {
@@ -171,6 +172,7 @@ impl HTTP2Transaction {
             ft_tc: FileTransferTracker::new(),
             ft_ts: FileTransferTracker::new(),
             escaped: Vec::with_capacity(16),
+            req_line: Vec::new(),
         }
     }
 

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -143,6 +143,7 @@ pub struct HTTP2Transaction {
     //must be attached to transaction for memory management (be freed at the right time)
     pub escaped: Vec<Vec<u8>>,
     pub req_line: Vec<u8>,
+    pub resp_line: Vec<u8>,
 }
 
 impl Transaction for HTTP2Transaction {
@@ -173,6 +174,7 @@ impl HTTP2Transaction {
             ft_ts: FileTransferTracker::new(),
             escaped: Vec::with_capacity(16),
             req_line: Vec::new(),
+            resp_line: Vec::new(),
         }
     }
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -66,9 +66,6 @@ static int PrefilterMpmHTTPFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHea
         MpmCtx *mpm_ctx, const DetectBufferMpmRegistry *mpm_reg, int list_id);
 
 /* file API */
-static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
-        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
-        void *alstate, void *txv, uint64_t tx_id);
 int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistry *mpm_reg, int list_id);
 
@@ -239,13 +236,6 @@ static void DetectFiledataSetupCallback(const DetectEngineCtx *de_ctx,
 }
 
 /* common */
-
-typedef struct PrefilterMpmFiledata {
-    int list_id;
-    int base_list_id;
-    const MpmCtx *mpm_ctx;
-    const DetectEngineTransforms *transforms;
-} PrefilterMpmFiledata;
 
 static void PrefilterMpmFiledataFree(void *ptr)
 {
@@ -588,7 +578,7 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
     }
 }
 
-static uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id)
 {

--- a/src/detect-file-data.h
+++ b/src/detect-file-data.h
@@ -27,4 +27,17 @@
 /* prototypes */
 void DetectFiledataRegister (void);
 
+typedef struct PrefilterMpmFiledata {
+    int list_id;
+    int base_list_id;
+    const MpmCtx *mpm_ctx;
+    const DetectEngineTransforms *transforms;
+} PrefilterMpmFiledata;
+
+uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
+int PrefilterMpmFiledataRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
+        const DetectBufferMpmRegistry *mpm_reg, int list_id);
+
 #endif /* __DETECT_FILEDATA_H__ */

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -43,6 +43,8 @@
 #include "detect-engine-content-inspection.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
+// PrefilterMpmFiledata
+#include "detect-file-data.h"
 
 #include "flow.h"
 #include "flow-var.h"
@@ -107,6 +109,11 @@ void DetectHttpClientBodyRegister(void)
     DetectAppLayerMpmRegister2("http_client_body", SIG_FLAG_TOSERVER, 2,
             PrefilterMpmHttpRequestBodyRegister, NULL, ALPROTO_HTTP1, HTP_REQUEST_BODY);
 
+    DetectAppLayerInspectEngineRegister2("http_client_body", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectFiledata, NULL);
+    DetectAppLayerMpmRegister2("http_client_body", SIG_FLAG_TOSERVER, 2,
+            PrefilterMpmFiledataRegister, NULL, ALPROTO_HTTP2, HTTP2StateDataClient);
+
     DetectBufferTypeSetDescriptionByName("http_client_body",
             "http request body");
 
@@ -158,7 +165,7 @@ static int DetectHttpClientBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s
 {
     if (DetectBufferSetActiveList(de_ctx, s, g_http_client_body_buffer_id) < 0)
         return -1;
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP1) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
     return 0;
 }

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -75,7 +75,7 @@ static int DetectHttpProtocolSetup(DetectEngineCtx *de_ctx, Signature *s, const 
     if (DetectBufferSetActiveList(de_ctx, s, g_buffer_id) < 0)
         return -1;
 
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP1) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
 
     return 0;
@@ -114,6 +114,20 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        InspectionBufferSetup(
+                det_ctx, list_id, buffer, (const uint8_t *)"HTTP/2", strlen("HTTP/2"));
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
 /**
  * \brief Registers the keyword handlers for the "http.protocol" keyword.
  */
@@ -134,6 +148,15 @@ void DetectHttpProtocolRegister(void)
             HTP_REQUEST_LINE, DetectEngineInspectBufferGeneric, GetData);
     DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_LINE, DetectEngineInspectBufferGeneric, GetData);
+
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
+    DetectAppLayerInspectEngineRegister2(BUFFER_NAME, ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegister2(BUFFER_NAME, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME,
             BUFFER_DESC);

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -70,6 +70,29 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         void *txv, const int list_id);
 static int g_http_request_line_buffer_id = 0;
 
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    SCEnter();
+
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        uint32_t b_len = 0;
+        const uint8_t *b = NULL;
+
+        if (rs_http2_tx_get_request_line(txv, &b, &b_len) != 1)
+            return NULL;
+        if (b == NULL || b_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
 /**
  * \brief Registers the keyword handlers for the "http_request_line" keyword.
  */
@@ -91,6 +114,11 @@ void DetectHttpRequestLineRegister(void)
 
     DetectAppLayerMpmRegister2("http_request_line", SIG_FLAG_TOSERVER, 2,
             PrefilterGenericMpmRegister, GetData, ALPROTO_HTTP1, HTP_REQUEST_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_request_line", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
+            HTTP2StateDataClient, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegister2("http_request_line", SIG_FLAG_TOSERVER, 2,
+            PrefilterGenericMpmRegister, GetData2, ALPROTO_HTTP2, HTTP2StateDataClient);
 
     DetectBufferTypeSetDescriptionByName("http_request_line",
             "http request line");
@@ -116,7 +144,7 @@ static int DetectHttpRequestLineSetup(DetectEngineCtx *de_ctx, Signature *s, con
     if (DetectBufferSetActiveList(de_ctx, s, g_http_request_line_buffer_id) < 0)
         return -1;
 
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP1) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
 
     return 0;

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -126,7 +126,7 @@ static int DetectHttpServerBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s
 {
     if (DetectBufferSetActiveList(de_ctx, s, g_file_data_buffer_id) < 0)
         return -1;
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP1) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
     return 0;
 }

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -72,6 +72,19 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t _flow_flags, void *txv, const int list_id);
 static int DetectHttpStatMsgSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 
+static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        InspectionBufferSetup(det_ctx, list_id, buffer, (const uint8_t *)"", 0);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+
+    return buffer;
+}
+
 /**
  * \brief Registration function for keyword: http_stat_msg
  */
@@ -100,6 +113,11 @@ void DetectHttpStatMsgRegister (void)
 
     DetectAppLayerMpmRegister2("http_stat_msg", SIG_FLAG_TOCLIENT, 3, PrefilterGenericMpmRegister,
             GetData, ALPROTO_HTTP1, HTP_RESPONSE_LINE);
+
+    DetectAppLayerInspectEngineRegister2("http_stat_msg", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
+            HTTP2StateDataServer, DetectEngineInspectBufferGeneric, GetData2);
+    DetectAppLayerMpmRegister2("http_stat_msg", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
+            GetData2, ALPROTO_HTTP2, HTTP2StateDataServer);
 
     DetectBufferTypeSetDescriptionByName("http_stat_msg",
             "http response status message");
@@ -137,7 +155,7 @@ static int DetectHttpStatMsgSetupSticky(DetectEngineCtx *de_ctx, Signature *s, c
 {
     if (DetectBufferSetActiveList(de_ctx, s, g_http_stat_msg_buffer_id) < 0)
         return -1;
-    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP1) < 0)
+    if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
     return 0;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4067

Describe changes:
- Support some HTTP keywords for HTTP2

`http.start` is the last one unsupported cf `git grep ALPROTO_HTTP1 src/detect-http*.c | grep DetectSignatureSetAppProto`

Should we warn on a rule `alert http` that is only for HTTP1 or HTTP2 based on its keywords ?

Modifies #8704 with rebase after merge of #8770 allowing S-V test to include `http.stat_msg` keyword with `bsize:0`

```
SV_BRANCH=pr/1197
```

https://github.com/OISF/suricata-verify/pull/1197
