### PR TITLE
Output alert applayer v2

### DIFF
--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -18,7 +18,7 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
-use crate::krb::krb5::{KRB5State,KRB5Transaction,test_weak_encryption};
+use crate::krb::krb5::{KRB5Transaction,test_weak_encryption};
 
 fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<(), JsonError>
 {
@@ -68,7 +68,7 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(jsb: &mut JsonBuilder, _state: &mut KRB5State, tx: &mut KRB5Transaction) -> bool
+pub extern "C" fn rs_krb5_log_json_response(tx: &mut KRB5Transaction, jsb: &mut JsonBuilder) -> bool
 {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/modbus/log.rs
+++ b/rust/src/modbus/log.rs
@@ -27,7 +27,6 @@ pub extern "C" fn rs_modbus_to_json(tx: &mut ModbusTransaction, js: &mut JsonBui
 
 /// populate a json object with transactional information, for logging
 fn log(tx: &ModbusTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("modbus")?;
     js.set_uint("id", tx.id)?;
 
     if let Some(req) = &tx.request {
@@ -42,7 +41,6 @@ fn log(tx: &ModbusTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.close()?;
     }
 
-    js.close()?;
     Ok(())
 }
 

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -17,7 +17,7 @@
 
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
-use super::mqtt::{MQTTState, MQTTTransaction};
+use super::mqtt::MQTTTransaction;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::mqtt::mqtt_message::{MQTTOperation, MQTTSubscribeTopicData};
 use crate::mqtt::parser::FixedHeader;
@@ -43,7 +43,6 @@ fn log_mqtt_header(js: &mut JsonBuilder, hdr: &FixedHeader) -> Result<(), JsonEr
 }
 
 fn log_mqtt(tx: &MQTTTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("mqtt")?;
     for msg in tx.msg.iter() {
         match msg.op {
             MQTTOperation::CONNECT(ref conn) => {
@@ -291,14 +290,13 @@ fn log_mqtt(tx: &MQTTTransaction, flags: u32, js: &mut JsonBuilder) -> Result<()
             MQTTOperation::UNASSIGNED => {}
         }
     }
-    js.close()?; // mqtt
 
     return Ok(());
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_mqtt_logger_log(
-    _state: &mut MQTTState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
     log_mqtt(tx, flags, js).is_ok()

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -89,7 +89,6 @@ fn quic_tls_extension_name(e: u16) -> Option<String> {
 }
 
 fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("quic")?;
     if tx.header.ty != QuicType::Short {
         js.set_string("version", String::from(tx.header.version).as_str())?;
 
@@ -144,7 +143,6 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
         js.close()?;
     }
 
-    js.close()?;
     Ok(())
 }
 

--- a/rust/src/rdp/log.rs
+++ b/rust/src/rdp/log.rs
@@ -30,7 +30,6 @@ pub extern "C" fn rs_rdp_to_json(tx: &mut RdpTransaction, js: &mut JsonBuilder) 
 
 /// populate a json object with transactional information, for logging
 fn log(tx: &RdpTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("rdp")?;
     js.set_uint("tx_id", tx.id)?;
 
     match &tx.item {
@@ -58,7 +57,6 @@ fn log(tx: &RdpTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         }
     }
 
-    js.close()?;
     Ok(())
 }
 

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -19,12 +19,10 @@
 
 use std;
 use std::fmt::Write;
-use super::rfb::{RFBState, RFBTransaction};
+use super::rfb::RFBTransaction;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 
 fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("rfb")?;
-
     // Protocol version
     if let Some(tx_spv) = &tx.tc_server_protocol_version {
         js.open_object("server_protocol_version")?;
@@ -107,14 +105,11 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.close()?;
     }
 
-    js.close()?;
-
     return Ok(());
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_rfb_logger_log(_state: &mut RFBState,
-                                    tx: *mut std::os::raw::c_void,
+pub unsafe extern "C" fn rs_rfb_logger_log(tx: *mut std::os::raw::c_void,
                                     js: &mut JsonBuilder) -> bool {
     let tx = cast_pointer!(tx, RFBTransaction);
     log_rfb(tx, js).is_ok()

--- a/rust/src/sip/log.rs
+++ b/rust/src/sip/log.rs
@@ -21,8 +21,6 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::sip::sip::SIPTransaction;
 
 fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
-    js.open_object("sip")?;
-
     if let Some(req) = &tx.request {
         js.set_string("method", &req.method)?
             .set_string("uri", &req.path)?
@@ -42,8 +40,6 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
     if let Some(resp_line) = &tx.response_line {
         js.set_string("response_line", resp_line)?;
     }
-
-    js.close()?;
 
     Ok(())
 }

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -18,7 +18,7 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
-use crate::snmp::snmp::{SNMPState,SNMPTransaction};
+use crate::snmp::snmp::SNMPTransaction;
 use crate::snmp::snmp_parser::{NetworkAddress,PduType};
 use std::borrow::Cow;
 
@@ -37,9 +37,9 @@ fn str_of_pdu_type(t:&PduType) -> Cow<str> {
     }
 }
 
-fn snmp_log_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMPTransaction) -> Result<(), JsonError>
+fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<(), JsonError>
 {
-    jsb.set_uint("version", state.version as u64)?;
+    jsb.set_uint("version", tx.version as u64)?;
     if tx.encrypted {
         jsb.set_string("pdu_type", "encrypted")?;
     } else {
@@ -75,7 +75,7 @@ fn snmp_log_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMP
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMPTransaction) -> bool
+pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder) -> bool
 {
-    snmp_log_response(jsb, state, tx).is_ok()
+    snmp_log_response(jsb, tx).is_ok()
 }

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -200,6 +200,10 @@ def logger_patch_output_c(proto):
     output = io.StringIO()
     inlines = open(filename).readlines()
     for i, line in enumerate(inlines):
+        if line.find("ALPROTO_TEMPLATE") > -1:
+            new_line = line.replace("TEMPLATE", proto.upper()).replace(
+                    "template", proto.lower())
+            output.write(new_line)
         if line.find("output-json-template.h") > -1:
             output.write(line.replace("template", proto.lower()))
         if line.find("/* Template JSON logger.") > -1:

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -150,101 +150,6 @@ static void AlertJsonTls(const Flow *f, JsonBuilder *js)
     return;
 }
 
-static void AlertJsonSsh(const Flow *f, JsonBuilder *js)
-{
-    void *ssh_state = FlowGetAppState(f);
-    if (ssh_state) {
-        JsonBuilderMark mark = { 0, 0, 0 };
-        void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
-        jb_get_mark(js, &mark);
-        jb_open_object(js, "ssh");
-        if (rs_ssh_log_json(tx_ptr, js)) {
-            jb_close(js);
-        } else {
-            jb_restore_mark(js, &mark);
-        }
-    }
-
-    return;
-}
-
-static void AlertJsonHttp2(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *h2_state = FlowGetAppState(f);
-    if (h2_state) {
-        void *tx_ptr = rs_http2_state_get_tx(h2_state, tx_id);
-        if (tx_ptr) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            jb_open_object(js, "http");
-            if (rs_http2_log_json(tx_ptr, js)) {
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-
-    return;
-}
-
-static void AlertJsonDnp3(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    DNP3State *dnp3_state = (DNP3State *)FlowGetAppState(f);
-    if (dnp3_state) {
-        DNP3Transaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_DNP3,
-            dnp3_state, tx_id);
-        if (tx) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            bool logged = false;
-            jb_open_object(js, "dnp3");
-            if (tx->is_request && tx->done) {
-                jb_open_object(js, "request");
-                JsonDNP3LogRequest(js, tx);
-                jb_close(js);
-                logged = true;
-            }
-            if (!tx->is_request && tx->done) {
-                jb_open_object(js, "response");
-                JsonDNP3LogResponse(js, tx);
-                jb_close(js);
-                logged = true;
-            }
-            if (logged) {
-                /* Close dnp3 object. */
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-}
-
-static void AlertJsonDns(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *dns_state = (void *)FlowGetAppState(f);
-    if (dns_state) {
-        void *txptr = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
-                                          dns_state, tx_id);
-        if (txptr) {
-            jb_open_object(js, "dns");
-            JsonBuilder *qjs = JsonDNSLogQuery(txptr);
-            if (qjs != NULL) {
-                jb_set_object(js, "query", qjs);
-                jb_free(qjs);
-            }
-            JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
-            if (ajs != NULL) {
-                jb_set_object(js, "answer", ajs);
-                jb_free(ajs);
-            }
-            jb_close(js);
-        }
-    }
-    return;
-}
-
 static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
 {
     void *snmp_state = (void *)FlowGetAppState(f);
@@ -255,41 +160,6 @@ static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
             jb_open_object(js, "snmp");
             rs_snmp_log_json_response(js, snmp_state, tx);
             jb_close(js);
-        }
-    }
-}
-
-static void AlertJsonRDP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *rdp_state = (void *)FlowGetAppState(f);
-    if (rdp_state != NULL) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_RDP, rdp_state,
-                tx_id);
-        if (tx != NULL) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            if (!rs_rdp_to_json(tx, js)) {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-}
-
-static void AlertJsonBitTorrentDHT(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *bittorrent_dht_state = (void *)FlowGetAppState(f);
-    if (bittorrent_dht_state != NULL) {
-        void *tx =
-                AppLayerParserGetTx(f->proto, ALPROTO_BITTORRENT_DHT, bittorrent_dht_state, tx_id);
-        if (tx != NULL) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            jb_open_object(js, "bittorrent_dht");
-            if (rs_bittorrent_dht_logger_log(tx, js)) {
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
         }
     }
 }
@@ -470,7 +340,24 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
         const uint64_t tx_id, const uint16_t option_flags)
 {
     const AppProto proto = FlowGetAppProtocol(p->flow);
+    AppLayerLogger *al = GetAppProtoLogger(proto);
     JsonBuilderMark mark = { 0, 0, 0 };
+    if (al && al->name) {
+        void *state = FlowGetAppState(p->flow);
+        if (state) {
+            void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
+            if (tx) {
+                jb_get_mark(jb, &mark);
+                jb_open_object(jb, al->name);
+                if (al->log(tx, jb)) {
+                    jb_close(jb);
+                } else {
+                    jb_restore_mark(jb, &mark);
+                }
+            }
+        }
+        return;
+    }
     switch (proto) {
         case ALPROTO_HTTP1:
             // TODO: Could result in an empty http object being logged.
@@ -487,9 +374,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             break;
         case ALPROTO_TLS:
             AlertJsonTls(p->flow, jb);
-            break;
-        case ALPROTO_SSH:
-            AlertJsonSsh(p->flow, jb);
             break;
         case ALPROTO_SMTP:
             jb_get_mark(jb, &mark);
@@ -534,9 +418,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 jb_restore_mark(jb, &mark);
             }
             break;
-        case ALPROTO_SIP:
-            JsonSIPAddMetadata(jb, p->flow, tx_id);
-            break;
         case ALPROTO_RFB:
             jb_get_mark(jb, &mark);
             if (!JsonRFBAddMetadata(p->flow, tx_id, jb)) {
@@ -548,15 +429,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             jb_open_object(jb, "ftp_data");
             EveFTPDataAddMetadata(p->flow, jb);
             jb_close(jb);
-            break;
-        case ALPROTO_DNP3:
-            AlertJsonDnp3(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_HTTP2:
-            AlertJsonHttp2(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_DNS:
-            AlertJsonDns(p->flow, tx_id, jb);
             break;
         case ALPROTO_IKE:
             jb_get_mark(jb, &mark);
@@ -570,26 +442,8 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 jb_restore_mark(jb, &mark);
             }
             break;
-        case ALPROTO_QUIC:
-            jb_get_mark(jb, &mark);
-            if (!JsonQuicAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
         case ALPROTO_SNMP:
             AlertJsonSNMP(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_RDP:
-            AlertJsonRDP(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_MODBUS:
-            jb_get_mark(jb, &mark);
-            if (!JsonModbusAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
-        case ALPROTO_BITTORRENT_DHT:
-            AlertJsonBitTorrentDHT(p->flow, tx_id, jb);
             break;
         default:
             break;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -418,12 +418,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 jb_restore_mark(jb, &mark);
             }
             break;
-        case ALPROTO_RFB:
-            jb_get_mark(jb, &mark);
-            if (!JsonRFBAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
         case ALPROTO_FTPDATA:
             jb_get_mark(jb, &mark);
             jb_open_object(jb, "ftp_data");

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -150,20 +150,6 @@ static void AlertJsonTls(const Flow *f, JsonBuilder *js)
     return;
 }
 
-static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *snmp_state = (void *)FlowGetAppState(f);
-    if (snmp_state != NULL) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_SNMP, snmp_state,
-                tx_id);
-        if (tx != NULL) {
-            jb_open_object(js, "snmp");
-            rs_snmp_log_json_response(js, snmp_state, tx);
-            jb_close(js);
-        }
-    }
-}
-
 static void AlertJsonSourceTarget(const Packet *p, const PacketAlert *pa,
                                   JsonBuilder *js, JsonAddrInfo *addr)
 {
@@ -429,9 +415,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             if (!EveIKEAddMetadata(p->flow, tx_id, jb)) {
                 jb_restore_mark(jb, &mark);
             }
-            break;
-        case ALPROTO_SNMP:
-            AlertJsonSNMP(p->flow, tx_id, jb);
             break;
         default:
             break;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -436,12 +436,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 jb_restore_mark(jb, &mark);
             }
             break;
-        case ALPROTO_MQTT:
-            jb_get_mark(jb, &mark);
-            if (!JsonMQTTAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
         case ALPROTO_SNMP:
             AlertJsonSNMP(p->flow, tx_id, jb);
             break;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -229,12 +229,12 @@ static void AlertJsonDns(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
                                           dns_state, tx_id);
         if (txptr) {
             jb_open_object(js, "dns");
-            JsonBuilder *qjs = JsonDNSLogQuery(txptr, tx_id);
+            JsonBuilder *qjs = JsonDNSLogQuery(txptr);
             if (qjs != NULL) {
                 jb_set_object(js, "query", qjs);
                 jb_free(qjs);
             }
-            JsonBuilder *ajs = JsonDNSLogAnswer(txptr, tx_id);
+            JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
             if (ajs != NULL) {
                 jb_set_object(js, "answer", ajs);
                 jb_free(ajs);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -210,6 +210,25 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 }
 
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js)
+{
+    DNP3Transaction *tx = (DNP3Transaction *)vtx;
+    bool logged = false;
+    if (tx->is_request && tx->done) {
+        jb_open_object(js, "request");
+        JsonDNP3LogRequest(js, tx);
+        jb_close(js);
+        logged = true;
+    }
+    if (!tx->is_request && tx->done) {
+        jb_open_object(js, "response");
+        JsonDNP3LogResponse(js, tx);
+        jb_close(js);
+        logged = true;
+    }
+    return logged;
+}
+
 static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id)
 {

--- a/src/output-json-dnp3.h
+++ b/src/output-json-dnp3.h
@@ -24,5 +24,6 @@ void JsonDNP3LogRequest(JsonBuilder *js, DNP3Transaction *);
 void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *);
 
 void JsonDNP3LogRegister(void);
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_DNP3_H__ */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -263,7 +263,7 @@ typedef struct LogDnsLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogDnsLogThread;
 
-JsonBuilder *JsonDNSLogQuery(void *txptr)
+static JsonBuilder *JsonDNSLogQuery(void *txptr)
 {
     JsonBuilder *queryjb = jb_new_array();
     if (queryjb == NULL) {
@@ -292,7 +292,7 @@ JsonBuilder *JsonDNSLogQuery(void *txptr)
     return queryjb;
 }
 
-JsonBuilder *JsonDNSLogAnswer(void *txptr)
+static JsonBuilder *JsonDNSLogAnswer(void *txptr)
 {
     if (!rs_dns_do_log_answer(txptr, LOG_ALL_RRTYPES)) {
         return NULL;
@@ -302,6 +302,21 @@ JsonBuilder *JsonDNSLogAnswer(void *txptr)
         jb_close(js);
         return js;
     }
+}
+
+bool AlertJsonDns(void *txptr, JsonBuilder *js)
+{
+    JsonBuilder *qjs = JsonDNSLogQuery(txptr);
+    if (qjs != NULL) {
+        jb_set_object(js, "query", qjs);
+        jb_free(qjs);
+    }
+    JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
+    if (ajs != NULL) {
+        jb_set_object(js, "answer", ajs);
+        jb_free(ajs);
+    }
+    return true;
 }
 
 static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -263,7 +263,7 @@ typedef struct LogDnsLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogDnsLogThread;
 
-JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id)
+JsonBuilder *JsonDNSLogQuery(void *txptr)
 {
     JsonBuilder *queryjb = jb_new_array();
     if (queryjb == NULL) {
@@ -292,7 +292,7 @@ JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id)
     return queryjb;
 }
 
-JsonBuilder *JsonDNSLogAnswer(void *txptr, uint64_t tx_id)
+JsonBuilder *JsonDNSLogAnswer(void *txptr)
 {
     if (!rs_dns_do_log_answer(txptr, LOG_ALL_RRTYPES)) {
         return NULL;

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,7 +26,6 @@
 
 void JsonDnsLogRegister(void);
 
-JsonBuilder *JsonDNSLogQuery(void *txptr) __attribute__((nonnull));
-JsonBuilder *JsonDNSLogAnswer(void *txptr) __attribute__((nonnull));
+bool AlertJsonDns(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,7 +26,7 @@
 
 void JsonDnsLogRegister(void);
 
-JsonBuilder *JsonDNSLogQuery(void *txptr, uint64_t tx_id) __attribute__((nonnull));
-JsonBuilder *JsonDNSLogAnswer(void *txptr, uint64_t tx_id) __attribute__((nonnull));
+JsonBuilder *JsonDNSLogQuery(void *txptr) __attribute__((nonnull));
+JsonBuilder *JsonDNSLogAnswer(void *txptr) __attribute__((nonnull));
 
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -46,7 +46,7 @@
 #include "app-layer-ftp.h"
 #include "output-json-ftp.h"
 
-static void EveFTPLogCommand(Flow *f, FTPTransaction *tx, JsonBuilder *jb)
+static void EveFTPLogCommand(FTPTransaction *tx, JsonBuilder *jb)
 {
     /* Preallocate array objects to simplify failure case */
     JsonBuilder *js_resplist = NULL;
@@ -173,7 +173,7 @@ static int JsonFTPLogger(ThreadVars *tv, void *thread_data,
         if (f->alproto == ALPROTO_FTPDATA) {
             EveFTPDataAddMetadata(f, jb);
         } else {
-            EveFTPLogCommand(f, tx, jb);
+            EveFTPLogCommand(tx, jb);
         }
 
         if (!jb_close(jb)) {

--- a/src/output-json-ftp.h
+++ b/src/output-json-ftp.h
@@ -25,5 +25,6 @@
 #define __OUTPUT_JSON_FTP_H__
 
 void JsonFTPLogRegister(void);
+bool EveFTPLogCommand(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_FTP_H__ */

--- a/src/output-json-krb5.c
+++ b/src/output-json-krb5.c
@@ -60,7 +60,7 @@ static int JsonKRB5Logger(ThreadVars *tv, void *thread_data,
     }
 
     jb_open_object(jb, "krb5");
-    if (!rs_krb5_log_json_response(jb, state, krb5tx)) {
+    if (!rs_krb5_log_json_response(krb5tx, jb)) {
         goto error;
     }
     jb_close(jb);

--- a/src/output-json-modbus.c
+++ b/src/output-json-modbus.c
@@ -53,10 +53,12 @@ static int JsonModbusLogger(ThreadVars *tv, void *thread_data, const Packet *p, 
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
+    jb_open_object(js, "modbus");
     if (!rs_modbus_to_json(tx, js)) {
         jb_free(js);
         return TM_ECODE_FAILED;
     }
+    jb_close(js);
     OutputJsonBuilderBuffer(js, thread->ctx);
 
     jb_free(js);
@@ -134,19 +136,6 @@ static TmEcode JsonModbusLogThreadDeinit(ThreadVars *t, void *data)
     FreeEveThreadCtx(thread->ctx);
     SCFree(thread);
     return TM_ECODE_OK;
-}
-
-bool JsonModbusAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_MODBUS, state, tx_id);
-        if (tx) {
-            return rs_modbus_to_json(tx, js);
-        }
-    }
-
-    return false;
 }
 
 void JsonModbusLogRegister(void)

--- a/src/output-json-modbus.h
+++ b/src/output-json-modbus.h
@@ -19,6 +19,5 @@
 #define __OUTPUT_JSON_MODBUS_H__
 
 void JsonModbusLogRegister(void);
-bool JsonModbusAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_MODBUS_H__ */

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -59,17 +59,9 @@ typedef struct LogMQTTLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogMQTTLogThread;
 
-bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
+bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js)
 {
-    MQTTState *state = FlowGetAppState(f);
-    if (state) {
-        MQTTTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_MQTT, state, tx_id);
-        if (tx) {
-            return rs_mqtt_logger_log(state, tx, MQTT_DEFAULTS, js);
-        }
-    }
-
-    return false;
+    return rs_mqtt_logger_log(vtx, MQTT_DEFAULTS, js);
 }
 
 static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
@@ -89,8 +81,10 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    if (!rs_mqtt_logger_log(state, tx, thread->mqttlog_ctx->flags, js))
+    jb_open_object(js, "mqtt");
+    if (!rs_mqtt_logger_log(tx, thread->mqttlog_ctx->flags, js))
         goto error;
+    jb_close(js);
 
     OutputJsonBuilderBuffer(js, thread->ctx);
     jb_free(js);

--- a/src/output-json-mqtt.h
+++ b/src/output-json-mqtt.h
@@ -25,6 +25,6 @@
 #define __OUTPUT_JSON_MQTT_H__
 
 void JsonMQTTLogRegister(void);
-bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
+bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_MQTT_H__ */

--- a/src/output-json-quic.c
+++ b/src/output-json-quic.c
@@ -59,10 +59,12 @@ static int JsonQuicLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
+    jb_open_object(js, "quic");
     if (!rs_quic_to_json(tx, js)) {
         jb_free(js);
         return TM_ECODE_FAILED;
     }
+    jb_close(js);
     OutputJsonBuilderBuffer(js, thread->ctx);
 
     jb_free(js);
@@ -138,19 +140,6 @@ static TmEcode JsonQuicLogThreadDeinit(ThreadVars *t, void *data)
     FreeEveThreadCtx(thread->ctx);
     SCFree(thread);
     return TM_ECODE_OK;
-}
-
-bool JsonQuicAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_QUIC, state, tx_id);
-        if (tx) {
-            return rs_quic_to_json(tx, js);
-        }
-    }
-
-    return false;
 }
 
 void JsonQuicLogRegister(void)

--- a/src/output-json-quic.h
+++ b/src/output-json-quic.h
@@ -22,7 +22,6 @@
 #ifndef __OUTPUT_JSON_QUIC_H__
 #define __OUTPUT_JSON_QUIC_H__
 
-bool JsonQuicAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 void JsonQuicLogRegister(void);
 
 #endif /* __OUTPUT_JSON_QUIC_H__ */

--- a/src/output-json-rdp.c
+++ b/src/output-json-rdp.c
@@ -51,10 +51,12 @@ static int JsonRdpLogger(ThreadVars *tv, void *thread_data,
     if (unlikely(js == NULL)) {
         return TM_ECODE_OK;
     }
+    jb_open_object(js, "rdp");
     if (!rs_rdp_to_json(tx, js)) {
         jb_free(js);
         return TM_ECODE_FAILED;
     }
+    jb_close(js);
     OutputJsonBuilderBuffer(js, thread);
 
     jb_free(js);

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -46,19 +46,6 @@
 
 #include "rust-bindings.h"
 
-bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    RFBState *state = FlowGetAppState(f);
-    if (state) {
-        RFBTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_RFB, state, tx_id);
-        if (tx) {
-            return rs_rfb_logger_log(state, tx, js);
-        }
-    }
-
-    return false;
-}
-
 static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
@@ -69,9 +56,11 @@ static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    if (!rs_rfb_logger_log(NULL, tx, js)) {
+    jb_open_object(js, "rfb");
+    if (!rs_rfb_logger_log(tx, js)) {
         goto error;
     }
+    jb_close(js);
 
     OutputJsonBuilderBuffer(js, thread);
     jb_free(js);

--- a/src/output-json-rfb.h
+++ b/src/output-json-rfb.h
@@ -26,6 +26,4 @@
 
 void JsonRFBLogRegister(void);
 
-bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
-
 #endif /* __OUTPUT_JSON_RFB_H__ */

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -48,17 +48,6 @@
 
 #include "rust.h"
 
-void JsonSIPAddMetadata(JsonBuilder *js, const Flow *f, uint64_t tx_id)
-{
-    SIPState *state = FlowGetAppState(f);
-    if (state) {
-        SIPTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_SIP, state, tx_id);
-        if (tx) {
-            rs_sip_log_json(tx, js);
-        }
-    }
-}
-
 static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {
@@ -70,9 +59,11 @@ static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_OK;
     }
 
+    jb_open_object(js, "sip");
     if (!rs_sip_log_json(siptx, js)) {
         goto error;
     }
+    jb_close(js);
 
     OutputJsonBuilderBuffer(js, thread);
     jb_free(js);

--- a/src/output-json-sip.h
+++ b/src/output-json-sip.h
@@ -26,6 +26,4 @@
 
 void JsonSIPLogRegister(void);
 
-void JsonSIPAddMetadata(JsonBuilder *js, const Flow *f, uint64_t tx_id);
-
 #endif /* __OUTPUT_JSON_SIP_H__ */

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -51,7 +51,7 @@
 #include "output-json-smtp.h"
 #include "output-json-email-common.h"
 
-static void EveSmtpDataLogger(const Flow *f, void *state, void *vtx, uint64_t tx_id, JsonBuilder *js)
+static void EveSmtpDataLogger(void *state, void *vtx, JsonBuilder *js)
 {
     SMTPTransaction *tx = vtx;
     SMTPString *rcptto_str;
@@ -81,7 +81,7 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         return TM_ECODE_OK;
 
     jb_open_object(jb, "smtp");
-    EveSmtpDataLogger(f, state, tx, tx_id, jb);
+    EveSmtpDataLogger(state, tx, jb);
     jb_close(jb);
 
     EveEmailLogJson(jhl, jb, p, f, state, tx, tx_id);
@@ -99,7 +99,7 @@ bool EveSMTPAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
     if (smtp_state) {
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, smtp_state, tx_id);
         if (tx) {
-            EveSmtpDataLogger(f, smtp_state, tx, tx_id, js);
+            EveSmtpDataLogger(smtp_state, tx, js);
             return true;
         }
     }

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -60,7 +60,7 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     }
 
     jb_open_object(jb, "snmp");
-    if (!rs_snmp_log_json_response(jb, state, snmptx)) {
+    if (!rs_snmp_log_json_response(snmptx, jb)) {
         goto error;
     }
     jb_close(jb);

--- a/src/output.c
+++ b/src/output.c
@@ -1151,7 +1151,7 @@ static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_KRB5, NULL, NULL }, // TODO state
     { ALPROTO_QUIC, "quic", rs_quic_to_json },
     { ALPROTO_DHCP, NULL, NULL }, // TODO logger with option
-    { ALPROTO_SNMP, NULL, NULL }, // TODO state
+    { ALPROTO_SNMP, "snmp", (bool (*)(void *tx, struct JsonBuilder *jb))rs_snmp_log_json_response },
     { ALPROTO_SIP, "sip", (bool (*)(void *tx, struct JsonBuilder *jb))rs_sip_log_json },
     { ALPROTO_RFB, "rfb", rs_rfb_logger_log },
     { ALPROTO_MQTT, "mqtt", JsonMQTTAddMetadata },

--- a/src/output.c
+++ b/src/output.c
@@ -1153,7 +1153,7 @@ static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_DHCP, NULL, NULL }, // TODO logger with option
     { ALPROTO_SNMP, NULL, NULL }, // TODO state
     { ALPROTO_SIP, "sip", (bool (*)(void *tx, struct JsonBuilder *jb))rs_sip_log_json },
-    { ALPROTO_RFB, NULL, NULL }, // TODO state
+    { ALPROTO_RFB, "rfb", rs_rfb_logger_log },
     { ALPROTO_MQTT, "mqtt", JsonMQTTAddMetadata },
     { ALPROTO_PGSQL, NULL, NULL },  // TODO flags
     { ALPROTO_TELNET, NULL, NULL }, // no logging

--- a/src/output.c
+++ b/src/output.c
@@ -1126,3 +1126,53 @@ void OutputRegisterLoggers(void)
     /* BitTorrent DHT JSON logger */
     JsonBitTorrentDHTLogRegister();
 }
+
+static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
+    { ALPROTO_UNKNOWN, NULL, NULL },
+    { ALPROTO_HTTP1, NULL, NULL }, // TODO empty http object and option_flags
+    { ALPROTO_FTP, NULL, NULL },
+    { ALPROTO_SMTP, NULL, NULL }, // TODO state, + log email
+    { ALPROTO_TLS, NULL, NULL },  // TODO log state
+    { ALPROTO_SSH, "ssh", rs_ssh_log_json },
+    { ALPROTO_IMAP, NULL, NULL },   // protocol detection only
+    { ALPROTO_JABBER, NULL, NULL }, // no parser, no logging
+    { ALPROTO_SMB, NULL, NULL },    // TODO state
+    { ALPROTO_DCERPC, NULL, NULL }, // TODO
+    { ALPROTO_IRC, NULL, NULL },    // no parser, no logging
+    { ALPROTO_DNS, "dns", AlertJsonDns },
+    { ALPROTO_MODBUS, "modbus", (bool (*)(void *tx, struct JsonBuilder *jb))rs_modbus_to_json },
+    { ALPROTO_ENIP, NULL, NULL }, // no logging
+    { ALPROTO_DNP3, "dnp3", AlertJsonDnp3 },
+    { ALPROTO_NFS, NULL, NULL },     // TODO log rpc field
+    { ALPROTO_NTP, NULL, NULL },     // no logging
+    { ALPROTO_FTPDATA, NULL, NULL }, // TODO state
+    { ALPROTO_TFTP, NULL, NULL },
+    { ALPROTO_IKE, NULL, NULL },  // TODO state + option
+    { ALPROTO_KRB5, NULL, NULL }, // TODO state
+    { ALPROTO_QUIC, "quic", rs_quic_to_json },
+    { ALPROTO_DHCP, NULL, NULL }, // TODO logger with option
+    { ALPROTO_SNMP, NULL, NULL }, // TODO state
+    { ALPROTO_SIP, "sip", (bool (*)(void *tx, struct JsonBuilder *jb))rs_sip_log_json },
+    { ALPROTO_RFB, NULL, NULL },    // TODO state
+    { ALPROTO_MQTT, NULL, NULL },   // TODO state + option
+    { ALPROTO_PGSQL, NULL, NULL },  // TODO flags
+    { ALPROTO_TELNET, NULL, NULL }, // no logging
+    { ALPROTO_TEMPLATE, "template", rs_template_logger_log },
+    { ALPROTO_RDP, "rdp", (bool (*)(void *tx, struct JsonBuilder *jb))rs_rdp_to_json },
+    { ALPROTO_HTTP2, "http", rs_http2_log_json },
+    { ALPROTO_BITTORRENT_DHT, "bittorrent_dht", rs_bittorrent_dht_logger_log },
+    { ALPROTO_HTTP, NULL, NULL }, // signature protocol, not for app-layer logging
+    { ALPROTO_FAILED, NULL, NULL },
+#ifdef UNITTESTS
+    { ALPROTO_TEST, NULL, NULL },
+#endif /* UNITESTS */
+};
+
+AppLayerLogger *GetAppProtoLogger(AppProto alproto)
+{
+    if (alproto < ALPROTO_MAX) {
+        BUG_ON(alert_applayer_loggers[alproto].proto != alproto);
+        return &alert_applayer_loggers[alproto];
+    }
+    return NULL;
+}

--- a/src/output.c
+++ b/src/output.c
@@ -1153,8 +1153,8 @@ static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_DHCP, NULL, NULL }, // TODO logger with option
     { ALPROTO_SNMP, NULL, NULL }, // TODO state
     { ALPROTO_SIP, "sip", (bool (*)(void *tx, struct JsonBuilder *jb))rs_sip_log_json },
-    { ALPROTO_RFB, NULL, NULL },    // TODO state
-    { ALPROTO_MQTT, NULL, NULL },   // TODO state + option
+    { ALPROTO_RFB, NULL, NULL }, // TODO state
+    { ALPROTO_MQTT, "mqtt", JsonMQTTAddMetadata },
     { ALPROTO_PGSQL, NULL, NULL },  // TODO flags
     { ALPROTO_TELNET, NULL, NULL }, // no logging
     { ALPROTO_TEMPLATE, "template", rs_template_logger_log },

--- a/src/output.c
+++ b/src/output.c
@@ -1130,7 +1130,7 @@ void OutputRegisterLoggers(void)
 static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_UNKNOWN, NULL, NULL },
     { ALPROTO_HTTP1, NULL, NULL }, // TODO empty http object and option_flags
-    { ALPROTO_FTP, NULL, NULL },
+    { ALPROTO_FTP, "ftp", EveFTPLogCommand },
     { ALPROTO_SMTP, NULL, NULL }, // TODO state, + log email
     { ALPROTO_TLS, NULL, NULL },  // TODO log state
     { ALPROTO_SSH, "ssh", rs_ssh_log_json },

--- a/src/output.c
+++ b/src/output.c
@@ -1147,8 +1147,8 @@ static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_NTP, NULL, NULL },     // no logging
     { ALPROTO_FTPDATA, NULL, NULL }, // TODO state
     { ALPROTO_TFTP, "tftp", (bool (*)(void *tx, struct JsonBuilder *jb))rs_tftp_log_json_request },
-    { ALPROTO_IKE, NULL, NULL },  // TODO state + option
-    { ALPROTO_KRB5, NULL, NULL }, // TODO state
+    { ALPROTO_IKE, NULL, NULL }, // TODO state + option
+    { ALPROTO_KRB5, "krb5", (bool (*)(void *tx, struct JsonBuilder *jb))rs_krb5_log_json_response },
     { ALPROTO_QUIC, "quic", rs_quic_to_json },
     { ALPROTO_DHCP, NULL, NULL }, // TODO logger with option
     { ALPROTO_SNMP, "snmp", (bool (*)(void *tx, struct JsonBuilder *jb))rs_snmp_log_json_response },

--- a/src/output.c
+++ b/src/output.c
@@ -1146,7 +1146,7 @@ static AppLayerLogger alert_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_NFS, NULL, NULL },     // TODO log rpc field
     { ALPROTO_NTP, NULL, NULL },     // no logging
     { ALPROTO_FTPDATA, NULL, NULL }, // TODO state
-    { ALPROTO_TFTP, NULL, NULL },
+    { ALPROTO_TFTP, "tftp", (bool (*)(void *tx, struct JsonBuilder *jb))rs_tftp_log_json_request },
     { ALPROTO_IKE, NULL, NULL },  // TODO state + option
     { ALPROTO_KRB5, NULL, NULL }, // TODO state
     { ALPROTO_QUIC, "quic", rs_quic_to_json },

--- a/src/output.h
+++ b/src/output.h
@@ -208,4 +208,12 @@ void OutputLoggerExitPrintStats(ThreadVars *, void *);
 void OutputSetupActiveLoggers(void);
 void OutputClearActiveLoggers(void);
 
+typedef struct AppLayerLogger {
+    AppProto proto;
+    const char *name;
+    bool (*log)(void *tx, struct JsonBuilder *jb);
+} AppLayerLogger;
+
+AppLayerLogger *GetAppProtoLogger(AppProto alproto);
+
 #endif /* ! __OUTPUT_H__ */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, preliminary work for https://redmine.openinfosecfoundation.org/issues/5053 and app-layer plugins
Continuation of https://github.com/OISF/suricata/pull/8772

Describe changes:
- Fix setup-app-layer script so that it adds app-layer metadata to alerts
- Adds ftp metadata to alerts
- Adds tftp metadata to alerts
- Adds krb5 metadata to alerts

Continues #8864 by incorporating more protocols : Mqtt, rfb, snmp and krb5 (which was not there before)

```
SV_BRANCH=pr/1196
```
https://github.com/OISF/suricata-verify/pull/1196

Still to do : 
- finish to list remaining protocols
- Create tickets for missing protocols : pgsql, dcerpc, dhcp, 
- A next iteration can have JsonGenericLogger to replace all JsonBitTorrentDHTLogger and remove output-json-bittorrent-dht.c