### PR TITLE
detect: Fix FTP bounce detection on little-endian platforms

### DIFF
--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -141,7 +141,7 @@ static int DetectFtpbounceMatchArgs(
             }
             if (noctet == 4) {
                 /* Different IP than src, ftp bounce scan */
-                ip = SCByteSwap32(ip);
+                ip = htonl(ip);
 
                 if (ip != ip_orig) {
                     SCLogDebug("Different ip, so Matched ip:%d <-> ip_orig:%d",


### PR DESCRIPTION
The argument ip_orig of DetectFtpbounceMatchArgs() is in network byte order but is compared to the ip parsed from the FTP payload that was converted to host byte order.

Fix the FTP bounce ip address comparison by converting ip_orig to host byte order.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [✓] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

No redmine ticket due to simplicity of fix.

Describe changes:
Fix FTP bounce IP address comparison between FTP payload IP address, in host byte-order, and original IP address, in network byte order.
