### PR TITLE
flowworker: simplify pseudo packet use

### DIFF
--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -407,12 +407,13 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
         /* no need to keep a flow ref beyond this point */
         FlowDeReference(&x->flow);
 
+        /* no further work to do for this pseudo packet, so we can return
+         * it to the pool immediately. */
         if (timeout) {
             PacketPoolReturnPacket(x);
         } else {
-            /* put these packets in the decode queue so that they are processed
-             * by the other thread modules before packet 'p'. */
-            PacketEnqueueNoLock(&tv->decode_pq, x);
+            /* to support IPS verdict logic, in the non-timeout case we need to do a bit more */
+            TmqhOutputPacketpool(tv, x);
         }
     }
 }


### PR DESCRIPTION
Pseudo packets originating in the flow worker do not need to leave the flow worker. Putting those in the ThreadVars::decode_pq will make them be evaluated by the next steps in the pipeline, but those will all ignore pseudo packets.

Instead, this patch returns them to the packet pool, while still honoring the IPS verdict logic.
