### PR TITLE
fuzz: make targets more resistant to allocation failures

### DIFF
--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -23,6 +23,7 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 
 AppLayerProtoDetectThreadCtx *alpd_tctx = NULL;
+SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -31,10 +32,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     bool reverse;
     AppProto alproto;
     AppProto alproto2;
-
-    if (size < HEADER_LEN) {
-        return 0;
-    }
 
     if (alpd_tctx == NULL) {
         //global init
@@ -50,6 +47,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         AppLayerParserSetup();
         AppLayerParserRegisterProtocolParsers();
         alpd_tctx = AppLayerProtoDetectGetCtxThread();
+        SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
+    }
+
+    if (size < HEADER_LEN) {
+        return 0;
     }
 
     f = TestHelperBuildFlow(AF_INET, "1.2.3.4", "5.6.7.8", (uint16_t)((data[2] << 8) | data[3]),

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -31,6 +31,7 @@ pcap-file:\n\
 
 ThreadVars *tv;
 DecodeThreadVars *dtv;
+SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
@@ -80,6 +81,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
+        SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
 
         initialized = 1;
     }

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -40,6 +40,7 @@ DecodeThreadVars *dtv;
 //FlowWorkerThreadData
 void *fwd;
 SCInstance surifuzz;
+SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
 #include "confyaml.c"
 
@@ -92,6 +93,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
+        SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
         initialized = 1;
     }
 

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -40,6 +40,7 @@ DecodeThreadVars *dtv;
 // FlowWorkerThreadData
 void *fwd;
 SCInstance surifuzz;
+SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
 #include "confyaml.c"
 
@@ -118,6 +119,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         extern uint16_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
+        SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
         initialized = 1;
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, but meta https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- fuzz: make targets more resistant to allocation failures

See also #8855 and https://github.com/google/oss-fuzz/pull/9902