### PR TITLE
http: complete multipart data on open

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1604,6 +1604,16 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
 
                     if (filedata_len >= (uint32_t)(expected_boundary_len + 2)) {
                         filedata_len -= (expected_boundary_len + 2 - 1);
+                        // take as much as we can until start of boundary
+                        for (size_t nb = 0; nb < (size_t)expected_boundary_len + 1; nb++) {
+                            if (filedata[filedata_len] == '\r') {
+                                if (nb == expected_boundary_len ||
+                                        filedata[filedata_len + 1] == '\n') {
+                                    break;
+                                }
+                            }
+                            filedata_len++;
+                        }
                         SCLogDebug("opening file with partial data");
                     } else {
                         filedata = NULL;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
preliminary work for https://redmine.openinfosecfoundation.org/issues/3487

Describe changes:
- Fix HTTP multipart file open then truncate to consume as many bytes as possible

See #8886 QA run that produced this

By the way, I do not know when the file gets closed (to get a chance to add the bytes it missed)

Modifies #8896 by fixing unit tests