### PR TITLE
streaming: fix intersect detection

### DIFF
--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -991,10 +991,8 @@ static void ListRegions(StreamingBuffer *sb)
  *  Takes the max gap into account.
  */
 static inline bool RegionsIntersect(const StreamingBuffer *sb, const StreamingBufferConfig *cfg,
-        const StreamingBufferRegion *r, const uint64_t offset, const uint32_t len)
+        const StreamingBufferRegion *r, const uint64_t offset, const uint64_t re)
 {
-    const uint64_t re = offset + len;
-
     /* create the data range for the region, adding the max gap */
     const uint64_t reg_o =
             r->stream_offset > cfg->region_gap ? (r->stream_offset - cfg->region_gap) : 0;
@@ -1287,11 +1285,11 @@ static StreamingBufferRegion *BufferInsertAtRegion(StreamingBuffer *sb,
             data_offset + data_len);
     ListRegions(sb);
 
-    if (RegionsIntersect(sb, cfg, &sb->region, data_offset, data_len)) {
+    if (RegionsIntersect(sb, cfg, &sb->region, data_offset, data_offset + data_len)) {
         SCLogDebug("data_offset %" PRIu64 ", data_len %u intersects with main region (next %p)",
                 data_offset, data_len, sb->region.next);
         if (sb->region.next == NULL ||
-                !RegionsIntersect(sb, cfg, sb->region.next, data_offset, data_len)) {
+                !RegionsIntersect(sb, cfg, sb->region.next, data_offset, data_offset + data_len)) {
             SCLogDebug(
                     "data_offset %" PRIu64
                     ", data_len %u intersects with main region, no next or way before next region",


### PR DESCRIPTION
Update logic to always use data right edge.

Bug: #6041.
