### PR TITLE
rust: use 2021 edition

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -1,7 +1,7 @@
 [package]
 name = "suricata"
 version = "@PACKAGE_VERSION@"
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = [".", "./derive"]

--- a/rust/derive/Cargo.toml.in
+++ b/rust/derive/Cargo.toml.in
@@ -1,7 +1,7 @@
 [package]
 name = "suricata-derive"
 version = "@PACKAGE_VERSION@"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
With the MSRV being bumped to 1.62 for 7.0, we can move the edition up
to 2021.

2021 isn't too exciting, but is mostly expected to be available for new Rust
code.

Rust 2021 Edition Guide:
https://doc.rust-lang.org/edition-guide/rust-2021/index.html

2021 Edition Release Announcement:
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html
