### PR TITLE
http: fix leak of normailzed uri

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2335,6 +2335,7 @@ static int HTPCallbackRequestLine(htp_tx_t *tx)
 
     tx_ud = htp_tx_get_user_data(tx);
     if (unlikely(tx_ud == NULL)) {
+        bstr_free(request_uri_normalized);
         return HTP_OK;
     }
     if (unlikely(tx_ud->request_uri_normalized != NULL))


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fix a memory leak found by nallocfuzz

Better fix would be to have tx_ud not allocation-fallible for HTTP1...