### PR TITLE
configure: Require c11 as the minimum C standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,14 @@
     AM_CONDITIONAL([HAVE_FETCH_COMMAND], [test "x$HAVE_WGET" != "xno" || test "x$HAVE_CURL" != "xno"])
     AM_CONDITIONAL([HAVE_WGET_COMMAND], [test "x$HAVE_WGET" != "xno"])
 
+    # We require c11+
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if __STDC_VERSION__ >= 201112L
+                                         int c11_supported;
+                                         #endif
+                                       ]])],
+                                       [],
+                                       [AC_MSG_ERROR([C11 support is required but not available.])])
+
     # Checks for libraries.
 
     # Checks for header files.


### PR DESCRIPTION
This commit modifies the configure script to check for C11 by comparing the __STDC_VERSION__ with 201112L

An error message is issued if the C version is older than the C11 standard version.

Issue: 6029

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6029](https://redmine.openinfosecfoundation.org/issues/6029)

Describe changes:
- Updated `configure` to check `__STDC_VERSION__` against the C11 value.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
