### PR TITLE
Fix midstream exception policy bug 5825 - v1

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -67,28 +67,26 @@ Exception policies are implemented for:
      - Expected behavior
    * - stream.memcap
      - memcap-policy
-     - If a stream memcap limit is reached, call the memcap policy on the packet
-       and flow.
+     - If a stream memcap limit is reached, apply the memcap policy to the packet and/or
+       flow.
    * - stream.midstream
      - midstream-policy
-     - If a session is picked up midstream, call the memcap policy on the packet
-       and flow.
+     - If a session is picked up midstream, apply the midstream policy to the flow.
    * - stream.reassembly.memcap
      - memcap-policy
-     - If stream reassembly reaches memcap limit, call the memcap policy on the
-       packet and flow.
+     - If stream reassembly reaches memcap limit, apply memcap policy to the
+       packet and/or flow.
    * - flow.memcap
      - memcap-policy
      - Apply policy when the memcap limit for flows is reached and no flow could
-       be freed up. Apply policy to the packet.
+       be freed up. **Policy can only be applied to the packet.**
    * - defrag.memcap
      - memcap-policy
      - Apply policy when the memcap limit for defrag is reached and no tracker
-       could be picked up. Apply policy to the packet.
+       could be picked up. **Policy can only be applied to the packet.**
    * - app-layer
      - error-policy
-     - Apply policy if a parser reaches an error state. Apply policy to the
-       packet and flow.
+     - Apply policy if a parser reaches an error state. Policy can be applied to packet and/or flow.
 
 To change any of these, go to the specific section in the suricata.yaml file
 (for more configuration details, check the :doc:`suricata.yaml's<suricata-yaml>`

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -114,6 +114,85 @@ are:
 The *drop*, *pass* and *reject* are similar to the rule actions described in :ref:`rule
 actions<suricata-yaml-action-order>`.
 
+Exception Policies and Midstream Pick-up Sessions
+-------------------------------------------------
+
+Suricata behavior can be difficult to track in case of midstream session
+pick-ups. Consider this matrix illustrating the different interactions for
+midstream pick-ups enabled or not and the various exception policy values:
+
+.. list-table:: **Exception Policy Behaviors - IDS Mode**
+   :widths: auto
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Exception Policy
+     - Midstream pick-up sessions ENABLED (stream.midstream=true)
+     - Midstream pick-up sessions DISABLED (stream.midstream=false)
+   * - Ignore
+     - Session tracket and parsed.
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+   * - Drop-flow
+     - Not valid.*
+     - Not valid.*
+   * - Drop-packet
+     - Not valid.*
+     - Not valid.*
+   * - Reject
+     - Not valid.*
+     - Session not tracked, flow REJECTED.
+   * - Pass-flow
+     - Track session, inspect and log app-layer traffic, no detection.
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+   * - Pass-packet
+     - Not valid.*
+     - Not valid.*
+   * - Bypass
+     - Not valid.*
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+
+The main difference between IDS and IPS scenarios is that in IPS mode flows can
+be allowed or blocked (as in with the PASS and DROP rule actions). Packet
+actions are not valid, as midstream pick-up is a configuration that affects the
+whole flow.
+
+.. list-table:: **Exception Policy Behaviors - IPS Mode**
+   :widths: 15 42 43
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Exception Policy
+     - Midstream pick-up sessions ENABLED (stream.midstream=true)
+     - Midstream pick-up sessions DISABLED (stream.midstream=false)
+   * - Ignore
+     - Session tracket and parsed.
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+   * - Drop-flow
+     - Not valid.*
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+       Flow DROPPED.
+   * - Drop-packet
+     - Not valid.*
+     - Not valid.*
+   * - Reject
+     - Not valid.*
+     - Session not tracked, flow DROPPED and REJECTED.
+   * - Pass-flow
+     - Track session, inspect and log app-layer traffic, no detection.
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+   * - Pass-packet
+     - Not valid.*
+     - Not valid.*
+   * - Bypass
+     - Not valid.*
+     - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
+       Packets ALLOWED.
+
+Notes:
+
+   * Not valid means that Suricata will error out and won't start.
+   * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender of the matching packet.
+
 Command-line Options for Simulating Exceptions
 ----------------------------------------------
 

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -131,11 +131,11 @@ midstream pick-ups enabled or not and the various exception policy values:
      - Session tracket and parsed.
      - Session not tracked. No app-layer inspection or logging. No detection. No stream reassembly.
    * - Drop-flow
-     - Not valid.*
-     - Not valid.*
+     - Drop isn't valid in IDS mode, so the policy is set to `ignore`.
+     - Drop isn't valid in IDS mode, so the policy is set to `ignore`.
    * - Drop-packet
-     - Not valid.*
-     - Not valid.*
+     - Drop isn't valid in IDS mode, so the policy is set to `ignore`.
+     - Drop isn't valid in IDS mode, so the policy is set to `ignore`.
    * - Reject
      - Not valid.*
      - Session not tracked, flow REJECTED.

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4753,6 +4753,32 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {
@@ -4910,8 +4936,7 @@
                                 {
                                     "$ref": "#/$defs/reject"
                                 }
-                            ],
-                            "additionalProperties": "false"
+                            ]
                         },
                         "memuse": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4886,6 +4886,33 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ],
+                            "additionalProperties": "false"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5479,6 +5506,27 @@
             "$comment": "Definition for TLS date formats",
             "type": "string",
             "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+        },
+        "drop_flow": {
+            "type": "object"
+        },
+        "drop_packet": {
+            "type": "object"
+        },
+        "pass_flow": {
+            "type": "object"
+        },
+        "pass_packet": {
+            "type": "object"
+        },
+        "bypass": {
+            "type": "object"
+        },
+        "ignore": {
+            "type": "object"
+        },
+        "reject": {
+            "type": "object"
         }
     }
 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5204,6 +5204,32 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1497,6 +1497,9 @@
                 "dest_port": {
                     "type": "integer"
                 },
+                "emergency": {
+                    "type": "boolean"
+                },
                 "end": {
                     "type": "string"
                 },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5278,6 +5278,32 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5222,6 +5222,32 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3863,7 +3863,7 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": true
                         },
                         "flow": {
                             "type": "object",
@@ -5601,6 +5601,32 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/drop_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/drop_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/bypass"
+                        },
+                        {
+                            "$ref": "#/$defs/ignore"
+                        },
+                        {
+                            "$ref": "#/$defs/reject"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -80,6 +80,13 @@ typedef struct AppLayerCounterNames_ {
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
     char alloc_error[MAX_COUNTER_SIZE];
+    char eps_error_ignore[MAX_COUNTER_SIZE];
+    char eps_error_reject[MAX_COUNTER_SIZE];
+    char eps_error_bypass[MAX_COUNTER_SIZE];
+    char eps_error_pass_flow[MAX_COUNTER_SIZE];
+    char eps_error_pass_packet[MAX_COUNTER_SIZE];
+    char eps_error_drop_flow[MAX_COUNTER_SIZE];
+    char eps_error_drop_packet[MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
@@ -89,6 +96,13 @@ typedef struct AppLayerCounters_ {
     uint16_t parser_error_id;
     uint16_t internal_error_id;
     uint16_t alloc_error_id;
+    uint16_t eps_error_ignore_id;
+    uint16_t eps_error_reject_id;
+    uint16_t eps_error_bypass_id;
+    uint16_t eps_error_pass_flow_id;
+    uint16_t eps_error_pass_packet_id;
+    uint16_t eps_error_drop_flow_id;
+    uint16_t eps_error_drop_packet_id;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
@@ -154,6 +168,38 @@ void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f)
 void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
 {
     const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
+static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum ExceptionPolicy policy)
+{
+    uint16_t id;
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_ignore_id;
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_reject_id;
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_bypass_id;
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_drop_flow_id;
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_drop_packet_id;
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_pass_packet_id;
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error_pass_flow_id;
+            break;
+    }
+
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -627,6 +673,7 @@ static int TCPProtoDetect(ThreadVars *tv,
     SCReturnInt(0);
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -696,6 +743,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         StreamTcpUpdateAppLayerProgress(ssn, direction, data_len);
         if (r < 0) {
             ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+            AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
             SCReturnInt(-1);
         }
         goto end;
@@ -781,6 +829,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 if (r < 0) {
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+                    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
                     SCReturnInt(-1);
                 }
             }
@@ -921,6 +970,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     }
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+        AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
         SCReturnInt(-1);
     }
 
@@ -1095,6 +1145,33 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_ignore,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_ignore),
+                            "%s%s%s.exception_policy.ignore", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_reject),
+                            "%s%s%s.exception_policy.reject", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_bypass),
+                            "%s%s%s.exception_policy.bypass", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_flow),
+                            "%s%s%s.exception_policy.pass_flow", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s%s.exception_policy.pass_packet", estr, alproto_str,
+                            ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_flow),
+                            "%s%s%s.exception_policy.drop_flow", estr, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_packet),
+                            "%s%s%s.exception_policy.drop_packet", estr, alproto_str,
+                            ipproto_suffix);
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1117,6 +1194,31 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s.internal", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_ignore,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_ignore),
+                            "%s%s.exception_policy.ignore", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_reject),
+                            "%s%s.exception_policy.reject", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].eps_error_bypass),
+                            "%s%s.exception_policy.bypass", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_flow),
+                            "%s%s.exception_policy.pass_flow", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s.exception_policy.pass_packet", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_drop_flow),
+                            "%s%s.exception_policy.drop_flow", estr, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                            sizeof(applayer_counter_names[ipproto_map][alproto]
+                                            .eps_error_pass_packet),
+                            "%s%s.exception_policy.drop_packet", estr, alproto_str);
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1160,6 +1262,28 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
                         applayer_counter_names[ipproto_map][alproto].parser_error, tv);
                 applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
                         applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_ignore_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_ignore, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_reject_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_reject, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_bypass_id = StatsRegisterCounter(
+                        applayer_counter_names[ipproto_map][alproto].eps_error_bypass, tv);
+                applayer_counters[ipproto_map][alproto].eps_error_pass_flow_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_pass_packet_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_drop_flow_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                                tv);
+                applayer_counters[ipproto_map][alproto].eps_error_drop_packet_id =
+                        StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                                tv);
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.c
+++ b/src/decode.c
@@ -612,6 +612,21 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+    /* Counters for Exception Policy Defrag values */
+    dtv->counter_defrag_memcap_eps_ignore =
+            StatsRegisterCounter("defrag.memcap_exception_policy.ignore", tv);
+    dtv->counter_defrag_memcap_eps_reject =
+            StatsRegisterCounter("defrag.memcap_exception_policy.reject", tv);
+    dtv->counter_defrag_memcap_eps_bypass =
+            StatsRegisterCounter("defrag.memcap_exception_policy.bypass", tv);
+    dtv->counter_defrag_memcap_eps_pass_flow =
+            StatsRegisterCounter("defrag.memcap_exception_policy.pass_flow", tv);
+    dtv->counter_defrag_memcap_eps_pass_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_defrag_memcap_eps_drop_flow =
+            StatsRegisterCounter("defrag.memcap_exception_policy.drop_flow", tv);
+    dtv->counter_defrag_memcap_eps_drop_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.drop_packet", tv);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.c
+++ b/src/decode.c
@@ -569,6 +569,21 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    /* Register stats counters for all exception policy values */
+    dtv->counter_flow_memcap_eps_ignore =
+            StatsRegisterCounter("flow.memcap_exception_policy.ignore", tv);
+    dtv->counter_flow_memcap_eps_reject =
+            StatsRegisterCounter("flow.memcap_exception_policy.reject", tv);
+    dtv->counter_flow_memcap_eps_bypass =
+            StatsRegisterCounter("flow.memcap_exception_policy.bypass", tv);
+    dtv->counter_flow_memcap_eps_pass_flow =
+            StatsRegisterCounter("flow.memcap_exception_policy.pass_flow", tv);
+    dtv->counter_flow_memcap_eps_pass_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_flow_memcap_eps_drop_flow =
+            StatsRegisterCounter("flow.memcap_exception_policy.drop_flow", tv);
+    dtv->counter_flow_memcap_eps_drop_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.drop_packet", tv);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -606,16 +606,10 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);
-    dtv->counter_defrag_ipv4_reassembled =
-        StatsRegisterCounter("defrag.ipv4.reassembled", tv);
-    dtv->counter_defrag_ipv4_timeouts =
-        StatsRegisterCounter("defrag.ipv4.timeouts", tv);
+    dtv->counter_defrag_ipv4_reassembled = StatsRegisterCounter("defrag.ipv4.reassembled", tv);
     dtv->counter_defrag_ipv6_fragments =
         StatsRegisterCounter("defrag.ipv6.fragments", tv);
-    dtv->counter_defrag_ipv6_reassembled =
-        StatsRegisterCounter("defrag.ipv6.reassembled", tv);
-    dtv->counter_defrag_ipv6_timeouts =
-        StatsRegisterCounter("defrag.ipv6.timeouts", tv);
+    dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/decode.h
+++ b/src/decode.h
@@ -717,6 +717,13 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    uint16_t counter_defrag_memcap_eps_ignore;
+    uint16_t counter_defrag_memcap_eps_reject;
+    uint16_t counter_defrag_memcap_eps_bypass;
+    uint16_t counter_defrag_memcap_eps_pass_flow;
+    uint16_t counter_defrag_memcap_eps_pass_packet;
+    uint16_t counter_defrag_memcap_eps_drop_flow;
+    uint16_t counter_defrag_memcap_eps_drop_packet;
 
     uint16_t counter_flow_memcap;
     uint16_t counter_flow_memcap_eps_ignore;

--- a/src/decode.h
+++ b/src/decode.h
@@ -714,10 +714,8 @@ typedef struct DecodeThreadVars_
     /** frag stats - defrag runs in the context of the decoder. */
     uint16_t counter_defrag_ipv4_fragments;
     uint16_t counter_defrag_ipv4_reassembled;
-    uint16_t counter_defrag_ipv4_timeouts;
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
-    uint16_t counter_defrag_ipv6_timeouts;
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;

--- a/src/decode.h
+++ b/src/decode.h
@@ -721,6 +721,13 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    uint16_t counter_flow_memcap_eps_ignore;
+    uint16_t counter_flow_memcap_eps_reject;
+    uint16_t counter_flow_memcap_eps_bypass;
+    uint16_t counter_flow_memcap_eps_pass_flow;
+    uint16_t counter_flow_memcap_eps_pass_packet;
+    uint16_t counter_flow_memcap_eps_drop_flow;
+    uint16_t counter_flow_memcap_eps_drop_packet;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -463,6 +463,34 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
     return CMP_DEFRAGTRACKER(t, p, id);
 }
 
+static void DefragExceptionPolicyStatsIncr(
+        ThreadVars *tv, DecodeThreadVars *dtv, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, dtv->counter_defrag_memcap_eps_pass_flow);
+            break;
+    }
+}
+
 /**
  *  \brief Get a new defrag tracker
  *
@@ -471,12 +499,13 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *
  *  \retval dt *LOCKED* tracker on succes, NULL on error.
  */
-static DefragTracker *DefragTrackerGetNew(Packet *p)
+static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
 #ifdef DEBUG
     if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
         SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
         ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+        DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
         return NULL;
     }
 #endif
@@ -501,6 +530,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerGetUsedDefragTracker();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -510,6 +540,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerAlloc();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -534,7 +565,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
  *
  * returns a *LOCKED* tracker or NULL
  */
-DefragTracker *DefragGetTrackerFromHash (Packet *p)
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     DefragTracker *dt = NULL;
 
@@ -546,7 +577,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
 
     /* see if the bucket already has a tracker */
     if (hb->head == NULL) {
-        dt = DefragTrackerGetNew(p);
+        dt = DefragTrackerGetNew(tv, dtv, p);
         if (dt == NULL) {
             DRLOCK_UNLOCK(hb);
             return NULL;
@@ -575,7 +606,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
             dt = dt->hnext;
 
             if (dt == NULL) {
-                dt = pdt->hnext = DefragTrackerGetNew(p);
+                dt = pdt->hnext = DefragTrackerGetNew(tv, dtv, p);
                 if (dt == NULL) {
                     DRLOCK_UNLOCK(hb);
                     return NULL;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -497,7 +497,7 @@ static void DefragExceptionPolicyStatsIncr(
  *  Get a new defrag tracker. We're checking memcap first and will try to make room
  *  if the memcap is reached.
  *
- *  \retval dt *LOCKED* tracker on succes, NULL on error.
+ *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
 static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -92,7 +92,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1041,8 +1041,10 @@ Defrag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 
     /* return a locked tracker or NULL */
     tracker = DefragGetTracker(tv, dtv, p);
-    if (tracker == NULL)
+    if (tracker == NULL) {
+        StatsIncr(tv, dtv->counter_defrag_max_hit);
         return NULL;
+    }
 
     Packet *rp = DefragInsertFrag(tv, dtv, tracker, p);
     DefragTrackerRelease(tracker);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -991,7 +991,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -605,6 +605,34 @@ static inline void NoFlowHandleIPS(Packet *p)
     ExceptionPolicyApply(p, flow_config.memcap_policy, PKT_DROP_REASON_FLOW_MEMCAP);
 }
 
+static void FlowExceptionPolicyStatsIncr(
+        ThreadVars *tv, FlowLookupStruct *fls, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, fls->dtv->counter_flow_memcap_eps_pass_flow);
+            break;
+    }
+}
+
 /**
  *  \brief Get a new flow
  *
@@ -623,6 +651,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
     if (g_eps_flow_memcap != UINT64_MAX && g_eps_flow_memcap == p->pcap_cnt) {
         NoFlowHandleIPS(p);
         StatsIncr(tv, fls->dtv->counter_flow_memcap);
+        FlowExceptionPolicyStatsIncr(tv, fls, flow_config.memcap_policy);
         return NULL;
     }
 #endif
@@ -648,6 +677,14 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
             f = FlowGetUsedFlow(tv, fls->dtv, p->ts);
             if (f == NULL) {
                 NoFlowHandleIPS(p);
+#ifdef UNITTESTS
+                if (tv != NULL && fls->dtv != NULL) {
+#endif
+                    StatsIncr(tv, fls->dtv->counter_flow_memcap);
+                    FlowExceptionPolicyStatsIncr(tv, fls, flow_config.memcap_policy);
+#ifdef UNITTESTS
+                }
+#endif
                 return NULL;
             }
 #ifdef UNITTESTS
@@ -673,6 +710,7 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
             }
 #endif
             NoFlowHandleIPS(p);
+            FlowExceptionPolicyStatsIncr(tv, fls, flow_config.memcap_policy);
             return NULL;
         }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -642,7 +642,8 @@ static void FlowExceptionPolicyStatsIncr(
  *  \param tv thread vars
  *  \param fls lookup support vars
  *
- *  \retval f *LOCKED* flow on succes, NULL on error.
+ *  \retval f *LOCKED* flow on success, NULL on error or if we should not create
+ *  a new flow.
  */
 static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
 {

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1947,6 +1947,34 @@ static int StreamTcpReassembleHandleSegmentUpdateACK (ThreadVars *tv,
     SCReturnInt(0);
 }
 
+static void StreamTcpReassembleExceptionPolicyStatsIncr(
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_pass_flow);
+            break;
+    }
+}
+
 int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         TcpSession *ssn, TcpStream *stream, Packet *p)
 {
@@ -2012,6 +2040,8 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
                     p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpReassembleExceptionPolicyStatsIncr(
+                    tv, ra_ctx, stream_config.reassembly_memcap_policy);
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -63,6 +63,14 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    uint16_t counter_tcp_reas_eps_ignore;
+    uint16_t counter_tcp_reas_eps_reject;
+    uint16_t counter_tcp_reas_eps_bypass;
+    uint16_t counter_tcp_reas_eps_pass_flow;
+    uint16_t counter_tcp_reas_eps_pass_packet;
+    uint16_t counter_tcp_reas_eps_drop_flow;
+    uint16_t counter_tcp_reas_eps_drop_packet;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5787,6 +5787,20 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_ignore =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.ignore", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_reject =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.reject", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_bypass =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.bypass", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_packet", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_packet", tv);
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -469,12 +469,13 @@ void StreamTcpInitConfig(bool quiet)
     stream_config.ssn_memcap_policy = ExceptionPolicyParse("stream.memcap-policy", true);
     stream_config.reassembly_memcap_policy =
             ExceptionPolicyParse("stream.reassembly.memcap-policy", true);
-    stream_config.midstream_policy = ExceptionPolicyParse("stream.midstream-policy", true);
-    if (stream_config.midstream && stream_config.midstream_policy != EXCEPTION_POLICY_NOT_SET) {
+    stream_config.midstream_policy =
+            ExceptionPolicyMidstreamParse("stream.midstream-policy", true, stream_config.midstream);
+    /* if (stream_config.midstream && stream_config.midstream_policy != EXCEPTION_POLICY_NOT_SET) {
         SCLogWarning("stream.midstream_policy setting conflicting with stream.midstream enabled. "
                      "Ignoring stream.midstream_policy. Bug #5825.");
         stream_config.midstream_policy = EXCEPTION_POLICY_NOT_SET;
-    }
+    } */
 
     if (!quiet) {
         SCLogConfig("stream.\"inline\": %s",

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -707,6 +707,34 @@ void StreamTcpFreeConfig(bool quiet)
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
 }
 
+static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_ignore);
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, stt->counter_tcp_ssn_memcap_eps_pass_flow);
+            break;
+    }
+}
+
 /** \internal
  *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
@@ -746,6 +774,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 #endif
@@ -753,6 +782,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 
@@ -5774,6 +5804,20 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    stt->counter_tcp_ssn_memcap_eps_ignore =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.ignore", tv);
+    stt->counter_tcp_ssn_memcap_eps_reject =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.reject", tv);
+    stt->counter_tcp_ssn_memcap_eps_bypass =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.bypass", tv);
+    stt->counter_tcp_ssn_memcap_eps_pass_flow =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.pass_flow", tv);
+    stt->counter_tcp_ssn_memcap_eps_pass_packet =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.pass_packet", tv);
+    stt->counter_tcp_ssn_memcap_eps_drop_flow =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.drop_flow", tv);
+    stt->counter_tcp_ssn_memcap_eps_drop_packet =
+            StatsRegisterCounter("tcp.ssn_memcap_exception_policy.drop_packet", tv);
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -111,7 +111,7 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_midstream_eps_drop_packet;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
-    /** ack for unseed data */
+    /** ack for unseen data */
     uint16_t counter_tcp_ack_unseen_data;
 
     /** tcp reassembly thread data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -101,6 +101,14 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    uint16_t counter_tcp_midstream_eps_ignore;
+    uint16_t counter_tcp_midstream_eps_reject;
+    uint16_t counter_tcp_midstream_eps_bypass;
+    uint16_t counter_tcp_midstream_eps_pass_flow;
+    uint16_t counter_tcp_midstream_eps_pass_packet;
+    uint16_t counter_tcp_midstream_eps_drop_flow;
+    uint16_t counter_tcp_midstream_eps_drop_packet;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseed data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -85,6 +85,14 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    uint16_t counter_tcp_ssn_memcap_eps_ignore;
+    uint16_t counter_tcp_ssn_memcap_eps_reject;
+    uint16_t counter_tcp_ssn_memcap_eps_bypass;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_packet;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_packet;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -145,6 +145,89 @@ static enum ExceptionPolicy PickPacketAction(const char *option, enum ExceptionP
     return p;
 }
 
+/**
+ * \brief Evaluate whether the provided exception policy configuration
+ * setting is valid in the given midstream policy scenario, and decide on the
+ * final exception policy value based on that.
+ */
+enum ExceptionPolicy ExceptionPolicyMidstreamParse(
+        enum ExceptionPolicy policy, bool midstream_enabled)
+{
+    if (EngineModeIsIPS()) {
+        if (midstream_enabled) {
+            /* only ignore and pass-flow are valid here */
+            if (policy == EXCEPTION_POLICY_PASS_FLOW) {
+                /* session tracked, inspect and log app-layer, no detection */
+            } else if (policy == EXCEPTION_POLICY_NOT_SET) {
+                /* Maybe here we don't have to do anything, this will be parsed and defined, and
+                 * then once ExceptionPolicyApply() is called, then this would be properly
+                 * processed? Or maybe this will be figured out when we _should_ call it, but, well,
+                 * won't for EPS isn't set */
+            }
+        } else {
+            /* Midstream disabled */
+            switch (policy) {
+                case EXCEPTION_POLICY_NOT_SET:
+                    /* in practice, we won't track nor do anything related to EPS */
+                    break;
+                case EXCEPTION_POLICY_DROP_FLOW:
+                    /* Session not tracked no app-layer inspection or logging. No detection. Flow
+                     * DROPPED*/
+                    break; // unneeded, right
+                case EXCEPTION_POLICY_DROP_PACKET:
+                    /* error out */
+                case EXCEPTION_POLICY_REJECT:
+                    /* Session not tracked flow DROPPED and REJECTED */
+                case EXCEPTION_POLICY_PASS_FLOW:
+                    /* in practice, we won't track nor do anything related to EPS */
+                    break;
+                case EXCEPTION_POLICY_PASS_PACKET:
+                    /* in practice, we won't track nor do anything related to EPS */
+                case EXCEPTION_POLICY_BYPASS_FLOW:
+                    /* in practice, we won't track nor do anything related to EPS. Packets ALLOWED
+                     */
+            }
+        }
+    } else {
+        /* IDS mode */
+        if (midstream_enabled) {
+            /* only ignore and pass-flow are valid here */
+            if (policy == EXCEPTION_POLICY_PASS_FLOW) {
+                /* session tracked, inspect and log app-layer, no detection */
+            } else if (policy == EXCEPTION_POLICY_NOT_SET) {
+                /* Maybe here we don't have to do anything, this will be parsed and defined, and
+                 * then once ExceptionPolicyApply() is called, then this would be properly
+                 * processed? Or maybe this will be figured out when we _should_ call it, but, well,
+                 * won't for EPS isn't set */
+            }
+        } else {
+            /* Midstream disabled */
+            switch (policy) {
+                case EXCEPTION_POLICY_NOT_SET:
+                    /* in practice, we won't track nor do anything related to EPS */
+                    break;
+                case EXCEPTION_POLICY_DROP_FLOW:
+                    /* error out */
+                    break; // unneeded, right
+                case EXCEPTION_POLICY_DROP_PACKET:
+                    /* error out */
+                case EXCEPTION_POLICY_REJECT:
+                    /* Session not tracked flow REJECTED */
+                case EXCEPTION_POLICY_PASS_FLOW:
+                    /* PASS flow */
+                    break;
+                case EXCEPTION_POLICY_PASS_PACKET:
+                    /* error out */
+                case EXCEPTION_POLICY_BYPASS_FLOW:
+                    /* same as ignore */
+            }
+        }
+    }
+
+    /* What do we have to take into account here?
+     iii) is this policy allowed in this scenario? */
+}
+
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow)
 {
     enum ExceptionPolicy policy = EXCEPTION_POLICY_NOT_SET;

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -38,6 +38,8 @@ void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);
+enum ExceptionPolicy ExceptionPolicyMidstreamParse(
+        const char *option, const bool support_flow, bool midstream_enabled);
 
 extern enum ExceptionPolicy g_eps_master_switch;
 #ifdef DEBUG


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5825

Notes:
- **need feedback** on behavior when `drop` values are passed in `IDS mode`. We currently adjust these to `ignore`, but the new approach would mean changing this behavior to erroring out in such cases. 
- this PR contains exception policy stats work that are here only for debugging, they're a WIP but lower priority, and have already received feedback

Describe changes:
- add function to parse midstream exception policy config values
- Introduce erroring out when existing, but invalid config values are passed
- Update Exception Policy docs to include a matrix with all scenarios (for IDS and IPS)

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=pr/1216
```

SV PR: https://github.com/OISF/suricata-verify/pull/1216

Matrix with Exception Policy  scenarios for Midstream:
![image](https://github.com/OISF/suricata/assets/16976857/c122f313-82a5-43cc-9512-0a467b240e8c)
