### PR TITLE
jsonbuilder: attempt to handle memory allocation errors - v5

### DIFF
--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -399,7 +399,7 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
 
 /// Log SOA section fields.
 fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_string_from_bytes("mname", &soa.mname)?;
     js.set_string_from_bytes("rname", &soa.rname)?;
@@ -415,7 +415,7 @@ fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
 
 /// Log SSHFP section fields.
 fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     let mut hex = Vec::new();
     for byte in &sshfp.fingerprint {
@@ -432,7 +432,7 @@ fn dns_log_sshfp(sshfp: &DNSRDataSSHFP) -> Result<JsonBuilder, JsonError> {
 
 /// Log SRV section fields.
 fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
 
     js.set_uint("priority", srv.priority as u64)?;
     js.set_uint("weight", srv.weight as u64)?;
@@ -444,7 +444,7 @@ fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
 }
 
 fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
-    let mut jsa = JsonBuilder::new_object();
+    let mut jsa = JsonBuilder::try_new_object()?;
 
     jsa.set_string_from_bytes("rrname", &answer.name)?;
     jsa.set_string("rrtype", &dns_rrtype_string(answer.rrtype))?;
@@ -516,7 +516,7 @@ fn dns_log_json_answer(
     js.set_string("rcode", &dns_rcode_string(header.flags))?;
 
     if !response.answers.is_empty() {
-        let mut js_answers = JsonBuilder::new_array();
+        let mut js_answers = JsonBuilder::try_new_array()?;
 
         // For grouped answers we use a HashMap keyed by the rrtype.
         let mut answer_types = HashMap::new();
@@ -527,7 +527,7 @@ fn dns_log_json_answer(
                 match &answer.data {
                     DNSRData::A(addr) | DNSRData::AAAA(addr) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string(&dns_print_addr(addr))?;
@@ -540,7 +540,7 @@ fn dns_log_json_answer(
                     | DNSRData::NULL(bytes)
                     | DNSRData::PTR(bytes) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_string_from_bytes(bytes)?;
@@ -548,7 +548,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SOA(soa) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_soa(soa)?)?;
@@ -556,7 +556,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SSHFP(sshfp) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_sshfp(sshfp)?)?;
@@ -564,7 +564,7 @@ fn dns_log_json_answer(
                     }
                     DNSRData::SRV(srv) => {
                         if !answer_types.contains_key(&type_string) {
-                            answer_types.insert(type_string.to_string(), JsonBuilder::new_array());
+                            answer_types.insert(type_string.to_string(), JsonBuilder::try_new_array()?);
                         }
                         if let Some(a) = answer_types.get_mut(&type_string) {
                             a.append_object(&dns_log_srv(srv)?)?;

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -159,7 +159,7 @@ impl JsonBuilder {
             State::None => {
                 debug_validate_fail!("invalid state");
                 Err(JsonError::InvalidState)
-            },
+            }
         }
     }
 
@@ -334,7 +334,7 @@ impl JsonBuilder {
             State::ArrayFirst => {
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -345,7 +345,7 @@ impl JsonBuilder {
                 self.buf.push(',');
                 self.buf.push('"');
                 for i in 0..val.len() {
-                    self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+                    self.buf.push(HEX[(val[i] >> 4) as usize] as char);
                     self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
                 }
                 self.buf.push('"');
@@ -522,7 +522,7 @@ impl JsonBuilder {
         self.buf.push_str(key);
         self.buf.push_str("\":\"");
         for i in 0..val.len() {
-            self.buf.push(HEX[(val[i] >>  4) as usize] as char);
+            self.buf.push(HEX[(val[i] >> 4) as usize] as char);
             self.buf.push(HEX[(val[i] & 0xf) as usize] as char);
         }
         self.buf.push('"');

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -46,7 +46,7 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
 }
 
 fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::new_object();
+    let mut js = JsonBuilder::try_new_object()?;
     match req {
         PgsqlFEMessage::StartupMessage(StartupPacket {
             length: _,
@@ -108,7 +108,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
 }
 
 fn log_response_object(tx: &PgsqlTransaction) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     let mut array_open = false;
     for response in &tx.responses {
         if let PgsqlBEMessage::ParameterStatus(msg) = response {
@@ -268,7 +268,7 @@ fn log_error_notice_field_types(
 }
 
 fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     // User is a mandatory field in a pgsql message
     jb.set_string_from_bytes("user", &params.user.value)?;
     if let Some(parameters) = &params.optional_params {
@@ -284,7 +284,7 @@ fn log_startup_parameters(params: &PgsqlStartupParameters) -> Result<JsonBuilder
 }
 
 fn log_pgsql_param(param: &PgsqlParameter) -> Result<JsonBuilder, JsonError> {
-    let mut jb = JsonBuilder::new_object();
+    let mut jb = JsonBuilder::try_new_object()?;
     jb.set_string_from_bytes(param.name.to_str(), &param.value)?;
     jb.close()?;
     Ok(jb)


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/6057
Previous PR: https://github.com/OISF/suricata/pull/8855

Changes from last PR:
- Fix per-commit check
- Remove base64 update, will do separate PR
