### PR TITLE
decode-ipv6: Set IPv6 proto incase of ext header parsing error

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -574,6 +574,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
         CLEAR_IPV6_PACKET(p);
         return TM_ECODE_FAILED;
     }
+    p->proto = IPV6_GET_NH(p);
 
 #ifdef DEBUG
     if (SCLogDebugEnabled()) { /* only convert the addresses if debug is really enabled */


### PR DESCRIPTION
Set the IPv6 packet proto before parsing the ext headers, similar to decode-ipv4, incase of an ext header parsing error. Otherwise rule decode-events are not triggered for packets encapsulated in IPv6.

Bug: #6086.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [✓] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6086

Link to suricata-verify test case:
https://github.com/OISF/suricata-verify/pull/1218

Describe changes:
Set the IPv6 packet proto before parsing the ext headers, similar to decode-ipv4, incase of an ext header parsing error.

SV_BRANCH=pr/1218