### PR TITLE
configure: Require c11 as the minimum C standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,9 +292,18 @@
     AC_MSG_RESULT(ok)
 
     # check if our target supports c11
-    AC_MSG_CHECKING(for c11 support)
+    AC_MSG_CHECKING(for required c11 support)
+    # We require c11+ now
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#if __STDC_VERSION__ >= 201112L
+                                         int c11_supported;
+                                         #endif
+                                       ]])],
+                                       [AC_MSG_RESULT([yes])],
+                                       [AC_MSG_ERROR([C11 support is required but not available.])])
+
     OCFLAGS=$CFLAGS
     CFLAGS="-std=c11"
+    AC_MSG_CHECKING(for tls support)
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],
                 [[ static _Thread_local int i; i = 1; i++; ]])],
             AC_MSG_RESULT([yes])
@@ -304,9 +313,6 @@
              CFLAGS="$OCFLAGS"
              have_c11=no
              have_c11_tls=no])
-    if [ test "x$have_c11" = "xno" ]; then
-        CFLAGS="$CFLAGS -std=gnu99"
-    fi
 
     # check if our target supports thread local storage
     AC_MSG_CHECKING(for thread local storage gnu __thread support)


### PR DESCRIPTION
Continuation of #8911 
This commit modifies the configure script to check for C11 by comparing the __STDC_VERSION__ with 201112L

An error message is issued if the C version is older than the C11 standard version.

Issue: 6029

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6029](https://redmine.openinfosecfoundation.org/issues/6029)

Describe changes:
- Updated `configure` to check `__STDC_VERSION__` against the C11 value.

Updates:
- Separate c11 from tls checks 

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
