### PR TITLE
6.0.x: fix for issues 5868

### DIFF
--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -175,7 +175,7 @@ pub struct NFSTransaction {
     pub file_handle: Vec<u8>,
 
     /// Procedure type specific data
-    /// TODO see if this can be an Option<Box<NFSTransactionTypeData>>. Initial
+    /// TODO see if this can be an `Option<Box<NFSTransactionTypeData>>`. Initial
     /// attempt failed.
     pub type_data: Option<NFSTransactionTypeData>,
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -557,9 +557,6 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
     // Outputs.
     OutputLoggerLog(tv, p, fw->output_thread);
 
-    /* Prune any stored files. */
-    FlowPruneFiles(p);
-
     /*  Release tcp segments. Done here after alerting can use them. */
     if (p->flow != NULL) {
         DEBUG_ASSERT_FLOW_LOCKED(p->flow);
@@ -582,6 +579,9 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
         Flow *f = p->flow;
         FlowDeReference(&p->flow);
         FLOWLOCK_UNLOCK(f);
+
+        /* Prune any stored files. */
+        FlowPruneFiles(p);
     }
 
 housekeeping:


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/5868

I have a feeling there is more to this than just delaying file cleanup.  With
master this appears to have been fixed with the move to per-tx file storage.

SV_BRANCH=pr/1225
