### PR TITLE
6.0.x - filedata - inspect http earlier - v2

### DIFF
--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -175,7 +175,7 @@ pub struct NFSTransaction {
     pub file_handle: Vec<u8>,
 
     /// Procedure type specific data
-    /// TODO see if this can be an Option<Box<NFSTransactionTypeData>>. Initial
+    /// TODO see if this can be an `Option<Box<NFSTransactionTypeData>>`. Initial
     /// attempt failed.
     pub type_data: Option<NFSTransactionTypeData>,
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/8950

This PR is for discussion of issue 5868. The issue is that `file_data` postpones inspection until the response body is complete, but by then the file has been pruned to the point where there is no data to save.  Example rule:

```
alert http any any -> any any (msg:"PDF LOGO"; flow:established,to_client; file_data; content:"PDF"; filestore; classtype:policy-violation; sid:9000000; rev:1;)
```

This behavior is expected if matching data at the end of the file, but the data is at the beginning for this test.  Removing `file_data` results in the file being completely logged as well, as it skips this optimization.

Ideally, we'd keep this optimization except when filestore is enabled, but I don't see a non-intrusive way to get that detail from `PrefilterTxHTTPFiledata`.

Git master does not see this issue file pruning does not appear to be occurring: https://github.com/OISF/suricata/pull/8950#discussion_r1214520123

Ticket: https://redmine.openinfosecfoundation.org/issues/5868
SV_BRANCH=pr/1225