### PR TITLE
debug: fix list-x command line options with debug

### DIFF
--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -31,6 +31,7 @@
 
 int ListKeywords(const char *keyword_info)
 {
+    EngineModeSetIDS();
     SCLogLoadConfig(0, 0, 0, 0);
     MpmTableSetup();
     SpmTableSetup();
@@ -41,6 +42,7 @@ int ListKeywords(const char *keyword_info)
 
 int ListAppLayerProtocols(const char *conf_filename)
 {
+    EngineModeSetIDS();
     if (ConfYamlLoadFile(conf_filename) != -1)
         SCLogLoadConfig(0, 0, 0, 0);
     MpmTableSetup();


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6089

Steps to reproduce :
- build with `./src/tests/fuzz/oss-fuzz-configure.sh`
- run `./src/suricata --list-keywords` or `./src/suricata --list-app-layer-protos`

This fails with stack trace
```
Assertion failed: (!((g_engine_mode == ENGINE_MODE_UNKNOWN))), function EngineModeIsIPS, file suricata.c, line 224.
Abort trap: 6
    #2 0x10b15e236 in EngineModeIsIPS suricata.c:224
    #3 0x10b1a76c3 in ExceptionPolicyParse util-exception-policy.c:215
    #4 0x10ae3aff1 in AppLayerParserRegisterProtocolParsers app-layer-parser.c:1743
    #5 0x10ad79df8 in AppLayerSetup app-layer.c:973
    #6 0x10b1faffa in ListKeywords util-running-modes.c:37
    #7 0x10b16615c in SuricataMain suricata.c:2918
```

This hinders oss-fuzz which relies on these commands 

Describe changes:
- Adds a new engine mode to prevent the assertion to trigger

Another fix could just be to `EngineModeSetIDS` in `ListKeywords`

Modifies #8921 with fix suggested by @lukashino 
