### PR TITLE
Detect files : 

### DIFF
--- a/src/detect-engine-file.c
+++ b/src/detect-engine-file.c
@@ -49,6 +49,29 @@
 #include "util-profiling.h"
 #include "util-validate.h"
 
+FileAppProto file_protos_ts_static[] = {
+    { ALPROTO_HTTP1, HTP_REQUEST_BODY },
+    { ALPROTO_SMTP, 0 },
+    { ALPROTO_FTP, 0 },
+    { ALPROTO_FTPDATA, 0 },
+    { ALPROTO_SMB, 0 },
+    { ALPROTO_NFS, 0 },
+    { ALPROTO_HTTP2, HTTP2StateDataClient },
+    { ALPROTO_UNKNOWN, 0 },
+};
+
+FileAppProto file_protos_tc_static[] = {
+    { ALPROTO_HTTP1, HTP_RESPONSE_BODY },
+    { ALPROTO_FTP, 0 },
+    { ALPROTO_FTPDATA, 0 },
+    { ALPROTO_SMB, 0 },
+    { ALPROTO_NFS, 0 },
+    { ALPROTO_HTTP2, HTTP2StateDataServer },
+    { ALPROTO_UNKNOWN, 0 },
+};
+
+FileAppProto *file_protos_ts = file_protos_ts_static;
+FileAppProto *file_protos_tc = file_protos_tc_static;
 
 /**
  *  \brief Inspect the file inspecting keywords.

--- a/src/detect-engine-file.h
+++ b/src/detect-engine-file.h
@@ -28,4 +28,12 @@ uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx 
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *_alstate, void *tx, uint64_t tx_id);
 
+typedef struct FileAppProto {
+    AppProto alproto;
+    int progress;
+} FileAppProto;
+
+extern FileAppProto *file_protos_ts;
+extern FileAppProto *file_protos_tc;
+
 #endif /* __DETECT_ENGINE_FILE_H__ */

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -197,11 +197,7 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     SCEnter();
 
     if (!DetectProtoContainsProto(&s->proto, IPPROTO_TCP) ||
-            (s->alproto != ALPROTO_UNKNOWN && s->alproto != ALPROTO_HTTP1 &&
-                    s->alproto != ALPROTO_SMTP && s->alproto != ALPROTO_SMB &&
-                    s->alproto != ALPROTO_HTTP2 && s->alproto != ALPROTO_FTP &&
-                    s->alproto != ALPROTO_FTPDATA && s->alproto != ALPROTO_HTTP &&
-                    s->alproto != ALPROTO_NFS)) {
+            (s->alproto != ALPROTO_UNKNOWN && !AppLayerParserSupportsFiles(IPPROTO_TCP, s->alproto))) {
         SCLogError("rule contains conflicting keywords.");
         return -1;
     }

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -34,6 +34,7 @@
 #include "detect-engine-mpm.h"
 #include "detect-engine-prefilter.h"
 #include "detect-engine-content-inspection.h"
+#include "detect-engine-file.h"
 
 #include "flow.h"
 #include "flow-var.h"
@@ -135,28 +136,21 @@ void DetectFilemagicRegister(void)
 
     g_file_match_list_id = DetectBufferTypeRegister("files");
 
-    AppProto protos_ts[] = { ALPROTO_HTTP1, ALPROTO_SMTP, ALPROTO_FTP, ALPROTO_SMB, ALPROTO_NFS,
-        ALPROTO_HTTP2, 0 };
-    AppProto protos_tc[] = { ALPROTO_HTTP1, ALPROTO_FTP, ALPROTO_SMB, ALPROTO_NFS, ALPROTO_HTTP2,
-        0 };
-
-    for (int i = 0; protos_ts[i] != 0; i++) {
-        DetectAppLayerInspectEngineRegister2("file.magic", protos_ts[i],
-                SIG_FLAG_TOSERVER, 0,
-                DetectEngineInspectFilemagic, NULL);
+    for (int i = 0; file_protos_ts[i].alproto != ALPROTO_UNKNOWN; i++) {
+        DetectAppLayerInspectEngineRegister2("file.magic", file_protos_ts[i].alproto,
+                SIG_FLAG_TOSERVER, file_protos_ts[i].progress, DetectEngineInspectFilemagic, NULL);
 
         DetectAppLayerMpmRegister2("file.magic", SIG_FLAG_TOSERVER, 2,
-                PrefilterMpmFilemagicRegister, NULL, protos_ts[i],
-                0);
+                PrefilterMpmFilemagicRegister, NULL, file_protos_ts[i].alproto,
+                file_protos_ts[i].progress);
     }
-    for (int i = 0; protos_tc[i] != 0; i++) {
-        DetectAppLayerInspectEngineRegister2("file.magic", protos_tc[i],
-                SIG_FLAG_TOCLIENT, 0,
-                DetectEngineInspectFilemagic, NULL);
+    for (int i = 0; file_protos_tc[i].alproto != ALPROTO_UNKNOWN; i++) {
+        DetectAppLayerInspectEngineRegister2("file.magic", file_protos_tc[i].alproto,
+                SIG_FLAG_TOCLIENT, file_protos_tc[i].progress, DetectEngineInspectFilemagic, NULL);
 
         DetectAppLayerMpmRegister2("file.magic", SIG_FLAG_TOCLIENT, 2,
-                PrefilterMpmFilemagicRegister, NULL, protos_tc[i],
-                0);
+                PrefilterMpmFilemagicRegister, NULL, file_protos_tc[i].alproto,
+                file_protos_tc[i].progress);
     }
 
     DetectBufferTypeSetDescriptionByName("file.magic",


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, preliminary work for https://redmine.openinfosecfoundation.org/issues/5053 and app-layer plugins (that can use files and their keywords)

Describe changes:
- detect/files: reuse AppLayerParserSupportsFiles instead of than relisting the protocols
- detect/files: centralize definition of protocols : so that they can be used by all file keywords

It still bothers me that `detect-filename.c` defines the `files` DetectBuffer that is used by all file keywords...

I do not know if it is a significant change but the progress for (like HTP_REQUEST_BODY for HTTP1) was not used in file name, file magic...