### PR TITLE
dpdk: support multiple same EAL arguments

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1965,6 +1965,7 @@ The whole DPDK configuration resides in the `dpdk:` node. This node encapsulates
     dpdk:
       eal-params:
         proc-type: primary
+        allow: ["0000:3b:00.0", "0000:3b:00.1"]
       interfaces:
         - interface: 0000:3b:00.0
           threads: auto
@@ -1988,7 +1989,14 @@ are typically provided through the command line, are contained in the node
 parameters. There are two ways to specify arguments: lengthy and short.
 Dashes are omitted when describing the arguments. This setup node can be
 used to set up the memory configuration, accessible NICs, and other EAL-related
-parameters, among other things. The definition of lcore affinity as an EAL
+parameters, among other things. The node `dpdk.eal-params` also supports 
+multiple arguments of the same type. This can be useful for EAL arguments 
+such as `--vdev`, `--allow`, or `--block`. Values for these EAL arguments 
+are specified as a comma-separated list. 
+An example of such usage can be found in the example above where the `allow` 
+argument only makes `0000:3b:00.0` and `0000:3b:00.1` accessible to Suricata. 
+arguments with list node. such as --vdev, --allow, --block eal options.
+The definition of lcore affinity as an EAL
 parameter is a standard practice. However, lcore parameters like `-l`, `-c`,
 and `--lcores`` are specified within the `suricata-yaml-threading`_ section
 to prevent configuration overlap.

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -271,6 +271,14 @@ static void InitEal(void)
     ArgumentsAdd(&args, AllocAndSetArgument("suricata"));
 
     TAILQ_FOREACH (param, &eal_params->head, next) {
+        if (ConfNodeIsSequence(param)) {
+            const char *key = param->name;
+            ConfNode *val;
+            TAILQ_FOREACH (val, &param->head, next) {
+                ArgumentsAddOptionAndArgument(&args, key, (const char *)val->val);
+            }
+            continue;
+        }
         ArgumentsAddOptionAndArgument(&args, param->name, param->val);
     }
 


### PR DESCRIPTION
DPDK apps can specify multiple arguments of the same type. YAML format only allows unique keys within a single node. This commit adds support for multiple EAL arguments of the same type to be used within suricata.yaml.

Ticket: #5964

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Ticket: #5964
Follow-up of #8947

Describe changes:
- dpdk.eal-params list option support 
- suricata-yaml.rst add dpdk.eal-params.allow example
