### PR TITLE
output/snmp: log version from tx

### DIFF
--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -18,7 +18,7 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
-use crate::snmp::snmp::{SNMPState,SNMPTransaction};
+use crate::snmp::snmp::SNMPTransaction;
 use crate::snmp::snmp_parser::{NetworkAddress,PduType};
 use std::borrow::Cow;
 
@@ -37,9 +37,9 @@ fn str_of_pdu_type(t:&PduType) -> Cow<str> {
     }
 }
 
-fn snmp_log_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMPTransaction) -> Result<(), JsonError>
+fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<(), JsonError>
 {
-    jsb.set_uint("version", state.version as u64)?;
+    jsb.set_uint("version", tx.version as u64)?;
     if tx.encrypted {
         jsb.set_string("pdu_type", "encrypted")?;
     } else {
@@ -75,7 +75,7 @@ fn snmp_log_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMP
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(jsb: &mut JsonBuilder, state: &mut SNMPState, tx: &mut SNMPTransaction) -> bool
+pub extern "C" fn rs_snmp_log_json_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> bool
 {
-    snmp_log_response(jsb, state, tx).is_ok()
+    snmp_log_response(jsb, tx).is_ok()
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -253,7 +253,7 @@ static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
                 tx_id);
         if (tx != NULL) {
             jb_open_object(js, "snmp");
-            rs_snmp_log_json_response(js, snmp_state, tx);
+            rs_snmp_log_json_response(js, tx);
             jb_close(js);
         }
     }

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -60,7 +60,7 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
     }
 
     jb_open_object(jb, "snmp");
-    if (!rs_snmp_log_json_response(jb, state, snmptx)) {
+    if (!rs_snmp_log_json_response(jb, snmptx)) {
         goto error;
     }
     jb_close(jb);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, preliminary work for https://redmine.openinfosecfoundation.org/issues/5053 and app-layer plugins

Describe changes:
- output/snmp: log version from tx, and not from state

This is a functional change from #8961 

If a SNMP flow starts with a V2 version exchange, then there is a V3, we will now log V3 for the second transaction