### PR TITLE
exception: in ids mode, only REJECT the packet - v1

### DIFF
--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -72,6 +72,9 @@ void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDro
         case EXCEPTION_POLICY_REJECT:
             SCLogDebug("EXCEPTION_POLICY_REJECT");
             PacketDrop(p, ACTION_REJECT, drop_reason);
+            if (!EngineModeIsIPS()) {
+                break;
+            }
             /* fall through */
         case EXCEPTION_POLICY_DROP_FLOW:
             SCLogDebug("EXCEPTION_POLICY_DROP_FLOW");


### PR DESCRIPTION
In case of 'EXCEPTION_POLICY_REJECT', we were applying the same behavior regardless of being in IDS or IPS mode.
This meant that at least the 'flow.action' was changed to drop when we hit an exception policy in IDS mode. This minor fix makes the SV test pass, but I'm afraid the bug can mean more than that.

Bug #6109

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6109

Describe changes:
- Check if we are in IPS mode before falling through drop actions when applying REJECT exception policy.
This fix 6109 test, but... is that enough?

I'm not confident about how REJECT works as a whole, so I feel this might not be enough to ensure that we'll still reject things properly. Also not sure if this would be the right approach in cases where we should reject the flow in IDS mode. 
Makes me wonder if we should have REJECT for flow or packet, like we have for DROP and PASS.

```
SV_BRANCH=pr/1229
```
https://github.com/OISF/suricata-verify/pull/1229