### PR TITLE
source-pcap-file: include unlink error in warning message

### DIFF
--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -47,7 +47,7 @@ void CleanupPcapFileFileVars(PcapFileFileVars *pfv)
             if (pfv->shared != NULL && pfv->shared->should_delete) {
                 SCLogDebug("Deleting pcap file %s", pfv->filename);
                 if (unlink(pfv->filename) != 0) {
-                    SCLogWarning("Failed to delete %s", pfv->filename);
+                    SCLogWarning("Failed to delete %s: %s", pfv->filename, strerror(errno));
                 }
             }
             SCFree(pfv->filename);


### PR DESCRIPTION
**Context:**

When `suricata` runs with option `--pcap-file-delete`, in some cases it can be failed to delete the pcap files because of several reasons. However, the warning message does not give any hints regarding the cause of unsuccessful delete operation. Therefore, including error of `unlink` function in the warning message could be beneficial for debugging.

---
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: N/A

Describe changes:
-  Include `unlink` function's error in warning message when deleting pcap files failed.