### PR TITLE
Ftp backports 6.0.13/v2

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -471,12 +471,13 @@ static int FTPGetLineForDirection(
                 state->current_line_len = lf_idx - state->input;
             }
 
-            if (state->input != lf_idx &&
-                *(lf_idx - 1) == 0x0D) {
-                state->current_line_len--;
-                state->current_line_delimiter_len = 2;
-            } else {
-                state->current_line_delimiter_len = 1;
+            if (!*current_line_truncated) {
+                if (state->input != lf_idx && *(lf_idx - 1) == 0x0D) {
+                    state->current_line_len--;
+                    state->current_line_delimiter_len = 2;
+                } else {
+                    state->current_line_delimiter_len = 1;
+                }
             }
         }
 

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -177,7 +177,8 @@ typedef struct FtpState_ {
     /** length of the line in current_line.  Doesn't include the delimiter */
     uint32_t current_line_len;
     uint8_t current_line_delimiter_len;
-    bool current_line_truncated;
+    bool current_line_truncated_ts;
+    bool current_line_truncated_tc;
 
     /* 0 for toserver, 1 for toclient */
     FtpLineState line_state[2];


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6055

\+ fixes

SV_BRANCH=pr/1222

Previous PR: https://github.com/OISF/suricata/pull/8973

Changes since v1:
- Don't update delimeter length either if delimeter didn't fall in the line boundary

Note: the code is a lot different from master so there was nothing to right away cherry-pick hence no `cherry-picked from ..`