### PR TITLE
http2: avoid quadratic complexity in headers backport6

### DIFF
--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -457,12 +457,15 @@ fn http2_parse_headers_block_literal_incindex<'a>(
                 } else {
                     dyn_headers.table.push(headcopy);
                 }
-                while dyn_headers.current_size > dyn_headers.max_size && dyn_headers.table.len() > 0
+                let mut toremove = 0;
+                while dyn_headers.current_size > dyn_headers.max_size
+                    && toremove < dyn_headers.table.len()
                 {
                     dyn_headers.current_size -=
-                        32 + dyn_headers.table[0].name.len() + dyn_headers.table[0].value.len();
-                    dyn_headers.table.remove(0);
+                        32 + dyn_headers.table[toremove].name.len() + dyn_headers.table[toremove].value.len();
+                    toremove += 1;
                 }
+                dyn_headers.table.drain(0..toremove);
             }
             return Ok((r, head));
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6125

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/8957
