### PR TITLE
Proto vecdeque 5809 backport6 v1

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2020 Open Information Security Foundation
+/* Copyright (C) 2018-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,6 +18,7 @@
 use std;
 use crate::core::{self, ALPROTO_UNKNOWN, AppProto, Flow, IPPROTO_TCP};
 use std::mem::transmute;
+use std::collections::VecDeque;
 use crate::applayer::{self, *};
 use std::ffi::CString;
 use nom;
@@ -65,7 +66,7 @@ impl Drop for TemplateTransaction {
 
 pub struct TemplateState {
     tx_id: u64,
-    transactions: Vec<TemplateTransaction>,
+    transactions: VecDeque<TemplateTransaction>,
     request_gap: bool,
     #[allow(dead_code)]
     response_gap: bool,
@@ -75,7 +76,7 @@ impl TemplateState {
     pub fn new() -> Self {
         Self {
             tx_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             request_gap: false,
             response_gap: false,
         }
@@ -152,7 +153,7 @@ impl TemplateState {
                     SCLogNotice!("Request: {}", request);
                     let mut tx = self.new_tx();
                     tx.request = Some(request);
-                    self.transactions.push(tx);
+                    self.transactions.push_back(tx);
                 },
                 Err(nom::Err::Incomplete(_)) => {
                     // Not enough data. This parser doesn't give us a good indication

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,6 +23,7 @@ use nom::error::ErrorKind;
 use nom::number::Endianness;
 use nom;
 use std::cmp;
+use std::collections::VecDeque;
 
 // Constant DCERPC UDP Header length
 pub const DCERPC_HDR_LEN: u16 = 16;
@@ -332,7 +333,7 @@ pub struct DCERPCState {
     pub header: Option<DCERPCHdr>,
     pub bind: Option<DCERPCBind>,
     pub bindack: Option<DCERPCBindAck>,
-    pub transactions: Vec<DCERPCTransaction>,
+    pub transactions: VecDeque<DCERPCTransaction>,
     pub buffer_ts: Vec<u8>,
     pub buffer_tc: Vec<u8>,
     pub pad: u8,
@@ -357,7 +358,7 @@ impl DCERPCState {
             header: None,
             bind: None,
             bindack: None,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             buffer_ts: Vec::new(),
             buffer_tc: Vec::new(),
             pad: 0,
@@ -740,7 +741,7 @@ impl DCERPCState {
                     sc_app_layer_parser_trigger_raw_stream_reassembly(flow, core::STREAM_TOSERVER.into());
                 }
                 tx.frag_cnt_ts = 1;
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
                 // Bytes parsed with `parse_dcerpc_bind` + (bytes parsed per bindctxitem [44] * number
                 // of bindctxitems)
                 (input.len() - leftover_bytes.len()) as i32 + retval * numctxitems as i32
@@ -921,7 +922,7 @@ impl DCERPCState {
                         tx.ctxid = request.ctxid;
                         tx.opnum = request.opnum;
                         tx.first_request_seen = request.first_request_seen;
-                        self.transactions.push(tx);
+                        self.transactions.push_back(tx);
                     }
                 }
                 let parsed = self.handle_common_stub(
@@ -1064,8 +1065,8 @@ impl DCERPCState {
                     } else {
                         let mut tx = self.create_tx(current_call_id);
                         tx.resp_cmd = x;
-                        self.transactions.push(tx);
-                        self.transactions.last_mut().unwrap()
+                        self.transactions.push_back(tx);
+                        self.transactions.back_mut().unwrap()
                     };
                     tx.resp_done = true;
                     tx.frag_cnt_tc = 1;
@@ -1090,7 +1091,7 @@ impl DCERPCState {
                         None => {
                             let mut tx = self.create_tx(current_call_id);
                             tx.resp_cmd = x;
-                            self.transactions.push(tx);
+                            self.transactions.push_back(tx);
                         }
                     };
                     retval = self.handle_common_stub(

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -22,6 +22,7 @@ use crate::core;
 use crate::dcerpc::dcerpc::{
     DCERPCTransaction, DCERPC_TYPE_REQUEST, DCERPC_TYPE_RESPONSE, PFCL1_FRAG, PFCL1_LASTFRAG,
 };
+use std::collections::VecDeque;
 use crate::dcerpc::parser;
 
 // Constant DCERPC UDP Header length
@@ -53,14 +54,14 @@ pub struct DCERPCHdrUdp {
 #[derive(Debug)]
 pub struct DCERPCUDPState {
     pub tx_id: u64,
-    pub transactions: Vec<DCERPCTransaction>,
+    pub transactions: VecDeque<DCERPCTransaction>,
 }
 
 impl DCERPCUDPState {
     pub fn new() -> DCERPCUDPState {
         return DCERPCUDPState {
             tx_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
         };
     }
 
@@ -138,8 +139,8 @@ impl DCERPCUDPState {
         if otx.is_none() {
             let ntx = self.create_tx(hdr);
             SCLogDebug!("new tx id {}, last tx_id {}, {} {}", ntx.id, self.tx_id, ntx.seqnum, ntx.activityuuid[0]);
-            self.transactions.push(ntx);
-            otx = self.transactions.last_mut();
+            self.transactions.push_back(ntx);
+            otx = self.transactions.back_mut();
         }
 
         if let Some(tx) = otx {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -407,7 +407,7 @@ pub struct DNSState {
     pub tx_id: u64,
 
     // Transactions.
-    pub transactions: Vec<DNSTransaction>,
+    pub transactions: VecDeque<DNSTransaction>,
 
     config: Option<ConfigTracker>,
 
@@ -419,7 +419,7 @@ impl DNSState {
     pub fn new() -> DNSState {
         return DNSState{
             tx_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             config: None,
             gap: false,
         };
@@ -428,7 +428,7 @@ impl DNSState {
     pub fn new_tcp() -> DNSState {
         return DNSState{
             tx_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             config: None,
             gap: false,
         };
@@ -530,7 +530,7 @@ impl DNSState {
                 let mut tx = self.new_tx();
                 tx.request = Some(request);
                 tx.tx_data.set_inspect_direction(STREAM_TOSERVER);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");
@@ -594,7 +594,7 @@ impl DNSState {
                 }
                 tx.response = Some(response);
                 tx.tx_data.set_inspect_direction(STREAM_TOCLIENT);
-                self.transactions.push(tx);
+                self.transactions.push_back(tx);
 
                 if z_flag {
                     SCLogDebug!("Z-flag set on DNS response");

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -428,7 +428,8 @@ impl DNSState {
     pub fn new_tcp() -> DNSState {
         return DNSState{
             tx_id: 0,
-            transactions: VecDeque::new(),
+            transactions: VecDeque
+            ::new(),
             config: None,
             gap: false,
         };

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -29,6 +29,7 @@ use crate::filetracker::*;
 use nom;
 use std;
 use std::ffi::{CStr, CString};
+use std::collections::VecDeque;
 use std::fmt;
 use std::io;
 use std::mem::transmute;
@@ -379,7 +380,7 @@ pub struct HTTP2State {
     response_frame_size: u32,
     dynamic_headers_ts: HTTP2DynTable,
     dynamic_headers_tc: HTTP2DynTable,
-    transactions: Vec<HTTP2Transaction>,
+    transactions: VecDeque<HTTP2Transaction>,
     progress: HTTP2ConnectionState,
     pub files: HTTP2Files,
 }
@@ -395,7 +396,7 @@ impl HTTP2State {
             // a variable number of dynamic headers
             dynamic_headers_ts: HTTP2DynTable::new(),
             dynamic_headers_tc: HTTP2DynTable::new(),
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             progress: HTTP2ConnectionState::Http2StateInit,
             files: HTTP2Files::new(),
         }
@@ -474,8 +475,8 @@ impl HTTP2State {
         self.tx_id += 1;
         tx.tx_id = self.tx_id;
         tx.state = HTTP2TransactionState::HTTP2StateGlobal;
-        self.transactions.push(tx);
-        return self.transactions.last_mut().unwrap();
+        self.transactions.push_back(tx);
+        return self.transactions.back_mut().unwrap();
     }
 
     pub fn find_or_create_tx(
@@ -515,8 +516,8 @@ impl HTTP2State {
             tx.tx_id = self.tx_id;
             tx.stream_id = sid;
             tx.state = HTTP2TransactionState::HTTP2StateOpen;
-            self.transactions.push(tx);
-            return self.transactions.last_mut().unwrap();
+            self.transactions.push_back(tx);
+            return self.transactions.back_mut().unwrap();
         }
     }
 

--- a/rust/src/rdp/rdp.rs
+++ b/rust/src/rdp/rdp.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Open Information Security Foundation
+/* Copyright (C) 2022 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,6 +25,7 @@ use crate::rdp::parser::*;
 use nom;
 use std;
 use std::mem::transmute;
+use std::collections::VecDeque;
 use tls_parser::{parse_tls_plaintext, TlsMessage, TlsMessageHandshake, TlsRecordType};
 
 static mut ALPROTO_RDP: AppProto = ALPROTO_UNKNOWN;
@@ -122,7 +123,7 @@ pub extern "C" fn rs_rdp_tx_get_progress(
 #[derive(Debug, PartialEq)]
 pub struct RdpState {
     next_id: u64,
-    transactions: Vec<RdpTransaction>,
+    transactions: VecDeque<RdpTransaction>,
     tls_parsing: bool,
     bypass_parsing: bool,
 }
@@ -131,7 +132,7 @@ impl RdpState {
     fn new() -> Self {
         Self {
             next_id: 0,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             tls_parsing: false,
             bypass_parsing: false,
         }
@@ -213,7 +214,7 @@ impl RdpState {
                             T123TpktChild::X224ConnectionRequest(x224) => {
                                 let tx =
                                     self.new_tx(RdpTransactionItem::X224ConnectionRequest(x224));
-                                self.transactions.push(tx);
+                                self.transactions.push_back(tx);
                             }
 
                             // X.223 data packet, evaluate what it encapsulates
@@ -222,7 +223,7 @@ impl RdpState {
                                     X223DataChild::McsConnectRequest(mcs) => {
                                         let tx =
                                             self.new_tx(RdpTransactionItem::McsConnectRequest(mcs));
-                                        self.transactions.push(tx);
+                                        self.transactions.push_back(tx);
                                     }
                                     // unknown message in X.223, skip
                                     _ => (),
@@ -292,7 +293,7 @@ impl RdpState {
                                     }
                                     let tx =
                                         self.new_tx(RdpTransactionItem::TlsCertificateChain(chain));
-                                    self.transactions.push(tx);
+                                    self.transactions.push_back(tx);
                                     self.bypass_parsing = true;
                                 }
                                 _ => {}
@@ -325,7 +326,7 @@ impl RdpState {
                             T123TpktChild::X224ConnectionConfirm(x224) => {
                                 let tx =
                                     self.new_tx(RdpTransactionItem::X224ConnectionConfirm(x224));
-                                self.transactions.push(tx);
+                                self.transactions.push_back(tx);
                             }
 
                             // X.223 data packet, evaluate what it encapsulates
@@ -334,7 +335,7 @@ impl RdpState {
                                     X223DataChild::McsConnectResponse(mcs) => {
                                         let tx = self
                                             .new_tx(RdpTransactionItem::McsConnectResponse(mcs));
-                                        self.transactions.push(tx);
+                                        self.transactions.push_back(tx);
                                         self.bypass_parsing = true;
                                         return AppLayerResult::ok();
                                     }
@@ -616,8 +617,8 @@ mod tests {
         let tx0 = state.new_tx(item0);
         let tx1 = state.new_tx(item1);
         assert_eq!(2, state.next_id);
-        state.transactions.push(tx0);
-        state.transactions.push(tx1);
+        state.transactions.push_back(tx0);
+        state.transactions.push_back(tx1);
         assert_eq!(2, state.transactions.len());
         assert_eq!(0, state.transactions[0].id);
         assert_eq!(1, state.transactions[1].id);
@@ -661,9 +662,9 @@ mod tests {
         let tx0 = state.new_tx(item0);
         let tx1 = state.new_tx(item1);
         let tx2 = state.new_tx(item2);
-        state.transactions.push(tx0);
-        state.transactions.push(tx1);
-        state.transactions.push(tx2);
+        state.transactions.push_back(tx0);
+        state.transactions.push_back(tx1);
+        state.transactions.push_back(tx2);
         state.free_tx(1);
         assert_eq!(3, state.next_id);
         assert_eq!(2, state.transactions.len());

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -144,8 +144,8 @@ impl SMBState {
                     SMBTransactionDCERPC::new_request(cmd, call_id)));
 
         SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 
@@ -159,8 +159,8 @@ impl SMBState {
                     SMBTransactionDCERPC::new_response(call_id)));
 
         SCLogDebug!("SMB: TX DCERPC created: ID {} hdr {:?}", tx.id, tx.hdr);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 

--- a/rust/src/smb/debug.rs
+++ b/rust/src/smb/debug.rs
@@ -24,8 +24,8 @@ impl SMBState {
     #[cfg(feature = "debug")]
     pub fn _debug_tx_stats(&self) {
         if self.transactions.len() > 1 {
-            let txf = self.transactions.first().unwrap();
-            let txl = self.transactions.last().unwrap();
+            let txf = self.transactions.front().unwrap();
+            let txl = self.transactions.back().unwrap();
 
             SCLogDebug!("TXs {} MIN {} MAX {}", self.transactions.len(), txf.id, txl.id);
             SCLogDebug!("- OLD tx.id {}: {:?}", txf.id, txf);

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -111,8 +111,8 @@ impl SMBState {
         tx.tx_data.init_files_opened();
         SCLogDebug!("SMB: new_file_tx: TX FILE created: ID {} NAME {}",
                 tx.id, String::from_utf8_lossy(file_name));
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         let (files, flags) = self.files.get(direction);
         return (tx_ref.unwrap(), files, flags)
     }

--- a/rust/src/smb/session.rs
+++ b/rust/src/smb/session.rs
@@ -52,8 +52,8 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
         SCLogDebug!("SMB: TX SESSIONSETUP created: ID {}", tx.id);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -34,6 +34,8 @@ use std::collections::HashMap;
 
 use nom;
 
+use std::collections::VecDeque;
+ 
 use crate::core::*;
 use crate::applayer;
 use crate::applayer::{AppLayerResult, AppLayerTxData};
@@ -413,8 +415,8 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
         SCLogDebug!("SMB: TX SETFILEPATHINFO created: ID {}", tx.id);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 
@@ -432,8 +434,8 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
         SCLogDebug!("SMB: TX SETFILEPATHINFO created: ID {}", tx.id);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 }
@@ -465,8 +467,8 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
         SCLogDebug!("SMB: TX RENAME created: ID {}", tx.id);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 }
@@ -809,7 +811,7 @@ pub struct SMBState<> {
     post_gap_files_checked: bool,
 
     /// transactions list
-    pub transactions: Vec<SMBTransaction>,
+    pub transactions: VecDeque<SMBTransaction>,
 
     /// tx counter for assigning incrementing id's to tx's
     tx_id: u64,
@@ -855,7 +857,7 @@ impl SMBState {
             tc_trunc: false,
             check_post_gap_file_txs: false,
             post_gap_files_checked: false,
-            transactions: Vec::new(),
+            transactions: VecDeque::new(),
             tx_id:0,
             dialect:0,
             dialect_vec: None,
@@ -981,15 +983,15 @@ impl SMBState {
 
         SCLogDebug!("SMB: TX GENERIC created: ID {} tx list {} {:?}",
                 tx.id, self.transactions.len(), &tx);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 
     pub fn get_last_tx(&mut self, smb_ver: u8, smb_cmd: u16)
         -> Option<&mut SMBTransaction>
     {
-        let tx_ref = self.transactions.last_mut();
+        let tx_ref = self.transactions.back_mut();
         match tx_ref {
             Some(tx) => {
                 let found = if tx.vercmd.get_version() == smb_ver {
@@ -1054,8 +1056,8 @@ impl SMBState {
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
         SCLogDebug!("SMB: TX NEGOTIATE created: ID {} SMB ver {}", tx.id, smb_ver);
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 
@@ -1093,8 +1095,8 @@ impl SMBState {
 
         SCLogDebug!("SMB: TX TREECONNECT created: ID {} NAME {}",
                 tx.id, String::from_utf8_lossy(&name));
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 
@@ -1127,8 +1129,8 @@ impl SMBState {
         tx.request_done = true;
         tx.response_done = self.tc_trunc; // no response expected if tc is truncated
 
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 

--- a/rust/src/smb/smb2_ioctl.rs
+++ b/rust/src/smb/smb2_ioctl.rs
@@ -49,8 +49,8 @@ impl SMBState {
 
         SCLogDebug!("SMB: TX IOCTL created: ID {} FUNC {:08x}: {}",
                 tx.id, func, &fsctl_func_to_string(func));
-        self.transactions.push(tx);
-        let tx_ref = self.transactions.last_mut();
+        self.transactions.push_back(tx);
+        let tx_ref = self.transactions.back_mut();
         return tx_ref.unwrap();
     }
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5809

Describe changes:
- Backport all protocols changes to use `VecDeque`
