### PR TITLE
windows: add -lntdll to fix windows builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,7 +273,7 @@
             CFLAGS="${CFLAGS} -DOS_WIN32"
             WINDOWS_PATH="yes"
             AC_DEFINE([HAVE_NON_POSIX_MKDIR], [1], [mkdir is not POSIX compliant: single arg])
-            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh -lbcrypt"
+            RUST_LDADD=" -lws2_32 -liphlpapi -lwbemuuid -lOle32 -lOleAut32 -lUuid -luserenv -lshell32 -ladvapi32 -lgcc_eh -lbcrypt -lntdll"
             TRY_WPCAP="yes"
             ;;
         *-*-cygwin)


### PR DESCRIPTION
Rust 1.70 has introduced some possible issues between LLVM and gcc
causing link errors that are fixed by explicitly adding -lntdll.
    
Thanks to https://github.com/extendr/rextendr/pull/285 for the fix.
