### PR TITLE
doc: add missing rule to engine-analysis section - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2474,6 +2474,8 @@ Example:
   [10703] 26/11/2010 -- 11:41:15 - (detect.c:560) <Info> (SigLoadSignatures)
   -- Engine-Analysis for fast_pattern printed to file - /var/log/suricata/rules_fast_pattern.txt
 
+  alert tcp any any -> any any (content:"Volume Serial Number"; sid:1292;)
+
   == Sid: 1292 ==
   Fast pattern matcher: content
   Fast pattern set: no


### PR DESCRIPTION
I was checking the documentation for engine analysis, and noticed that the first example was missing the accompanying rule that should be associated with it.

I checked the suricata-verify repo and found a rule that seemed to be a good match for it, so cleaned it up and added it to the section.