### PR TITLE
stream-reassemble/debug: Improve segment pool tracking under DEBUG

### DIFF
--- a/src/stream-tcp-cache.c
+++ b/src/stream-tcp-cache.c
@@ -157,19 +157,19 @@ void StreamTcpThreadCacheCleanup(void)
     /* sessions */
     SCLogDebug("tcp_pool_cache.ssns_cache_idx %u", tcp_pool_cache.ssns_cache_idx);
     for (uint32_t i = 0; i < tcp_pool_cache.ssns_cache_idx; i++) {
-        PoolThreadReturn(segment_thread_pool, tcp_pool_cache.ssns_cache[i]);
+        PoolThreadReturn(ssn_pool, tcp_pool_cache.ssns_cache[i]);
     }
     tcp_pool_cache.ssns_cache_idx = 0;
 
     SCLogDebug("tcp_pool_cache.ssns_returns_idx %u", tcp_pool_cache.ssns_returns_idx);
     if (tcp_pool_cache.ssns_returns_idx) {
         PoolThreadId pool_id = tcp_pool_cache.ssns_returns[0]->pool_id;
-        PoolThreadLock(segment_thread_pool, pool_id);
+        PoolThreadLock(ssn_pool, pool_id);
         for (uint32_t i = 0; i < tcp_pool_cache.ssns_returns_idx; i++) {
             TcpSession *ret_ssn = tcp_pool_cache.ssns_returns[i];
-            PoolThreadReturnRaw(segment_thread_pool, pool_id, ret_ssn);
+            PoolThreadReturnRaw(ssn_pool, pool_id, ret_ssn);
         }
-        PoolThreadUnlock(segment_thread_pool, pool_id);
+        PoolThreadUnlock(ssn_pool, pool_id);
         tcp_pool_cache.ssns_returns_idx = 0;
     }
 

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -546,7 +546,8 @@ void StreamTcpReassembleFree(bool quiet)
 
 #ifdef DEBUG
     if (segment_pool_memuse > 0)
-        SCLogDebug("segment_pool_memuse %" PRIu64 "", segment_pool_memuse);
+        SCLogDebug("segment_pool_memuse %" PRIu64 " segment_pool_memcnt %" PRIu64 "",
+                segment_pool_memuse, segment_pool_memcnt);
     SCMutexDestroy(&segment_pool_memuse_mutex);
 #endif
 }

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -54,14 +54,14 @@ static int PoolMemset(void *pitem, void *initdata)
 
 /**
  * \brief Check if data is preallocated
- * \retval 0 if not inside the prealloc'd block, 1 if inside */
-static int PoolDataPreAllocated(Pool *p, void *data)
+ * \retval false if not inside the prealloc'd block, true if inside */
+static bool PoolDataPreAllocated(Pool *p, void *data)
 {
     ptrdiff_t delta = data - p->data_buffer;
     if ((delta < 0) || (delta > p->data_buffer_size)) {
-        return 0;
+        return false;
     }
-    return 1;
+    return true;
 }
 
 /** \brief Init a Pool
@@ -233,7 +233,7 @@ void PoolFree(Pool *p)
         p->alloc_stack = pb->next;
         if (p->Cleanup)
             p->Cleanup(pb->data);
-        if (PoolDataPreAllocated(p, pb->data) == 0) {
+        if (!PoolDataPreAllocated(p, pb->data)) {
             if (p->Free)
                 p->Free(pb->data);
             else
@@ -251,7 +251,7 @@ void PoolFree(Pool *p)
         if (pb->data!= NULL) {
             if (p->Cleanup)
                 p->Cleanup(pb->data);
-            if (PoolDataPreAllocated(p, pb->data) == 0) {
+            if (!PoolDataPreAllocated(p, pb->data)) {
                 if (p->Free)
                     p->Free(pb->data);
                 else
@@ -350,7 +350,7 @@ void PoolReturn(Pool *p, void *data)
         if (p->Cleanup != NULL) {
             p->Cleanup(data);
         }
-        if (PoolDataPreAllocated(p, data) == 0) {
+        if (!PoolDataPreAllocated(p, data)) {
             if (p->Free)
                 p->Free(data);
             else


### PR DESCRIPTION
Continuation of #8960 

Track segment pool memory when DEBUG is enabled.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5563](https://redmine.openinfosecfoundation.org/issues/5563)

Describe changes:
- Return TCP sessions to the session pool and not the segment_thread_pool

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
