### PR TITLE
suricata-update: install example configuration files

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -270,6 +270,14 @@ jobs:
       - run: make install
       - run: suricatasc -h
       - run: suricata-update -V
+      - name: Check if Suricata-Update example configuration files are installed
+        run: |
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/disable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/drop.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/enable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/modify.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/threshold.in
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/update.yaml
 
   almalinux-9-templates:
     name: AlmaLinux 9 Test Templates

--- a/suricata-update/Makefile.am
+++ b/suricata-update/Makefile.am
@@ -34,6 +34,14 @@ LIBS =	\
 	suricata/update/util.py \
 	suricata/update/version.py
 
+CONFIGS = \
+	suricata/update/configs/disable.conf \
+	suricata/update/configs/drop.conf \
+	suricata/update/configs/enable.conf \
+	suricata/update/configs/modify.conf \
+	suricata/update/configs/threshold.in \
+	suricata/update/configs/update.yaml
+
 BINS =	suricata-update
 
 if HAVE_PYTHON
@@ -45,6 +53,9 @@ install-exec-local:
 	install -d -m 0755 "$(DESTDIR)$(prefix)/lib/suricata/python/suricata/update/data"
 	for lib in $(LIBS); do \
 		install $(srcdir)/$$lib "$(DESTDIR)$(prefix)/lib/suricata/python/$$lib"; \
+	done
+	for config in $(CONFIGS); do \
+		install -m 0644 $(srcdir)/$$config "$(DESTDIR)$(prefix)/lib/suricata/python/$$config"; \
 	done
 	for bin in $(BINS); do \
 		cat "$(srcdir)/bin/$$bin" | \


### PR DESCRIPTION
Fix `suricata-update --dump-sample-configs`.  The files were not being installed as part of `make install`.

Ticket: https://redmine.openinfosecfoundation.org/issues/6132
