### PR TITLE
github-ci: update actions - v1

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -39,7 +39,7 @@ jobs:
       - run: echo ${{ github.event.number }} > new-authors/pr-number.txt
       - run: ls -l
       - name: Upload new authors
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: new-authors
           path: new-authors

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2402,7 +2402,7 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
       - uses: actions/checkout@v3.5.3
-      - uses: msys2/setup-msys2@fa138fa56e2558760b9f2205135313c7345c5f3f
+      - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
           update: true
@@ -2502,7 +2502,7 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
       - uses: actions/checkout@v3.5.3
-      - uses: msys2/setup-msys2@fa138fa56e2558760b9f2205135313c7345c5f3f
+      - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
           update: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -825,7 +825,7 @@ jobs:
                 which \
                 zlib-devel
       - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
@@ -1015,7 +1015,7 @@ jobs:
                 which \
                 zlib-devel
       - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
@@ -1209,7 +1209,7 @@ jobs:
                 which \
                 zlib-devel
       - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -171,13 +171,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -286,7 +286,7 @@ jobs:
     needs: [prepare-deps]
     steps:
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           # TODO: Find some variable that matches the job name.
@@ -295,7 +295,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -379,13 +379,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -509,13 +509,13 @@ jobs:
     needs: [prepare-deps, almalinux-8]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/yum
           key: ${{ github.job }}-yum
@@ -590,13 +590,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -684,13 +684,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -783,7 +783,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -870,13 +870,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -974,7 +974,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1065,13 +1065,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -1168,7 +1168,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1341,13 +1341,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
       - name: Cache RPMs
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -1410,7 +1410,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1527,7 +1527,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1624,7 +1624,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1713,7 +1713,7 @@ jobs:
     needs: almalinux-8
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1773,7 +1773,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1850,7 +1850,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -1945,7 +1945,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2007,7 +2007,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2100,7 +2100,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2194,7 +2194,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2270,7 +2270,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2343,7 +2343,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2397,7 +2397,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2453,7 +2453,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -2497,7 +2497,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -104,7 +104,7 @@ jobs:
 
       # Now checkout Suricata for the bundle script.
       - name: Checking out Suricata
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@v3.5.3
 
       - name: Fetching libhtp
         run: |
@@ -183,7 +183,7 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
 
       # Download and extract dependency archives created during prep
       # job.
@@ -300,7 +300,7 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
 
       # Download and extract dependency archives created during prep
       # job.
@@ -391,7 +391,7 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
 
       # Prebuild check for duplicate SIDs
       - name: Check for duplicate SIDs
@@ -644,7 +644,7 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -736,7 +736,7 @@ jobs:
                 systemd-devel \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -824,7 +824,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: prep
@@ -921,7 +921,7 @@ jobs:
                 systemd-devel \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1014,7 +1014,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: prep
@@ -1116,7 +1116,7 @@ jobs:
                 systemd-devel \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1208,7 +1208,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: prep
@@ -1298,7 +1298,7 @@ jobs:
                 which \
                 zlib-devel
       - run: adduser suricata
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1388,7 +1388,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1460,7 +1460,7 @@ jobs:
       # packaged Rust version is too old for coverage, so get from rustup
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1580,7 +1580,7 @@ jobs:
       # packaged Rust version is too old for coverage, so get from rustup
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1668,7 +1668,7 @@ jobs:
                 zlib1g-dev \
                 exuberant-ctags \
                 dpdk-dev
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1815,7 +1815,7 @@ jobs:
                 zlib1g \
                 zlib1g-dev \
                 exuberant-ctags
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1906,7 +1906,7 @@ jobs:
       - name: Install Coccinelle
         run: |
           apt -y install coccinelle
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -1984,7 +1984,7 @@ jobs:
                 zlib1g \
                 zlib1g-dev
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2058,7 +2058,7 @@ jobs:
                 linux-headers-$(uname -r)
 
       - name: Checkout Netmap repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
         with:
           repository: luigirizzo/netmap
           # gets cloned to $GITHUB_WORKSPACE/netmap/
@@ -2071,7 +2071,7 @@ jobs:
           make -j2
           sudo make install
 
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2169,7 +2169,7 @@ jobs:
           ninja -C build install
           ldconfig
           cd $HOME
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2239,7 +2239,7 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2313,7 +2313,7 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2368,7 +2368,7 @@ jobs:
         run: cargo install --debug --version 0.24.3 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: pip3 install PyYAML
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - name: Downloading prep archive
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
@@ -2401,7 +2401,7 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: msys2/setup-msys2@fa138fa56e2558760b9f2205135313c7345c5f3f
         with:
           msystem: MINGW64
@@ -2411,7 +2411,7 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2457,7 +2457,7 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2467,7 +2467,7 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
@@ -2501,7 +2501,7 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: msys2/setup-msys2@fa138fa56e2558760b9f2205135313c7345c5f3f
         with:
           msystem: MINGW64
@@ -2511,7 +2511,7 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.5.3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -16,7 +16,7 @@ jobs:
     container: ubuntu:20.04
     steps:
       - name: Caching ~/.cargo
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: commit-check-cargo

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo/registry
           key: cargo-registry

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -86,7 +86,7 @@ jobs:
       # My patience simply ran too short to keep on looking. See follow-on
       # action to manually fix this up.
       - name: Checkout - might be merge commit!
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0
         # Use last commit of branch, not potential merge commit!

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install cbindgen
         run: cargo install --debug cbindgen
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - run: git config --global --add safe.directory /__w/suricata/suricata
       - run: ./scripts/bundle.sh
       - run: ./autogen.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     container: almalinux:9
     steps:
       - name: Cache rust
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: check-rust

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -59,7 +59,7 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.3
       - run: ./scripts/bundle.sh
       - run: ./autogen.sh
       - run: scan-build-16 ./configure --enable-dpdk --enable-nfqueue --enable-nflog

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -11,7 +11,7 @@ jobs:
     container: ubuntu:23.04
     steps:
       - name: Cache scan-build
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
           key: scan-build

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2.3.1
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Update github-actions to their latest versions. Resolves some warnings that GitHub Actions was outputting on our jobs.