### PR TITLE
Backports 6.0.13/s/v1

### DIFF
--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -93,7 +93,7 @@ named!(pub parse_smb1_write_andx_request_record<Smb1WriteRequestRecord>,
         >>  _padding_evasion: cond!(data_offset > 36+2*(wct as u16), take!(data_offset - (36+2*(wct as u16))))
         >>  file_data: rest
         >> (Smb1WriteRequestRecord {
-                offset: if high_offset != None { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+                offset: ((high_offset.unwrap_or(0) as u64) << 32) | offset as u64,
                 len: (((data_len_high as u32) << 16) as u32)|(data_len_low as u32),
                 fid,
                 data:file_data,

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -596,6 +596,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
         CLEAR_IPV6_PACKET(p);
         return TM_ECODE_FAILED;
     }
+    p->proto = IPV6_GET_NH(p);
 
 #ifdef DEBUG
     if (SCLogDebugEnabled()) { /* only convert the addresses if debug is really enabled */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- https://redmine.openinfosecfoundation.org/issues/6138
- https://redmine.openinfosecfoundation.org/issues/6139 minus the commit https://github.com/OISF/suricata/pull/8965/commits/abc76e27de7184d6f64040fb53d7d0a4d2b3df17 because it seems that ANDX support was added as a part of https://github.com/oISF/suricata/commit/2d1460622411552
which seems to have been targeted only as a feature for 7. ref: https://redmine.openinfosecfoundation.org/issues/3475#note-22