### PR TITLE
radix: Don't leak memory when key can't be added

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2599,7 +2599,7 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 if (strchr(pval->val, ':') != NULL) {
                     SCLogDebug("LIBHTP adding ipv6 server %s at %s: %p",
                                s->name, pval->val, cfg_prec->cfg);
-                    if (SCRadixAddKeyIPV6String(pval->val, tree, cfg_prec) == NULL) {
+                    if (!SCRadixAddKeyIPV6String(pval->val, tree, cfg_prec)) {
                         SCLogWarning("LIBHTP failed to "
                                      "add ipv6 server %s, ignoring",
                                 pval->val);
@@ -2607,7 +2607,7 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 } else {
                     SCLogDebug("LIBHTP adding ipv4 server %s at %s: %p",
                                s->name, pval->val, cfg_prec->cfg);
-                    if (SCRadixAddKeyIPV4String(pval->val, tree, cfg_prec) == NULL) {
+                    if (!SCRadixAddKeyIPV4String(pval->val, tree, cfg_prec)) {
                         SCLogWarning("LIBHTP failed "
                                      "to add ipv4 server %s, ignoring",
                                 pval->val);

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -51,13 +51,19 @@ static void DefragPolicyAddHostInfo(char *host_ip_range, uint64_t timeout)
 
     if (strchr(host_ip_range, ':') != NULL) {
         SCLogDebug("adding ipv6 host %s", host_ip_range);
-        if (SCRadixAddKeyIPV6String(host_ip_range, defrag_tree, (void *)user_data) == NULL) {
-            SCLogWarning("failed to add ipv6 host %s", host_ip_range);
+        if (!SCRadixAddKeyIPV6String(host_ip_range, defrag_tree, (void *)user_data)) {
+            SCFree(user_data);
+            if (sc_errno != SC_EEXIST) {
+                SCLogWarning("failed to add ipv6 host %s", host_ip_range);
+            }
         }
     } else {
         SCLogDebug("adding ipv4 host %s", host_ip_range);
-        if (SCRadixAddKeyIPV4String(host_ip_range, defrag_tree, (void *)user_data) == NULL) {
+        if (!SCRadixAddKeyIPV4String(host_ip_range, defrag_tree, (void *)user_data)) {
+            SCFree(user_data);
             SCLogWarning("failed to add ipv4 host %s", host_ip_range);
+        } else if (sc_errno == SC_EEXIST) {
+            SCFree(user_data);
         }
     }
 }

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -46,7 +46,7 @@
 SC_ATOMIC_DECLARE(uint32_t, srep_eversion);
 /** reputation version set to the host's reputation,
  *  this will be set to 1 before rep files are loaded,
- *  so hosts will always have a minial value of 1 */
+ *  so hosts will always have a minimal value of 1 */
 static uint32_t srep_version = 0;
 
 static uint32_t SRepIncrVersion(void)

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -100,6 +100,7 @@ static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8
 
         SCLogDebug("adding ipv6 host %s", ip);
         if (SCRadixAddKeyIPV6String(ip, cidr_ctx->srepIPV6_tree[cat], (void *)user_data) == NULL) {
+            SCFree(user_data);
             SCLogWarning("failed to add ipv6 host %s", ip);
         }
 
@@ -115,6 +116,7 @@ static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8
 
         SCLogDebug("adding ipv4 host %s", ip);
         if (SCRadixAddKeyIPV4String(ip, cidr_ctx->srepIPV4_tree[cat], (void *)user_data) == NULL) {
+            SCFree(user_data);
             SCLogWarning("failed to add ipv4 host %s", ip);
         }
     }

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -99,9 +99,10 @@ static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8
         }
 
         SCLogDebug("adding ipv6 host %s", ip);
-        if (SCRadixAddKeyIPV6String(ip, cidr_ctx->srepIPV6_tree[cat], (void *)user_data) == NULL) {
+        if (!SCRadixAddKeyIPV6String(ip, cidr_ctx->srepIPV6_tree[cat], (void *)user_data)) {
             SCFree(user_data);
-            SCLogWarning("failed to add ipv6 host %s", ip);
+            if (sc_errno != SC_EEXIST)
+                SCLogWarning("failed to add ipv6 host %s", ip);
         }
 
     } else {
@@ -115,9 +116,10 @@ static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8
         }
 
         SCLogDebug("adding ipv4 host %s", ip);
-        if (SCRadixAddKeyIPV4String(ip, cidr_ctx->srepIPV4_tree[cat], (void *)user_data) == NULL) {
+        if (!SCRadixAddKeyIPV4String(ip, cidr_ctx->srepIPV4_tree[cat], (void *)user_data)) {
             SCFree(user_data);
-            SCLogWarning("failed to add ipv4 host %s", ip);
+            if (sc_errno != SC_EEXIST)
+                SCLogWarning("failed to add ipv4 host %s", ip);
         }
     }
 }

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -46,6 +46,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_ENOMEM);
         CASE_CODE(SC_EINVAL);
         CASE_CODE(SC_ELIMIT);
+        CASE_CODE(SC_EEXIST);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -29,6 +29,7 @@ typedef enum {
     SC_ENOMEM,
     SC_EINVAL,
     SC_ELIMIT,
+    SC_EEXIST,
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -295,16 +295,14 @@ static int SCRadixPrefixNetmaskCount(SCRadixPrefix *prefix)
  *
  * \param prefix      Pointer to the ip prefix that is being checked.
  * \param netmask     The netmask value for which we will have to return the user_data
- * \param exact_match Bool flag which indicates if we should check if the prefix
+ * \param exact_match flag which indicates if we should check if the prefix
  *                    holds proper netblock(< 32 for ipv4 and < 128 for ipv6) or not.
  *
  * \retval 1 On match.
  * \retval 0 On no match.
  */
-static int SCRadixPrefixContainNetmaskAndSetUserData(SCRadixPrefix *prefix,
-                                                     uint16_t netmask,
-                                                     int exact_match,
-                                                     void **user_data_result)
+static int SCRadixPrefixContainNetmaskAndSetUserData(
+        SCRadixPrefix *prefix, uint16_t netmask, bool exact_match, void **user_data_result)
 {
     SCRadixUserData *user_data = NULL;
 
@@ -1449,7 +1447,8 @@ static inline SCRadixNode *SCRadixFindKeyIPNetblock(
 
             if (key_bitlen % 8 == 0 ||
                 (node->prefix->stream[bytes] & mask) == (key_stream[bytes] & mask)) {
-                if (SCRadixPrefixContainNetmaskAndSetUserData(node->prefix, netmask_node->netmasks[j], 0, user_data_result))
+                if (SCRadixPrefixContainNetmaskAndSetUserData(
+                            node->prefix, netmask_node->netmasks[j], false, user_data_result))
                     return node;
             }
         }
@@ -1469,7 +1468,7 @@ static inline SCRadixNode *SCRadixFindKeyIPNetblock(
  * \param netmask     Netmask used during exact match
  */
 static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint8_t key_bitlen, uint8_t netmask,
-        SCRadixTree *tree, int exact_match, void **user_data_result)
+        SCRadixTree *tree, bool exact_match, void **user_data_result)
 {
     if (tree == NULL || tree->head == NULL)
         return NULL;
@@ -1506,7 +1505,7 @@ static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint8_t key_bitlen, uint
         if (key_bitlen % 8 == 0 ||
             (node->prefix->stream[bytes] & mask) == (tmp_stream[bytes] & mask)) {
             if (SCRadixPrefixContainNetmaskAndSetUserData(
-                        node->prefix, netmask, 1, user_data_result)) {
+                        node->prefix, netmask, true, user_data_result)) {
                 return node;
             }
         }
@@ -1530,7 +1529,7 @@ static SCRadixNode *SCRadixFindKey(uint8_t *key_stream, uint8_t key_bitlen, uint
  */
 SCRadixNode *SCRadixFindKeyIPV4ExactMatch(uint8_t *key_stream, SCRadixTree *tree, void **user_data_result)
 {
-    return SCRadixFindKey(key_stream, 32, 32, tree, 1, user_data_result);
+    return SCRadixFindKey(key_stream, 32, 32, tree, true, user_data_result);
 }
 
 /**
@@ -1542,7 +1541,7 @@ SCRadixNode *SCRadixFindKeyIPV4ExactMatch(uint8_t *key_stream, SCRadixTree *tree
  */
 SCRadixNode *SCRadixFindKeyIPV4BestMatch(uint8_t *key_stream, SCRadixTree *tree, void **user_data_result)
 {
-    return SCRadixFindKey(key_stream, 32, 32, tree, 0, user_data_result);
+    return SCRadixFindKey(key_stream, 32, 32, tree, false, user_data_result);
 }
 
 /**
@@ -1558,7 +1557,7 @@ SCRadixNode *SCRadixFindKeyIPV4Netblock(uint8_t *key_stream, SCRadixTree *tree,
 #if defined(DEBUG_VALIDATION) || defined(UNITTESTS)
     SCRadixValidateIPv4Key(key_stream, netmask);
 #endif
-    SCRadixNode *node = SCRadixFindKey(key_stream, 32, netmask, tree, 1, user_data_result);
+    SCRadixNode *node = SCRadixFindKey(key_stream, 32, netmask, tree, true, user_data_result);
     return node;
 }
 
@@ -1575,7 +1574,7 @@ SCRadixNode *SCRadixFindKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
 #if defined(DEBUG_VALIDATION) || defined(UNITTESTS)
     SCRadixValidateIPv6Key(key_stream, netmask);
 #endif
-    SCRadixNode *node = SCRadixFindKey(key_stream, 128, netmask, tree, 1, user_data_result);
+    SCRadixNode *node = SCRadixFindKey(key_stream, 128, netmask, tree, true, user_data_result);
     return node;
 }
 
@@ -1588,7 +1587,7 @@ SCRadixNode *SCRadixFindKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
  */
 SCRadixNode *SCRadixFindKeyIPV6ExactMatch(uint8_t *key_stream, SCRadixTree *tree, void **user_data_result)
 {
-    return SCRadixFindKey(key_stream, 128, 128, tree, 1, user_data_result);
+    return SCRadixFindKey(key_stream, 128, 128, tree, true, user_data_result);
 }
 
 /**
@@ -1600,7 +1599,7 @@ SCRadixNode *SCRadixFindKeyIPV6ExactMatch(uint8_t *key_stream, SCRadixTree *tree
  */
 SCRadixNode *SCRadixFindKeyIPV6BestMatch(uint8_t *key_stream, SCRadixTree *tree, void **user_data_result)
 {
-    return SCRadixFindKey(key_stream, 128, 128, tree, 0, user_data_result);
+    return SCRadixFindKey(key_stream, 128, 128, tree, false, user_data_result);
 }
 
 /**

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -959,9 +959,14 @@ SCRadixNode *SCRadixAddKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
  * \param user       Pointer to the user data that has to be associated with
  *                   the key
  *
- * \retval node Pointer to the newly created node
+ * \retval bool true (false) if the node was (wasn't) added.
+ *
+ * sc_errno is set:
+ * - SC_OK: Node added
+ * - SC_EEXIST: Node already exists
+ * - SC_EINVAL: Parameter value error
  */
-SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *user)
+bool SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *user)
 {
     uint32_t ip;
     uint8_t netmask = 32;
@@ -973,6 +978,7 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
     strlcpy(ip_str, str, sizeof(ip_str) - 2);
     *(ip_str + (sizeof(ip_str) - 1)) = '\0';
 
+    sc_errno = SC_OK;
     /* Does it have a mask? */
     if (NULL != (mask_str = strchr(ip_str, '/'))) {
         uint8_t cidr;
@@ -980,12 +986,14 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
 
         /* Dotted type netmask not supported (yet) */
         if (strchr(mask_str, '.') != NULL) {
-            return NULL;
+            sc_errno = SC_EINVAL;
+            return false;
         }
 
         /* Get binary values for cidr mask */
         if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 32) < 0) {
-            return NULL;
+            sc_errno = SC_EINVAL;
+            return false;
         }
 
         netmask = (uint8_t)cidr;
@@ -993,7 +1001,8 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
 
     /* Validate the IP */
     if (inet_pton(AF_INET, ip_str, &addr) <= 0) {
-        return NULL;
+        sc_errno = SC_EINVAL;
+        return false;
     }
     ip = addr.s_addr;
     if (netmask != 32) {
@@ -1009,7 +1018,20 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
         SCRadixValidateIPv4Key((uint8_t *)&ip, netmask);
 #endif
     }
-    return SCRadixAddKey((uint8_t *)&ip, 32, tree, user, netmask);
+
+    if (SCRadixFindKeyIPV4Netblock((uint8_t *)&ip, tree, netmask, NULL) != NULL) {
+        SCLogDebug("IP already added; returning existing node");
+        sc_errno = SC_EEXIST;
+        return false;
+    }
+
+    /* Doesn't exist so let's add it */
+    if (SCRadixAddKey((uint8_t *)&ip, 32, tree, user, netmask) == NULL) {
+        sc_errno = SC_EINVAL;
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -1020,14 +1042,20 @@ SCRadixNode *SCRadixAddKeyIPV4String(const char *str, SCRadixTree *tree, void *u
  * \param user       Pointer to the user data that has to be associated with
  *                   the key
  *
- * \retval node Pointer to the newly created node
+ * \retval bool true (false) if the node was (wasn't) added.
+ * sc_errno is set:
+ * - SC_OK: Node added
+ * - SC_EEXIST: Node already exists
+ * - SC_EINVAL: Parameter value error
  */
-SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *user)
+bool SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *user)
 {
     uint8_t netmask = 128;
     char ip_str[80]; /* Max length for full ipv6/mask string with NUL */
     char *mask_str = NULL;
     struct in6_addr addr;
+
+    sc_errno = SC_OK;
 
     /* Make a copy of the string so it can be modified */
     strlcpy(ip_str, str, sizeof(ip_str) - 2);
@@ -1040,12 +1068,14 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
 
         /* Dotted type netmask not supported (yet) */
         if (strchr(mask_str, '.') != NULL) {
-            return NULL;
+            sc_errno = SC_EINVAL;
+            return false;
         }
 
         /* Get binary values for cidr mask */
         if (StringParseU8RangeCheck(&cidr, 10, 0, (const char *)mask_str, 0, 128) < 0) {
-            return NULL;
+            sc_errno = SC_EINVAL;
+            return false;
         }
 
         netmask = (uint8_t)cidr;
@@ -1053,7 +1083,8 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
 
     /* Validate the IP */
     if (inet_pton(AF_INET6, ip_str, &addr) <= 0) {
-        return NULL;
+        sc_errno = SC_EINVAL;
+        return false;
     }
 
     if (netmask != 128) {
@@ -1075,7 +1106,19 @@ SCRadixNode *SCRadixAddKeyIPV6String(const char *str, SCRadixTree *tree, void *u
 #endif
     }
 
-    return SCRadixAddKey(addr.s6_addr, 128, tree, user, netmask);
+    if (SCRadixFindKeyIPV6Netblock(addr.s6_addr, tree, netmask, NULL) != NULL) {
+        SCLogDebug("IP already added; returning existing node");
+        sc_errno = SC_EEXIST;
+        return false;
+    }
+
+    /* Doesn't exist so let's add it */
+    if (SCRadixAddKey(addr.s6_addr, 128, tree, user, netmask) == NULL) {
+        sc_errno = SC_EINVAL;
+        return false;
+    }
+
+    return true;
 }
 
 static void SCRadixTransferNetmasksBWNodes(SCRadixNode *dest, SCRadixNode *src)

--- a/src/util-radix-tree.h
+++ b/src/util-radix-tree.h
@@ -102,8 +102,8 @@ SCRadixNode *SCRadixAddKeyIPV4Netblock(uint8_t *, SCRadixTree *, void *,
                                        uint8_t);
 SCRadixNode *SCRadixAddKeyIPV6Netblock(uint8_t *, SCRadixTree *, void *,
                                        uint8_t);
-SCRadixNode *SCRadixAddKeyIPV4String(const char *, SCRadixTree *, void *);
-SCRadixNode *SCRadixAddKeyIPV6String(const char *, SCRadixTree *, void *);
+bool SCRadixAddKeyIPV4String(const char *, SCRadixTree *, void *);
+bool SCRadixAddKeyIPV6String(const char *, SCRadixTree *, void *);
 
 void SCRadixRemoveKeyGeneric(uint8_t *, uint16_t, SCRadixTree *);
 void SCRadixRemoveKeyIPV4Netblock(uint8_t *, SCRadixTree *, uint8_t);


### PR DESCRIPTION
Continuation of #9025  

Thanks to @glongo for the contributions included in the redmine ticket.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5748](https://redmine.openinfosecfoundation.org/issues/5748)

Describe changes:
- Check for duplicate keys before adding to radix tree.
-  Free key memory when key is a duplicate

Updates:
- Fix compile commit check

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=pr/1190
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
