### PR TITLE
detect/http: request/response header support multi buffer

### DIFF
--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -750,6 +750,7 @@ void DetectHttpRequestHeaderRegister(void)
 
     DetectBufferTypeSetDescriptionByName("http_request_header", "HTTP header name and value");
     g_http_request_header_buffer_id = DetectBufferTypeGetByName("http_request_header");
+    DetectBufferTypeSupportsMultiInstance("http_request_header");
 }
 
 static int DetectHTTPResponseHeaderSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -784,6 +785,7 @@ void DetectHttpResponseHeaderRegister(void)
 
     DetectBufferTypeSetDescriptionByName("http_response_header", "HTTP header name and value");
     g_http_response_header_buffer_id = DetectBufferTypeGetByName("http_response_header");
+    DetectBufferTypeSupportsMultiInstance("http_response_header");
 }
 
 /************************************Unittests*********************************/


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6163

Describe changes:
- detect/http: request/response header support multi buffer

This was forgotten because of merging at the same time https://redmine.openinfosecfoundation.org/issues/5780 and https://redmine.openinfosecfoundation.org/issues/5784 and not merging the S-V test

https://github.com/OISF/suricata-verify/pull/1258
```
SV_BRANCH=pr/1258
```
