### PR TITLE
smb: fix wrong data offset when wct = 12 (backport6)

### DIFF
--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -93,7 +93,7 @@ named!(pub parse_smb1_write_andx_request_record<Smb1WriteRequestRecord>,
         >>  _padding_evasion: cond!(data_offset > 36+2*(wct as u16), take!(data_offset - (36+2*(wct as u16))))
         >>  file_data: rest
         >> (Smb1WriteRequestRecord {
-                offset: if high_offset != None { ((high_offset.unwrap() as u64) << 32)|(offset as u64) } else { 0 },
+                offset: ((high_offset.unwrap_or(0) as u64) << 32) | offset as u64,
                 len: (((data_len_high as u32) << 16) as u32)|(data_len_low as u32),
                 fid,
                 data:file_data,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6139

Describe changes:
- Backport of 000eb91078d5ca88ee93006340d7e68f97ade4bc

https://github.com/OISF/suricata-verify/pull/1260
```
SV_BRANCH=pr/1260
```
