### PR TITLE
exception: master switch not applied to midstream - v1

### DIFF
--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -174,7 +174,8 @@ static enum ExceptionPolicy ExceptionPolicyConfigValueParse(
     return policy;
 }
 
-static enum ExceptionPolicy ExceptionPolicyPickAuto(bool midstream_enabled, bool support_flow)
+/* Select an exception policy in case the configuration value was set to 'auto' */
+static enum ExceptionPolicy ExceptionPolicyParseAuto(bool midstream_enabled, bool support_flow)
 {
     enum ExceptionPolicy policy = EXCEPTION_POLICY_NOT_SET;
     if (!midstream_enabled && EngineModeIsIPS()) {
@@ -191,7 +192,7 @@ static enum ExceptionPolicy ExceptionPolicyMasterParse(const char *value)
 {
     enum ExceptionPolicy policy = ExceptionPolicyConfigValueParse("exception-policy", value);
     if (policy == EXCEPTION_POLICY_AUTO) {
-        policy = ExceptionPolicyPickAuto(false, true);
+        policy = ExceptionPolicyParseAuto(false, true);
     } else if (!EngineModeIsIPS() &&
                (policy == EXCEPTION_POLICY_DROP_PACKET || policy == EXCEPTION_POLICY_DROP_FLOW)) {
         policy = EXCEPTION_POLICY_NOT_SET;
@@ -235,7 +236,7 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, bool support_flow)
         } else {
             policy = ExceptionPolicyConfigValueParse(option, value_str);
             if (policy == EXCEPTION_POLICY_AUTO) {
-                policy = ExceptionPolicyPickAuto(false, support_flow);
+                policy = ExceptionPolicyParseAuto(false, support_flow);
             }
             if (!support_flow) {
                 policy = PickPacketAction(option, policy);
@@ -257,7 +258,7 @@ enum ExceptionPolicy ExceptionPolicyMidstreamParse(bool midstream_enabled)
     if ((ConfGet("stream.midstream-policy", &value_str)) == 1 && value_str != NULL) {
         policy = ExceptionPolicyConfigValueParse("midstream-policy", value_str);
         if (policy == EXCEPTION_POLICY_AUTO) {
-            policy = ExceptionPolicyPickAuto(midstream_enabled, true);
+            policy = ExceptionPolicyParseAuto(midstream_enabled, true);
         } else if (midstream_enabled) {
             if (policy != EXCEPTION_POLICY_NOT_SET && policy != EXCEPTION_POLICY_PASS_FLOW) {
                 FatalErrorOnInit(

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -277,7 +277,7 @@ enum ExceptionPolicy ExceptionPolicyMidstreamParse(bool midstream_enabled)
             }
         }
     } else {
-        policy = ExceptionPolicyPickAuto(midstream_enabled, true);
+        policy = ExceptionPolicyGetDefault("stream.midstream-policy", true, midstream_enabled);
     }
 
     if (policy == EXCEPTION_POLICY_PASS_PACKET || policy == EXCEPTION_POLICY_DROP_PACKET) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6169

Describe changes:
- When the midstream policy fix was merged, we ended up with a solution that would use the default (auto) value regardless of the master switch being defined or not. This led to Suri not applying the master switch config to the midstream. This was noticed when I retook the work with the master switch sv tests, which had not been merged yet.
- Renamed the function for choosing what 'auto' means, and added a brief comment to it, as I think a poor name and lack of documentation might have led to the situation just described, in the first place.

```
SV_BRANCH=pr/1264
```
https://github.com/OISF/suricata-verify/pull/1264