### PR TITLE
detect/multi-tenant: Eliminate crashes processing tenant config

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -247,11 +247,11 @@ void DetectAppLayerInspectEngineRegister2(const char *name,
         direction = 1;
     }
 
-    DetectEngineAppInspectionEngine *new_engine = SCMalloc(sizeof(DetectEngineAppInspectionEngine));
+    DetectEngineAppInspectionEngine *new_engine =
+            SCCalloc(1, sizeof(DetectEngineAppInspectionEngine));
     if (unlikely(new_engine == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(new_engine, 0, sizeof(*new_engine));
     new_engine->alproto = alproto;
     new_engine->dir = direction;
     new_engine->sm_list = (uint16_t)sm_list;
@@ -2459,11 +2459,10 @@ retry:
 
 static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, const char *prefix)
 {
-    DetectEngineCtx *de_ctx = SCMalloc(sizeof(DetectEngineCtx));
+    DetectEngineCtx *de_ctx = SCCalloc(1, sizeof(DetectEngineCtx));
     if (unlikely(de_ctx == NULL))
         goto error;
 
-    memset(de_ctx,0,sizeof(DetectEngineCtx));
     memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
     TAILQ_INIT(&de_ctx->sig_stat.failed_sigs);
     de_ctx->sigerror = NULL;
@@ -3028,13 +3027,11 @@ static int DetectEngineThreadCtxInitKeywords(DetectEngineCtx *de_ctx, DetectEngi
 {
     if (de_ctx->keyword_id > 0) {
         // coverity[suspicious_sizeof : FALSE]
-        det_ctx->keyword_ctxs_array = SCMalloc(de_ctx->keyword_id * sizeof(void *));
+        det_ctx->keyword_ctxs_array = SCCalloc(1, de_ctx->keyword_id * sizeof(void *));
         if (det_ctx->keyword_ctxs_array == NULL) {
             SCLogError("setting up thread local detect ctx");
             return TM_ECODE_FAILED;
         }
-
-        memset(det_ctx->keyword_ctxs_array, 0x00, de_ctx->keyword_id * sizeof(void *));
 
         det_ctx->keyword_ctxs_size = de_ctx->keyword_id;
 
@@ -3212,13 +3209,10 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
     /* DeState */
     if (de_ctx->sig_array_len > 0) {
         det_ctx->match_array_len = de_ctx->sig_array_len;
-        det_ctx->match_array = SCMalloc(det_ctx->match_array_len * sizeof(Signature *));
+        det_ctx->match_array = SCCalloc(1, det_ctx->match_array_len * sizeof(Signature *));
         if (det_ctx->match_array == NULL) {
             return TM_ECODE_FAILED;
         }
-        memset(det_ctx->match_array, 0,
-               det_ctx->match_array_len * sizeof(Signature *));
-
         RuleMatchCandidateTxArrayInit(det_ctx, de_ctx->sig_array_len);
     }
 
@@ -3299,10 +3293,9 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
  */
 TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 {
-    DetectEngineThreadCtx *det_ctx = SCMalloc(sizeof(DetectEngineThreadCtx));
+    DetectEngineThreadCtx *det_ctx = SCCalloc(1, sizeof(DetectEngineThreadCtx));
     if (unlikely(det_ctx == NULL))
         return TM_ECODE_FAILED;
-    memset(det_ctx, 0, sizeof(DetectEngineThreadCtx));
 
     det_ctx->tv = tv;
     det_ctx->de_ctx = DetectEngineGetCurrent();
@@ -3365,10 +3358,9 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
         ThreadVars *tv, DetectEngineCtx *new_de_ctx, int mt)
 {
-    DetectEngineThreadCtx *det_ctx = SCMalloc(sizeof(DetectEngineThreadCtx));
+    DetectEngineThreadCtx *det_ctx = SCCalloc(1, sizeof(DetectEngineThreadCtx));
     if (unlikely(det_ctx == NULL))
         return NULL;
-    memset(det_ctx, 0, sizeof(DetectEngineThreadCtx));
 
     det_ctx->tenant_id = new_de_ctx->tenant_id;
     det_ctx->tv = tv;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3077,7 +3077,7 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
     DetectEngineTenantMapping *map_array = NULL;
     uint32_t map_array_size = 0;
     uint32_t map_cnt = 0;
-    int max_tenant_id = 0;
+    uint32_t max_tenant_id = 0;
     DetectEngineCtx *list = master->list;
     HashTable *mt_det_ctxs_hash = NULL;
 
@@ -4426,7 +4426,7 @@ static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p
     return p->pcap_v.tenant_id;
 }
 
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id)
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -111,7 +111,7 @@ uint32_t DetectEngineGetVersion(void);
 void DetectEngineBumpVersion(void);
 int DetectEngineAddToMaster(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineGetCurrent(void);
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id);
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);

--- a/src/detect.h
+++ b/src/detect.h
@@ -826,7 +826,7 @@ enum DetectEngineType
 typedef struct DetectEngineCtx_ {
     int failure_fatal;
 
-    int tenant_id;
+    uint32_t tenant_id;
 
     Signature *sig_list;
     uint32_t sig_cnt;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -59,7 +59,7 @@ int unix_socket_mode_is_running = 0;
 typedef struct PcapFiles_ {
     char *filename;
     char *output_dir;
-    int tenant_id;
+    uint32_t tenant_id;
     time_t delay;
     time_t poll_interval;
     bool continuous;
@@ -265,16 +265,8 @@ static void PcapFilesFree(PcapFiles *cfile)
  *
  * \retval 0 in case of error, 1 in case of success
  */
-static TmEcode UnixListAddFile(
-    PcapCommand *this,
-    const char *filename,
-    const char *output_dir,
-    int tenant_id,
-    bool continuous,
-    bool should_delete,
-    time_t delay,
-    time_t poll_interval
-)
+static TmEcode UnixListAddFile(PcapCommand *this, const char *filename, const char *output_dir,
+        uint32_t tenant_id, bool continuous, bool should_delete, time_t delay, time_t poll_interval)
 {
     PcapFiles *cfile = NULL;
     if (filename == NULL || this == NULL)
@@ -327,7 +319,7 @@ static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data
     PcapCommand *this = (PcapCommand *) data;
     const char *filename;
     const char *output_dir;
-    int tenant_id = 0;
+    uint32_t tenant_id = 0;
     bool should_delete = false;
     time_t delay = 30;
     time_t poll_interval = 5;
@@ -876,7 +868,7 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -957,7 +949,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -1042,7 +1034,7 @@ TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1118,7 +1110,7 @@ TmEcode UnixSocketReloadTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1188,7 +1180,7 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     SCLogInfo("remove-tenant: removing tenant %d", tenant_id);
 


### PR DESCRIPTION
Continuation of #9056 

This PR eliminates crashes during parallel loading of tenant configurations by serializing processing of the .config files
- reference.config
- threshold.config
- classification.config

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6047](https://redmine.openinfosecfoundation.org/issues/6047)

Describe changes:
- Formatting fixups
- Removal of commit that triggered "uninitialized variable" errors.


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
