### PR TITLE
detect/http2: warning that http2.header is removed

### DIFF
--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -806,6 +806,10 @@ static int DetectEngineInspectHttp2HeaderName(
 
 static int DetectHTTP2headerSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
+    SCLogWarning(SC_WARN_DEPRECATED,
+            "Experimental keyword http2.header is removed in Suricata 7, and replaced "
+            "by http.request_header and http.response_header, see "
+            "https://redmine.openinfosecfoundation.org/issues/5780");
     if (DetectBufferSetActiveList(s, g_http2_header_buffer_id) < 0)
         return -1;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5780

Describe changes:
- detect/http2: warning that http2.header is removed

See https://github.com/OISF/suricata/pull/8775#issuecomment-1576215565

>> Do we keep the deprecated keyword in 6 ?
> Yes. But maybe it will be good to add a warning that it is removed in 7.

Modifies #9019 with review about the warning code