### PR TITLE
Nallocfuzz v1

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -83,8 +83,6 @@ uint16_t packet_alert_max = PACKET_ALERT_MAX;
 PacketAlert *PacketAlertCreate(void)
 {
     PacketAlert *pa_array = SCCalloc(packet_alert_max, sizeof(PacketAlert));
-    BUG_ON(pa_array == NULL);
-
     return pa_array;
 }
 
@@ -176,7 +174,10 @@ Packet *PacketGetFromAlloc(void)
     if (unlikely(p == NULL)) {
         return NULL;
     }
-    PacketInit(p);
+    if (unlikely(!PacketInit(p))) {
+        SCFree(p);
+        return NULL;
+    }
     p->ReleasePacket = PacketFree;
 
     SCLogDebug("allocated a new packet only using alloc...");

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1106,7 +1106,10 @@ static Packet *BuildTestPacket(uint8_t proto, uint16_t id, uint16_t off, int mf,
     if (unlikely(p == NULL))
         return NULL;
 
-    PacketInit(p);
+    if (unlikely(!PacketInit(p))) {
+        SCFree(p);
+        return NULL;
+    }
 
     struct timeval tval;
     gettimeofday(&tval, NULL);
@@ -1178,7 +1181,10 @@ static Packet *IPV6BuildTestPacket(uint8_t proto, uint32_t id, uint16_t off,
     if (unlikely(p == NULL))
         return NULL;
 
-    PacketInit(p);
+    if (unlikely(!PacketInit(p))) {
+        SCFree(p);
+        return NULL;
+    }
 
     struct timeval tval;
     gettimeofday(&tval, NULL);

--- a/src/packet.c
+++ b/src/packet.c
@@ -59,12 +59,17 @@ bool PacketCheckAction(const Packet *p, const uint8_t a)
 /**
  *  \brief Initialize a packet structure for use.
  */
-void PacketInit(Packet *p)
+bool PacketInit(Packet *p)
 {
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
+    if (p->alerts.alerts == NULL) {
+        SCSpinDestroy(&p->persistent.tunnel_lock);
+        return false;
+    }
     PACKET_RESET_CHECKSUMS(p);
     p->livedev = NULL;
+    return true;
 }
 
 void PacketReleaseRefs(Packet *p)

--- a/src/packet.h
+++ b/src/packet.h
@@ -30,7 +30,7 @@ static inline uint8_t PacketTestAction(const Packet *p, const uint8_t a)
 }
 #endif
 
-void PacketInit(Packet *p);
+bool PacketInit(Packet *p);
 void PacketReleaseRefs(Packet *p);
 void PacketReinit(Packet *p);
 void PacketRecycle(Packet *p);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None yet, generic fuzzing, resist allocation failures

Describe changes:
- Make `sig_init` target ready for allocations failures
- packet: handle allocation failure graciously (fuzz_predef_pcap_aware)
- One commit to make `DetectEngineReload` resist allocations failures (`DetectMpmInitializeAppMpms` is another instance to fix)

See also https://github.com/OISF/libhtp/pull/395
```
LIBHTP_BRANCH=pr/395
```

For info, also one leak found in smtp/mime 
