### PR TITLE
python: use portable python shebang

### DIFF
--- a/python/suricata/ctl/main.py
+++ b/python/suricata/ctl/main.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2018 Open Information Security Foundation
+#!/usr/bin/env python
+# Copyright (C) 2018-2023 Open Information Security Foundation
 #
 # You can copy, redistribute or modify this Program under the terms of
 # the GNU General Public License version 2 as published by the Free

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-# Copyright(C) 2012-2020 Open Information Security Foundation
+#!/usr/bin/env python
+# Copyright(C) 2012-2023 Open Information Security Foundation
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/3432

We no longer use distutils as stated in the bug but this shebang is anyway more portable.
