### PR TITLE
log-pcap: don't crash if directory unwritable and lz4 enabled - v2

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1187,6 +1187,10 @@ static void PcapLogDataFree(PcapLogData *pl)
     SCFree(pl->filename);
     SCFree(pl->prefix);
 
+    if (pl->pcap_dead_handle) {
+      pcap_close(pl->pcap_dead_handle);
+    }
+
 #ifdef HAVE_LIBLZ4
     if (pl->compression.format == PCAP_LOG_COMPRESSION_FORMAT_LZ4) {
         SCFree(pl->compression.buffer);

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -429,14 +429,18 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
 #ifdef HAVE_LIBLZ4
         else if (pl->compression.format == PCAP_LOG_COMPRESSION_FORMAT_LZ4) {
             PcapLogCompressionData *comp = &pl->compression;
-            if ((pl->pcap_dumper = pcap_dump_fopen(pl->pcap_dead_handle,
-                    comp->pcap_buf_wrapper)) == NULL) {
-                SCLogError("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
-                return TM_ECODE_FAILED;
-            }
+
             comp->file = fopen(pl->filename, "w");
             if (comp->file == NULL) {
                 SCLogError("Error opening file for compressed output: %s", strerror(errno));
+                return TM_ECODE_FAILED;
+            }
+
+            if ((pl->pcap_dumper = pcap_dump_fopen(pl->pcap_dead_handle, comp->pcap_buf_wrapper)) ==
+                    NULL) {
+                SCLogError("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
+                fclose(comp->file);
+                comp->file = NULL;
                 return TM_ECODE_FAILED;
             }
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -179,6 +179,8 @@ typedef struct PcapLogData_ {
     char *filename_parts[MAX_TOKS];
     int filename_part_cnt;
     struct timeval last_pcap_dump;
+    int fopen_err;      /**< set to the last fopen error */
+    bool pcap_open_err; /**< true if the last pcap open errored */
 
     PcapLogCompressionData compression;
 } PcapLogData;
@@ -422,8 +424,13 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
         if (pl->compression.format == PCAP_LOG_COMPRESSION_FORMAT_NONE) {
             if ((pl->pcap_dumper = pcap_dump_open(pl->pcap_dead_handle,
                     pl->filename)) == NULL) {
-                SCLogInfo("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
+                if (!pl->pcap_open_err) {
+                    SCLogError("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
+                    pl->pcap_open_err = true;
+                }
                 return TM_ECODE_FAILED;
+            } else {
+                pl->pcap_open_err = false;
             }
         }
 #ifdef HAVE_LIBLZ4
@@ -432,16 +439,26 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
 
             comp->file = fopen(pl->filename, "w");
             if (comp->file == NULL) {
-                SCLogError("Error opening file for compressed output: %s", strerror(errno));
+                if (errno != pl->fopen_err) {
+                    SCLogError("Error opening file for compressed output: %s", strerror(errno));
+                    pl->fopen_err = errno;
+                }
                 return TM_ECODE_FAILED;
+            } else {
+                pl->fopen_err = 0;
             }
 
             if ((pl->pcap_dumper = pcap_dump_fopen(pl->pcap_dead_handle, comp->pcap_buf_wrapper)) ==
                     NULL) {
-                SCLogError("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
+                if (!pl->pcap_open_err) {
+                    SCLogError("Error opening dump file %s", pcap_geterr(pl->pcap_dead_handle));
+                    pl->pcap_open_err = true;
+                }
                 fclose(comp->file);
                 comp->file = NULL;
                 return TM_ECODE_FAILED;
+            } else {
+                pl->pcap_open_err = false;
             }
 
             uint64_t bytes_written = LZ4F_compressBegin(comp->lz4f_context,


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/5022

Also adds one-time error output as the error was hidden without lz4, and was now very noisy with lz4.

Previous PR:
https://github.com/OISF/suricata/pull/9088

Changes from last PR:
- Fix memory leak on exit

SV_BRANCH=pr/1271

OISF/suricata-verify#1271
