### PR TITLE
doc/conf: remove deprecated fn call

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -138,10 +138,7 @@ if not on_rtd:
     except:
         html_theme = 'default'
     def setup(app):
-        if hasattr(app, 'add_css_file'):
-            app.add_css_file('css/suricata.css')
-        else:
-            app.add_stylesheet('css/suricata.css')
+        app.add_css_file('css/suricata.css')
 else:
     html_context = {
         'css_files': [


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/4371

The warning isn't there anymore but the fn call mentioned in the warning was deprecated long ago and still was used in our code. ref: https://github.com/sphinx-doc/sphinx/issues/7747

It has been deprecated since 1.8.0. I have 4.3.2 now.