### PR TITLE
 detect/flow: remove dead code

### DIFF
--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -237,10 +237,6 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
                 if (fd->flags & DETECT_FLOW_FLAG_NOT_ESTABLISHED) {
                     SCLogError("DETECT_FLOW_FLAG_NOT_ESTABLISHED flag is already set");
                     goto error;
-                } else if (fd->flags & DETECT_FLOW_FLAG_NOT_ESTABLISHED) {
-                    SCLogError("cannot set DETECT_FLOW_FLAG_NOT_ESTABLISHED, "
-                               "DETECT_FLOW_FLAG_ESTABLISHED already set");
-                    goto error;
                 }
                 fd->flags |= DETECT_FLOW_FLAG_NOT_ESTABLISHED;
             } else if (strcasecmp(args[i], "stateless") == 0) {


### PR DESCRIPTION
 The second check in "else if" branch is useless, because the condition
 was checked earlier in "if" branch.

 Found by Security Code with Svace Static Analyzer
 Signed-off-by: Maxim Korotkov <m.korotkov@securitycode.ru>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- deleted useless check

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
