### PR TITLE
af-packet: Remove support for rollover 

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -74,6 +74,8 @@ Deprecations
 - Multiple "include" fields in the configuration file will now issue a
   warning and in Suricata 8.0 will not be supported. See
   :ref:`includes` for documentation on including multiple files.
+- For AF-Packet, the `cluster_rollover` setting is no longer supported. If this is used, a warning
+  message will be printed and `cluster_flow` will be used instead.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -375,7 +375,12 @@ static void *ParseAFPConfig(const char *iface)
         SCLogConfig("%s: using round-robin cluster mode for AF_PACKET", aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_LB;
         cluster_type = PACKET_FANOUT_LB;
-    } else if (strcmp(tmpctype, "cluster_flow") == 0) {
+    } else if (strcmp(tmpctype, "cluster_flow") == 0 || strcmp(tmpctype, "cluster_rollover") == 0) {
+        if (strcmp(tmpctype, "cluster_rollover") == 0) {
+            SCLogWarning("%s: cluster_rollover deprecated; using \"cluster_flow\" instead. See "
+                         "https://redmine.openinfosecfoundation.org/issues/6128",
+                    aconf->iface);
+        }
         /* In hash mode, we also ask for defragmentation needed to
          * compute the hash */
         uint16_t defrag = 0;
@@ -400,13 +405,6 @@ static void *ParseAFPConfig(const char *iface)
         SCLogConfig("%s: using random based cluster mode for AF_PACKET", aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_RND;
         cluster_type = PACKET_FANOUT_RND;
-    } else if (strcmp(tmpctype, "cluster_rollover") == 0) {
-        SCLogConfig("%s: using rollover based cluster mode for AF_PACKET", aconf->iface);
-        SCLogWarning("%s: rollover mode is causing severe flow "
-                     "tracking issues, use it at your own risk.",
-                iface);
-        aconf->cluster_type = PACKET_FANOUT_ROLLOVER;
-        cluster_type = PACKET_FANOUT_ROLLOVER;
 #ifdef HAVE_PACKET_EBPF
     } else if (strcmp(tmpctype, "cluster_ebpf") == 0) {
         SCLogInfo("%s: using ebpf based cluster mode for AF_PACKET", aconf->iface);

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -321,7 +321,9 @@ int LiveDeviceListClean(void)
             SCLogNotice("%s: packets: %" PRIu64 ", drops: %" PRIu64
                         " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
-                    100 * ((double)SC_ATOMIC_GET(pd->drop)) / (double)SC_ATOMIC_GET(pd->pkts),
+                    SC_ATOMIC_GET(pd->pkts) > 0 ? 100 * ((double)SC_ATOMIC_GET(pd->drop)) /
+                                                          (double)SC_ATOMIC_GET(pd->pkts)
+                                                : 0,
                     SC_ATOMIC_GET(pd->invalid_checksums));
         }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -621,6 +621,7 @@ af-packet:
     #  more info.
     # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
     # with capture card using RSS (requires cpu affinity tuning and system IRQ tuning)
+    # cluster_rollover has been deprecated; if used, it'll be replaced with cluster_flow.
     cluster-type: cluster_flow
     # In some fragmentation cases, the hash can not be computed. If "defrag" is set
     # to yes, the kernel will do the needed defragmentation before sending the packets.


### PR DESCRIPTION
Continuation of #9069 
This MR removes support for AF-Packet rollover.

Rollover support is defined [here](https://www.man7.org/linux/man-pages/man7/packet.7.html).

If `cluster-type: cluster_rollover` is configured, a warning message will be displayed and the clustering used will be `cluster_flow`.

The warning message:
```
Warning: af-packet: enp6s0f0: cluster_rollover deprecated; using "cluster_flow" instead. See https://redmine.openinfosecfoundation.org/issues/6128
```
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6128](https://redmine.openinfosecfoundation.org/issues/6128)

Describe changes:
- Document deprecation in upgrade notes
- Detect when rollover is used (`cluster-type: cluster_rollover`) and use `cluster_flow` instead

Updates
- Removed `rollover` handling per review feedback.
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
