### PR TITLE
6.0.x: log-pcap: don't crash if directory unwritable and lz4 enabled - v1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,11 @@ Describe changes:
 
 ### Provide values to any of the below to override the defaults.
 
-To use a pull request use a branch name like `pr/N` where `N` is the pull request number.
+To use a pull request use a branch name like `pr/N` where `N` is the
+pull request number.
+
+Alternatively, `SV_BRANCH` may also be a link to an
+OISF/suricata-verify pull-request.
 
 ```
 SV_REPO=

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -90,7 +90,13 @@ jobs:
 
       - name: Fetching suricata-verify
         run: |
-          pr=$(echo "${SV_BRANCH}" | sed -n 's/^pr\/\([[:digit:]]\+\)$/\1/p')
+          # Looking for a pull request number. in the SV_BRANCH
+          # value. This could be "pr/NNN", "pull/NNN" or a link to an
+          # OISF/suricata-verify pull request.
+          pr=$(echo "${SV_BRANCH}" | sed -n \
+              -e 's/^https:\/\/github.com\/OISF\/suricata-verify\/pull\/\([0-9]*\)$/\1/p' \
+              -e 's/^pull\/\([0-9]*\)$/\1/p' \
+              -e 's/^pr\/\([0-9]*\)$/\1/p')
           if [ "${pr}" ]; then
               SV_BRANCH="refs/pull/${pr}/head"
               echo "Using suricata-verify pull-request ${SV_BRANCH}"

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1028,6 +1028,10 @@ static void PcapLogDataFree(PcapLogData *pl)
     SCFree(pl->filename);
     SCFree(pl->prefix);
 
+    if (pl->pcap_dead_handle) {
+        pcap_close(pl->pcap_dead_handle);
+    }
+
 #ifdef HAVE_LIBLZ4
     if (pl->compression.format == PCAP_LOG_COMPRESSION_FORMAT_LZ4) {
         SCFree(pl->compression.buffer);

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -404,17 +404,20 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
 #ifdef HAVE_LIBLZ4
         else if (pl->compression.format == PCAP_LOG_COMPRESSION_FORMAT_LZ4) {
             PcapLogCompressionData *comp = &pl->compression;
-            if ((pl->pcap_dumper = pcap_dump_fopen(pl->pcap_dead_handle,
-                    comp->pcap_buf_wrapper)) == NULL) {
-                SCLogError(SC_ERR_OPENING_FILE, "Error opening dump file %s",
-                        pcap_geterr(pl->pcap_dead_handle));
-                return TM_ECODE_FAILED;
-            }
             comp->file = fopen(pl->filename, "w");
             if (comp->file == NULL) {
                 SCLogError(SC_ERR_OPENING_FILE,
                         "Error opening file for compressed output: %s",
                         strerror(errno));
+                return TM_ECODE_FAILED;
+            }
+
+            if ((pl->pcap_dumper = pcap_dump_fopen(pl->pcap_dead_handle, comp->pcap_buf_wrapper)) ==
+                    NULL) {
+                SCLogError(SC_ERR_OPENING_FILE, "Error opening dump file %s",
+                        pcap_geterr(pl->pcap_dead_handle));
+                fclose(comp->file);
+                comp->file = NULL;
                 return TM_ECODE_FAILED;
             }
 


### PR DESCRIPTION
Backport of https://github.com/OISF/suricata/pull/9093.
Ticket: https://redmine.openinfosecfoundation.org/issues/5022
Backport ticket: https://redmine.openinfosecfoundation.org/issues/6182
Related SV PR (now merged): https://github.com/OISF/suricata-verify/pull/1271
