### PR TITLE
exception: master switch not applied to midstream - v2

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -45,10 +45,13 @@ also defined in the yaml file.
 Auto
 ''''
 
-**In IPS mode**, the default behavior for all exception policies is to drop
-the flow, or the packet, when the flow action is not supported. It is possible
-to disable this default, by setting the exception policies' "master switch" yaml
-config option to ``ignore``.
+**In IPS mode**, the default behavior for most of the exception policies is to
+fail close. This means droping the flow, or the packet, when the flow action is
+not supported. The default policy for the midstream exception will be ignore if
+midstream flows are accepted.
+
+It is possible to disable this default, by setting the exception policies'
+"master switch" yaml config option to ``ignore``.
 
 **In IDS mode**, setting ``auto`` mode actually means disabling the
 ``master-switch``, or ignoring the exception policies.

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -174,6 +174,7 @@ static enum ExceptionPolicy ExceptionPolicyConfigValueParse(
     return policy;
 }
 
+/* Select an exception policy in case the configuration value was set to 'auto' */
 static enum ExceptionPolicy ExceptionPolicyPickAuto(bool midstream_enabled, bool support_flow)
 {
     enum ExceptionPolicy policy = EXCEPTION_POLICY_NOT_SET;
@@ -190,10 +191,8 @@ static enum ExceptionPolicy ExceptionPolicyPickAuto(bool midstream_enabled, bool
 static enum ExceptionPolicy ExceptionPolicyMasterParse(const char *value)
 {
     enum ExceptionPolicy policy = ExceptionPolicyConfigValueParse("exception-policy", value);
-    if (policy == EXCEPTION_POLICY_AUTO) {
-        policy = ExceptionPolicyPickAuto(false, true);
-    } else if (!EngineModeIsIPS() &&
-               (policy == EXCEPTION_POLICY_DROP_PACKET || policy == EXCEPTION_POLICY_DROP_FLOW)) {
+    if (!EngineModeIsIPS() &&
+            (policy == EXCEPTION_POLICY_DROP_PACKET || policy == EXCEPTION_POLICY_DROP_FLOW)) {
         policy = EXCEPTION_POLICY_NOT_SET;
     }
     g_eps_have_exception_policy = true;
@@ -209,6 +208,11 @@ static enum ExceptionPolicy ExceptionPolicyGetDefault(
     enum ExceptionPolicy p = EXCEPTION_POLICY_NOT_SET;
     if (g_eps_have_exception_policy) {
         p = GetMasterExceptionPolicy(option);
+
+        if (p == EXCEPTION_POLICY_AUTO) {
+            p = ExceptionPolicyPickAuto(midstream, support_flow);
+        }
+
         if (!support_flow) {
             p = PickPacketAction(option, p);
         }
@@ -277,7 +281,7 @@ enum ExceptionPolicy ExceptionPolicyMidstreamParse(bool midstream_enabled)
             }
         }
     } else {
-        policy = ExceptionPolicyPickAuto(midstream_enabled, true);
+        policy = ExceptionPolicyGetDefault("stream.midstream-policy", true, midstream_enabled);
     }
 
     if (policy == EXCEPTION_POLICY_PASS_PACKET || policy == EXCEPTION_POLICY_DROP_PACKET) {


### PR DESCRIPTION
If an exception policy wasn't set up individually, use the GetDefault function to pick one. This will check for the master switch option and handle 'auto' cases.

Instead of deciding what the auto value should be when we are parsing the master switch, leave that for when some of the other policies is to be set via the master switch, when since this can change for specific exception policies - like for midstream, for instance.

Update exceptions policies documentation to clarify that the default configuration in IPS when midstream is enabled is `ignore`, not `drop-flow`.

Bug #6169Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6169

Previous PR: #9059 

Describe changes:
- If an exception policy wasn't set up individually, use the GetDefault function to pick one. This will check for the master switch option and handle 'auto' cases.
- Instead of deciding what the auto value should be when we are parsing the master switch, leave that for when some of the other policies is to be set via the master switch, when since this can change for specific exception policies - like for midstream, for instance.
- Update exceptions policies documentation to clarify that the default configuration in IPS when midstream is enabled is `ignore`, not `drop-flow`.
- rebase

```
SV_BRANCH=pr/1280
```
https://github.com/OISF/suricata-verify/pull/1280
