### PR TITLE
6.0.x: issue 5868: file_data fix for http1 response files - v4

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -103,6 +103,9 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
 
         flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
 
+        /* Depend on the detection engine for file pruning. */
+        flags |= FILE_USE_DETECT;
+
         if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
                 ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
             flags |= FILE_STORE;


### PR DESCRIPTION
Possible fix for: https://redmine.openinfosecfoundation.org/issues/5868

Previous PR: https://github.com/OISF/suricata/pull/9063

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1225
