### PR TITLE
github-ci: debian 12, centos stream - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -375,10 +375,8 @@ jobs:
         run: cargo clippy --all-features
         working-directory: rust
 
-  # AlmaLinux 8 builder and distribution archive builder that some
-  # other builds will depend on.
   almalinux-8:
-    name: AlmaLinux 8 (Dist builder)
+    name: AlmaLinux 8
     runs-on: ubuntu-latest
     container: almalinux:8
     needs: [prepare-deps, prepare-cbindgen]
@@ -498,21 +496,12 @@ jobs:
       - run: make install
       - run: suricatasc -h
       - run: suricata-update -V
-      - name: Preparing distribution
-        run: |
-          mkdir dist
-          mv suricata-*.tar.gz dist
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        name: Uploading distribution
-        with:
-          name: dist
-          path: dist
 
   centos-7:
     name: CentOS 7
     runs-on: ubuntu-latest
     container: centos:7
-    needs: [prepare-deps, almalinux-8]
+    needs: [prepare-deps, debian-12-dist]
     steps:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
@@ -2278,6 +2267,85 @@ jobs:
       - run: make install
       - run: suricata-update -V
       - run: suricatasc -h
+
+  debian-12-dist:
+    name: Debian 12 Dist Builder
+    runs-on: ubuntu-latest
+    container: debian:12
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - run: apt update
+      - run: |
+          apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cargo \
+              cbindgen \
+              cmake \
+              curl \
+              git \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libmagic-dev \
+              libjansson-dev \
+              libjansson4 \
+              libnss3-dev \
+              libnspr4-dev \
+              liblz4-dev \
+              libssl-dev \
+              liblzma-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              rustc \
+              sphinx-doc \
+              sphinx-common \
+              texlive-latex-base \
+              texlive-fonts-recommended \
+              texlive-fonts-extra \
+              texlive-latex-extra \
+              zlib1g \
+              zlib1g-dev
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make dist
+      - run: test -e doc/userguide/suricata.1
+      - run: test -e doc/userguide/userguide.pdf
+      - name: Preparing distribution
+        run: |
+          mkdir dist
+          mv suricata-*.tar.gz dist
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        name: Uploading distribution
+        with:
+          name: dist
+          path: dist
 
   debian-11:
     name: Debian 11 (xdp)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -497,6 +497,197 @@ jobs:
       - run: suricatasc -h
       - run: suricata-update -V
 
+  centos-stream9:
+    name: CentOS Stream 9
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    needs: [prepare-deps, debian-12-dist]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3.3.1
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Install system packages
+        run: |
+          dnf -y install dnf-plugins-core epel-release
+          dnf config-manager --set-enabled crb
+          dnf -y install \
+                autoconf \
+                automake \
+                cargo-vendor \
+                cbindgen \
+                diffutils \
+                numactl-devel \
+                dpdk-devel \
+                file-devel \
+                gcc \
+                gcc-c++ \
+                git \
+                jansson-devel \
+                jq \
+                lua-devel \
+                libtool \
+                libyaml-devel \
+                libnfnetlink-devel \
+                libnetfilter_queue-devel \
+                libnet-devel \
+                libcap-ng-devel \
+                libevent-devel \
+                libmaxminddb-devel \
+                libpcap-devel \
+                libtool \
+                lz4-devel \
+                make \
+                nss-devel \
+                pcre2-devel \
+                pkgconfig \
+                python3-devel \
+                python3-sphinx \
+                python3-yaml \
+                rust-toolset \
+                sudo \
+                which \
+                zlib-devel
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: dist
+      - run: tar zxvf suricata-*.tar.gz --strip-components=1
+      - name: ./configure
+        run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j2
+      - run: make install
+      - run: make install-conf
+      - run: suricatasc -h
+      - run: suricata-update -V
+      - name: Check if Suricata-Update example configuration files are installed
+        run: |
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/disable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/drop.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/enable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/modify.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/threshold.in
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/update.yaml
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: python3 ./suricata-verify/run.py -q
+      - run: suricata-update -V
+      - run: suricatasc -h
+
+  centos-stream8:
+    name: CentOS Stream 8
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream8
+    needs: [prepare-deps, debian-12-dist]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3.3.1
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Install system packages
+        run: |
+          dnf -y install dnf-plugins-core epel-release
+          dnf config-manager --set-enabled powertools
+          dnf -y install \
+                autoconf \
+                automake \
+                diffutils \
+                numactl-devel \
+                dpdk-devel \
+                file-devel \
+                gcc \
+                gcc-c++ \
+                git \
+                jansson-devel \
+                jq \
+                lua-devel \
+                libtool \
+                libyaml-devel \
+                libnfnetlink-devel \
+                libnetfilter_queue-devel \
+                libnet-devel \
+                libcap-ng-devel \
+                libevent-devel \
+                libmaxminddb-devel \
+                libpcap-devel \
+                libtool \
+                lz4-devel \
+                make \
+                nss-devel \
+                pcre2-devel \
+                pkgconfig \
+                python3-devel \
+                python3-sphinx \
+                python3-yaml \
+                rust-toolset \
+                sudo \
+                which \
+                zlib-devel
+          # These packages required to build the PDF.
+          dnf -y install \
+                texlive-latex \
+                texlive-cmap \
+                texlive-collection-latexrecommended \
+                texlive-fncychap \
+                texlive-titlesec \
+                texlive-tabulary \
+                texlive-framed \
+                texlive-wrapfig \
+                texlive-upquote \
+                texlive-capt-of \
+                texlive-needspace
+      - name: Download suricata.tar.gz
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: dist
+      - run: tar zxvf suricata-*.tar.gz --strip-components=1
+      - name: ./configure
+        run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j2
+      - run: make install
+      - run: make install-conf
+      - run: suricatasc -h
+      - run: suricata-update -V
+      - name: Check if Suricata-Update example configuration files are installed
+        run: |
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/disable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/drop.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/enable.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/modify.conf
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/threshold.in
+          test -e /usr/local/lib/suricata/python/suricata/update/configs/update.yaml
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: python3 ./suricata-verify/run.py -q
+      - run: suricata-update -V
+      - run: suricatasc -h
+
   centos-7:
     name: CentOS 7
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2192,6 +2192,93 @@ jobs:
       - run: make -j2
       - run: make check
 
+  debian-12:
+    name: Debian 12
+    runs-on: ubuntu-latest
+    container: debian:12
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - run: apt update
+      - run: |
+          apt -y install \
+              autoconf \
+              automake \
+              build-essential \
+              cargo \
+              cbindgen \
+              cmake \
+              curl \
+              dpdk-dev \
+              git \
+              jq \
+              make \
+              libpcre3 \
+              libpcre3-dbg \
+              libpcre3-dev \
+              libpcre2-dev \
+              libtool \
+              libpcap-dev \
+              libnet1-dev \
+              libyaml-0-2 \
+              libyaml-dev \
+              libcap-ng-dev \
+              libcap-ng0 \
+              libmagic-dev \
+              libmaxminddb-dev \
+              libjansson-dev \
+              libjansson4 \
+              liblua5.1-dev \
+              libnss3-dev \
+              libnspr4-dev \
+              libnuma-dev \
+              liblz4-dev \
+              libssl-dev \
+              liblzma-dev \
+              pkg-config \
+              python3 \
+              python3-yaml \
+              rustc \
+              sphinx-doc \
+              sphinx-common \
+              texlive-latex-base \
+              texlive-fonts-recommended \
+              texlive-fonts-extra \
+              texlive-latex-extra \
+              zlib1g \
+              zlib1g-dev
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests
+      - run: make -j2
+      - run: make check
+      - run: make -j2 distcheck
+        env:
+          DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-lua --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk"
+      - run: test -e doc/userguide/suricata.1
+      - run: test -e doc/userguide/userguide.pdf
+      - name: Building Rust documentation
+        run: make doc
+        working-directory: rust
+      - name: Running suricata-verify
+        run: python3 ./suricata-verify/run.py -q
+      - run: make install
+      - run: suricata-update -V
+      - run: suricatasc -h
+
   debian-11:
     name: Debian 11 (xdp)
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add a Debian 12 builder
- Use Debian 12 as dist builder instead of AlmaLinux 8
  - Gives us newer Sphinx
  - Avoid RHEL fall-out
- Add CentOS Stream 8 and 9 builders
