### PR TITLE
af-packet: Remove support for rollover settings

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -74,6 +74,8 @@ Deprecations
 - Multiple "include" fields in the configuration file will now issue a
   warning and in Suricata 8.0 will not be supported. See
   :ref:`includes` for documentation on including multiple files.
+- For AF-Packet, the `cluster_rollover` setting is no longer supported. If this is used, a warning
+  message will be printed and `cluster_flow` will be used instead.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -74,8 +74,8 @@ Deprecations
 - Multiple "include" fields in the configuration file will now issue a
   warning and in Suricata 8.0 will not be supported. See
   :ref:`includes` for documentation on including multiple files.
-- For AF-Packet, the `cluster_rollover` setting is no longer supported. If this is used, a warning
-  message will be printed and `cluster_flow` will be used instead.
+- For AF-Packet, the `cluster_rollover` setting is no longer supported. Configuration settings using ``cluster_rollover``
+  will cause a warning message and act as though `cluster_flow`` was specified. Please update your configuration settings.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -321,7 +321,9 @@ int LiveDeviceListClean(void)
             SCLogNotice("%s: packets: %" PRIu64 ", drops: %" PRIu64
                         " (%.2f%%), invalid chksum: %" PRIu64,
                     pd->dev, SC_ATOMIC_GET(pd->pkts), SC_ATOMIC_GET(pd->drop),
-                    100 * ((double)SC_ATOMIC_GET(pd->drop)) / (double)SC_ATOMIC_GET(pd->pkts),
+                    SC_ATOMIC_GET(pd->pkts) > 0 ? 100 * ((double)SC_ATOMIC_GET(pd->drop)) /
+                                                          (double)SC_ATOMIC_GET(pd->pkts)
+                                                : 0,
                     SC_ATOMIC_GET(pd->invalid_checksums));
         }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -621,6 +621,7 @@ af-packet:
     #  more info.
     # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
     # with capture card using RSS (requires cpu affinity tuning and system IRQ tuning)
+    # cluster_rollover has been deprecated; if used, it'll be replaced with cluster_flow.
     cluster-type: cluster_flow
     # In some fragmentation cases, the hash can not be computed. If "defrag" is set
     # to yes, the kernel will do the needed defragmentation before sending the packets.


### PR DESCRIPTION
Continuation of #9123 
This MR removes support for AF-Packet rollover.

Rollover support is defined [here](https://www.man7.org/linux/man-pages/man7/packet.7.html).

If `cluster-type: cluster_rollover` is configured, a warning message will be displayed and the clustering used will be `cluster_flow`.

The warning message:
```
Warning: af-packet: enp6s0f0: cluster_rollover deprecated; using "cluster_flow" instead. See ticket #6128
```
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6128](https://redmine.openinfosecfoundation.org/issues/6128)

Describe changes:
- Document deprecation in upgrade notes
- Detect when rollover is used (`cluster-type: cluster_rollover`) and use `cluster_flow` instead

Updates
- Ignore `rollerover` setting and issue warning instead.
- Improve wording in documentation that mentions rollover removal.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
