### PR TITLE
tls: update x509 crate to v0.8

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -44,6 +44,7 @@ tls-parser = "0.9"
 # required by x509 to keep MSRV support
 chrono = "=0.4.19"
 thiserror = "=1.0.39"
+data-encoding = "=2.3.3"
 x509-parser = "0.8.2"
 libc = "0.2.67"
 

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -41,7 +41,10 @@ ntp-parser = "0.4"
 ipsec-parser = "0.5"
 snmp-parser = "0.6"
 tls-parser = "0.9"
-x509-parser = "0.6.5"
+# required by x509 to keep MSRV support
+chrono = "=0.4.19"
+thiserror = "=1.0.39"
+x509-parser = "0.8.2"
 libc = "0.2.67"
 
 [dev-dependencies]

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -30,12 +30,8 @@ pub enum X509DecodeError {
     InvalidCert,
     /// Some length does not match, or certificate is incomplete
     InvalidLength,
-    InvalidVersion,
-    InvalidSerial,
-    InvalidAlgorithmIdentifier,
     InvalidX509Name,
     InvalidDate,
-    InvalidExtensions,
     /// DER structure is invalid
     InvalidDER,
 }
@@ -112,8 +108,8 @@ pub unsafe extern "C" fn rs_x509_get_validity(
         return -1;
     }
     let x509 = &*ptr;
-    let n_b = x509.0.tbs_certificate.validity.not_before.to_timespec().sec;
-    let n_a = x509.0.tbs_certificate.validity.not_after.to_timespec().sec;
+    let n_b = x509.0.tbs_certificate.validity.not_before.timestamp();
+    let n_a = x509.0.tbs_certificate.validity.not_after.timestamp();
     *not_before = n_b;
     *not_after = n_a;
     0
@@ -136,12 +132,8 @@ fn x509_parse_error_to_errcode(e: &nom::Err<X509Error>) -> X509DecodeError {
     match e {
         nom::Err::Incomplete(_) => X509DecodeError::InvalidLength,
         nom::Err::Error(e) | nom::Err::Failure(e) => match e {
-            X509Error::InvalidVersion => X509DecodeError::InvalidVersion,
-            X509Error::InvalidSerial => X509DecodeError::InvalidSerial,
-            X509Error::InvalidAlgorithmIdentifier => X509DecodeError::InvalidAlgorithmIdentifier,
             X509Error::InvalidX509Name => X509DecodeError::InvalidX509Name,
             X509Error::InvalidDate => X509DecodeError::InvalidDate,
-            X509Error::InvalidExtensions => X509DecodeError::InvalidExtensions,
             X509Error::Der(_) => X509DecodeError::InvalidDER,
             _ => X509DecodeError::InvalidCert,
         },


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5439

Describe changes:
- tls: update x509 crate to v0.8

This is not a backport

On, master, v0.15 is used, but it requires an updated MSRV

### Provide values to any of the below to override the defaults.

https://github.com/OISF/suricata-verify/pull/1255
```
SV_BRANCH=pr/1255
```

#9109 by pinning some indirect dependencies to a patch version compatible with MSRV