### PR TITLE
detect/byte-jump: Permit variable name for nbytes value

### DIFF
--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -263,6 +263,16 @@ See :doc:`http-keywords` for all HTTP keywords.
    use ``byte_extract`` and ``byte_test`` to verify that they
    work as expected.
 
+
+``byte_jump`` Keyword
+---------------------
+
+-  Suricata allows a variable name from ``byte_extract`` or
+   ``byte_math`` to be specified for the ``nbytes`` value. The
+   value of ``nbytes`` must adhere to the same constraints
+   as if it were supplied directly in the rule.
+
+
 ``byte_math`` Keyword
 ---------------------
 
@@ -276,7 +286,7 @@ See :doc:`http-keywords` for all HTTP keywords.
    uint32 value. Snort rejects ``rvalue`` values of ``0`` and requires
    values to be between ``[1..max-uint32 value]``.
 
-- Suricata will never match if there's a zero divisor. Division by 0 is undefined.
+-  Suricata will never match if there's a zero divisor. Division by 0 is undefined.
 
 
 ``isdataat`` Keyword

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -516,7 +516,7 @@ The ``byte_jump`` keyword allows for the ability to select a ``<num of bytes>`` 
 
 Format::
 
-  byte_jump:<num of bytes>, <offset> [, relative][, multiplier <mult_value>] \
+  byte_jump:<num of bytes> | <variable-name>, <offset> [, relative][, multiplier <mult_value>] \
         [, <endian>][, string, <num_type>][, align][, from_beginning][, from_end] \
         [, post_offset <value>][, dce][, bitmask <value>];
 
@@ -524,6 +524,7 @@ Format::
 
 +-----------------------+-----------------------------------------------------------------------+
 | <num of bytes>        | The number of bytes selected from the packet to be converted          |
+|                       | or the name of a byte_extract/byte_math variable.                     |
 +-----------------------+-----------------------------------------------------------------------+
 | <offset>		| Number of bytes into the payload					|
 +-----------------------+-----------------------------------------------------------------------+

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -40,14 +40,15 @@
 #define DETECT_BYTEJUMP_DCE       BIT_U16(6) /**< "dce" enabled */
 #define DETECT_BYTEJUMP_OFFSET_BE BIT_U16(7) /**< "byte extract" enabled */
 #define DETECT_BYTEJUMP_END       BIT_U16(8) /**< "from_end" jump */
+#define DETECT_BYTEJUMP_NBYTES_VAR BIT_U16(9) /**< nbytes string*/
 
 typedef struct DetectBytejumpData_ {
     uint8_t nbytes;                   /**< Number of bytes to compare */
     uint8_t base;                     /**< String value base (oct|dec|hex) */
     uint16_t flags;                   /**< Flags (big|little|relative|string) */
-    uint32_t multiplier;              /**< Multiplier for nbytes (multiplier n)*/
     int32_t offset;                   /**< Offset in payload to extract value */
     int32_t post_offset;              /**< Offset to adjust post-jump */
+    uint16_t multiplier;              /**< Multiplier for nbytes (multiplier n)*/
 } DetectBytejumpData;
 
 /* prototypes */
@@ -77,7 +78,7 @@ void DetectBytejumpRegister (void);
  *       error as a match.
  */
 int DetectBytejumpDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *,
-                          const uint8_t *, uint32_t, uint16_t, int32_t);
+        const uint8_t *, uint32_t, uint16_t, int32_t, int32_t);
 
 #endif /* __DETECT_BYTEJUMP_H__ */
 

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -509,9 +509,16 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
         DetectBytejumpData *bjd = (DetectBytejumpData *)smd->ctx;
         uint16_t bjflags = bjd->flags;
         int32_t offset = bjd->offset;
+        int32_t nbytes;
 
         if (bjflags & DETECT_CONTENT_OFFSET_VAR) {
             offset = det_ctx->byte_values[offset];
+        }
+
+        if (bjflags & DETECT_BYTEJUMP_NBYTES_VAR) {
+            nbytes = det_ctx->byte_values[bjd->nbytes];
+        } else {
+            nbytes = bjd->nbytes;
         }
 
         /* if we have dce enabled we will have to use the endianness
@@ -523,8 +530,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                       DETECT_BYTEJUMP_LITTLE: 0);
         }
 
-        if (DetectBytejumpDoMatch(det_ctx, s, smd->ctx, buffer, buffer_len,
-                                  bjflags, offset) != 1) {
+        if (DetectBytejumpDoMatch(
+                    det_ctx, s, smd->ctx, buffer, buffer_len, bjflags, nbytes, offset) != 1) {
             goto no_match;
         }
 


### PR DESCRIPTION
Continuation of #9145
  
This PR adds the ability to use a variable name with the nbytes value in a `byte_jump` keyword option list.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6105](https://redmine.openinfosecfoundation.org/issues/6105)

Describe changes:
- Add logic to detect and use variable names for `nbytes` in the `byte_jump` option list
- Document variable name and add to Snort difference document.

Updates
- Refactored nbyte validation logic to eliminate error messages if using a variable.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the pull request number.

```
SV_REPO=
SV_BRANCH=pr/1254
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
