### PR TITLE
userguide: add eve schema generate doc - v3

### DIFF
--- a/doc/userguide/.gitignore
+++ b/doc/userguide/.gitignore
@@ -1,1 +1,2 @@
 _build
+_generated

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -1,4 +1,5 @@
 EXTRA_DIST = \
+	_generated \
 	_static \
 	3rd-party-integration \
 	acknowledgements.rst \
@@ -88,6 +89,7 @@ man: $(dist_man1_MANS)
 # Remove build artifacts that aren't tracked by autotools.
 clean-local:
 	rm -rf $(top_builddir)/doc/userguide/_build
+	rm -rf $(top_builddir)/doc/userguide/_generated
 	rm -f $(top_builddir)/doc/userguide/suricata*.1
 	rm -f $(top_builddir)/doc/userguide/userguide.pdf
 

--- a/doc/userguide/appendix/eve-index.rst
+++ b/doc/userguide/appendix/eve-index.rst
@@ -1,0 +1,7 @@
+EVE Index
+=========
+
+.. toctree::
+   :maxdepth: 1
+
+.. include:: ../_generated/eve-index.rst

--- a/doc/userguide/appendix/index.rst
+++ b/doc/userguide/appendix/index.rst
@@ -1,0 +1,7 @@
+Appendix
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   eve-index

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -338,3 +338,11 @@ rst_epilog = """
     "sysconfdir": os.getenv("sysconfdir", "/etc"),
     "localstatedir": os.getenv("localstatedir", "/var"),
 }
+
+# Custom code generate some documentation.
+evedoc = "./evedoc.py"
+eve_schema = "../../etc/schema.json"
+os.makedirs("_generated", exist_ok=True)
+subprocess.call([evedoc, "--output", "_generated/eve-index.rst", eve_schema])
+for proto in ["quic", "pgsql"]:
+    subprocess.call([evedoc, "--output", "_generated/{}.rst".format(proto), "--object", proto, eve_schema])

--- a/doc/userguide/evedoc.py
+++ b/doc/userguide/evedoc.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python3
+#
+# Generate Sphinx documentation from JSON schema
+
+import argparse
+import sys
+import json
+import re
+
+
+def find_ref(schema: dict, ref: str) -> dict:
+    parts = ref.split("/")
+
+    root = parts.pop(0)
+    if root != "#":
+        raise Exception("Unsupported reference: {}".format(ref))
+
+    while parts:
+        schema = schema[parts.pop(0)]
+
+    return schema
+
+
+def get_type(props: dict, name: str) -> str:
+    prop_type = props["type"]
+    if prop_type == "array":
+        try:
+            array_type = props["items"]["type"]
+        except KeyError:
+            print("Array property without items: {}".format(name), file=sys.stderr)
+            array_type = "unknown"
+        prop_type = "array of {}s".format(array_type)
+    return prop_type
+            
+def render(schema: dict):
+    stack = [(schema, [], "object")]
+
+    while stack:
+        (current, path, type) = stack.pop(0)
+
+        items = []
+        
+        for name, props in current["properties"].items():
+            if "$ref" in props:
+                ref = find_ref(schema, props["$ref"])
+                if not ref:
+                    raise Exception("Reference not found: {}".format(props["$ref"]))
+                props = ref
+            prop_type = get_type(props, name)
+            description = props.get("description", "")
+
+            items.append({"name": name, "type": prop_type, "description": description})
+
+            if props["type"] == "object" and "properties" in props:
+                stack.insert(0, (props, path + [name], "object"))
+            elif props["type"] == "array" and "items" in props and "properties" in props["items"]:
+                array_type = props["items"]["type"]
+                stack.insert(0, (props["items"], path + ["{}".format(name)], "array of {}s".format(array_type)))
+
+        render_table(items, path, type)
+        
+
+def render_table(items: list, path: list, type: str):
+    if not path:
+        title = "Top Level"
+    else:
+        title = ".".join(path)
+    title = "{} ({})".format(title, type)
+    print(title)
+    print("^" * len(title))
+
+    name_len = max([len(item["name"]) for item in items] + [len("Name")])
+    desc_len = max([len(item["description"]) for item in items] + [len("Description")])
+    type_len = max([len(item["type"]) for item in items])
+
+    print(".. table::")
+    print("   :width: 100%")
+    print("   :widths: 30 25 45")
+    print("")
+
+    print("   {} {} {}".format("=" * name_len, "=" * type_len, "=" * desc_len))
+    print("   {} {} {}".format("Name".ljust(name_len), "Type".ljust(type_len), "Description".ljust(desc_len)))
+    print("   {} {} {}".format("=" * name_len, "=" * type_len, "=" * desc_len))
+    for item in items:
+        print("   {} {} {}".format(
+            item["name"].ljust(name_len),
+            item["type"].ljust(type_len),
+            item["description"].ljust(desc_len)
+        ))
+    print("   {} {} {}".format("=" * name_len, "=" * type_len, "=" * desc_len))
+    print("")
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate documentation from JSON schema")
+    parser.add_argument("--object", help="Object name")
+    parser.add_argument("--output", help="Output file")
+    parser.add_argument("filename", help="JSON schema file")
+    args = parser.parse_args()
+
+    root = json.load(open(args.filename))
+    schema = root
+
+    if args.object:
+        schema = schema["properties"][args.object]
+
+    if args.output:
+        sys.stdout = open(args.output, "w")
+
+    render(schema)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/userguide/index.rst
+++ b/doc/userguide/index.rst
@@ -31,3 +31,4 @@ Suricata User Guide
    acknowledgements
    licenses/index.rst
    devguide/index.rst
+   appendix/index.rst

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2218,6 +2218,10 @@ The two ``pgsql`` events in this example represent a rejected ``SSL handshake`` 
     }
   }
 
+Field Reference
+~~~~~~~~~~~~~~~
+
+.. include:: ../../_generated/pgsql.rst
 
 Event type: IKE
 ---------------
@@ -2464,6 +2468,11 @@ Example of QUIC logging with a CYU hash:
         }
     ]
   }
+
+Output Reference
+~~~~~~~~~~~~~~~~
+
+.. include:: ../../_generated/quic.rst
 
 Event type: DHCP
 -----------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3031,15 +3031,18 @@
             "optional": true,
             "properties": {
                 "cyu": {
+                    "description": "ja3-like fingerprint for versions of QUIC before standardization",
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
                             "hash": {
+                                "description": "cyu hash hex representation",
                                 "type": "string"
                             },
                             "string": {
+                                "description": "cyu hash string representation",
                                 "type": "string"
                             }
                         },
@@ -3047,18 +3050,22 @@
                     }
                 },
                 "extensions": {
+                    "description": "list of extensions in hello",
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "object",
                         "properties": {
                             "name": {
+                                "description": "human-friendly name of the extension",
                                 "type": "string"
                             },
                             "type": {
+                                "description": "integer identifier of the extension",
                                 "type": "integer"
                             },
                             "values": {
+                                "description": "extension values",
                                 "type": "array",
                                 "minItems": 1,
                                 "items": {
@@ -3070,38 +3077,47 @@
                     }
                 },
                 "ja3": {
+                    "description": "ja3 from client, as in TLS",
                     "type": "object",
                     "optional": true,
                     "properties": {
                         "hash": {
+                            "description": "ja3 hex representation",
                             "type": "string"
                         },
                         "string": {
+                            "description": "ja3 string representation",
                             "type": "string"
                         }
                     },
                     "additionalProperties": false
                 },
                 "ja3s": {
+                    "description": "ja3 from server, as in TLS",
                     "type": "object",
                     "optional": true,
                     "properties": {
                         "hash": {
+                            "description": "ja3s hex representation",
                             "type": "string"
                         },
                         "string": {
+                            "description": "ja3s string representation",
                             "type": "string"
                         }
                     },
                     "additionalProperties": false
                 },
                 "sni": {
+                    "description": "Server Name Indication",
                     "type": "string"
                 },
                 "ua": {
+                    "description": "User Agent for versions of QUIC before standardization",
                     "type": "string"
                 },
                 "version": {
+                    "description": "Quic protocol version",
                     "type": "string"
                 }
             },


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/8971

Just a new PR for cleaner history, contains requested changes from
https://github.com/OISF/suricata/pull/8933.

Also contains updated QUIC doc from https://github.com/OISF/suricata/pull/9097.

Generated documentation:
- QUIC: https://jasonish-suricata.readthedocs.io/en/evedoc-v3/output/eve/eve-json-format.html?highlight=quic#event-type-quic
- PGSQL: https://jasonish-suricata.readthedocs.io/en/evedoc-v3/output/eve/eve-json-format.html?highlight=pgsql#field-reference- Complete: https://jasonish-suricata.readthedocs.io/en/evedoc-v3/appendix/eve-index.html

Redmine issue: https://redmine.openinfosecfoundation.org/issues/6288