### PR TITLE
Warnint 64to32 6186 v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1591,7 +1591,7 @@ jobs:
           CC: "clang-14"
           CXX: "clang++-14"
           RUSTFLAGS: "-C instrument-coverage"
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Wshorten-64-to-32 -Werror"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Wshorten-64-to-32"
           CXXFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion -Wimplicit-int-conversion"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1591,7 +1591,7 @@ jobs:
           CC: "clang-14"
           CXX: "clang++-14"
           RUSTFLAGS: "-C instrument-coverage"
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Werror"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Wshorten-64-to-32 -Werror"
           CXXFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion -Wimplicit-int-conversion"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -686,7 +686,7 @@ static uint32_t AppLayerProtoDetectProbingParserGetMask(AppProto alproto)
         FatalError("Unknown protocol detected - %u", alproto);
     }
 
-    SCReturnUInt(1UL << (uint32_t)alproto);
+    SCReturnUInt((uint32_t)1 << (uint32_t)alproto);
 }
 
 static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParserElementAlloc(void)

--- a/src/app-layer-dnp3-objects.c
+++ b/src/app-layer-dnp3-objects.c
@@ -139,8 +139,7 @@ static int DNP3ReadUint24(const uint8_t **buf, uint32_t *len, uint32_t *out)
     *out = ((uint32_t)(*buf)[0] << 16) | ((uint32_t)(*buf)[1] << 8) |
            (uint32_t)(*buf)[2];
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
-    *out = ((uint64_t)(*buf)[0]) | ((uint64_t)(*buf)[1] << 8) |
-           ((uint64_t)(*buf)[2] << 16);
+    *out = ((uint32_t)(*buf)[0]) | ((uint32_t)(*buf)[1] << 8) | ((uint32_t)(*buf)[2] << 16);
 #endif
 
     *buf += 3;

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -342,7 +342,9 @@ static int FrameSlide(const char *ds, Frames *frames, const TcpStream *stream, c
     }
     frames->cnt = x;
     uint64_t o = STREAM_BASE_OFFSET(stream) + slide;
-    frames->left_edge_rel = le - (STREAM_BASE_OFFSET(stream) + slide);
+    BUG_ON(o > le);
+    BUG_ON(le - o > UINT32_MAX);
+    frames->left_edge_rel = (uint32_t)(le - o);
 
 #ifdef DEBUG
     SCLogDebug("end: left edge %" PRIu64 ", left_edge_rel %u, stream base %" PRIu64
@@ -353,7 +355,6 @@ static int FrameSlide(const char *ds, Frames *frames, const TcpStream *stream, c
     snprintf(pf, sizeof(pf), "%s:post_slide", ds);
     AppLayerFrameDumpForFrames(pf, frames);
 #endif
-    BUG_ON(o > le);
     BUG_ON(x != start - removed);
     return 0;
 }
@@ -745,7 +746,9 @@ static void FramePrune(Frames *frames, const TcpStream *stream, const bool eof)
         }
     }
     frames->cnt = x;
-    frames->left_edge_rel = le - STREAM_BASE_OFFSET(stream);
+    BUG_ON(le < STREAM_BASE_OFFSET(stream));
+    BUG_ON(le - STREAM_BASE_OFFSET(stream) > UINT32_MAX);
+    frames->left_edge_rel = (uint32_t)(le - STREAM_BASE_OFFSET(stream));
 #ifdef DEBUG
     SCLogDebug("end: left edge %" PRIu64 ", left_edge_rel %u, stream base %" PRIu64
                ", cnt %u, removed %u, start %u",
@@ -753,7 +756,6 @@ static void FramePrune(Frames *frames, const TcpStream *stream, const bool eof)
             STREAM_BASE_OFFSET(stream), frames->cnt, removed, start);
     AppLayerFrameDumpForFrames("post_slide", frames);
 #endif
-    BUG_ON(le < STREAM_BASE_OFFSET(stream));
     if (frames->cnt > 0) { // if we removed all this can fail
         BUG_ON(frames_le_start > le);
     }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -374,7 +374,7 @@ static AppLayerResult FTPGetLineForDirection(
         //      lf_idx = 5010
         //      max_line_len = 4096
         uint32_t o_consumed = input->consumed;
-        input->consumed = lf_idx - input->buf + 1;
+        input->consumed = (uint32_t)(lf_idx - input->buf + 1);
         line->len = input->consumed - o_consumed;
         input->len -= line->len;
         line->lf_found = true;

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -87,7 +87,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
  */
 int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
 {
-    uint32_t len = bstr_len(rawvalue);
+    uint32_t len = (uint32_t)bstr_len(rawvalue);
     return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
 }
 
@@ -175,7 +175,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     uint8_t *keyurl;
     uint32_t keylen;
     if (tx->request_hostname != NULL) {
-        keylen = bstr_len(tx->request_hostname) + filename_len;
+        keylen = (uint32_t)bstr_len(tx->request_hostname) + filename_len;
         keyurl = SCMalloc(keylen);
         if (keyurl == NULL) {
             SCReturnInt(-1);

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -139,7 +139,7 @@ static inline bool ContainerValueRangeTimeout(HttpRangeContainerFile *cu, const 
     return false;
 }
 
-static void ContainerUrlRangeUpdate(HttpRangeContainerFile *cu, uint32_t expire)
+static void ContainerUrlRangeUpdate(HttpRangeContainerFile *cu, uint64_t expire)
 {
     cu->expire = expire;
 }
@@ -410,9 +410,9 @@ int HttpRangeAppendData(const StreamingBufferConfig *sbcfg, HttpRangeContainerBl
         if (c->files) {
             if (data == NULL) {
                 // gap overlapping already known data
-                r = FileAppendData(c->files, sbcfg, NULL, len - c->toskip);
+                r = FileAppendData(c->files, sbcfg, NULL, (uint32_t)(len - c->toskip));
             } else {
-                r = FileAppendData(c->files, sbcfg, data + c->toskip, len - c->toskip);
+                r = FileAppendData(c->files, sbcfg, data + c->toskip, (uint32_t)(len - c->toskip));
             }
         }
         c->toskip = 0;
@@ -543,14 +543,24 @@ File *HttpRangeClose(const StreamingBufferConfig *sbcfg, HttpRangeContainerBlock
             // a new range just begins where we ended, append it
             if (range->gap > 0) {
                 // if the range had a gap, begin by it
-                if (FileAppendData(c->container->files, sbcfg, NULL, range->gap) != 0) {
+                uint32_t gap = (uint32_t)range->gap;
+                if (range->gap > UINT32_MAX) {
+                    gap = UINT32_MAX;
+                }
+                if (FileAppendData(c->container->files, sbcfg, NULL, gap) != 0) {
                     c->container->lastsize = f->size;
                     HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
                     c->container->error = true;
                     return f;
                 }
             }
-            if (FileAppendData(c->container->files, sbcfg, range->buffer, range->offset) != 0) {
+            if (range->offset > UINT32_MAX) {
+                c->container->lastsize = f->size;
+                HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
+                c->container->error = true;
+                return f;
+            } else if (FileAppendData(c->container->files, sbcfg, range->buffer,
+                               (uint32_t)range->offset) != 0) {
                 c->container->lastsize = f->size;
                 HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
                 c->container->error = true;
@@ -562,7 +572,11 @@ File *HttpRangeClose(const StreamingBufferConfig *sbcfg, HttpRangeContainerBlock
             if (overlap < range->offset) {
                 if (range->gap > 0) {
                     // if the range had a gap, begin by it
-                    if (FileAppendData(c->container->files, sbcfg, NULL, range->gap) != 0) {
+                    uint32_t gap = (uint32_t)range->gap;
+                    if (range->gap > UINT32_MAX) {
+                        gap = UINT32_MAX;
+                    }
+                    if (FileAppendData(c->container->files, sbcfg, NULL, gap) != 0) {
                         c->container->lastsize = f->size;
                         HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
                         c->container->error = true;
@@ -571,8 +585,13 @@ File *HttpRangeClose(const StreamingBufferConfig *sbcfg, HttpRangeContainerBlock
                 }
                 // And the range ends beyond where we ended
                 // in this case of overlap, only add the extra data
-                if (FileAppendData(c->container->files, sbcfg, range->buffer + overlap,
-                            range->offset - overlap) != 0) {
+                if (range->offset - overlap > UINT32_MAX) {
+                    c->container->lastsize = f->size;
+                    HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
+                    c->container->error = true;
+                    return f;
+                } else if (FileAppendData(c->container->files, sbcfg, range->buffer + overlap,
+                                   (uint32_t)(range->offset - overlap)) != 0) {
                     c->container->lastsize = f->size;
                     HttpRangeFileClose(sbcfg, c->container, flags | FILE_TRUNCATED);
                     c->container->error = true;

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -63,7 +63,7 @@ typedef struct HttpRangeContainerFile {
     /** key length */
     uint32_t len;
     /** expire time in epoch */
-    uint32_t expire;
+    uint64_t expire;
     /** pointer to hashtable data, for locking and use count */
     THashData *hdata;
     /** total expected size of the file in ranges */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -560,12 +560,12 @@ static uint32_t AppLayerHtpComputeChunkLength(uint64_t content_len_so_far, uint3
         (content_len_so_far < (uint64_t)body_limit) &&
         (content_len_so_far + (uint64_t)data_len) > body_limit)
     {
-        chunk_len = body_limit - content_len_so_far;
+        chunk_len = (uint32_t)(body_limit - content_len_so_far);
     } else if ((flags & HTP_STREAM_DEPTH_SET) && stream_depth > 0 &&
                (content_len_so_far < (uint64_t)stream_depth) &&
                (content_len_so_far + (uint64_t)data_len) > stream_depth)
     {
-        chunk_len = stream_depth - content_len_so_far;
+        chunk_len = (uint32_t)(stream_depth - content_len_so_far);
     }
     SCLogDebug("len %u", chunk_len);
     return (chunk_len == 0 ? data_len : chunk_len);
@@ -963,7 +963,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
 
     htp_time_t ts = { SCTIME_SECS(f->startts), SCTIME_USECS(f->startts) };
     htp_tx_t *tx = NULL;
-    size_t consumed = 0;
+    uint32_t consumed = 0;
     if (input_len > 0) {
         const int r = htp_connp_res_data(hstate->connp, &ts, input, input_len);
         switch (r) {
@@ -986,7 +986,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
                     if (tx->request_port_number != -1) {
                         dp = (uint16_t)tx->request_port_number;
                     }
-                    consumed = htp_connp_res_data_consumed(hstate->connp);
+                    consumed = (uint32_t)htp_connp_res_data_consumed(hstate->connp);
                     hstate->slice = NULL;
                     if (!AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2)) {
                         HTPSetEvent(hstate, NULL, STREAM_TOCLIENT,
@@ -1273,7 +1273,7 @@ static void HtpRequestBodyMultipartParseHeader(HtpState *hstate,
         if (next_line == NULL) {
             line_len = header_len;
         } else {
-            line_len = next_line - header;
+            line_len = (uint32_t)(next_line - header);
         }
         uint8_t *sc = (uint8_t *)memchr(line, ':', line_len);
         if (sc == NULL) {
@@ -1392,10 +1392,12 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
     /* end marker belonging to header_start */
     const uint8_t *header_end = NULL;
     if (header_start != NULL) {
-        header_end = Bs2bmSearch(header_start, chunks_buffer_len - (header_start - chunks_buffer),
+        header_end = Bs2bmSearch(header_start,
+                (uint32_t)(chunks_buffer_len - (header_start - chunks_buffer)),
                 (uint8_t *)"\r\n\r\n", 4);
-        form_end = Bs2bmSearch(header_start, chunks_buffer_len - (header_start - chunks_buffer),
-                boundary, expected_boundary_end_len);
+        form_end = Bs2bmSearch(header_start,
+                (uint32_t)(chunks_buffer_len - (header_start - chunks_buffer)), boundary,
+                expected_boundary_end_len);
     }
 
     SCLogDebug("header_start %p, header_end %p, form_end %p", header_start,
@@ -1421,7 +1423,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 } else if (header_start > filedata + 2) {
                     SCLogDebug("some data from last file before the boundary");
                     /* some data from last file before the boundary */
-                    filedata_len = header_start - filedata - 2;
+                    filedata_len = (uint32_t)(header_start - filedata - 2);
                 }
             }
             /* body parsing done, we did not get our form end. Use all data
@@ -1504,7 +1506,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
         uint8_t *filetype = NULL;
         uint16_t filetype_len = 0;
 
-        uint32_t header_len = header_end - header_start;
+        uint32_t header_len = (uint32_t)(header_end - header_start);
         SCLogDebug("header_len %u", header_len);
         uint8_t *header = (uint8_t *)header_start;
 
@@ -1546,7 +1548,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     goto end;
                 }
 
-                filedata_len = form_end - (header_end + 4 + 2);
+                filedata_len = (uint32_t)(form_end - (header_end + 4 + 2));
                 SCLogDebug("filedata_len %"PRIuMAX, (uintmax_t)filedata_len);
 
                 /* or is it? */
@@ -1587,7 +1589,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 SCLogDebug("chunk doesn't contain form end");
 
                 filedata = header_end + 4;
-                filedata_len = chunks_buffer_len - (filedata - chunks_buffer);
+                filedata_len = (uint32_t)(chunks_buffer_len - (filedata - chunks_buffer));
                 SCLogDebug("filedata_len %u (chunks_buffer_len %u)", filedata_len, chunks_buffer_len);
 
                 if (filedata_len > chunks_buffer_len) {
@@ -1609,7 +1611,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 if (header_next == NULL) {
                     SCLogDebug("more file data to come");
 
-                    uint32_t offset = (header_end + 4) - chunks_buffer;
+                    uint32_t offset = (uint32_t)((header_end + 4) - chunks_buffer);
                     SCLogDebug("offset %u", offset);
                     htud->request_body.body_parsed += offset;
 
@@ -1642,7 +1644,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     SCLogDebug("htud->request_body.body_parsed %"PRIu64, htud->request_body.body_parsed);
 
                 } else if (header_next - filedata > 2) {
-                    filedata_len = header_next - filedata - 2;
+                    filedata_len = (uint32_t)(header_next - filedata - 2);
                     SCLogDebug("filedata_len %u", filedata_len);
 
                     result = HTPFileOpen(hstate, htud, filename, filename_len, filedata,
@@ -1668,7 +1670,7 @@ next:
                 header_start, header_end, form_end);
 
         /* Search next boundary entry after the start of body */
-        uint32_t cursizeread = header_end - chunks_buffer;
+        uint32_t cursizeread = (uint32_t)(header_end - chunks_buffer);
         header_start = Bs2bmSearch(header_end + 4,
                 chunks_buffer_len - (cursizeread + 4),
                 boundary, expected_boundary_len);

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -82,16 +82,18 @@ void HTTP2MimicHttp1Request(void *alstate_orig, void *h2s)
         return;
     }
     // else
-    rs_http2_tx_set_method(h2s, bstr_ptr(h1tx->request_method), bstr_len(h1tx->request_method));
+    rs_http2_tx_set_method(
+            h2s, bstr_ptr(h1tx->request_method), (uint32_t)bstr_len(h1tx->request_method));
     if (h1tx->request_uri != NULL) {
         // A request line without spaces gets interpreted as a request_method
         // and has request_uri=NULL
-        rs_http2_tx_set_uri(h2s, bstr_ptr(h1tx->request_uri), bstr_len(h1tx->request_uri));
+        rs_http2_tx_set_uri(
+                h2s, bstr_ptr(h1tx->request_uri), (uint32_t)bstr_len(h1tx->request_uri));
     }
     size_t nbheaders = htp_table_size(h1tx->request_headers);
     for (size_t i = 0; i < nbheaders; i++) {
         htp_header_t *h = htp_table_get_index(h1tx->request_headers, i, NULL);
-        rs_http2_tx_add_header(
-                h2s, bstr_ptr(h->name), bstr_len(h->name), bstr_ptr(h->value), bstr_len(h->value));
+        rs_http2_tx_add_header(h2s, bstr_ptr(h->name), (uint32_t)bstr_len(h->name),
+                bstr_ptr(h->value), (uint32_t)bstr_len(h->value));
     }
 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -521,8 +521,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 flags |= FILE_STORE;
             }
 
-            uint32_t depth = smtp_config.content_inspect_min_size +
-                (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+            uint32_t depth = (uint32_t)(
+                    smtp_config.content_inspect_min_size +
+                    (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp));
+            if (smtp_config.content_inspect_min_size +
+                            (smtp_state->toserver_data_count -
+                                    smtp_state->toserver_last_data_stamp) >
+                    UINT32_MAX) {
+                depth = UINT32_MAX;
+            }
             SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %"PRIu32, depth);
             StreamTcpReassemblySetMinInspectDepth(flow->protoctx, STREAM_TOSERVER, depth);
 
@@ -553,7 +560,12 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 } else {
                     SCLogDebug("File already closed");
                 }
-                depth = smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp;
+                depth = (uint32_t)(
+                        smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+                if (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
 
                 AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
@@ -574,7 +586,12 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
             } else {
                 SCLogDebug("File already closed");
             }
-            uint32_t depth = smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp;
+            uint32_t depth = (uint32_t)(
+                    smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+            if (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp >
+                    UINT32_MAX) {
+                depth = UINT32_MAX;
+            }
             AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
             SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
                     depth);
@@ -595,8 +612,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
 
             if (files->tail && files->tail->content_inspected == 0 &&
                     files->tail->size >= smtp_config.content_inspect_min_size) {
-                uint32_t depth = smtp_config.content_inspect_min_size +
-                    (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+                uint32_t depth = (uint32_t)(
+                        smtp_config.content_inspect_min_size +
+                        (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp));
+                if (smtp_config.content_inspect_min_size +
+                                (smtp_state->toserver_data_count -
+                                        smtp_state->toserver_last_data_stamp) >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
                 AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
                         depth);
@@ -611,8 +635,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
             /* expand the limit as long as we get file data, as the file data is bigger on the
              * wire due to base64 */
             } else {
-                uint32_t depth = smtp_config.content_inspect_min_size +
-                    (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+                uint32_t depth = (uint32_t)(
+                        smtp_config.content_inspect_min_size +
+                        (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp));
+                if (smtp_config.content_inspect_min_size +
+                                (smtp_state->toserver_data_count -
+                                        smtp_state->toserver_last_data_stamp) >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %"PRIu32,
                         depth);
                 StreamTcpReassemblySetMinInspectDepth(flow->protoctx,
@@ -665,7 +696,7 @@ static AppLayerResult SMTPGetLine(
          *      lf_idx = 5010
          *      max_line_len = 4096 */
         uint32_t o_consumed = input->consumed;
-        input->consumed = lf_idx - input->buf + 1;
+        input->consumed = (uint32_t)(lf_idx - input->buf + 1);
         line->len = input->consumed - o_consumed;
         line->lf_found = true;
         DEBUG_VALIDATE_BUG_ON(line->len < 0);

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -124,7 +124,7 @@ typedef struct SMTPState_ {
     /** current command in progress */
     uint8_t current_command;
     /** bdat chunk len */
-    uint32_t bdat_chunk_len;
+    uint64_t bdat_chunk_len;
     /** bdat chunk idx */
     uint32_t bdat_chunk_idx;
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -225,12 +225,12 @@ struct SSLDecoderResult {
 #define SSL_DECODER_OK(c)                                                                          \
     (struct SSLDecoderResult)                                                                      \
     {                                                                                              \
-        (c), 0                                                                                     \
+        (uint32_t)(c), 0                                                                           \
     }
 #define SSL_DECODER_INCOMPLETE(c, n)                                                               \
     (struct SSLDecoderResult)                                                                      \
     {                                                                                              \
-        (c), (n)                                                                                   \
+        (uint32_t)(c), (n)                                                                         \
     }
 
 static inline int SafeMemcpy(void *dst, size_t dst_offset, size_t dst_size,
@@ -572,7 +572,7 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
 
 next:
     input += cert_len;
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 error:
     if (err_code != 0)
@@ -725,7 +725,7 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
 
     input += SSLV3_CLIENT_HELLO_VERSION_LEN;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static inline int TLSDecodeHSHelloRandom(SSLState *ssl_state,
@@ -752,7 +752,7 @@ static inline int TLSDecodeHSHelloRandom(SSLState *ssl_state,
     /* Skip random */
     input += SSLV3_CLIENT_HELLO_RANDOM_LEN;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static inline int TLSDecodeHSHelloSessionID(SSLState *ssl_state,
@@ -797,7 +797,7 @@ static inline int TLSDecodeHSHelloSessionID(SSLState *ssl_state,
 
     input += session_id_length;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -872,7 +872,7 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         input += cipher_suites_length;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -903,7 +903,7 @@ static inline int TLSDecodeHSHelloCompressionMethods(SSLState *ssl_state,
         input += compression_methods_length;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid_length");
@@ -965,7 +965,7 @@ static inline int TLSDecodeHSHelloExtensionSni(SSLState *ssl_state,
         SSLSetEvent(ssl_state,
                 TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS);
         input += sni_len;
-        return (input - initial_input);
+        return (uint32_t)(input - initial_input);
     }
 
     const size_t sni_strlen = sni_len + 1;
@@ -984,7 +984,7 @@ static inline int TLSDecodeHSHelloExtensionSni(SSLState *ssl_state,
 
     input += sni_len;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1050,7 +1050,7 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
         input += 2;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1107,7 +1107,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
         input += elliptic_curves_len;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1161,7 +1161,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurvePF(SSLState *ssl_state,
         input += ec_pf_len;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1348,7 +1348,7 @@ end:
         }
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1712,7 +1712,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input
                     ssl_state->curr_connp->hs_buffer_message_size);
             input += input_len;
             SSLParserHSReset(ssl_state->curr_connp);
-            return (input - initial_input);
+            return (uint32_t)(input - initial_input);
 
         } else {
             /* full record, parse it now */
@@ -1730,7 +1730,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input
         }
         SCLogDebug("input_len left %u", input_len);
     }
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 /**
@@ -1935,7 +1935,7 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
 
     ssl_state->curr_connp->bytes_processed += (input - initial_input);
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
@@ -2019,7 +2019,7 @@ static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
 
     ssl_state->curr_connp->bytes_processed += (input - initial_input);
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static struct SSLDecoderResult SSLv2Decode(uint8_t direction, SSLState *ssl_state,
@@ -2566,7 +2566,7 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
                 input += r.retval;
                 SCLogDebug("returning consumed %" PRIuMAX " needed %u",
                         (uintmax_t)(input - init_input), r.needed);
-                SCReturnStruct(APP_LAYER_INCOMPLETE(input - init_input, r.needed));
+                SCReturnStruct(APP_LAYER_INCOMPLETE((uint32_t)(input - init_input), r.needed));
             }
             input_len -= r.retval;
             input += r.retval;
@@ -2591,7 +2591,7 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
                 input += r.retval;
                 SCLogDebug("returning consumed %" PRIuMAX " needed %u",
                         (uintmax_t)(input - init_input), r.needed);
-                SCReturnStruct(APP_LAYER_INCOMPLETE(input - init_input, r.needed));
+                SCReturnStruct(APP_LAYER_INCOMPLETE((uint32_t)(input - init_input), r.needed));
             }
             input_len -= r.retval;
             input += r.retval;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -113,7 +113,7 @@ static AppLayerResult TFTPParseRequest(Flow *f, void *state, AppLayerParserState
         SCReturnStruct(APP_LAYER_OK);
     }
 
-    int res = rs_tftp_request(state, input, input_len);
+    int64_t res = rs_tftp_request(state, input, input_len);
     if (res < 0) {
         SCReturnStruct(APP_LAYER_ERROR);
     }

--- a/src/counters.c
+++ b/src/counters.c
@@ -1034,9 +1034,9 @@ static uint32_t CountersIdHashFunc(HashTable *ht, void *data, uint16_t datalen)
 {
     CountersIdType *t = (CountersIdType *)data;
     uint32_t hash = 0;
-    int len = strlen(t->string);
+    size_t len = strlen(t->string);
 
-    for (int i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         hash += u8_tolower((unsigned char)t->string[i]);
 
     hash = hash % ht->array_size;
@@ -1048,8 +1048,8 @@ static char CountersIdHashCompareFunc(void *data1, uint16_t datalen1,
 {
     CountersIdType *t1 = (CountersIdType *)data1;
     CountersIdType *t2 = (CountersIdType *)data2;
-    int len1 = 0;
-    int len2 = 0;
+    size_t len1 = 0;
+    size_t len2 = 0;
 
     if (t1 == NULL || t2 == NULL)
         return 0;

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -53,8 +53,8 @@ typedef struct {
     {                                                                                              \
         .secs = 0, .usecs = 0                                                                      \
     }
-#define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
-#define SCTIME_SECS(t)           ((uint64_t)(t).secs)
+#define SCTIME_USECS(t)          ((t).usecs)
+#define SCTIME_SECS(t)           ((t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
 #define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
 #define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))


### PR DESCRIPTION
[Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- ci : add the `-Wshorten-64-to-32` flag to clang after `-Wimplicit-int-conversion`
- fix these warnings for all src/a*.c

```
LIBHTP_BRANCH=pr/399
```
https://github.com/OISF/libhtp/pull/399

Modifies #9155 with temporary disabling of Terror to get full warnings list

How can I fix the CI about format ? Locally `./scripts/clang-format.sh branch` is happy