### PR TITLE
doc: add multi buffer matching documentation v3

### DIFF
--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -67,3 +67,8 @@ DNS query on the wire (snippet)::
 ``dns.query`` buffer::
 
     mail.google.com
+
+Multiple Buffer Matching
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``dns.query`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -18,6 +18,8 @@ Example::
 
   filename:"secret";
 
+``file.name`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 fileext
 -------
 
@@ -46,6 +48,8 @@ Example::
 
 Note: as libmagic versions differ between installations, the returned
 information may also slightly change. See also #437.
+
+``file.magic`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 filestore
 ---------

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -839,3 +839,8 @@ Notes
    pattern '<html' is absent from the first inspected chunk.
 
 -  ``file.data`` can also be used with SMTP
+
+Multiple Buffer Matching
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``file.data`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -109,6 +109,7 @@ Examples::
 
 ``http2.header_name`` can be used as ``fast_pattern``.
 
+``http2.header_name`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 Additional information
 ----------------------

--- a/doc/userguide/rules/ike-keywords.rst
+++ b/doc/userguide/rules/ike-keywords.rst
@@ -84,6 +84,8 @@ Examples::
 
     ike.vendor:4a131c81070358455c5728f20e95452f;
 
+``ike.vendor`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 
 ike.key_exchange_payload
 ------------------------

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -42,3 +42,4 @@ Suricata Rules
    datasets
    lua-detection
    differences-from-snort
+   multi-buffer-matching

--- a/doc/userguide/rules/kerberos-keywords.rst
+++ b/doc/userguide/rules/kerberos-keywords.rst
@@ -52,6 +52,8 @@ Signature example::
 
 ``krb5_cname`` can be used as ``fast_pattern``.
 
+``krb5.cname`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 krb5_sname
 ----------
 
@@ -74,6 +76,8 @@ Signature example::
 ``krb5_sname`` is a 'sticky buffer'.
 
 ``krb5_sname`` can be used as ``fast_pattern``.
+
+``krb5.sname`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 krb5_err_code
 -------------

--- a/doc/userguide/rules/mqtt-keywords.rst
+++ b/doc/userguide/rules/mqtt-keywords.rst
@@ -237,6 +237,8 @@ Examples::
 
 ``mqtt.subscribe.topic`` is a 'sticky buffer' and can be used as ``fast_pattern``.
 
+``mqtt.subscribe.topic`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 
 mqtt.unsubscribe.topic
 ----------------------
@@ -248,6 +250,8 @@ Examples::
   mqtt.unsubscribe.topic; content:"mytopic";
 
 ``mqtt.unsubscribe.topic`` is a 'sticky buffer' and can be used as ``fast_pattern``.
+
+``mqtt.unsubscribe.topic`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 
 Additional information

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -1,0 +1,78 @@
+Multiple Buffer Matching
+========================
+
+Suricata 7 and newer now supports matching contents in multiple
+buffers within the same transaction.
+
+For example a single DNS transaction that has two queries in it:
+
+query 1: example.net
+query 2: something.com
+
+Example rule:
+
+.. container:: example-rule
+
+    `alert dns $HOME_NET any -> $EXTERNAL_NET any (msg:"DNS Multiple Question Example Rule"; dns.query; content:"example"; dns.query; content:".com"; sid:1;)`
+
+Within the single DNS query transaction, there are two queries
+and Suricata will set up two instances of a dns.query buffer.
+
+The first ``dns.query`` buffer will look for content:"example";
+
+The second ``dns.query`` buffer will look for content:".com";
+
+The example rule will alert on the example query since all the
+content matches are satisfied for the rule.
+
+Existing behavior when using sticky buffers still applies:
+
+Example rule:
+
+.. container:: example-rule
+
+   `alert dns $HOME_NET any -> $EXTERNAL_NET any (msg:"DNS Query Sticky Buffer Classic Example Rule"; dns.query; content:"example"; content:".net"; sid:1;)`
+
+The above rule will alert on a single dns query containing
+"example.net" or "example.domain.net" since the rule content
+matches are within a single ``dns.query`` buffer and all 
+content match requirements of the rule are met.
+
+**Note:** This is new behavior, in versions of Suricata prior to
+version 7 multiple statements of the same sticky buffer did not
+make a second instance of the buffer. For example:
+
+dns.query; content:"example"; dns.query; content:".com";
+
+would be equivalent to:
+
+dns.query; content:"example"; content:".com";
+
+Using our example from above, the first query is for example.net
+which matches content:"example"; but does not match content:".com";
+
+The second query is for something.com which would match on the
+content:".com"; but not the content:"example"; 
+
+So with the Suricata behavior prior to Suricata 7, the signature
+would not fire in this case since both content conditions will
+not be met.
+
+Multiple buffer matching is currently enabled for use with the
+following keywords:
+
+``dns.query``
+``file.data``
+``file.magic``
+``file.name``
+``http2.header``
+``http2.header_name``
+``ike.vendor``
+``krb5_cname``
+``krb5_sname``
+``mqtt.subscribe.topic``
+``mqtt.unsubscribe.topic``
+``quic.cyu.hash``
+``quic.cyu.string``
+``tls.certs``
+``tls.cert_subject``

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -61,18 +61,18 @@ not be met.
 Multiple buffer matching is currently enabled for use with the
 following keywords:
 
-``dns.query``
-``file.data``
-``file.magic``
-``file.name``
-``http2.header``
-``http2.header_name``
-``ike.vendor``
-``krb5_cname``
-``krb5_sname``
-``mqtt.subscribe.topic``
-``mqtt.unsubscribe.topic``
-``quic.cyu.hash``
-``quic.cyu.string``
-``tls.certs``
-``tls.cert_subject``
+* ``dns.query``
+* ``file.data``
+* ``file.magic``
+* ``file.name``
+* ``http2.header``
+* ``http2.header_name``
+* ``ike.vendor``
+* ``krb5_cname``
+* ``krb5_sname``
+* ``mqtt.subscribe.topic``
+* ``mqtt.unsubscribe.topic``
+* ``quic.cyu.hash``
+* ``quic.cyu.string``
+* ``tls.certs``
+* ``tls.cert_subject``

--- a/doc/userguide/rules/quic-keywords.rst
+++ b/doc/userguide/rules/quic-keywords.rst
@@ -18,6 +18,8 @@ Examples::
     quic.cyu.hash; content:"7b3ceb1adc974ad360cfa634e8d0a730"; \
     sid:1;)
 
+``quic.cyu.hash`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 quic.cyu.string
 ---------------
 
@@ -28,6 +30,8 @@ Examples::
   alert quic any any -> any any (msg:"QUIC CYU STRING"; \
     quic.cyu.string; content:"46,PAD-SNI-VER-CCS-UAID-TCID-PDMD-SMHL-ICSL-NONP-MIDS-SCLS-CSCT-COPT-IRTT-CFCW-SFCW"; \
     sid:2;)
+
+``quic.cyu.string`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 quic.version
 ------------

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -17,6 +17,8 @@ Examples::
 
 ``tls.cert_subject`` can be used as ``fast_pattern``.
 
+``tls.cert_subject`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
 tls.subject
 ~~~~~~~~~~~
 
@@ -173,6 +175,8 @@ Example::
 ``tls.certs`` is a 'sticky buffer'.
 
 ``tls.certs`` can be used as ``fast_pattern``.
+
+``tls.certs`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
 tls.version
 -----------


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/6032

Describe changes:
- Add documentation describing multi buffer matching behavior
- Add links to relevant keyword documentation for multi buffer matching
- Address comments/feedback from #9161 

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
