### PR TITLE
detect/byte_test: Permit variable name for nbytes value

### DIFF
--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -278,6 +278,13 @@ See :doc:`http-keywords` for all HTTP keywords.
 
 - Suricata will never match if there's a zero divisor. Division by 0 is undefined.
 
+``byte_test`` Keyword
+---------------------
+
+- Suricata allows a variable name from ``byte_extract`` or ``byte_math``
+  to be specified for the ``nbytes`` value. The value of ``nbytes`` must adhere
+  to the same constraints as though a value was directly supplied by the rule.
+
 
 ``isdataat`` Keyword
 --------------------

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -368,13 +368,14 @@ and the final result will be right shifted one bit for each trailing ``0`` in
 the ``<bitmask value>``.
 
 Format::
-  
-  byte_test:<num of bytes>, [!]<operator>, <test value>, <offset> [,relative] \
-  [,<endian>][, string, <num type>][, dce][, bitmask <bitmask value>]; 
+
+  byte_test:<num of bytes> | <ariable_name>, [!]<operator>, <test value>, <offset> [,relative] \
+  [,<endian>][, string, <num type>][, dce][, bitmask <bitmask value>];
 
 
 +----------------+------------------------------------------------------------------------------+
 | <num of bytes> | The number of bytes selected from the packet to be converted			|
+|                | or the name of a byte_extract/byte_math variable.            		|
 +----------------+------------------------------------------------------------------------------+
 | <operator>	 | 										|
 |		 | - [!] Negation can prefix other operators					|

--- a/src/detect-bytetest.h
+++ b/src/detect-bytetest.h
@@ -40,21 +40,22 @@
 #define DETECT_BYTETEST_BASE_HEX   16 /**< "hex" type value string */
 
 /** Bytetest Flags */
-#define DETECT_BYTETEST_LITTLE    BIT_U8(0) /**< "little" endian value */
-#define DETECT_BYTETEST_BIG       BIT_U8(1) /**< "bi" endian value */
-#define DETECT_BYTETEST_STRING    BIT_U8(2) /**< "string" value */
-#define DETECT_BYTETEST_RELATIVE  BIT_U8(3) /**< "relative" offset */
-#define DETECT_BYTETEST_DCE       BIT_U8(4) /**< dce enabled */
-#define DETECT_BYTETEST_BITMASK   BIT_U8(5) /**< bitmask supplied*/
-#define DETECT_BYTETEST_VALUE_VAR  BIT_U8(6) /**< byte extract value enabled */
-#define DETECT_BYTETEST_OFFSET_VAR BIT_U8(7) /**< byte extract value enabled */
+#define DETECT_BYTETEST_LITTLE     BIT_U16(0) /**< "little" endian value */
+#define DETECT_BYTETEST_BIG        BIT_U16(1) /**< "bi" endian value */
+#define DETECT_BYTETEST_STRING     BIT_U16(2) /**< "string" value */
+#define DETECT_BYTETEST_RELATIVE   BIT_U16(3) /**< "relative" offset */
+#define DETECT_BYTETEST_DCE        BIT_U16(4) /**< dce enabled */
+#define DETECT_BYTETEST_BITMASK    BIT_U16(5) /**< bitmask supplied*/
+#define DETECT_BYTETEST_VALUE_VAR  BIT_U16(6) /**< byte extract value enabled */
+#define DETECT_BYTETEST_OFFSET_VAR BIT_U16(7) /**< byte extract value enabled */
+#define DETECT_BYTETEST_NBYTES_VAR BIT_U16(8) /**< byte extract value enabled */
 
 typedef struct DetectBytetestData_ {
     uint8_t nbytes;                   /**< Number of bytes to compare */
     uint8_t op;                       /**< Operator used to compare */
     uint8_t base;                     /**< String value base (oct|dec|hex) */
     uint8_t bitmask_shift_count;      /**< bitmask trailing 0 count */
-    uint8_t flags;                   /**< Flags (big|little|relative|string|bitmask) */
+    uint16_t flags;                   /**< Flags (big|little|relative|string|bitmask) */
     bool neg_op;
     int32_t offset;                   /**< Offset in payload */
     uint32_t bitmask;                 /**< bitmask value */
@@ -70,8 +71,7 @@ typedef struct DetectBytetestData_ {
  */
 void DetectBytetestRegister (void);
 
-int DetectBytetestDoMatch(DetectEngineThreadCtx *, const Signature *,
-                          const SigMatchCtx *ctx, const uint8_t *, uint32_t,
-                          uint8_t, int32_t, uint64_t);
+int DetectBytetestDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *ctx,
+        const uint8_t *, uint32_t, uint8_t, int32_t, int32_t, uint64_t);
 
 #endif /* __DETECT_BYTETEST_H__ */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -479,14 +479,18 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
 
     } else if (smd->type == DETECT_BYTETEST) {
         DetectBytetestData *btd = (DetectBytetestData *)smd->ctx;
-        uint8_t btflags = btd->flags;
+        uint16_t btflags = btd->flags;
         int32_t offset = btd->offset;
         uint64_t value = btd->value;
+        int32_t nbytes = btd->nbytes;
         if (btflags & DETECT_BYTETEST_OFFSET_VAR) {
             offset = det_ctx->byte_values[offset];
         }
         if (btflags & DETECT_BYTETEST_VALUE_VAR) {
             value = det_ctx->byte_values[value];
+        }
+        if (btflags & DETECT_BYTETEST_NBYTES_VAR) {
+            nbytes = det_ctx->byte_values[nbytes];
         }
 
         /* if we have dce enabled we will have to use the endianness
@@ -498,8 +502,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                       DETECT_BYTETEST_LITTLE: 0);
         }
 
-        if (DetectBytetestDoMatch(det_ctx, s, smd->ctx, buffer, buffer_len, btflags,
-                                  offset, value) != 1) {
+        if (DetectBytetestDoMatch(det_ctx, s, smd->ctx, buffer, buffer_len, btflags, offset, nbytes,
+                    value) != 1) {
             goto no_match;
         }
 


### PR DESCRIPTION
Allow byte_test to accept a variable name for the nbytes value. The value is subject to the same value constraints regardless of how it is supplied.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6144](https://redmine.openinfosecfoundation.org/issues/6144)

Describe changes:
- Allow nbytes value to be a variable name subject to the same value constraints

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1297
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
