### PR TITLE
base64 data issue/v10

### DIFF
--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -107,9 +107,9 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
         /* Get decimal representation */
         val = GetBase64Value(src[i]);
         if (val < 0) {
-            if ((mode == BASE64_MODE_RFC2045) && (src[i] == ' ')) {
+            if (mode == BASE64_MODE_RFC2045 && src[i] != '=') {
                 if (bbidx == 0) {
-                    /* Special case where last block of data has a leading space */
+                    /* Special case where last block of data has a leading space or invalid char */
                     leading_sp++;
                 }
                 sp++;
@@ -156,7 +156,7 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
         }
     }
 
-    if (!valid && mode == BASE64_MODE_RFC4648) {
+    if (bbidx > 0 && bbidx < 4 && ((!valid && mode == BASE64_MODE_RFC4648))) {
         padding = B64_BLOCK - bbidx;
         *decoded_bytes += ASCII_BLOCK - padding;
         DecodeBase64Block(dptr, b64);
@@ -304,9 +304,12 @@ static int B64TestVectorsRFC2045(void)
     const char *fin_str8 = "foobar";
 
     const char *src9 = "Zm$9vYm.Fy";
-    const char *fin_str9 = "";
+    const char *fin_str9 = "foobar";
 
-    TEST_RFC2045(src1, fin_str1, strlen(fin_str1), strlen(fin_str1), strlen(src1), BASE64_ECODE_OK);
+    const char *src10 = "Y21Wd2IzSjBaVzFoYVd4bWNtRjFaRUJoZEc4dVoyOTJMbUYxOmpqcHh4b3Rhb2w%5d";
+    const char *fin_str10 = "cmVwb3J0ZW1haWxmcmF1ZEBhdG8uZ292LmF1:jjpxxotaol9t";
+
+    TEST_RFC2045(src1, fin_str1, ASCII_BLOCK * 2, strlen(fin_str1), strlen(src1), BASE64_ECODE_OK);
     TEST_RFC2045(src2, fin_str2, ASCII_BLOCK * 2, strlen(fin_str2), strlen(src2), BASE64_ECODE_OK);
     TEST_RFC2045(src3, fin_str3, ASCII_BLOCK * 2, strlen(fin_str3), strlen(src3), BASE64_ECODE_OK);
     TEST_RFC2045(src4, fin_str4, ASCII_BLOCK * 2, strlen(fin_str4), strlen(src4), BASE64_ECODE_OK);
@@ -314,8 +317,9 @@ static int B64TestVectorsRFC2045(void)
     TEST_RFC2045(src6, fin_str6, ASCII_BLOCK * 2, strlen(fin_str6), strlen(src6), BASE64_ECODE_OK);
     TEST_RFC2045(src7, fin_str7, ASCII_BLOCK * 2, strlen(fin_str7), strlen(src7), BASE64_ECODE_OK);
     TEST_RFC2045(src8, fin_str8, ASCII_BLOCK * 2, strlen(fin_str8), strlen(src8), BASE64_ECODE_OK);
-    TEST_RFC2045(src9, fin_str9, ASCII_BLOCK * 2, 0, 0,
-            BASE64_ECODE_ERR); // TODO this should be accepted just like the previous string
+    TEST_RFC2045(src9, fin_str9, ASCII_BLOCK * 2, strlen(fin_str9), strlen(src9), BASE64_ECODE_OK);
+    TEST_RFC2045(src10, fin_str10, strlen(fin_str10) + 3, strlen(fin_str10), strlen(src10),
+            BASE64_ECODE_OK);
     PASS;
 }
 

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -196,7 +196,7 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
     {                                                                                              \
         uint32_t consumed_bytes = 0, num_decoded = 0;                                              \
         uint8_t dst[dest_size];                                                                    \
-        Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),   \
+        Base64Ecode code = DecodeBase64(dst, dest_size, (const uint8_t *)src, strlen(src),         \
                 &consumed_bytes, &num_decoded, BASE64_MODE_RFC2045);                               \
         FAIL_IF(code != ecode);                                                                    \
         FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);                                       \
@@ -208,7 +208,7 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
     {                                                                                              \
         uint32_t consumed_bytes = 0, num_decoded = 0;                                              \
         uint8_t dst[dest_size];                                                                    \
-        Base64Ecode code = DecodeBase64(dst, strlen(fin_str), (const uint8_t *)src, strlen(src),   \
+        Base64Ecode code = DecodeBase64(dst, dest_size, (const uint8_t *)src, strlen(src),         \
                 &consumed_bytes, &num_decoded, BASE64_MODE_RFC4648);                               \
         FAIL_IF(code != ecode);                                                                    \
         FAIL_IF(memcmp(dst, fin_str, strlen(fin_str)) != 0);                                       \

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -157,7 +157,8 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
     }
 
     if (bbidx > 0 && bbidx < 4 && ((!valid && mode == BASE64_MODE_RFC4648))) {
-        padding = B64_BLOCK - bbidx;
+        /* Decoded bytes for 1 or 2 base64 encoded bytes is 1 */
+        padding = bbidx > 1 ? B64_BLOCK - bbidx : 2;
         *decoded_bytes += ASCII_BLOCK - padding;
         DecodeBase64Block(dptr, b64);
         *consumed_bytes += bbidx;

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -165,6 +165,11 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
             ecode = BASE64_ECODE_BUF;
             return ecode;
         }
+        /* if the destination size is not at least 3 Bytes long, it'll give a dynamic
+         * buffer overflow while decoding, so, return and let the caller take care of the
+         * remaining bytes to be decoded which should always be < 4 at this stage */
+        if (dest_size - *decoded_bytes < 3)
+            return BASE64_ECODE_BUF;
         *decoded_bytes += numDecoded_blk;
         DecodeBase64Block(dptr, b64);
         *consumed_bytes += bbidx;

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -159,7 +159,13 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
     if (bbidx > 0 && bbidx < 4 && ((!valid && mode == BASE64_MODE_RFC4648))) {
         /* Decoded bytes for 1 or 2 base64 encoded bytes is 1 */
         padding = bbidx > 1 ? B64_BLOCK - bbidx : 2;
-        *decoded_bytes += ASCII_BLOCK - padding;
+        uint32_t numDecoded_blk = ASCII_BLOCK - (padding < B64_BLOCK ? padding : ASCII_BLOCK);
+        if (dest_size < *decoded_bytes + numDecoded_blk) {
+            SCLogDebug("Destination buffer full");
+            ecode = BASE64_ECODE_BUF;
+            return ecode;
+        }
+        *decoded_bytes += numDecoded_blk;
         DecodeBase64Block(dptr, b64);
         *consumed_bytes += bbidx;
     }

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -233,7 +233,7 @@ static int B64DecodeInCompleteString(void)
      * SGVsbG8gV29ybGR6 : Hello Worldz
      * */
     const char *src = "SGVsbG8gV29ybGR";
-    const char *fin_str = "Hello Wor"; // bc it'll error out on last 3 bytes
+    const char *fin_str = "Hello Wor";
     TEST_RFC2045(src, fin_str, strlen(fin_str), strlen(fin_str), strlen(src) - 3, BASE64_ECODE_OK);
     PASS;
 }
@@ -246,7 +246,7 @@ static int B64DecodeCompleteStringWSp(void)
 
     const char *src = "SGVs bG8 gV29y bGQ=";
     const char *fin_str = "Hello World";
-    TEST_RFC2045(src, fin_str, strlen(fin_str) + 1, strlen(fin_str), strlen(src), BASE64_ECODE_OK);
+    TEST_RFC2045(src, fin_str, strlen(fin_str) + 3, strlen(fin_str), strlen(src), BASE64_ECODE_OK);
     PASS;
 }
 
@@ -259,7 +259,8 @@ static int B64DecodeInCompleteStringWSp(void)
 
     const char *src = "SGVs bG8 gV29y bGQ";
     const char *fin_str = "Hello Wor";
-    TEST_RFC2045(src, fin_str, strlen(fin_str), strlen(fin_str), strlen(src) - 3, BASE64_ECODE_OK);
+    TEST_RFC2045(src, fin_str, strlen(fin_str) + 1 /* 12 B in dest_size */, strlen(fin_str),
+            strlen(src) - 3, BASE64_ECODE_OK);
     PASS;
 }
 
@@ -318,8 +319,8 @@ static int B64TestVectorsRFC2045(void)
     const char *src9 = "Zm$9vYm.Fy";
     const char *fin_str9 = "foobar";
 
-    const char *src10 = "Y21Wd2IzSjBaVzFoYVd4bWNtRjFaRUJoZEc4dVoyOTJMbUYxOmpqcHh4b3Rhb2w%5d";
-    const char *fin_str10 = "cmVwb3J0ZW1haWxmcmF1ZEBhdG8uZ292LmF1:jjpxxotaol9t";
+    const char *src10 = "Y21Wd2IzSjBaVzFoYVd4bWNtRjFaRUJoZEc4dVoyOTJMbUYxOmpqcHh4b3Rhb2w%5";
+    const char *fin_str10 = "cmVwb3J0ZW1haWxmcmF1ZEBhdG8uZ292LmF1:jjpxxotaol9";
 
     TEST_RFC2045(src1, fin_str1, ASCII_BLOCK * 2, strlen(fin_str1), strlen(src1), BASE64_ECODE_OK);
     TEST_RFC2045(src2, fin_str2, ASCII_BLOCK * 2, strlen(fin_str2), strlen(src2), BASE64_ECODE_OK);
@@ -330,7 +331,7 @@ static int B64TestVectorsRFC2045(void)
     TEST_RFC2045(src7, fin_str7, ASCII_BLOCK * 2, strlen(fin_str7), strlen(src7), BASE64_ECODE_OK);
     TEST_RFC2045(src8, fin_str8, ASCII_BLOCK * 2, strlen(fin_str8), strlen(src8), BASE64_ECODE_OK);
     TEST_RFC2045(src9, fin_str9, ASCII_BLOCK * 2, strlen(fin_str9), strlen(src9), BASE64_ECODE_OK);
-    TEST_RFC2045(src10, fin_str10, strlen(fin_str10) + 3, strlen(fin_str10), strlen(src10),
+    TEST_RFC2045(src10, fin_str10, strlen(fin_str10) + 2, strlen(fin_str10), strlen(src10),
             BASE64_ECODE_OK);
     PASS;
 }

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -348,6 +348,9 @@ static int B64TestVectorsRFC4648(void)
     const char *src9 = "Zm$9vYm.Fy";
     const char *fin_str9 = "f";
 
+    const char *src10 = "Y21Wd2IzSjBaVzFoYVd4bWNtRjFaRUJoZEc4dVoyOTJMbUYxOmpqcHh4b3Rhb2w%3D";
+    const char *fin_str10 = "cmVwb3J0ZW1haWxmcmF1ZEBhdG8uZ292LmF1:jjpxxotaol";
+
     TEST_RFC4648(src1, fin_str1, ASCII_BLOCK * 2, strlen(fin_str1), strlen(src1), BASE64_ECODE_OK);
     TEST_RFC4648(src2, fin_str2, ASCII_BLOCK * 2, strlen(fin_str2), strlen(src2), BASE64_ECODE_OK);
     TEST_RFC4648(src3, fin_str3, ASCII_BLOCK * 2, strlen(fin_str3), strlen(src3), BASE64_ECODE_OK);
@@ -357,6 +360,8 @@ static int B64TestVectorsRFC4648(void)
     TEST_RFC4648(src7, fin_str7, ASCII_BLOCK * 2, strlen(fin_str7), strlen(src7), BASE64_ECODE_OK);
     TEST_RFC4648(src8, fin_str8, ASCII_BLOCK * 2, 1 /* f */, 2 /* Zm */, BASE64_ECODE_ERR);
     TEST_RFC4648(src9, fin_str9, ASCII_BLOCK * 2, 1 /* f */, 2 /* Zm */, BASE64_ECODE_ERR);
+    TEST_RFC4648(src10, fin_str10, strlen(fin_str10) + 1, strlen(fin_str10), strlen(src10) - 3,
+            BASE64_ECODE_ERR);
     PASS;
 }
 

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -45,8 +45,8 @@ typedef enum {
      * BASE64("fooba") = "Zm9vYmE="
      * BASE64("foobar") = "Zm9vYmFy"
      * BASE64("foobar") = "Zm 9v Ym Fy"   <-- Notice how the spaces are ignored
-     * BASE64("f") = "Zm$9vYm.Fy"    # TODO according to RFC, All line breaks or *other characters*
-     * not found in base64 alphabet must be ignored by decoding software
+     * BASE64("foobar") = "Zm$9vYm.Fy"    # According to RFC 2045, All line breaks or *other
+     * characters* not found in base64 alphabet must be ignored by decoding software
      * */
     BASE64_MODE_RFC2045, /* SPs are allowed during transfer but must be skipped by Decoder */
     BASE64_MODE_STRICT,


### PR DESCRIPTION
- util/base64: add test for long string w RFC4648
- util/base64: skip any invalid char for RFC2045
- util/base64: fix padding bytes for trailing data
- util/base64: check for dest buf size in last block
- util/base64: check dest buf size to hold 3Bytes
- util/base64: update test macro to use user data
- util/base64: fix tests for RFC2045

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6135

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1295

Previous PR: #9172

Changes since v9:
- Remove unneeded use of sp and leading_sp in calculating consumed bytes for RFC 4648
