### PR TITLE
6.0.x : output/file: http2 metdata is logged in http object backport

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -179,7 +179,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, const bool
             break;
         case ALPROTO_HTTP2:
             jb_get_mark(js, &mark);
-            jb_open_object(js, "http2");
+            jb_open_object(js, "http");
             if (EveHTTP2AddMetadata(p->flow, ff->txid, js)) {
                 jb_close(js);
             } else {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6166

Describe changes:
- Backport of #9052 

