### PR TITLE
6.0.x: dev guide fix for newer versions of sphinx - v1

### DIFF
--- a/doc/devguide/conf.py
+++ b/doc/devguide/conf.py
@@ -74,7 +74,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
Newer Sphinx does not allow a language of none, set to "en" like we do
for the user guide.
