### PR TITLE
dpdk: runmode user improvements

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -66,41 +66,46 @@ Dependencies
 
 For Suricata's compilation you'll need the following libraries and their development headers installed::
 
-  libjansson, libpcap, libpcre2, libmagic, zlib, libyaml
+  libjansson, libpcap, libpcre2, libyaml, zlib
 
 The following tools are required::
 
-  make gcc (or clang) pkg-config
-
-For full features, also add::
-
-  libgeoip, liblua5.1, libhiredis, libevent
+  make gcc (or clang) pkg-config rustc cargo
 
 Rust support::
 
   rustc, cargo
 
-  Not every distro provides Rust packages yet. Rust can also be installed
-  directly from the Rust project itself::
+  Some distros provide outdated/don't provide Rust packages.
+  Rust can also be installed directly from the Rust project itself::
 
-  https://www.rust-lang.org/en-US/install.html
+    1) Install Rust https://www.rust-lang.org/en-US/install.html
+    2) Install cbinggen - cargo install --force cbindgen
+    3) Make sure the cargo path is within your PATH environment
+        e.g. echo 'export PATH=”${PATH}:~/.cargo/bin”' >> ~/.bashrc
+        e.g. export PATH="${PATH}:/root/.cargo/bin"
 
 Ubuntu/Debian
 """""""""""""
 
 Minimal::
 
-    apt-get install build-essential libpcap-dev   \
-                    libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
-                    make libmagic-dev libjansson libjansson-dev libpcre2-dev
+    # Installed Rust and cargo as indicated above
+    apt-get install build-essential git libjansson-dev libpcap-dev \
+                    libpcre2-dev libtool libyaml-dev make pkg-config zlib1g-dev
+    cargo install --force cbindgen
 
 Recommended::
 
-    apt-get install build-essential libpcap-dev   \
-                    libnet1-dev libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
-                    libcap-ng-dev libcap-ng0 make libmagic-dev         \
-                    libgeoip-dev liblua5.1-dev libhiredis-dev libevent-dev \
-                    python-yaml rustc cargo libpcre2-dev
+    # Installed Rust and cargo as indicated above
+    apt-get install autoconf automake build-essential ccache clang curl git \
+                    gosu jq libbpf-dev libcap-ng0 libcap-ng-dev libelf-dev \
+                    libevent-dev libgeoip-dev libhiredis-dev libjansson-dev \
+                    liblua5.1-dev libmagic-dev libnet1-dev libpcap-dev \
+                    libpcre2-dev libtool libyaml-0-2 libyaml-dev m4 make \
+                    pkg-config python3 python3-dev python3-yaml sudo zlib1g \
+                    zlib1g-dev
+    cargo install --force cbindgen
 
 Extra for iptables/nftables IPS integration::
 
@@ -108,10 +113,55 @@ Extra for iptables/nftables IPS integration::
                     libnetfilter-log-dev libnetfilter-log1      \
                     libnfnetlink-dev libnfnetlink0
 
-For Rust support::
+CentOS, AlmaLinux, RockyLinux, Fedora, etc
+""""""""""""""""""""""""""""""""""""""""""
 
-    apt-get install rustc cargo
-    cargo install --force --debug --version 0.14.1 cbindgen
+To install all minimal dependencies, it is required to enable extra package
+repository in most distros. You can enable it possibly by
+one of the following ways::
+
+    dnf -y update
+    dnf -y install dnf-plugins-core
+    # AlmaLinux 8
+    dnf config-manager --set-enabled powertools
+    # AlmaLinux 9
+    dnf config-manager --set-enable crb
+    # Oracle Linux 8
+    dnf -y install epel-release
+    dnf config-manager --set-enable ol8_codeready_builder
+    # Oracle Linux 9
+    dnf config-manager --set-enable ol9_codeready_builder
+
+Minimal::
+
+    # Installed Rust and cargo as indicated above
+    dnf install -y gcc gcc-c++ git jansson-devel libpcap-devel libtool \
+                   libyaml-devel make pcre2-devel which zlib-devel
+    cargo install --force cbindgen
+
+Recommended::
+
+    # Installed Rust and cargo as indicated above
+    dnf install -y autoconf automake diffutils file-devel gcc gcc-c++ git \
+                   jansson-devel jq libcap-ng-devel libevent-devel \
+                   libmaxminddb-devel libnet-devel libnetfilter_queue-devel \
+                   libnfnetlink-devel libpcap-devel libtool libyaml-devel \
+                   lua-devel lz4-devel make nss-devel pcre2-devel pkgconfig \
+                   python3-devel python3-sphinx python3-yaml sudo which \
+                   zlib-devel
+    cargo install --force cbindgen
+
+Compilation
+"""""""""""
+
+Follow these steps from your Suricata directory::
+
+    ./scripts/bundle.sh
+    ./autogen.sh
+    ./configure # you may want to add additional parameters here
+    # ./configure --help to get all available parameters
+    make -j8 # j is for paralleling, you may de/increase depending on your CPU
+    make install # to install your Suricata compiled binary
 
 .. _install-binary-packages:
 

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -85,6 +85,7 @@ TmEcode NoDPDKSupportExit(ThreadVars *tv, const void *initdata, void **data)
 
 #else /* We have DPDK support */
 
+#include "util-affinity.h"
 #include "util-dpdk.h"
 #include "util-dpdk-i40e.h"
 #include "util-dpdk-bonding.h"

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -87,6 +87,11 @@ void AffinitySetupLoadFromConfig(void);
 ThreadsAffinityType * GetAffinityTypeFromName(const char *name);
 
 uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf);
+uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
+#ifdef HAVE_DPDK
+uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
+void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
+#endif /* HAVE_DPDK */
 
 void BuildCpusetWithCallback(const char *name, ConfNode *node,
                              void (*Callback)(int i, void * data),

--- a/src/util-dpdk.c
+++ b/src/util-dpdk.c
@@ -49,10 +49,10 @@ void DPDKCloseDevice(LiveDevice *ldev)
             return;
         }
 
-        SCLogInfo("%s: closing device", ldev->dev);
+        SCLogPerf("%s: closing device", ldev->dev);
         rte_eth_dev_close(port_id);
 
-        SCLogInfo("%s: releasing packet mempool", ldev->dev);
+        SCLogDebug("%s: releasing packet mempool", ldev->dev);
         rte_mempool_free(ldev->dpdk_vars.pkt_mp);
     }
 #endif


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

https://redmine.openinfosecfoundation.org/issues/5987
https://redmine.openinfosecfoundation.org/issues/6106
https://redmine.openinfosecfoundation.org/issues/6115
https://redmine.openinfosecfoundation.org/issues/6116

Describe changes:
- updated compile/install instructions in the docs
- threads must have CPU affinity set to run DPDK runmode
- additional startup checks so that management/worker threads do not overlap 
- auto assigning threads to individual interfaces depending on how many threads are available. distributions of threads are equal to all interfaces
- reworded log messages so it follows the format of "[interface]: [log msg]"
- fixed negative socket return value
