### PR TITLE
detect/byte_math: Permit variable name for bytes value

### DIFF
--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -278,6 +278,10 @@ See :doc:`http-keywords` for all HTTP keywords.
 
 - Suricata will never match if there's a zero divisor. Division by 0 is undefined.
 
+-  Suricata allows a variable name from ``byte_extract`` to be specified for
+   the ``nbytes`` value. The value of ``nbytes`` must adhere to the same constraints
+   as if it were supplied directly in the rule.
+
 
 ``isdataat`` Keyword
 --------------------

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -458,13 +458,14 @@ other rule options later in the rule.
 
 Format::
 
-  byte_math:bytes <num of bytes>, offset <offset>, oper <operator>, rvalue <rvalue>, \
+  byte_math:bytes <num of bytes> | <variable-name> , offset <offset>, oper <operator>, rvalue <rvalue>, \
         result <result_var> [, relative] [, endian <endian>] [, string <number-type>] \
         [, dce] [, bitmask <value>];
 
 
 +-----------------------+-----------------------------------------------------------------------+
 | <num of bytes>        | The number of bytes selected from the packet                          |
+|                       | or the name of a byte_extract variable.                               |
 +-----------------------+-----------------------------------------------------------------------+
 | <offset>              | Number of bytes into the payload                                      |
 +-----------------------+-----------------------------------------------------------------------+

--- a/src/detect-bytemath.h
+++ b/src/detect-bytemath.h
@@ -28,6 +28,6 @@ void DetectBytemathRegister(void);
 
 SigMatch *DetectByteMathRetrieveSMVar(const char *, const Signature *);
 int DetectByteMathDoMatch(DetectEngineThreadCtx *, const SigMatchData *, const Signature *,
-                             const uint8_t *, uint16_t, uint64_t, uint64_t *, uint8_t);
+        const uint8_t *, uint16_t, uint8_t, uint64_t, uint64_t *, uint8_t);
 
 #endif /* __DETECT_BYTEMATH_H__ */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -572,7 +572,7 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
         }
         uint64_t rvalue;
         if (bmd->flags & DETECT_BYTEMATH_FLAG_RVALUE_VAR) {
-            rvalue = det_ctx->byte_values[bmd->local_id];
+            rvalue = det_ctx->byte_values[bmd->rvalue];
         } else {
             rvalue = bmd->rvalue;
         }

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -577,8 +577,15 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
             rvalue = bmd->rvalue;
         }
 
+        uint8_t nbytes;
+        if (bmd->flags & DETECT_BYTEMATH_FLAG_NBYTES_VAR) {
+            nbytes = (uint8_t) det_ctx->byte_values[bmd->nbytes];
+        } else {
+            nbytes = bmd->nbytes;
+        }
+
         DEBUG_VALIDATE_BUG_ON(buffer_len > UINT16_MAX);
-        if (DetectByteMathDoMatch(det_ctx, smd, s, buffer, (uint16_t)buffer_len, rvalue,
+        if (DetectByteMathDoMatch(det_ctx, smd, s, buffer, (uint16_t)buffer_len, nbytes, rvalue,
                     &det_ctx->byte_values[bmd->local_id], endian) != 1) {
             goto no_match;
         }


### PR DESCRIPTION
Continuation of #9194

Permit a variable name from byte_extract to be used with byte_math -- the `bytes` value can be an integer value or optionally, a variable name.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6145](https://redmine.openinfosecfoundation.org/issues/6145)

Describe changes:
- Document the variable name in the userguide and snort difference doc
- Modify the rust parser to accept a variable name
- Use the variable name or integer value when performing content inspection.

Updates
- Fix implicit conversion issue

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1301
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
