### PR TITLE
Base64 fuzz fix/v4

### DIFF
--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -64,6 +64,21 @@ static inline int GetBase64Value(uint8_t c)
 }
 
 /**
+ * \brief Checks if the given char in a byte array is Base64 alphabet
+ *
+ * \param Char that needs to be checked
+ *
+ * \return True if the char was Base64 alphabet, False otherwise
+ */
+bool IsBase64Alphabet(uint8_t encoded_byte)
+{
+    if (GetBase64Value(encoded_byte) < 0) {
+        return false;
+    }
+    return true;
+}
+
+/**
  * \brief Decodes a 4-byte base64-encoded block into a 3-byte ascii-encoded block
  *
  * \param ascii the 3-byte ascii output block

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -78,6 +78,7 @@ typedef enum {
 /* Function prototypes */
 Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, uint32_t len,
         uint32_t *consumed_bytes, uint32_t *decoded_bytes, Base64Mode mode);
+bool IsBase64Alphabet(uint8_t encoded_byte);
 
 #endif
 

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1274,8 +1274,8 @@ static inline MimeDecRetCode ProcessBase64BodyLineCopyRemainder(
 
     for (uint32_t i = offset; i < buf_len; i++) {
         if (buf[i] != ' ') {
-            DEBUG_VALIDATE_BUG_ON(state->bvr_len >= B64_BLOCK);
-            if (state->bvr_len >= B64_BLOCK)
+            DEBUG_VALIDATE_BUG_ON(state->bvr_len > B64_BLOCK);
+            if (state->bvr_len > B64_BLOCK)
                 return MIME_DEC_ERR_DATA;
             state->bvremain[state->bvr_len++] = buf[i];
         }

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1184,7 +1184,7 @@ static uint32_t ProcessBase64Remainder(
 
     /* Strip spaces in remainder */
     for (uint8_t i = 0; i < state->bvr_len; i++) {
-        if (state->bvremain[i] != ' ') {
+        if (IsBase64Alphabet(state->bvremain[i])) {
             block[cnt++] = state->bvremain[i];
         }
     }
@@ -1192,7 +1192,7 @@ static uint32_t ProcessBase64Remainder(
     /* if we don't have 4 bytes see if we can fill it from `buf` */
     if (buf && len > 0 && cnt != B64_BLOCK) {
         for (uint32_t i = 0; i < len && cnt < B64_BLOCK; i++) {
-            if (buf[i] != ' ') {
+            if (IsBase64Alphabet(buf[i])) {
                 block[cnt++] = buf[i];
             }
             buf_consumed++;
@@ -1265,21 +1265,40 @@ static uint32_t ProcessBase64Remainder(
     return buf_consumed;
 }
 
+/**
+ * \brief Skip any characters outside of the base64 alphabet as RFC 2045
+ * is followed for MIME parsing. Also, update bvr_len accordingly as if the
+ * DecodeBase64 returned more than 4 Bytes in there, it is likely because
+ * of the presence of invalid characters in the encoded string.
+ *
+ * \param buf The current line
+ * \param len The length of the line
+ * \param offset The offset where to start reading the data from
+ * \param state The current parser state
+ * */
+static inline MimeDecRetCode B64SkipUnneededCharsLastBlk(
+        const uint8_t *buf, const uint32_t buf_len, const uint32_t offset, MimeDecParseState *state)
+{
+    for (uint32_t i = offset; i < buf_len; i++) {
+        if (IsBase64Alphabet(buf[i])) {
+            state->bvremain[state->bvr_len++] = buf[i];
+        }
+        DEBUG_VALIDATE_BUG_ON(state->bvr_len > B64_BLOCK);
+        if (state->bvr_len > B64_BLOCK)
+            return MIME_DEC_ERR_DATA;
+    }
+
+    return MIME_DEC_OK;
+}
+
 static inline MimeDecRetCode ProcessBase64BodyLineCopyRemainder(
         const uint8_t *buf, const uint32_t buf_len, const uint32_t offset, MimeDecParseState *state)
 {
     DEBUG_VALIDATE_BUG_ON(offset > buf_len);
-    if (offset > buf_len)
+    if ((offset > buf_len) ||
+            (B64SkipUnneededCharsLastBlk(buf, buf_len, offset, state) != MIME_DEC_OK))
         return MIME_DEC_ERR_DATA;
 
-    for (uint32_t i = offset; i < buf_len; i++) {
-        if (buf[i] != ' ') {
-            DEBUG_VALIDATE_BUG_ON(state->bvr_len > B64_BLOCK);
-            if (state->bvr_len > B64_BLOCK)
-                return MIME_DEC_ERR_DATA;
-            state->bvremain[state->bvr_len++] = buf[i];
-        }
-    }
     return MIME_DEC_OK;
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6207
https://redmine.openinfosecfoundation.org/issues/6135

Previous PR: #9208

Changes since v3:
- return before bvremain can go out of bounds

Note: s-v test is still under works. Seeing if there could be any other issues diagnosed by CI
