### PR TITLE
http2: do not append data after closing file

### DIFF
--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -152,7 +152,7 @@ impl FileTransferTracker {
         self.fill_bytes = fill_bytes;
         self.chunk_is_last = is_last;
 
-        if self.file_is_truncated {
+        if self.file_is_truncated || self.file_closed {
             return 0;
         }
         if !self.file_open {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6211

Describe changes:
- http2: do not append data after closing file
