### PR TITLE
Inashivb/base64 fuzz fix/v8

### DIFF
--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -64,6 +64,21 @@ static inline int GetBase64Value(uint8_t c)
 }
 
 /**
+ * \brief Checks if the given char in a byte array is Base64 alphabet
+ *
+ * \param Char that needs to be checked
+ *
+ * \return True if the char was Base64 alphabet, False otherwise
+ */
+bool IsBase64Alphabet(uint8_t encoded_byte)
+{
+    if (GetBase64Value(encoded_byte) < 0 && encoded_byte != '=') {
+        return false;
+    }
+    return true;
+}
+
+/**
  * \brief Decodes a 4-byte base64-encoded block into a 3-byte ascii-encoded block
  *
  * \param ascii the 3-byte ascii output block

--- a/src/util-base64.h
+++ b/src/util-base64.h
@@ -78,6 +78,7 @@ typedef enum {
 /* Function prototypes */
 Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, uint32_t len,
         uint32_t *consumed_bytes, uint32_t *decoded_bytes, Base64Mode mode);
+bool IsBase64Alphabet(uint8_t encoded_byte);
 
 #endif
 

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1184,9 +1184,8 @@ static uint32_t ProcessBase64Remainder(
 
     /* Strip spaces in remainder */
     for (uint8_t i = 0; i < state->bvr_len; i++) {
-        if (IsBase64Alphabet(state->bvremain[i])) {
-            block[cnt++] = state->bvremain[i];
-        }
+        DEBUG_VALIDATE_BUG_ON(!IsBase64Alphabet(state->bvremain[i]));
+        block[cnt++] = state->bvremain[i];
     }
 
     /* if we don't have 4 bytes see if we can fill it from `buf` */

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1184,7 +1184,7 @@ static uint32_t ProcessBase64Remainder(
 
     /* Strip spaces in remainder */
     for (uint8_t i = 0; i < state->bvr_len; i++) {
-        if (state->bvremain[i] != ' ') {
+        if (IsBase64Alphabet(state->bvremain[i])) {
             block[cnt++] = state->bvremain[i];
         }
     }
@@ -1192,7 +1192,7 @@ static uint32_t ProcessBase64Remainder(
     /* if we don't have 4 bytes see if we can fill it from `buf` */
     if (buf && len > 0 && cnt != B64_BLOCK) {
         for (uint32_t i = 0; i < len && cnt < B64_BLOCK; i++) {
-            if (buf[i] != ' ') {
+            if (IsBase64Alphabet(buf[i])) {
                 block[cnt++] = buf[i];
             }
             buf_consumed++;
@@ -1273,7 +1273,8 @@ static inline MimeDecRetCode ProcessBase64BodyLineCopyRemainder(
         return MIME_DEC_ERR_DATA;
 
     for (uint32_t i = offset; i < buf_len; i++) {
-        if (buf[i] != ' ') {
+        // Skip any characters outside of the base64 alphabet as per RFC 2045
+        if (IsBase64Alphabet(buf[i])) {
             DEBUG_VALIDATE_BUG_ON(state->bvr_len >= B64_BLOCK);
             if (state->bvr_len >= B64_BLOCK)
                 return MIME_DEC_ERR_DATA;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6207
https://redmine.openinfosecfoundation.org/issues/6135

Previous PR: #9217

Changes since v6:
- Accounts for `=` in the base64 alphabet
- Adds an optional optimization commit

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1307