### PR TITLE
output/eve: add 'verdict' field to 'alert' and 'drop' events -  v10

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -89,22 +89,16 @@ generated the event.
 Event type: Alert
 -----------------
 
-Field action
-~~~~~~~~~~~~
+This field contains data about a signature that matched, such as
+``signature_id`` (``sid`` in the rule) and the ``signature`` (``msg`` in the
+rule).
 
-Possible values: "allowed" and "blocked"
-
-Example:
-
-::
-
-
-  "action":"allowed"
-
-Action is set to "allowed" unless a rule used the "drop" action and Suricata is in IPS mode, or when the rule used the "reject" action.
-
-It can also contain information about Source and Target of the attack in the alert.source and alert.target field if target keyword is used in
+It can also contain information about Source and Target of the attack in the
+``alert.source`` and ``alert.target`` field if target keyword is used in
 the signature.
+
+This event will also have the ``pcap_cnt`` field, when running in pcap mode, to
+indicate which packet triggered the signature.
 
 ::
 
@@ -146,6 +140,49 @@ the signature.
       ]
     }
   },
+
+Action field
+~~~~~~~~~~~~
+
+Possible values: "allowed" and "blocked".
+
+Example:
+
+::
+
+  "action":"allowed"
+
+Action is set to "allowed" unless a rule used the "drop" action and Suricata is
+in IPS mode, or when the rule used the "reject" action. It is important to note
+that this does not necessarily indicate the final verdict for a given packet or
+flow, since one packet may match on several rules.
+
+.. _verdict-alert:
+
+Verdict
+~~~~~~~
+
+An object containning info on the final action that will be applied to a given
+packet, based on all the signatures triggered by it and other possible events
+(e.g., a flow drop). For that reason, it is possible for an alert with
+an action ``allowed`` to have a verdict ``drop``, in IPS mode, for instance, if
+that packet was dropped due to a different alert.
+
+* Action: ``alert``, ``pass``, ``drop`` (this latter only occurs in IPS mode)
+* Reject-target: ``destination``, ``source``, ``both`` (only occurs for 'reject' rules)
+* Reject: an array of strings with possible reject types: ``tcp-reset``,
+  ``icmp-prohib`` (only occurs for 'reject' rules)
+
+Example:
+
+::
+
+    "verdict": {
+       "action": "drop",
+       "reject-target": "source",
+       "reject": "[icmp-prohib]"
+     }
+
 
 Pcap Field
 ~~~~~~~~~~

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -264,6 +264,19 @@ enabled, then the log gets more verbose.
 
 By using ``custom`` it is possible to select which TLS fields to log.
 
+Drops
+~~~~~
+
+Drops are event types logged when the engine drops a packet.
+
+Config::
+
+    - drop:
+        alerts: yes      # log alerts that caused drops
+        flows: all       # start or all: 'start' logs only a single drop
+                         # per flow direction. All logs each dropped pkt.
+
+
 Date modifiers in filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -94,6 +94,9 @@
             "type": "string",
             "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+[+\\-]\\d+$"
         },
+        "verdict": {
+            "$ref": "#/$defs/verdict_type"
+        },
         "direction": {
             "type": "string"
         },
@@ -5393,6 +5396,32 @@
             "$comment": "Definition for TLS date formats",
             "type": "string",
             "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
+        },
+        "verdict_type": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "reject": {
+                    "type": "array",
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "icmp-proihib": {
+                                    "type": "string"
+                                },
+                                "tcp-reset": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "reject_target": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1292,6 +1292,9 @@
                 },
                 "reason": {
                     "type": "string"
+                },
+                "verdict": {
+                    "$ref": "#/$defs/verdict_type"
                 }
             },
             "additionalProperties": false

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2022 Open Information Security Foundation
+/* Copyright (C) 2013-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -101,6 +101,7 @@
 #define LOG_JSON_HTTP_BODY_BASE64  BIT_U16(7)
 #define LOG_JSON_RULE_METADATA     BIT_U16(8)
 #define LOG_JSON_RULE              BIT_U16(9)
+#define LOG_JSON_VERDICT           BIT_U16(10)
 
 #define METADATA_DEFAULTS ( LOG_JSON_FLOW |                        \
             LOG_JSON_APP_LAYER  |                                  \
@@ -665,6 +666,56 @@ static void AlertAddFrame(const Packet *p, JsonBuilder *jb, const int64_t frame_
     }
 }
 
+/**
+ * \brief    Build verdict object
+ *
+ * \param p  Pointer to Packet current being logged
+ *
+ */
+void GetVerdictJson(JsonBuilder *jb, const Packet *p)
+{
+    jb_open_object(jb, "verdict");
+
+    /* add verdict info */
+    if (PacketCheckAction(p, ACTION_REJECT_ANY)) {
+        // check rule to define type of reject packet sent
+        if (EngineModeIsIPS()) {
+            JB_SET_STRING(jb, "action", "drop");
+        } else {
+            JB_SET_STRING(jb, "action", "alert");
+        }
+        if (PacketCheckAction(p, ACTION_REJECT)) {
+            JB_SET_STRING(jb, "reject_target", "source");
+        } else if (PacketCheckAction(p, ACTION_REJECT_DST)) {
+            JB_SET_STRING(jb, "reject_target", "destination");
+        } else if (PacketCheckAction(p, ACTION_REJECT_BOTH)) {
+            JB_SET_STRING(jb, "reject_target", "both");
+        }
+        jb_open_array(jb, "reject");
+        switch (p->proto) {
+            case IPPROTO_ICMP:
+            case IPPROTO_ICMPV6:
+                jb_append_string(jb, "icmp-prohib");
+                break;
+            case IPPROTO_TCP:
+                jb_append_string(jb, "tcp-reset");
+                break;
+        }
+        jb_close(jb);
+
+    } else if (PacketCheckAction(p, ACTION_DROP) && EngineModeIsIPS()) {
+        JB_SET_STRING(jb, "action", "drop");
+    } else if (p->alerts.alerts[p->alerts.cnt].action & ACTION_PASS) {
+        JB_SET_STRING(jb, "action", "pass");
+    } else {
+        // TODO make sure we don't have a situation where this wouldn't work
+        JB_SET_STRING(jb, "action", "alert");
+    }
+
+    /* Close verdict */
+    jb_close(jb);
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     MemBuffer *payload = aft->payload_buffer;
@@ -826,6 +877,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         char *pcap_filename = PcapLogGetFilename();
         if (pcap_filename != NULL) {
             jb_set_string(jb, "capture_file", pcap_filename);
+        }
+
+        if (json_output_ctx->flags & LOG_JSON_VERDICT) {
+            GetVerdictJson(jb, p);
         }
 
         OutputJsonBuilderBuffer(jb, aft->ctx);
@@ -1016,6 +1071,7 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
         SetFlag(conf, "payload-printable", LOG_JSON_PAYLOAD, &flags);
         SetFlag(conf, "http-body-printable", LOG_JSON_HTTP_BODY, &flags);
         SetFlag(conf, "http-body", LOG_JSON_HTTP_BODY_BASE64, &flags);
+        SetFlag(conf, "verdict", LOG_JSON_VERDICT, &flags);
 
         /* Check for obsolete flags and warn that they have no effect. */
         static const char *deprecated_flags[] = { "http", "tls", "ssh", "smtp", "dnp3", "app-layer",

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2014 Open Information Security Foundation
+/* Copyright (C) 2013-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -30,6 +30,7 @@
 void JsonAlertLogRegister(void);
 void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuilder *js,
         uint16_t flags, JsonAddrInfo *addr, char *xff_buffer);
+void GetVerdictJson(JsonBuilder *jb, const Packet *p);
 
 #endif /* __OUTPUT_JSON_ALERT_H__ */
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -82,7 +82,7 @@ static int g_droplog_flows_start = 1;
  * \param tv    Pointer the current thread variables
  * \param p     Pointer the packet which is being logged
  *
- * \return return TM_EODE_OK on success
+ * \return return TM_ECODE_OK on success
  */
 static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 {
@@ -306,7 +306,7 @@ static OutputInitResult JsonDropLogInitCtxSub(ConfNode *conf, OutputCtx *parent_
  * \param data  Pointer to the droplog struct
  * \param p     Pointer the packet which is being logged
  *
- * \retval 0 on succes
+ * \retval 0 on success
  */
 static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -168,6 +168,10 @@ outputs:
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
             tagged-packets: yes
+            # Enable logging the final action taken on a packet by the engine
+            # (e.g: the alert may have action 'allowed' but the verdict be
+            # 'drop' due to another alert. That's the engine's verdict)
+            verdict: yes
         # app layer frames
         - frame:
             # disabled by default as this is very verbose.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5464

Previous PR: https://github.com/OISF/suricata/pull/9162

Describe changes from previous PR:
- try a different approach for `verdict.action: pass` cases

SV_BRANCH=pr/1310
https://github.com/OISF/suricata-verify/pull/1310

Some output samples:
```json
# IPS mode, reject rule, TCP-reset
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 54186,
  "dest_ip": "82.165.177.154",
  "dest_port": 80,
  "proto": "TCP",
  "pkt_src": "wire/pcap",
  "alert": {
    "action": "blocked",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "verdict": {
    "action": "drop",
    "reject_target": "destination",
    "reject": [
      "tcp-reset"
    ]
  }
# packet with alert and pass rules triggered:
{
 "event_type": "alert",
  "verdict": {
    "action": "pass"
  }
}
```