### PR TITLE
readme: update redmine/readthedocs links - v2

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 Contributing to Suricata
 ========================
 
-We're happily taking patches and other contributions. The process is documented at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing Please have a look at this document before submitting.
+We're happily taking patches and other contributions. The process is documented at
+[Contribution Process](https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html). Please have a look at this document before submitting.
 
 Contribution Agreement
 ----------------------

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Make sure these boxes are signed before submitting your Pull Request -- thank you.
 
-- [ ] I have read the contributing guide lines at https://suricata.readthedocs.io/en/latest/devguide/codebase/contributing/contribution-process.html
+- [ ] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
 - [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
 - [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ You can follow the [Suricata user guide](https://docs.suricata.io/en/latest/) to
 Contributing
 ------------
 
-We're happily taking patches and other contributions. Please see https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing for how to get started.
+We're happily taking patches and other contributions. Please see our
+[Contribution Process](https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html)
+for how to get started.
 
 Suricata is a complex piece of software dealing with mostly untrusted input. Mishandling this input will have serious consequences:
 
@@ -91,9 +93,12 @@ A: It depends, if it's a major feature or considered a high risk change, it will
 
 __Q: Why was my PR closed?__
 
-A: As documented in the Suricata GitHub workflow here https://redmine.openinfosecfoundation.org/projects/suricata/wiki/GitHub_work_flow, we expect a new pull request for every change.
+A: As documented in the [Suricata GitHub workflow](https://docs.suricata.io/en/latest/devguide/codebase/contributing/github-pr-workflow.html),
+we expect a new pull request for every change.
 
-Normally, the team (or community) will give feedback on a pull request after which it is expected to be replaced by an improved PR. So look at the comments. If you disagree with the comments we can still discuss them in the closed PR.
+Normally, the team (or community) will give feedback on a pull request after which
+it is expected to be replaced by an improved PR. So look at the comments. If you
+disagree with the comments we can still discuss them in the closed PR.
 
 If the PR was closed without comments it's likely due to QA failure. If the GitHub-CI checks failed, the PR should be fixed right away. No need for a discussion about it, unless you believe the QA failure is incorrect.
 

--- a/doc/userguide/devguide/codebase/installation-from-git.rst
+++ b/doc/userguide/devguide/codebase/installation-from-git.rst
@@ -1,3 +1,5 @@
+.. _Installation from GIT:
+
 Installation from GIT
 =====================
 

--- a/doc/userguide/performance/packet-profiling.rst
+++ b/doc/userguide/performance/packet-profiling.rst
@@ -11,13 +11,12 @@ packets take to be processed. It is a way to figure out why certain
 packets are being processed quicker than others, and this way a good
 tool for developing Suricata.
 
-Update Suricata by following the steps from `Installation from Git
-<https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Installation_from_Git>`_. Start
+Update Suricata by following the steps from :ref:`Installation from GIT`. Start
 at the end at
 
 ::
 
-  cd suricata/oisf
+  cd suricata/suricata
   git pull
 
 And follow the described next steps. To enable packet profiling, make


### PR DESCRIPTION
Readme was still pointing to the redmine wiki, replace with docs.suricata links.

Pull request template was still pointing to readthedocs.

So did the contributing.md file.

Previous PR: #9179