### PR TITLE
detect/multi-tenant: Make tenant_id 32 bits everywhere

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2591,7 +2591,7 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
     DetectEngineTenantMapping *map_array = NULL;
     uint32_t map_array_size = 0;
     uint32_t map_cnt = 0;
-    int max_tenant_id = 0;
+    uint32_t max_tenant_id = 0;
     DetectEngineCtx *list = master->list;
     HashTable *mt_det_ctxs_hash = NULL;
 
@@ -3923,7 +3923,7 @@ static uint32_t DetectEngineTentantGetIdFromPcap(const void *ctx, const Packet *
     return p->pcap_v.tenant_id;
 }
 
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id)
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -92,7 +92,7 @@ uint32_t DetectEngineGetVersion(void);
 void DetectEngineBumpVersion(void);
 int DetectEngineAddToMaster(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineGetCurrent(void);
-DetectEngineCtx *DetectEngineGetByTenantId(int tenant_id);
+DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);

--- a/src/detect.h
+++ b/src/detect.h
@@ -759,7 +759,7 @@ typedef struct DetectEngineCtx_ {
     uint8_t flags;
     int failure_fatal;
 
-    int tenant_id;
+    uint32_t tenant_id;
 
     Signature *sig_list;
     uint32_t sig_cnt;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -56,7 +56,7 @@ int unix_socket_mode_is_running = 0;
 typedef struct PcapFiles_ {
     char *filename;
     char *output_dir;
-    int tenant_id;
+    uint32_t tenant_id;
     time_t delay;
     time_t poll_interval;
     bool continuous;
@@ -246,16 +246,8 @@ static void PcapFilesFree(PcapFiles *cfile)
  *
  * \retval 0 in case of error, 1 in case of success
  */
-static TmEcode UnixListAddFile(
-    PcapCommand *this,
-    const char *filename,
-    const char *output_dir,
-    int tenant_id,
-    bool continuous,
-    bool should_delete,
-    time_t delay,
-    time_t poll_interval
-)
+static TmEcode UnixListAddFile(PcapCommand *this, const char *filename, const char *output_dir,
+        uint32_t tenant_id, bool continuous, bool should_delete, time_t delay, time_t poll_interval)
 {
     PcapFiles *cfile = NULL;
     if (filename == NULL || this == NULL)
@@ -308,7 +300,7 @@ static TmEcode UnixSocketAddPcapFileImpl(json_t *cmd, json_t* answer, void *data
     PcapCommand *this = (PcapCommand *) data;
     const char *filename;
     const char *output_dir;
-    int tenant_id = 0;
+    uint32_t tenant_id = 0;
     bool should_delete = false;
     time_t delay = 30;
     time_t poll_interval = 5;
@@ -769,7 +761,7 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -850,7 +842,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -935,7 +927,7 @@ TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1011,7 +1003,7 @@ TmEcode UnixSocketReloadTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1081,7 +1073,7 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    int tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id = json_integer_value(jarg);
 
     SCLogInfo("remove-tenant: removing tenant %d", tenant_id);
 


### PR DESCRIPTION
Issue: 6047

This commit ensures that the tenant id is contained in a unsigned 32 bit container.

(cherry picked from commit 9fd77c737f4f2d14f0e79df8958c21a3ccb3ed85)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6220](https://redmine.openinfosecfoundation.org/issues/6220)

Describe changes:
- Cherry-pick tenant-id size change

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
