### PR TITLE
decode: fix offset for DCE layer

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -1202,7 +1202,8 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             if (unlikely(len < ETHERNET_DCE_HEADER_LEN)) {
                 ENGINE_SET_INVALID_EVENT(p, DCE_PKT_TOO_SMALL);
             } else {
-                DecodeEthernet(tv, dtv, p, data, len);
+                // DCE layer is ethernet + 2 bytes, followed by another ethernet
+                DecodeEthernet(tv, dtv, p, data + 2, len - 2);
             }
             break;
         case ETHERNET_TYPE_VNTAG:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3637

Describe changes:
- decode: fix offset for DCE layer

Jason, it looks like your commit 95015a3f6d0a4a21100e586a1fb19cb9f3206be7 was right but got broken in between

Rebase https://github.com/OISF/suricata/pull/9153 now that 7 is released to get attention for 7.0.1

https://github.com/OISF/suricata-verify/pull/1289
```
SV_BRANCH=pr/1289
```
