### PR TITLE
decode-ipv6: Set L4 proto on ipv6 incase of GRE decode error

### DIFF
--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -614,6 +614,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
             DecodeIP6inIP6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
             return TM_ECODE_OK;
         case IPPROTO_GRE:
+            IPV6_SET_L4PROTO(p, IPPROTO_GRE);
             DecodeGRE(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
             break;
         case IPPROTO_FRAGMENT:


### PR DESCRIPTION
Set the L4 proto before decoding GRE in ipv6 decoding in case there is a GRE header decoding error.

Bug: #6222

- [✓] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6222

Describe changes:
Set the L4 proto before decoding GRE in ipv6 decoding in case there is a GRE header decoding error.

[OISF/suricata-verify/pull/1320](https://github.com/OISF/suricata-verify/pull/1320)

```
SV_BRANCH=pr/1320
```
