### PR TITLE
dcerpc: accept ALTER_CONTEXT as a valid request

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1278,7 +1278,7 @@ pub unsafe extern "C" fn rs_dcerpc_get_stub_data(
 fn probe(input: &[u8]) -> (bool, bool) {
     match parser::parse_dcerpc_header(input) {
         Ok((_, hdr)) => {
-            let is_request = hdr.hdrtype == 0x00;
+            let is_request = hdr.hdrtype == 0x00 || hdr.hdrtype == 0x0e;
             let is_dcerpc = hdr.rpc_vers == 0x05 &&
                 hdr.rpc_vers_minor == 0x00 &&
                 hdr.packed_drep[0] & 0xee == 0 &&


### PR DESCRIPTION
So far, if only the starting request was a DCERPC request, it would be considered DCERPC traffic. Since ALTER_CONTEXT is a valid request type, it should be accepted too.

Reported and patch proposed in the following Redmine ticket. Bug 6191

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6191

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1324