### PR TITLE
eve/stats: log all stats, even those that are unscoped

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3679,6 +3679,12 @@
                 "uptime": {
                     "type": "integer"
                 },
+                "memcap_pressure": {
+                    "type": "integer"
+                },
+                "memcap_pressure_max": {
+                    "type": "integer"
+                },
                 "app_layer": {
                     "type": "object",
                     "properties": {

--- a/src/counters.c
+++ b/src/counters.c
@@ -604,9 +604,8 @@ static uint16_t StatsRegisterQualifiedCounter(const char *name, const char *tm_n
         return(temp->id);
 
     /* if we reach this point we don't have a counter registered by this name */
-    if ( (pc = SCMalloc(sizeof(StatsCounter))) == NULL)
+    if ((pc = SCCalloc(1, sizeof(StatsCounter))) == NULL)
         return 0;
-    memset(pc, 0, sizeof(StatsCounter));
 
     /* assign a unique id to this StatsCounter.  The id is local to this
      * thread context.  Please note that the id start from 1, and not 0 */
@@ -878,10 +877,9 @@ static void StatsLogSummary(void)
 void StatsInit(void)
 {
     BUG_ON(stats_ctx != NULL);
-    if ( (stats_ctx = SCMalloc(sizeof(StatsGlobalContext))) == NULL) {
+    if ((stats_ctx = SCCalloc(1, sizeof(StatsGlobalContext))) == NULL) {
         FatalError("Fatal error encountered in StatsInitCtx. Exiting...");
     }
-    memset(stats_ctx, 0, sizeof(StatsGlobalContext));
 
     StatsPublicThreadContextInit(&stats_ctx->global_counter_ctx);
 }
@@ -1118,11 +1116,10 @@ static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext
 
 
     StatsThreadStore *temp = NULL;
-    if ( (temp = SCMalloc(sizeof(StatsThreadStore))) == NULL) {
+    if ((temp = SCCalloc(1, sizeof(StatsThreadStore))) == NULL) {
         SCMutexUnlock(&stats_ctx->sts_lock);
         return 0;
     }
-    memset(temp, 0, sizeof(StatsThreadStore));
 
     temp->ctx = pctx;
     temp->name = thread_name;
@@ -1167,10 +1164,9 @@ static int StatsGetCounterArrayRange(uint16_t s_id, uint16_t e_id,
         return -1;
     }
 
-    if ( (pca->head = SCMalloc(sizeof(StatsLocalCounter) * (e_id - s_id  + 2))) == NULL) {
+    if ((pca->head = SCCalloc(1, sizeof(StatsLocalCounter) * (e_id - s_id + 2))) == NULL) {
         return -1;
     }
-    memset(pca->head, 0, sizeof(StatsLocalCounter) * (e_id - s_id  + 2));
 
     pc = pctx->head;
     while (pc->id != s_id)

--- a/src/counters.c
+++ b/src/counters.c
@@ -324,7 +324,7 @@ static void StatsInitCtxPostOutput(void)
 }
 
 /**
- * \brief Releases the resources alloted to the output context of the
+ * \brief Releases the resources allotted to the output context of the
  *        Stats API
  */
 static void StatsReleaseCtx(void)
@@ -1263,7 +1263,7 @@ uint64_t StatsGetLocalCounterValue(ThreadVars *tv, uint16_t id)
 }
 
 /**
- * \brief Releases the resources alloted by the Stats API
+ * \brief Releases the resources allotted by the Stats API
  */
 void StatsReleaseResources(void)
 {

--- a/src/counters.c
+++ b/src/counters.c
@@ -611,6 +611,12 @@ static uint16_t StatsRegisterQualifiedCounter(const char *name, const char *tm_n
      * thread context.  Please note that the id start from 1, and not 0 */
     pc->id = ++(pctx->curr_id);
     pc->name = name;
+
+    /* Precalculate the short name */
+    if (strrchr(name, '.') != NULL) {
+        pc->short_name = &name[strrchr(name, '.') - name + 1];
+    }
+
     pc->type = type_q;
     pc->Func = Func;
 
@@ -729,6 +735,7 @@ static int StatsOutput(ThreadVars *tv)
             }
             thread_table[pc->gid].updates = pc->updates;
             table[pc->gid].name = pc->name;
+            table[pc->gid].short_name = pc->short_name;
 
             pc = pc->next;
         }
@@ -773,6 +780,7 @@ static int StatsOutput(ThreadVars *tv)
             r->pvalue = r->value;
             r->value = 0;
             r->name = table[c].name;
+            r->short_name = table[c].short_name;
             r->tm_name = sts->name;
 
             switch (e->type) {

--- a/src/counters.h
+++ b/src/counters.h
@@ -113,7 +113,7 @@ void StatsSpawnThreads(void);
 void StatsRegisterTests(void);
 bool StatsEnabled(void);
 
-/* functions used to free the resources alloted by the Stats API */
+/* functions used to free the resources allotted by the Stats API */
 void StatsReleaseResources(void);
 
 /* counter registration functions */

--- a/src/counters.h
+++ b/src/counters.h
@@ -52,6 +52,7 @@ typedef struct StatsCounter_ {
 
     /* name of the counter */
     const char *name;
+    const char *short_name;
 
     /* the next perfcounter for this tv's tm instance */
     struct StatsCounter_ *next;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -23,8 +23,6 @@
  */
 
 #include "suricata-common.h"
-#include "suricata.h"
-#include "decode.h"
 #include "conf.h"
 #include "threadvars.h"
 #include "tm-threads.h"
@@ -37,25 +35,20 @@
 #include "flow-queue.h"
 #include "flow-hash.h"
 #include "flow-util.h"
-#include "flow-var.h"
 #include "flow-private.h"
 #include "flow-timeout.h"
 #include "flow-manager.h"
 #include "flow-storage.h"
 #include "flow-spare-pool.h"
 
-#include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp.h"
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
-#include "util-byte.h"
 #include "util-device.h"
 
 #include "util-debug.h"
-#include "util-privs.h"
-#include "util-signal.h"
 
 #include "threads.h"
 #include "detect.h"
@@ -70,7 +63,6 @@
 #include "app-layer-htp-range.h"
 
 #include "output-flow.h"
-#include "util-validate.h"
 
 #include "runmode-unix-socket.h"
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -752,7 +752,7 @@ static void GetWorkUnitSizing(const uint32_t rows, const uint32_t mp, const bool
 
 /** \brief Thread that manages the flow table and times out flows.
  *
- *  \param td ThreadVars casted to void ptr
+ *  \param td ThreadVars cast to void ptr
  *
  *  Keeps an eye on the spare list, alloc flows if needed...
  */
@@ -1043,7 +1043,7 @@ extern uint32_t flow_spare_pool_block_size;
 
 /** \brief Thread that manages timed out flows.
  *
- *  \param td ThreadVars casted to void ptr
+ *  \param td ThreadVars cast to void ptr
  */
 static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 {

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -227,20 +227,24 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
         for (u = 0; u < st->nstats; u++) {
             if (st->stats[u].name == NULL)
                 continue;
-            const char *name = st->stats[u].name;
-            const char *shortname = name;
-            if (strrchr(name, '.') != NULL) {
-                shortname = &name[strrchr(name, '.') - name + 1];
+            json_t *js_type = NULL;
+            const char *stat_name = st->stats[u].short_name;
+            /*
+             * When there's no short-name, the stat is added to
+             * the "global" stats namespace, just like "uptime"
+             */
+            if (st->stats[u].short_name == NULL) {
+                stat_name = st->stats[u].name;
+                js_type = js_stats;
+            } else {
+                js_type = OutputStats2Json(js_stats, st->stats[u].name);
             }
-            json_t *js_type = OutputStats2Json(js_stats, name);
             if (js_type != NULL) {
-                json_object_set_new(js_type, shortname,
-                    json_integer(st->stats[u].value));
+                json_object_set_new(js_type, stat_name, json_integer(st->stats[u].value));
 
                 if (flags & JSON_STATS_DELTAS) {
-                    char deltaname[strlen(shortname) + strlen(delta_suffix) + 1];
-                    snprintf(deltaname, sizeof(deltaname), "%s%s", shortname,
-                        delta_suffix);
+                    char deltaname[strlen(stat_name) + strlen(delta_suffix) + 1];
+                    snprintf(deltaname, sizeof(deltaname), "%s%s", stat_name, delta_suffix);
                     json_object_set_new(js_type, deltaname,
                         json_integer(st->stats[u].value - st->stats[u].pvalue));
                 }
@@ -265,18 +269,23 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                 if (st->tstats[u].name == NULL)
                     continue;
 
-                char str[256];
-                snprintf(str, sizeof(str), "%s.%s", st->tstats[u].tm_name, st->tstats[u].name);
-                char *shortname = &str[strrchr(str, '.') - str + 1];
-                json_t *js_type = OutputStats2Json(threads, str);
+                json_t *js_type = NULL;
+                const char *stat_name = st->tstats[u].short_name;
+                if (st->tstats[u].short_name == NULL) {
+                    stat_name = st->tstats[u].name;
+                    js_type = threads;
+                } else {
+                    char str[256];
+                    snprintf(str, sizeof(str), "%s.%s", st->tstats[u].tm_name, st->tstats[u].name);
+                    js_type = OutputStats2Json(threads, str);
+                }
 
                 if (js_type != NULL) {
-                    json_object_set_new(js_type, shortname, json_integer(st->tstats[u].value));
+                    json_object_set_new(js_type, stat_name, json_integer(st->tstats[u].value));
 
                     if (flags & JSON_STATS_DELTAS) {
-                        char deltaname[strlen(shortname) + strlen(delta_suffix) + 1];
-                        snprintf(deltaname, sizeof(deltaname), "%s%s",
-                            shortname, delta_suffix);
+                        char deltaname[strlen(stat_name) + strlen(delta_suffix) + 1];
+                        snprintf(deltaname, sizeof(deltaname), "%s%s", stat_name, delta_suffix);
                         json_object_set_new(js_type, deltaname,
                             json_integer(st->tstats[u].value - st->tstats[u].pvalue));
                     }

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -30,6 +30,7 @@
 
 typedef struct StatsRecord_ {
     const char *name;
+    const char *short_name;
     const char *tm_name;
     int64_t value;  /**< total value */
     int64_t pvalue; /**< prev value (may be higher for memuse counters) */


### PR DESCRIPTION
Continuation of #9293 

Make sure that all stats are logged -- even those that are not scoped (missing the `.` -- e.g., `mempressure_max` vs `decoder.pkts`.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6094](https://redmine.openinfosecfoundation.org/issues/6094)

Describe changes:
- Precalculate the statistic's short-name during registration
- Use the short-name value to determine the scope.
- Add unscoped stats to the "global" record; scoped stats are handled as they were previously.

Updates:
- Addressed scan-build issue

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
