### PR TITLE
af-packet: Error on invalid peer device setting

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -661,6 +661,10 @@ static void AFPWritePacket(Packet *p, int version)
     }
 
     /* Index of the network device */
+    if (p->afp_v.peer == NULL) {
+        SCLogError("Peer network device invalid");
+        return;
+    }
     socket_address.sll_ifindex = SC_ATOMIC_GET(p->afp_v.peer->if_idx);
     /* Address length*/
     socket_address.sll_halen = ETH_ALEN;


### PR DESCRIPTION
If the copy-iface was set to the same as the af-packet interface, the peer won't be set. This leads to segfault. Catch it and return properly.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5870