### PR TITLE
doc/userguide: improve SCStreamingBuffer example

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -960,7 +960,13 @@ SCStreamingBuffer
 ::
 
   function log(args)
-      data = SCStreamingBuffer()
+      -- sb_ts and sb_tc are bools indicating the direction of the data
+      data, sb_open, sb_close, sb_ts, sb_tc = SCStreamingBuffer()
+      if sb_ts then
+        print("->")
+      else
+        print("<-")
+      end
       hex_dump(data)
   end
 


### PR DESCRIPTION
Add direction indication in SCStreamingBuffer usage example.
This adds documentation for the changes introduced by commit 5b1d8c7e94ef613107870d4d9d9cdde76d4c3438.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: none

Describe changes:
- Improve Lua API `SCStreamingBuffer()` documentation

