### PR TITLE
af-packet: terminate on same iface and copyiface

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1024,6 +1024,10 @@ static TmEcode ParseInterfacesList(const int runmode, char *pcap_dev)
                 SCLogError("No interface found in config for af-packet");
                 SCReturnInt(TM_ECODE_FAILED);
             }
+            int retval = CheckAFPacketIPSDevs();
+            if (retval == -1) {
+                FatalError("af-packet IPS setting is incorrect");
+            }
         }
 #endif
 #ifdef HAVE_AF_XDP

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -271,6 +271,36 @@ const char *LiveGetShortName(const char *dev)
     return live_dev->dev_short;
 }
 
+int CheckAFPacketIPSDevs(void)
+{
+    ConfNode *base = ConfGetNode("af-packet");
+    ConfNode *child;
+
+    if (base == NULL)
+        return 0;
+
+    TAILQ_FOREACH (child, &base->head, next) {
+        ConfNode *subchild;
+        const char *iface = NULL, *copyiface = NULL;
+        TAILQ_FOREACH (subchild, &child->head, next) {
+            if (!strcmp(subchild->name, "interface"))
+                iface = subchild->val;
+            if (!strcmp(subchild->name, "copy-iface"))
+                copyiface = subchild->val;
+            if (iface && copyiface && !strcmp(iface, copyiface)) {
+                SCLogError("af-packet interface and copy-iface cannot be the same");
+                return -1;
+            }
+            if (iface && copyiface) {
+                iface = NULL;
+                copyiface = NULL;
+            }
+        }
+    }
+
+    return 1;
+}
+
 int LiveBuildDeviceList(const char *runmode)
 {
     return LiveBuildDeviceListCustom(runmode, "interface");

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -86,6 +86,7 @@ int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);
 const char *LiveGetShortName(const char *dev);
+int CheckAFPacketIPSDevs(void);
 int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5870

Previous PR: https://github.com/OISF/suricata/pull/9307

Changes since v2:
- add void to function params