### PR TITLE
af-packet: terminate on same interface & copyiface

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -292,6 +292,10 @@ static void *ParseAFPConfig(const char *iface)
         }
     }
 
+    if (strcmp(iface, out_iface) == 0) {
+        FatalError("Invalid config: interface and copy-iface can't be the same");
+    }
+
     if (ConfGetChildValueBoolWithDefault(if_root, if_default, "use-mmap", (int *)&boolval) == 1) {
         if (!boolval) {
             SCLogWarning(


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5870

Previous PR: https://github.com/OISF/suricata/pull/9308

Changes since v3:
- add the check in af-packet space