### PR TITLE
Bug fix #6238 and AF_XDP program loading

### DIFF
--- a/src/runmode-af-xdp.h
+++ b/src/runmode-af-xdp.h
@@ -28,5 +28,6 @@ int RunModeIdsAFXDPSingle(void);
 int RunModeIdsAFXDPWorkers(void);
 void RunModeIdsAFXDPRegister(void);
 const char *RunModeAFXDPGetDefaultMode(void);
+void RunModeAFXDPRemoveProg(void);
 
 #endif /* __RUNMODE_AFXDP_H__ */

--- a/src/source-af-xdp.h
+++ b/src/source-af-xdp.h
@@ -41,6 +41,7 @@ typedef struct AFXDPIfaceConfig {
     uint32_t busy_poll_budget;
     uint32_t gro_flush_timeout;
     uint32_t napi_defer_hard_irqs;
+    bool inhibit_prog_load;
 
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2818,8 +2818,10 @@ static void SuricataMainLoop(SCInstance *suri)
 {
     while(1) {
         if (sigterm_count || sigint_count) {
+#ifdef HAVE_AF_XDP
             if (suricata.run_mode == RUNMODE_AFXDP_DEV)
                 RunModeAFXDPRemoveProg();
+#endif
             suricata_ctl_flags |= SURICATA_STOP;
         }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2818,6 +2818,8 @@ static void SuricataMainLoop(SCInstance *suri)
 {
     while(1) {
         if (sigterm_count || sigint_count) {
+            if (suricata.run_mode == RUNMODE_AFXDP_DEV)
+                RunModeAFXDPRemoveProg();
             suricata_ctl_flags |= SURICATA_STOP;
         }
 


### PR DESCRIPTION
fixed bug by adding program loading support and program unloading after suricata stops. This is done by adding support for adding and removing AF_XDP programs.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [JR ] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [JR ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ JR] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6238

Describe changes:
fixed bug by adding program loading support and program unloading after suricata stops. This is done by adding support for adding and removing AF_XDP programs. Added RunModeAFXDPRemoveProg() and RunModeLoadAFXDPProg() in runmode-af-xdp.c. Also added flag in the AFXDPIfaceConfig struct called inhibit_prog_load which if true will set a libxdp flag that prevents the default AF_XDP program from being loaded; this is needed if the user wants to load their own AF_XDP program. source-af-xdp.c was also changed to act on this flag being set. The user can now add the "xdp-program" item in the suricata.yaml file to point to a xdp-program the user wishes to load. Finally, added check in suricata.c to unload xdp-programs before the threads are shutdown, which fixes the race condition described in the ticket.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
