### PR TITLE
af-packet: terminate on same interface & copyiface

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -292,6 +292,11 @@ static void *ParseAFPConfig(const char *iface)
         }
     }
 
+    if (strcmp(iface, out_iface) == 0) {
+        FatalError("Invalid config: interface (%s) and copy-iface (%s) can't be the same", iface,
+                out_iface);
+    }
+
     if (ConfGetChildValueBoolWithDefault(if_root, if_default, "use-mmap", (int *)&boolval) == 1) {
         if (!boolval) {
             SCLogWarning(


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5870

Previous PR: https://github.com/OISF/suricata/pull/9314

Changes since v4:
- add interface and copy-iface values in the error message