### PR TITLE
doc: display version on main page of userguide - v1

### DIFF
--- a/doc/userguide/index.rst
+++ b/doc/userguide/index.rst
@@ -1,6 +1,8 @@
 Suricata User Guide
 ===================
 
+This is the documentation for Suricata |version|.
+
 .. toctree::
    :numbered:
    :maxdepth: 2


### PR DESCRIPTION
When viewing the docs online at Readthedocs, or similar it might be immediately apparent what version of the documentation is being displayed. Display the version on the first line before the table of contents to make it clear.


