### PR TITLE
doc: display version on main page of userguide - v2

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,10 @@
 name: CIFuzz
-on: [pull_request]
+
+on:
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+
 permissions: read-all
 jobs:
  Fuzzing:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,13 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - "doc/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    paths-ignore:
+      - "doc/**"
   schedule:
     - cron: '18 21 * * 1'
 

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -6,7 +6,11 @@ on:
     branches-ignore:
       - 'master'
       - 'master-*'
+    paths-ignore:
+      - "doc/**"
   pull_request:
+    paths-ignore:
+      - "doc/**"
 
 permissions: read-all
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,8 +1,12 @@
 name: Check Rust
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - "doc/**"
+  pull_request:
+    paths-ignore:
+      - "doc/**"
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,8 +1,12 @@
 name: Scan-build
 
 on:
-  - push
-  - pull_request
+  push:
+    paths-ignore:
+      - "doc/**"
+  pull_request:
+    paths-ignore:
+      - "doc/**"
 
 jobs:
   scan-build:

--- a/doc/userguide/index.rst
+++ b/doc/userguide/index.rst
@@ -1,6 +1,8 @@
 Suricata User Guide
 ===================
 
+This is the documentation for Suricata |version|.
+
 .. toctree::
    :numbered:
    :maxdepth: 2


### PR DESCRIPTION
When viewing the docs online at Readthedocs, or similar it might be immediately apparent what version of the documentation is being displayed. Display the version on the first line before the table of contents to make it clear.

Also, disable some GitHub CI workflows on documentation-only changes.