### PR TITLE
Bug 5870/v7

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -354,6 +354,8 @@ int ConfGetChildValue(const ConfNode *base, const char *name, const char **vptr)
         return 0;
     }
     else {
+        if (node->val == NULL)
+            return 0;
         *vptr = node->val;
         return 1;
     }

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -289,6 +289,10 @@ static void *ParseAFPConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
         if (strlen(out_iface) > 0) {
             aconf->out_iface = out_iface;
+            if (strcmp(iface, out_iface) == 0) {
+                FatalError("Invalid config: interface (%s) and copy-iface (%s) can't be the same",
+                        iface, out_iface);
+            }
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5870

Previous PR: https://github.com/OISF/suricata/pull/9324

Changes since v6:
- add null check in `ConfGetChildValue`