### PR TITLE
detect/analysis: Move globals to engine ctx

### DIFF
--- a/src/detect-engine-analyzer.h
+++ b/src/detect-engine-analyzer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,20 +26,17 @@
 
 #include <stdint.h>
 
-int SetupFPAnalyzer(void);
-void CleanupFPAnalyzer(void);
+struct DetectEngineCtx_;
 
-int SetupRuleAnalyzer(void);
-void CleanupRuleAnalyzer (void);
+void SetupEngineAnalysis(struct DetectEngineCtx_ *de_ctx, bool *, bool *);
+void CleanupEngineAnalysis(struct DetectEngineCtx_ *de_ctx);
 
-int PerCentEncodingSetup (void);
+void EngineAnalysisFP(const struct DetectEngineCtx_ *de_ctx, const Signature *s, char *line);
+void EngineAnalysisRules(
+        const struct DetectEngineCtx_ *de_ctx, const Signature *s, const char *line);
+void EngineAnalysisRulesFailure(
+        const struct DetectEngineCtx_ *de_ctx, char *line, char *file, int lineno);
 
-void EngineAnalysisFP(const DetectEngineCtx *de_ctx,
-        const Signature *s, char *line);
-void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
-        const Signature *s, const char *line);
-void EngineAnalysisRulesFailure(char *line, char *file, int lineno);
-
-void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s);
+void EngineAnalysisRules2(const struct DetectEngineCtx_ *de_ctx, const Signature *s);
 
 #endif /* __DETECT_ENGINE_ANALYZER_H__ */

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1896,7 +1896,7 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
     SCReturnInt(0);
 }
 
-extern int rule_engine_analysis_set;
+extern bool rule_engine_analysis_set;
 /** \internal
  *  \brief perform final per signature setup tasks
  *

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -50,8 +50,8 @@
 
 extern int rule_reload;
 extern int engine_analysis;
-static int fp_engine_analysis_set = 0;
-int rule_engine_analysis_set = 0;
+static bool fp_engine_analysis_set = false;
+bool rule_engine_analysis_set = false;
 
 /**
  *  \brief Create the path if default-rule-path was specified
@@ -203,7 +203,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
                 }
             }
             if (rule_engine_analysis_set) {
-                EngineAnalysisRulesFailure(line, sig_file, lineno - multiline);
+                EngineAnalysisRulesFailure(de_ctx, line, sig_file, lineno - multiline);
             }
             if (!de_ctx->sigerror_ok) {
                 bad++;
@@ -301,8 +301,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
-        fp_engine_analysis_set = SetupFPAnalyzer();
-        rule_engine_analysis_set = SetupRuleAnalyzer();
+        SetupEngineAnalysis(de_ctx, &fp_engine_analysis_set, &rule_engine_analysis_set);
     }
 
     /* ok, let's load signature files from the general config */
@@ -387,12 +386,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
  end:
     gettimeofday(&de_ctx->last_reload, NULL);
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
-        if (rule_engine_analysis_set) {
-            CleanupRuleAnalyzer();
-        }
-        if (fp_engine_analysis_set) {
-            CleanupFPAnalyzer();
-        }
+        CleanupEngineAnalysis(de_ctx);
     }
 
     DetectParseDupSigHashFree(de_ctx);

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -413,7 +413,7 @@ struct FBAnalyze {
     uint32_t toggle_sids_size;
 };
 
-extern int rule_engine_analysis_set;
+extern bool rule_engine_analysis_set;
 static void DetectFlowbitsAnalyzeDump(const DetectEngineCtx *de_ctx,
         struct FBAnalyze *array, uint32_t elements);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1020,6 +1020,9 @@ typedef struct DetectEngineCtx_ {
     HashTable *reference_conf_ht;
     pcre2_code *reference_conf_regex;
     pcre2_match_data *reference_conf_regex_match;
+
+    /* --engine-analysis */
+    struct EngineAnalysisCtx_ *ea;
 
 } DetectEngineCtx;
 


### PR DESCRIPTION
Issue: 6239

This commit moves the global variables associated with engine analysis into the detect engine context. Doing so provides encapsulation of the analysis components as well as thread-safe operation in a multi-tenant (context) deployment.



Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6239](https://redmine.openinfosecfoundation.org/issues/6239)

Describe changes:
- Move engine analysis globals into a per-context structure and associate with the `DetectEngineCtx`
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
