### PR TITLE
userguide/install: add info on ubuntu ppa installs - 60x backports - v1

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -115,17 +115,87 @@ For Rust support::
 Binary packages
 ---------------
 
-Ubuntu
-^^^^^^
+Ubuntu from Personal Package Archives (PPA)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For Ubuntu, the OISF maintains a PPA ``suricata-stable`` that always contains the latest stable release.
+For Ubuntu, OISF maintains a PPA ``suricata-6.0`` that always contains the
+latest stable release for Suricata 6.
 
-To use it::
+Setup to install the latest stable Suricata 6::
 
     sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:oisf/suricata-stable
+    sudo add-apt-repository ppa:oisf/suricata-6.0
     sudo apt-get update
+
+Then, you can install the latest stable with::
+
     sudo apt-get install suricata
+
+After installing you can proceed to the :ref:`Basic setup`.
+
+`OISF launchpad: suricata-6.0 <https://launchpad.net/~oisf/+archive/ubuntu/suricata-6.0>`_.
+
+Upgrading
+"""""""""
+
+To upgrade::
+
+    sudo apt-get update
+    sudo apt-get upgrade suricata
+
+Remove
+""""""
+
+To remove Suricata from your system::
+
+    sudo apt-get remove suricata
+
+
+
+Getting Debug or Pre-release Versions
+"""""""""""""""""""""""""""""""""""""
+
+If you want Suricata with built-in (enabled) debugging, you can install the
+debug package::
+
+    sudo apt-get install suricata-dbg
+
+If you would like to help test the Release Candidate (RC) packages, the same procedures
+apply, just using another PPA: ``suricata-beta``::
+
+    sudo add-apt-repository ppa:oisf/suricata-beta
+    sudo apt-get update
+    sudo apt-get upgrade
+
+You can use both the suricata-stable and suricata-beta repositories together.
+Suricata will then always be the latest release, stable or beta.
+
+`OISF launchpad: suricata-beta <https://launchpad.net/~oisf/+archive/suricata-beta>`_.
+
+Daily Releases
+""""""""""""""
+
+If you would like to help test the daily build packages from our latest git(dev)
+repository, the same procedures as above apply, just using another PPA,
+``suricata-daily``::
+
+    sudo add-apt-repository ppa:oisf/suricata-daily-allarch
+    sudo apt-get update
+    sudo apt-get upgrade
+
+.. note::
+
+    Please have in mind that this is packaged from our latest development git master
+    and is therefore potentially unstable.
+
+    We do our best to make others aware of continuing development and items
+    within the engine that are not yet complete or optimal. With this in mind,
+    please refer to `Suricata's issue tracker on Redmine 
+    <http://redmine.openinfosecfoundation.org/projects/suricata/issues>`_ 
+    for an up-to-date list of what we are working on, planned roadmap, 
+    and to report issues.
+
+`OISF launchpad: suricata-daily <https://launchpad.net/~oisf/+archive/suricata-daily>`_.
 
 Debian
 ^^^^^^

--- a/doc/userguide/quickstart.rst
+++ b/doc/userguide/quickstart.rst
@@ -29,6 +29,8 @@ running and with what options as well as the service state::
     sudo suricata --build-info
     sudo systemctl status suricata
 
+.. _Basic setup:
+
 Basic setup
 -----------
 


### PR DESCRIPTION
Bringing info that was only in our Redmine wiki to our documentation, and update package to Suricata-6.0, now that the stable points to Suricata 7.

Task #6231

(cherry picked from commit 4fd3205bf06a00ccda8affe6631985defec9f56c)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6234

Describe changes:
- bring installation from Ubuntu PPAs info into our userdocs, taking into account Suricata-6.0 package
- add label to the basic setup

This doesn't yet cover separating the different distros into pages, because this could take a bit more time to be merged, and we have already had users complain about the ppa instructions only pointing to 7, with no reference to Suri 6.
