### PR TITLE
af-xdp: detach XDP program early v5

### DIFF
--- a/src/runmode-af-xdp.c
+++ b/src/runmode-af-xdp.c
@@ -62,6 +62,8 @@
 #include <linux/if_xdp.h>
 #include <linux/if_link.h>
 #include <xdp/xsk.h>
+#include <xdp/libxdp.h>
+#include <net/if.h>
 #endif
 
 const char *RunModeAFXDPGetDefaultMode(void)
@@ -385,6 +387,7 @@ int RunModeIdsAFXDPWorkers(void)
 #endif /* HAVE_AF_XDP */
     SCReturnInt(0);
 }
+
 /**
  * @}
  */


### PR DESCRIPTION
To mitigate a bug with AF_XDP sockets in high traffic scenarios, the XDP program must be detatched before the sockets are closed. This issue happens when large ammounts of traffic are sent to suricata and the XDP program is not removed before AF_XDP sockets are closed. I believe this is a race condition bug as detailed here: https://bugzilla.kernel.org/show_bug.cgi?id=217712

Further investigation shows this may be a bug exclusive to the driver/AMD processor combination.

This commit addresses the bug by ensuring the first thread to run the deinit function removes the XDP program, which fixes the bug as detailed in the bugzilla link.

Bug #6238

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X ] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6238

Describe changes:
Added a RunModeAFXDPRemoveProg function to remove an AF_XDP program before closing sockets as this prevents the crash when receiving high traffic volume and shutting down suricata. Also fixed error for building and an error with an unread return value.
previous PR #9337 

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
