### PR TITLE
detect/proto: support gre protocol in rule selection

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -77,6 +77,7 @@ concerns. You can choose between several basic protocols:
 * icmpv6
 * icmp (both icmpv4 and icmpv6)
 * sctp
+* gre
 * ip4 or ipv4 ('all' or 'any' IPv4 traffic)
 * ip6 or ipv6 ('all' or 'any' IPv6 traffic)
 * ip (ip stands for 'all' or 'any' both IPv4 and IPv6 traffic)

--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -69,12 +69,17 @@ Protocol
     alert :example-rule-emphasis:`http` $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP GET Request Containing Rule in URI"; flow:established,to_server; http.method; content:"GET"; http.uri; content:"rule"; fast_pattern; classtype:bad-unknown; sid:123; rev:1;)
 
 This keyword in a signature tells Suricata which protocol it
-concerns. You can choose between four basic protocols:
+concerns. You can choose between several basic protocols:
 
 * tcp (for tcp-traffic)
 * udp
-* icmp
-* ip (ip stands for 'all' or 'any')
+* icmpv4
+* icmpv6
+* icmp (both icmpv4 and icmpv6)
+* sctp
+* ip4 or ipv4 ('all' or 'any' IPv4 traffic)
+* ip6 or ipv6 ('all' or 'any' IPv6 traffic)
+* ip (ip stands for 'all' or 'any' both IPv4 and IPv6 traffic)
 
 There are a couple of additional TCP related protocol options:
 

--- a/src/detect-engine-proto.c
+++ b/src/detect-engine-proto.c
@@ -98,6 +98,9 @@ int DetectProtoParse(DetectProto *dp, const char *str)
         dp->flags |= DETECT_PROTO_ANY;
         memset(dp->proto, 0xff, sizeof(dp->proto));
         SCLogDebug("IP protocol detected");
+    } else if (strcasecmp(str, "gre") == 0) {
+        dp->proto[IPPROTO_GRE / 8] |= 1 << (IPPROTO_GRE % 8);
+        SCLogDebug("GRE protocol detected");
     } else {
         goto error;
 


### PR DESCRIPTION
This allows the GRE rules to be specific to GRE decoded traffic and not checked against non GRE packets.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6261

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1350
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
