### PR TITLE
Bug 5831/v2

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1573,7 +1573,7 @@ sockaddr_ll) + ETH_HLEN) - ETH_HLEN);
     int snaplen = default_packet_size;
 
     if (snaplen == 0) {
-        snaplen = GetIfaceMaxPacketSize(ptv->iface);
+        snaplen = GetIfaceMaxPacketSize(ptv->livedev);
         if (snaplen <= 0) {
             SCLogWarning("%s: unable to get MTU, setting snaplen default of 1514", ptv->iface);
             snaplen = 1514;
@@ -1607,7 +1607,7 @@ static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
     int snaplen = default_packet_size;
 
     if (snaplen == 0) {
-        snaplen = GetIfaceMaxPacketSize(ptv->iface);
+        snaplen = GetIfaceMaxPacketSize(ptv->livedev);
         if (snaplen <= 0) {
             SCLogWarning("%s: unable to get MTU, setting snaplen default of 1514", ptv->iface);
             snaplen = 1514;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -492,7 +492,6 @@ static TmEcode AFPPeersListAdd(AFPThreadVars *ptv)
     SCEnter();
     AFPPeer *peer = SCMalloc(sizeof(AFPPeer));
     AFPPeer *pitem;
-    int mtu, out_mtu;
 
     if (unlikely(peer == NULL)) {
         SCReturnInt(TM_ECODE_FAILED);
@@ -527,12 +526,14 @@ static TmEcode AFPPeersListAdd(AFPThreadVars *ptv)
                 continue;
             peer->peer = pitem;
             pitem->peer = peer;
-            mtu = GetIfaceMTU(ptv->iface);
-            out_mtu = GetIfaceMTU(ptv->out_iface);
-            if (mtu != out_mtu) {
+
+            LiveDevice *iface = ptv->livedev;
+            LiveDevice *out_iface = LiveGetDevice(ptv->out_iface);
+            if (iface->mtu != out_iface->mtu) {
                 SCLogWarning("MTU on %s (%d) and %s (%d) are not equal, "
                              "transmission of packets bigger than %d will fail.",
-                        ptv->iface, mtu, ptv->out_iface, out_mtu, MIN(out_mtu, mtu));
+                        ptv->iface, iface->mtu, ptv->out_iface, out_iface->mtu,
+                        MIN(out_iface->mtu, iface->mtu));
             }
             peerslist.peered += 2;
             break;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -514,7 +514,7 @@ static TmEcode ReceivePcapThreadInit(ThreadVars *tv, const void *initdata, void 
 
     if (pcapconfig->snaplen == 0) {
         /* We set snaplen if we can get the MTU */
-        ptv->pcap_snaplen = GetIfaceMaxPacketSize(pcapconfig->iface);
+        ptv->pcap_snaplen = GetIfaceMaxPacketSize(ptv->livedev);
     } else {
         ptv->pcap_snaplen = pcapconfig->snaplen;
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2496,7 +2496,8 @@ static int ConfigGetCaptureValue(SCInstance *suri)
                             dev[len-1] = '\0';
                         }
                     }
-                    unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(dev);
+                    LiveDevice *ld = LiveGetDevice(dev);
+                    unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(ld);
                     if (iface_max_packet_size > default_packet_size)
                         default_packet_size = iface_max_packet_size;
                 }

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -49,6 +49,7 @@ typedef struct {
 typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
     char dev_short[MAX_DEVNAME + 1];
+    int mtu; /* MTU of the device */
     bool tenant_id_set;
 
     uint16_t id;

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -114,11 +114,12 @@ int GetIfaceMTU(const char *dev)
  * for the link. In case of uncertainty, it will output a
  * majorant to be sure avoid the cost of dynamic allocation.
  *
- * \param Name of a network interface
+ * \param LiveDevice object
  * \retval 0 in case of error
  */
-int GetIfaceMaxPacketSize(const char *pcap_dev)
+int GetIfaceMaxPacketSize(LiveDevice *ld)
 {
+    const char *dev = ld->dev;
     if ((dev == NULL) || strlen(dev) == 0)
         return 0;
 

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -55,26 +55,16 @@
  *
  * \param Name of a network interface
  */
-static int GetIfaceMaxHWHeaderLength(const char *pcap_dev)
+static int GetIfaceMaxHWHeaderLength(const char *dev)
 {
-    if ((!strcmp("eth", pcap_dev))
-            ||
-            (!strcmp("br", pcap_dev))
-            ||
-            (!strcmp("bond", pcap_dev))
-            ||
-            (!strcmp("wlan", pcap_dev))
-            ||
-            (!strcmp("tun", pcap_dev))
-            ||
-            (!strcmp("tap", pcap_dev))
-            ||
-            (!strcmp("lo", pcap_dev))) {
+    if ((!strcmp("eth", dev)) || (!strcmp("br", dev)) || (!strcmp("bond", dev)) ||
+            (!strcmp("wlan", dev)) || (!strcmp("tun", dev)) || (!strcmp("tap", dev)) ||
+            (!strcmp("lo", dev))) {
         /* Add possible VLAN tag or Qing headers */
         return 8 + ETHERNET_HEADER_LEN;
     }
 
-    if (!strcmp("ppp", pcap_dev))
+    if (!strcmp("ppp", dev))
         return SLL_HEADER_LEN;
     /* SLL_HEADER_LEN is the biggest one and
        add possible VLAN tag and Qing headers */
@@ -88,29 +78,29 @@ static int GetIfaceMaxHWHeaderLength(const char *pcap_dev)
  * \param Name of link
  * \retval -1 in case of error, 0 if MTU can not be found
  */
-int GetIfaceMTU(const char *pcap_dev)
+int GetIfaceMTU(const char *dev)
 {
 #if defined SIOCGIFMTU
     struct ifreq ifr;
     int fd;
 
-    (void)strlcpy(ifr.ifr_name, pcap_dev, sizeof(ifr.ifr_name));
+    (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
         return -1;
     }
 
     if (ioctl(fd, SIOCGIFMTU, (char *)&ifr) < 0) {
-        SCLogWarning("Failure when trying to get MTU via ioctl for '%s': %s (%d)", pcap_dev,
+        SCLogWarning("Failure when trying to get MTU via ioctl for '%s': %s (%d)", dev,
                 strerror(errno), errno);
         close(fd);
         return -1;
     }
     close(fd);
-    SCLogInfo("%s: MTU %d", pcap_dev, ifr.ifr_mtu);
+    SCLogInfo("%s: MTU %d", dev, ifr.ifr_mtu);
     return ifr.ifr_mtu;
 #elif defined OS_WIN32
-    return GetIfaceMTUWin32(pcap_dev);
+    return GetIfaceMTUWin32(dev);
 #else
     /* ioctl is not defined, let's pretend returning 0 is ok */
     return 0;
@@ -129,16 +119,16 @@ int GetIfaceMTU(const char *pcap_dev)
  */
 int GetIfaceMaxPacketSize(const char *pcap_dev)
 {
-    if ((pcap_dev == NULL) || strlen(pcap_dev) == 0)
+    if ((dev == NULL) || strlen(dev) == 0)
         return 0;
 
-    int mtu = GetIfaceMTU(pcap_dev);
+    int mtu = GetIfaceMTU(dev);
     switch (mtu) {
         case 0:
         case -1:
             return 0;
     }
-    int ll_header = GetIfaceMaxHWHeaderLength(pcap_dev);
+    int ll_header = GetIfaceMaxHWHeaderLength(dev);
     if (ll_header == -1) {
         /* be conservative, choose a big one */
         ll_header = 16;

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -129,6 +129,7 @@ int GetIfaceMaxPacketSize(LiveDevice *ld)
         case -1:
             return 0;
     }
+    ld->mtu = mtu;
     int ll_header = GetIfaceMaxHWHeaderLength(dev);
     if (ll_header == -1) {
         /* be conservative, choose a big one */

--- a/src/util-ioctl.h
+++ b/src/util-ioctl.h
@@ -25,7 +25,7 @@
 #include "util-device.h"
 
 int GetIfaceMTU(const char *pcap_dev);
-int GetIfaceMaxPacketSize(const char *pcap_dev);
+int GetIfaceMaxPacketSize(LiveDevice *ld);
 int GetIfaceOffloading(const char *dev, int csum, int other);
 int GetIfaceRSSQueuesNum(const char *pcap_dev);
 #ifdef SIOCGIFFLAGS


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5831

Previous PR: https://github.com/OISF/suricata/pull/9372

Changes since v1:
- mtu type changed to int
- unneeded fn call removed
- minor ioctl varname cleanup