### PR TITLE
eve: fix double free of sensor_name on failures - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -39,6 +39,11 @@
         "flow_id": {
             "type": "integer"
         },
+        "host": {
+            "$comment": "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
+            "description": "the sensor-name, if configured",
+            "type": "string"
+        },
         "icmp_code": {
             "type": "integer"
         },

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1206,9 +1206,6 @@ error_exit:
         if (json_ctx->file_ctx->prefix) {
             SCFree(json_ctx->file_ctx->prefix);
         }
-        if (json_ctx->file_ctx->sensor_name) {
-            SCFree(json_ctx->file_ctx->sensor_name);
-        }
         LogFileFreeCtx(json_ctx->file_ctx);
     }
     SCFree(json_ctx);


### PR DESCRIPTION
- Also adds "host" to the eve schema.

Ticket: https://redmine.openinfosecfoundation.org/issues/6256