### PR TITLE
memory/alloc: Use SCCalloc instead of malloc/memset

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -374,10 +374,9 @@ static TmEcode AlertDebugLogDecoderEvent(ThreadVars *tv, const Packet *p, void *
 
 static TmEcode AlertDebugLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    AlertDebugLogThread *aft = SCMalloc(sizeof(AlertDebugLogThread));
+    AlertDebugLogThread *aft = SCCalloc(1, sizeof(AlertDebugLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(AlertDebugLogThread));
 
     if(initdata == NULL)
     {
@@ -447,11 +446,10 @@ static OutputInitResult AlertDebugLogInitCtx(ConfNode *conf)
         goto error;
     }
 
-    OutputCtx *output_ctx = SCMalloc(sizeof(OutputCtx));
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
         goto error;
 
-    memset(output_ctx, 0x00, sizeof(OutputCtx));
     output_ctx->data = file_ctx;
     output_ctx->DeInit = AlertDebugLogDeInitCtx;
 

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -188,10 +188,9 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
 
 TmEcode AlertFastLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    AlertFastLogThread *aft = SCMalloc(sizeof(AlertFastLogThread));
+    AlertFastLogThread *aft = SCCalloc(1, sizeof(AlertFastLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(AlertFastLogThread));
     if(initdata == NULL)
     {
         SCLogDebug("Error getting context for AlertFastLog.  \"initdata\" argument NULL");

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -121,13 +121,12 @@ static OutputInitResult AlertSyslogInitCtx(ConfNode *conf)
 
     openlog(ident, LOG_PID|LOG_NDELAY, facility);
 
-    OutputCtx *output_ctx = SCMalloc(sizeof(OutputCtx));
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         SCLogDebug("could not create new OutputCtx");
         LogFileFreeCtx(logfile_ctx);
         return result;
     }
-    memset(output_ctx, 0x00, sizeof(OutputCtx));
 
     output_ctx->data = logfile_ctx;
     output_ctx->DeInit = AlertSyslogDeInitCtx;
@@ -155,11 +154,9 @@ static TmEcode AlertSyslogThreadInit(ThreadVars *t, const void *initdata, void *
         return TM_ECODE_FAILED;
     }
 
-    AlertSyslogThread *ast = SCMalloc(sizeof(AlertSyslogThread));
+    AlertSyslogThread *ast = SCCalloc(1, sizeof(AlertSyslogThread));
     if (unlikely(ast == NULL))
         return TM_ECODE_FAILED;
-
-    memset(ast, 0, sizeof(AlertSyslogThread));
 
     /** Use the Output Context (file pointer and mutex) */
     ast->file_ctx = ((OutputCtx *)initdata)->data;

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -693,11 +693,11 @@ static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParser
 {
     SCEnter();
 
-    AppLayerProtoDetectProbingParserElement *p = SCMalloc(sizeof(AppLayerProtoDetectProbingParserElement));
+    AppLayerProtoDetectProbingParserElement *p =
+            SCCalloc(1, sizeof(AppLayerProtoDetectProbingParserElement));
     if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(p, 0, sizeof(AppLayerProtoDetectProbingParserElement));
 
     SCReturnPtr(p, "AppLayerProtoDetectProbingParserElement");
 }
@@ -714,11 +714,11 @@ static AppLayerProtoDetectProbingParserPort *AppLayerProtoDetectProbingParserPor
 {
     SCEnter();
 
-    AppLayerProtoDetectProbingParserPort *p = SCMalloc(sizeof(AppLayerProtoDetectProbingParserPort));
+    AppLayerProtoDetectProbingParserPort *p =
+            SCCalloc(1, sizeof(AppLayerProtoDetectProbingParserPort));
     if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(p, 0, sizeof(AppLayerProtoDetectProbingParserPort));
 
     SCReturnPtr(p, "AppLayerProtoDetectProbingParserPort");
 }
@@ -752,11 +752,10 @@ static AppLayerProtoDetectProbingParser *AppLayerProtoDetectProbingParserAlloc(v
 {
     SCEnter();
 
-    AppLayerProtoDetectProbingParser *p = SCMalloc(sizeof(AppLayerProtoDetectProbingParser));
+    AppLayerProtoDetectProbingParser *p = SCCalloc(1, sizeof(AppLayerProtoDetectProbingParser));
     if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(p, 0, sizeof(AppLayerProtoDetectProbingParser));
 
     SCReturnPtr(p, "AppLayerProtoDetectProbingParser");
 }
@@ -1269,10 +1268,9 @@ static int AppLayerProtoDetectPMMapSignatures(AppLayerProtoDetectPMCtx *ctx)
     int mpm_ret;
     SigIntId id = 0;
 
-    ctx->map = SCMalloc(ctx->max_sig_id * sizeof(AppLayerProtoDetectPMSignature *));
+    ctx->map = SCCalloc(1, ctx->max_sig_id * sizeof(AppLayerProtoDetectPMSignature *));
     if (ctx->map == NULL)
         goto error;
-    memset(ctx->map, 0, ctx->max_sig_id * sizeof(AppLayerProtoDetectPMSignature *));
 
     /* add an array indexed by rule id to look up the sig */
     for (s = ctx->head; s != NULL; ) {
@@ -1980,10 +1978,9 @@ AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)
         }
     }
 
-    alpd_tctx = SCMalloc(sizeof(*alpd_tctx));
+    alpd_tctx = SCCalloc(1, sizeof(*alpd_tctx));
     if (alpd_tctx == NULL)
         goto error;
-    memset(alpd_tctx, 0, sizeof(*alpd_tctx));
 
     /* Get the max pat id for all the mpm ctxs. */
     if (PmqSetup(&alpd_tctx->pmq) < 0)

--- a/src/app-layer-enip-common.c
+++ b/src/app-layer-enip-common.c
@@ -140,8 +140,6 @@ static CIPServiceEntry *CIPServiceAlloc(ENIPTransaction *tx)
     if (unlikely(svc == NULL))
         return NULL;
 
-    memset(svc, 0x00, sizeof(CIPServiceEntry));
-
     TAILQ_INIT(&svc->segment_list);
     TAILQ_INIT(&svc->attrib_list);
 

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -144,11 +144,9 @@ static int ENIPStateGetEventInfoById(int event_id, const char **event_name,
 static void *ENIPStateAlloc(void *orig_state, AppProto proto_orig)
 {
     SCLogDebug("ENIPStateAlloc");
-    void *s = SCMalloc(sizeof(ENIPState));
+    void *s = SCCalloc(1, sizeof(ENIPState));
     if (unlikely(s == NULL))
         return NULL;
-
-    memset(s, 0, sizeof(ENIPState));
 
     ENIPState *enip_state = (ENIPState *) s;
 
@@ -242,7 +240,6 @@ static ENIPTransaction *ENIPTransactionAlloc(ENIPState *state)
     state->curr = tx;
     state->transaction_max++;
 
-    memset(tx, 0x00, sizeof(ENIPTransaction));
     TAILQ_INIT(&tx->service_list);
 
     tx->enip  = state;

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -91,11 +91,10 @@ int AppLayerGetPktEventInfo(const char *event_name, int *event_id)
 void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t event)
 {
     if (*sevents == NULL) {
-        AppLayerDecoderEvents *new_devents = SCMalloc(sizeof(AppLayerDecoderEvents));
+        AppLayerDecoderEvents *new_devents = SCCalloc(1, sizeof(AppLayerDecoderEvents));
         if (new_devents == NULL)
             return;
 
-        memset(new_devents, 0, sizeof(AppLayerDecoderEvents));
         *sevents = new_devents;
 
     }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1216,11 +1216,10 @@ static AppLayerGetFileState FTPDataStateGetTxFiles(void *_state, void *tx, uint8
 
 static void FTPSetMpmState(void)
 {
-    ftp_mpm_ctx = SCMalloc(sizeof(MpmCtx));
+    ftp_mpm_ctx = SCCalloc(1, sizeof(MpmCtx));
     if (unlikely(ftp_mpm_ctx == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(ftp_mpm_ctx, 0, sizeof(MpmCtx));
     MpmInitCtx(ftp_mpm_ctx, FTP_MPM);
 
     uint32_t i = 0;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -3011,10 +3011,9 @@ void HTPConfigure(void)
         SCLogDebug("LIBHTP server %s", s->name);
 
         HTPCfgRec *nextrec = cfglist.next;
-        HTPCfgRec *htprec = SCMalloc(sizeof(HTPCfgRec));
+        HTPCfgRec *htprec = SCCalloc(1, sizeof(HTPCfgRec));
         if (NULL == htprec)
             exit(EXIT_FAILURE);
-        memset(htprec, 0x00, sizeof(*htprec));
 
         cfglist.next = htprec;
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -238,10 +238,9 @@ AppLayerParserState *AppLayerParserStateAlloc(void)
 {
     SCEnter();
 
-    AppLayerParserState *pstate = (AppLayerParserState *)SCMalloc(sizeof(*pstate));
+    AppLayerParserState *pstate = (AppLayerParserState *)SCCalloc(1, sizeof(*pstate));
     if (pstate == NULL)
         goto end;
-    memset(pstate, 0, sizeof(*pstate));
 
  end:
     SCReturnPtr(pstate, "AppLayerParserState");

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1521,10 +1521,9 @@ static AppLayerResult SMTPParseServerRecord(Flow *f, void *alstate, AppLayerPars
  */
 void *SMTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    SMTPState *smtp_state = SCMalloc(sizeof(SMTPState));
+    SMTPState *smtp_state = SCCalloc(1, sizeof(SMTPState));
     if (unlikely(smtp_state == NULL))
         return NULL;
-    memset(smtp_state, 0, sizeof(SMTPState));
 
     smtp_state->cmds = SCMalloc(sizeof(uint8_t) *
                                 SMTP_COMMAND_BUFFER_STEPS);
@@ -1541,10 +1540,9 @@ void *SMTPStateAlloc(void *orig_state, AppProto proto_orig)
 
 static SMTPString *SMTPStringAlloc(void)
 {
-    SMTPString *smtp_string = SCMalloc(sizeof(SMTPString));
+    SMTPString *smtp_string = SCCalloc(1, sizeof(SMTPString));
     if (unlikely(smtp_string == NULL))
         return NULL;
-    memset(smtp_string, 0, sizeof(SMTPString));
 
     return smtp_string;
 }
@@ -1656,11 +1654,10 @@ static void SMTPStateFree(void *p)
 
 static void SMTPSetMpmState(void)
 {
-    smtp_mpm_ctx = SCMalloc(sizeof(MpmCtx));
+    smtp_mpm_ctx = SCCalloc(1, sizeof(MpmCtx));
     if (unlikely(smtp_mpm_ctx == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(smtp_mpm_ctx, 0, sizeof(MpmCtx));
     MpmInitCtx(smtp_mpm_ctx, SMTP_MPM);
 
     uint32_t i = 0;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2646,10 +2646,9 @@ static AppLayerResult SSLParseServerRecord(Flow *f, void *alstate, AppLayerParse
  */
 static void *SSLStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    SSLState *ssl_state = SCMalloc(sizeof(SSLState));
+    SSLState *ssl_state = SCCalloc(1, sizeof(SSLState));
     if (unlikely(ssl_state == NULL))
         return NULL;
-    memset(ssl_state, 0, sizeof(SSLState));
     ssl_state->client_connp.cert_log_flag = 0;
     ssl_state->server_connp.cert_log_flag = 0;
     memset(ssl_state->client_connp.random, 0, TLS_RANDOM_LEN);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -992,10 +992,9 @@ AppLayerThreadCtx *AppLayerGetCtxThread(ThreadVars *tv)
 {
     SCEnter();
 
-    AppLayerThreadCtx *app_tctx = SCMalloc(sizeof(*app_tctx));
+    AppLayerThreadCtx *app_tctx = SCCalloc(1, sizeof(*app_tctx));
     if (app_tctx == NULL)
         goto error;
-    memset(app_tctx, 0, sizeof(*app_tctx));
 
     if ((app_tctx->alpd_tctx = AppLayerProtoDetectGetCtxThread()) == NULL)
         goto error;

--- a/src/decode.c
+++ b/src/decode.c
@@ -689,9 +689,8 @@ DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *tv)
 {
     DecodeThreadVars *dtv = NULL;
 
-    if ( (dtv = SCMalloc(sizeof(DecodeThreadVars))) == NULL)
+    if ((dtv = SCCalloc(1, sizeof(DecodeThreadVars))) == NULL)
         return NULL;
-    memset(dtv, 0, sizeof(DecodeThreadVars));
 
     dtv->app_tctx = AppLayerGetCtxThread(tv);
 

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -93,11 +93,9 @@ static DefragTracker *DefragTrackerAlloc(void)
 
     (void) SC_ATOMIC_ADD(defrag_memuse, sizeof(DefragTracker));
 
-    DefragTracker *dt = SCMalloc(sizeof(DefragTracker));
+    DefragTracker *dt = SCCalloc(1, sizeof(DefragTracker));
     if (unlikely(dt == NULL))
         goto error;
-
-    memset(dt, 0x00, sizeof(DefragTracker));
 
     SCMutexInit(&dt->lock, NULL);
     SC_ATOMIC_INIT(dt->use_cnt);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -228,10 +228,9 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
         goto error;
     }
 
-    bed = SCMalloc(sizeof(DetectByteExtractData));
+    bed = SCCalloc(1, sizeof(DetectByteExtractData));
     if (unlikely(bed == NULL))
         goto error;
-    memset(bed, 0, sizeof(DetectByteExtractData));
 
     /* no of bytes to extract */
     char nbytes_str[64] = "";

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -284,9 +284,8 @@ static int DetectIPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     sm->type = DETECT_IPV4_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -381,9 +380,8 @@ static int DetectTCPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->type = DETECT_TCPV4_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -478,9 +476,8 @@ static int DetectTCPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->type = DETECT_TCPV6_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -575,9 +572,8 @@ static int DetectUDPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->type = DETECT_UDPV4_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -672,9 +668,8 @@ static int DetectUDPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->type = DETECT_UDPV6_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -767,9 +762,8 @@ static int DetectICMPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 
     sm->type = DETECT_ICMPV4_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
@@ -865,9 +859,8 @@ static int DetectICMPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 
     sm->type = DETECT_ICMPV6_CSUM;
 
-    if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
+    if ((cd = SCCalloc(1, sizeof(DetectCsumData))) == NULL)
         goto error;
-    memset(cd, 0, sizeof(DetectCsumData));
 
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -139,11 +139,9 @@ static DetectThresholdData *DetectDetectionFilterParse(const char *rawstr)
         goto error;
     }
 
-    df = SCMalloc(sizeof(DetectThresholdData));
+    df = SCCalloc(1, sizeof(DetectThresholdData));
     if (unlikely(df == NULL))
         goto error;
-
-    memset(df, 0, sizeof(DetectThresholdData));
 
     df->type = TYPE_DETECTION;
 

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1384,10 +1384,9 @@ int SigAddressPrepareStage1(DetectEngineCtx *de_ctx)
 
     de_ctx->sig_array_len = DetectEngineGetMaxSigId(de_ctx);
     de_ctx->sig_array_size = (de_ctx->sig_array_len * sizeof(Signature *));
-    de_ctx->sig_array = (Signature **)SCMalloc(de_ctx->sig_array_size);
+    de_ctx->sig_array = (Signature **)SCCalloc(1, de_ctx->sig_array_size);
     if (de_ctx->sig_array == NULL)
         goto error;
-    memset(de_ctx->sig_array,0,de_ctx->sig_array_size);
 
     SCLogDebug("signature lookup array: %" PRIu32 " sigs, %" PRIu32 " bytes",
                de_ctx->sig_array_len, de_ctx->sig_array_size);

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -74,10 +74,9 @@ static IPOnlyCIDRItem *IPOnlyCIDRItemNew(void)
     SCEnter();
     IPOnlyCIDRItem *item = NULL;
 
-    item = SCMalloc(sizeof(IPOnlyCIDRItem));
+    item = SCCalloc(1, sizeof(IPOnlyCIDRItem));
     if (unlikely(item == NULL))
         SCReturnPtr(NULL, "IPOnlyCIDRItem");
-    memset(item, 0, sizeof(IPOnlyCIDRItem));
 
     SCReturnPtr(item, "IPOnlyCIDRItem");
 }
@@ -550,19 +549,17 @@ static void SigNumArrayPrint(void *tmp)
 static SigNumArray *SigNumArrayNew(DetectEngineCtx *de_ctx,
                             DetectEngineIPOnlyCtx *io_ctx)
 {
-    SigNumArray *new = SCMalloc(sizeof(SigNumArray));
+    SigNumArray *new = SCCalloc(1, sizeof(SigNumArray));
 
     if (unlikely(new == NULL)) {
         FatalError("Fatal error encountered in SigNumArrayNew. Exiting...");
     }
-    memset(new, 0, sizeof(SigNumArray));
 
-    new->array = SCMalloc(io_ctx->max_idx / 8 + 1);
+    new->array = SCCalloc(1, io_ctx->max_idx / 8 + 1);
     if (new->array == NULL) {
        exit(EXIT_FAILURE);
     }
 
-    memset(new->array, 0, io_ctx->max_idx / 8 + 1);
     new->size = io_ctx->max_idx / 8 + 1;
 
     SCLogDebug("max idx= %u", io_ctx->max_idx);
@@ -580,13 +577,12 @@ static SigNumArray *SigNumArrayNew(DetectEngineCtx *de_ctx,
  */
 static SigNumArray *SigNumArrayCopy(SigNumArray *orig)
 {
-    SigNumArray *new = SCMalloc(sizeof(SigNumArray));
+    SigNumArray *new = SCCalloc(1, sizeof(SigNumArray));
 
     if (unlikely(new == NULL)) {
         FatalError("Fatal error encountered in SigNumArrayCopy. Exiting...");
     }
 
-    memset(new, 0, sizeof(SigNumArray));
     new->size = orig->size;
 
     new->array = SCMalloc(orig->size);

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -86,18 +86,14 @@ void SigGroupHeadInitDataFree(SigGroupHeadInitData *sghid)
 
 static SigGroupHeadInitData *SigGroupHeadInitDataAlloc(uint32_t size)
 {
-    SigGroupHeadInitData *sghid = SCMalloc(sizeof(SigGroupHeadInitData));
+    SigGroupHeadInitData *sghid = SCCalloc(1, sizeof(SigGroupHeadInitData));
     if (unlikely(sghid == NULL))
         return NULL;
 
-    memset(sghid, 0x00, sizeof(SigGroupHeadInitData));
-
     /* initialize the signature bitarray */
     sghid->sig_size = size;
-    if ( (sghid->sig_array = SCMalloc(sghid->sig_size)) == NULL)
+    if ((sghid->sig_array = SCCalloc(1, sghid->sig_size)) == NULL)
         goto error;
-
-    memset(sghid->sig_array, 0, sghid->sig_size);
 
     return sghid;
 error:
@@ -139,10 +135,9 @@ void SigGroupHeadStore(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
  */
 static SigGroupHead *SigGroupHeadAlloc(const DetectEngineCtx *de_ctx, uint32_t size)
 {
-    SigGroupHead *sgh = SCMalloc(sizeof(SigGroupHead));
+    SigGroupHead *sgh = SCCalloc(1, sizeof(SigGroupHead));
     if (unlikely(sgh == NULL))
         return NULL;
-    memset(sgh, 0, sizeof(SigGroupHead));
 
     sgh->init = SigGroupHeadInitDataAlloc(size);
     if (sgh->init == NULL)
@@ -498,11 +493,9 @@ int SigGroupHeadBuildMatchArray(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 
     BUG_ON(sgh->init->match_array != NULL);
 
-    sgh->init->match_array = SCMalloc(sgh->init->sig_cnt * sizeof(Signature *));
+    sgh->init->match_array = SCCalloc(1, sgh->init->sig_cnt * sizeof(Signature *));
     if (sgh->init->match_array == NULL)
         return -1;
-
-    memset(sgh->init->match_array, 0, sgh->init->sig_cnt * sizeof(Signature *));
 
     for (sig = 0; sig < max_idx + 1; sig++) {
         if (!(sgh->init->sig_array[(sig / 8)] & (1 << (sig % 8))) )
@@ -679,15 +672,13 @@ int SigGroupHeadBuildNonPrefilterArray(DetectEngineCtx *de_ctx, SigGroupHead *sg
     }
 
     if (non_pf > 0) {
-        sgh->non_pf_other_store_array = SCMalloc(non_pf * sizeof(SignatureNonPrefilterStore));
+        sgh->non_pf_other_store_array = SCCalloc(1, non_pf * sizeof(SignatureNonPrefilterStore));
         BUG_ON(sgh->non_pf_other_store_array == NULL);
-        memset(sgh->non_pf_other_store_array, 0, non_pf * sizeof(SignatureNonPrefilterStore));
     }
 
     if (non_pf_syn > 0) {
-        sgh->non_pf_syn_store_array = SCMalloc(non_pf_syn * sizeof(SignatureNonPrefilterStore));
+        sgh->non_pf_syn_store_array = SCCalloc(1, non_pf_syn * sizeof(SignatureNonPrefilterStore));
         BUG_ON(sgh->non_pf_syn_store_array == NULL);
-        memset(sgh->non_pf_syn_store_array, 0, non_pf_syn * sizeof(SignatureNonPrefilterStore));
     }
 
     for (sig = 0; sig < sgh->init->sig_cnt; sig++) {

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -98,10 +98,9 @@ static void SCSigRegisterSignatureOrderingFunc(DetectEngineCtx *de_ctx,
         curr = curr->next;
     }
 
-    if ( (temp = SCMalloc(sizeof(SCSigOrderFunc))) == NULL) {
+    if ((temp = SCCalloc(1, sizeof(SCSigOrderFunc))) == NULL) {
         FatalError("Fatal error encountered in SCSigRegisterSignatureOrderingFunc. Exiting...");
     }
-    memset(temp, 0, sizeof(SCSigOrderFunc));
 
     temp->SWCompare = SWCompare;
 
@@ -708,9 +707,8 @@ static inline SCSigSignatureWrapper *SCSigAllocSignatureWrapper(Signature *sig)
 {
     SCSigSignatureWrapper *sw = NULL;
 
-    if ( (sw = SCMalloc(sizeof(SCSigSignatureWrapper))) == NULL)
+    if ((sw = SCCalloc(1, sizeof(SCSigSignatureWrapper))) == NULL)
         return NULL;
-    memset(sw, 0, sizeof(SCSigSignatureWrapper));
 
     sw->sig = sig;
 

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -84,10 +84,9 @@ static inline int StateIsValid(uint16_t alproto, void *alstate)
 
 static DeStateStore *DeStateStoreAlloc(void)
 {
-    DeStateStore *d = SCMalloc(sizeof(DeStateStore));
+    DeStateStore *d = SCCalloc(1, sizeof(DeStateStore));
     if (unlikely(d == NULL))
         return NULL;
-    memset(d, 0, sizeof(DeStateStore));
 
     return d;
 }
@@ -163,10 +162,9 @@ static void DeStateSignatureAppend(DetectEngineState *state,
 
 DetectEngineState *DetectEngineStateAlloc(void)
 {
-    DetectEngineState *d = SCMalloc(sizeof(DetectEngineState));
+    DetectEngineState *d = SCCalloc(1, sizeof(DetectEngineState));
     if (unlikely(d == NULL))
         return NULL;
-    memset(d, 0, sizeof(DetectEngineState));
 
     return d;
 }

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -91,11 +91,10 @@ int TagHostHasTag(Host *host)
 
 static DetectTagDataEntry *DetectTagDataCopy(DetectTagDataEntry *dtd)
 {
-    DetectTagDataEntry *tde = SCMalloc(sizeof(DetectTagDataEntry));
+    DetectTagDataEntry *tde = SCCalloc(1, sizeof(DetectTagDataEntry));
     if (unlikely(tde == NULL)) {
         return NULL;
     }
-    memset(tde, 0, sizeof(DetectTagDataEntry));
 
     tde->sid = dtd->sid;
     tde->gid = dtd->gid;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -248,11 +248,11 @@ void DetectAppLayerInspectEngineRegister2(const char *name,
         direction = 1;
     }
 
-    DetectEngineAppInspectionEngine *new_engine = SCMalloc(sizeof(DetectEngineAppInspectionEngine));
+    DetectEngineAppInspectionEngine *new_engine =
+            SCCalloc(1, sizeof(DetectEngineAppInspectionEngine));
     if (unlikely(new_engine == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(new_engine, 0, sizeof(*new_engine));
     new_engine->alproto = alproto;
     new_engine->dir = direction;
     new_engine->sm_list = (uint16_t)sm_list;
@@ -2460,11 +2460,10 @@ retry:
 
 static DetectEngineCtx *DetectEngineCtxInitReal(enum DetectEngineType type, const char *prefix)
 {
-    DetectEngineCtx *de_ctx = SCMalloc(sizeof(DetectEngineCtx));
+    DetectEngineCtx *de_ctx = SCCalloc(1, sizeof(DetectEngineCtx));
     if (unlikely(de_ctx == NULL))
         goto error;
 
-    memset(de_ctx,0,sizeof(DetectEngineCtx));
     memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
     TAILQ_INIT(&de_ctx->sig_stat.failed_sigs);
     de_ctx->sigerror = NULL;
@@ -3037,13 +3036,11 @@ static int DetectEngineThreadCtxInitKeywords(DetectEngineCtx *de_ctx, DetectEngi
 {
     if (de_ctx->keyword_id > 0) {
         // coverity[suspicious_sizeof : FALSE]
-        det_ctx->keyword_ctxs_array = SCMalloc(de_ctx->keyword_id * sizeof(void *));
+        det_ctx->keyword_ctxs_array = SCCalloc(1, de_ctx->keyword_id * sizeof(void *));
         if (det_ctx->keyword_ctxs_array == NULL) {
             SCLogError("setting up thread local detect ctx");
             return TM_ECODE_FAILED;
         }
-
-        memset(det_ctx->keyword_ctxs_array, 0x00, de_ctx->keyword_id * sizeof(void *));
 
         det_ctx->keyword_ctxs_size = de_ctx->keyword_id;
 
@@ -3221,12 +3218,10 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
     /* DeState */
     if (de_ctx->sig_array_len > 0) {
         det_ctx->match_array_len = de_ctx->sig_array_len;
-        det_ctx->match_array = SCMalloc(det_ctx->match_array_len * sizeof(Signature *));
+        det_ctx->match_array = SCCalloc(1, det_ctx->match_array_len * sizeof(Signature *));
         if (det_ctx->match_array == NULL) {
             return TM_ECODE_FAILED;
         }
-        memset(det_ctx->match_array, 0,
-               det_ctx->match_array_len * sizeof(Signature *));
 
         RuleMatchCandidateTxArrayInit(det_ctx, de_ctx->sig_array_len);
     }
@@ -3308,10 +3303,9 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
  */
 TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 {
-    DetectEngineThreadCtx *det_ctx = SCMalloc(sizeof(DetectEngineThreadCtx));
+    DetectEngineThreadCtx *det_ctx = SCCalloc(1, sizeof(DetectEngineThreadCtx));
     if (unlikely(det_ctx == NULL))
         return TM_ECODE_FAILED;
-    memset(det_ctx, 0, sizeof(DetectEngineThreadCtx));
 
     det_ctx->tv = tv;
     det_ctx->de_ctx = DetectEngineGetCurrent();
@@ -3374,10 +3368,9 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
 DetectEngineThreadCtx *DetectEngineThreadCtxInitForReload(
         ThreadVars *tv, DetectEngineCtx *new_de_ctx, int mt)
 {
-    DetectEngineThreadCtx *det_ctx = SCMalloc(sizeof(DetectEngineThreadCtx));
+    DetectEngineThreadCtx *det_ctx = SCCalloc(1, sizeof(DetectEngineThreadCtx));
     if (unlikely(det_ctx == NULL))
         return NULL;
-    memset(det_ctx, 0, sizeof(DetectEngineThreadCtx));
 
     det_ctx->tenant_id = new_de_ctx->tenant_id;
     det_ctx->tv = tv;

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -95,10 +95,9 @@ static void Add(SCFPSupportSMList **list, const int list_id, const int priority)
     }
 
     if (*list == NULL) {
-        SCFPSupportSMList *new = SCMalloc(sizeof(SCFPSupportSMList));
+        SCFPSupportSMList *new = SCCalloc(1, sizeof(SCFPSupportSMList));
         if (unlikely(new == NULL))
             exit(EXIT_FAILURE);
-        memset(new, 0, sizeof(SCFPSupportSMList));
         new->list_id = list_id;
         new->priority = priority;
 
@@ -106,10 +105,9 @@ static void Add(SCFPSupportSMList **list, const int list_id, const int priority)
         return;
     }
 
-    SCFPSupportSMList *new = SCMalloc(sizeof(SCFPSupportSMList));
+    SCFPSupportSMList *new = SCCalloc(1, sizeof(SCFPSupportSMList));
     if (unlikely(new == NULL))
         exit(EXIT_FAILURE);
-    memset(new, 0, sizeof(SCFPSupportSMList));
     new->list_id = list_id;
     new->priority = priority;
     if (ip == NULL) {

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -201,11 +201,9 @@ static DetectFileHashData *DetectFileHashParse (const DetectEngineCtx *de_ctx,
     char *rule_filename = NULL;
 
     /* We have a correct hash algorithm option */
-    filehash = SCMalloc(sizeof(DetectFileHashData));
+    filehash = SCCalloc(1, sizeof(DetectFileHashData));
     if (unlikely(filehash == NULL))
         goto error;
-
-    memset(filehash, 0x00, sizeof(DetectFileHashData));
 
     if (strlen(str) && str[0] == '!') {
         filehash->negated = 1;

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -408,10 +408,9 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
             }
         }
 
-        fd = SCMalloc(sizeof(DetectFilestoreData));
+        fd = SCCalloc(1, sizeof(DetectFilestoreData));
         if (unlikely(fd == NULL))
             goto error;
-        memset(fd, 0x00, sizeof(DetectFilestoreData));
 
         if (args[0] != NULL) {
             SCLogDebug("first arg %s", args[0]);

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -164,10 +164,9 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     if (res == -1)
         goto error;
 
-    fd = SCMalloc(sizeof(DetectFlowvarData));
+    fd = SCCalloc(1, sizeof(DetectFlowvarData));
     if (unlikely(fd == NULL))
         goto error;
-    memset(fd, 0x00, sizeof(*fd));
 
     fd->content = SCMalloc(contentlen);
     if (unlikely(fd->content == NULL))
@@ -268,10 +267,9 @@ int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t 
     SigMatch *sm = NULL;
     DetectFlowvarData *fv = NULL;
 
-    fv = SCMalloc(sizeof(DetectFlowvarData));
+    fv = SCCalloc(1, sizeof(DetectFlowvarData));
     if (unlikely(fv == NULL))
         goto error;
-    memset(fv, 0x00, sizeof(*fv));
 
     /* we only need the idx */
     fv->idx = idx;

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -198,11 +198,9 @@ static DetectFragBitsData *DetectFragBitsParse (const char *rawstr)
         goto error;
     }
 
-    de = SCMalloc(sizeof(DetectFragBitsData));
+    de = SCCalloc(1, sizeof(DetectFragBitsData));
     if (unlikely(de == NULL))
         goto error;
-
-    memset(de,0,sizeof(DetectFragBitsData));
 
     /** First parse args[0] */
 

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -305,11 +305,9 @@ static DetectGeoipData *DetectGeoipDataParse (DetectEngineCtx *de_ctx, const cha
         goto error;
 
     /* We have a correct geoip options string */
-    geoipdata = SCMalloc(sizeof(DetectGeoipData));
+    geoipdata = SCCalloc(1, sizeof(DetectGeoipData));
     if (unlikely(geoipdata == NULL))
         goto error;
-
-    memset(geoipdata, 0x00, sizeof(DetectGeoipData));
 
     /* Parse the geoip option string */
     while (pos <= slen)

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -596,12 +596,11 @@ static void *DetectLuaThreadInit(void *data)
     DetectLuaData *lua = (DetectLuaData *)data;
     BUG_ON(lua == NULL);
 
-    DetectLuaThreadData *t = SCMalloc(sizeof(DetectLuaThreadData));
+    DetectLuaThreadData *t = SCCalloc(1, sizeof(DetectLuaThreadData));
     if (unlikely(t == NULL)) {
         SCLogError("couldn't alloc ctx memory");
         return NULL;
     }
-    memset(t, 0x00, sizeof(DetectLuaThreadData));
 
     t->alproto = lua->alproto;
     t->flags = lua->flags;
@@ -681,11 +680,9 @@ static DetectLuaData *DetectLuaParse (DetectEngineCtx *de_ctx, const char *str)
     DetectLuaData *lua = NULL;
 
     /* We have a correct lua option */
-    lua = SCMalloc(sizeof(DetectLuaData));
+    lua = SCCalloc(1, sizeof(DetectLuaData));
     if (unlikely(lua == NULL))
         goto error;
-
-    memset(lua, 0x00, sizeof(DetectLuaData));
 
     if (strlen(str) && str[0] == '!') {
         lua->negated = 1;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -321,11 +321,10 @@ int DetectEngineContentModifierBufferSetup(DetectEngineCtx *de_ctx,
 
 SigMatch *SigMatchAlloc(void)
 {
-    SigMatch *sm = SCMalloc(sizeof(SigMatch));
+    SigMatch *sm = SCCalloc(1, sizeof(SigMatch));
     if (unlikely(sm == NULL))
         return NULL;
 
-    memset(sm, 0, sizeof(SigMatch));
     sm->prev = NULL;
     sm->next = NULL;
     return sm;
@@ -1478,10 +1477,9 @@ int SignatureInitDataBufferCheckExpand(Signature *s)
 
 Signature *SigAlloc (void)
 {
-    Signature *sig = SCMalloc(sizeof(Signature));
+    Signature *sig = SCCalloc(1, sizeof(Signature));
     if (unlikely(sig == NULL))
         return NULL;
-    memset(sig, 0, sizeof(Signature));
 
     sig->init_data = SCCalloc(1, sizeof(SignatureInitData));
     if (sig->init_data == NULL) {
@@ -2427,11 +2425,10 @@ static inline int DetectEngineSignatureIsDuplicate(DetectEngineCtx *de_ctx,
     SigDuplWrapper *sw = NULL;
 
     /* used for making a duplicate_sig_hash_table entry */
-    sw = SCMalloc(sizeof(SigDuplWrapper));
+    sw = SCCalloc(1, sizeof(SigDuplWrapper));
     if (unlikely(sw == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(sw, 0, sizeof(SigDuplWrapper));
     sw->s = sig;
 
     /* check if we have a duplicate entry for this signature */

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -179,12 +179,11 @@ static DetectSshVersionData *DetectSshVersionParse (DetectEngineCtx *de_ctx, con
         }
 
         /* We have a correct id option */
-        ssh = SCMalloc(sizeof(DetectSshVersionData));
+        ssh = SCCalloc(1, sizeof(DetectSshVersionData));
         if (unlikely(ssh == NULL)) {
             pcre2_substring_free((PCRE2_UCHAR *)str_ptr);
             goto error;
         }
-        memset(ssh, 0x00, sizeof(DetectSshVersionData));
 
         /* If we expect a protocol version 2 or 1.99 (considered 2, we
          * will compare it with both strings) */

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -218,10 +218,9 @@ static DetectFlagsData *DetectFlagsParse (const char *rawstr)
         goto error;
     }
 
-    de = SCMalloc(sizeof(DetectFlagsData));
+    de = SCCalloc(1, sizeof(DetectFlagsData));
     if (unlikely(de == NULL))
         goto error;
-    memset(de, 0, sizeof(DetectFlagsData));
     de->ignored_flags = 0xff;
 
     /** First parse args1 */

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -154,11 +154,9 @@ static DetectThresholdData *DetectThresholdParse(const char *rawstr)
         goto error;
     }
 
-    de = SCMalloc(sizeof(DetectThresholdData));
+    de = SCCalloc(1, sizeof(DetectThresholdData));
     if (unlikely(de == NULL))
         goto error;
-
-    memset(de,0,sizeof(DetectThresholdData));
 
     for (i = 0; i < (ret - 1); i++) {
 

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -62,12 +62,11 @@ Flow *FlowAlloc(void)
 
     (void) SC_ATOMIC_ADD(flow_memuse, size);
 
-    f = SCMalloc(size);
+    f = SCCalloc(1, size);
     if (unlikely(f == NULL)) {
         (void)SC_ATOMIC_SUB(flow_memuse, size);
         return NULL;
     }
-    memset(f, 0, size);
 
     /* coverity[missing_lock] */
     FLOW_INITIALIZE(f);

--- a/src/host.c
+++ b/src/host.c
@@ -115,11 +115,9 @@ Host *HostAlloc(void)
     }
     (void) SC_ATOMIC_ADD(host_memuse, g_host_size);
 
-    Host *h = SCMalloc(g_host_size);
+    Host *h = SCCalloc(1, g_host_size);
     if (unlikely(h == NULL))
         goto error;
-
-    memset(h, 0x00, g_host_size);
 
     SCMutexInit(&h->m, NULL);
     SC_ATOMIC_INIT(h->use_cnt);

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -114,11 +114,9 @@ IPPair *IPPairAlloc(void)
 
     (void) SC_ATOMIC_ADD(ippair_memuse, g_ippair_size);
 
-    IPPair *h = SCMalloc(g_ippair_size);
+    IPPair *h = SCCalloc(1, g_ippair_size);
     if (unlikely(h == NULL))
         goto error;
-
-    memset(h, 0x00, g_ippair_size);
 
     SCMutexInit(&h->m, NULL);
     SC_ATOMIC_INIT(h->use_cnt);

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -503,10 +503,9 @@ int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, v
 
 TmEcode LogHttpLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogHttpLogThread *aft = SCMalloc(sizeof(LogHttpLogThread));
+    LogHttpLogThread *aft = SCCalloc(1, sizeof(LogHttpLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogHttpLogThread));
 
     if(initdata == NULL)
     {
@@ -561,12 +560,11 @@ OutputInitResult LogHttpLogInitCtx(ConfNode *conf)
         return result;
     }
 
-    LogHttpFileCtx *httplog_ctx = SCMalloc(sizeof(LogHttpFileCtx));
+    LogHttpFileCtx *httplog_ctx = SCCalloc(1, sizeof(LogHttpFileCtx));
     if (unlikely(httplog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
         return result;
     }
-    memset(httplog_ctx, 0x00, sizeof(LogHttpFileCtx));
 
     httplog_ctx->file_ctx = file_ctx;
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1357,11 +1357,10 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
     int en;
     PCRE2_SIZE eo = 0;
 
-    PcapLogData *pl = SCMalloc(sizeof(PcapLogData));
+    PcapLogData *pl = SCCalloc(1, sizeof(PcapLogData));
     if (unlikely(pl == NULL)) {
         FatalError("Failed to allocate Memory for PcapLogData");
     }
-    memset(pl, 0, sizeof(PcapLogData));
 
     pl->h = SCMalloc(sizeof(*pl->h));
     if (pl->h == NULL) {
@@ -1745,11 +1744,10 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
     SCTime_t ts = TimeGet();
 
     /* Place to store the name of our PCAP file */
-    PcapFileName *pf = SCMalloc(sizeof(PcapFileName));
+    PcapFileName *pf = SCCalloc(1, sizeof(PcapFileName));
     if (unlikely(pf == NULL)) {
         return -1;
     }
-    memset(pf, 0, sizeof(PcapFileName));
 
     if (pl->mode == LOGMODE_SGUIL) {
         struct tm local_tm;

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -165,10 +165,9 @@ static int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *s
 
 TmEcode LogStatsLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogStatsLogThread *aft = SCMalloc(sizeof(LogStatsLogThread));
+    LogStatsLogThread *aft = SCCalloc(1, sizeof(LogStatsLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogStatsLogThread));
 
     if(initdata == NULL)
     {
@@ -223,12 +222,11 @@ static OutputInitResult LogStatsLogInitCtx(ConfNode *conf)
         return result;
     }
 
-    LogStatsFileCtx *statslog_ctx = SCMalloc(sizeof(LogStatsFileCtx));
+    LogStatsFileCtx *statslog_ctx = SCCalloc(1, sizeof(LogStatsFileCtx));
     if (unlikely(statslog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
         return result;
     }
-    memset(statslog_ctx, 0x00, sizeof(LogStatsFileCtx));
 
     statslog_ctx->flags = LOG_STATS_TOTALS;
 

--- a/src/log-tcp-data.c
+++ b/src/log-tcp-data.c
@@ -165,10 +165,9 @@ int LogTcpDataLogger(ThreadVars *tv, void *thread_data, const Flow *f,
 
 TmEcode LogTcpDataLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogTcpDataLogThread *aft = SCMalloc(sizeof(LogTcpDataLogThread));
+    LogTcpDataLogThread *aft = SCCalloc(1, sizeof(LogTcpDataLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogTcpDataLogThread));
 
     if(initdata == NULL)
     {
@@ -222,12 +221,11 @@ OutputInitResult LogTcpDataLogInitCtx(ConfNode *conf)
         return result;
     }
 
-    LogTcpDataFileCtx *tcpdatalog_ctx = SCMalloc(sizeof(LogTcpDataFileCtx));
+    LogTcpDataFileCtx *tcpdatalog_ctx = SCCalloc(1, sizeof(LogTcpDataFileCtx));
     if (unlikely(tcpdatalog_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
         return result;
     }
-    memset(tcpdatalog_ctx, 0x00, sizeof(LogTcpDataFileCtx));
 
     tcpdatalog_ctx->file_ctx = file_ctx;
 

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -141,11 +141,9 @@ int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
 static TmEcode LogTlsLogThreadInit(ThreadVars *t, const void *initdata,
                                    void **data)
 {
-    LogTlsLogThread *aft = SCMalloc(sizeof(LogTlsLogThread));
+    LogTlsLogThread *aft = SCCalloc(1, sizeof(LogTlsLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-
-    memset(aft, 0, sizeof(LogTlsLogThread));
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for TLSLog. \"initdata\" argument NULL");

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -275,10 +275,9 @@ static int LogTlsStoreLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
 static TmEcode LogTlsStoreLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogTlsStoreLogThread *aft = SCMalloc(sizeof(LogTlsStoreLogThread));
+    LogTlsStoreLogThread *aft = SCCalloc(1, sizeof(LogTlsStoreLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(LogTlsStoreLogThread));
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for LogTLSStore. \"initdata\" argument NULL");

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -59,10 +59,9 @@ int OutputRegisterFileLogger(LoggerId id, const char *name, FileLogger LogFunc,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputFileLogger *op = SCMalloc(sizeof(*op));
+    OutputFileLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->output_ctx = output_ctx;
@@ -188,9 +187,8 @@ TmEcode OutputFileLogThreadInit(ThreadVars *tv, OutputFileLoggerThreadData **dat
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-/* todo */      BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                /* todo */ BUG_ON(ts == NULL);
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -57,10 +57,9 @@ int OutputRegisterFiledataLogger(LoggerId id, const char *name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputFiledataLogger *op = SCMalloc(sizeof(*op));
+    OutputFiledataLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->output_ctx = output_ctx;
@@ -204,10 +203,9 @@ void OutputFiledataLogFfc(ThreadVars *tv, OutputFiledataLoggerThreadData *td, Pa
  *  loggers */
 TmEcode OutputFiledataLogThreadInit(ThreadVars *tv, OutputFiledataLoggerThreadData **data)
 {
-    OutputFiledataLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputFiledataLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
     *data = td;
 
 #ifdef HAVE_MAGIC
@@ -225,9 +223,8 @@ TmEcode OutputFiledataLogThreadInit(ThreadVars *tv, OutputFiledataLoggerThreadDa
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
                 /* todo */ BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-filestore.c
+++ b/src/output-filestore.c
@@ -263,10 +263,9 @@ static int OutputFilestoreLogger(ThreadVars *tv, void *thread_data, const Packet
 static TmEcode OutputFilestoreLogThreadInit(ThreadVars *t, const void *initdata,
         void **data)
 {
-    OutputFilestoreLogThread *aft = SCMalloc(sizeof(OutputFilestoreLogThread));
+    OutputFilestoreLogThread *aft = SCCalloc(1, sizeof(OutputFilestoreLogThread));
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
-    memset(aft, 0, sizeof(OutputFilestoreLogThread));
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for LogFileStore. \"initdata\" argument NULL");

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -55,10 +55,9 @@ int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputFlowLogger *op = SCMalloc(sizeof(*op));
+    OutputFlowLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->output_ctx = output_ctx;
@@ -123,10 +122,9 @@ TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f)
  *  loggers */
 TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void *initdata, void **data)
 {
-    OutputFlowLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputFlowLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
 
@@ -137,9 +135,8 @@ TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void *initdata, void **data)
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-/* todo */      BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                /* todo */ BUG_ON(ts == NULL);
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1145,11 +1145,10 @@ static OutputInitResult JsonAlertLogInitCtxSub(ConfNode *conf, OutputCtx *parent
     if (unlikely(output_ctx == NULL))
         return result;
 
-    json_output_ctx = SCMalloc(sizeof(AlertJsonOutputCtx));
+    json_output_ctx = SCCalloc(1, sizeof(AlertJsonOutputCtx));
     if (unlikely(json_output_ctx == NULL)) {
         goto error;
     }
-    memset(json_output_ctx, 0, sizeof(AlertJsonOutputCtx));
 
     json_output_ctx->file_ctx = ajt->file_ctx;
     json_output_ctx->eve_ctx = ajt;

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -543,11 +543,10 @@ static OutputInitResult JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_c
 
     OutputJsonCtx *ojc = parent_ctx->data;
 
-    LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
+    LogDnsFileCtx *dnslog_ctx = SCCalloc(1, sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {
         return result;
     }
-    memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
     dnslog_ctx->eve_ctx = ojc;
 

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -477,11 +477,10 @@ static OutputInitResult JsonFrameLogInitCtxSub(ConfNode *conf, OutputCtx *parent
     if (unlikely(output_ctx == NULL))
         return result;
 
-    json_output_ctx = SCMalloc(sizeof(FrameJsonOutputCtx));
+    json_output_ctx = SCCalloc(1, sizeof(FrameJsonOutputCtx));
     if (unlikely(json_output_ctx == NULL)) {
         goto error;
     }
-    memset(json_output_ctx, 0, sizeof(FrameJsonOutputCtx));
 
     json_output_ctx->file_ctx = ajt->file_ctx;
     json_output_ctx->eve_ctx = ajt;

--- a/src/output-json-http2.c
+++ b/src/output-json-http2.c
@@ -153,7 +153,7 @@ static OutputInitResult OutputHttp2LogInitSub(ConfNode *conf, OutputCtx *parent_
     OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
-    OutputHttp2Ctx *http2_ctx = SCMalloc(sizeof(OutputHttp2Ctx));
+    OutputHttp2Ctx *http2_ctx = SCCalloc(1, sizeof(OutputHttp2Ctx));
     if (unlikely(http2_ctx == NULL))
         return result;
 

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -114,7 +114,7 @@ static OutputInitResult OutputPgsqlLogInitSub(ConfNode *conf, OutputCtx *parent_
     OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
-    OutputPgsqlCtx *pgsql_ctx = SCMalloc(sizeof(OutputPgsqlCtx));
+    OutputPgsqlCtx *pgsql_ctx = SCCalloc(1, sizeof(OutputPgsqlCtx));
     if (unlikely(pgsql_ctx == NULL))
         return result;
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -122,7 +122,7 @@ static OutputInitResult OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_c
     OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
-    OutputJsonEmailCtx *email_ctx = SCMalloc(sizeof(OutputJsonEmailCtx));
+    OutputJsonEmailCtx *email_ctx = SCCalloc(1, sizeof(OutputJsonEmailCtx));
     if (unlikely(email_ctx == NULL))
         return result;
 

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -608,10 +608,9 @@ static OutputInitResult OutputLuaLogInitSub(ConfNode *conf, OutputCtx *parent_ct
     if (conf == NULL)
         return result;
 
-    LogLuaCtx *lua_ctx = SCMalloc(sizeof(LogLuaCtx));
+    LogLuaCtx *lua_ctx = SCCalloc(1, sizeof(LogLuaCtx));
     if (unlikely(lua_ctx == NULL))
         return result;
-    memset(lua_ctx, 0x00, sizeof(*lua_ctx));
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
@@ -844,10 +843,9 @@ static void OutputLuaLogDoDeinit(LogLuaCtx *lua_ctx)
  */
 static TmEcode LuaLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
-    LogLuaThreadCtx *td = SCMalloc(sizeof(*td));
+    LogLuaThreadCtx *td = SCCalloc(1, sizeof(*td));
     if (unlikely(td == NULL))
         return TM_ECODE_FAILED;
-    memset(td, 0, sizeof(*td));
 
     if (initdata == NULL) {
         SCLogDebug("Error getting context for LuaLog. \"initdata\" argument NULL");

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -58,10 +58,9 @@ int OutputRegisterPacketLogger(LoggerId logger_id, const char *name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputPacketLogger *op = SCMalloc(sizeof(*op));
+    OutputPacketLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->ConditionFunc = ConditionFunc;
@@ -126,10 +125,9 @@ static TmEcode OutputPacketLog(ThreadVars *tv, Packet *p, void *thread_data)
  *  loggers */
 static TmEcode OutputPacketLogThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
-    OutputPacketLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputPacketLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
 
@@ -140,9 +138,8 @@ static TmEcode OutputPacketLogThreadInit(ThreadVars *tv, const void *initdata, v
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-/* todo */      BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                /* todo */ BUG_ON(ts == NULL);
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-stats.c
+++ b/src/output-stats.c
@@ -54,10 +54,9 @@ int OutputRegisterStatsLogger(const char *name, StatsLogger LogFunc,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputStatsLogger *op = SCMalloc(sizeof(*op));
+    OutputStatsLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->output_ctx = output_ctx;
@@ -112,10 +111,9 @@ TmEcode OutputStatsLog(ThreadVars *tv, void *thread_data, StatsTable *st)
  *  loggers */
 static TmEcode OutputStatsLogThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
-    OutputStatsLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputStatsLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
 
@@ -126,9 +124,8 @@ static TmEcode OutputStatsLogThreadInit(ThreadVars *tv, const void *initdata, vo
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-/* todo */      BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                /* todo */ BUG_ON(ts == NULL);
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -67,10 +67,9 @@ int OutputRegisterStreamingLogger(LoggerId id, const char *name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
-    OutputStreamingLogger *op = SCMalloc(sizeof(*op));
+    OutputStreamingLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->LogFunc = LogFunc;
     op->output_ctx = output_ctx;
@@ -365,10 +364,9 @@ static TmEcode OutputStreamingLog(ThreadVars *tv, Packet *p, void *thread_data)
  *  This will run the thread init functions for the individual registered
  *  loggers */
 static TmEcode OutputStreamingLogThreadInit(ThreadVars *tv, const void *initdata, void **data) {
-    OutputStreamingLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputStreamingLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
 
@@ -379,9 +377,8 @@ static TmEcode OutputStreamingLogThreadInit(ThreadVars *tv, const void *initdata
         if (logger->ThreadInit) {
             void *retptr = NULL;
             if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-/* todo */      BUG_ON(ts == NULL);
-                memset(ts, 0x00, sizeof(*ts));
+                OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                /* todo */ BUG_ON(ts == NULL);
 
                 /* store thread handle */
                 ts->thread_data = retptr;

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -77,10 +77,9 @@ int OutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto,
                 "%s logger not enabled: protocol %s is disabled", name, AppProtoToString(alproto));
         return -1;
     }
-    OutputTxLogger *op = SCMalloc(sizeof(*op));
+    OutputTxLogger *op = SCCalloc(1, sizeof(*op));
     if (op == NULL)
         return -1;
-    memset(op, 0x00, sizeof(*op));
 
     op->alproto = alproto;
     op->LogFunc = LogFunc;
@@ -541,10 +540,9 @@ end:
  *  loggers */
 static TmEcode OutputTxLogThreadInit(ThreadVars *tv, const void *_initdata, void **data)
 {
-    OutputTxLoggerThreadData *td = SCMalloc(sizeof(*td));
+    OutputTxLoggerThreadData *td = SCCalloc(1, sizeof(*td));
     if (td == NULL)
         return TM_ECODE_FAILED;
-    memset(td, 0x00, sizeof(*td));
 
     *data = (void *)td;
     SCLogDebug("OutputTxLogThreadInit happy (*data %p)", *data);
@@ -555,9 +553,8 @@ static TmEcode OutputTxLogThreadInit(ThreadVars *tv, const void *_initdata, void
             if (logger->ThreadInit) {
                 void *retptr = NULL;
                 if (logger->ThreadInit(tv, (void *)logger->output_ctx, &retptr) == TM_ECODE_OK) {
-                    OutputLoggerThreadStore *ts = SCMalloc(sizeof(*ts));
-    /* todo */      BUG_ON(ts == NULL);
-                    memset(ts, 0x00, sizeof(*ts));
+                    OutputLoggerThreadStore *ts = SCCalloc(1, sizeof(*ts));
+                    /* todo */ BUG_ON(ts == NULL);
 
                     /* store thread handle */
                     ts->thread_data = retptr;

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -80,10 +80,9 @@ static void SRepCIDRFreeUserData(void *data)
 static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8_t value)
 {
     SReputation *user_data = NULL;
-    if ((user_data = SCMalloc(sizeof(SReputation))) == NULL) {
+    if ((user_data = SCCalloc(1, sizeof(SReputation))) == NULL) {
         FatalError("Error allocating memory. Exiting");
     }
-    memset(user_data, 0x00, sizeof(SReputation));
 
     user_data->version = SRepGetVersion();
     user_data->rep[cat] = value;
@@ -486,10 +485,8 @@ int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)
                 //SCLogInfo("host %p", h);
 
                 if (h->iprep == NULL) {
-                    h->iprep = SCMalloc(sizeof(SReputation));
+                    h->iprep = SCCalloc(1, sizeof(SReputation));
                     if (h->iprep != NULL) {
-                        memset(h->iprep, 0x00, sizeof(SReputation));
-
                         HostIncrUsecnt(h);
                     }
                 }
@@ -588,10 +585,9 @@ int SRepInit(DetectEngineCtx *de_ctx)
     int init = 0;
     int i = 0;
 
-    de_ctx->srepCIDR_ctx = (SRepCIDRTree *)SCMalloc(sizeof(SRepCIDRTree));
+    de_ctx->srepCIDR_ctx = (SRepCIDRTree *)SCCalloc(1, sizeof(SRepCIDRTree));
     if (de_ctx->srepCIDR_ctx == NULL)
         exit(EXIT_FAILURE);
-    memset(de_ctx->srepCIDR_ctx, 0, sizeof(SRepCIDRTree));
     SRepCIDRTree *cidr_ctx = de_ctx->srepCIDR_ctx;
 
     for (i = 0; i < SREP_MAX_CATS; i++) {

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -272,12 +272,11 @@ static TmEcode UnixListAddFile(PcapCommand *this, const char *filename, const ch
     PcapFiles *cfile = NULL;
     if (filename == NULL || this == NULL)
         return TM_ECODE_FAILED;
-    cfile = SCMalloc(sizeof(PcapFiles));
+    cfile = SCCalloc(1, sizeof(PcapFiles));
     if (unlikely(cfile == NULL)) {
         SCLogError("Unable to allocate new file");
         return TM_ECODE_FAILED;
     }
-    memset(cfile, 0, sizeof(PcapFiles));
 
     cfile->filename = SCStrdup(filename);
     if (unlikely(cfile->filename == NULL)) {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -490,14 +490,13 @@ TmEcode AFPPeersListCheck(void)
 static TmEcode AFPPeersListAdd(AFPThreadVars *ptv)
 {
     SCEnter();
-    AFPPeer *peer = SCMalloc(sizeof(AFPPeer));
+    AFPPeer *peer = SCCalloc(1, sizeof(AFPPeer));
     AFPPeer *pitem;
     int mtu, out_mtu;
 
     if (unlikely(peer == NULL)) {
         SCReturnInt(TM_ECODE_FAILED);
     }
-    memset(peer, 0, sizeof(AFPPeer));
     SC_ATOMIC_INIT(peer->socket);
     SC_ATOMIC_INIT(peer->sock_usage);
     SC_ATOMIC_INIT(peer->if_idx);
@@ -2492,12 +2491,11 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    AFPThreadVars *ptv = SCMalloc(sizeof(AFPThreadVars));
+    AFPThreadVars *ptv = SCCalloc(1, sizeof(AFPThreadVars));
     if (unlikely(ptv == NULL)) {
         afpconfig->DerefFunc(afpconfig);
         SCReturnInt(TM_ECODE_FAILED);
     }
-    memset(ptv, 0, sizeof(AFPThreadVars));
 
     ptv->tv = tv;
 

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -602,12 +602,11 @@ static TmEcode ReceiveAFXDPThreadInit(ThreadVars *tv, const void *initdata, void
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    AFXDPThreadVars *ptv = SCMalloc(sizeof(AFXDPThreadVars));
+    AFXDPThreadVars *ptv = SCCalloc(1, sizeof(AFXDPThreadVars));
     if (unlikely(ptv == NULL)) {
         afxdpconfig->DerefFunc(afxdpconfig);
         SCReturnInt(TM_ECODE_FAILED);
     }
-    memset(ptv, 0, sizeof(AFXDPThreadVars));
 
     ptv->tv = tv;
 

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -186,12 +186,10 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ErfDagThreadVars *ewtn = SCMalloc(sizeof(ErfDagThreadVars));
+    ErfDagThreadVars *ewtn = SCMClloc(1, sizeof(ErfDagThreadVars));
     if (unlikely(ewtn == NULL)) {
         FatalError("Failed to allocate memory for ERF DAG thread vars.");
     }
-
-    memset(ewtn, 0, sizeof(*ewtn));
 
     /* dag_parse_name will return a DAG device name and stream number
      * to open for this thread.

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -233,13 +233,12 @@ ReceiveErfFileThreadInit(ThreadVars *tv, const void *initdata, void **data)
         exit(EXIT_FAILURE);
     }
 
-    ErfFileThreadVars *etv = SCMalloc(sizeof(ErfFileThreadVars));
+    ErfFileThreadVars *etv = SCCalloc(1, sizeof(ErfFileThreadVars));
     if (unlikely(etv == NULL)) {
         SCLogError("Failed to allocate memory for ERF file thread vars.");
         fclose(erf);
         SCReturnInt(TM_ECODE_FAILED);
     }
-    memset(etv, 0, sizeof(*etv));
     etv->erf = erf;
     etv->tv = tv;
     *data = (void *)etv;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -650,10 +650,8 @@ TmEcode VerdictIPFWThreadInit(ThreadVars *tv, const void *initdata, void **data)
     SCEnter();
 
     /* Setup Thread vars */
-    if ( (ptv = SCMalloc(sizeof(IPFWThreadVars))) == NULL)
+    if ((ptv = SCCalloc(1, sizeof(IPFWThreadVars))) == NULL)
         SCReturnInt(TM_ECODE_FAILED);
-    memset(ptv, 0, sizeof(IPFWThreadVars));
-
 
     *data = (void *)ptv;
 

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -219,12 +219,11 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, const void *initdata, void **data
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    NFLOGThreadVars *ntv = SCMalloc(sizeof(NFLOGThreadVars));
+    NFLOGThreadVars *ntv = SCCalloc(1, sizeof(NFLOGThreadVars));
     if (unlikely(ntv == NULL)) {
         nflconfig->DerefFunc(nflconfig);
         SCReturnInt(TM_ECODE_FAILED);
     }
-    memset(ntv, 0, sizeof(NFLOGThreadVars));
 
     ntv->tv = tv;
     ntv->group = nflconfig->group;

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -414,12 +414,11 @@ TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
             } else {
                 SCLogDebug("Processing file %s", current_file->filename);
 
-                PcapFileFileVars *pftv = SCMalloc(sizeof(PcapFileFileVars));
+                PcapFileFileVars *pftv = SCCalloc(1, sizeof(PcapFileFileVars));
                 if (unlikely(pftv == NULL)) {
                     SCLogError("Failed to allocate PcapFileFileVars");
                     SCReturnInt(TM_ECODE_FAILED);
                 }
-                memset(pftv, 0, sizeof(PcapFileFileVars));
 
                 pftv->filename = SCStrdup(current_file->filename);
                 if (unlikely(pftv->filename == NULL)) {

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -205,11 +205,10 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         SCReturnInt(TM_ECODE_OK);
     }
 
-    PcapFileThreadVars *ptv = SCMalloc(sizeof(PcapFileThreadVars));
+    PcapFileThreadVars *ptv = SCCalloc(1, sizeof(PcapFileThreadVars));
     if (unlikely(ptv == NULL)) {
         SCReturnInt(TM_ECODE_OK);
     }
-    memset(ptv, 0, sizeof(PcapFileThreadVars));
     memset(&ptv->shared.last_processed, 0, sizeof(struct timespec));
 
     intmax_t tenant = 0;
@@ -250,13 +249,12 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
 
     if(directory == NULL) {
         SCLogDebug("argument %s was a file", (char *)initdata);
-        PcapFileFileVars *pv = SCMalloc(sizeof(PcapFileFileVars));
+        PcapFileFileVars *pv = SCCalloc(1, sizeof(PcapFileFileVars));
         if (unlikely(pv == NULL)) {
             SCLogError("Failed to allocate file vars");
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);
         }
-        memset(pv, 0, sizeof(PcapFileFileVars));
 
         pv->filename = SCStrdup((char *)initdata);
         if (unlikely(pv->filename == NULL)) {
@@ -279,14 +277,13 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
         }
     } else {
         SCLogInfo("Argument %s was a directory", (char *)initdata);
-        PcapFileDirectoryVars *pv = SCMalloc(sizeof(PcapFileDirectoryVars));
+        PcapFileDirectoryVars *pv = SCCalloc(1, sizeof(PcapFileDirectoryVars));
         if (unlikely(pv == NULL)) {
             SCLogError("Failed to allocate directory vars");
             closedir(directory);
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);
         }
-        memset(pv, 0, sizeof(PcapFileDirectoryVars));
 
         pv->filename = SCStrdup((char*)initdata);
         if (unlikely(pv->filename == NULL)) {

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -497,12 +497,11 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, const void *initdata, void **dat
     if (pfconf == NULL)
         return TM_ECODE_FAILED;
 
-    PfringThreadVars *ptv = SCMalloc(sizeof(PfringThreadVars));
+    PfringThreadVars *ptv = SCCalloc(1, sizeof(PfringThreadVars));
     if (unlikely(ptv == NULL)) {
         pfconf->DerefFunc(pfconf);
         return TM_ECODE_FAILED;
     }
-    memset(ptv, 0, sizeof(PfringThreadVars));
 
     ptv->tv = tv;
     ptv->threads = 1;

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -561,11 +561,9 @@ void StreamTcpReassembleFree(bool quiet)
 TcpReassemblyThreadCtx *StreamTcpReassembleInitThreadCtx(ThreadVars *tv)
 {
     SCEnter();
-    TcpReassemblyThreadCtx *ra_ctx = SCMalloc(sizeof(TcpReassemblyThreadCtx));
+    TcpReassemblyThreadCtx *ra_ctx = SCCalloc(1, sizeof(TcpReassemblyThreadCtx));
     if (unlikely(ra_ctx == NULL))
         return NULL;
-
-    memset(ra_ctx, 0x00, sizeof(TcpReassemblyThreadCtx));
 
     ra_ctx->app_tctx = AppLayerGetCtxThread(tv);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5750,10 +5750,9 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueueNoLock *pq)
 TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 {
     SCEnter();
-    StreamTcpThread *stt = SCMalloc(sizeof(StreamTcpThread));
+    StreamTcpThread *stt = SCCalloc(1, sizeof(StreamTcpThread));
     if (unlikely(stt == NULL))
         SCReturnInt(TM_ECODE_FAILED);
-    memset(stt, 0, sizeof(StreamTcpThread));
     stt->ssn_pool_id = -1;
     StreamTcpThreadCacheEnable();
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -471,10 +471,9 @@ static int SetBpfString(int argc, char *argv[])
     if (bpf_len == 0)
         return TM_ECODE_OK;
 
-    bpf_filter = SCMalloc(bpf_len);
+    bpf_filter = SCCalloc(1, bpf_len);
     if (unlikely(bpf_filter == NULL))
         return TM_ECODE_FAILED;
-    memset(bpf_filter, 0x00, bpf_len);
 
     tmpindex = optind;
     while(argv[tmpindex] != NULL) {
@@ -519,12 +518,11 @@ static void SetBpfStringFromFile(char *filename)
     }
     bpf_len = st.st_size + 1;
 
-    bpf_filter = SCMalloc(bpf_len);
+    bpf_filter = SCCalloc(1, bpf_len);
     if (unlikely(bpf_filter == NULL)) {
         SCLogError("Failed to allocate buffer for bpf filter in file %s", filename);
         exit(EXIT_FAILURE);
     }
-    memset(bpf_filter, 0x00, bpf_len);
 
     nm = fread(bpf_filter, 1, bpf_len - 1, fp);
     if ((ferror(fp) != 0) || (nm != (bpf_len - 1))) {

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -639,10 +639,9 @@ error:
  */
 void TmSlotSetFuncAppend(ThreadVars *tv, TmModule *tm, const void *data)
 {
-    TmSlot *slot = SCMalloc(sizeof(TmSlot));
+    TmSlot *slot = SCCalloc(1, sizeof(TmSlot));
     if (unlikely(slot == NULL))
         return;
-    memset(slot, 0, sizeof(TmSlot));
     SC_ATOMIC_INITPTR(slot->slot_data);
     slot->SlotThreadInit = tm->ThreadInit;
     slot->slot_initdata = data;
@@ -913,10 +912,9 @@ ThreadVars *TmThreadCreate(const char *name, const char *inq_name, const char *i
     SCLogDebug("creating thread \"%s\"...", name);
 
     /* XXX create separate function for this: allocate a thread container */
-    tv = SCMalloc(sizeof(ThreadVars));
+    tv = SCCalloc(1, sizeof(ThreadVars));
     if (unlikely(tv == NULL))
         goto error;
-    memset(tv, 0, sizeof(ThreadVars));
 
     SC_ATOMIC_INIT(tv->flags);
     SCMutexInit(&tv->perf_public_ctx.m, NULL);

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -133,11 +133,10 @@ static int StoreQueueId(TmqhFlowCtx *ctx, char *name)
 
     if (ctx->queues == NULL) {
         ctx->size = 1;
-        ctx->queues = SCMalloc(ctx->size * sizeof(TmqhFlowMode));
+        ctx->queues = SCCalloc(1, ctx->size * sizeof(TmqhFlowMode));
         if (ctx->queues == NULL) {
             return -1;
         }
-        memset(ctx->queues, 0, ctx->size * sizeof(TmqhFlowMode));
     } else {
         ctx->size++;
         ptmp = SCRealloc(ctx->queues, ctx->size * sizeof(TmqhFlowMode));
@@ -172,10 +171,9 @@ void *TmqhOutputFlowSetupCtx(const char *queue_str)
 
     SCLogDebug("queue_str %s", queue_str);
 
-    TmqhFlowCtx *ctx = SCMalloc(sizeof(TmqhFlowCtx));
+    TmqhFlowCtx *ctx = SCCalloc(1, sizeof(TmqhFlowCtx));
     if (unlikely(ctx == NULL))
         return NULL;
-    memset(ctx,0x00,sizeof(TmqhFlowCtx));
 
     char *str = SCStrdup(queue_str);
     if (unlikely(str == NULL)) {

--- a/src/util-bloomfilter-counting.c
+++ b/src/util-bloomfilter-counting.c
@@ -48,20 +48,18 @@ BloomFilterCounting *BloomFilterCountingInit(uint32_t size, uint8_t type, uint8_
     }
 
     /* setup the filter */
-    bf = SCMalloc(sizeof(BloomFilterCounting));
+    bf = SCCalloc(1, sizeof(BloomFilterCounting));
     if (unlikely(bf == NULL))
         goto error;
-    memset(bf,0,sizeof(BloomFilterCounting));
     bf->type = type; /* size of the type: 1, 2, 4 */
     bf->array_size = size;
     bf->hash_iterations = iter;
     bf->Hash = Hash;
 
     /* setup the bitarray */
-    bf->array = SCMalloc(bf->array_size * bf->type);
+    bf->array = SCCalloc(1, bf->array_size * bf->type);
     if (bf->array == NULL)
         goto error;
-    memset(bf->array,0,bf->array_size * bf->type);
 
     return bf;
 

--- a/src/util-bloomfilter.c
+++ b/src/util-bloomfilter.c
@@ -40,19 +40,17 @@ BloomFilter *BloomFilterInit(uint32_t size, uint8_t iter,
     }
 
     /* setup the filter */
-    bf = SCMalloc(sizeof(BloomFilter));
+    bf = SCCalloc(1, sizeof(BloomFilter));
     if (unlikely(bf == NULL))
         goto error;
-    memset(bf,0,sizeof(BloomFilter));
     bf->bitarray_size = size;
     bf->hash_iterations = iter;
     bf->Hash = Hash;
 
     /* setup the bitarray */
-    bf->bitarray = SCMalloc((bf->bitarray_size/8)+1);
+    bf->bitarray = SCCalloc(1, (bf->bitarray_size / 8) + 1);
     if (bf->bitarray == NULL)
         goto error;
-    memset(bf->bitarray,0,(bf->bitarray_size/8)+1);
 
     return bf;
 

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -42,12 +42,11 @@ MemBuffer *MemBufferCreateNew(uint32_t size)
 
     uint32_t total_size = size + sizeof(MemBuffer);
 
-    MemBuffer *buffer = SCMalloc(total_size);
+    MemBuffer *buffer = SCCalloc(1, total_size);
     if (unlikely(buffer == NULL)) {
         sc_errno = SC_ENOMEM;
         return NULL;
     }
-    memset(buffer, 0, total_size);
 
     buffer->size = size;
     buffer->buffer = (uint8_t *)buffer + sizeof(MemBuffer);

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -392,9 +392,8 @@ static SCClassConfClasstype *SCClassConfAllocClasstype(uint16_t classtype_id,
     if (classtype == NULL)
         return NULL;
 
-    if ( (ct = SCMalloc(sizeof(SCClassConfClasstype))) == NULL)
+    if ((ct = SCCalloc(1, sizeof(SCClassConfClasstype))) == NULL)
         return NULL;
-    memset(ct, 0, sizeof(SCClassConfClasstype));
 
     if ((ct->classtype = SCClassConfStringToLowercase(classtype)) == NULL) {
         SCClassConfDeAllocClasstype(ct);

--- a/src/util-debug-filters.c
+++ b/src/util-debug-filters.c
@@ -579,11 +579,10 @@ int SCLogCheckFDFilterEntry(const char *function)
         return 1;
     }
 
-    if ( (thread_list_temp = SCMalloc(sizeof(SCLogFDFilterThreadList))) == NULL) {
+    if ((thread_list_temp = SCCalloc(1, sizeof(SCLogFDFilterThreadList))) == NULL) {
         SCMutexUnlock(&sc_log_fd_filters_tl_m);
         return 0;
     }
-    memset(thread_list_temp, 0, sizeof(SCLogFDFilterThreadList));
 
     thread_list_temp->t = self;
     thread_list_temp->entered++;
@@ -694,11 +693,10 @@ int SCLogAddFDFilter(const char *function)
         curr = curr->next;
     }
 
-    if ( (temp = SCMalloc(sizeof(SCLogFDFilter))) == NULL) {
-        printf("Error Allocating memory (SCMalloc)\n");
+    if ((temp = SCCalloc(1, sizeof(SCLogFDFilter))) == NULL) {
+        printf("Error Allocating memory (SCCalloc)\n");
         exit(EXIT_FAILURE);
     }
-    memset(temp, 0, sizeof(SCLogFDFilter));
 
     if ( (temp->func = SCStrdup(function)) == NULL) {
         printf("Error Allocating memory (SCStrdup)\n");
@@ -864,30 +862,27 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
     SCLogFGFilterFunc *fgf_func_temp = NULL;
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
-    if ( (fgf_file_temp = SCMalloc(sizeof(SCLogFGFilterFile))) == NULL) {
+    if ((fgf_file_temp = SCCalloc(1, sizeof(SCLogFGFilterFile))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
-    memset(fgf_file_temp, 0, sizeof(SCLogFGFilterFile));
 
     if ( file != NULL && (fgf_file_temp->file = SCStrdup(file)) == NULL) {
         printf("Error Allocating memory\n");
         exit(EXIT_FAILURE);
     }
 
-    if ( (fgf_func_temp = SCMalloc(sizeof(SCLogFGFilterFunc))) == NULL) {
+    if ((fgf_func_temp = SCCalloc(1, sizeof(SCLogFGFilterFunc))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
-    memset(fgf_func_temp, 0, sizeof(SCLogFGFilterFunc));
 
     if ( function != NULL && (fgf_func_temp->func = SCStrdup(function)) == NULL) {
         printf("Error Allocating memory\n");
         exit(EXIT_FAILURE);
     }
 
-    if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
+    if ((fgf_line_temp = SCCalloc(1, sizeof(SCLogFGFilterLine))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFFileList. Exiting...");
     }
-    memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 
     fgf_line_temp->line = line;
 
@@ -925,20 +920,18 @@ void SCLogAddToFGFFuncList(SCLogFGFilterFile *fgf_file,
     SCLogFGFilterFunc *fgf_func_temp = NULL;
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
-    if ( (fgf_func_temp = SCMalloc(sizeof(SCLogFGFilterFunc))) == NULL) {
+    if ((fgf_func_temp = SCCalloc(1, sizeof(SCLogFGFilterFunc))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
     }
-    memset(fgf_func_temp, 0, sizeof(SCLogFGFilterFunc));
 
     if ( function != NULL && (fgf_func_temp->func = SCStrdup(function)) == NULL) {
         printf("Error Allocating memory\n");
         exit(EXIT_FAILURE);
     }
 
-    if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
+    if ((fgf_line_temp = SCCalloc(1, sizeof(SCLogFGFilterLine))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFFuncList. Exiting...");
     }
-    memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 
     fgf_line_temp->line = line;
 
@@ -972,10 +965,9 @@ void SCLogAddToFGFLineList(SCLogFGFilterFunc *fgf_func,
 {
     SCLogFGFilterLine *fgf_line_temp = NULL;
 
-    if ( (fgf_line_temp = SCMalloc(sizeof(SCLogFGFilterLine))) == NULL) {
+    if ((fgf_line_temp = SCCalloc(1, sizeof(SCLogFGFilterLine))) == NULL) {
         FatalError("Fatal error encountered in SCLogAddToFGFLineList. Exiting...");
     }
-    memset(fgf_line_temp, 0, sizeof(SCLogFGFilterLine));
 
     fgf_line_temp->line = line;
 

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -266,11 +266,10 @@ void MimeDecFreeUrl(MimeDecUrl *url)
  */
 MimeDecField * MimeDecAddField(MimeDecEntity *entity)
 {
-    MimeDecField *node = SCMalloc(sizeof(MimeDecField));
+    MimeDecField *node = SCCalloc(1, sizeof(MimeDecField));
     if (unlikely(node == NULL)) {
         return NULL;
     }
-    memset(node, 0x00, sizeof(MimeDecField));
 
     /* If list is empty, then set as head of list */
     if (entity->field_list == NULL) {
@@ -351,11 +350,10 @@ MimeDecField * MimeDecFindField(const MimeDecEntity *entity, const char *name) {
  */
 static MimeDecUrl * MimeDecAddUrl(MimeDecEntity *entity, uint8_t *url, uint32_t url_len, uint8_t flags)
 {
-    MimeDecUrl *node = SCMalloc(sizeof(MimeDecUrl));
+    MimeDecUrl *node = SCCalloc(1, sizeof(MimeDecUrl));
     if (unlikely(node == NULL)) {
         return NULL;
     }
-    memset(node, 0x00, sizeof(MimeDecUrl));
 
     node->url = url;
     node->url_len = url_len;
@@ -384,11 +382,10 @@ static MimeDecUrl * MimeDecAddUrl(MimeDecEntity *entity, uint8_t *url, uint32_t 
  */
 MimeDecEntity * MimeDecAddEntity(MimeDecEntity *parent)
 {
-    MimeDecEntity *curr, *node = SCMalloc(sizeof(MimeDecEntity));
+    MimeDecEntity *curr, *node = SCCalloc(1, sizeof(MimeDecEntity));
     if (unlikely(node == NULL)) {
         return NULL;
     }
-    memset(node, 0x00, sizeof(MimeDecEntity));
 
     /* If parent is NULL then just return the new pointer */
     if (parent != NULL) {
@@ -466,7 +463,7 @@ static MimeDecStackNode * PushStack(MimeDecStack *stack)
     /* Attempt to pull from free nodes list */
     MimeDecStackNode *node = stack->free_nodes;
     if (node == NULL) {
-        node = SCMalloc(sizeof(MimeDecStackNode));
+        node = SCCalloc(1, sizeof(MimeDecStackNode));
         if (unlikely(node == NULL)) {
             return NULL;
         }
@@ -474,8 +471,8 @@ static MimeDecStackNode * PushStack(MimeDecStack *stack)
         /* Move free nodes pointer over */
         stack->free_nodes = stack->free_nodes->next;
         stack->free_nodes_cnt--;
+        memset(node, 0x00, sizeof(MimeDecStackNode));
     }
-    memset(node, 0x00, sizeof(MimeDecStackNode));
 
     /* Push to top of stack */
     node->next = stack->top;
@@ -563,11 +560,10 @@ static void FreeMimeDecStack(MimeDecStack *stack)
  */
 static DataValue * AddDataValue(DataValue *dv)
 {
-    DataValue *curr, *node = SCMalloc(sizeof(DataValue));
+    DataValue *curr, *node = SCCalloc(1, sizeof(DataValue));
     if (unlikely(node == NULL)) {
         return NULL;
     }
-    memset(node, 0x00, sizeof(DataValue));
 
     if (dv != NULL) {
         curr = dv;
@@ -2403,26 +2399,23 @@ MimeDecParseState * MimeDecInitParser(void *data,
     MimeDecParseState *state;
     MimeDecEntity *mimeMsg;
 
-    state = SCMalloc(sizeof(MimeDecParseState));
+    state = SCCalloc(1, sizeof(MimeDecParseState));
     if (unlikely(state == NULL)) {
         return NULL;
     }
-    memset(state, 0x00, sizeof(MimeDecParseState));
 
-    state->stack = SCMalloc(sizeof(MimeDecStack));
+    state->stack = SCCalloc(1, sizeof(MimeDecStack));
     if (unlikely(state->stack == NULL)) {
         SCFree(state);
         return NULL;
     }
-    memset(state->stack, 0x00, sizeof(MimeDecStack));
 
-    mimeMsg = SCMalloc(sizeof(MimeDecEntity));
+    mimeMsg = SCCalloc(1, sizeof(MimeDecEntity));
     if (unlikely(mimeMsg == NULL)) {
         SCFree(state->stack);
         SCFree(state);
         return NULL;
     }
-    memset(mimeMsg, 0x00, sizeof(MimeDecEntity));
     mimeMsg->ctnt_flags |= CTNT_IS_MSG;
 
     /* Init state */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -493,12 +493,11 @@ static void FilePrune(FileContainer *ffc, const StreamingBufferConfig *cfg)
  */
 FileContainer *FileContainerAlloc(void)
 {
-    FileContainer *new = SCMalloc(sizeof(FileContainer));
+    FileContainer *new = SCCalloc(1, sizeof(FileContainer));
     if (unlikely(new == NULL)) {
         SCLogError("Error allocating mem");
         return NULL;
     }
-    memset(new, 0, sizeof(FileContainer));
     new->head = new->tail = NULL;
     return new;
 }
@@ -554,12 +553,11 @@ void FileContainerFree(FileContainer *ffc, const StreamingBufferConfig *cfg)
  */
 static File *FileAlloc(const uint8_t *name, uint16_t name_len)
 {
-    File *new = SCMalloc(sizeof(File));
+    File *new = SCCalloc(1, sizeof(File));
     if (unlikely(new == NULL)) {
         SCLogError("Error allocating mem");
         return NULL;
     }
-    memset(new, 0, sizeof(File));
 
     new->name = SCMalloc(name_len);
     if (new->name == NULL) {

--- a/src/util-fmemopen.c
+++ b/src/util-fmemopen.c
@@ -183,11 +183,10 @@ static int CloseFn(void *handler)
  */
 FILE *SCFmemopen(void *buf, size_t size, const char *mode)
 {
-    SCFmem *mem = (SCFmem *) SCMalloc(sizeof(SCFmem));
+    SCFmem *mem = (SCFmem *)SCCalloc(1, sizeof(SCFmem));
     if (mem == NULL)
         return NULL;
 
-    memset(mem, 0, sizeof(SCFmem));
     mem->size = size, mem->buffer = buf;
 
     return funopen(mem, ReadFn, WriteFn, SeekFn, CloseFn);

--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -46,10 +46,9 @@ HashTable* HashTableInit(uint32_t size, uint32_t (*Hash)(struct HashTable_ *, vo
     }
 
     /* setup the filter */
-    ht = SCMalloc(sizeof(HashTable));
+    ht = SCCalloc(1, sizeof(HashTable));
     if (unlikely(ht == NULL))
-    goto error;
-    memset(ht,0,sizeof(HashTable));
+        goto error;
     ht->array_size = size;
     ht->Hash = Hash;
     ht->Free = Free;
@@ -60,10 +59,9 @@ HashTable* HashTableInit(uint32_t size, uint32_t (*Hash)(struct HashTable_ *, vo
         ht->Compare = HashTableDefaultCompare;
 
     /* setup the bitarray */
-    ht->array = SCMalloc(ht->array_size * sizeof(HashTableBucket *));
+    ht->array = SCCalloc(1, ht->array_size * sizeof(HashTableBucket *));
     if (ht->array == NULL)
         goto error;
-    memset(ht->array,0,ht->array_size * sizeof(HashTableBucket *));
 
     return ht;
 
@@ -118,10 +116,9 @@ int HashTableAdd(HashTable *ht, void *data, uint16_t datalen)
 
     uint32_t hash = ht->Hash(ht, data, datalen);
 
-    HashTableBucket *hb = SCMalloc(sizeof(HashTableBucket));
+    HashTableBucket *hb = SCCalloc(1, sizeof(HashTableBucket));
     if (unlikely(hb == NULL))
         goto error;
-    memset(hb, 0, sizeof(HashTableBucket));
     hb->data = data;
     hb->size = datalen;
     hb->next = NULL;

--- a/src/util-hashlist.c
+++ b/src/util-hashlist.c
@@ -50,12 +50,11 @@ HashListTable *HashListTableInit(uint32_t size,
     }
 
     /* setup the filter */
-    ht = SCMalloc(sizeof(HashListTable));
+    ht = SCCalloc(1, sizeof(HashListTable));
     if (unlikely(ht == NULL)) {
         sc_errno = SC_ENOMEM;
         goto error;
     }
-    memset(ht,0,sizeof(HashListTable));
     ht->array_size = size;
     ht->Hash = Hash;
     ht->Free = Free;
@@ -66,12 +65,11 @@ HashListTable *HashListTableInit(uint32_t size,
         ht->Compare = HashListTableDefaultCompare;
 
     /* setup the bitarray */
-    ht->array = SCMalloc(ht->array_size * sizeof(HashListTableBucket *));
+    ht->array = SCCalloc(1, ht->array_size * sizeof(HashListTableBucket *));
     if (ht->array == NULL) {
         sc_errno = SC_ENOMEM;
         goto error;
     }
-    memset(ht->array,0,ht->array_size * sizeof(HashListTableBucket *));
 
     ht->listhead = NULL;
     ht->listtail = NULL;
@@ -130,10 +128,9 @@ int HashListTableAdd(HashListTable *ht, void *data, uint16_t datalen)
 
     SCLogDebug("ht %p hash %"PRIu32"", ht, hash);
 
-    HashListTableBucket *hb = SCMalloc(sizeof(HashListTableBucket));
+    HashListTableBucket *hb = SCCalloc(1, sizeof(HashListTableBucket));
     if (unlikely(hb == NULL))
         goto error;
-    memset(hb, 0, sizeof(HashListTableBucket));
     hb->data = data;
     hb->size = datalen;
     hb->bucknext = NULL;

--- a/src/util-hyperscan.c
+++ b/src/util-hyperscan.c
@@ -43,11 +43,10 @@ char *HSRenderPattern(const uint8_t *pat, uint16_t pat_len)
         return NULL;
     }
     const size_t hex_len = (pat_len * 4) + 1;
-    char *str = SCMalloc(hex_len);
+    char *str = SCCalloc(1, hex_len);
     if (str == NULL) {
         return NULL;
     }
-    memset(str, 0, hex_len);
     char *sp = str;
     for (uint16_t i = 0; i < pat_len; i++) {
         snprintf(sp, 5, "\\x%02x", pat[i]);

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -428,11 +428,10 @@ static inline void SCACBSCreateFailureTable(MpmCtx *mpm_ctx)
 
     /* allot space for the failure table.  A failure entry in the table for
      * every state(SCACBSCtx->state_count) */
-    ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
+    ctx->failure_table = SCCalloc(1, ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
         FatalError("Error allocating memory");
     }
-    memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
     /* add the failure transitions for the 0th state, and add every non-fail
      * transition from the 0th state to the queue for further processing
@@ -680,23 +679,20 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
          * but by avoiding it, we save a lot of time on handling alignment */
         size += (ctx->state_count * sizeof(SC_AC_BS_STATE_TYPE_U16) +
                  256 * sizeof(SC_AC_BS_STATE_TYPE_U16) * 1);
-        ctx->state_table_mod = SCMalloc(size);
+        ctx->state_table_mod = SCCalloc(1, size);
         if (ctx->state_table_mod == NULL) {
             FatalError("Error allocating memory");
         }
-        memset(ctx->state_table_mod, 0, size);
 
         mpm_ctx->memory_cnt++;
         mpm_ctx->memory_size += size;
 
         /* buffer to hold pointers in the buffer, so that a state can use it
          * directly to access its state data */
-        ctx->state_table_mod_pointers = SCMalloc(ctx->state_count * sizeof(uint8_t *));
+        ctx->state_table_mod_pointers = SCCalloc(1, ctx->state_count * sizeof(uint8_t *));
         if (ctx->state_table_mod_pointers == NULL) {
             FatalError("Error allocating memory");
         }
-        memset(ctx->state_table_mod_pointers, 0,
-               ctx->state_count * sizeof(uint8_t *));
 
         SC_AC_BS_STATE_TYPE_U16 temp_states[256];
         uint16_t *curr_loc = (uint16_t *)ctx->state_table_mod;
@@ -752,23 +748,20 @@ static inline void SCACBSCreateModDeltaTable(MpmCtx *mpm_ctx)
          * but by avoiding it, we save a lot of time on handling alignment */
         size += (ctx->state_count * sizeof(SC_AC_BS_STATE_TYPE_U32) +
                  256 * sizeof(SC_AC_BS_STATE_TYPE_U32) * 1);
-        ctx->state_table_mod = SCMalloc(size);
+        ctx->state_table_mod = SCCalloc(1, size);
         if (ctx->state_table_mod == NULL) {
             FatalError("Error allocating memory");
         }
-        memset(ctx->state_table_mod, 0, size);
 
         mpm_ctx->memory_cnt++;
         mpm_ctx->memory_size += size;
 
         /* buffer to hold pointers in the buffer, so that a state can use it
          * directly to access its state data */
-        ctx->state_table_mod_pointers = SCMalloc(ctx->state_count * sizeof(uint8_t *));
+        ctx->state_table_mod_pointers = SCCalloc(1, ctx->state_count * sizeof(uint8_t *));
         if (ctx->state_table_mod_pointers == NULL) {
             FatalError("Error allocating memory");
         }
-        memset(ctx->state_table_mod_pointers, 0,
-               ctx->state_count * sizeof(uint8_t *));
 
         SC_AC_BS_STATE_TYPE_U32 temp_states[256];
         uint32_t *curr_loc = (uint32_t *)ctx->state_table_mod;
@@ -876,11 +869,9 @@ int SCACBSPreparePatterns(MpmCtx *mpm_ctx)
     }
 
     /* alloc the pattern array */
-    ctx->parray = (MpmPattern **)SCMalloc(mpm_ctx->pattern_cnt *
-                                           sizeof(MpmPattern *));
+    ctx->parray = (MpmPattern **)SCCalloc(1, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
     if (ctx->parray == NULL)
         goto error;
-    memset(ctx->parray, 0, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += (mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
 
@@ -904,11 +895,10 @@ int SCACBSPreparePatterns(MpmCtx *mpm_ctx)
     ctx->single_state_size = sizeof(int32_t) * 256;
 
     /* handle no case patterns */
-    ctx->pid_pat_list = SCMalloc((mpm_ctx->max_pat_id + 1)* sizeof(SCACBSPatternList));
+    ctx->pid_pat_list = SCCalloc(1, (mpm_ctx->max_pat_id + 1) * sizeof(SCACBSPatternList));
     if (ctx->pid_pat_list == NULL) {
         FatalError("Error allocating memory");
     }
-    memset(ctx->pid_pat_list, 0, (mpm_ctx->max_pat_id + 1) * sizeof(SCACBSPatternList));
 
     for (i = 0; i < mpm_ctx->pattern_cnt; i++) {
         if (!(ctx->parray[i]->flags & MPM_PATTERN_FLAG_NOCASE)) {
@@ -959,11 +949,10 @@ void SCACBSInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
 {
     memset(mpm_thread_ctx, 0, sizeof(MpmThreadCtx));
 
-    mpm_thread_ctx->ctx = SCMalloc(sizeof(SCACBSThreadCtx));
+    mpm_thread_ctx->ctx = SCCalloc(1, sizeof(SCACBSThreadCtx));
     if (mpm_thread_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_thread_ctx->ctx, 0, sizeof(SCACBSThreadCtx));
     mpm_thread_ctx->memory_cnt++;
     mpm_thread_ctx->memory_size += sizeof(SCACBSThreadCtx);
 
@@ -980,21 +969,19 @@ void SCACBSInitCtx(MpmCtx *mpm_ctx)
     if (mpm_ctx->ctx != NULL)
         return;
 
-    mpm_ctx->ctx = SCMalloc(sizeof(SCACBSCtx));
+    mpm_ctx->ctx = SCCalloc(1, sizeof(SCACBSCtx));
     if (mpm_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->ctx, 0, sizeof(SCACBSCtx));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCACBSCtx);
 
     /* initialize the hash we use to speed up pattern insertions */
-    mpm_ctx->init_hash = SCMalloc(sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
+    mpm_ctx->init_hash = SCCalloc(1, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
     if (mpm_ctx->init_hash == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->init_hash, 0, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
 
     /* get conf values for AC from our yaml file.  We have no conf values for
      * now.  We will certainly need this, as we develop the algo */

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -511,11 +511,10 @@ static void SCACTileCreateFailureTable(MpmCtx *mpm_ctx)
 
     /* Allocate space for the failure table.  A failure entry in the table for
      * every state(SCACTileCtx->state_count) */
-    ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
+    ctx->failure_table = SCCalloc(1, ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
         FatalError("Error allocating memory");
     }
-    memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
     /* Add the failure transitions for the 0th state, and add every non-fail
      * transition from the 0th state to the queue for further processing
@@ -712,11 +711,10 @@ static void SCACTileClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
 
     /* Allocate next-state table. */
     int size = ctx->state_count * ctx->bytes_per_state * ctx->alphabet_storage;
-    void *state_table = SCMalloc(size);
+    void *state_table = SCCalloc(1, size);
     if (unlikely(state_table == NULL)) {
         FatalError("Error allocating memory");
     }
-    memset(state_table, 0, size);
     ctx->state_table = state_table;
 
     mpm_ctx->memory_cnt++;
@@ -879,11 +877,9 @@ int SCACTilePreparePatterns(MpmCtx *mpm_ctx)
     }
 
     /* alloc the pattern array */
-    ctx->parray = (MpmPattern **)SCMalloc(mpm_ctx->pattern_cnt *
-                                               sizeof(MpmPattern *));
+    ctx->parray = (MpmPattern **)SCCalloc(1, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
     if (ctx->parray == NULL)
         goto error;
-    memset(ctx->parray, 0, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
 
     /* populate it with the patterns in the hash */
     uint32_t i = 0, p = 0;
@@ -971,11 +967,10 @@ void SCACTileInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
 {
     memset(mpm_thread_ctx, 0, sizeof(MpmThreadCtx));
 
-    mpm_thread_ctx->ctx = SCMalloc(sizeof(SCACTileThreadCtx));
+    mpm_thread_ctx->ctx = SCCalloc(1, sizeof(SCACTileThreadCtx));
     if (mpm_thread_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_thread_ctx->ctx, 0, sizeof(SCACTileThreadCtx));
     mpm_thread_ctx->memory_cnt++;
     mpm_thread_ctx->memory_size += sizeof(SCACTileThreadCtx);
 }
@@ -991,11 +986,10 @@ void SCACTileInitCtx(MpmCtx *mpm_ctx)
         return;
 
     /* Search Context */
-    mpm_ctx->ctx = SCMalloc(sizeof(SCACTileSearchCtx));
+    mpm_ctx->ctx = SCCalloc(1, sizeof(SCACTileSearchCtx));
     if (mpm_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->ctx, 0, sizeof(SCACTileSearchCtx));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCACTileSearchCtx);
@@ -1003,21 +997,19 @@ void SCACTileInitCtx(MpmCtx *mpm_ctx)
     SCACTileSearchCtx *search_ctx = (SCACTileSearchCtx *)mpm_ctx->ctx;
 
     /* MPM Creation context */
-    search_ctx->init_ctx = SCMalloc(sizeof(SCACTileCtx));
+    search_ctx->init_ctx = SCCalloc(1, sizeof(SCACTileCtx));
     if (search_ctx->init_ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(search_ctx->init_ctx, 0, sizeof(SCACTileCtx));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCACTileCtx);
 
     /* initialize the hash we use to speed up pattern insertions */
-    mpm_ctx->init_hash = SCMalloc(sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
+    mpm_ctx->init_hash = SCCalloc(1, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
     if (mpm_ctx->init_hash == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->init_hash, 0, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
 
     /* get conf values for AC from our yaml file.  We have no conf values for
      * now.  We will certainly need this, as we develop the algo */

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -479,11 +479,10 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
 
     /* allot space for the failure table.  A failure entry in the table for
      * every state(SCACCtx->state_count) */
-    ctx->failure_table = SCMalloc(ctx->state_count * sizeof(int32_t));
+    ctx->failure_table = SCCalloc(1, ctx->state_count * sizeof(int32_t));
     if (ctx->failure_table == NULL) {
         FatalError("Error allocating memory");
     }
-    memset(ctx->failure_table, 0, ctx->state_count * sizeof(int32_t));
 
     /* add the failure transitions for the 0th state, and add every non-fail
      * transition from the 0th state to the queue for further processing
@@ -740,11 +739,9 @@ int SCACPreparePatterns(MpmCtx *mpm_ctx)
     }
 
     /* alloc the pattern array */
-    ctx->parray = (MpmPattern **)SCMalloc(mpm_ctx->pattern_cnt *
-                                           sizeof(MpmPattern *));
+    ctx->parray = (MpmPattern **)SCCalloc(1, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
     if (ctx->parray == NULL)
         goto error;
-    memset(ctx->parray, 0, mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += (mpm_ctx->pattern_cnt * sizeof(MpmPattern *));
 
@@ -768,11 +765,10 @@ int SCACPreparePatterns(MpmCtx *mpm_ctx)
     ctx->single_state_size = sizeof(int32_t) * 256;
 
     /* handle no case patterns */
-    ctx->pid_pat_list = SCMalloc((mpm_ctx->max_pat_id + 1)* sizeof(SCACPatternList));
+    ctx->pid_pat_list = SCCalloc(1, (mpm_ctx->max_pat_id + 1) * sizeof(SCACPatternList));
     if (ctx->pid_pat_list == NULL) {
         FatalError("Error allocating memory");
     }
-    memset(ctx->pid_pat_list, 0, (mpm_ctx->max_pat_id + 1) * sizeof(SCACPatternList));
 
     for (i = 0; i < mpm_ctx->pattern_cnt; i++) {
         if (!(ctx->parray[i]->flags & MPM_PATTERN_FLAG_NOCASE)) {
@@ -830,11 +826,10 @@ void SCACInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
 {
     memset(mpm_thread_ctx, 0, sizeof(MpmThreadCtx));
 
-    mpm_thread_ctx->ctx = SCMalloc(sizeof(SCACThreadCtx));
+    mpm_thread_ctx->ctx = SCCalloc(1, sizeof(SCACThreadCtx));
     if (mpm_thread_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_thread_ctx->ctx, 0, sizeof(SCACThreadCtx));
     mpm_thread_ctx->memory_cnt++;
     mpm_thread_ctx->memory_size += sizeof(SCACThreadCtx);
 
@@ -851,21 +846,19 @@ void SCACInitCtx(MpmCtx *mpm_ctx)
     if (mpm_ctx->ctx != NULL)
         return;
 
-    mpm_ctx->ctx = SCMalloc(sizeof(SCACCtx));
+    mpm_ctx->ctx = SCCalloc(1, sizeof(SCACCtx));
     if (mpm_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->ctx, 0, sizeof(SCACCtx));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCACCtx);
 
     /* initialize the hash we use to speed up pattern insertions */
-    mpm_ctx->init_hash = SCMalloc(sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
+    mpm_ctx->init_hash = SCCalloc(1, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
     if (mpm_ctx->init_hash == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->init_hash, 0, sizeof(MpmPattern *) * MPM_INIT_HASH_SIZE);
 
     /* get conf values for AC from our yaml file.  We have no conf values for
      * now.  We will certainly need this, as we develop the algo */

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -178,11 +178,10 @@ static inline SCHSPattern *SCHSInitHashLookup(SCHSCtx *ctx, uint8_t *pat,
  */
 static inline SCHSPattern *SCHSAllocPattern(MpmCtx *mpm_ctx)
 {
-    SCHSPattern *p = SCMalloc(sizeof(SCHSPattern));
+    SCHSPattern *p = SCCalloc(1, sizeof(SCHSPattern));
     if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(p, 0, sizeof(SCHSPattern));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCHSPattern);
@@ -380,37 +379,32 @@ typedef struct SCHSCompileData_ {
 
 static SCHSCompileData *SCHSAllocCompileData(unsigned int pattern_cnt)
 {
-    SCHSCompileData *cd = SCMalloc(pattern_cnt * sizeof(SCHSCompileData));
+    SCHSCompileData *cd = SCCalloc(1, pattern_cnt * sizeof(SCHSCompileData));
     if (cd == NULL) {
         goto error;
     }
-    memset(cd, 0, pattern_cnt * sizeof(SCHSCompileData));
 
     cd->pattern_cnt = pattern_cnt;
 
-    cd->ids = SCMalloc(pattern_cnt * sizeof(unsigned int));
+    cd->ids = SCCalloc(1, pattern_cnt * sizeof(unsigned int));
     if (cd->ids == NULL) {
         goto error;
     }
-    memset(cd->ids, 0, pattern_cnt * sizeof(unsigned int));
 
-    cd->flags = SCMalloc(pattern_cnt * sizeof(unsigned int));
+    cd->flags = SCCalloc(1, pattern_cnt * sizeof(unsigned int));
     if (cd->flags == NULL) {
         goto error;
     }
-    memset(cd->flags, 0, pattern_cnt * sizeof(unsigned int));
 
-    cd->expressions = SCMalloc(pattern_cnt * sizeof(char *));
+    cd->expressions = SCCalloc(1, pattern_cnt * sizeof(char *));
     if (cd->expressions == NULL) {
         goto error;
     }
-    memset(cd->expressions, 0, pattern_cnt * sizeof(char *));
 
-    cd->ext = SCMalloc(pattern_cnt * sizeof(hs_expr_ext_t *));
+    cd->ext = SCCalloc(1, pattern_cnt * sizeof(hs_expr_ext_t *));
     if (cd->ext == NULL) {
         goto error;
     }
-    memset(cd->ext, 0, pattern_cnt * sizeof(hs_expr_ext_t *));
 
     return cd;
 
@@ -556,23 +550,20 @@ static void PatternDatabaseTableFree(void *data)
 
 static PatternDatabase *PatternDatabaseAlloc(uint32_t pattern_cnt)
 {
-    PatternDatabase *pd = SCMalloc(sizeof(PatternDatabase));
+    PatternDatabase *pd = SCCalloc(1, sizeof(PatternDatabase));
     if (pd == NULL) {
         return NULL;
     }
-    memset(pd, 0, sizeof(PatternDatabase));
     pd->pattern_cnt = pattern_cnt;
     pd->ref_cnt = 0;
     pd->hs_db = NULL;
 
     /* alloc the pattern array */
-    pd->parray =
-        (SCHSPattern **)SCMalloc(pd->pattern_cnt * sizeof(SCHSPattern *));
+    pd->parray = (SCHSPattern **)SCCalloc(1, pd->pattern_cnt * sizeof(SCHSPattern *));
     if (pd->parray == NULL) {
         SCFree(pd);
         return NULL;
     }
-    memset(pd->parray, 0, pd->pattern_cnt * sizeof(SCHSPattern *));
 
     return pd;
 }
@@ -667,12 +658,11 @@ int SCHSPreparePatterns(MpmCtx *mpm_ctx)
         cd->expressions[i] = HSRenderPattern(p->original_pat, p->len);
 
         if (p->flags & (MPM_PATTERN_FLAG_OFFSET | MPM_PATTERN_FLAG_DEPTH)) {
-            cd->ext[i] = SCMalloc(sizeof(hs_expr_ext_t));
+            cd->ext[i] = SCCalloc(1, sizeof(hs_expr_ext_t));
             if (cd->ext[i] == NULL) {
                 SCMutexUnlock(&g_db_table_mutex);
                 goto error;
             }
-            memset(cd->ext[i], 0, sizeof(hs_expr_ext_t));
 
             if (p->flags & MPM_PATTERN_FLAG_OFFSET) {
                 cd->ext[i]->flags |= HS_EXT_FLAG_MIN_OFFSET;
@@ -756,13 +746,12 @@ void SCHSInitThreadCtx(MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx)
 {
     memset(mpm_thread_ctx, 0, sizeof(MpmThreadCtx));
 
-    SCHSThreadCtx *ctx = SCMalloc(sizeof(SCHSThreadCtx));
+    SCHSThreadCtx *ctx = SCCalloc(1, sizeof(SCHSThreadCtx));
     if (ctx == NULL) {
         exit(EXIT_FAILURE);
     }
     mpm_thread_ctx->ctx = ctx;
 
-    memset(ctx, 0, sizeof(SCHSThreadCtx));
     mpm_thread_ctx->memory_cnt++;
     mpm_thread_ctx->memory_size += sizeof(SCHSThreadCtx);
 
@@ -807,22 +796,20 @@ void SCHSInitCtx(MpmCtx *mpm_ctx)
     if (mpm_ctx->ctx != NULL)
         return;
 
-    mpm_ctx->ctx = SCMalloc(sizeof(SCHSCtx));
+    mpm_ctx->ctx = SCCalloc(1, sizeof(SCHSCtx));
     if (mpm_ctx->ctx == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(mpm_ctx->ctx, 0, sizeof(SCHSCtx));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(SCHSCtx);
 
     /* initialize the hash we use to speed up pattern insertions */
     SCHSCtx *ctx = (SCHSCtx *)mpm_ctx->ctx;
-    ctx->init_hash = SCMalloc(sizeof(SCHSPattern *) * INIT_HASH_SIZE);
+    ctx->init_hash = SCCalloc(1, sizeof(SCHSPattern *) * INIT_HASH_SIZE);
     if (ctx->init_hash == NULL) {
         exit(EXIT_FAILURE);
     }
-    memset(ctx->init_hash, 0, sizeof(SCHSPattern *) * INIT_HASH_SIZE);
 }
 
 /**

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -133,11 +133,10 @@ int32_t MpmFactoryIsMpmCtxAvailable(const DetectEngineCtx *de_ctx, const MpmCtx 
 MpmCtx *MpmFactoryGetMpmCtxForProfile(const DetectEngineCtx *de_ctx, int32_t id, int direction)
 {
     if (id == MPM_CTX_FACTORY_UNIQUE_CONTEXT) {
-        MpmCtx *mpm_ctx = SCMalloc(sizeof(MpmCtx));
+        MpmCtx *mpm_ctx = SCCalloc(1, sizeof(MpmCtx));
         if (unlikely(mpm_ctx == NULL)) {
             FatalError("Error allocating memory");
         }
-        memset(mpm_ctx, 0, sizeof(MpmCtx));
         return mpm_ctx;
     } else if (id < -1) {
         SCLogError("Invalid argument - %d\n", id);
@@ -330,11 +329,10 @@ static inline MpmPattern *MpmInitHashLookup(MpmCtx *ctx,
  */
 static inline MpmPattern *MpmAllocPattern(MpmCtx *mpm_ctx)
 {
-    MpmPattern *p = SCMalloc(sizeof(MpmPattern));
+    MpmPattern *p = SCCalloc(1, sizeof(MpmPattern));
     if (unlikely(p == NULL)) {
         exit(EXIT_FAILURE);
     }
-    memset(p, 0, sizeof(MpmPattern));
 
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += sizeof(MpmPattern);

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -107,13 +107,11 @@ Pool *PoolInit(uint32_t size, uint32_t prealloc_size, uint32_t elt_size,
     }
 
     /* setup the filter */
-    p = SCMalloc(sizeof(Pool));
+    p = SCCalloc(1, sizeof(Pool));
     if (unlikely(p == NULL)) {
         sc_errno = SC_ENOMEM;
         goto error;
     }
-
-    memset(p,0,sizeof(Pool));
 
     p->max_buckets = size;
     p->preallocated = prealloc_size;
@@ -158,12 +156,11 @@ Pool *PoolInit(uint32_t size, uint32_t prealloc_size, uint32_t elt_size,
     /* prealloc the buckets and requeue them to the alloc list */
     for (u32 = 0; u32 < prealloc_size; u32++) {
         if (size == 0) { /* unlimited */
-            PoolBucket *pb = SCMalloc(sizeof(PoolBucket));
+            PoolBucket *pb = SCCalloc(1, sizeof(PoolBucket));
             if (unlikely(pb == NULL)) {
                 sc_errno = SC_ENOMEM;
                 goto error;
             }
-            memset(pb, 0, sizeof(PoolBucket));
 
             if (p->Alloc) {
                 pb->data = p->Alloc();

--- a/src/util-profiling-keywords.c
+++ b/src/util-profiling-keywords.c
@@ -241,9 +241,8 @@ SCProfilingKeywordUpdateCounter(DetectEngineThreadCtx *det_ctx, int id, uint64_t
 
 static SCProfileKeywordDetectCtx *SCProfilingKeywordInitCtx(void)
 {
-    SCProfileKeywordDetectCtx *ctx = SCMalloc(sizeof(SCProfileKeywordDetectCtx));
+    SCProfileKeywordDetectCtx *ctx = SCCalloc(1, sizeof(SCProfileKeywordDetectCtx));
     if (ctx != NULL) {
-        memset(ctx, 0x00, sizeof(SCProfileKeywordDetectCtx));
 
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
             FatalError("Failed to initialize hash table mutex.");
@@ -284,9 +283,8 @@ void SCProfilingKeywordThreadSetup(SCProfileKeywordDetectCtx *ctx, DetectEngineT
     if (ctx == NULL)
         return;
 
-    SCProfileKeywordData *a = SCMalloc(sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
+    SCProfileKeywordData *a = SCCalloc(1, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
     if (a != NULL) {
-        memset(a, 0x00, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
         det_ctx->keyword_perf_data = a;
     }
 
@@ -296,12 +294,10 @@ void SCProfilingKeywordThreadSetup(SCProfileKeywordDetectCtx *ctx, DetectEngineT
 
     int i;
     for (i = 0; i < nlists; i++) {
-        SCProfileKeywordData *b = SCMalloc(sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
+        SCProfileKeywordData *b = SCCalloc(1, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
         if (b != NULL) {
-            memset(b, 0x00, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
             det_ctx->keyword_perf_data_per_list[i] = b;
         }
-
     }
 }
 
@@ -373,9 +369,8 @@ SCProfilingKeywordInitCounters(DetectEngineCtx *de_ctx)
     de_ctx->profile_keyword_ctx = SCProfilingKeywordInitCtx();
     BUG_ON(de_ctx->profile_keyword_ctx == NULL);
 
-    de_ctx->profile_keyword_ctx->data = SCMalloc(sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
+    de_ctx->profile_keyword_ctx->data = SCCalloc(1, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
     BUG_ON(de_ctx->profile_keyword_ctx->data == NULL);
-    memset(de_ctx->profile_keyword_ctx->data, 0x00, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
 
     de_ctx->profile_keyword_ctx_per_list = SCCalloc(nlists, sizeof(SCProfileKeywordDetectCtx *));
     BUG_ON(de_ctx->profile_keyword_ctx_per_list == NULL);
@@ -384,9 +379,9 @@ SCProfilingKeywordInitCounters(DetectEngineCtx *de_ctx)
     for (i = 0; i < nlists; i++) {
         de_ctx->profile_keyword_ctx_per_list[i] = SCProfilingKeywordInitCtx();
         BUG_ON(de_ctx->profile_keyword_ctx_per_list[i] == NULL);
-        de_ctx->profile_keyword_ctx_per_list[i]->data = SCMalloc(sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
+        de_ctx->profile_keyword_ctx_per_list[i]->data =
+                SCCalloc(1, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
         BUG_ON(de_ctx->profile_keyword_ctx_per_list[i]->data == NULL);
-        memset(de_ctx->profile_keyword_ctx_per_list[i]->data, 0x00, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
     }
 
     SCLogPerf("Registered %"PRIu32" keyword profiling counters.", DETECT_TBLSIZE);

--- a/src/util-profiling-prefilter.c
+++ b/src/util-profiling-prefilter.c
@@ -210,10 +210,8 @@ void SCProfilingPrefilterUpdateCounter(DetectEngineThreadCtx *det_ctx, int id, u
 
 static SCProfilePrefilterDetectCtx *SCProfilingPrefilterInitCtx(void)
 {
-    SCProfilePrefilterDetectCtx *ctx = SCMalloc(sizeof(SCProfilePrefilterDetectCtx));
+    SCProfilePrefilterDetectCtx *ctx = SCCalloc(1, sizeof(SCProfilePrefilterDetectCtx));
     if (ctx != NULL) {
-        memset(ctx, 0x00, sizeof(SCProfilePrefilterDetectCtx));
-
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
             FatalError("Failed to initialize hash table mutex.");
         }
@@ -248,9 +246,8 @@ void SCProfilingPrefilterThreadSetup(SCProfilePrefilterDetectCtx *ctx, DetectEng
 
     const uint32_t size = det_ctx->de_ctx->prefilter_id;
 
-    SCProfilePrefilterData *a = SCMalloc(sizeof(SCProfilePrefilterData) * size);
+    SCProfilePrefilterData *a = SCCalloc(1, sizeof(SCProfilePrefilterData) * size);
     if (a != NULL) {
-        memset(a, 0x00, sizeof(SCProfilePrefilterData) * size);
         det_ctx->prefilter_perf_data = a;
     }
 }
@@ -310,9 +307,8 @@ SCProfilingPrefilterInitCounters(DetectEngineCtx *de_ctx)
     BUG_ON(de_ctx->profile_prefilter_ctx == NULL);
     de_ctx->profile_prefilter_ctx->size = size;
 
-    de_ctx->profile_prefilter_ctx->data = SCMalloc(sizeof(SCProfilePrefilterData) * size);
+    de_ctx->profile_prefilter_ctx->data = SCCalloc(1, sizeof(SCProfilePrefilterData) * size);
     BUG_ON(de_ctx->profile_prefilter_ctx->data == NULL);
-    memset(de_ctx->profile_prefilter_ctx->data, 0x00, sizeof(SCProfilePrefilterData) * size);
 
     HashListTableBucket *hb = HashListTableGetListHead(de_ctx->prefilter_hash_table);
     for ( ; hb != NULL; hb = HashListTableGetListNext(hb)) {

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -562,10 +562,8 @@ SCProfilingRuleUpdateCounter(DetectEngineThreadCtx *det_ctx, uint16_t id, uint64
 
 static SCProfileDetectCtx *SCProfilingRuleInitCtx(void)
 {
-    SCProfileDetectCtx *ctx = SCMalloc(sizeof(SCProfileDetectCtx));
+    SCProfileDetectCtx *ctx = SCCalloc(1, sizeof(SCProfileDetectCtx));
     if (ctx != NULL) {
-        memset(ctx, 0x00, sizeof(SCProfileDetectCtx));
-
         if (pthread_mutex_init(&ctx->data_m, NULL) != 0) {
             FatalError("Failed to initialize hash table mutex.");
         }
@@ -590,10 +588,8 @@ void SCProfilingRuleThreadSetup(SCProfileDetectCtx *ctx, DetectEngineThreadCtx *
     if (ctx == NULL|| ctx->size == 0)
         return;
 
-    SCProfileData *a = SCMalloc(sizeof(SCProfileData) * ctx->size);
+    SCProfileData *a = SCCalloc(1, sizeof(SCProfileData) * ctx->size);
     if (a != NULL) {
-        memset(a, 0x00, sizeof(SCProfileData) * ctx->size);
-
         det_ctx->rule_perf_data = a;
         det_ctx->rule_perf_data_size = ctx->size;
     }
@@ -669,9 +665,8 @@ SCProfilingRuleInitCounters(DetectEngineCtx *de_ctx)
     }
 
     if (count > 0) {
-        de_ctx->profile_ctx->data = SCMalloc(sizeof(SCProfileData) * de_ctx->profile_ctx->size);
+        de_ctx->profile_ctx->data = SCCalloc(1, sizeof(SCProfileData) * de_ctx->profile_ctx->size);
         BUG_ON(de_ctx->profile_ctx->data == NULL);
-        memset(de_ctx->profile_ctx->data, 0x00, sizeof(SCProfileData) * de_ctx->profile_ctx->size);
 
         sig = de_ctx->sig_list;
         while (sig != NULL) {

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -47,13 +47,11 @@
  */
 static SCRadixUserData *SCRadixAllocSCRadixUserData(uint8_t netmask, void *user)
 {
-    SCRadixUserData *user_data = SCMalloc(sizeof(SCRadixUserData));
+    SCRadixUserData *user_data = SCCalloc(1, sizeof(SCRadixUserData));
     if (unlikely(user_data == NULL)) {
         SCLogError("Error allocating memory");
         return NULL;
     }
-
-    memset(user_data, 0, sizeof(SCRadixUserData));
 
     user_data->netmask = netmask;
     user_data->user = user;
@@ -143,15 +141,11 @@ static SCRadixPrefix *SCRadixCreatePrefix(uint8_t *key_stream,
         return NULL;
     }
 
-    if ( (prefix = SCMalloc(sizeof(SCRadixPrefix))) == NULL)
+    if ((prefix = SCCalloc(1, sizeof(SCRadixPrefix))) == NULL)
         goto error;
 
-    memset(prefix, 0, sizeof(SCRadixPrefix));
-
-    if ( (prefix->stream = SCMalloc(key_bitlen / 8)) == NULL)
+    if ((prefix->stream = SCCalloc(1, key_bitlen / 8)) == NULL)
         goto error;
-
-    memset(prefix->stream, 0, key_bitlen / 8);
 
     memcpy(prefix->stream, key_stream, key_bitlen / 8);
     prefix->bitlen = key_bitlen;
@@ -382,11 +376,10 @@ static inline SCRadixNode *SCRadixCreateNode(void)
 {
     SCRadixNode *node = NULL;
 
-    if ( (node = SCMalloc(sizeof(SCRadixNode))) == NULL) {
+    if ((node = SCCalloc(1, sizeof(SCRadixNode))) == NULL) {
         SCLogError("Fatal error encountered in SCRadixCreateNode. Mem not allocated...");
         return NULL;
     }
-    memset(node, 0, sizeof(SCRadixNode));
 
     return node;
 }
@@ -425,10 +418,9 @@ SCRadixTree *SCRadixCreateRadixTree(void (*Free)(void*), void (*PrintData)(void*
 {
     SCRadixTree *tree = NULL;
 
-    if ( (tree = SCMalloc(sizeof(SCRadixTree))) == NULL) {
+    if ((tree = SCCalloc(1, sizeof(SCRadixTree))) == NULL) {
         FatalError("Fatal error encountered in SCRadixCreateRadixTree. Exiting...");
     }
-    memset(tree, 0, sizeof(SCRadixTree));
 
     tree->Free = Free;
     tree->PrintData = PrintData;

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -360,10 +360,9 @@ SCRConfReference *SCRConfAllocSCRConfReference(const char *system,
         return NULL;
     }
 
-    if ((ref = SCMalloc(sizeof(SCRConfReference))) == NULL) {
+    if ((ref = SCCalloc(1, sizeof(SCRConfReference))) == NULL) {
         return NULL;
     }
-    memset(ref, 0, sizeof(SCRConfReference));
 
     if ((ref->system = SCRConfStringToLowercase(system)) == NULL) {
         SCFree(ref);

--- a/src/util-rohash.c
+++ b/src/util-rohash.c
@@ -74,12 +74,11 @@ ROHashTable *ROHashInit(uint8_t hash_bits, uint16_t item_size)
 
     uint32_t size = hashsize(hash_bits) * sizeof(ROHashTableOffsets);
 
-    ROHashTable *table = SCMalloc(sizeof(ROHashTable) + size);
+    ROHashTable *table = SCCalloc(1, sizeof(ROHashTable) + size);
     if (unlikely(table == NULL)) {
         SCLogError("failed to alloc memory");
         return NULL;
     }
-    memset(table, 0, sizeof(ROHashTable) + size);
 
     table->items = 0;
     table->item_size = item_size;
@@ -161,9 +160,8 @@ int ROHashInitQueueValue(ROHashTable *table, void *value, uint16_t size)
         return 0;
     }
 
-    ROHashTableItem *item = SCMalloc(sizeof(ROHashTableItem) + table->item_size);
+    ROHashTableItem *item = SCCalloc(1, sizeof(ROHashTableItem) + table->item_size);
     if (item != NULL) {
-        memset(item, 0x00, sizeof(ROHashTableItem));
         memcpy((void *)item + sizeof(ROHashTableItem), value, table->item_size);
         TAILQ_INSERT_TAIL(&table->head, item, next);
         return 1;
@@ -208,12 +206,11 @@ int ROHashInitFinalize(ROHashTable *table)
 
     /* get the data block */
     uint32_t newsize = table->items * table->item_size;
-    table->data = SCMalloc(newsize);
+    table->data = SCCalloc(1, newsize);
     if (table->data == NULL) {
         SCLogError("failed to alloc memory");
         return 0;
     }
-    memset(table->data, 0x00, newsize);
 
     /* calc offsets into the block per hash value */
     uint32_t total = 0;

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -62,12 +62,11 @@ char *RunmodeAutoFpCreatePickupQueuesString(int n)
     size_t queues_size = n * 13;
     char qname[TM_QUEUE_NAME_MAX];
 
-    char *queues = SCMalloc(queues_size);
+    char *queues = SCCalloc(1, queues_size);
     if (unlikely(queues == NULL)) {
         SCLogError("failed to alloc queues buffer: %s", strerror(errno));
         return NULL;
     }
-    memset(queues, 0x00, queues_size);
 
     for (int thread = 0; thread < n; thread++) {
         if (strlen(queues) > 0)

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -391,21 +391,19 @@ typedef struct SpmBmCtx_ {
 static SpmCtx *BMInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
                          SpmGlobalThreadCtx *global_thread_ctx)
 {
-    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    SpmCtx *ctx = SCCalloc(1, sizeof(SpmCtx));
     if (ctx == NULL) {
         SCLogDebug("Unable to alloc SpmCtx.");
         return NULL;
     }
-    memset(ctx, 0, sizeof(*ctx));
     ctx->matcher = SPM_BM;
 
-    SpmBmCtx *sctx = SCMalloc(sizeof(SpmBmCtx));
+    SpmBmCtx *sctx = SCCalloc(1, sizeof(SpmBmCtx));
     if (sctx == NULL) {
         SCLogDebug("Unable to alloc SpmBmCtx.");
         SCFree(ctx);
         return NULL;
     }
-    memset(sctx, 0, sizeof(*sctx));
 
     sctx->needle = SCMalloc(needle_len);
     if (sctx->needle == NULL) {
@@ -463,12 +461,11 @@ static uint8_t *BMScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
 
 static SpmGlobalThreadCtx *BMInitGlobalThreadCtx(void)
 {
-    SpmGlobalThreadCtx *global_thread_ctx = SCMalloc(sizeof(SpmGlobalThreadCtx));
+    SpmGlobalThreadCtx *global_thread_ctx = SCCalloc(1, sizeof(SpmGlobalThreadCtx));
     if (global_thread_ctx == NULL) {
         SCLogDebug("Unable to alloc SpmThreadCtx.");
         return NULL;
     }
-    memset(global_thread_ctx, 0, sizeof(*global_thread_ctx));
     global_thread_ctx->matcher = SPM_BM;
     return global_thread_ctx;
 }
@@ -490,12 +487,11 @@ static void BMDestroyThreadCtx(SpmThreadCtx *thread_ctx)
 }
 
 static SpmThreadCtx *BMMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx) {
-    SpmThreadCtx *thread_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    SpmThreadCtx *thread_ctx = SCCalloc(1, sizeof(SpmThreadCtx));
     if (thread_ctx == NULL) {
         SCLogDebug("Unable to alloc SpmThreadCtx.");
         return NULL;
     }
-    memset(thread_ctx, 0, sizeof(*thread_ctx));
     thread_ctx->matcher = SPM_BM;
     return thread_ctx;
 }

--- a/src/util-spm-hs.c
+++ b/src/util-spm-hs.c
@@ -108,15 +108,14 @@ static int HSBuildDatabase(const uint8_t *needle, uint16_t needle_len,
 static SpmCtx *HSInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
                          SpmGlobalThreadCtx *global_thread_ctx)
 {
-    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    SpmCtx *ctx = SCCalloc(1, sizeof(SpmCtx));
     if (ctx == NULL) {
         SCLogDebug("Unable to alloc SpmCtx.");
         return NULL;
     }
-    memset(ctx, 0, sizeof(SpmCtx));
     ctx->matcher = SPM_HS;
 
-    SpmHsCtx *sctx = SCMalloc(sizeof(SpmHsCtx));
+    SpmHsCtx *sctx = SCCalloc(1, sizeof(SpmHsCtx));
     if (sctx == NULL) {
         SCLogDebug("Unable to alloc SpmHsCtx.");
         SCFree(ctx);
@@ -124,7 +123,6 @@ static SpmCtx *HSInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
     }
     ctx->ctx = sctx;
 
-    memset(sctx, 0, sizeof(SpmHsCtx));
     if (HSBuildDatabase(needle, needle_len, nocase, sctx,
                         global_thread_ctx) != 0) {
         SCLogDebug("HSBuildDatabase failed.");
@@ -168,12 +166,11 @@ static uint8_t *HSScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
 
 static SpmGlobalThreadCtx *HSInitGlobalThreadCtx(void)
 {
-    SpmGlobalThreadCtx *global_thread_ctx = SCMalloc(sizeof(SpmGlobalThreadCtx));
+    SpmGlobalThreadCtx *global_thread_ctx = SCCalloc(1, sizeof(SpmGlobalThreadCtx));
     if (global_thread_ctx == NULL) {
         SCLogDebug("Unable to alloc SpmGlobalThreadCtx.");
         return NULL;
     }
-    memset(global_thread_ctx, 0, sizeof(*global_thread_ctx));
     global_thread_ctx->matcher = SPM_HS;
 
     /* We store scratch in the HS-specific ctx. This will be initialized as
@@ -203,12 +200,11 @@ static void HSDestroyThreadCtx(SpmThreadCtx *thread_ctx)
 
 static SpmThreadCtx *HSMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx)
 {
-    SpmThreadCtx *thread_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    SpmThreadCtx *thread_ctx = SCCalloc(1, sizeof(SpmThreadCtx));
     if (thread_ctx == NULL) {
         SCLogDebug("Unable to alloc SpmThreadCtx.");
         return NULL;
     }
-    memset(thread_ctx, 0, sizeof(*thread_ctx));
     thread_ctx->matcher = SPM_HS;
 
     if (global_thread_ctx->ctx != NULL) {

--- a/src/util-storage.c
+++ b/src/util-storage.c
@@ -118,11 +118,9 @@ int StorageRegister(const StorageEnum type, const char *name, const unsigned int
         list = list->next;
     }
 
-    StorageList *entry = SCMalloc(sizeof(StorageList));
+    StorageList *entry = SCCalloc(1, sizeof(StorageList));
     if (unlikely(entry == NULL))
         return -1;
-
-    memset(entry, 0x00, sizeof(StorageList));
 
     entry->map.type = type;
     entry->map.name = name;
@@ -151,18 +149,16 @@ int StorageFinalize(void)
     if (count == 0)
         return 0;
 
-    storage_map = SCMalloc(sizeof(StorageMapping *) * STORAGE_MAX);
+    storage_map = SCCalloc(1, sizeof(StorageMapping *) * STORAGE_MAX);
     if (unlikely(storage_map == NULL)) {
         return -1;
     }
-    memset(storage_map, 0x00, sizeof(StorageMapping *) * STORAGE_MAX);
 
     for (i = 0; i < STORAGE_MAX; i++) {
         if (storage_max_id[i] > 0) {
-            storage_map[i] = SCMalloc(sizeof(StorageMapping) * storage_max_id[i]);
+            storage_map[i] = SCCalloc(1, sizeof(StorageMapping) * storage_max_id[i]);
             if (storage_map[i] == NULL)
                 return -1;
-            memset(storage_map[i], 0x00, sizeof(StorageMapping) * storage_max_id[i]);
         }
     }
 
@@ -266,10 +262,9 @@ void *StorageAllocById(Storage **storage, StorageEnum type, int id)
     Storage *store = *storage;
     if (store == NULL) {
         // coverity[suspicious_sizeof : FALSE]
-        store = SCMalloc(sizeof(void *) * storage_max_id[type]);
+        store = SCCalloc(1, sizeof(void *) * storage_max_id[type]);
         if (unlikely(store == NULL))
-        return NULL;
-        memset(store, 0x00, sizeof(void *) * storage_max_id[type]);
+            return NULL;
     }
     SCLogDebug("store %p", store);
 

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -399,10 +399,9 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 continue;
             }
 
-            de = SCMalloc(sizeof(DetectThresholdData));
+            de = SCCalloc(1, sizeof(DetectThresholdData));
             if (unlikely(de == NULL))
                 goto error;
-            memset(de,0,sizeof(DetectThresholdData));
 
             de->type = parsed_type;
             de->track = parsed_track;
@@ -440,10 +439,9 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                     continue;
                 }
 
-                de = SCMalloc(sizeof(DetectThresholdData));
+                de = SCCalloc(1, sizeof(DetectThresholdData));
                 if (unlikely(de == NULL))
                     goto error;
-                memset(de,0,sizeof(DetectThresholdData));
 
                 de->type = parsed_type;
                 de->track = parsed_track;
@@ -514,10 +512,9 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 }
             }
 
-            de = SCMalloc(sizeof(DetectThresholdData));
+            de = SCCalloc(1, sizeof(DetectThresholdData));
             if (unlikely(de == NULL))
                 goto error;
-            memset(de,0,sizeof(DetectThresholdData));
 
             de->type = parsed_type;
             de->track = parsed_track;


### PR DESCRIPTION
Continuation of #9385 

Replace `SCMalloc/memset` with `SCCalloc`

There are many places that use the following pattern:
```
     mem = SCMalloc(sizeof(foo));
     if (mem) {
        memset(&mem, 0, sizeof(foo));
    }
```

These can all be replaced by using `SCCalloc` which returns 0-filled memory.

Describe changes:
- Changed `SCMalloc` followed by `memset` to `SCCalloc` 

Updates:
- Fix issue with previous rebase.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
