### PR TITLE
Conf null/v3

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -469,6 +469,57 @@ int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt,
 }
 
 /**
+ * \brief Retrieve the value of a child configuration node as string.
+ *
+ * This function will return the value for a configuration node based
+ * on the full name of the node. In case the node exists but does not
+ * have a corresponding value, it is considered an error.
+ *
+ * \param base Base node to find the other nodes from.
+ * \param name Name of configuration parameter to get.
+ * \param vptr Pointer that will be set to the configuration value parameter.
+ *   Note that this is just a reference to the actual value, not a copy.
+ *
+ * \retval 1 will be returned if the name is found
+ * \retval 0 will be returned if the name is not found or has NULL value
+ */
+int ConfGetChildValueString(const ConfNode *base, const char *name, const char **vptr)
+{
+    int ret = ConfGetChildValue(base, name, vptr);
+
+    if ((ret == 1 && vptr && *vptr == NULL) || (ret == 0)) {
+        /* Cannot convert NULL to string */
+        return 0;
+    }
+    return 1;
+}
+
+/**
+ * \brief Retrieve the value of a child configuration node as string.
+ *
+ * This function will return the value for a configuration node based
+ * on the full name of the node.
+ *
+ * \param base Base node to find the other nodes from.
+ * \param dflt Default node to use as base.
+ * \param name Name of configuration parameter to get.
+ * \param vptr Pointer that will be set to the configuration value parameter.
+ *   Note that this is just a reference to the actual value, not a copy.
+ *
+ * \retval 1 will be returned if the name is found and is a valid string, 0 otherwise
+ */
+int ConfGetChildValueStringWithDefault(
+        const ConfNode *base, const ConfNode *dflt, const char *name, const char **vptr)
+{
+    int ret = ConfGetChildValueString(base, name, vptr);
+    /* Get 'default' value */
+    if (ret == 0 && dflt) {
+        return ConfGetChildValueString(dflt, name, vptr);
+    }
+    return ret;
+}
+
+/**
  * \brief Retrieve a configuration value as a boolean.
  *
  * \param name Name of configuration parameter to get.

--- a/src/conf.h
+++ b/src/conf.h
@@ -87,6 +87,9 @@ bool ConfNodeHasChildren(const ConfNode *node);
 ConfNode *ConfGetChildWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name);
 ConfNode *ConfNodeLookupKeyValue(const ConfNode *base, const char *key, const char *value);
 int ConfGetChildValue(const ConfNode *base, const char *name, const char **vptr);
+int ConfGetChildValueString(const ConfNode *base, const char *name, const char **vptr);
+int ConfGetChildValueStringWithDefault(
+        const ConfNode *base, const ConfNode *dflt, const char *name, const char **vptr);
 int ConfGetChildValueInt(const ConfNode *base, const char *name, intmax_t *val);
 int ConfGetChildValueBool(const ConfNode *base, const char *name, int *val);
 int ConfGetChildValueWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, const char **vptr);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -286,7 +286,7 @@ static void *ParseAFPConfig(const char *iface)
         }
     }
 
-    if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
+    if (ConfGetChildValueStringWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
         if (out_iface != NULL) {
             if (strlen(out_iface) > 0) {
                 aconf->out_iface = out_iface;


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/9374

Changes since v2:
- add a `ConfGetChildValueString` fn more compliant w standards and code