### PR TITLE
config/flow: Avoid divide by zero at startup

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -671,7 +671,8 @@ void FlowInitConfig(bool quiet)
     uint32_t sz = sizeof(Flow) + FlowStorageSize();
     SCLogConfig("flow size %u, memcap allows for %" PRIu64 " flows. Per hash row in perfect "
                 "conditions %" PRIu64,
-            sz, flow_memcap_copy / sz, (flow_memcap_copy / sz) / flow_config.hash_size);
+            sz, flow_memcap_copy / sz,
+            flow_config.hash_size > 0 ? (flow_memcap_copy / sz) / flow_config.hash_size : 0);
     return;
 }
 


### PR DESCRIPTION
Accommodate flow hash sizes of 0 for startup message. We don't expect the hash-size to be configured to 0, but if it is, avoid divide by 0 when displaying the config information.

Issue: 6255

Describe changes:
- Handle a flow hash-size of 0 in config startup message.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
