### PR TITLE
dhcp: Log Vendor Client Identifier (continuation of #9382)

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -560,10 +560,16 @@
                 "renewal_time": {
                     "type": "integer"
                 },
+                "requested_ip":{
+                    "type": "string"
+                },
                 "subnet_mask": {
                     "type": "string"
                 },
                 "type": {
+                    "type": "string"
+                },
+                "vendor_class_identifier":{
                     "type": "string"
                 },
                 "dns_servers": {

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -42,6 +42,7 @@ pub const DHCP_OPT_TYPE: u8 = 53;
 pub const DHCP_OPT_PARAMETER_LIST: u8 = 55;
 pub const DHCP_OPT_RENEWAL_TIME: u8 = 58;
 pub const DHCP_OPT_REBINDING_TIME: u8 = 59;
+pub const DHCP_OPT_VENDOR_CLASS_ID: u8 = 60;
 pub const DHCP_OPT_CLIENT_ID: u8 = 61;
 pub const DHCP_OPT_END: u8 = 255;
 

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -168,6 +168,12 @@ impl DHCPLogger {
                                 self.log_opt_routers(js, option)?;
                             }
                         }
+                        DHCP_OPT_VENDOR_CLASS_ID => {
+                            if self.extended && !option.data.is_empty(){
+                                js.set_string_from_bytes("vendor_class_identifier",
+                                                         &option.data)?;
+                            }
+                        }
                         _ => {}
                     }
                 }


### PR DESCRIPTION
Log Vendor Class Identifier from dhcp packets if present (continuation of https://github.com/OISF/suricata/pull/9382)


- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4587](https://redmine.openinfosecfoundation.org/issues/4587)

Describe changes:
* Log vendor client identifier (dhcp option 60) if extended dhcp logging is turned on. This required the `vendor_client_identifier` to be added to the json schema. Validation done using an SV Test
* Added `requested_ip` to the json schema as well, since it was missing. My SV test failed without it. 

Make sure these boxes are signed before submitting your Pull Request -- thank you.
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=https://github.com/OISF/suricata-verify/
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1367
```
