### PR TITLE
config/mt: Add vlan-inner MT selector

### DIFF
--- a/doc/userguide/configuration/multi-tenant.rst
+++ b/doc/userguide/configuration/multi-tenant.rst
@@ -18,7 +18,7 @@ Add a new section in the main ("master") Suricata configuration file -- ``surica
 Settings:
 
 * `enabled`: yes/no -> is multi-tenancy support enabled
-* `selector`: direct (for unix socket pcap processing, see below), VLAN or device
+* `selector`: direct (for unix socket pcap processing, see below), vlan, vlan-inner or device
 * `loaders`: number of `loader` threads, for parallel tenant loading at startup
 * `tenants`: list of tenants
 * `config-path`: path from where the tenant yamls are loaded
@@ -28,14 +28,14 @@ Settings:
 
 * `mappings`:
 
-  * VLAN id or device: The outermost VLAN is used to match.
+  * VLAN id or device: The VLAN is used to match. The outermost is chosen unless the ``vlan-inner`` was used..
   * tenant id: tenant to associate with the VLAN id or device
 
 ::
 
   multi-detect:
     enabled: yes
-    #selector: direct # direct or vlan
+    #selector: direct # direct or vlan, vlan-inner
     selector: vlan
     loaders: 3
 
@@ -97,7 +97,10 @@ configuration:
 vlan-id
 ~~~~~~~
 
-Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value.
+Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value when
+the selector is ``vlan`` (default). The innermost VLAN id is used when the selector is ``vlan-inner``.
+Use care when using ``vlan-inner`` as Suricata chooses the tenant, and hence the rules, rule variables,
+and rules-related configuration according to the inner-most VLAN id regardless of the outer VLAN id.
 Multiple VLANs can have the same tenant id. VLAN id values must be between 1 and 4094.
 
 Example of VLAN mapping::
@@ -195,25 +198,34 @@ Live traffic mode
 
 Multi-tenancy supports both VLAN and devices with live traffic.
 
-In the master configuration yaml file, specify ``device`` or ``vlan`` for the ``selector`` setting.
+In the master configuration yaml file, specify ``device``, ``vlan`` or ``vlan-inner`` for the ``selector`` setting.
 
 Registration
 ~~~~~~~~~~~~
 
 Tenants can be mapped to vlan ids.
 
-``register-tenant-handler <tenant id> vlan <vlan id>``
+::
+
+  register-tenant-handler <tenant id> vlan <vlan id>
+  register-tenant-handler <tenant id> vlan-inner <vlan id>
 
 ::
 
   register-tenant-handler 1 vlan 1000
+  register-tenant-handler 1 vlan-inner 1000
 
-``unregister-tenant-handler <tenant id> vlan <vlan id>``
+::
+
+  unregister-tenant-handler <tenant id> vlan <vlan id>
+  unregister-tenant-handler <tenant id> vlan-inner <vlan id>
 
 ::
 
   unregister-tenant-handler 4 vlan 1111
   unregister-tenant-handler 1 vlan 1000
+  unregister-tenant-handler 4 vlan-inner 1111
+  unregister-tenant-handler 1 vlan-inner 1000
 
 The registration of tenant and tenant handlers can be done on a
 running engine.

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -101,6 +101,7 @@ static char TenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len
 static void TenantIdFree(void *d);
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
+static uint32_t DetectEngineTenantGetIdFromVlanIdInner(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
 
 static DetectEngineAppInspectionEngine *g_app_inspect_engines = NULL;
@@ -3171,6 +3172,10 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
         case TENANT_SELECTOR_UNKNOWN:
             SCLogDebug("TENANT_SELECTOR_UNKNOWN");
             break;
+        case TENANT_SELECTOR_VLAN_INNER:
+            det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanIdInner;
+            SCLogDebug("TENANT_SELECTOR_VLAN_INNER");
+            break;
         case TENANT_SELECTOR_VLAN:
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanId;
             SCLogDebug("TENANT_SELECTOR_VLAN");
@@ -4187,9 +4192,6 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
                 goto bad_mapping;
             }
 
-            if (DetectEngineTenantRegisterVlanId(tenant_id, vlan_id) != 0) {
-                goto error;
-            }
             SCLogConfig("vlan %u connected to tenant-id %u", vlan_id, tenant_id);
             mapping_cnt++;
             continue;
@@ -4234,8 +4236,11 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         if (ConfGet("multi-detect.selector", &handler) == 1) {
             SCLogConfig("multi-tenant selector type %s", handler);
 
-            if (strcmp(handler, "vlan") == 0) {
-                tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
+            if (strcmp(handler, "vlan") == 0 || strcmp(handler, "vlan-inner") == 0) {
+                if (strcmp(handler, "vlan-inner") == 0)
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN_INNER;
+                else
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
 
                 int vlanbool = 0;
                 if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
@@ -4244,7 +4249,6 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
                     SCMutexUnlock(&master->lock);
                     goto error;
                 }
-
             } else if (strcmp(handler, "direct") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_DIRECT;
             } else if (strcmp(handler, "device") == 0) {
@@ -4379,28 +4383,41 @@ error:
     return -1;
 }
 
-static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p)
+static inline uint32_t DetectEngineTenantGetIdVlanInternal(
+        const DetectEngineThreadCtx *det_ctx, const uint32_t vlan_id)
 {
-    const DetectEngineThreadCtx *det_ctx = ctx;
-    uint32_t x = 0;
-    uint32_t vlan_id = 0;
-
-    if (p->vlan_idx == 0)
-        return 0;
-
-    vlan_id = p->vlan_id[0];
-
-    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
-        return 0;
-
     /* not very efficient, but for now we're targeting only limited amounts.
      * Can use hash/tree approach later. */
-    for (x = 0; x < det_ctx->tenant_array_size; x++) {
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
         if (det_ctx->tenant_array[x].traffic_id == vlan_id)
             return det_ctx->tenant_array[x].tenant_id;
     }
 
     return 0;
+}
+
+static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p)
+{
+    if (p->vlan_idx == 0)
+        return 0;
+
+    const DetectEngineThreadCtx *det_ctx = ctx;
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    return DetectEngineTenantGetIdVlanInternal(det_ctx, (const uint32_t)p->vlan_id[0]);
+}
+
+static uint32_t DetectEngineTenantGetIdFromVlanIdInner(const void *ctx, const Packet *p)
+{
+    if (p->vlan_idx == 0)
+        return 0;
+
+    const DetectEngineThreadCtx *det_ctx = ctx;
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    return DetectEngineTenantGetIdVlanInternal(det_ctx, (const uint32_t)p->vlan_id[p->vlan_idx]);
 }
 
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p)
@@ -4506,6 +4523,18 @@ int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 {
     return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN, tenant_id, (uint32_t)vlan_id);
+}
+
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id)
+{
+    return DetectEngineTenantRegisterSelector(
+            TENANT_SELECTOR_VLAN_INNER, tenant_id, (uint32_t)vlan_id);
+}
+
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id)
+{
+    return DetectEngineTenantUnregisterSelector(
+            TENANT_SELECTOR_VLAN_INNER, tenant_id, (uint32_t)vlan_id);
 }
 
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id)

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -133,6 +133,8 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1493,12 +1493,12 @@ typedef struct SigGroupHead_ {
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_VLAN_INNER,  /**< map inner vlan to tenant id */
 };
 
 typedef struct DetectEngineTenantMapping_ {

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -885,7 +885,7 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
     int r = -1;
     if (strcmp(htype, "pcap") == 0) {
         r = DetectEngineTenantRegisterPcapFile(tenant_id);
-    } else if (strcmp(htype, "vlan") == 0) {
+    } else if (strcmp(htype, "vlan") == 0 || strcmp(htype, "vlan-inner") == 0) {
         if (traffic_id < 0) {
             json_object_set_new(answer, "message", json_string("vlan requires argument"));
             return TM_ECODE_FAILED;
@@ -896,7 +896,11 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         }
 
         SCLogInfo("VLAN handler: id %u maps to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTenantRegisterVlanId(tenant_id, (uint16_t)traffic_id);
+        if (strcmp(htype, "vlan") == 0) {
+            r = DetectEngineTenantRegisterVlanId(tenant_id, (uint16_t)traffic_id);
+        } else {
+            r = DetectEngineTenantRegisterVlanIdInner(tenant_id, (uint16_t)traffic_id);
+        }
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler setup failure"));
@@ -966,7 +970,7 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
     int r = -1;
     if (strcmp(htype, "pcap") == 0) {
         r = DetectEngineTenantUnregisterPcapFile(tenant_id);
-    } else if (strcmp(htype, "vlan") == 0) {
+    } else if (strcmp(htype, "vlan") == 0 || strcmp(htype, "vlan-inner") == 0) {
         if (traffic_id < 0) {
             json_object_set_new(answer, "message", json_string("vlan requires argument"));
             return TM_ECODE_FAILED;
@@ -977,7 +981,11 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         }
 
         SCLogInfo("VLAN handler: removing mapping of %u to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTenantUnregisterVlanId(tenant_id, (uint16_t)traffic_id);
+        if (strcmp(htype, "vlan") == 0) {
+            r = DetectEngineTenantUnregisterVlanId(tenant_id, (uint16_t)traffic_id);
+        } else {
+            r = DetectEngineTenantUnregisterVlanIdInner(tenant_id, (uint16_t)traffic_id);
+        }
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler unregister failure"));


### PR DESCRIPTION
Continuation of #9398

Add a new MT selector type to support use cases where the inner VLAN should be used to determine the MT tenant.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6237](https://redmine.openinfosecfoundation.org/issues/6237)

Describe changes:
- Add and document a new MT selector -- VLAN inner -- for use cases where the innermost VLAN determines the tenant.

Updates
- Formatting fixup

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1354
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
