### PR TITLE
stats: Track stream reassembly drops

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -40,7 +40,8 @@
             "type": "integer"
         },
         "host": {
-            "$comment": "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
+            "$comment":
+                    "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
             "description": "the sensor-name, if configured",
             "type": "string"
         },
@@ -4087,6 +4088,9 @@
                                     "type": "integer"
                                 },
                                 "stream_midstream": {
+                                    "type": "integer"
+                                },
+                                "stream_reassembly": {
                                     "type": "integer"
                                 },
                                 "nfq_error": {

--- a/src/decode.c
+++ b/src/decode.c
@@ -804,6 +804,8 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "stream memcap";
         case PKT_DROP_REASON_STREAM_MIDSTREAM:
             return "stream midstream";
+        case PKT_DROP_REASON_STREAM_REASSEMBLY:
+            return "stream reassembly";
         case PKT_DROP_REASON_APPLAYER_ERROR:
             return "applayer error";
         case PKT_DROP_REASON_APPLAYER_MEMCAP:
@@ -842,6 +844,8 @@ static const char *PacketDropReasonToJsonString(enum PacketDropReason r)
             return "ips.drop_reason.stream_memcap";
         case PKT_DROP_REASON_STREAM_MIDSTREAM:
             return "ips.drop_reason.stream_midstream";
+        case PKT_DROP_REASON_STREAM_REASSEMBLY:
+            return "ips.drop_reason.stream_reassembly";
         case PKT_DROP_REASON_APPLAYER_ERROR:
             return "ips.drop_reason.applayer_error";
         case PKT_DROP_REASON_APPLAYER_MEMCAP:

--- a/src/decode.h
+++ b/src/decode.h
@@ -401,6 +401,7 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_ERROR,
     PKT_DROP_REASON_STREAM_MEMCAP,
     PKT_DROP_REASON_STREAM_MIDSTREAM,
+    PKT_DROP_REASON_STREAM_REASSEMBLY,
     PKT_DROP_REASON_NFQ_ERROR,    /**< no nfq verdict, must be error */
     PKT_DROP_REASON_INNER_PACKET, /**< drop issued by inner (tunnel) packet */
     PKT_DROP_REASON_MAX,

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -2017,7 +2017,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             SCLogDebug("StreamTcpReassembleHandleSegmentHandleData error");
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
-                    p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+                    p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_REASSEMBLY);
             SCReturnInt(-1);
         }
 


### PR DESCRIPTION
Issue: 6235

Track drops due to reassembly memcap limits under a different  enum for discrete reporting.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6235](https://redmine.openinfosecfoundation.org/issues/6235)

Describe changes:
- Track reassembly drops under a different enum for discrete stat/reporting.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
