### PR TITLE
iprep: fix parsing ip-rep data with carriage return

### DIFF
--- a/src/reputation.c
+++ b/src/reputation.c
@@ -282,7 +282,8 @@ static int SRepSplitLine(SRepCIDRTree *cidr_ctx, char *line, Address *ip, uint8_
     char *origline = line;
 
     while (i < (int)line_len) {
-        if (line[i] == ',' || line[i] == '\n' || line[i] == '\0' || i == (int)(line_len - 1)) {
+        if (line[i] == ',' || line[i] == '\n' || line[i] == '\r' || line[i] == '\0' ||
+                i == (int)(line_len - 1)) {
             line[i] = '\0';
 
             ptrs[idx] = line;


### PR DESCRIPTION
Commit e7c0f0ad91fd removed uses of atoi with a new number parsing functions. This broke parsing ip-reputation data files that contained trailing carriage returns as it was being included in the number string to convert.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6243

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1343
