### PR TITLE
config/flow: fix division by zero

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -606,8 +606,12 @@ void FlowInitConfig(bool quiet)
             FatalError("Invalid value for flow.hash-size: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val) > 0 || configval == 0) {
-            flow_config.hash_size = configval;
+        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val)) {
+            if (configval != 0) {
+                flow_config.hash_size = configval;
+            } else {
+                FatalError("Invalid value for flow.hash-size: 0, valid range is 1-4294967295");
+            }
         } else {
             FatalError("Invalid value for flow.hash-size");
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6255
https://redmine.openinfosecfoundation.org/issues/5920

Describe changes:
- Fixes commit 805b07fa4236 to really fix the division by zero if user supplies a configuration value of 0 for hash size

Replaces https://github.com/OISF/suricata/pull/9431 with better error message