### PR TITLE
Rust clippy172 v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -44,7 +44,7 @@ impl StreamSlice {
     #[cfg(test)]
     pub fn from_slice(slice: &[u8], flags: u8, offset: u64) -> Self {
         Self {
-            input: slice.as_ptr() as *const u8,
+            input: slice.as_ptr(),
             input_len: slice.len() as u32,
             flags,
             offset

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -432,7 +432,7 @@ pub unsafe extern "C" fn ScByteMathParse(c_arg: *const c_char) -> *mut DetectByt
         }
     };
     match parse_bytemath(arg) {
-        Ok((_, detect)) => return Box::into_raw(Box::new(detect)) as *mut DetectByteMathData,
+        Ok((_, detect)) => return Box::into_raw(Box::new(detect)),
         Err(_) => return std::ptr::null_mut(),
     }
 }
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn ScByteMathParse(c_arg: *const c_char) -> *mut DetectByt
 #[no_mangle]
 pub unsafe extern "C" fn ScByteMathFree(ptr: *mut DetectByteMathData) {
     if !ptr.is_null() {
-        let _ = Box::from_raw(ptr as *mut DetectByteMathData);
+        let _ = Box::from_raw(ptr);
     }
 }
 

--- a/rust/src/detect/iprep.rs
+++ b/rust/src/detect/iprep.rs
@@ -24,6 +24,7 @@ use nom7::Err;
 use nom7::IResult;
 
 use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 use std::str::FromStr;
 
 #[repr(u8)]
@@ -71,7 +72,7 @@ pub fn is_alphanumeric_or_slash(chr: char) -> bool {
 }
 
 extern "C" {
-    pub fn SRepCatGetByShortname(name: *const i8) -> u8;
+    pub fn SRepCatGetByShortname(name: *const c_char) -> u8;
 }
 
 pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData> {
@@ -84,7 +85,7 @@ pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData> {
     let (i, name) = take_while(is_alphanumeric_or_slash)(i)?;
     // copy as to have final zero
     let namez = CString::new(name).unwrap();
-    let cat = unsafe { SRepCatGetByShortname(namez.as_ptr() as *const i8) };
+    let cat = unsafe { SRepCatGetByShortname(namez.as_ptr()) };
     if cat == 0 {
         return Err(Err::Error(make_error(i, ErrorKind::MapOpt)));
     }

--- a/rust/src/ffi/base64.rs
+++ b/rust/src/ffi/base64.rs
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn Base64Encode(
     if encoded.len() + 1 > *output_len as usize {
         return Base64ReturnCode::SC_BASE64_OVERFLOW;
     }
-    let output = std::slice::from_raw_parts_mut(&mut *(output as *mut u8), *output_len as usize);
+    let output = std::slice::from_raw_parts_mut(&mut *output, *output_len as usize);
     output[0..encoded.len()].copy_from_slice(encoded.as_bytes());
     output[encoded.len()] = 0;
     *output_len = encoded.len() as c_ulong;

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -593,7 +593,7 @@ pub fn pgsql_parse_startup_packet(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, b) = take(len - PGSQL_LENGTH_FIELD)(i)?;
     let (_, message) =
         match proto_major {
-            1 | 2 | 3 => {
+            1..=3 => {
                 let (b, proto_major) = be_u16(b)?;
                 let (b, proto_minor) = be_u16(b)?;
                 let (b, params) = pgsql_parse_startup_parameters(b)?;

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -160,7 +160,8 @@ pub enum Protocol {
 // rdp-spec, section 2.2.1.1.1
 bitflags! {
     pub struct ProtocolFlags: u32 {
-        const PROTOCOL_RDP = Protocol::ProtocolRdp as u32;
+        //Protocol::ProtocolRdp is 0 as always supported
+        //and bitflags crate does not like zero-bit flags
         const PROTOCOL_SSL = Protocol::ProtocolSsl as u32;
         const PROTOCOL_HYBRID = Protocol::ProtocolHybrid as u32;
         const PROTOCOL_RDSTLS = Protocol::ProtocolRdsTls as u32;
@@ -1089,7 +1090,7 @@ mod tests_negotiate_49350 {
                 cookie: None,
                 negotiation_request: Some(NegotiationRequest {
                     flags: NegotiationRequestFlags::empty(),
-                    protocols: ProtocolFlags::PROTOCOL_RDP,
+                    protocols: ProtocolFlags { bits: Protocol::ProtocolRdp as u32 },
                 }),
                 data: Vec::new(),
             }),
@@ -1179,7 +1180,7 @@ mod tests_core_49350 {
             ),
             client_dig_product_id: Some(String::from("")),
             connection_hint: Some(ConnectionHint::ConnectionHintNotProvided),
-            server_selected_protocol: Some(ProtocolFlags::PROTOCOL_RDP),
+            server_selected_protocol: Some(ProtocolFlags { bits: Protocol::ProtocolRdp as u32 }),
             desktop_physical_width: None,
             desktop_physical_height: None,
             desktop_orientation: None,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- Fix clippy 1.72 warnings

https://github.com/OISF/suricata/pull/9418 with better fix for ARM where `char` is unsigned