### PR TITLE
config/flow: fix division by zero

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -606,10 +606,11 @@ void FlowInitConfig(bool quiet)
             FatalError("Invalid value for flow.hash-size: NULL");
         }
 
-        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val) > 0 || configval == 0) {
+        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val) && configval != 0) {
             flow_config.hash_size = configval;
         } else {
-            FatalError("Invalid value for flow.hash-size");
+            FatalError("Invalid value for flow.hash-size. Must be a numeric value in the range "
+                       "1-4294967295");
         }
     }
     if ((ConfGet("flow.prealloc", &conf_val)) == 1)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6255
https://redmine.openinfosecfoundation.org/issues/5920

Describe changes:
- Fixes commit 805b07fa4236 to really fix the division by zero if user supplies a configuration value of 0 for hash size

Replaces https://github.com/OISF/suricata/pull/9432 with single error message