### PR TITLE
community-id: Fix IPv6 address sorting not respecting byte order v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2095,7 +2095,6 @@ jobs:
               libjansson-dev \
               libjansson4 \
               liblua5.1-dev \
-              libnss3-dev \
               libnspr4-dev \
               libnuma-dev \
               liblz4-dev \
@@ -2179,7 +2178,6 @@ jobs:
               libmagic-dev \
               libjansson-dev \
               libjansson4 \
-              libnss3-dev \
               libnspr4-dev \
               liblz4-dev \
               libssl-dev \
@@ -2259,7 +2257,6 @@ jobs:
               libjansson-dev \
               libjansson4 \
               liblua5.1-dev \
-              libnss3-dev \
               libnspr4-dev \
               libnuma-dev \
               liblz4-dev \

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -638,18 +638,6 @@ static bool CalculateCommunityFlowIdv4(const Flow *f,
     return false;
 }
 
-static inline bool FlowHashRawAddressIPv6LtU32(const uint32_t *a, const uint32_t *b)
-{
-    for (int i = 0; i < 4; i++) {
-        if (a[i] < b[i])
-            return true;
-        if (a[i] > b[i])
-            break;
-    }
-
-    return false;
-}
-
 static bool CalculateCommunityFlowIdv6(const Flow *f,
         const uint16_t seed, unsigned char *base64buf)
 {
@@ -673,9 +661,8 @@ static bool CalculateCommunityFlowIdv6(const Flow *f,
     dp = htons(dp);
 
     ipv6.seed = htons(seed);
-    if (FlowHashRawAddressIPv6LtU32(f->src.addr_data32, f->dst.addr_data32) ||
-            ((memcmp(&f->src, &f->dst, sizeof(f->src)) == 0) && sp < dp))
-    {
+    int cmp_r = memcmp(&f->src, &f->dst, sizeof(f->src));
+    if ((cmp_r < 0) || (cmp_r == 0 && sp < dp)) {
         memcpy(&ipv6.src, &f->src.addr_data32, 16);
         memcpy(&ipv6.dst, &f->dst.addr_data32, 16);
         ipv6.sp = sp;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6276

Describe changes:
When comparing IPv6 addresses based on uint32_t chunks, one needs to apply ntohl() conversion to the individual parts, otherwise on little endian systems individual bytes are compared in the wrong order. Avoid this all and leverage memcmp(), it'll short circuit on the first differing byte and its return values tells us which address sorts lower.

### Provide values to any of the below to override the defaults.

https://github.com/OISF/suricata-verify/pull/1360

```
SV_BRANCH=pr/1360
```

https://github.com/OISF/suricata/pull/9399 rebased with ticket number in commit
+ adding https://github.com/OISF/suricata/commit/31c61f9eeb71f9b0ba2cb3139c31f93f80d3c37a