### PR TITLE
fuzz: enable by default all protocols

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1902,6 +1902,11 @@ int AppLayerProtoDetectConfProtoDetectionEnabledDefault(
     if (RunmodeIsUnittests())
         goto enabled;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    // so that fuzzig takes place for DNP3 and such
+    default_enabled = true;
+#endif
+
     r = snprintf(param, sizeof(param), "%s%s%s", "app-layer.protocols.",
                  alproto, ".enabled");
     if (r < 0) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6189

Describe changes:
- fuzz: enable by default all protocols

So that oss-fuzz running `./src/suricata --list-app-layer-protos` lists DNP3, ENIP and NFS for app-layer parsing protocol-specific fuzz targets
