### PR TITLE
docs: check for min sphinx version; fix rtd theme - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2230,29 +2230,29 @@ fi
     fi
 
 # sphinx-build for documentation, and also check for a new enough version
-    AC_PATH_PROG(HAVE_SPHINXBUILD, sphinx-build, "no")
-    if test "$HAVE_SPHINXBUILD" != "no"; then
+    AC_PATH_PROG([SPHINX_BUILD], [sphinx-build], [no])
+    if test "$SPHINX_BUILD" != "no"; then
         MIN_SPHINX_BUILD_VERSION="3.4.3"
-        sphinx_build_version=$($HAVE_SPHINXBUILD --version 2>&1 | cut -d' ' -f2-)
+        sphinx_build_version=$($SPHINX_BUILD --version 2>&1 | cut -d' ' -f2-)
         AC_MSG_CHECKING([for sphinx-build >= $MIN_SPHINX_BUILD_VERSION])
         AS_VERSION_COMPARE([$sphinx_build_version], [$MIN_SPHINX_BUILD_VERSION],
             [
                 AC_MSG_RESULT([no, documentation will not be built])
-                HAVE_SPHINXBUILD="no"
+                SPHINX_BUILD="no"
             ],
             [], [])
-        if test "$HAVE_SPHINXBUILD" != "no"; then
-            AC_MSG_RESULT(yes)
+        if test "$SPHINX_BUILD" != "no"; then
+            AC_MSG_RESULT([yes])
         fi
     fi
 
-    if test "$HAVE_SPHINXBUILD" = "no"; then
+    if test "$SPHINX_BUILD" = "no"; then
        enable_sphinxbuild=no
        if test -e "$srcdir/doc/userguide/suricata.1"; then
            have_suricata_man=yes
        fi
     fi
-    AM_CONDITIONAL([HAVE_SPHINXBUILD], [test "x$enable_sphinxbuild" != "xno"])
+    AM_CONDITIONAL([SPHINX_BUILD], [test "x$enable_sphinxbuild" != "xno"])
     AM_CONDITIONAL([HAVE_SURICATA_MAN], [test "x$have_suricata_man" = "xyes"])
 
 # pdflatex for the pdf version of the user manual

--- a/configure.ac
+++ b/configure.ac
@@ -2229,8 +2229,23 @@ fi
         AC_DEFINE([CLS],[64],[L1 cache line size])
     fi
 
-# sphinx for documentation
+# sphinx-build for documentation, and also check for a new enough version
     AC_PATH_PROG(HAVE_SPHINXBUILD, sphinx-build, "no")
+    if test "$HAVE_SPHINXBUILD" != "no"; then
+        MIN_SPHINX_BUILD_VERSION="3.4.3"
+        sphinx_build_version=$($HAVE_SPHINXBUILD --version 2>&1 | cut -d' ' -f2-)
+        AC_MSG_CHECKING([for sphinx-build >= $MIN_SPHINX_BUILD_VERSION])
+        AS_VERSION_COMPARE([$sphinx_build_version], [$MIN_SPHINX_BUILD_VERSION],
+            [
+                AC_MSG_RESULT([no, documentation will not be built])
+                HAVE_SPHINXBUILD="no"
+            ],
+            [], [])
+        if test "$HAVE_SPHINXBUILD" != "no"; then
+            AC_MSG_RESULT(yes)
+        fi
+    fi
+
     if test "$HAVE_SPHINXBUILD" = "no"; then
        enable_sphinxbuild=no
        if test -e "$srcdir/doc/userguide/suricata.1"; then

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -37,7 +37,7 @@ if HAVE_SURICATA_MAN
 dist_man1_MANS = suricata.1 suricatasc.1 suricatactl.1 suricatactl-filestore.1
 endif
 
-if HAVE_SPHINXBUILD
+if SPHINX_BUILD
 dist_man1_MANS = suricata.1 suricatasc.1 suricatactl.1 suricatactl-filestore.1
 
 if HAVE_PDFLATEX
@@ -92,4 +92,4 @@ clean-local:
 	rm -f $(top_builddir)/doc/userguide/suricata*.1
 	rm -f $(top_builddir)/doc/userguide/userguide.pdf
 
-endif # HAVE_SPHINXBUILD
+endif # SPHINX_BUILD

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -143,6 +143,7 @@ if not on_rtd:
         else:
             app.add_stylesheet('css/suricata.css')
 else:
+    html_theme = 'sphinx_rtd_theme'
     html_context = {
         'css_files': [
             'https://media.readthedocs.org/css/sphinx_rtd_theme.css',


### PR DESCRIPTION
Check for a minimum version of Sphinx before enabling the building of
documentation. Many distributions still ship with very old versions.

Ticket: https://redmine.openinfosecfoundation.org/issues/6297

Also, pin the theme when running on ReadTheDocs.  RTD changed the default theme
for projects that don't explicitly set it.
