### PR TITLE
detect: SigMatchAppendSMToList can fail

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -286,12 +286,16 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
     sm->ctx = (SigMatchCtx *)data;
 
     if (event_type == APP_LAYER_EVENT_TYPE_PACKET) {
-        SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+        if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+            goto error;
+        }
     } else {
         if (DetectSignatureSetAppProto(s, data->alproto) != 0)
             goto error;
 
-        SigMatchAppendSMToList(s, sm, g_applayer_events_list_id);
+        if (SigMatchAppendSMToList(s, sm, g_applayer_events_list_id) < 0) {
+            goto error;
+        }
         s->flags |= SIG_FLAG_APPLAYER;
     }
 

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -176,12 +176,18 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
     sm->type = DETECT_AL_APP_LAYER_PROTOCOL;
     sm->ctx = (void *)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        goto error;
+    }
     return 0;
 
 error:
     if (data != NULL)
         SCFree(data);
+    if (sm) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+    }
     return -1;
 }
 

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -138,7 +138,12 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
     sm->type = DETECT_ASN1;
     sm->ctx = (SigMatchCtx *)ad;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        DetectAsn1Free(de_ctx, ad);
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        return -1;
+    }
 
     return 0;
 }

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -615,8 +615,9 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         goto error;
     sm->type = DETECT_BYTE_EXTRACT;
     sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
-
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        goto error;
+    }
 
     if (!(data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE))
         goto okay;
@@ -636,6 +637,10 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     ret = 0;
     return ret;
  error:
+    if (sm) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+    }
     DetectByteExtractFree(de_ctx, data);
     return ret;
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -434,7 +434,7 @@ void SigTableApplyStrictCommandLineOption(const char *str)
  * \param new  The sig match to append.
  * \param list The list to append to.
  */
-void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
+int SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
 {
     if (new->type == DETECT_CONTENT) {
         s->init_data->max_content_list_id = MAX(s->init_data->max_content_list_id, (uint32_t)list);
@@ -473,7 +473,7 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
                 s->init_data->curbuf == NULL) {
             if (SignatureInitDataBufferCheckExpand(s) < 0) {
                 SCLogError("failed to expand rule buffer array");
-                // return -1; TODO error handle
+                return -1;
             }
 
             /* initialize new buffer */
@@ -502,6 +502,7 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
                     sigmatch_table[sm->type].name, sm->idx);
         }
     }
+    return 0;
 }
 
 void SigMatchRemoveSMFromList(Signature *s, SigMatch *sm, int sm_list)

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -75,7 +75,7 @@ SigMatchData* SigMatchList2DataArray(SigMatch *head);
 void SigParseRegisterTests(void);
 Signature *DetectEngineAppendSig(DetectEngineCtx *, const char *);
 
-void SigMatchAppendSMToList(Signature *, SigMatch *, int);
+int SigMatchAppendSMToList(Signature *, SigMatch *, int);
 void SigMatchRemoveSMFromList(Signature *, SigMatch *, int);
 int SigMatchListSMBelongsTo(const Signature *, const SigMatch *);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6104

Describe changes:
- fixes buffer overflow in rules parsing

Draft : all calls to `SigMatchAppendSMToList` now need to get their return value checked and handle it properly...
Is it good for now ? (100 more files to go)