### PR TITLE
detect: SigMatchAppendSMToList can fail

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -286,12 +286,22 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
     sm->ctx = (SigMatchCtx *)data;
 
     if (event_type == APP_LAYER_EVENT_TYPE_PACKET) {
-        SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+        if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+            sm->ctx = NULL;
+            SigMatchFree(de_ctx, sm);
+            sm = NULL;
+            goto error;
+        }
     } else {
         if (DetectSignatureSetAppProto(s, data->alproto) != 0)
             goto error;
 
-        SigMatchAppendSMToList(s, sm, g_applayer_events_list_id);
+        if (SigMatchAppendSMToList(s, sm, g_applayer_events_list_id) < 0) {
+            sm->ctx = NULL;
+            SigMatchFree(de_ctx, sm);
+            sm = NULL;
+            goto error;
+        }
         s->flags |= SIG_FLAG_APPLAYER;
     }
 

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -176,7 +176,12 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
     sm->type = DETECT_AL_APP_LAYER_PROTOCOL;
     sm->ctx = (void *)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -138,7 +138,13 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
     sm->type = DETECT_ASN1;
     sm->ctx = (SigMatchCtx *)ad;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectAsn1Free(de_ctx, ad);
+        return -1;
+    }
 
     return 0;
 }

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -232,7 +232,12 @@ static int DetectBase64DecodeSetup(DetectEngineCtx *de_ctx, Signature *s,
     }
     sm->type = DETECT_BASE64_DECODE;
     sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     if (!data->bytes) {
         data->bytes = BASE64_DECODE_MAX;

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -218,7 +218,12 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     sm->type = DETECT_BSIZE;
     sm->ctx = (void *)bsz;
 
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(s, sm, list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCReturnInt(0);
 

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -83,7 +83,12 @@ static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
 
     sm->type = DETECT_BYPASS;
     sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        return -1;
+    }
 
     return 0;
 }

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -615,8 +615,12 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         goto error;
     sm->type = DETECT_BYTE_EXTRACT;
     sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
-
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     if (!(data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE))
         goto okay;

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -681,7 +681,12 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         goto error;
     sm->type = DETECT_BYTEJUMP;
     sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     if (!(data->flags & DETECT_BYTEJUMP_RELATIVE))
         goto okay;

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -398,7 +398,12 @@ static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         goto error;
     sm->type = DETECT_BYTEMATH;
     sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     if (!(data->flags & DETECT_BYTEMATH_FLAG_RELATIVE))
         goto okay;

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -701,7 +701,12 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         goto error;
     sm->type = DETECT_BYTETEST;
     sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     if (!(data->flags & DETECT_BYTETEST_RELATIVE))
         goto okay;

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -224,7 +224,12 @@ static int DetectCipServiceSetup(DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_CIPSERVICE;
     sm->ctx = (void *) cipserviced;
 
-    SigMatchAppendSMToList(s, sm, g_cip_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_cip_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     SCReturnInt(0);
 
 error:
@@ -394,7 +399,12 @@ static int DetectEnipCommandSetup(DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_ENIPCOMMAND;
     sm->ctx = (void *) enipcmdd;
 
-    SigMatchAppendSMToList(s, sm, g_enip_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_enip_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     SCReturnInt(0);
 
 error:

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -298,7 +298,12 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
 
     sm->ctx = (SigMatchCtx*)fd;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     pcre2_match_data_free(match);
     return 0;

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -358,7 +358,12 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
         goto error;
     sm->ctx = (void *)cd;
     sm->type = DETECT_CONTENT;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -293,7 +293,12 @@ static int DetectIPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -390,7 +395,12 @@ static int DetectTCPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -487,7 +497,12 @@ static int DetectTCPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -584,7 +599,12 @@ static int DetectUDPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -681,7 +701,12 @@ static int DetectUDPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
 
     sm->ctx = (void *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -776,7 +801,12 @@ static int DetectICMPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 
@@ -874,7 +904,12 @@ static int DetectICMPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -358,7 +358,12 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 
     sm->type = DETECT_DATAREP;
     sm->ctx = (SigMatchCtx *)cd;
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(s, sm, list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -430,7 +430,12 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
 
     sm->type = DETECT_DATASET;
     sm->ctx = (SigMatchCtx *)cd;
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(s, sm, list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -156,13 +156,20 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
     SigMatch *sm = SigMatchAlloc();
     if (sm == NULL) {
+        DetectDceIfaceFree(de_ctx, did);
         return -1;
     }
 
     sm->type = DETECT_DCE_IFACE;
     sm->ctx = did;
 
-    SigMatchAppendSMToList(s, sm, g_dce_generic_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_dce_generic_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectDceIfaceFree(de_ctx, did);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -151,7 +151,13 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     sm->type = DETECT_DCE_OPNUM;
     sm->ctx = (void *)dod;
 
-    SigMatchAppendSMToList(s, sm, g_dce_generic_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_dce_generic_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectDceOpnumFree(de_ctx, dod);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -247,7 +247,12 @@ static int DetectDetectionFilterSetup(DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = DETECT_DETECTION_FILTER;
     sm->ctx = (SigMatchCtx *)df;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-dhcp-leasetime.c
+++ b/src/detect-dhcp-leasetime.c
@@ -100,7 +100,12 @@ static int DetectDHCPLeaseTimeSetup(DetectEngineCtx *de_ctx, Signature *s, const
     sm->type = DETECT_AL_DHCP_LEASETIME;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-dhcp-rebinding-time.c
+++ b/src/detect-dhcp-rebinding-time.c
@@ -100,7 +100,12 @@ static int DetectDHCPRebindingTimeSetup(DetectEngineCtx *de_ctx, Signature *s, c
     sm->type = DETECT_AL_DHCP_REBINDING_TIME;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-dhcp-renewal-time.c
+++ b/src/detect-dhcp-renewal-time.c
@@ -100,7 +100,12 @@ static int DetectDHCPRenewalTimeSetup(DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = DETECT_AL_DHCP_RENEWAL_TIME;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -229,7 +229,12 @@ static int DetectDNP3FuncSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     sm->type = DETECT_AL_DNP3FUNC;
     sm->ctx = (void *)dnp3;
 
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCReturnInt(0);
 error:
@@ -314,7 +319,12 @@ static int DetectDNP3IndSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     sm->type = DETECT_AL_DNP3IND;
     sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCReturnInt(0);
 error:
@@ -388,7 +398,12 @@ static int DetectDNP3ObjSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     sm->type = DETECT_AL_DNP3OBJ;
     sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto fail;
+    }
 
     SCReturnInt(1);
 fail:

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -48,8 +48,13 @@ static int DetectDnsOpcodeSetup(DetectEngineCtx *de_ctx, Signature *s,
 
     sm->type = DETECT_AL_DNS_OPCODE;
     sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, dns_opcode_list_id);
-    
+    if (SigMatchAppendSMToList(s, sm, dns_opcode_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
+
     SCReturnInt(0);
 
 error:

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -147,7 +147,12 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     sm->type = DETECT_DSIZE;
     sm->ctx = (SigMatchCtx *)dd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCLogDebug("dd->arg1 %" PRIu16 ", dd->arg2 %" PRIu16 ", dd->mode %" PRIu8 "", dd->arg1,
             dd->arg2, dd->mode);

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -220,7 +220,13 @@ static int DetectEngineEventSetupDo(
     sm->type = smtype;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        SCFree(de);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -336,7 +336,12 @@ int DetectFileHashSetup(
     sm->type = type;
     sm->ctx = (void *)filehash;
 
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(s, sm, list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     s->file_flags |= FILE_SIG_NEED_FILE;
 

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -136,7 +136,12 @@ static int DetectFilesizeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_FILESIZE;
     sm->ctx = (SigMatchCtx *)fsd;
 
-    SigMatchAppendSMToList(s, sm, g_file_match_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_file_match_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     s->file_flags |= (FILE_SIG_NEED_FILE|FILE_SIG_NEED_SIZE);
     SCReturnInt(0);

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -465,7 +465,12 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         AppLayerHtpNeedFileInspection();
     }
 
-    SigMatchAppendSMToList(s, sm, g_file_match_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_file_match_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->filestore_ctx = (const DetectFilestoreData *)sm->ctx;
 
     sm = SigMatchAlloc();
@@ -473,7 +478,12 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         goto error;
     sm->type = DETECT_FILESTORE_POSTMATCH;
     sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     s->flags |= SIG_FLAG_FILESTORE;
 

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -55,7 +55,13 @@ static int DetectFlowAgeSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_FLOW_AGE;
     sm->ctx = (SigMatchCtx *)du32;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectFlowAgeFree(de_ctx, du32);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -416,7 +416,12 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     }
 
     if (sm != NULL) {
-        SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+        if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+            sm->ctx = NULL;
+            SigMatchFree(de_ctx, sm);
+            sm = NULL;
+            goto error;
+        }
     }
     return 0;
 

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -352,14 +352,24 @@ int DetectFlowbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         case DETECT_FLOWBITS_CMD_ISNOTSET:
         case DETECT_FLOWBITS_CMD_ISSET:
             /* checks, so packet list */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         case DETECT_FLOWBITS_CMD_SET:
         case DETECT_FLOWBITS_CMD_UNSET:
         case DETECT_FLOWBITS_CMD_TOGGLE:
             /* modifiers, only run when entire sig has matched */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         // suppress coverity warning as scan-build-7 warns w/o this.

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -388,7 +388,12 @@ static int DetectFlowintSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
         case FLOWINT_MODIFIER_SET:
         case FLOWINT_MODIFIER_ADD:
         case FLOWINT_MODIFIER_SUB:
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         case FLOWINT_MODIFIER_LT:
@@ -399,7 +404,12 @@ static int DetectFlowintSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
         case FLOWINT_MODIFIER_GT:
         case FLOWINT_MODIFIER_ISSET:
         case FLOWINT_MODIFIER_NOTSET:
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
         default:
             goto error;

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -191,7 +191,12 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     sm->type = DETECT_FLOWVAR;
     sm->ctx = (SigMatchCtx *)fd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCFree(content);
     return 0;
@@ -284,7 +289,12 @@ int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t 
     sm->type = DETECT_FLOWVAR_POSTMATCH;
     sm->ctx = (SigMatchCtx *)fv;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 error:
     if (fv != NULL)

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -300,7 +300,12 @@ static int DetectFragBitsSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_FRAGBITS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -241,7 +241,12 @@ static int DetectFragOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_FRAGOFFSET;
     sm->ctx = (SigMatchCtx *)fragoff;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -230,6 +230,11 @@ int DetectFtpbounceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *ftpb
      */
     sm->ctx = NULL;
 
-    SigMatchAppendSMToList(s, sm, g_ftp_request_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_ftp_request_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        return -1;
+    }
     SCReturnInt(0);
 }

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -199,7 +199,13 @@ static int DetectFtpdataSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_FTPDATA;
     sm->ctx = (void *)ftpcommandd;
 
-    SigMatchAppendSMToList(s, sm, g_ftpdata_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_ftpdata_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectFtpdataFree(de_ctx, ftpcommandd);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -423,7 +423,12 @@ static int DetectGeoipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *o
     sm->type = DETECT_GEOIP;
     sm->ctx = (SigMatchCtx *)geoipdata;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -419,14 +419,24 @@ int DetectHostbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         case DETECT_XBITS_CMD_ISNOTSET:
         case DETECT_XBITS_CMD_ISSET:
             /* checks, so packet list */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         case DETECT_XBITS_CMD_SET:
         case DETECT_XBITS_CMD_UNSET:
         case DETECT_XBITS_CMD_TOGGLE:
             /* modifiers, only run when entire sig has matched */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         // suppress coverity warning as scan-build-7 warns w/o this.

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -272,7 +272,13 @@ static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = DETECT_HTTP2_FRAMETYPE;
     sm->ctx = (SigMatchCtx *)http2ft;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectHTTP2frametypeFree(NULL, http2ft);
+        return -1;
+    }
 
     return 0;
 }
@@ -357,7 +363,13 @@ static int DetectHTTP2errorcodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = DETECT_HTTP2_ERRORCODE;
     sm->ctx = (SigMatchCtx *)http2ec;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectHTTP2errorcodeFree(NULL, http2ec);
+        return -1;
+    }
 
     return 0;
 }
@@ -424,7 +436,13 @@ static int DetectHTTP2prioritySetup (DetectEngineCtx *de_ctx, Signature *s, cons
     sm->type = DETECT_HTTP2_PRIORITY;
     sm->ctx = (SigMatchCtx *)prio;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        rs_detect_u8_free(prio);
+        return -1;
+    }
 
     return 0;
 }
@@ -491,7 +509,13 @@ static int DetectHTTP2windowSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     sm->type = DETECT_HTTP2_WINDOW;
     sm->ctx = (SigMatchCtx *)wu;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        rs_detect_u32_free(wu);
+        return -1;
+    }
 
     return 0;
 }
@@ -548,7 +572,13 @@ static int DetectHTTP2sizeUpdateSetup (DetectEngineCtx *de_ctx, Signature *s, co
     sm->type = DETECT_HTTP2_SIZEUPDATE;
     sm->ctx = (SigMatchCtx *)su;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectHTTP2settingsFree(NULL, su);
+        return -1;
+    }
 
     return 0;
 }
@@ -605,7 +635,13 @@ static int DetectHTTP2settingsSetup (DetectEngineCtx *de_ctx, Signature *s, cons
     sm->type = DETECT_HTTP2_SETTINGS;
     sm->ctx = (SigMatchCtx *)http2set;
 
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectHTTP2settingsFree(NULL, http2set);
+        return -1;
+    }
 
     return 0;
 }

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -252,7 +252,12 @@ static int DetectIcmpIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_ICMP_ID;
     sm->ctx = (SigMatchCtx *)iid;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -255,7 +255,12 @@ static int DetectIcmpSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char
     sm->type = DETECT_ICMP_SEQ;
     sm->ctx = (SigMatchCtx *)iseq;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -123,7 +123,13 @@ static int DetectICMPv6mtuSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     sm->type = DETECT_ICMPV6MTU;
     sm->ctx = (SigMatchCtx *)icmpv6mtud;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectICMPv6mtuFree(de_ctx, icmpv6mtud);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     s->proto.flags |= DETECT_PROTO_IPV6;
 

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -129,7 +129,12 @@ static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
     sm->type = DETECT_ICODE;
     sm->ctx = (SigMatchCtx *)icd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -208,7 +208,13 @@ int DetectIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *idstr)
     sm->type = DETECT_ID;
     sm->ctx = (SigMatchCtx *)id_d;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectIdFree(de_ctx, id_d);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -218,7 +218,12 @@ static int DetectIkeChosenSaSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_IKE_CHOSEN_SA;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_ike_chosen_sa_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_ike_chosen_sa_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ike-exch-type.c
+++ b/src/detect-ike-exch-type.c
@@ -122,7 +122,12 @@ static int DetectIkeExchTypeSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_IKE_EXCH_TYPE;
     sm->ctx = (SigMatchCtx *)ike_exch_type;
 
-    SigMatchAppendSMToList(s, sm, g_ike_exch_type_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_ike_exch_type_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ike-key-exchange-payload-length.c
+++ b/src/detect-ike-key-exchange-payload-length.c
@@ -128,7 +128,12 @@ static int DetectIkeKeyExchangePayloadLengthSetup(
     sm->type = DETECT_AL_IKE_KEY_EXCHANGE_PAYLOAD_LENGTH;
     sm->ctx = (SigMatchCtx *)key_exchange_payload_length;
 
-    SigMatchAppendSMToList(s, sm, g_ike_key_exch_payload_length_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_ike_key_exch_payload_length_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ike-nonce-payload-length.c
+++ b/src/detect-ike-nonce-payload-length.c
@@ -122,7 +122,12 @@ static int DetectIkeNoncePayloadLengthSetup(
     sm->type = DETECT_AL_IKE_NONCE_PAYLOAD_LENGTH;
     sm->ctx = (SigMatchCtx *)nonce_payload_length;
 
-    SigMatchAppendSMToList(s, sm, g_ike_nonce_payload_length_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_ike_nonce_payload_length_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -223,7 +223,12 @@ static int DetectIpOptsSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_IPOPTS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -419,7 +419,12 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
         goto error;
     sm->type = DETECT_IPPROTO;
     sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -232,7 +232,12 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
     sm->type = DETECT_IPREP;
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -278,7 +278,12 @@ int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, const char *isda
         goto end;
     sm->type = DETECT_ISDATAAT;
     sm->ctx = (SigMatchCtx *)idad;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto end;
+    }
 
     if (!(idad->flags & ISDATAAT_RELATIVE)) {
         ret = 0;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -140,7 +140,12 @@ static int DetectITypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
     sm->type = DETECT_ITYPE;
     sm->ctx = (SigMatchCtx *)itd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -192,7 +192,12 @@ static int DetectKrb5ErrCodeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     sm->type = DETECT_AL_KRB5_ERRCODE;
     sm->ctx = (void *)krb5d;
 
-    SigMatchAppendSMToList(s, sm, g_krb5_err_code_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_krb5_err_code_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -189,7 +189,12 @@ static int DetectKrb5MsgTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     sm->type = DETECT_AL_KRB5_MSGTYPE;
     sm->ctx = (void *)krb5d;
 
-    SigMatchAppendSMToList(s, sm, g_krb5_msg_type_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_krb5_msg_type_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-krb5-ticket-encryption.c
+++ b/src/detect-krb5-ticket-encryption.c
@@ -60,7 +60,12 @@ static int DetectKrb5TicketEncryptionSetup(
     sm->type = DETECT_AL_KRB5_TICKET_ENCRYPTION;
     sm->ctx = (void *)krb5d;
 
-    SigMatchAppendSMToList(s, sm, g_krb5_ticket_encryption_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_krb5_ticket_encryption_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -1118,7 +1118,12 @@ static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *st
         goto error;
     }
 
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(s, sm, list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -214,7 +214,12 @@ static int DetectMarkSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
 
     /* Append it to the list of post match, so the mark is set if the
      * full signature matches. */
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 #endif
 }

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -218,7 +218,8 @@ static int DetectMarkSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
         sm->ctx = NULL;
         SigMatchFree(de_ctx, sm);
         sm = NULL;
-        goto error;
+        DetectMarkDataFree(de_ctx, data);
+        return -1;
     }
     return 0;
 #endif

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -103,7 +103,12 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     sm->type    = DETECT_AL_MODBUS;
     sm->ctx     = (void *) modbus;
 
-    SigMatchAppendSMToList(s, sm, g_modbus_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_modbus_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     SCReturnInt(0);
 

--- a/src/detect-mqtt-connack-sessionpresent.c
+++ b/src/detect-mqtt-connack-sessionpresent.c
@@ -172,7 +172,12 @@ static int DetectMQTTConnackSessionPresentSetup (DetectEngineCtx *de_ctx, Signat
     sm->type = DETECT_AL_MQTT_CONNACK_SESSION_PRESENT;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_connack_session_present_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_connack_session_present_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -230,7 +230,12 @@ static int DetectMQTTConnectFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, co
     sm->type = DETECT_AL_MQTT_CONNECT_FLAGS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_connect_flags_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_connect_flags_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -214,7 +214,12 @@ static int DetectMQTTFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_AL_MQTT_FLAGS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_flags_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_flags_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-protocol-version.c
+++ b/src/detect-mqtt-protocol-version.c
@@ -123,7 +123,12 @@ static int DetectMQTTProtocolVersionSetup(DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_AL_MQTT_PROTOCOL_VERSION;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_protocol_version_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_protocol_version_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-qos.c
+++ b/src/detect-mqtt-qos.c
@@ -151,7 +151,12 @@ static int DetectMQTTQosSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_AL_MQTT_QOS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_qos_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_qos_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-reason-code.c
+++ b/src/detect-mqtt-reason-code.c
@@ -167,7 +167,12 @@ static int DetectMQTTReasonCodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = DETECT_AL_MQTT_REASON_CODE;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_reason_code_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_reason_code_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-mqtt-type.c
+++ b/src/detect-mqtt-type.c
@@ -156,7 +156,12 @@ static int DetectMQTTTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_AL_MQTT_TYPE;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, mqtt_type_id);
+    if (SigMatchAppendSMToList(s, sm, mqtt_type_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -176,7 +176,12 @@ static int DetectNfsProcedureSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->ctx = (void *)dd;
 
     SCLogDebug("low %u hi %u", dd->arg1, dd->arg2);
-    SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -160,7 +160,12 @@ static int DetectNfsVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->ctx = (void *)dd;
 
     SCLogDebug("low %u hi %u", dd->arg1, dd->arg2);
-    SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -434,7 +434,7 @@ void SigTableApplyStrictCommandLineOption(const char *str)
  * \param new  The sig match to append.
  * \param list The list to append to.
  */
-void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
+int SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
 {
     if (new->type == DETECT_CONTENT) {
         s->init_data->max_content_list_id = MAX(s->init_data->max_content_list_id, (uint32_t)list);
@@ -473,7 +473,7 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
                 s->init_data->curbuf == NULL) {
             if (SignatureInitDataBufferCheckExpand(s) < 0) {
                 SCLogError("failed to expand rule buffer array");
-                // return -1; TODO error handle
+                return -1;
             }
 
             /* initialize new buffer */
@@ -502,6 +502,7 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
                     sigmatch_table[sm->type].name, sm->idx);
         }
     }
+    return 0;
 }
 
 void SigMatchRemoveSMFromList(Signature *s, SigMatch *sm, int sm_list)

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -75,7 +75,7 @@ SigMatchData* SigMatchList2DataArray(SigMatch *head);
 void SigParseRegisterTests(void);
 Signature *DetectEngineAppendSig(DetectEngineCtx *, const char *);
 
-void SigMatchAppendSMToList(Signature *, SigMatch *, int);
+int SigMatchAppendSMToList(Signature *, SigMatch *, int);
 void SigMatchRemoveSMFromList(Signature *, SigMatch *, int);
 int SigMatchListSMBelongsTo(const Signature *, const SigMatch *);
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -923,7 +923,12 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
         goto error;
     sm->type = DETECT_PCRE;
     sm->ctx = (void *)pd;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    if (SigMatchAppendSMToList(s, sm, sm_list) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     for (uint8_t x = 0; x < pd->idx; x++) {
         if (DetectFlowvarPostMatchSetup(de_ctx, s, pd->capids[x]) < 0)

--- a/src/detect-pktvar.c
+++ b/src/detect-pktvar.c
@@ -160,7 +160,12 @@ static int DetectPktvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_PKTVAR;
     sm->ctx = (SigMatchCtx *)cd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     pcre2_match_data_free(match);
     return 0;

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -164,7 +164,12 @@ int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *replac
     }
     sm->type = DETECT_REPLACE;
     sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -226,7 +226,12 @@ static int DetectRfbSecresultSetup (DetectEngineCtx *de_ctx, Signature *s, const
     sm->type = DETECT_AL_RFB_SECRESULT;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, rfb_secresult_id);
+    if (SigMatchAppendSMToList(s, sm, rfb_secresult_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -134,7 +134,12 @@ static int DetectRfbSectypeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_RFB_SECTYPE;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_rfb_sectype_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_rfb_sectype_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -278,7 +278,12 @@ int DetectRpcSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rpcstr)
     sm->type = DETECT_RPC;
     sm->ctx = (SigMatchCtx *)rd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-sameip.c
+++ b/src/detect-sameip.c
@@ -102,7 +102,12 @@ static int DetectSameipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     sm->type = DETECT_SAMEIP;
     sm->ctx = NULL;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -201,7 +201,12 @@ static int DetectSNMPPduTypeSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->ctx = (void *)dd;
 
     SCLogDebug("snmp.pdu_type %d", dd->pdu_type);
-    SigMatchAppendSMToList(s, sm, g_snmp_pdu_type_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_snmp_pdu_type_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -153,7 +153,12 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->ctx = (void *)dd;
 
     SCLogDebug("snmp.version %d", dd->arg1);
-    SigMatchAppendSMToList(s, sm, g_snmp_version_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_snmp_version_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -251,7 +251,12 @@ static int DetectSshVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_SSH_PROTOVERSION;
     sm->ctx = (void *)ssh;
 
-    SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -238,7 +238,12 @@ static int DetectSshSoftwareVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_AL_SSH_SOFTWAREVERSION;
     sm->ctx = (void *)ssh;
 
-    SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -319,7 +319,12 @@ static int DetectSslStateSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     sm->type = DETECT_AL_SSL_STATE;
     sm->ctx = (SigMatchCtx*)ssd;
 
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_generic_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -308,7 +308,12 @@ static int DetectSslVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_SSL_VERSION;
     sm->ctx = (void *)ssl;
 
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_generic_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -155,7 +155,13 @@ static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_STREAM_SIZE;
     sm->ctx = (SigMatchCtx *)sd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectStreamSizeFree(de_ctx, sd);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -313,7 +313,13 @@ int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, const char *tagstr)
     sm->ctx = (SigMatchCtx *)td;
 
     /* Append it to the list of tags */
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_TMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_TMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTagDataFree(de_ctx, td);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -127,7 +127,12 @@ static int DetectAckSetup(DetectEngineCtx *de_ctx, Signature *s, const char *opt
     }
     sm->ctx = (SigMatchCtx*)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -493,7 +493,12 @@ static int DetectFlagsSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     sm->type = DETECT_FLAGS;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -122,7 +122,12 @@ static int DetectSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char *op
     }
     sm->ctx = (SigMatchCtx*)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -195,7 +195,12 @@ static int DetectWindowSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_WINDOW;
     sm->ctx = (SigMatchCtx *)wd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -114,7 +114,13 @@ static int DetectTcpmssSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_TCPMSS;
     sm->ctx = (SigMatchCtx *)tcpmssd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTcpmssFree(de_ctx, tcpmssd);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -201,7 +201,13 @@ static int DetectTemplateSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_TEMPLATE;
     sm->ctx = (void *)templated;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTemplateFree(de_ctx, templated);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -121,7 +121,13 @@ static int DetectTemplate2Setup (DetectEngineCtx *de_ctx, Signature *s, const ch
     sm->type = DETECT_TEMPLATE2;
     sm->ctx = (SigMatchCtx *)template2d;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTemplate2Free(de_ctx, template2d);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -266,7 +266,12 @@ static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_THRESHOLD;
     sm->ctx = (SigMatchCtx *)de;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -441,7 +441,12 @@ static int DetectTlsExpiredSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_AL_TLS_EXPIRED;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:
@@ -492,7 +497,12 @@ static int DetectTlsValidSetup (DetectEngineCtx *de_ctx, Signature *s,
     sm->type = DETECT_AL_TLS_VALID;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:
@@ -588,7 +598,12 @@ static int DetectTlsValiditySetup (DetectEngineCtx *de_ctx, Signature *s,
 
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -350,7 +350,13 @@ static int DetectTLSCertChainLenSetup(DetectEngineCtx *de_ctx, Signature *s, con
     sm->type = KEYWORD_ID;
     sm->ctx = (void *)dd;
 
-    SigMatchAppendSMToList(s, sm, g_tls_cert_buffer_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_cert_buffer_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        rs_detect_u32_free(dd);
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -250,7 +250,12 @@ static int DetectTlsVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_TLS_VERSION;
     sm->ctx = (void *)tls;
 
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_generic_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
 
     return 0;
 

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -316,7 +316,12 @@ static int DetectTlsSubjectSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     sm->type = DETECT_AL_TLS_SUBJECT;
     sm->ctx = (void *)tls;
 
-    SigMatchAppendSMToList(s, sm, g_tls_cert_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_cert_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:
@@ -512,7 +517,12 @@ static int DetectTlsIssuerDNSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     sm->type = DETECT_AL_TLS_ISSUERDN;
     sm->ctx = (void *)tls;
 
-    SigMatchAppendSMToList(s, sm, g_tls_cert_list_id);
+    if (SigMatchAppendSMToList(s, sm, g_tls_cert_list_id) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        goto error;
+    }
     return 0;
 
 error:
@@ -606,7 +616,12 @@ static int DetectTlsStoreSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     sm->type = DETECT_AL_TLS_STORE;
     s->flags |= SIG_FLAG_TLSSTORE;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -194,7 +194,13 @@ static int DetectTosSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg
     sm->type = DETECT_TOS;
     sm->ctx = (SigMatchCtx *)tosd;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTosFree(de_ctx, tosd);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -125,7 +125,13 @@ static int DetectTtlSetup (DetectEngineCtx *de_ctx, Signature *s, const char *tt
     sm->type = DETECT_TTL;
     sm->ctx = (SigMatchCtx *)ttld;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+        sm->ctx = NULL;
+        SigMatchFree(de_ctx, sm);
+        sm = NULL;
+        DetectTtlFree(de_ctx, ttld);
+        return -1;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -116,18 +116,21 @@ static int DetectUrilenSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->type = DETECT_AL_URILEN;
     sm->ctx = (void *)urilend;
 
-    if (urilend->raw_buffer)
+    if (urilend->raw_buffer) {
         if (SigMatchAppendSMToList(s, sm, g_http_raw_uri_buffer_id) < 0) {
             sm->ctx = NULL;
             SigMatchFree(de_ctx, sm);
             sm = NULL;
             goto error;
-        } else if (SigMatchAppendSMToList(s, sm, g_http_uri_buffer_id) < 0) {
+        }
+    } else {
+        if (SigMatchAppendSMToList(s, sm, g_http_uri_buffer_id) < 0) {
             sm->ctx = NULL;
             SigMatchFree(de_ctx, sm);
             sm = NULL;
             goto error;
         }
+    }
 
     SCReturnInt(0);
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -117,9 +117,17 @@ static int DetectUrilenSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     sm->ctx = (void *)urilend;
 
     if (urilend->raw_buffer)
-        SigMatchAppendSMToList(s, sm, g_http_raw_uri_buffer_id);
-    else
-        SigMatchAppendSMToList(s, sm, g_http_uri_buffer_id);
+        if (SigMatchAppendSMToList(s, sm, g_http_raw_uri_buffer_id) < 0) {
+            sm->ctx = NULL;
+            SigMatchFree(de_ctx, sm);
+            sm = NULL;
+            goto error;
+        } else if (SigMatchAppendSMToList(s, sm, g_http_uri_buffer_id) < 0) {
+            sm->ctx = NULL;
+            SigMatchFree(de_ctx, sm);
+            sm = NULL;
+            goto error;
+        }
 
     SCReturnInt(0);
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -362,14 +362,24 @@ int DetectXbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
         case DETECT_XBITS_CMD_ISNOTSET:
         case DETECT_XBITS_CMD_ISSET:
             /* checks, so packet list */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
 
         case DETECT_XBITS_CMD_SET:
         case DETECT_XBITS_CMD_UNSET:
         case DETECT_XBITS_CMD_TOGGLE:
             /* modifiers, only run when entire sig has matched */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
             break;
     }
 

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -274,7 +274,12 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
 
             sm->type = DETECT_THRESHOLD;
             sm->ctx = (void *)de;
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
         }
     } else if (id == 0 && gid > 0)    {
         if (parsed_track == TRACK_RULE) {
@@ -304,7 +309,12 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
             sm->type = DETECT_THRESHOLD;
             sm->ctx = (void *)de;
 
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
         }
     } else if (id > 0 && gid == 0) {
         SCLogError("Can't use a event config that has "
@@ -336,7 +346,12 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
             sm->type = DETECT_THRESHOLD;
             sm->ctx = (void *)de;
 
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
         }
     }
 
@@ -423,7 +438,12 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 sm->type = DETECT_THRESHOLD;
             sm->ctx = (void *)de;
 
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
         }
 
     } else if (id == 0 && gid > 0) {
@@ -464,7 +484,12 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                     sm->type = DETECT_THRESHOLD;
                 sm->ctx = (void *)de;
 
-                SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+                if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD) < 0) {
+                    sm->ctx = NULL;
+                    SigMatchFree(de_ctx, sm);
+                    sm = NULL;
+                    goto error;
+                }
             }
         }
     } else if (id > 0 && gid == 0) {
@@ -538,7 +563,12 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 sm->type = DETECT_THRESHOLD;
             sm->ctx = (void *)de;
 
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+            if (SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD) < 0) {
+                sm->ctx = NULL;
+                SigMatchFree(de_ctx, sm);
+                sm = NULL;
+                goto error;
+            }
         }
     }
 end:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6104

Describe changes:
- fixes buffer overflow in rules parsing
- fixes memory leak in parsing `dcerpc.iface` on OOM condition (if `SigMatchAlloc` returns NULL)

#9453 not draft as all calls are checked

Steps to do this
1. `git grep SigMatchAppendSMToList src/*.c | cut -d: -f1 | uniq | while read i; do python3 sig.py $i; done` see script below
2. `ls src/*.patch | while read i; do mv $i `echo $i | sed s/.patch//`; done`
3. Compile and fix the errors by reusing the code of the last failure handling (ie return -1 instead of goto error) 

```sig.py
import sys

f = open(sys.argv[1], "r")
f2 = open(sys.argv[1]+".patch", "w")
for l in f.readlines():
    if "SigMatchAppendSMToList(s, sm," in l:
        l=l.replace("SigMatchAppendSMToList", "if (SigMatchAppendSMToList").replace(";", " < 0) {\n        sm->ctx = NULL;\n        SigMatchFree(de_ctx, sm);\n        sm = NULL;\n        goto error;\n    }")
    f2.write(l)
```