### PR TITLE
detect: do not run tx detection without update

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -152,6 +152,10 @@ static void DetectRun(ThreadVars *th_v,
                 DetectRunFrames(th_v, de_ctx, det_ctx, p, pflow, &scratch);
                 // PACKET_PROFILING_DETECT_END(p, PROF_DETECT_TX);
             }
+            // no update to transactions
+            if (p->app_update_direction == UPDATE_DIR_NONE) {
+                goto end;
+            }
         } else if (p->proto == IPPROTO_UDP) {
             DetectRunFrames(th_v, de_ctx, det_ctx, p, pflow, &scratch);
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6299

Describe changes:
- Optimization to not run transaction detection when a TCP packet did not update anything (no call to AppLayerParserParse)

Let's see what QA thinks of this

Maybe this check can go up with `if (pflow && pflow->alstate && likely(pflow->proto == p->proto)) {`