### PR TITLE
issue 6300: correctly handle configuration includes from arrays - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -374,8 +374,9 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
         }
         else if (event.type == YAML_SEQUENCE_START_EVENT) {
             SCLogDebug("event.type=YAML_SEQUENCE_START_EVENT; state=%d", state);
-            if (ConfYamlParse(parser, node, 1, rlevel, state == CONF_INCLUDE ? CONF_INCLUDE : 0) !=
-                    0)
+            /* If we're processing a list of includes, use the current parent. */
+            if (ConfYamlParse(parser, state == CONF_INCLUDE ? parent : node, 1, rlevel,
+                        state == CONF_INCLUDE ? CONF_INCLUDE : 0) != 0)
                 goto fail;
             node->is_seq = 1;
             state = CONF_KEY;


### PR DESCRIPTION
Includes from an "include" array were being loaded into the wrong
parent as the logic for array handing in include context was not
updated.

If we are descending into an array in include context, pass through
the current parent so the included configuration is included where it
is expected.

Bug: https://redmine.openinfosecfoundation.org/issues/6300

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1382

