### PR TITLE
af-packet: handle null bpf filter - v1

### DIFF
--- a/src/util-bpf.c
+++ b/src/util-bpf.c
@@ -42,7 +42,7 @@ void ConfSetBPFFilter(
         }
     } else if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", bpf_filter) ==
                1) { // reading from a file
-        if (strlen(*bpf_filter) > 0) {
+        if (*bpf_filter && strlen(*bpf_filter) > 0) {
             SCLogConfig("%s: using file provided bpf filter %s", iface, *bpf_filter);
         }
     } else {


### PR DESCRIPTION
Commit 587c326d736851ea169d500b2989c94fc6a64521 made our YAML parser
more cmopliant with respect to what should be a NULL value and now when
a key contains no value it is NULL instead of an empty string, or
something else like a literal "null" or "~".

Check that the returned bpf_filter is null before checking strlen.

Bug: https://redmine.openinfosecfoundation.org/issues/6302
