### PR TITLE
detect/bytejump: Restrict post_offset to buffer

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -132,10 +132,10 @@ static bool DetectBytejumpValidateNbytes(const DetectBytejumpData *data, int32_t
  *  \param m byte jump sigmatch
  *  \param payload ptr to the payload
  *  \param payload_len length of the payload
- *  \retval 1 match
- *  \retval 0 no match
+ *  \retval true match
+ *  \retval false no match
  */
-int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
+bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         const SigMatchCtx *ctx, const uint8_t *payload, uint32_t payload_len, uint16_t flags,
         int32_t nbytes, int32_t offset)
 {
@@ -148,7 +148,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     int extbytes;
 
     if (payload_len == 0) {
-        SCReturnInt(0);
+        SCReturnBool(false);
     }
 
     /* Validate the number of bytes we are testing
@@ -161,7 +161,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
             SCLogDebug("Invalid byte_jump nbytes "
                        "seen in byte_jump - %d",
                     nbytes);
-            SCReturnInt(0);
+            SCReturnBool(false);
         }
     }
 
@@ -177,7 +177,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
         /* No match if there is no relative base */
         if (ptr == NULL || len <= 0) {
-            SCReturnInt(0);
+            SCReturnBool(false);
         }
     }
     else {
@@ -190,7 +190,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         SCLogDebug("Data not within payload "
                    "pkt=%p, ptr=%p, len=%d, nbytes=%d",
                 payload, ptr, len, nbytes);
-        SCReturnInt(0);
+        SCReturnBool(false);
     }
 
     /* Extract the byte data */
@@ -198,7 +198,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         extbytes = ByteExtractStringUint64(&val, data->base, nbytes, (const char *)ptr);
         if(extbytes <= 0) {
             SCLogDebug("error extracting %d bytes of string data: %d", nbytes, extbytes);
-            SCReturnInt(0);
+            SCReturnBool(false);
         }
     }
     else {
@@ -206,7 +206,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         extbytes = ByteExtractUint64(&val, endianness, (uint16_t)nbytes, ptr);
         if (extbytes != nbytes) {
             SCLogDebug("error extracting %d bytes of numeric data: %d", nbytes, extbytes);
-            SCReturnInt(0);
+            SCReturnBool(false);
         }
     }
 
@@ -239,7 +239,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         SCLogDebug("Jump location (%" PRIu64 ") is not within "
                    "payload (%" PRIu32 ")",
                 val, payload_len);
-        SCReturnInt(0);
+        SCReturnBool(false);
     }
 
 #ifdef DEBUG
@@ -252,7 +252,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     /* Adjust the detection context to the jump location. */
     det_ctx->buffer_offset = val;
 
-    SCReturnInt(1);
+    SCReturnBool(true);
 }
 
 static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,

--- a/src/detect-bytejump.h
+++ b/src/detect-bytejump.h
@@ -68,16 +68,10 @@ void DetectBytejumpRegister (void);
  * \param p pointer to the current packet
  * \param m pointer to the sigmatch that we will cast into DetectBytejumpData
  *
- * \retval -1 error
- * \retval  0 no match
- * \retval  1 match
- *
- * \todo The return seems backwards.  We should return a non-zero error code.
- *       One of the error codes is "no match".  As-is if someone accidentally
- *       does: if (DetectBytejumpMatch(...)) { match }, then they catch an
- *       error as a match.
+ * \retval  false no match
+ * \retval  true
  */
-int DetectBytejumpDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *,
+bool DetectBytejumpDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchCtx *,
         const uint8_t *, uint32_t, uint16_t, int32_t, int32_t);
 
 #endif /* __DETECT_BYTEJUMP_H__ */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -534,8 +534,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                       DETECT_BYTEJUMP_LITTLE: 0);
         }
 
-        if (DetectBytejumpDoMatch(
-                    det_ctx, s, smd->ctx, buffer, buffer_len, bjflags, nbytes, offset) != 1) {
+        if (!DetectBytejumpDoMatch(
+                    det_ctx, s, smd->ctx, buffer, buffer_len, bjflags, nbytes, offset)) {
             goto no_match;
         }
 


### PR DESCRIPTION
Restrict `post_offset` to remain in the buffer. When a negative `post_offset` value would point before the buffer beginning, treat it as though it points to the beginning of the buffer

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4624](https://redmine.openinfosecfoundation.org/issues/4624)

Describe changes:
- Changed "domatch" signature to return a bool to disambiguate return values
- Restrict `post_offset` to buffer.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1384
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
