### PR TITLE
conf: require non-null value when getting child value - v3

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -354,6 +354,8 @@ int ConfGetChildValue(const ConfNode *base, const char *name, const char **vptr)
         return 0;
     }
     else {
+        if (node->val == NULL)
+            return 0;
         *vptr = node->val;
         return 1;
     }


### PR DESCRIPTION
For ConfGetChildValue and related, return false if the value is NULL.

This means that this functions requires a non-null value.

This is a rebase of https://github.com/OISF/suricata/pull/9374.

Tickets:
- https://redmine.openinfosecfoundation.org/issues/6303
- https://redmine.openinfosecfoundation.org/issues/6249
- https://redmine.openinfosecfoundation.org/issues/6302
