### PR TITLE
napatech: emit HBA deprecation only once

### DIFF
--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -200,7 +200,12 @@ static void *NapatechConfigParser(const char *device)
     if (ConfGetInt("napatech.hba", &conf->hba) == 0) {
         conf->hba = -1;
     } else {
-        SCLogWarning("Napatech Host Buffer Allocation (hba) will be deprecated in Suricata v7.0.");
+        static bool warn_once = false;
+        if (!warn_once) {
+            SCLogWarning(
+                    "Napatech Host Buffer Allowance (hba) will be deprecated in Suricata v8.0.");
+            warn_once = true;
+        }
     }
     return (void *) conf;
 }


### PR DESCRIPTION
Issue: 6313
This commit removes duplicate HBA deprecation messages from being emitted.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6313

Describe changes:
- This commit removes duplicate HBA deprecation messages from being emitted.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
