### PR TITLE
detect/analyzer: add more details for ipopts - v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -39,6 +39,7 @@
 #include "detect-bytetest.h"
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
+#include "detect-ipopts.h"
 #include "feature.h"
 #include "util-print.h"
 #include "util-time.h"
@@ -848,6 +849,15 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 if (cd->flags & DETECT_BYTETEST_DCE)
                     jb_append_string(js, "dce");
                 jb_close(js);
+                jb_close(js);
+                break;
+            }
+            case DETECT_IPOPTS: {
+                const DetectIpOptsData *cd = (const DetectIpOptsData *)smd->ctx;
+
+                jb_open_object(js, "ipopts");
+                const char *flag = IpOptsFlagToString(cd->ipopt);
+                jb_set_string(js, "option", flag);
                 jb_close(js);
                 break;
             }

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -120,6 +120,39 @@ struct DetectIpOpts_ {
 };
 
 /**
+ * \brief Return human readable value for ipopts flag
+ *
+ * \param flag uint16_t DetectIpOptsData ipopts flag value
+ */
+const char *IpOptsFlagToString(uint16_t flag)
+{
+    switch (flag) {
+        case IPV4_OPT_FLAG_RR:
+            return "rr";
+        case IPV4_OPT_FLAG_LSRR:
+            return "lsrr";
+        case IPV4_OPT_FLAG_EOL:
+            return "eol";
+        case IPV4_OPT_FLAG_NOP:
+            return "nop";
+        case IPV4_OPT_FLAG_TS:
+            return "ts";
+        case IPV4_OPT_FLAG_SEC:
+            return "sec";
+        case IPV4_OPT_FLAG_ESEC:
+            return "esec";
+        case IPV4_OPT_FLAG_SSRR:
+            return "ssrr";
+        case IPV4_OPT_FLAG_SID:
+            return "satid";
+        case 0xffff:
+            return "any";
+        default:
+            return NULL;
+    }
+}
+
+/**
  * \internal
  * \brief This function is used to match ip option on a packet with those passed via ipopts:
  *

--- a/src/detect-ipopts.h
+++ b/src/detect-ipopts.h
@@ -45,5 +45,7 @@ typedef struct DetectIpOptsData_ {
 
 void DetectIpOptsRegister (void);
 
+const char *IpOptsFlagToString(uint16_t flag);
+
 #endif /*__DETECT_IPOPTS_H__ */
 


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6348

Describe changes:
- output `ipopts` matched value when running engine analysis

This contribution is also meant to serve as example for other newcomer contributions, especially Outreachy applicants, _if_ it's good enough...

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1387

Output example:
```json
{
  "raw": "alert ip $EXTERNAL_NET any -> $HOME_NET any (msg:\"GPL MISC source route ssrr\"; ipopts:ssrr ; reference:arachnids,422; classtype:bad-unknown; sid:2100502; rev:3; metadata:created_at 2010_09_23, updated_at 2010_09_23;)",
  "id": 2100502,
  "gid": 1,
  "rev": 3,
  "msg": "GPL MISC source route ssrr",
  "app_proto": "unknown",
  "requirements": [],
  "type": "pkt",
  "flags": [
    "sp_any",
    "dp_any",
    "need_packet",
    "toserver",
    "toclient"
  ],
  "pkt_engines": [
    {
      "name": "packet",
      "is_mpm": false
    }
  ],
  "frame_engines": [],
  "lists": {
    "packet": {
      "matches": [
        {
          "name": "ipopts",
          "ipopts": {
            "option": "ssrr"
          }
        }
      ]
    }
  }
}
```