### PR TITLE
detect/rule: Use correct buffer index for sizing mpm_stats array

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -640,7 +640,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     uint32_t mpms_min = 0;
     uint32_t mpms_max = 0;
 
-    int max_buffer_type_id = DetectBufferTypeMaxId() + 1;
+    int max_buffer_type_id = de_ctx->buffer_type_id;
 
     struct {
         uint32_t total;
@@ -755,6 +755,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
             if (w > mpms_max)
                 mpms_max = w;
 
+            BUG_ON(mpm_list >= max_buffer_type_id);
             mpm_stats[mpm_list].total += w;
             mpm_stats[mpm_list].cnt++;
             if (mpm_stats[mpm_list].min == 0 || w < mpm_stats[mpm_list].min)

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -668,10 +668,8 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
 
     json_t *js_array = json_array();
 
-    const Signature *s;
-    uint32_t x;
-    for (x = 0; x < sgh->init->sig_cnt; x++) {
-        s = sgh->init->match_array[x];
+    for (uint32_t x = 0; x < sgh->init->sig_cnt; x++) {
+        const Signature *s = sgh->init->match_array[x];
         if (s == NULL)
             continue;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1893,7 +1893,6 @@ int DetectEngineBufferTypeGetByIdTransforms(
     BUG_ON(HashListTableAdd(de_ctx->buffer_type_hash_name, (void *)map, 0) != 0);
     BUG_ON(HashListTableAdd(de_ctx->buffer_type_hash_id, (void *)map, 0) != 0);
     SCLogDebug("buffer %s registered with id %d, parent %d", map->name, map->id, map->parent_id);
-    de_ctx->buffer_type_id++;
 
     if (map->frame) {
         DetectFrameInspectEngineCopy(de_ctx, map->parent_id, map->id, &map->transforms);


### PR DESCRIPTION

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5211](https://redmine.openinfosecfoundation.org/issues/5211)

Describe changes:
- Removed excess increment of buffer index
- Size mpm stats array to DE context buffer id max


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
