### PR TITLE
draft: cleanup flow logging for plugin/library use - v1

### DIFF
--- a/examples/plugins/c-flow-logger/.gitignore
+++ b/examples/plugins/c-flow-logger/.gitignore
@@ -1,0 +1,3 @@
+!Makefile
+*.so
+*.o

--- a/examples/plugins/c-flow-logger/Makefile
+++ b/examples/plugins/c-flow-logger/Makefile
@@ -1,0 +1,18 @@
+SRCS :=		flowlogger.c
+
+LIBSURICATA_CONFIG ?= libsuricata-config
+
+CPPFLAGS +=	`$(LIBSURICATA_CONFIG) --cflags`
+CPPFLAGS +=	-DSURICATA_PLUGIN -I.
+CPPFLAGS +=	"-D__SCFILENAME__=\"$(*F)\""
+
+OBJS :=		$(SRCS:.c=.o)
+
+flowlogger.so: $(OBJS)
+	$(CC) -fPIC -shared -o $@ $(OBJS)
+
+%.o: %.c
+	$(CC) -fPIC $(CPPFLAGS) -c -o $@ $<
+
+clean:
+	rm -f *.o *.so *~

--- a/examples/plugins/c-flow-logger/README.md
+++ b/examples/plugins/c-flow-logger/README.md
@@ -1,0 +1,4 @@
+# Example Flow Logging Plugin
+
+This is an example of a low level flow logging plugin for Suricata
+8.0.

--- a/examples/plugins/c-flow-logger/flowlogger.c
+++ b/examples/plugins/c-flow-logger/flowlogger.c
@@ -1,0 +1,88 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "suricata-plugin.h"
+#include "util-mem.h"
+#include "util-debug.h"
+
+// For PrintInet
+#include "util-print.h"
+
+#include "output-flow.h"
+
+static TmEcode ThreadInit(ThreadVars *tv, const void *initdata, void **data)
+{
+    return TM_ECODE_OK;
+}
+
+static TmEcode ThreadDeinit(ThreadVars *tv, void *data)
+{
+    // Nothing to do. If we allocated data in ThreadInit we would free
+    // it here.
+}
+
+static int FlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
+{
+    char src_ip[46] = { 0 }, dst_ip[46] = { 0 };
+    Port sp, dp;
+
+    if ((f->flags & FLOW_DIR_REVERSED) == 0) {
+        if (FLOW_IS_IPV4(f)) {
+            PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), src_ip, sizeof(src_ip));
+            PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), dst_ip, sizeof(dst_ip));
+        } else if (FLOW_IS_IPV6(f)) {
+            PrintInet(AF_INET6, (const void *)&(f->src.address), src_ip, sizeof(src_ip));
+            PrintInet(AF_INET6, (const void *)&(f->dst.address), dst_ip, sizeof(dst_ip));
+        }
+        sp = f->sp;
+        dp = f->dp;
+    } else {
+        if (FLOW_IS_IPV4(f)) {
+            PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), src_ip, sizeof(src_ip));
+            PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), dst_ip, sizeof(dst_ip));
+        } else if (FLOW_IS_IPV6(f)) {
+            PrintInet(AF_INET6, (const void *)&(f->dst.address), src_ip, sizeof(src_ip));
+            PrintInet(AF_INET6, (const void *)&(f->src.address), dst_ip, sizeof(dst_ip));
+        }
+        sp = f->dp;
+        dp = f->sp;
+    }
+
+    SCLogNotice("Flow: %s:%u -> %s:%u", src_ip, sp, dst_ip, dp);
+
+    return 0;
+}
+
+static void Init(void)
+{
+    OutputRegisterFlowLogger("custom-flow-logger", FlowLogger, NULL, ThreadInit, ThreadDeinit);
+}
+
+const SCPlugin PluginRegistration = {
+    .name = "FlowLogger",
+    .author = "Jason Ish",
+    .license = "GPLv2",
+    .Init = Init,
+};
+
+const SCPlugin *SCPluginRegister()
+{
+    return &PluginRegistration;
+}

--- a/src/decode.c
+++ b/src/decode.c
@@ -695,7 +695,7 @@ DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *tv)
 
     dtv->app_tctx = AppLayerGetCtxThread(tv);
 
-    if (OutputFlowLogThreadInit(tv, NULL, &dtv->output_flow_thread_data) != TM_ECODE_OK) {
+    if (OutputFlowLogThreadInit(tv, &dtv->output_flow_thread_data) != TM_ECODE_OK) {
         SCLogError("initializing flow log API for thread failed");
         DecodeThreadVarsFree(tv, dtv);
         return NULL;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -983,7 +983,7 @@ static TmEcode FlowRecyclerThreadInit(ThreadVars *t, const void *initdata, void 
     FlowRecyclerThreadData *ftd = SCCalloc(1, sizeof(FlowRecyclerThreadData));
     if (ftd == NULL)
         return TM_ECODE_FAILED;
-    if (OutputFlowLogThreadInit(t, NULL, &ftd->output_thread_data) != TM_ECODE_OK) {
+    if (OutputFlowLogThreadInit(t, &ftd->output_thread_data) != TM_ECODE_OK) {
         SCLogError("initializing flow log API for thread failed");
         SCFree(ftd);
         return TM_ECODE_FAILED;

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -312,7 +312,7 @@ static TmEcode FlowWorkerThreadInit(ThreadVars *tv, const void *initdata, void *
         FlowWorkerThreadDeinit(tv, fw);
         return TM_ECODE_FAILED;
     }
-    if (OutputFlowLogThreadInit(tv, NULL, &fw->output_thread_flow) != TM_ECODE_OK) {
+    if (OutputFlowLogThreadInit(tv, &fw->output_thread_flow) != TM_ECODE_OK) {
         SCLogError("initializing flow log API for thread failed");
         FlowWorkerThreadDeinit(tv, fw);
         return TM_ECODE_FAILED;

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -121,7 +121,7 @@ TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f)
 /** \brief thread init for the flow logger
  *  This will run the thread init functions for the individual registered
  *  loggers */
-TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void *initdata, void **data)
+TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void **data)
 {
     OutputFlowLoggerThreadData *td = SCMalloc(sizeof(*td));
     if (td == NULL)

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -42,7 +42,10 @@ typedef struct OutputFlowLogger_ {
     FlowLogger LogFunc;
     OutputCtx *output_ctx;
     struct OutputFlowLogger_ *next;
+
+    /** A name for this logger, used for debugging only. */
     const char *name;
+
     TmEcode (*ThreadInit)(ThreadVars *, const void *, void **);
     TmEcode (*ThreadDeinit)(ThreadVars *, void *);
     void (*ThreadExitPrintStats)(ThreadVars *, void *);
@@ -50,6 +53,14 @@ typedef struct OutputFlowLogger_ {
 
 static OutputFlowLogger *list = NULL;
 
+/**
+ * \brief Register a new low-level flow logger.
+ *
+ * \param name The name of this logger. Its only used for debugging,
+ *     so choose something unique.
+ *
+ * \retval 0 on success, -1 on failure.
+ */
 int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc,
     OutputCtx *output_ctx, ThreadInitFunc ThreadInit,
     ThreadDeinitFunc ThreadDeinit,

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -39,7 +39,7 @@ typedef struct OutputFlowLoggerThreadData_ {
  * it's perfectly valid that have multiple instances of the same
  * log module (e.g. http.log) with different output ctx'. */
 typedef struct OutputFlowLogger_ {
-    FlowLogger LogFunc;
+    SCFlowLoggerFunc LogFunc;
 
     /** Data that will be passed to the ThreadInit callback. */
     void *initdata;
@@ -64,7 +64,7 @@ static OutputFlowLogger *list = NULL;
  *
  * \retval 0 on success, -1 on failure.
  */
-int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc, void *initdata,
+int OutputRegisterFlowLogger(const char *name, SCFlowLoggerFunc LogFunc, void *initdata,
         ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
 {
     OutputFlowLogger *op = SCMalloc(sizeof(*op));

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -38,7 +38,7 @@ int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc,
 void OutputFlowShutdown(void);
 
 TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f);
-TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void *initdata, void **data);
+TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void **data);
 TmEcode OutputFlowLogThreadDeinit(ThreadVars *tv, void *thread_data);
 void OutputFlowLogExitPrintStats(ThreadVars *tv, void *thread_data);
 

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -31,9 +31,9 @@
 /** flow logger function pointer type */
 typedef int (*FlowLogger)(ThreadVars *, void *thread_data, Flow *f);
 
-int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc,
-    OutputCtx *, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
+int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc, void *,
+        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
+        ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
 void OutputFlowShutdown(void);
 

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -32,14 +32,12 @@
 typedef int (*FlowLogger)(ThreadVars *, void *thread_data, Flow *f);
 
 int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc, void *,
-        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-        ThreadExitPrintStatsFunc ThreadExitPrintStats);
+        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit);
 
 void OutputFlowShutdown(void);
 
 TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f);
 TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void **data);
 TmEcode OutputFlowLogThreadDeinit(ThreadVars *tv, void *thread_data);
-void OutputFlowLogExitPrintStats(ThreadVars *tv, void *thread_data);
 
 #endif /* __OUTPUT_FLOW_H__ */

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -28,14 +28,13 @@
 
 #include "tm-modules.h"
 
-/** flow logger function pointer type */
-typedef int (*FlowLogger)(ThreadVars *, void *thread_data, Flow *f);
+/** Flow logging callback function pointer type. */
+typedef int (*SCFlowLoggerFunc)(ThreadVars *, void *thread_data, Flow *f);
 
-int OutputRegisterFlowLogger(const char *name, FlowLogger LogFunc, void *,
+int OutputRegisterFlowLogger(const char *name, SCFlowLoggerFunc LogFunc, void *,
         ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit);
 
 void OutputFlowShutdown(void);
-
 TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f);
 TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void **data);
 TmEcode OutputFlowLogThreadDeinit(ThreadVars *tv, void *thread_data);

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -26,7 +26,9 @@
 #ifndef __OUTPUT_FLOW_H__
 #define __OUTPUT_FLOW_H__
 
+#include "decode.h"
 #include "tm-modules.h"
+#include "flow.h"
 
 /** Flow logging callback function pointer type. */
 typedef int (*SCFlowLoggerFunc)(ThreadVars *, void *thread_data, Flow *f);

--- a/src/output.c
+++ b/src/output.c
@@ -584,11 +584,10 @@ error:
  *
  * \retval Returns 0 on success, -1 on failure.
  */
-void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    FlowLogger FlowLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats)
+void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name, const char *name,
+        const char *conf_name, OutputInitSubFunc InitFunc, SCFlowLoggerFunc FlowLogFunc,
+        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
+        ThreadExitPrintStatsFunc ThreadExitPrintStats)
 {
     if (unlikely(FlowLogFunc == NULL)) {
         goto error;

--- a/src/output.h
+++ b/src/output.h
@@ -71,7 +71,7 @@ typedef struct OutputModule_ {
     TxLoggerCondition TxLogCondition;
     FileLogger FileLogFunc;
     FiledataLogger FiledataLogFunc;
-    FlowLogger FlowLogFunc;
+    SCFlowLoggerFunc FlowLogFunc;
     StreamingLogger StreamingLogFunc;
     StatsLogger StatsLogFunc;
     AppProto alproto;
@@ -154,11 +154,10 @@ void OutputRegisterFiledataSubModule(LoggerId, const char *parent_name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
-void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    FlowLogger FlowLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
+void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name, const char *name,
+        const char *conf_name, OutputInitSubFunc InitFunc, SCFlowLoggerFunc FlowLogFunc,
+        ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
+        ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
 void OutputRegisterStreamingModule(LoggerId id, const char *name,
     const char *conf_name, OutputInitFunc InitFunc,

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -626,9 +626,8 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
 {
     /* flow logger doesn't run in the packet path */
     if (module->FlowLogFunc) {
-        OutputRegisterFlowLogger(module->name, module->FlowLogFunc,
-            output_ctx, module->ThreadInit, module->ThreadDeinit,
-            module->ThreadExitPrintStats);
+        OutputRegisterFlowLogger(module->name, module->FlowLogFunc, output_ctx, module->ThreadInit,
+                module->ThreadDeinit);
         return;
     }
     /* stats logger doesn't run in the packet path */


### PR DESCRIPTION
Some cleanups around the low level flow logging output as I was testing it from library/plugin context:
- remove unused arguments
- some renames to better form a public api
- should we put examples right in suricata proper?
- function level documentation
- TODO: devguide documentation

The idea is to give all the low level loggers the same treatment.