### PR TITLE
mime: process chunk as soon as possible

### DIFF
--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -1386,6 +1386,9 @@ static int ProcessBase64BodyLine(const uint8_t *buf, uint32_t len,
         remaining = leftover_bytes;
         offset += consumed_bytes;
     }
+    if (ret == MIME_DEC_OK && state->data_chunk_len > 0) {
+        ret = ProcessDecodedDataChunk(state->data_chunk, state->data_chunk_len, state);
+    }
     return ret;
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6367

Describe changes:
- mime : process chunk right away (instead of buffering for later)

https://github.com/OISF/suricata-verify/pull/1390
```
SV_BRANCH=pr/1390
```

This allows to have more contents of a file just before stream depth is reached (as will be shown by QA diff on SURI_TLPW1_files_sha256)

Required for https://github.com/OISF/suricata/pull/9424

#9435 with ticket number and S-V test