### PR TITLE
doc/rule-profiling: fix suricatasc typo

### DIFF
--- a/doc/userguide/rule-management/rule-profiling.rst
+++ b/doc/userguide/rule-management/rule-profiling.rst
@@ -6,11 +6,11 @@ can be activated on demand from the unix socket and dumped from it.
 
 To start profiling ::
 
- surictasc -c ruleset-profile-start
+ suricatasc -c ruleset-profile-start
 
 To stop profiling ::
 
- surictasc -c ruleset-profile-stop
+ suricatasc -c ruleset-profile-stop
 
 To dump profiling ::
 
@@ -18,9 +18,9 @@ To dump profiling ::
 
 A typical scenario to get rules performance would be ::
 
- surictasc -c ruleset-profile-start
+ suricatasc -c ruleset-profile-start
  sleep 30
- surictasc -c ruleset-profile-stop
+ suricatasc -c ruleset-profile-stop
  suricatasc -c ruleset-profile
 
 On busy systems, using the sampling capability to capture performance


### PR DESCRIPTION
corrected typo in suricatasc

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#6371](https://redmine.openinfosecfoundation.org/issues/6371)

Describe changes:
- changed spelling of surictasc to suricatasc

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
