### PR TITLE
mpm: thread ctx cleanups

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1998,7 +1998,7 @@ AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)
         for (j = 0; j < 2; j++) {
             mpm_ctx = &alpd_ctx.ctx_ipp[i].ctx_pm[j].mpm_ctx;
             mpm_tctx = &alpd_tctx->mpm_tctx[i][j];
-            mpm_table[mpm_ctx->mpm_type].InitThreadCtx(mpm_ctx, mpm_tctx);
+            MpmInitThreadCtx(mpm_tctx, mpm_ctx->mpm_type);
         }
     }
 
@@ -2028,7 +2028,7 @@ void AppLayerProtoDetectDestroyCtxThread(AppLayerProtoDetectThreadCtx *alpd_tctx
         for (dir = 0; dir < 2; dir++) {
             mpm_ctx = &alpd_ctx.ctx_ipp[ipproto_map].ctx_pm[dir].mpm_ctx;
             mpm_tctx = &alpd_tctx->mpm_tctx[ipproto_map][dir];
-            mpm_table[mpm_ctx->mpm_type].DestroyThreadCtx(mpm_ctx, mpm_tctx);
+            MpmDestroyThreadCtx(mpm_tctx, mpm_ctx->mpm_type);
         }
     }
     PmqFree(&alpd_tctx->pmq);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -277,7 +277,7 @@ static void FTPLocalStorageFree(void *ptr)
         }
 
         if (td->ftp_mpm_thread_ctx != NULL) {
-            mpm_table[FTP_MPM].DestroyThreadCtx(ftp_mpm_ctx, td->ftp_mpm_thread_ctx);
+            MpmDestroyThreadCtx(td->ftp_mpm_thread_ctx, FTP_MPM);
             SCFree(td->ftp_mpm_thread_ctx);
         }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1590,7 +1590,7 @@ static void SMTPLocalStorageFree(void *ptr)
         }
 
         if (td->smtp_mpm_thread_ctx != NULL) {
-            mpm_table[SMTP_MPM].DestroyThreadCtx(smtp_mpm_ctx, td->smtp_mpm_thread_ctx);
+            MpmDestroyThreadCtx(td->smtp_mpm_thread_ctx, SMTP_MPM);
             SCFree(td->smtp_mpm_thread_ctx);
         }
 

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -165,9 +165,8 @@ static void PrefilterTxDnsQuery(DetectEngineThreadCtx *det_ctx, const void *pect
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -126,7 +126,7 @@ static int FrameStreamDataPrefilterFunc(
         // PrintRawDataFp(stdout, data, data_len);
 
         (void)mpm_table[mpm_ctx->mpm_type].Search(
-                mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
         SCLogDebug("det_ctx->pmq.rule_id_array_cnt %u", det_ctx->pmq.rule_id_array_cnt);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
     }
@@ -167,7 +167,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
 
         if (data != NULL && data_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
             SCLogDebug("det_ctx->pmq.rule_id_array_cnt %u", det_ctx->pmq.rule_id_array_cnt);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
         }

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -895,8 +895,7 @@ void PatternMatchThreadPrint(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
 void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
 {
     SCLogDebug("mpm_thread_ctx %p, mpm_matcher %"PRIu16"", mpm_thread_ctx, mpm_matcher);
-    if (mpm_table[mpm_matcher].DestroyThreadCtx != NULL)
-        mpm_table[mpm_matcher].DestroyThreadCtx(NULL, mpm_thread_ctx);
+    MpmDestroyThreadCtx(mpm_thread_ctx, mpm_matcher);
 }
 void PatternMatchThreadPrepare(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
 {

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -64,9 +64,8 @@ static int StreamMpmFunc(
         smd->det_ctx->stream_mpm_cnt++;
         smd->det_ctx->stream_mpm_size += data_len;
 #endif
-        (void)mpm_table[smd->mpm_ctx->mpm_type].Search(smd->mpm_ctx,
-                &smd->det_ctx->mtcs, &smd->det_ctx->pmq,
-                data, data_len);
+        (void)mpm_table[smd->mpm_ctx->mpm_type].Search(
+                smd->mpm_ctx, &smd->det_ctx->mtc, &smd->det_ctx->pmq, data, data_len);
         PREFILTER_PROFILING_ADD_BYTES(smd->det_ctx, data_len);
     }
     return 0;

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -731,8 +731,8 @@ static void PrefilterMpm(DetectEngineThreadCtx *det_ctx, const void *pectx, Pack
     //PrintRawDataFp(stdout, data, data_len);
 
     if (data != NULL && data_len >= mpm_ctx->minlen) {
-        (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+        (void)mpm_table[mpm_ctx->mpm_type].Search(
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
     }
 }
@@ -801,8 +801,8 @@ static void PrefilterMpmPkt(DetectEngineThreadCtx *det_ctx,
     //PrintRawDataFp(stdout, data, data_len);
 
     if (data != NULL && data_len >= mpm_ctx->minlen) {
-        (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+        (void)mpm_table[mpm_ctx->mpm_type].Search(
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
     }
 }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3200,8 +3200,6 @@ error:
 static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx)
 {
     PatternMatchThreadPrepare(&det_ctx->mtc, de_ctx->mpm_matcher);
-    PatternMatchThreadPrepare(&det_ctx->mtcs, de_ctx->mpm_matcher);
-    PatternMatchThreadPrepare(&det_ctx->mtcu, de_ctx->mpm_matcher);
 
     PmqSetup(&det_ctx->pmq);
 
@@ -3452,8 +3450,6 @@ static void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
     /** \todo get rid of this static */
     if (det_ctx->de_ctx != NULL) {
         PatternMatchThreadDestroy(&det_ctx->mtc, det_ctx->de_ctx->mpm_matcher);
-        PatternMatchThreadDestroy(&det_ctx->mtcs, det_ctx->de_ctx->mpm_matcher);
-        PatternMatchThreadDestroy(&det_ctx->mtcu, det_ctx->de_ctx->mpm_matcher);
     }
 
     PmqFree(&det_ctx->pmq);
@@ -3541,7 +3537,6 @@ void DetectEngineThreadCtxInfo(ThreadVars *t, DetectEngineThreadCtx *det_ctx)
 {
     /* XXX */
     PatternMatchThreadPrint(&det_ctx->mtc, det_ctx->de_ctx->mpm_matcher);
-    PatternMatchThreadPrint(&det_ctx->mtcu, det_ctx->de_ctx->mpm_matcher);
 }
 
 static uint32_t DetectKeywordCtxHashFunc(HashListTable *ht, void *data, uint16_t datalen)

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -471,8 +471,7 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
 
             if (buffer->inspect_len >= mpm_ctx->minlen) {
                 uint32_t prev_rule_id_array_cnt = det_ctx->pmq.rule_id_array_cnt;
-                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                        &det_ctx->mtcu, &det_ctx->pmq,
+                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx, &det_ctx->mtc, &det_ctx->pmq,
                         buffer->inspect, buffer->inspect_len);
                 PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
 

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -376,8 +376,7 @@ static void PrefilterTxFilemagic(DetectEngineThreadCtx *det_ctx, const void *pec
                 continue;
 
             if (buffer->inspect_len >= mpm_ctx->minlen) {
-                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                        &det_ctx->mtcu, &det_ctx->pmq,
+                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx, &det_ctx->mtc, &det_ctx->pmq,
                         buffer->inspect, buffer->inspect_len);
                 PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
             }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -313,8 +313,7 @@ static void PrefilterTxFilename(DetectEngineThreadCtx *det_ctx, const void *pect
                 continue;
 
             if (buffer->inspect_len >= mpm_ctx->minlen) {
-                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                        &det_ctx->mtcu, &det_ctx->pmq,
+                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx, &det_ctx->mtc, &det_ctx->pmq,
                         buffer->inspect, buffer->inspect_len);
                 PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
             }

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -373,7 +373,7 @@ static void PrefilterTxHttpRequestBody(DetectEngineThreadCtx *det_ctx, const voi
 
     if (buffer->inspect_len >= mpm_ctx->minlen) {
         (void)mpm_table[mpm_ctx->mpm_type].Search(
-                mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
     }
 }

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -268,8 +268,8 @@ static void PrefilterMpmHttpHeader(DetectEngineThreadCtx *det_ctx, const void *p
     //PrintRawDataFp(stdout, data, data_len);
 
     if (data != NULL && data_len >= mpm_ctx->minlen) {
-        (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+        (void)mpm_table[mpm_ctx->mpm_type].Search(
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
     }
 }
@@ -520,7 +520,7 @@ static void PrefilterTxHttp2Header(DetectEngineThreadCtx *det_ctx, const void *p
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 
@@ -658,7 +658,7 @@ static void PrefilterTxHttp1Header(DetectEngineThreadCtx *det_ctx, const void *p
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -262,8 +262,8 @@ static void PrefilterMpmHttpHeaderRaw(DetectEngineThreadCtx *det_ctx, const void
     //PrintRawDataFp(stdout, data, data_len);
 
     if (data != NULL && data_len >= mpm_ctx->minlen) {
-        (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                &det_ctx->mtcu, &det_ctx->pmq, data, data_len);
+        (void)mpm_table[mpm_ctx->mpm_type].Search(
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
         PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
     }
 }

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -687,9 +687,8 @@ static void PrefilterTxHttp2HName(DetectEngineThreadCtx *det_ctx, const void *pe
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -105,7 +105,7 @@ static void PrefilterTxIkeVendor(DetectEngineThreadCtx *det_ctx, const void *pec
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
         local_id++;

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -157,9 +157,8 @@ static void PrefilterTxKrb5CName(DetectEngineThreadCtx *det_ctx, const void *pec
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -157,9 +157,8 @@ static void PrefilterTxKrb5SName(DetectEngineThreadCtx *det_ctx, const void *pec
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -158,9 +158,8 @@ static void PrefilterTxMQTTSubscribeTopic(DetectEngineThreadCtx *det_ctx, const 
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
         local_id++;

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -158,9 +158,8 @@ static void PrefilterTxMQTTUnsubscribeTopic(DetectEngineThreadCtx *det_ctx, cons
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
         local_id++;

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -155,7 +155,7 @@ static void PrefilterTxQuicHash(DetectEngineThreadCtx *det_ctx, const void *pect
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -147,7 +147,7 @@ static void PrefilterTxQuicString(DetectEngineThreadCtx *det_ctx, const void *pe
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
             (void)mpm_table[mpm_ctx->mpm_type].Search(
-                    mpm_ctx, &det_ctx->mtcu, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -232,9 +232,8 @@ static void PrefilterTxTlsCerts(DetectEngineThreadCtx *det_ctx, const void *pect
             break;
 
         if (buffer->inspect_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
-                    &det_ctx->mtcu, &det_ctx->pmq,
-                    buffer->inspect, buffer->inspect_len);
+            (void)mpm_table[mpm_ctx->mpm_type].Search(
+                    mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, buffer->inspect, buffer->inspect_len);
             PREFILTER_PROFILING_ADD_BYTES(det_ctx, buffer->inspect_len);
         }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1172,12 +1172,7 @@ typedef struct DetectEngineThreadCtx_ {
     SignatureNonPrefilterStore *non_pf_store_ptr;
     uint32_t non_pf_store_cnt;
 
-    /** pointer to the current mpm ctx that is stored
-     *  in a rule group head -- can be either a content
-     *  or uricontent ctx. */
-    MpmThreadCtx mtc;   /**< thread ctx for the mpm */
-    MpmThreadCtx mtcu;  /**< thread ctx for uricontent mpm */
-    MpmThreadCtx mtcs;  /**< thread ctx for stream mpm */
+    MpmThreadCtx mtc; /**< thread ctx for the mpm */
     PrefilterRuleStore pmq;
 
     /** SPM thread context used for scanning. This has been cloned from the

--- a/src/util-mpm-ac-bs.h
+++ b/src/util-mpm-ac-bs.h
@@ -71,11 +71,4 @@ typedef struct SCACBSCtx_ {
     uint16_t single_state_size;
 } SCACBSCtx;
 
-typedef struct SCACBSThreadCtx_ {
-    /* the total calls we make to the search function */
-    uint32_t total_calls;
-    /* the total patterns that we ended up matching against */
-    uint64_t total_matches;
-} SCACBSThreadCtx;
-
 void MpmACBSRegister(void);

--- a/src/util-mpm-ac-ks.h
+++ b/src/util-mpm-ac-ks.h
@@ -145,14 +145,6 @@ typedef struct SCACTileSearchCtx_ {
 
 } SCACTileSearchCtx;
 
-
-typedef struct SCACTileThreadCtx_ {
-    /* the total calls we make to the search function */
-    uint32_t total_calls;
-    /* the total patterns that we ended up matching against */
-    uint64_t total_matches;
-} SCACTileThreadCtx;
-
 void MpmACTileRegister(void);
 
 #endif /* __UTIL_MPM_AC_KS__H__ */

--- a/src/util-mpm-ac.h
+++ b/src/util-mpm-ac.h
@@ -77,13 +77,6 @@ typedef struct SCACCtx_ {
 
 } SCACCtx;
 
-typedef struct SCACThreadCtx_ {
-    /* the total calls we make to the search function */
-    uint32_t total_calls;
-    /* the total patterns that we ended up matching against */
-    uint64_t total_matches;
-} SCACThreadCtx;
-
 void MpmACRegister(void);
 
 #endif /* __UTIL_MPM_AC__H__ */

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -197,7 +197,16 @@ void MpmFactoryDeRegisterAllMpmCtxProfiles(DetectEngineCtx *de_ctx)
 
 void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t matcher)
 {
-    mpm_table[matcher].InitThreadCtx(NULL, mpm_thread_ctx);
+    if (mpm_table[matcher].InitThreadCtx != NULL) {
+        mpm_table[matcher].InitThreadCtx(NULL, mpm_thread_ctx);
+    }
+}
+
+void MpmDestroyThreadCtx(MpmThreadCtx *mpm_thread_ctx, const uint16_t matcher)
+{
+    if (mpm_table[matcher].DestroyThreadCtx != NULL) {
+        mpm_table[matcher].DestroyThreadCtx(NULL, mpm_thread_ctx);
+    }
 }
 
 void MpmInitCtx(MpmCtx *mpm_ctx, uint8_t matcher)

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -184,6 +184,7 @@ void MpmRegisterTests(void);
 
 void MpmInitCtx(MpmCtx *mpm_ctx, uint8_t matcher);
 void MpmInitThreadCtx(MpmThreadCtx *mpm_thread_ctx, uint16_t);
+void MpmDestroyThreadCtx(MpmThreadCtx *mpm_thread_ctx, const uint16_t matcher);
 
 int MpmAddPatternCS(struct MpmCtx_ *mpm_ctx, uint8_t *pat, uint16_t patlen,
                     uint16_t offset, uint16_t depth,


### PR DESCRIPTION
Remove unused thread ctx' from AC variants

Use single thread store in detection.

Minor cleanups.

Think this would be ok for 7, but can also wait for 8 if considered too intrusive.