### PR TITLE
output/alert: rewrite code for app-layer properties

### DIFF
--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -20,12 +20,14 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use std;
 
 fn log_template(tx: &TemplateTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("template")?;
     if let Some(ref request) = tx.request {
         js.set_string("request", request)?;
     }
     if let Some(ref response) = tx.response {
         js.set_string("response", response)?;
     }
+    js.close()?;
     Ok(())
 }
 

--- a/rust/src/bittorrent_dht/logger.rs
+++ b/rust/src/bittorrent_dht/logger.rs
@@ -48,6 +48,7 @@ fn print_ip_addr(addr: &[u8]) -> std::string::String {
 fn log_bittorrent_dht(
     tx: &BitTorrentDHTTransaction, js: &mut JsonBuilder,
 ) -> Result<(), JsonError> {
+    js.open_object("bittorrent_dht")?;
     js.set_hex("transaction_id", &tx.transaction_id)?;
     if let Some(client_version) = &tx.client_version {
         js.set_hex("client_version", client_version)?;
@@ -125,6 +126,7 @@ fn log_bittorrent_dht(
         }
         js.close()?;
     };
+    js.close()?;
     Ok(())
 }
 

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -192,6 +192,7 @@ fn log_http2_frames(frames: &[HTTP2Frame], js: &mut JsonBuilder) -> Result<bool,
 }
 
 fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonError> {
+    js.open_object("http")?;
     js.set_string("version", "2")?;
 
     let mut common: HashMap<HeaderName, &Vec<u8>> = HashMap::new();
@@ -261,8 +262,8 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
     let has_response = log_http2_frames(&tx.frames_tc, js)?;
     js.close()?;
 
-    // Close http2.
-    js.close()?;
+    js.close()?; // http2
+    js.close()?; // http
 
     return Ok(has_request || has_response || has_headers);
 }

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -88,7 +88,7 @@ fn quic_tls_extension_name(e: u16) -> Option<String> {
     }
 }
 
-fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
+fn log_quic(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.open_object("quic")?;
     if tx.header.ty != QuicType::Short {
         js.set_string("version", String::from(tx.header.version).as_str())?;
@@ -153,5 +153,5 @@ pub unsafe extern "C" fn rs_quic_to_json(
     tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, QuicTransaction);
-    log_template(tx, js).is_ok()
+    log_quic(tx, js).is_ok()
 }

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -39,6 +39,7 @@ fn str_of_pdu_type(t:&PduType) -> Cow<str> {
 
 fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<(), JsonError>
 {
+    jsb.open_object("snmp")?;
     jsb.set_uint("version", tx.version as u64)?;
     if tx.encrypted {
         jsb.set_string("pdu_type", "encrypted")?;
@@ -71,11 +72,12 @@ fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<
         }
     }
 
+    jsb.close()?;
     return Ok(());
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> bool
+pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder) -> bool
 {
     snmp_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -19,6 +19,7 @@ use super::ssh::SSHTransaction;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 
 fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError> {
+    js.open_object("ssh")?;
     if tx.cli_hdr.protover.is_empty() && tx.srv_hdr.protover.is_empty() {
         return Ok(false);
     }
@@ -58,6 +59,7 @@ fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError>
         }
         js.close()?;
     }
+    js.close()?;
     return Ok(true);
 }
 

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -200,6 +200,10 @@ def logger_patch_output_c(proto):
     output = io.StringIO()
     inlines = open(filename).readlines()
     for i, line in enumerate(inlines):
+        if line.find("ALPROTO_TEMPLATE") > -1:
+            new_line = line.replace("TEMPLATE", proto.upper()).replace(
+                    "template", proto.lower())
+            output.write(new_line)
         if line.find("output-json-template.h") > -1:
             output.write(line.replace("template", proto.lower()))
         if line.find("/* Template JSON logger.") > -1:

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1405,13 +1405,10 @@ uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
     return c == NULL ? len : (uint16_t)(c - buffer + 1);
 }
 
-void EveFTPDataAddMetadata(const Flow *f, JsonBuilder *jb)
+bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb)
 {
-    const FtpDataState *ftp_state = NULL;
-    if (f->alstate == NULL)
-        return;
-
-    ftp_state = (FtpDataState *)f->alstate;
+    const FtpDataState *ftp_state = (FtpDataState *)vtx;
+    jb_open_object(jb, "ftp_data");
 
     if (ftp_state->file_name) {
         jb_set_string_from_bytes(jb, "filename", ftp_state->file_name, ftp_state->file_len);
@@ -1426,6 +1423,8 @@ void EveFTPDataAddMetadata(const Flow *f, JsonBuilder *jb)
         default:
             break;
     }
+    jb_close(jb);
+    return true;
 }
 
 /**

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -190,7 +190,7 @@ uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 
 uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len);
-void EveFTPDataAddMetadata(const Flow *f, JsonBuilder *jb);
+bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb);
 
 #endif /* __APP_LAYER_FTP_H__ */
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -137,164 +137,6 @@ static int AlertJsonDumpStreamSegmentCallback(
     return 1;
 }
 
-static void AlertJsonTls(const Flow *f, JsonBuilder *js)
-{
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(f);
-    if (ssl_state) {
-        jb_open_object(js, "tls");
-
-        JsonTlsLogJSONExtended(js, ssl_state);
-
-        jb_close(js);
-    }
-
-    return;
-}
-
-static void AlertJsonSsh(const Flow *f, JsonBuilder *js)
-{
-    void *ssh_state = FlowGetAppState(f);
-    if (ssh_state) {
-        JsonBuilderMark mark = { 0, 0, 0 };
-        void *tx_ptr = rs_ssh_state_get_tx(ssh_state, 0);
-        jb_get_mark(js, &mark);
-        jb_open_object(js, "ssh");
-        if (rs_ssh_log_json(tx_ptr, js)) {
-            jb_close(js);
-        } else {
-            jb_restore_mark(js, &mark);
-        }
-    }
-
-    return;
-}
-
-static void AlertJsonHttp2(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *h2_state = FlowGetAppState(f);
-    if (h2_state) {
-        void *tx_ptr = rs_http2_state_get_tx(h2_state, tx_id);
-        if (tx_ptr) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            jb_open_object(js, "http");
-            if (rs_http2_log_json(tx_ptr, js)) {
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-
-    return;
-}
-
-static void AlertJsonDnp3(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    DNP3State *dnp3_state = (DNP3State *)FlowGetAppState(f);
-    if (dnp3_state) {
-        DNP3Transaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_DNP3,
-            dnp3_state, tx_id);
-        if (tx) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            bool logged = false;
-            jb_open_object(js, "dnp3");
-            if (tx->is_request && tx->done) {
-                jb_open_object(js, "request");
-                JsonDNP3LogRequest(js, tx);
-                jb_close(js);
-                logged = true;
-            }
-            if (!tx->is_request && tx->done) {
-                jb_open_object(js, "response");
-                JsonDNP3LogResponse(js, tx);
-                jb_close(js);
-                logged = true;
-            }
-            if (logged) {
-                /* Close dnp3 object. */
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-}
-
-static void AlertJsonDns(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *dns_state = (void *)FlowGetAppState(f);
-    if (dns_state) {
-        void *txptr = AppLayerParserGetTx(f->proto, ALPROTO_DNS,
-                                          dns_state, tx_id);
-        if (txptr) {
-            jb_open_object(js, "dns");
-            JsonBuilder *qjs = JsonDNSLogQuery(txptr);
-            if (qjs != NULL) {
-                jb_set_object(js, "query", qjs);
-                jb_free(qjs);
-            }
-            JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
-            if (ajs != NULL) {
-                jb_set_object(js, "answer", ajs);
-                jb_free(ajs);
-            }
-            jb_close(js);
-        }
-    }
-    return;
-}
-
-static void AlertJsonSNMP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *snmp_state = (void *)FlowGetAppState(f);
-    if (snmp_state != NULL) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_SNMP, snmp_state,
-                tx_id);
-        if (tx != NULL) {
-            jb_open_object(js, "snmp");
-            rs_snmp_log_json_response(js, tx);
-            jb_close(js);
-        }
-    }
-}
-
-static void AlertJsonRDP(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *rdp_state = (void *)FlowGetAppState(f);
-    if (rdp_state != NULL) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_RDP, rdp_state,
-                tx_id);
-        if (tx != NULL) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            if (!rs_rdp_to_json(tx, js)) {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-}
-
-static void AlertJsonBitTorrentDHT(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
-{
-    void *bittorrent_dht_state = (void *)FlowGetAppState(f);
-    if (bittorrent_dht_state != NULL) {
-        void *tx =
-                AppLayerParserGetTx(f->proto, ALPROTO_BITTORRENT_DHT, bittorrent_dht_state, tx_id);
-        if (tx != NULL) {
-            JsonBuilderMark mark = { 0, 0, 0 };
-            jb_get_mark(js, &mark);
-            jb_open_object(js, "bittorrent_dht");
-            if (rs_bittorrent_dht_logger_log(tx, js)) {
-                jb_close(js);
-            } else {
-                jb_restore_mark(js, &mark);
-            }
-        }
-    }
-}
-
 static void AlertJsonSourceTarget(const Packet *p, const PacketAlert *pa,
                                   JsonBuilder *js, JsonAddrInfo *addr)
 {
@@ -471,7 +313,21 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
         const uint64_t tx_id, const uint16_t option_flags)
 {
     const AppProto proto = FlowGetAppProtocol(p->flow);
+    SimpleJsonAppLayerLogger *al = GetAppProtoSimpleJsonLogger(proto);
     JsonBuilderMark mark = { 0, 0, 0 };
+    if (al && al->LogTx) {
+        void *state = FlowGetAppState(p->flow);
+        if (state) {
+            void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
+            if (tx) {
+                jb_get_mark(jb, &mark);
+                if (!al->LogTx(tx, jb)) {
+                    jb_restore_mark(jb, &mark);
+                }
+            }
+        }
+        return;
+    }
     switch (proto) {
         case ALPROTO_HTTP1:
             // TODO: Could result in an empty http object being logged.
@@ -485,12 +341,6 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 }
             }
             jb_close(jb);
-            break;
-        case ALPROTO_TLS:
-            AlertJsonTls(p->flow, jb);
-            break;
-        case ALPROTO_SSH:
-            AlertJsonSsh(p->flow, jb);
             break;
         case ALPROTO_SMTP:
             jb_get_mark(jb, &mark);
@@ -535,62 +385,11 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                 jb_restore_mark(jb, &mark);
             }
             break;
-        case ALPROTO_SIP:
-            JsonSIPAddMetadata(jb, p->flow, tx_id);
-            break;
-        case ALPROTO_RFB:
-            jb_get_mark(jb, &mark);
-            if (!JsonRFBAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
-        case ALPROTO_FTPDATA:
-            jb_get_mark(jb, &mark);
-            jb_open_object(jb, "ftp_data");
-            EveFTPDataAddMetadata(p->flow, jb);
-            jb_close(jb);
-            break;
-        case ALPROTO_DNP3:
-            AlertJsonDnp3(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_HTTP2:
-            AlertJsonHttp2(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_DNS:
-            AlertJsonDns(p->flow, tx_id, jb);
-            break;
         case ALPROTO_IKE:
             jb_get_mark(jb, &mark);
             if (!EveIKEAddMetadata(p->flow, tx_id, jb)) {
                 jb_restore_mark(jb, &mark);
             }
-            break;
-        case ALPROTO_MQTT:
-            jb_get_mark(jb, &mark);
-            if (!JsonMQTTAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
-        case ALPROTO_QUIC:
-            jb_get_mark(jb, &mark);
-            if (!JsonQuicAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
-        case ALPROTO_SNMP:
-            AlertJsonSNMP(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_RDP:
-            AlertJsonRDP(p->flow, tx_id, jb);
-            break;
-        case ALPROTO_MODBUS:
-            jb_get_mark(jb, &mark);
-            if (!JsonModbusAddMetadata(p->flow, tx_id, jb)) {
-                jb_restore_mark(jb, &mark);
-            }
-            break;
-        case ALPROTO_BITTORRENT_DHT:
-            AlertJsonBitTorrentDHT(p->flow, tx_id, jb);
             break;
         default:
             break;

--- a/src/output-json-bittorrent-dht.c
+++ b/src/output-json-bittorrent-dht.c
@@ -65,11 +65,9 @@ static int JsonBitTorrentDHTLogger(ThreadVars *tv, void *thread_data, const Pack
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(js, "bittorrent_dht");
     if (!rs_bittorrent_dht_logger_log(tx, js)) {
         goto error;
     }
-    jb_close(js);
 
     OutputJsonBuilderBuffer(js, thread->ctx);
     jb_free(js);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -210,6 +210,27 @@ void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 }
 
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js)
+{
+    DNP3Transaction *tx = (DNP3Transaction *)vtx;
+    bool logged = false;
+    jb_open_object(js, "dnp3");
+    if (tx->is_request && tx->done) {
+        jb_open_object(js, "request");
+        JsonDNP3LogRequest(js, tx);
+        jb_close(js);
+        logged = true;
+    }
+    if (!tx->is_request && tx->done) {
+        jb_open_object(js, "response");
+        JsonDNP3LogResponse(js, tx);
+        jb_close(js);
+        logged = true;
+    }
+    jb_close(js);
+    return logged;
+}
+
 static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id)
 {

--- a/src/output-json-dnp3.h
+++ b/src/output-json-dnp3.h
@@ -24,5 +24,6 @@ void JsonDNP3LogRequest(JsonBuilder *js, DNP3Transaction *);
 void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *);
 
 void JsonDNP3LogRegister(void);
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_DNP3_H__ */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -263,7 +263,7 @@ typedef struct LogDnsLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogDnsLogThread;
 
-JsonBuilder *JsonDNSLogQuery(void *txptr)
+static JsonBuilder *JsonDNSLogQuery(void *txptr)
 {
     JsonBuilder *queryjb = jb_new_array();
     if (queryjb == NULL) {
@@ -292,7 +292,7 @@ JsonBuilder *JsonDNSLogQuery(void *txptr)
     return queryjb;
 }
 
-JsonBuilder *JsonDNSLogAnswer(void *txptr)
+static JsonBuilder *JsonDNSLogAnswer(void *txptr)
 {
     if (!rs_dns_do_log_answer(txptr, LOG_ALL_RRTYPES)) {
         return NULL;
@@ -302,6 +302,23 @@ JsonBuilder *JsonDNSLogAnswer(void *txptr)
         jb_close(js);
         return js;
     }
+}
+
+bool AlertJsonDns(void *txptr, JsonBuilder *js)
+{
+    jb_open_object(js, "dns");
+    JsonBuilder *qjs = JsonDNSLogQuery(txptr);
+    if (qjs != NULL) {
+        jb_set_object(js, "query", qjs);
+        jb_free(qjs);
+    }
+    JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
+    if (ajs != NULL) {
+        jb_set_object(js, "answer", ajs);
+        jb_free(ajs);
+    }
+    jb_close(js);
+    return true;
 }
 
 static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,7 +26,6 @@
 
 void JsonDnsLogRegister(void);
 
-JsonBuilder *JsonDNSLogQuery(void *txptr) __attribute__((nonnull));
-JsonBuilder *JsonDNSLogAnswer(void *txptr) __attribute__((nonnull));
+bool AlertJsonDns(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/output-json-http2.c
+++ b/src/output-json-http2.c
@@ -61,19 +61,6 @@ typedef struct JsonHttp2LogThread_ {
     OutputJsonThreadCtx *ctx;
 } JsonHttp2LogThread;
 
-
-bool EveHTTP2AddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *jb)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_HTTP2, state, tx_id);
-        if (tx) {
-            return rs_http2_log_json(tx, jb);
-        }
-    }
-    return false;
-}
-
 static int JsonHttp2Logger(ThreadVars *tv, void *thread_data, const Packet *p,
                          Flow *f, void *state, void *txptr, uint64_t tx_id)
 {
@@ -88,11 +75,9 @@ static int JsonHttp2Logger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    jb_open_object(js, "http");
     if (!rs_http2_log_json(txptr, js)) {
         goto end;
     }
-    jb_close(js);
     OutputJsonBuilderBuffer(js, aft->ctx);
 end:
     jb_free(js);

--- a/src/output-json-http2.h
+++ b/src/output-json-http2.h
@@ -25,6 +25,5 @@
 #define __OUTPUT_JSON_HTTP2_H__
 
 void JsonHttp2LogRegister(void);
-bool EveHTTP2AddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *jb);
 
 #endif /* __OUTPUT_JSON_HTTP2_H__ */

--- a/src/output-json-modbus.c
+++ b/src/output-json-modbus.c
@@ -136,19 +136,6 @@ static TmEcode JsonModbusLogThreadDeinit(ThreadVars *t, void *data)
     return TM_ECODE_OK;
 }
 
-bool JsonModbusAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_MODBUS, state, tx_id);
-        if (tx) {
-            return rs_modbus_to_json(tx, js);
-        }
-    }
-
-    return false;
-}
-
 void JsonModbusLogRegister(void)
 {
     /* Register as an eve sub-module. */

--- a/src/output-json-modbus.h
+++ b/src/output-json-modbus.h
@@ -19,6 +19,5 @@
 #define __OUTPUT_JSON_MODBUS_H__
 
 void JsonModbusLogRegister(void);
-bool JsonModbusAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_MODBUS_H__ */

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -59,17 +59,9 @@ typedef struct LogMQTTLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogMQTTLogThread;
 
-bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
+bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js)
 {
-    MQTTState *state = FlowGetAppState(f);
-    if (state) {
-        MQTTTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_MQTT, state, tx_id);
-        if (tx) {
-            return rs_mqtt_logger_log(tx, MQTT_DEFAULTS, js);
-        }
-    }
-
-    return false;
+    return rs_mqtt_logger_log(vtx, MQTT_DEFAULTS, js);
 }
 
 static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,

--- a/src/output-json-mqtt.h
+++ b/src/output-json-mqtt.h
@@ -25,6 +25,6 @@
 #define __OUTPUT_JSON_MQTT_H__
 
 void JsonMQTTLogRegister(void);
-bool JsonMQTTAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
+bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_MQTT_H__ */

--- a/src/output-json-quic.c
+++ b/src/output-json-quic.c
@@ -140,19 +140,6 @@ static TmEcode JsonQuicLogThreadDeinit(ThreadVars *t, void *data)
     return TM_ECODE_OK;
 }
 
-bool JsonQuicAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        void *tx = AppLayerParserGetTx(f->proto, ALPROTO_QUIC, state, tx_id);
-        if (tx) {
-            return rs_quic_to_json(tx, js);
-        }
-    }
-
-    return false;
-}
-
 void JsonQuicLogRegister(void)
 {
     /* Register as an eve sub-module. */

--- a/src/output-json-quic.h
+++ b/src/output-json-quic.h
@@ -22,7 +22,6 @@
 #ifndef __OUTPUT_JSON_QUIC_H__
 #define __OUTPUT_JSON_QUIC_H__
 
-bool JsonQuicAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 void JsonQuicLogRegister(void);
 
 #endif /* __OUTPUT_JSON_QUIC_H__ */

--- a/src/output-json-rfb.c
+++ b/src/output-json-rfb.c
@@ -46,19 +46,6 @@
 
 #include "rust-bindings.h"
 
-bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
-{
-    void *state = FlowGetAppState(f);
-    if (state) {
-        RFBTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_RFB, state, tx_id);
-        if (tx) {
-            return rs_rfb_logger_log(tx, js);
-        }
-    }
-
-    return false;
-}
-
 static int JsonRFBLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {

--- a/src/output-json-rfb.h
+++ b/src/output-json-rfb.h
@@ -26,6 +26,4 @@
 
 void JsonRFBLogRegister(void);
 
-bool JsonRFBAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
-
 #endif /* __OUTPUT_JSON_RFB_H__ */

--- a/src/output-json-sip.c
+++ b/src/output-json-sip.c
@@ -48,17 +48,6 @@
 
 #include "rust.h"
 
-void JsonSIPAddMetadata(JsonBuilder *js, const Flow *f, uint64_t tx_id)
-{
-    SIPState *state = FlowGetAppState(f);
-    if (state) {
-        SIPTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_SIP, state, tx_id);
-        if (tx) {
-            rs_sip_log_json(tx, js);
-        }
-    }
-}
-
 static int JsonSIPLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {

--- a/src/output-json-sip.h
+++ b/src/output-json-sip.h
@@ -26,6 +26,4 @@
 
 void JsonSIPLogRegister(void);
 
-void JsonSIPAddMetadata(JsonBuilder *js, const Flow *f, uint64_t tx_id);
-
 #endif /* __OUTPUT_JSON_SIP_H__ */

--- a/src/output-json-snmp.c
+++ b/src/output-json-snmp.c
@@ -59,11 +59,9 @@ static int JsonSNMPLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(jb, "snmp");
-    if (!rs_snmp_log_json_response(jb, snmptx)) {
+    if (!rs_snmp_log_json_response(snmptx, jb)) {
         goto error;
     }
-    jb_close(jb);
 
     OutputJsonBuilderBuffer(jb, thread);
 

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -64,11 +64,9 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     if (unlikely(js == NULL))
         return 0;
 
-    jb_open_object(js, "ssh");
     if (!rs_ssh_log_json(txptr, js)) {
         goto end;
     }
-    jb_close(js);
     OutputJsonBuilderBuffer(js, thread);
 
 end:

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -74,11 +74,9 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data, const Packet *p
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(js, "template");
     if (!rs_template_logger_log(tx, js)) {
         goto error;
     }
-    jb_close(js);
 
     OutputJsonBuilderBuffer(js, thread->ctx);
     jb_free(js);

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -29,6 +29,6 @@ void JsonTlsLogRegister(void);
 #include "app-layer-ssl.h"
 
 void JsonTlsLogJSONBasic(JsonBuilder *js, SSLState *ssl_state);
-void JsonTlsLogJSONExtended(JsonBuilder *js, SSLState *ssl_state);
+bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js);
 
 #endif /* __OUTPUT_JSON_TLS_H__ */

--- a/src/output.h
+++ b/src/output.h
@@ -208,4 +208,13 @@ void OutputLoggerExitPrintStats(ThreadVars *, void *);
 void OutputSetupActiveLoggers(void);
 void OutputClearActiveLoggers(void);
 
+typedef bool (*SimpleJsonTxLogFunc)(void *, struct JsonBuilder *);
+
+typedef struct SimpleJsonAppLayerLogger {
+    AppProto proto;
+    SimpleJsonTxLogFunc LogTx;
+} SimpleJsonAppLayerLogger;
+
+SimpleJsonAppLayerLogger *GetAppProtoSimpleJsonLogger(AppProto alproto);
+
 #endif /* ! __OUTPUT_H__ */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3827
preliminary work for https://redmine.openinfosecfoundation.org/issues/5053 and app-layer plugins
preliminary work for https://redmine.openinfosecfoundation.org/issues/5977 as well
Part of https://github.com/OISF/suricata/pull/8961

Describe changes:
- Fix setup-app-layer script so that it adds app-layer metadata to alerts

After that, there is still from https://github.com/OISF/suricata/pull/8961
- addition of protocols missing alert metadata (like krb5) + behavioral change for dns alert metadata 
- reusing these `SimpleTxLogFunc` from a JsonGenericLogger to remove many C files

#9252 with some renaming as per code review + reusing code for output-json-file.c

Same as #9499 but without the force-push on github