### PR TITLE
Warnint 64to32 6186 v10

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1559,7 +1559,7 @@ jobs:
           CC: "clang-14"
           CXX: "clang++-14"
           RUSTFLAGS: "-C instrument-coverage"
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Werror"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Wshorten-64-to-32 -Werror"
           CXXFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion -Wimplicit-int-conversion"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -686,7 +686,7 @@ static uint32_t AppLayerProtoDetectProbingParserGetMask(AppProto alproto)
         FatalError("Unknown protocol detected - %u", alproto);
     }
 
-    SCReturnUInt(1UL << (uint32_t)alproto);
+    SCReturnUInt((uint32_t)1 << (uint32_t)alproto);
 }
 
 static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParserElementAlloc(void)

--- a/src/app-layer-dnp3-objects.c
+++ b/src/app-layer-dnp3-objects.c
@@ -139,8 +139,7 @@ static int DNP3ReadUint24(const uint8_t **buf, uint32_t *len, uint32_t *out)
     *out = ((uint32_t)(*buf)[0] << 16) | ((uint32_t)(*buf)[1] << 8) |
            (uint32_t)(*buf)[2];
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
-    *out = ((uint64_t)(*buf)[0]) | ((uint64_t)(*buf)[1] << 8) |
-           ((uint64_t)(*buf)[2] << 16);
+    *out = ((uint32_t)(*buf)[0]) | ((uint32_t)(*buf)[1] << 8) | ((uint32_t)(*buf)[2] << 16);
 #endif
 
     *buf += 3;

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -342,7 +342,9 @@ static int FrameSlide(const char *ds, Frames *frames, const TcpStream *stream, c
     }
     frames->cnt = x;
     uint64_t o = STREAM_BASE_OFFSET(stream) + slide;
-    frames->left_edge_rel = le - (STREAM_BASE_OFFSET(stream) + slide);
+    BUG_ON(o > le);
+    BUG_ON(le - o > UINT32_MAX);
+    frames->left_edge_rel = (uint32_t)(le - o);
 
 #ifdef DEBUG
     SCLogDebug("end: left edge %" PRIu64 ", left_edge_rel %u, stream base %" PRIu64
@@ -353,7 +355,6 @@ static int FrameSlide(const char *ds, Frames *frames, const TcpStream *stream, c
     snprintf(pf, sizeof(pf), "%s:post_slide", ds);
     AppLayerFrameDumpForFrames(pf, frames);
 #endif
-    BUG_ON(o > le);
     BUG_ON(x != start - removed);
     return 0;
 }
@@ -745,7 +746,9 @@ static void FramePrune(Frames *frames, const TcpStream *stream, const bool eof)
         }
     }
     frames->cnt = x;
-    frames->left_edge_rel = le - STREAM_BASE_OFFSET(stream);
+    BUG_ON(le < STREAM_BASE_OFFSET(stream));
+    BUG_ON(le - STREAM_BASE_OFFSET(stream) > UINT32_MAX);
+    frames->left_edge_rel = (uint32_t)(le - STREAM_BASE_OFFSET(stream));
 #ifdef DEBUG
     SCLogDebug("end: left edge %" PRIu64 ", left_edge_rel %u, stream base %" PRIu64
                ", cnt %u, removed %u, start %u",
@@ -753,7 +756,6 @@ static void FramePrune(Frames *frames, const TcpStream *stream, const bool eof)
             STREAM_BASE_OFFSET(stream), frames->cnt, removed, start);
     AppLayerFrameDumpForFrames("post_slide", frames);
 #endif
-    BUG_ON(le < STREAM_BASE_OFFSET(stream));
     if (frames->cnt > 0) { // if we removed all this can fail
         BUG_ON(frames_le_start > le);
     }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -374,7 +374,7 @@ static AppLayerResult FTPGetLineForDirection(
         //      lf_idx = 5010
         //      max_line_len = 4096
         uint32_t o_consumed = input->consumed;
-        input->consumed = lf_idx - input->buf + 1;
+        input->consumed = (uint32_t)(lf_idx - input->buf + 1);
         line->len = input->consumed - o_consumed;
         input->len -= line->len;
         line->lf_found = true;

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -95,7 +95,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
  */
 int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
 {
-    uint32_t len = bstr_len(rawvalue);
+    uint32_t len = (uint32_t)bstr_len(rawvalue);
     return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
 }
 
@@ -186,13 +186,17 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     uint8_t *keyurl;
     uint32_t keylen;
     if (tx->request_hostname != NULL) {
-        keylen = bstr_len(tx->request_hostname) + filename_len;
+        uint32_t hlen = (uint32_t)bstr_len(tx->request_hostname);
+        if (bstr_len(tx->request_hostname) > UINT16_MAX) {
+            hlen = UINT16_MAX;
+        }
+        keylen = hlen + filename_len;
         keyurl = SCMalloc(keylen);
         if (keyurl == NULL) {
             SCReturnInt(-1);
         }
-        memcpy(keyurl, bstr_ptr(tx->request_hostname), bstr_len(tx->request_hostname));
-        memcpy(keyurl + bstr_len(tx->request_hostname), filename, filename_len);
+        memcpy(keyurl, bstr_ptr(tx->request_hostname), hlen);
+        memcpy(keyurl + hlen, filename, filename_len);
     } else {
         // do not reassemble file without host info
         SCReturnInt(0);

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -40,7 +40,7 @@ typedef struct HttpRangeContainerBuffer {
     /** offset of bytes written in buffer (relative to the start of the range) */
     uint64_t offset;
     /** number of gaped bytes */
-    uint64_t gap;
+    uint32_t gap;
 } HttpRangeContainerBuffer;
 
 int HttpRangeContainerBufferCompare(HttpRangeContainerBuffer *a, HttpRangeContainerBuffer *b);
@@ -63,7 +63,7 @@ typedef struct HttpRangeContainerFile {
     /** key length */
     uint32_t len;
     /** expire time in epoch */
-    uint32_t expire;
+    uint64_t expire;
     /** pointer to hashtable data, for locking and use count */
     THashData *hdata;
     /** total expected size of the file in ranges */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -560,12 +560,12 @@ static uint32_t AppLayerHtpComputeChunkLength(uint64_t content_len_so_far, uint3
         (content_len_so_far < (uint64_t)body_limit) &&
         (content_len_so_far + (uint64_t)data_len) > body_limit)
     {
-        chunk_len = body_limit - content_len_so_far;
+        chunk_len = (uint32_t)(body_limit - content_len_so_far);
     } else if ((flags & HTP_STREAM_DEPTH_SET) && stream_depth > 0 &&
                (content_len_so_far < (uint64_t)stream_depth) &&
                (content_len_so_far + (uint64_t)data_len) > stream_depth)
     {
-        chunk_len = stream_depth - content_len_so_far;
+        chunk_len = (uint32_t)(stream_depth - content_len_so_far);
     }
     SCLogDebug("len %u", chunk_len);
     return (chunk_len == 0 ? data_len : chunk_len);
@@ -963,7 +963,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
 
     htp_time_t ts = { SCTIME_SECS(f->startts), SCTIME_USECS(f->startts) };
     htp_tx_t *tx = NULL;
-    size_t consumed = 0;
+    uint32_t consumed = 0;
     if (input_len > 0) {
         const int r = htp_connp_res_data(hstate->connp, &ts, input, input_len);
         switch (r) {
@@ -986,7 +986,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
                     if (tx->request_port_number != -1) {
                         dp = (uint16_t)tx->request_port_number;
                     }
-                    consumed = htp_connp_res_data_consumed(hstate->connp);
+                    consumed = (uint32_t)htp_connp_res_data_consumed(hstate->connp);
                     hstate->slice = NULL;
                     if (!AppLayerRequestProtocolChange(hstate->f, dp, ALPROTO_HTTP2)) {
                         HTPSetEvent(hstate, NULL, STREAM_TOCLIENT,
@@ -1273,7 +1273,7 @@ static void HtpRequestBodyMultipartParseHeader(HtpState *hstate,
         if (next_line == NULL) {
             line_len = header_len;
         } else {
-            line_len = next_line - header;
+            line_len = (uint32_t)(next_line - header);
         }
         uint8_t *sc = (uint8_t *)memchr(line, ':', line_len);
         if (sc == NULL) {
@@ -1392,10 +1392,12 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
     /* end marker belonging to header_start */
     const uint8_t *header_end = NULL;
     if (header_start != NULL) {
-        header_end = Bs2bmSearch(header_start, chunks_buffer_len - (header_start - chunks_buffer),
+        header_end = Bs2bmSearch(header_start,
+                (uint32_t)(chunks_buffer_len - (header_start - chunks_buffer)),
                 (uint8_t *)"\r\n\r\n", 4);
-        form_end = Bs2bmSearch(header_start, chunks_buffer_len - (header_start - chunks_buffer),
-                boundary, expected_boundary_end_len);
+        form_end = Bs2bmSearch(header_start,
+                (uint32_t)(chunks_buffer_len - (header_start - chunks_buffer)), boundary,
+                expected_boundary_end_len);
     }
 
     SCLogDebug("header_start %p, header_end %p, form_end %p", header_start,
@@ -1421,7 +1423,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 } else if (header_start > filedata + 2) {
                     SCLogDebug("some data from last file before the boundary");
                     /* some data from last file before the boundary */
-                    filedata_len = header_start - filedata - 2;
+                    filedata_len = (uint32_t)(header_start - filedata - 2);
                 }
             }
             /* body parsing done, we did not get our form end. Use all data
@@ -1504,7 +1506,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
         uint8_t *filetype = NULL;
         uint16_t filetype_len = 0;
 
-        uint32_t header_len = header_end - header_start;
+        uint32_t header_len = (uint32_t)(header_end - header_start);
         SCLogDebug("header_len %u", header_len);
         uint8_t *header = (uint8_t *)header_start;
 
@@ -1546,7 +1548,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     goto end;
                 }
 
-                filedata_len = form_end - (header_end + 4 + 2);
+                filedata_len = (uint32_t)(form_end - (header_end + 4 + 2));
                 SCLogDebug("filedata_len %"PRIuMAX, (uintmax_t)filedata_len);
 
                 /* or is it? */
@@ -1587,7 +1589,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 SCLogDebug("chunk doesn't contain form end");
 
                 filedata = header_end + 4;
-                filedata_len = chunks_buffer_len - (filedata - chunks_buffer);
+                filedata_len = (uint32_t)(chunks_buffer_len - (filedata - chunks_buffer));
                 SCLogDebug("filedata_len %u (chunks_buffer_len %u)", filedata_len, chunks_buffer_len);
 
                 if (filedata_len > chunks_buffer_len) {
@@ -1609,7 +1611,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                 if (header_next == NULL) {
                     SCLogDebug("more file data to come");
 
-                    uint32_t offset = (header_end + 4) - chunks_buffer;
+                    uint32_t offset = (uint32_t)((header_end + 4) - chunks_buffer);
                     SCLogDebug("offset %u", offset);
                     htud->request_body.body_parsed += offset;
 
@@ -1642,7 +1644,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     SCLogDebug("htud->request_body.body_parsed %"PRIu64, htud->request_body.body_parsed);
 
                 } else if (header_next - filedata > 2) {
-                    filedata_len = header_next - filedata - 2;
+                    filedata_len = (uint32_t)(header_next - filedata - 2);
                     SCLogDebug("filedata_len %u", filedata_len);
 
                     result = HTPFileOpen(hstate, htud, filename, filename_len, filedata,
@@ -1668,7 +1670,7 @@ next:
                 header_start, header_end, form_end);
 
         /* Search next boundary entry after the start of body */
-        uint32_t cursizeread = header_end - chunks_buffer;
+        uint32_t cursizeread = (uint32_t)(header_end - chunks_buffer);
         header_start = Bs2bmSearch(header_end + 4,
                 chunks_buffer_len - (cursizeread + 4),
                 boundary, expected_boundary_len);

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -82,16 +82,18 @@ void HTTP2MimicHttp1Request(void *alstate_orig, void *h2s)
         return;
     }
     // else
-    rs_http2_tx_set_method(h2s, bstr_ptr(h1tx->request_method), bstr_len(h1tx->request_method));
+    rs_http2_tx_set_method(
+            h2s, bstr_ptr(h1tx->request_method), (uint32_t)bstr_len(h1tx->request_method));
     if (h1tx->request_uri != NULL) {
         // A request line without spaces gets interpreted as a request_method
         // and has request_uri=NULL
-        rs_http2_tx_set_uri(h2s, bstr_ptr(h1tx->request_uri), bstr_len(h1tx->request_uri));
+        rs_http2_tx_set_uri(
+                h2s, bstr_ptr(h1tx->request_uri), (uint32_t)bstr_len(h1tx->request_uri));
     }
     size_t nbheaders = htp_table_size(h1tx->request_headers);
     for (size_t i = 0; i < nbheaders; i++) {
         htp_header_t *h = htp_table_get_index(h1tx->request_headers, i, NULL);
-        rs_http2_tx_add_header(
-                h2s, bstr_ptr(h->name), bstr_len(h->name), bstr_ptr(h->value), bstr_len(h->value));
+        rs_http2_tx_add_header(h2s, bstr_ptr(h->name), (uint32_t)bstr_len(h->name),
+                bstr_ptr(h->value), (uint32_t)bstr_len(h->value));
     }
 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -519,8 +519,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 flags |= FILE_STORE;
             }
 
-            uint32_t depth = smtp_config.content_inspect_min_size +
-                (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+            uint32_t depth = (uint32_t)(smtp_config.content_inspect_min_size +
+                                        (smtp_state->toserver_data_count -
+                                                smtp_state->toserver_last_data_stamp));
+            if (smtp_config.content_inspect_min_size +
+                            (smtp_state->toserver_data_count -
+                                    smtp_state->toserver_last_data_stamp) >
+                    UINT32_MAX) {
+                depth = UINT32_MAX;
+            }
             SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %"PRIu32, depth);
             StreamTcpReassemblySetMinInspectDepth(flow->protoctx, STREAM_TOSERVER, depth);
 
@@ -551,7 +558,12 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
                 } else {
                     SCLogDebug("File already closed");
                 }
-                depth = smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp;
+                depth = (uint32_t)(smtp_state->toserver_data_count -
+                                   smtp_state->toserver_last_data_stamp);
+                if (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
 
                 AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
@@ -572,7 +584,12 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
             } else {
                 SCLogDebug("File already closed");
             }
-            uint32_t depth = smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp;
+            uint32_t depth = (uint32_t)(smtp_state->toserver_data_count -
+                                        smtp_state->toserver_last_data_stamp);
+            if (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp >
+                    UINT32_MAX) {
+                depth = UINT32_MAX;
+            }
             AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
             SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
                     depth);
@@ -593,8 +610,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
 
             if (files->tail && files->tail->content_inspected == 0 &&
                     files->tail->size >= smtp_config.content_inspect_min_size) {
-                uint32_t depth = smtp_config.content_inspect_min_size +
-                    (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+                uint32_t depth = (uint32_t)(smtp_config.content_inspect_min_size +
+                                            (smtp_state->toserver_data_count -
+                                                    smtp_state->toserver_last_data_stamp));
+                if (smtp_config.content_inspect_min_size +
+                                (smtp_state->toserver_data_count -
+                                        smtp_state->toserver_last_data_stamp) >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
                 AppLayerParserTriggerRawStreamReassembly(flow, STREAM_TOSERVER);
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %u",
                         depth);
@@ -609,8 +633,15 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
             /* expand the limit as long as we get file data, as the file data is bigger on the
              * wire due to base64 */
             } else {
-                uint32_t depth = smtp_config.content_inspect_min_size +
-                    (smtp_state->toserver_data_count - smtp_state->toserver_last_data_stamp);
+                uint32_t depth = (uint32_t)(smtp_config.content_inspect_min_size +
+                                            (smtp_state->toserver_data_count -
+                                                    smtp_state->toserver_last_data_stamp));
+                if (smtp_config.content_inspect_min_size +
+                                (smtp_state->toserver_data_count -
+                                        smtp_state->toserver_last_data_stamp) >
+                        UINT32_MAX) {
+                    depth = UINT32_MAX;
+                }
                 SCLogDebug("StreamTcpReassemblySetMinInspectDepth STREAM_TOSERVER %"PRIu32,
                         depth);
                 StreamTcpReassemblySetMinInspectDepth(flow->protoctx,
@@ -663,7 +694,7 @@ static AppLayerResult SMTPGetLine(
          *      lf_idx = 5010
          *      max_line_len = 4096 */
         uint32_t o_consumed = input->consumed;
-        input->consumed = lf_idx - input->buf + 1;
+        input->consumed = (uint32_t)(lf_idx - input->buf + 1);
         line->len = input->consumed - o_consumed;
         line->lf_found = true;
         DEBUG_VALIDATE_BUG_ON(line->len < 0);

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -124,7 +124,7 @@ typedef struct SMTPState_ {
     /** current command in progress */
     uint8_t current_command;
     /** bdat chunk len */
-    uint32_t bdat_chunk_len;
+    uint64_t bdat_chunk_len;
     /** bdat chunk idx */
     uint32_t bdat_chunk_idx;
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -225,12 +225,12 @@ struct SSLDecoderResult {
 #define SSL_DECODER_OK(c)                                                                          \
     (struct SSLDecoderResult)                                                                      \
     {                                                                                              \
-        (c), 0                                                                                     \
+        (uint32_t)(c), 0                                                                           \
     }
 #define SSL_DECODER_INCOMPLETE(c, n)                                                               \
     (struct SSLDecoderResult)                                                                      \
     {                                                                                              \
-        (c), (n)                                                                                   \
+        (uint32_t)(c), (n)                                                                         \
     }
 
 static inline int SafeMemcpy(void *dst, size_t dst_offset, size_t dst_size,
@@ -572,7 +572,7 @@ static int TlsDecodeHSCertificate(SSLState *ssl_state, SSLStateConnp *connp,
 
 next:
     input += cert_len;
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 error:
     if (err_code != 0)
@@ -725,7 +725,7 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
 
     input += SSLV3_CLIENT_HELLO_VERSION_LEN;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static inline int TLSDecodeHSHelloRandom(SSLState *ssl_state,
@@ -752,7 +752,7 @@ static inline int TLSDecodeHSHelloRandom(SSLState *ssl_state,
     /* Skip random */
     input += SSLV3_CLIENT_HELLO_RANDOM_LEN;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static inline int TLSDecodeHSHelloSessionID(SSLState *ssl_state,
@@ -797,7 +797,7 @@ static inline int TLSDecodeHSHelloSessionID(SSLState *ssl_state,
 
     input += session_id_length;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -872,7 +872,7 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         input += cipher_suites_length;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -903,7 +903,7 @@ static inline int TLSDecodeHSHelloCompressionMethods(SSLState *ssl_state,
         input += compression_methods_length;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid_length");
@@ -965,7 +965,7 @@ static inline int TLSDecodeHSHelloExtensionSni(SSLState *ssl_state,
         SSLSetEvent(ssl_state,
                 TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS);
         input += sni_len;
-        return (input - initial_input);
+        return (uint32_t)(input - initial_input);
     }
 
     const size_t sni_strlen = sni_len + 1;
@@ -984,7 +984,7 @@ static inline int TLSDecodeHSHelloExtensionSni(SSLState *ssl_state,
 
     input += sni_len;
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1050,7 +1050,7 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
         input += 2;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1107,7 +1107,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
         input += elliptic_curves_len;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1161,7 +1161,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurvePF(SSLState *ssl_state,
         input += ec_pf_len;
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1348,7 +1348,7 @@ end:
         }
     }
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 
 invalid_length:
     SCLogDebug("TLS handshake invalid length");
@@ -1712,7 +1712,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input
                     ssl_state->curr_connp->hs_buffer_message_size);
             input += input_len;
             SSLParserHSReset(ssl_state->curr_connp);
-            return (input - initial_input);
+            return (uint32_t)(input - initial_input);
 
         } else {
             /* full record, parse it now */
@@ -1730,7 +1730,7 @@ static int SSLv3ParseHandshakeProtocol(SSLState *ssl_state, const uint8_t *input
         }
         SCLogDebug("input_len left %u", input_len);
     }
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 /**
@@ -1935,7 +1935,7 @@ static int SSLv3ParseRecord(uint8_t direction, SSLState *ssl_state,
 
     ssl_state->curr_connp->bytes_processed += (input - initial_input);
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
@@ -2019,7 +2019,7 @@ static int SSLv2ParseRecord(uint8_t direction, SSLState *ssl_state,
 
     ssl_state->curr_connp->bytes_processed += (input - initial_input);
 
-    return (input - initial_input);
+    return (uint32_t)(input - initial_input);
 }
 
 static struct SSLDecoderResult SSLv2Decode(uint8_t direction, SSLState *ssl_state,
@@ -2566,7 +2566,7 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
                 input += r.retval;
                 SCLogDebug("returning consumed %" PRIuMAX " needed %u",
                         (uintmax_t)(input - init_input), r.needed);
-                SCReturnStruct(APP_LAYER_INCOMPLETE(input - init_input, r.needed));
+                SCReturnStruct(APP_LAYER_INCOMPLETE((uint32_t)(input - init_input), r.needed));
             }
             input_len -= r.retval;
             input += r.retval;
@@ -2591,7 +2591,7 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
                 input += r.retval;
                 SCLogDebug("returning consumed %" PRIuMAX " needed %u",
                         (uintmax_t)(input - init_input), r.needed);
-                SCReturnStruct(APP_LAYER_INCOMPLETE(input - init_input, r.needed));
+                SCReturnStruct(APP_LAYER_INCOMPLETE((uint32_t)(input - init_input), r.needed));
             }
             input_len -= r.retval;
             input += r.retval;

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -113,7 +113,7 @@ static AppLayerResult TFTPParseRequest(Flow *f, void *state, AppLayerParserState
         SCReturnStruct(APP_LAYER_OK);
     }
 
-    int res = rs_tftp_request(state, input, input_len);
+    int64_t res = rs_tftp_request(state, input, input_len);
     if (res < 0) {
         SCReturnStruct(APP_LAYER_ERROR);
     }

--- a/src/counters.c
+++ b/src/counters.c
@@ -1040,9 +1040,9 @@ static uint32_t CountersIdHashFunc(HashTable *ht, void *data, uint16_t datalen)
 {
     CountersIdType *t = (CountersIdType *)data;
     uint32_t hash = 0;
-    int len = strlen(t->string);
+    size_t len = strlen(t->string);
 
-    for (int i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         hash += u8_tolower((unsigned char)t->string[i]);
 
     hash = hash % ht->array_size;
@@ -1054,8 +1054,8 @@ static char CountersIdHashCompareFunc(void *data1, uint16_t datalen1,
 {
     CountersIdType *t1 = (CountersIdType *)data1;
     CountersIdType *t2 = (CountersIdType *)data2;
-    int len1 = 0;
-    int len2 = 0;
+    size_t len1 = 0;
+    size_t len2 = 0;
 
     if (t1 == NULL || t2 == NULL)
         return 0;

--- a/src/datasets-string.c
+++ b/src/datasets-string.c
@@ -55,7 +55,7 @@ int StringAsBase64(const void *s, char *out, size_t out_size)
 
     strlcpy(out, (const char *)encoded_data, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 int StringSet(void *dst, void *src)

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -521,8 +521,8 @@ static int DatasetLoadString(Dataset *set)
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
-                    strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            Base64Ecode code = DecodeBase64(decoded, (uint32_t)strlen(line), (const uint8_t *)line,
+                    (uint32_t)strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
             if (code == BASE64_ECODE_ERR) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -542,8 +542,8 @@ static int DatasetLoadString(Dataset *set)
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
-                    strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            Base64Ecode code = DecodeBase64(decoded, (uint32_t)strlen(line), (const uint8_t *)line,
+                    (uint32_t)strlen(line), &consumed, &num_decoded, BASE64_MODE_STRICT);
             if (code == BASE64_ECODE_ERR) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -1002,7 +1002,7 @@ static int SaveCallback(void *ctx, const uint8_t *data, const uint32_t data_len)
     FILE *fp = ctx;
     //PrintRawDataFp(fp, data, data_len);
     if (fp) {
-        return fwrite(data, data_len, 1, fp);
+        return (int)fwrite(data, data_len, 1, fp);
     }
     return 0;
 }
@@ -1014,7 +1014,7 @@ static int Md5AsAscii(const void *s, char *out, size_t out_size)
     PrintHexString(str, sizeof(str), (uint8_t *)md5->md5, sizeof(md5->md5));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int Sha256AsAscii(const void *s, char *out, size_t out_size)
@@ -1024,7 +1024,7 @@ static int Sha256AsAscii(const void *s, char *out, size_t out_size)
     PrintHexString(str, sizeof(str), (uint8_t *)sha->sha256, sizeof(sha->sha256));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int IPv4AsAscii(const void *s, char *out, size_t out_size)
@@ -1034,7 +1034,7 @@ static int IPv4AsAscii(const void *s, char *out, size_t out_size)
     PrintInet(AF_INET, ip4->ipv4, str, sizeof(str));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int IPv6AsAscii(const void *s, char *out, size_t out_size)
@@ -1055,7 +1055,7 @@ static int IPv6AsAscii(const void *s, char *out, size_t out_size)
     }
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 void DatasetsSave(void)
@@ -1600,8 +1600,9 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(string), (const uint8_t *)string,
-                    strlen(string), &consumed, &num_decoded, BASE64_MODE_STRICT);
+            Base64Ecode code =
+                    DecodeBase64(decoded, (uint32_t)strlen(string), (const uint8_t *)string,
+                            (uint32_t)strlen(string), &consumed, &num_decoded, BASE64_MODE_STRICT);
             if (code == BASE64_ECODE_ERR) {
                 return -2;
             }

--- a/src/decode-teredo.c
+++ b/src/decode-teredo.c
@@ -182,7 +182,7 @@ int DecodeTeredo(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
         if (len ==  IPV6_HEADER_LEN +
                 IPV6_GET_RAW_PLEN(thdr) + (start - pkt)) {
-            int blen = len - (start - pkt);
+            uint32_t blen = len - (uint32_t)(start - pkt);
             /* spawn off tunnel packet */
             Packet *tp = PacketTunnelPktSetup(tv, dtv, p, start, blen,
                     DECODE_TUNNEL_IPV6_TEREDO);

--- a/src/decode.c
+++ b/src/decode.c
@@ -726,7 +726,7 @@ void DecodeThreadVarsFree(ThreadVars *tv, DecodeThreadVars *dtv)
  */
 inline int PacketSetData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
-    SET_PKT_LEN(p, (size_t)pktlen);
+    SET_PKT_LEN(p, pktlen);
     if (unlikely(!pktdata)) {
         return -1;
     }

--- a/src/decode.c
+++ b/src/decode.c
@@ -291,7 +291,7 @@ inline int PacketCopyDataOffset(Packet *p, uint32_t offset, const uint8_t *data,
  */
 inline int PacketCopyData(Packet *p, const uint8_t *pktdata, uint32_t pktlen)
 {
-    SET_PKT_LEN(p, (size_t)pktlen);
+    SET_PKT_LEN(p, pktlen);
     return PacketCopyDataOffset(p, 0, pktdata, pktlen);
 }
 

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -125,7 +125,7 @@ static void DefragParseParameters(ConfNode *n)
     }
 }
 
-void DefragSetDefaultTimeout(intmax_t timeout)
+void DefragSetDefaultTimeout(int timeout)
 {
     default_timeout = timeout;
     SCLogDebug("default timeout %d", default_timeout);

--- a/src/defrag-config.h
+++ b/src/defrag-config.h
@@ -27,7 +27,7 @@
 
 #include "decode.h"
 
-void DefragSetDefaultTimeout(intmax_t timeout);
+void DefragSetDefaultTimeout(int timeout);
 void DefragPolicyLoadFromConfig(void);
 int DefragPolicyGetHostTimeout(Packet *p);
 void DefragTreeDestroy(void);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -189,13 +189,13 @@ DefragContextNew(void)
 
     /* Initialize the pool of frags. */
     intmax_t frag_pool_size;
-    if (!ConfGetInt("defrag.max-frags", &frag_pool_size) || frag_pool_size == 0) {
+    if (!ConfGetInt("defrag.max-frags", &frag_pool_size) || frag_pool_size == 0 ||
+            frag_pool_size > UINT32_MAX) {
         frag_pool_size = DEFAULT_DEFRAG_POOL_SIZE;
     }
-    intmax_t frag_pool_prealloc = frag_pool_size / 2;
-    dc->frag_pool = PoolInit(frag_pool_size, frag_pool_prealloc,
-        sizeof(Frag),
-        NULL, DefragFragInit, dc, NULL, NULL);
+    uint32_t frag_pool_prealloc = (uint32_t)frag_pool_size / 2;
+    dc->frag_pool = PoolInit((uint32_t)frag_pool_size, frag_pool_prealloc, sizeof(Frag), NULL,
+            DefragFragInit, dc, NULL, NULL);
     if (dc->frag_pool == NULL) {
         FatalError("Defrag: Failed to initialize fragment pool.");
     }
@@ -215,7 +215,7 @@ DefragContextNew(void)
         else if (timeout > TIMEOUT_MAX) {
             FatalError("defrag: Timeout greater than maximum allowed value.");
         }
-        dc->timeout = timeout;
+        dc->timeout = (int)timeout;
     }
 
     SCLogDebug("Defrag Initialized:");

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -37,7 +37,7 @@ typedef struct DefragContext_ {
     Pool *frag_pool; /**< Pool of fragments. */
     SCMutex frag_pool_lock;
 
-    time_t timeout; /**< Default timeout. */
+    int timeout; /**< Default timeout. */
 } DefragContext;
 
 /**

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -176,9 +176,9 @@ static int SigParseGetMaxBsize(DetectU64Data *bsz)
     switch (bsz->mode) {
         case DETECT_UINT_LT:
         case DETECT_UINT_EQ:
-            return bsz->arg1;
+            return (int)bsz->arg1;
         case DETECT_UINT_RA:
-            return bsz->arg2;
+            return (int)bsz->arg2;
         case DETECT_UINT_GT:
         default:
             SCReturnInt(-2);
@@ -210,6 +210,8 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
 
     DetectU64Data *bsz = DetectBsizeParse(sizestr);
     if (bsz == NULL)
+        goto error;
+    if (bsz->arg1 > INT_MAX || bsz->arg2 > INT_MAX)
         goto error;
 
     sm = SigMatchAlloc();

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -194,7 +194,7 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
 
     ptr += extbytes;
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     *value = val;
     SCLogDebug("extracted value is %"PRIu64, val);

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -250,7 +250,7 @@ int DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 #endif /* DEBUG */
 
     /* Adjust the detection context to the jump location. */
-    det_ctx->buffer_offset = val;
+    det_ctx->buffer_offset = (uint32_t)val;
 
     SCReturnInt(1);
 }
@@ -362,7 +362,7 @@ static int DetectBytejumpMatch(DetectEngineThreadCtx *det_ctx,
 #endif /* DEBUG */
 
     /* Adjust the detection context to the jump location. */
-    det_ctx->buffer_offset = jumpptr - p->payload;
+    det_ctx->buffer_offset = (uint32_t)(jumpptr - p->payload);
 
     return 1;
 }

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -189,7 +189,7 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *sm
             break;
     }
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     if (data->flags & DETECT_BYTEMATH_FLAG_BITMASK) {
         val &= data->bitmask_val;

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -411,7 +411,7 @@ static DetectBytetestData *DetectBytetestParse(
             data->neg_op = true;
             op_ptr = &args[1][1];
             while (isspace((char)*op_ptr) || (*op_ptr == ',')) op_ptr++;
-            op_offset = op_ptr - &args[1][0];
+            op_offset = (uint32_t)(op_ptr - &args[1][0]);
         } else {
             data->neg_op = false;
         }

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -118,12 +118,10 @@ static uint8_t DetectEngineInspectDnsQuery(DetectEngineCtx *de_ctx, DetectEngine
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -476,7 +476,7 @@ void SetupEngineAnalysis(DetectEngineCtx *de_ctx, bool *fp_analysis, bool *rule_
     }
 
     ea->file_prefix = NULL;
-    int cfg_prefix_len = strlen(de_ctx->config_prefix);
+    size_t cfg_prefix_len = strlen(de_ctx->config_prefix);
     if (cfg_prefix_len > 0) {
         /* length of prefix + NULL + "." */
         ea->file_prefix = SCCalloc(1, cfg_prefix_len + 1 + 1);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -161,7 +161,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                 int distance = cd->distance;
                 if (cd->flags & DETECT_CONTENT_DISTANCE) {
                     if (cd->flags & DETECT_CONTENT_DISTANCE_VAR) {
-                        distance = det_ctx->byte_values[cd->distance];
+                        DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[cd->distance] > UINT32_MAX);
+                        distance = (uint32_t)det_ctx->byte_values[cd->distance];
                     }
                     if (distance < 0 && (uint32_t)(abs(distance)) > offset)
                         offset = 0;
@@ -175,7 +176,12 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                 if (cd->flags & DETECT_CONTENT_WITHIN) {
                     if (cd->flags & DETECT_CONTENT_WITHIN_VAR) {
                         if ((int32_t)depth > (int32_t)(prev_buffer_offset + det_ctx->byte_values[cd->within] + distance)) {
-                            depth = prev_buffer_offset + det_ctx->byte_values[cd->within] + distance;
+                            DEBUG_VALIDATE_BUG_ON(prev_buffer_offset +
+                                                          det_ctx->byte_values[cd->within] +
+                                                          distance >
+                                                  UINT32_MAX);
+                            depth = (uint32_t)(prev_buffer_offset +
+                                               det_ctx->byte_values[cd->within] + distance);
                         }
                     } else {
                         if ((int32_t)depth > (int32_t)(prev_buffer_offset + cd->within + distance)) {
@@ -199,7 +205,9 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
 
                 if (cd->flags & DETECT_CONTENT_DEPTH_VAR) {
                     if ((det_ctx->byte_values[cd->depth] + prev_buffer_offset) < depth) {
-                        depth = prev_buffer_offset + det_ctx->byte_values[cd->depth];
+                        DEBUG_VALIDATE_BUG_ON(
+                                prev_buffer_offset + det_ctx->byte_values[cd->depth] > UINT32_MAX);
+                        depth = (uint32_t)(prev_buffer_offset + det_ctx->byte_values[cd->depth]);
                     }
                 } else {
                     if (cd->depth != 0) {
@@ -212,8 +220,10 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                 }
 
                 if (cd->flags & DETECT_CONTENT_OFFSET_VAR) {
-                    if (det_ctx->byte_values[cd->offset] > offset)
-                        offset = det_ctx->byte_values[cd->offset];
+                    if (det_ctx->byte_values[cd->offset] > offset) {
+                        DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[cd->offset] > UINT32_MAX);
+                        offset = (uint32_t)det_ctx->byte_values[cd->offset];
+                    }
                 } else {
                     if (cd->offset > offset) {
                         offset = cd->offset;
@@ -223,7 +233,8 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
             } else { /* implied no relative matches */
                 /* set depth */
                 if (cd->flags & DETECT_CONTENT_DEPTH_VAR) {
-                    depth = det_ctx->byte_values[cd->depth];
+                    DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[cd->depth] > UINT32_MAX);
+                    depth = (uint32_t)det_ctx->byte_values[cd->depth];
                 } else {
                     if (cd->depth != 0) {
                         depth = cd->depth;
@@ -241,10 +252,12 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                 }
 
                 /* set offset */
-                if (cd->flags & DETECT_CONTENT_OFFSET_VAR)
-                    offset = det_ctx->byte_values[cd->offset];
-                else
+                if (cd->flags & DETECT_CONTENT_OFFSET_VAR) {
+                    DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[cd->offset] > UINT32_MAX);
+                    offset = (uint32_t)det_ctx->byte_values[cd->offset];
+                } else {
                     offset = cd->offset;
+                }
                 prev_buffer_offset = 0;
             }
 
@@ -484,13 +497,15 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
         uint64_t value = btd->value;
         int32_t nbytes = btd->nbytes;
         if (btflags & DETECT_BYTETEST_OFFSET_VAR) {
-            offset = det_ctx->byte_values[offset];
+            DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[offset] > UINT32_MAX);
+            offset = (uint32_t)det_ctx->byte_values[offset];
         }
         if (btflags & DETECT_BYTETEST_VALUE_VAR) {
             value = det_ctx->byte_values[value];
         }
         if (btflags & DETECT_BYTETEST_NBYTES_VAR) {
-            nbytes = det_ctx->byte_values[nbytes];
+            DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[nbytes] > UINT32_MAX);
+            nbytes = (uint32_t)det_ctx->byte_values[nbytes];
         }
 
         /* if we have dce enabled we will have to use the endianness
@@ -516,11 +531,13 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
         int32_t nbytes;
 
         if (bjflags & DETECT_CONTENT_OFFSET_VAR) {
-            offset = det_ctx->byte_values[offset];
+            DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[offset] > UINT32_MAX);
+            offset = (uint32_t)det_ctx->byte_values[offset];
         }
 
         if (bjflags & DETECT_BYTEJUMP_NBYTES_VAR) {
-            nbytes = det_ctx->byte_values[bjd->nbytes];
+            DEBUG_VALIDATE_BUG_ON(det_ctx->byte_values[bjd->nbytes] > UINT32_MAX);
+            nbytes = (uint32_t)det_ctx->byte_values[bjd->nbytes];
         } else {
             nbytes = bjd->nbytes;
         }

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -257,12 +257,14 @@ static void BufferSetupUdp(InspectionBuffer *buffer, const Frame *frame, const P
     uint8_t ci_flags = DETECT_CI_FLAGS_START;
     uint32_t frame_len;
     if (frame->len == -1) {
-        frame_len = p->payload_len - frame->offset;
+        DEBUG_VALIDATE_BUG_ON(frame->offset > UINT32_MAX);
+        frame_len = p->payload_len - (uint32_t)frame->offset;
     } else {
         frame_len = (uint32_t)frame->len;
     }
     if (frame->offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->offset;
+        DEBUG_VALIDATE_BUG_ON(frame->offset > UINT32_MAX);
+        frame_len = p->payload_len - (uint32_t)frame->offset;
     } else {
         ci_flags |= DETECT_CI_FLAGS_END;
     }
@@ -345,7 +347,7 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
         SCLogDebug("have frame data start");
 
         if (frame->len >= 0) {
-            data_len = MIN(input_len, frame->len);
+            data_len = (uint32_t)MIN(input_len, frame->len);
             if (data_len == frame->len) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
@@ -372,20 +374,23 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
 
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
 
             uint32_t in_data_excess = 0;
             if (so_input_re >= so_frame_re) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
-                in_data_excess = so_input_re - so_frame_re;
+                DEBUG_VALIDATE_BUG_ON(so_input_re - so_frame_re > UINT32_MAX);
+                in_data_excess = (uint32_t)(so_input_re - so_frame_re);
             }
             data_len = input_len - in_data_offset - in_data_excess;
         } else {
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
             data_len = input_len - in_data_offset;
         }
@@ -481,8 +486,9 @@ static int FrameStreamDataInspectFunc(
 #endif
     BUG_ON(fsd->frame->len > 0 && (int64_t)data_len > fsd->frame->len);
 
+    DEBUG_VALIDATE_BUG_ON(data_offset > UINT32_MAX);
     int r = DetectEngineContentInspection(det_ctx->de_ctx, det_ctx, s, engine->smd, p, p->flow,
-            (uint8_t *)data, data_len, data_offset, buffer->flags,
+            (uint8_t *)data, data_len, (uint32_t)data_offset, buffer->flags,
             DETECT_ENGINE_CONTENT_INSPECTION_MODE_FRAME);
     if (r == 1) {
         SCLogDebug("DETECT_ENGINE_INSPECT_SIG_MATCH");

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -129,7 +129,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
         return -1;
     }
 
-    while(fgets(line + offset, (int)sizeof(line) - offset, fp) != NULL) {
+    while (fgets(line + offset, (int)(sizeof(line) - offset), fp) != NULL) {
         lineno++;
         size_t len = strlen(line);
 

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -33,7 +33,7 @@ static uint32_t PrefilterPacketHeaderHashFunc(HashListTable *ht, void *data, uin
     PrefilterPacketHeaderCtx *ctx = data;
     uint64_t hash = ctx->v1.u64[0] + ctx->v1.u64[1] + ctx->type + ctx->value;
     hash %= ht->array_size;
-    return hash;
+    return (uint32_t)hash;
 }
 
 static char PrefilterPacketHeaderCompareFunc(void *data1, uint16_t len1,

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -83,8 +83,8 @@ static inline void QuickSortSigIntId(SigIntId *sids, uint32_t n)
             r--;
         }
     }
-    QuickSortSigIntId(sids, r - sids + 1);
-    QuickSortSigIntId(l, sids + n - l);
+    QuickSortSigIntId(sids, (uint32_t)(r - sids) + 1);
+    QuickSortSigIntId(l, n - (uint32_t)(l - sids));
 }
 
 /**
@@ -592,7 +592,7 @@ static uint32_t PrefilterStoreHashFunc(HashListTable *ht, void *data, uint16_t d
 {
     PrefilterStore *ctx = data;
 
-    uint32_t hash = strlen(ctx->name);
+    uint32_t hash = (uint32_t)strlen(ctx->name);
 
     for (size_t u = 0; u < strlen(ctx->name); u++) {
         hash += ctx->name[u];

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -356,7 +356,7 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
     }
 }
 
-static void SigMultilinePrint(int i, const char *prefix)
+static void SigMultilinePrint(size_t i, const char *prefix)
 {
     if (sigmatch_table[i].desc) {
         printf("%sDescription: %s\n", prefix, sigmatch_table[i].desc);

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -263,7 +263,7 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
 
     while (iter != NULL) {
         /* update counters */
-        iter->last_ts = SCTIME_SECS(p->ts);
+        iter->last_ts = (uint32_t)SCTIME_SECS(p->ts);
         switch (iter->metric) {
             case DETECT_TAG_METRIC_PACKET:
                 iter->packets++;
@@ -385,7 +385,7 @@ static void TagHandlePacketHost(Host *host, Packet *p)
     prev = NULL;
     while (iter != NULL) {
         /* update counters */
-        iter->last_ts = SCTIME_SECS(p->ts);
+        iter->last_ts = (uint32_t)SCTIME_SECS(p->ts);
         switch (iter->metric) {
             case DETECT_TAG_METRIC_PACKET:
                 iter->packets++;

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -349,7 +349,7 @@ static int IsThresholdReached(
             if (lookup_tsh->current_count > td->count) {
                 /* Then we must enable the new action by setting a
                 * timeout */
-                lookup_tsh->tv_timeout = SCTIME_SECS(packet_time);
+                lookup_tsh->tv_timeout = (uint32_t)SCTIME_SECS(packet_time);
                 ret = 1;
             }
         } else {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2199,13 +2199,13 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
     det_ctx->buffer_offset = 0;
     det_ctx->inspection_recursion_counter = 0;
 
+    if (offset > UINT32_MAX) {
+        return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
+    }
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
-    int r = DetectEngineContentInspection(de_ctx, det_ctx,
-                                          s, engine->smd,
-                                          NULL, f,
-                                          (uint8_t *)data, data_len, offset, ci_flags,
-                                          DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+    int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
+            data_len, (uint32_t)offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
@@ -3548,9 +3548,10 @@ static uint32_t DetectKeywordCtxHashFunc(HashListTable *ht, void *data, uint16_t
 {
     DetectEngineThreadKeywordCtxItem *ctx = data;
     const char *name = ctx->name;
-    uint64_t hash = StringHashDjb2((const uint8_t *)name, strlen(name)) + (ptrdiff_t)ctx->data;
+    uint64_t hash =
+            StringHashDjb2((const uint8_t *)name, (uint32_t)strlen(name)) + (ptrdiff_t)ctx->data;
     hash %= ht->array_size;
-    return hash;
+    return (uint32_t)hash;
 }
 
 static char DetectKeywordCtxCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -418,12 +418,12 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
         det_ctx->buffer_offset = 0;
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
-        match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, ciflags,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        if (buffer->inspect_offset > UINT32_MAX) {
+            return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
+        }
+        match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, (uint32_t)buffer->inspect_offset,
+                ciflags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match) {
             break;
         }

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -323,12 +323,10 @@ static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngin
         det_ctx->buffer_offset = 0;
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
-        int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         } else {

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -260,12 +260,10 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
         det_ctx->buffer_offset = 0;
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
-        int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         } else {

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -29,7 +29,13 @@ static int DetectFlowAgeMatch(
     if (p->flow == NULL) {
         return 0;
     }
-    uint32_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
+    if (SCTIME_SECS(p->flow->lastts) < SCTIME_SECS(p->flow->startts)) {
+        return 0;
+    }
+    uint32_t age = (uint32_t)(SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts));
+    if (SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts) > UINT32_MAX) {
+        age = UINT32_MAX;
+    }
 
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
     return DetectU32Match(age, du32);

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -106,7 +106,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_src);
 
-            HostBitToggle(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitToggle(p->host_src, fd->idx, (uint32_t)SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -118,7 +118,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_dst);
 
-            HostBitToggle(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitToggle(p->host_dst, fd->idx, (uint32_t)SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_dst);
             break;
     }
@@ -166,7 +166,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            HostBitSet(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitSet(p->host_src, fd->idx, (uint32_t)SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -177,7 +177,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            HostBitSet(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitSet(p->host_dst, fd->idx, (uint32_t)SCTIME_SECS(p->ts) + fd->expire);
             HostUnlock(p->host_dst);
             break;
     }
@@ -196,7 +196,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsset(p->host_src, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -207,7 +207,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsset(p->host_dst, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
             HostUnlock(p->host_dst);
             return r;
     }
@@ -226,7 +226,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsnotset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsnotset(p->host_src, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -237,7 +237,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsnotset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsnotset(p->host_dst, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
             HostUnlock(p->host_dst);
             return r;
     }

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -327,10 +327,13 @@ static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
     det_ctx->buffer_offset = 0;
     det_ctx->inspection_recursion_counter = 0;
 
+    if (offset > UINT32_MAX) {
+        return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
+    }
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
     int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
-            data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+            data_len, (uint32_t)offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     }

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -187,7 +187,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
+        const uint32_t data_len = (uint32_t)bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
@@ -215,7 +215,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
+        const uint32_t data_len = (uint32_t)bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -115,7 +115,7 @@ static uint8_t *GetBufferForTX(
         SCLogDebug("size %"PRIuMAX" + buf->len %u vs buf->size %u",
                 (uintmax_t)size, buf->len, buf->size);
         if (size + buf->len > buf->size) {
-            if (HttpHeaderExpandBuffer(hdr_td, buf, size) != 0) {
+            if (HttpHeaderExpandBuffer(hdr_td, buf, (uint32_t)size) != 0) {
                 return NULL;
             }
         }

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -118,7 +118,7 @@ static uint8_t *GetBufferForTX(
             size += 2;
 #endif
         if (size + buf->len > buf->size) {
-            if (HttpHeaderExpandBuffer(hdr_td, buf, size) != 0) {
+            if (HttpHeaderExpandBuffer(hdr_td, buf, (uint32_t)size) != 0) {
                 return NULL;
             }
         }
@@ -197,17 +197,16 @@ static uint8_t DetectEngineInspectBufferHttpHeader(DetectEngineCtx *de_ctx,
 
     const uint32_t data_len = buffer->inspect_len;
     const uint8_t *data = buffer->inspect;
-    const uint64_t offset = buffer->inspect_offset;
 
     det_ctx->discontinue_matching = 0;
     det_ctx->buffer_offset = 0;
     det_ctx->inspection_recursion_counter = 0;
 
+    // buffer->inspect_offset is always 0 here
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
-    int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-            NULL, f, (uint8_t *)data, data_len, offset,
-            DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+    int r = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, (uint8_t *)data,
+            data_len, 0, DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
     SCLogDebug("r = %d", r);
     if (r == 1) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
@@ -554,9 +553,10 @@ static uint8_t DetectEngineInspectHttp2Header(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
+        // buffer->inspect_offset is always 0 here
         const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
-                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }
@@ -613,7 +613,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx, cons
         size_t size2 = bstr_size(h->value);
         size_t b_len = size1 + 2 + size2;
         if (b_len > buf->size) {
-            if (HttpHeaderExpandBuffer(hdr_td, buf, b_len) != 0) {
+            if (HttpHeaderExpandBuffer(hdr_td, buf, (uint32_t)b_len) != 0) {
                 return NULL;
             }
         }
@@ -621,7 +621,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx, cons
         buf->buffer[size1] = ':';
         buf->buffer[size1 + 1] = ' ';
         memcpy(buf->buffer + size1 + 2, bstr_ptr(h->value), bstr_size(h->value));
-        buf->len = b_len;
+        buf->len = (uint32_t)b_len;
     } else {
         InspectionBufferSetupMultiEmpty(buffer);
         return NULL;
@@ -706,9 +706,10 @@ static uint8_t DetectEngineInspectHttp1Header(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
+        // buffer->inspect_offset is always 0 here
         const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
-                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -64,7 +64,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
+        const uint32_t data_len = (uint32_t)bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
@@ -120,7 +120,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
+        const uint32_t data_len = (uint32_t)bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -245,7 +245,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (tx->request_hostname == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->request_hostname);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->request_hostname);
         const uint8_t *data = bstr_ptr(tx->request_hostname);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
@@ -355,10 +355,10 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
                 return NULL;
 
             data = (const uint8_t *)bstr_ptr(h->value);
-            data_len = bstr_len(h->value);
+            data_len = (uint32_t)bstr_len(h->value);
         } else {
             data = (const uint8_t *)bstr_ptr(tx->parsed_uri->hostname);
-            data_len = bstr_len(tx->parsed_uri->hostname);
+            data_len = (uint32_t)bstr_len(tx->parsed_uri->hostname);
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -206,7 +206,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (tx->request_method == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->request_method);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->request_method);
         const uint8_t *data = bstr_ptr(tx->request_method);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -100,7 +100,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        uint32_t data_len = bstr_size(str);
+        uint32_t data_len = (uint32_t)bstr_size(str);
         uint8_t *data = bstr_ptr(str);
         if (data == NULL || data_len == 0) {
             SCLogDebug("HTTP protocol not present");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -161,7 +161,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(tx->request_line == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->request_line);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->request_line);
         const uint8_t *data = bstr_ptr(tx->request_line);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -160,7 +160,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(tx->response_line == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->response_line);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->response_line);
         const uint8_t *data = bstr_ptr(tx->response_line);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -105,7 +105,7 @@ static uint8_t *GetBufferForTX(
 
     size_t line_size = bstr_len(line) + 2;
     if (line_size + buf->len > buf->size) {
-        if (HttpHeaderExpandBuffer(hdr_td, buf, line_size) != 0) {
+        if (HttpHeaderExpandBuffer(hdr_td, buf, (uint32_t)line_size) != 0) {
             return NULL;
         }
     }
@@ -124,7 +124,7 @@ static uint8_t *GetBufferForTX(
         if (i + 1 == no_of_headers)
             size += 2;
         if (size + buf->len > buf->size) {
-            if (HttpHeaderExpandBuffer(hdr_td, buf, size) != 0) {
+            if (HttpHeaderExpandBuffer(hdr_td, buf, (uint32_t)size) != 0) {
                 return NULL;
             }
         }

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -164,7 +164,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (tx->response_status == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->response_status);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->response_status);
         const uint8_t *data = bstr_ptr(tx->response_status);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -173,7 +173,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (tx->response_message == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->response_message);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->response_message);
         const uint8_t *data = bstr_ptr(tx->response_message);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -171,7 +171,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
+        const uint32_t data_len = (uint32_t)bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -233,7 +233,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(tx_ud->request_uri_normalized);
+        const uint32_t data_len = (uint32_t)bstr_len(tx_ud->request_uri_normalized);
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
@@ -324,7 +324,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(tx->request_uri == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->request_uri);
+        const uint32_t data_len = (uint32_t)bstr_len(tx->request_uri);
         const uint8_t *data = bstr_ptr(tx->request_uri);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -737,12 +737,10 @@ static uint8_t DetectEngineInspectHttp2HeaderName(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -159,9 +159,10 @@ static uint8_t DetectEngineInspectIkeVendor(DetectEngineCtx *de_ctx, DetectEngin
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
+        // buffer->inspect_offset is always 0 here
         const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
-                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -108,12 +108,10 @@ static uint8_t DetectEngineInspectKrb5CName(DetectEngineCtx *de_ctx, DetectEngin
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -108,12 +108,10 @@ static uint8_t DetectEngineInspectKrb5SName(DetectEngineCtx *de_ctx, DetectEngin
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-mqtt-subscribe-topic.c
+++ b/src/detect-mqtt-subscribe-topic.c
@@ -111,12 +111,10 @@ static uint8_t DetectEngineInspectMQTTSubscribeTopic(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }
@@ -202,7 +200,11 @@ void DetectMQTTSubscribeTopicRegister (void)
 
     intmax_t val = 0;
     if (ConfGetInt("app-layer.protocols.mqtt.subscribe-topic-match-limit", &val)) {
-        subscribe_topic_match_limit = val;
+        if (val >= 0 && val <= UINT32_MAX) {
+            subscribe_topic_match_limit = (uint32_t)val;
+        } else {
+            SCLogWarning("mqtt.subscribe-topic-match-limit is outside of valid range: %ji", val);
+        }
     }
     if (subscribe_topic_match_limit <= 0) {
         SCLogDebug("Using unrestricted MQTT SUBSCRIBE topic matching");

--- a/src/detect-mqtt-unsubscribe-topic.c
+++ b/src/detect-mqtt-unsubscribe-topic.c
@@ -111,12 +111,10 @@ static uint8_t DetectEngineInspectMQTTUnsubscribeTopic(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f,
-                                              (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }
@@ -202,7 +200,11 @@ void DetectMQTTUnsubscribeTopicRegister (void)
 
     intmax_t val = 0;
     if (ConfGetInt("app-layer.protocols.mqtt.unsubscribe-topic-match-limit", &val)) {
-        unsubscribe_topic_match_limit = val;
+        if (val >= 0 && val <= UINT32_MAX) {
+            unsubscribe_topic_match_limit = (uint32_t)val;
+        } else {
+            SCLogWarning("mqtt.unsubscribe-topic-match-limit is outside of valid range: %ji", val);
+        }
     }
     if (unsubscribe_topic_match_limit <= 0) {
         SCLogDebug("Using unrestricted MQTT UNSUBSCRIBE topic matching");

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -113,7 +113,7 @@ void DetectPcreRegister (void)
         SCLogDebug("Using PCRE match-limit setting of: %i", pcre_match_limit);
     }
     else    {
-        pcre_match_limit = val;
+        pcre_match_limit = (int)val;
         if (pcre_match_limit != SC_MATCH_LIMIT_DEFAULT) {
             SCLogInfo("Using PCRE match-limit setting of: %i", pcre_match_limit);
         } else {
@@ -128,7 +128,7 @@ void DetectPcreRegister (void)
         SCLogDebug("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
     }
     else    {
-        pcre_match_limit_recursion = val;
+        pcre_match_limit_recursion = (int)val;
         if (pcre_match_limit_recursion != SC_MATCH_LIMIT_RECURSION_DEFAULT) {
             SCLogInfo("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
         } else {
@@ -194,7 +194,7 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
     int start_offset = 0;
     if (det_ctx->pcre_match_start_offset != 0) {
-        start_offset = (payload + det_ctx->pcre_match_start_offset - ptr);
+        start_offset = (uint32_t)(payload - ptr) + det_ctx->pcre_match_start_offset;
     }
 
     /* run the actual pcre detection */
@@ -291,8 +291,8 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
             PCRE2_SIZE *ov = pcre2_get_ovector_pointer(match);
             /* update offset for pcre RELATIVE */
-            det_ctx->buffer_offset = (ptr + ov[1]) - payload;
-            det_ctx->pcre_match_start_offset = (ptr + ov[0] + 1) - payload;
+            det_ctx->buffer_offset = (uint32_t)(ptr + ov[1] - payload);
+            det_ctx->pcre_match_start_offset = (uint32_t)((ptr + ov[0] + 1) - payload);
 
             ret = 1;
         }
@@ -370,13 +370,13 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         SCLogDebug("regexstr %s", regexstr);
 
         if (fcap && !pcap)
-            cut_capture = fcap - regexstr;
+            cut_capture = (int)(fcap - regexstr);
         else if (pcap && !fcap)
-            cut_capture = pcap - regexstr;
+            cut_capture = (int)(pcap - regexstr);
         else {
             BUG_ON(pcap == NULL); // added to assist cppcheck
             BUG_ON(fcap == NULL);
-            cut_capture = MIN((pcap - regexstr), (fcap - regexstr));
+            cut_capture = (int)MIN((pcap - regexstr), (fcap - regexstr));
         }
 
         SCLogDebug("cut_capture %d", cut_capture);

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -94,9 +94,9 @@ static int DetectPrioritySetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (s->init_data->init_flags & SIG_FLAG_INIT_PRIO_EXPLICIT) {
         SCLogWarning("duplicate priority "
                      "keyword. Using highest priority in the rule");
-        s->prio = MIN(s->prio, prio);
+        s->prio = MIN(s->prio, (int)prio);
     } else {
-        s->prio = prio;
+        s->prio = (int)prio;
         s->init_data->init_flags |= SIG_FLAG_INIT_PRIO_EXPLICIT;
     }
     return 0;

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -110,9 +110,10 @@ static uint8_t DetectEngineInspectQuicHash(DetectEngineCtx *de_ctx, DetectEngine
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
+        // buffer->inspect_offset is always 0 here
         const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
-                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -108,9 +108,10 @@ static uint8_t DetectEngineInspectQuicString(DetectEngineCtx *de_ctx,
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
+        // buffer->inspect_offset is always 0 here
         const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                (uint8_t *)buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
-                DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -106,7 +106,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
 
             tde.sid = s->id;
             tde.gid = s->gid;
-            tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
+            tde.last_ts = tde.first_ts = (uint32_t)SCTIME_SECS(p->ts);
             tde.metric = td->metric;
             tde.count = td->count;
             if (td->direction == DETECT_TAG_DIR_SRC)
@@ -123,7 +123,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
                 /* If it already exists it will be updated */
                 tde.sid = s->id;
                 tde.gid = s->gid;
-                tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
+                tde.last_ts = tde.first_ts = (uint32_t)SCTIME_SECS(p->ts);
                 tde.metric = td->metric;
                 tde.count = td->count;
 

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -150,7 +150,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_fingerprint);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_fingerprint);
         const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -139,7 +139,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_issuerdn);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_issuerdn);
         const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -149,7 +149,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_serial);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_serial);
         const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -140,7 +140,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_subject);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_subject);
         const uint8_t *data = (uint8_t *)connp->cert0_subject;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -198,11 +198,10 @@ static uint8_t DetectEngineInspectTlsCerts(DetectEngineCtx *de_ctx, DetectEngine
         det_ctx->discontinue_matching = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd,
-                                              NULL, f, (uint8_t *)buffer->inspect,
-                                              buffer->inspect_len,
-                                              buffer->inspect_offset, DETECT_CI_FLAGS_SINGLE,
-                                              DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        // buffer->inspect_offset is always 0 here
+        const int match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)buffer->inspect, buffer->inspect_len, 0, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match == 1) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;
         }

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -151,7 +151,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_hash;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -141,7 +141,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_str->data;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -149,7 +149,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_hash;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -141,7 +141,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_str->data;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -119,7 +119,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.sni);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.sni);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.sni;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);

--- a/src/detect-transform-compress-whitespace.c
+++ b/src/detect-transform-compress-whitespace.c
@@ -129,7 +129,7 @@ static void TransformCompressWhitespace(InspectionBuffer *buffer, void *options)
             }
         }
     }
-    uint32_t output_size = oi - os;
+    uint32_t output_size = (uint32_t)(oi - os);
     //PrintRawDataFp(stdout, output, output_size);
 
     InspectionBufferCopy(buffer, os, output_size);

--- a/src/detect-transform-dotprefix.c
+++ b/src/detect-transform-dotprefix.c
@@ -107,7 +107,7 @@ static int DetectTransformDotPrefixSetup (DetectEngineCtx *de_ctx, Signature *s,
  */
 static void TransformDotPrefix(InspectionBuffer *buffer, void *options)
 {
-    const size_t input_len = buffer->inspect_len;
+    const uint32_t input_len = buffer->inspect_len;
 
     if (input_len) {
         uint8_t output[input_len + 1]; // For the leading '.'

--- a/src/detect-transform-strip-whitespace.c
+++ b/src/detect-transform-strip-whitespace.c
@@ -116,7 +116,7 @@ static void TransformStripWhitespace(InspectionBuffer *buffer, void *options)
         }
         input++;
     }
-    uint32_t output_size = oi - os;
+    uint32_t output_size = (uint32_t)(oi - os);
     //PrintRawDataFp(stdout, output, output_size);
 
     InspectionBufferCopy(buffer, os, output_size);

--- a/src/detect-transform-urldecode.c
+++ b/src/detect-transform-urldecode.c
@@ -111,7 +111,7 @@ static bool BufferUrlDecode(const uint8_t *input, const uint32_t input_len, uint
             *oi++ = input[i];
         }
     }
-    *output_size = oi - output;
+    *output_size = (uint32_t)(oi - output);
     return changed;
 }
 

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -88,7 +88,11 @@ static int DetectIPPairbitMatchToggle (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitToggle(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+    if (SCTIME_SECS(p->ts) + fd->expire > UINT32_MAX) {
+        IPPairRelease(pair);
+        return 0;
+    }
+    IPPairBitToggle(pair, fd->idx, (uint32_t)(SCTIME_SECS(p->ts) + fd->expire));
     IPPairRelease(pair);
     return 1;
 }
@@ -111,7 +115,11 @@ static int DetectIPPairbitMatchSet (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitSet(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+    if (SCTIME_SECS(p->ts) + fd->expire > UINT32_MAX) {
+        IPPairRelease(pair);
+        return 0;
+    }
+    IPPairBitSet(pair, fd->idx, (uint32_t)(SCTIME_SECS(p->ts) + fd->expire));
     IPPairRelease(pair);
     return 1;
 }
@@ -123,7 +131,11 @@ static int DetectIPPairbitMatchIsset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    r = IPPairBitIsset(pair, fd->idx, SCTIME_SECS(p->ts));
+    if (SCTIME_SECS(p->ts) > UINT32_MAX) {
+        IPPairRelease(pair);
+        return 0;
+    }
+    r = IPPairBitIsset(pair, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
     IPPairRelease(pair);
     return r;
 }
@@ -135,7 +147,11 @@ static int DetectIPPairbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 1;
 
-    r = IPPairBitIsnotset(pair, fd->idx, SCTIME_SECS(p->ts));
+    if (SCTIME_SECS(p->ts) > UINT32_MAX) {
+        IPPairRelease(pair);
+        return 1;
+    }
+    r = IPPairBitIsnotset(pair, fd->idx, (uint32_t)SCTIME_SECS(p->ts));
     IPPairRelease(pair);
     return r;
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -368,7 +368,7 @@ static inline void DetectPrefilterMergeSort(DetectEngineCtx *de_ctx,
         }
     }
 
-    det_ctx->match_array_cnt = match_array - det_ctx->match_array;
+    det_ctx->match_array_cnt = (uint32_t)(match_array - det_ctx->match_array);
     DEBUG_VALIDATE_BUG_ON((det_ctx->pmq.rule_id_array_cnt + det_ctx->non_pf_id_cnt) < det_ctx->match_array_cnt);
     PMQ_RESET(&det_ctx->pmq);
 }

--- a/src/feature.c
+++ b/src/feature.c
@@ -42,9 +42,9 @@ static uint32_t FeatureHashFunc(HashListTable *ht, void *data,
 {
     FeatureEntryType *f = (FeatureEntryType *)data;
     uint32_t hash = 0;
-    int len = strlen(f->feature);
+    size_t len = strlen(f->feature);
 
-    for (int i = 0; i < len; i++)
+    for (size_t i = 0; i < len; i++)
         hash += u8_tolower((unsigned char)f->feature[i]);
 
     return (hash % ht->array_size);
@@ -55,8 +55,8 @@ static char FeatureHashCompareFunc(void *data1, uint16_t datalen1,
 {
     FeatureEntryType *f1 = (FeatureEntryType *)data1;
     FeatureEntryType *f2 = (FeatureEntryType *)data2;
-    int len1 = 0;
-    int len2 = 0;
+    size_t len1 = 0;
+    size_t len2 = 0;
 
     if (f1 == NULL || f2 == NULL)
         return 0;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -407,7 +407,7 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td, SCTime_t ts, const
 #define TYPE uint32_t
 #endif
 
-    const uint32_t ts_secs = SCTIME_SECS(ts);
+    const uint32_t ts_secs = (uint32_t)SCTIME_SECS(ts);
     for (uint32_t idx = hash_min; idx < hash_max; idx+=BITS) {
         TYPE check_bits = 0;
         const uint32_t check = MIN(BITS, (hash_max - idx));
@@ -906,8 +906,8 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             struct timeval cond_tv;
             gettimeofday(&cond_tv, NULL);
             struct timeval add_tv;
-            add_tv.tv_sec = 0;
-            add_tv.tv_usec = (sleep_per_wu * 1000);
+            add_tv.tv_sec = sleep_per_wu / 1000;
+            add_tv.tv_usec = (sleep_per_wu % 1000) * 1000;
             timeradd(&cond_tv, &add_tv, &cond_tv);
 
             struct timespec cond_time = FROM_TIMEVAL(cond_tv);

--- a/src/log-cf-common.c
+++ b/src/log-cf-common.c
@@ -123,7 +123,7 @@ int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
                 n = LOG_NODE_STRLEN-2;
                 np = NULL; /* End */
             }else{
-                n = np-p;
+                n = (uint32_t)(np - p);
             }
             strlcpy(node->data,p,n+1);
             p = np;
@@ -151,7 +151,7 @@ int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
                 np = strchr(p, '}');
                 if (np != NULL && np-p > 1 && np-p < LOG_NODE_STRLEN-2) {
                     p++;
-                    n = np-p;
+                    n = (uint32_t)(np - p);
                     strlcpy(node->data, p, n+1);
                     p = np;
                 } else {

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -131,7 +131,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
 {
     LogHttpFileCtx *httplog_ctx = aft->httplog_ctx;
     uint32_t i;
-    uint32_t datalen;
+    size_t datalen;
     char buf[128];
 
     uint8_t *cvalue = NULL;
@@ -252,9 +252,9 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
                 if (tx->request_headers != NULL) {
                     h_request_hdr = htp_table_get_c(tx->request_headers, "Cookie");
                     if (h_request_hdr != NULL) {
-                        cvalue_len = GetCookieValue((uint8_t *) bstr_ptr(h_request_hdr->value),
-                                    bstr_len(h_request_hdr->value), (char *) node->data,
-                                    &cvalue);
+                        cvalue_len = GetCookieValue((uint8_t *)bstr_ptr(h_request_hdr->value),
+                                (uint32_t)bstr_len(h_request_hdr->value), (char *)node->data,
+                                &cvalue);
                     }
                 }
                 if (cvalue_len > 0 && cvalue != NULL) {

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1546,7 +1546,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
             } else {
                 lvl = 0;
             }
-            comp->lz4f_prefs.compressionLevel = lvl;
+            comp->lz4f_prefs.compressionLevel = (int)lvl;
 
             /* Allocate resources for lz4. */
 

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -92,9 +92,8 @@ typedef struct LogTlsLogThread_ {
     MemBuffer *buffer;
 } LogTlsLogThread;
 
-int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
-                         Port* sp, char* dstip, size_t dstip_len, Port* dp,
-                         int ipproto)
+int TLSGetIPInformations(const Packet *p, char *srcip, socklen_t srcip_len, Port *sp, char *dstip,
+        socklen_t dstip_len, Port *dp, int ipproto)
 {
     if ((PKT_IS_TOSERVER(p))) {
         switch (ipproto) {

--- a/src/log-tlslog.h
+++ b/src/log-tlslog.h
@@ -27,9 +27,8 @@
 
 void LogTlsLogRegister(void);
 
-int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
-                             Port* sp, char* dstip, size_t dstip_len,
-                             Port* dp, int ipproto);
+int TLSGetIPInformations(const Packet *p, char *srcip, socklen_t srcip_len, Port *sp, char *dstip,
+        socklen_t dstip_len, Port *dp, int ipproto);
 
 #endif /* __LOG_TLSLOG_H__ */
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -849,8 +849,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                     if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
                         uint8_t printable_buf[payload->offset + 1];
                         uint32_t offset = 0;
-                        PrintStringsToBuffer(printable_buf, &offset,
-                                sizeof(printable_buf),
+                        PrintStringsToBuffer(printable_buf, &offset, payload->offset + 1,
                                 payload->buffer, payload->offset);
                         jb_set_string(jb, "payload_printable", (char *)printable_buf);
                     }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -376,7 +376,7 @@ TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *
     SCReturnInt(TM_ECODE_OK);
 }
 
-bool EveEmailAddMetadata(const Flow *f, uint32_t tx_id, JsonBuilder *js)
+bool EveEmailAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
 {
     SMTPState *smtp_state = (SMTPState *)FlowGetAppState(f);
     if (smtp_state) {

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -36,7 +36,7 @@ typedef struct JsonEmailLogThread_ {
 } JsonEmailLogThread;
 
 TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
-bool EveEmailAddMetadata(const Flow *f, uint32_t tx_id, JsonBuilder *js);
+bool EveEmailAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 
 void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx);
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -44,6 +44,7 @@
 #include "util-proto-name.h"
 #include "util-logopenfile.h"
 #include "util-time.h"
+#include "util-validate.h"
 #include "output-json.h"
 #include "output-json-flow.h"
 
@@ -225,7 +226,9 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
     CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
     jb_set_string(jb, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    DEBUG_VALIDATE_BUG_ON((int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) < INT32_MIN ||
+                          (int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) > INT32_MAX);
+    int32_t age = (int32_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(jb, "age", age);
 
     if (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY)

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -153,7 +153,8 @@ static void FrameAddPayloadTCP(JsonBuilder *js, const TcpStream *stream, const F
     }
 
     if (frame->len >= 0) {
-        sb_data_len = MIN(frame->len, (int32_t)sb_data_len);
+        DEBUG_VALIDATE_BUG_ON(frame->len > UINT32_MAX);
+        sb_data_len = MIN((uint32_t)frame->len, sb_data_len);
     }
     SCLogDebug("frame data_offset %" PRIu64 ", data_len %u frame len %" PRIi64, data_offset,
             sb_data_len, frame->len);
@@ -190,12 +191,12 @@ static void FrameAddPayloadUDP(JsonBuilder *js, const Packet *p, const Frame *fr
 
     uint32_t frame_len;
     if (frame->len == -1) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = p->payload_len - (uint32_t)frame->offset;
     } else {
         frame_len = (uint32_t)frame->len;
     }
     if (frame->offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = p->payload_len - (uint32_t)frame->offset;
         JB_SET_FALSE(js, "complete");
     } else {
         JB_SET_TRUE(js, "complete");

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -198,8 +198,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 {
     /* hostname */
     if (tx->request_hostname != NULL) {
-        jb_set_string_from_bytes(
-                js, "hostname", bstr_ptr(tx->request_hostname), bstr_len(tx->request_hostname));
+        jb_set_string_from_bytes(js, "hostname", bstr_ptr(tx->request_hostname),
+                (uint32_t)bstr_len(tx->request_hostname));
     }
 
     /* port */
@@ -214,7 +214,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 
     /* uri */
     if (tx->request_uri != NULL) {
-        jb_set_string_from_bytes(js, "url", bstr_ptr(tx->request_uri), bstr_len(tx->request_uri));
+        jb_set_string_from_bytes(
+                js, "url", bstr_ptr(tx->request_uri), (uint32_t)bstr_len(tx->request_uri));
     }
 
     if (tx->request_headers != NULL) {
@@ -222,14 +223,14 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
         htp_header_t *h_user_agent = htp_table_get_c(tx->request_headers, "user-agent");
         if (h_user_agent != NULL) {
             jb_set_string_from_bytes(js, "http_user_agent", bstr_ptr(h_user_agent->value),
-                    bstr_len(h_user_agent->value));
+                    (uint32_t)bstr_len(h_user_agent->value));
         }
 
         /* x-forwarded-for */
         htp_header_t *h_x_forwarded_for = htp_table_get_c(tx->request_headers, "x-forwarded-for");
         if (h_x_forwarded_for != NULL) {
             jb_set_string_from_bytes(js, "xff", bstr_ptr(h_x_forwarded_for->value),
-                    bstr_len(h_x_forwarded_for->value));
+                    (uint32_t)bstr_len(h_x_forwarded_for->value));
         }
     }
 
@@ -248,8 +249,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
         htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
         if (h_content_range != NULL) {
             jb_open_object(js, "content_range");
-            jb_set_string_from_bytes(
-                    js, "raw", bstr_ptr(h_content_range->value), bstr_len(h_content_range->value));
+            jb_set_string_from_bytes(js, "raw", bstr_ptr(h_content_range->value),
+                    (uint32_t)bstr_len(h_content_range->value));
             HTTPContentRange crparsed;
             if (HTPParseContentRange(h_content_range->value, &crparsed) == 0) {
                 if (crparsed.start >= 0)
@@ -273,19 +274,19 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
     }
     if (h_referer != NULL) {
         jb_set_string_from_bytes(
-                js, "http_refer", bstr_ptr(h_referer->value), bstr_len(h_referer->value));
+                js, "http_refer", bstr_ptr(h_referer->value), (uint32_t)bstr_len(h_referer->value));
     }
 
     /* method */
     if (tx->request_method != NULL) {
-        jb_set_string_from_bytes(
-                js, "http_method", bstr_ptr(tx->request_method), bstr_len(tx->request_method));
+        jb_set_string_from_bytes(js, "http_method", bstr_ptr(tx->request_method),
+                (uint32_t)bstr_len(tx->request_method));
     }
 
     /* protocol */
     if (tx->request_protocol != NULL) {
-        jb_set_string_from_bytes(
-                js, "protocol", bstr_ptr(tx->request_protocol), bstr_len(tx->request_protocol));
+        jb_set_string_from_bytes(js, "protocol", bstr_ptr(tx->request_protocol),
+                (uint32_t)bstr_len(tx->request_protocol));
     }
 
     /* response status */
@@ -294,13 +295,13 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
         char status_string[status_size];
         BytesToStringBuffer(bstr_ptr(tx->response_status), bstr_len(tx->response_status),
                 status_string, status_size);
-        unsigned int val = strtoul(status_string, NULL, 10);
+        unsigned long val = strtoul(status_string, NULL, 10);
         jb_set_uint(js, "status", val);
 
         htp_header_t *h_location = htp_table_get_c(tx->response_headers, "location");
         if (h_location != NULL) {
-            jb_set_string_from_bytes(
-                    js, "redirect", bstr_ptr(h_location->value), bstr_len(h_location->value));
+            jb_set_string_from_bytes(js, "redirect", bstr_ptr(h_location->value),
+                    (uint32_t)bstr_len(h_location->value));
         }
     }
 
@@ -378,9 +379,7 @@ static void BodyPrintableBuffer(JsonBuilder *js, HtpBody *body, const char *key)
         }
 
         uint8_t printable_buf[body_data_len + 1];
-        PrintStringsToBuffer(printable_buf, &offset,
-                             sizeof(printable_buf),
-                             body_data, body_data_len);
+        PrintStringsToBuffer(printable_buf, &offset, body_data_len + 1, body_data, body_data_len);
         if (offset > 0) {
             jb_set_string(js, key, (char *)printable_buf);
         }

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -44,6 +44,7 @@
 #include "util-proto-name.h"
 #include "util-logopenfile.h"
 #include "util-time.h"
+#include "util-validate.h"
 #include "output-json.h"
 #include "output-json-netflow.h"
 
@@ -193,7 +194,9 @@ static void NetFlowLogEveToServer(JsonBuilder *js, Flow *f)
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    DEBUG_VALIDATE_BUG_ON((int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) < INT32_MIN ||
+                          (int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) > INT32_MAX);
+    int32_t age = (int32_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(js, "age", age);
 
     jb_set_uint(js, "min_ttl", f->min_ttl_toserver);
@@ -237,7 +240,9 @@ static void NetFlowLogEveToClient(JsonBuilder *js, Flow *f)
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    DEBUG_VALIDATE_BUG_ON((int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) < INT32_MIN ||
+                          (int64_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts)) > INT32_MAX);
+    int32_t age = (int32_t)(SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(js, "age", age);
 
     /* To client is zero if we did not see any packet */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -206,24 +206,18 @@ static void EveAddPacketVars(const Packet *p, JsonBuilder *js_vars)
             if (pv->key != NULL) {
                 uint32_t offset = 0;
                 uint8_t keybuf[pv->key_len + 1];
-                PrintStringsToBuffer(keybuf, &offset,
-                        sizeof(keybuf),
-                        pv->key, pv->key_len);
+                PrintStringsToBuffer(keybuf, &offset, pv->key_len + 1, pv->key, pv->key_len);
                 uint32_t len = pv->value_len;
                 uint8_t printable_buf[len + 1];
                 offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        pv->value, pv->value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, pv->value, pv->value_len);
                 jb_set_string(js_vars, (char *)keybuf, (char *)printable_buf);
             } else {
                 const char *varname = VarNameStoreLookupById(pv->id, VAR_TYPE_PKT_VAR);
                 uint32_t len = pv->value_len;
                 uint8_t printable_buf[len + 1];
                 uint32_t offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        pv->value, pv->value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, pv->value, pv->value_len);
                 jb_set_string(js_vars, varname, (char *)printable_buf);
             }
             jb_close(js_vars);
@@ -278,9 +272,8 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
                     uint32_t len = fv->data.fv_str.value_len;
                     uint8_t printable_buf[len + 1];
                     uint32_t offset = 0;
-                    PrintStringsToBuffer(printable_buf, &offset,
-                            sizeof(printable_buf),
-                            fv->data.fv_str.value, fv->data.fv_str.value_len);
+                    PrintStringsToBuffer(printable_buf, &offset, len + 1, fv->data.fv_str.value,
+                            fv->data.fv_str.value_len);
 
                     jb_start_object(js_flowvars);
                     jb_set_string(js_flowvars, varname, (char *)printable_buf);
@@ -295,16 +288,13 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
 
                 uint8_t keybuf[fv->keylen + 1];
                 uint32_t offset = 0;
-                PrintStringsToBuffer(keybuf, &offset,
-                        sizeof(keybuf),
-                        fv->key, fv->keylen);
+                PrintStringsToBuffer(keybuf, &offset, fv->keylen + 1, fv->key, fv->keylen);
 
                 uint32_t len = fv->data.fv_str.value_len;
                 uint8_t printable_buf[len + 1];
                 offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        fv->data.fv_str.value, fv->data.fv_str.value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, fv->data.fv_str.value,
+                        fv->data.fv_str.value_len);
 
                 jb_start_object(js_flowvars);
                 jb_set_string(js_flowvars, (const char *)keybuf, (char *)printable_buf);
@@ -436,9 +426,9 @@ void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
  * \param js JSON object
  * \param max_length If non-zero, restricts the number of packet data bytes handled.
  */
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
+void EvePacket(const Packet *p, JsonBuilder *js, uint32_t max_length)
 {
-    unsigned long max_len = max_length == 0 ? GET_PKT_LEN(p) : max_length;
+    uint32_t max_len = max_length == 0 ? GET_PKT_LEN(p) : max_length;
     jb_set_base64(js, "packet", GET_PKT_DATA(p), max_len);
 
     if (!jb_open_object(js, "packet_info")) {
@@ -891,7 +881,8 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data)
         MemBufferExpand(memb, wrapper->expand_by);
     }
 
-    MemBufferWriteRaw((*memb), str, size);
+    DEBUG_VALIDATE_BUG_ON(size > UINT32_MAX);
+    MemBufferWriteRaw((*memb), str, (uint32_t)size);
     return 0;
 }
 
@@ -945,11 +936,12 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
     }
 
     size_t jslen = jb_len(js);
+    DEBUG_VALIDATE_BUG_ON(jb_len(js) > UINT32_MAX);
     if (MEMBUFFER_OFFSET(*buffer) + jslen >= MEMBUFFER_SIZE(*buffer)) {
-        MemBufferExpand(buffer, jslen);
+        MemBufferExpand(buffer, (uint32_t)jslen);
     }
 
-    MemBufferWriteRaw((*buffer), jb_ptr(js), jslen);
+    MemBufferWriteRaw((*buffer), jb_ptr(js), (uint32_t)jslen);
     LogFileWrite(file_ctx, *buffer);
 
     return 0;
@@ -1103,7 +1095,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             {
                 FatalError("Failed to allocate memory for eve-log.prefix setting.");
             }
-            json_ctx->file_ctx->prefix_len = strlen(prefix);
+            json_ctx->file_ctx->prefix_len = (uint32_t)strlen(prefix);
         }
 
         /* Threaded file output */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -65,7 +65,7 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir,
 /* helper struct for OutputJSONMemBufferCallback */
 typedef struct OutputJSONMemBufferWrapper_ {
     MemBuffer **buffer; /**< buffer to use & expand as needed */
-    size_t expand_by;   /**< expand by this size */
+    uint32_t expand_by; /**< expand by this size */
 } OutputJSONMemBufferWrapper;
 
 typedef struct OutputJsonCommonSettings_ {
@@ -97,7 +97,7 @@ json_t *SCJsonString(const char *val);
 void CreateEveFlowId(JsonBuilder *js, const Flow *f);
 void EveFileInfo(JsonBuilder *js, const File *file, const uint64_t tx_id, const uint16_t flags);
 void EveTcpFlags(uint8_t flags, JsonBuilder *js);
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
+void EvePacket(const Packet *p, JsonBuilder *js, uint32_t max_length);
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx);
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -280,7 +280,8 @@ static int TcpDataLogger (Flow *f, TcpSession *ssn, TcpStream *stream,
             progress, &progress, eof);
 
     if (progress > STREAM_LOG_PROGRESS(stream)) {
-        uint32_t slide = progress - STREAM_LOG_PROGRESS(stream);
+        DEBUG_VALIDATE_BUG_ON(progress - STREAM_LOG_PROGRESS(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(progress - STREAM_LOG_PROGRESS(stream));
         stream->log_progress_rel += slide;
     }
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -619,12 +619,12 @@ static void *ParseAFPConfig(const char *iface)
     }
 
     if ((ConfGetChildValueIntWithDefault(if_root, if_default, "buffer-size", &value)) == 1) {
-        aconf->buffer_size = value;
+        aconf->buffer_size = (int)value;
     } else {
         aconf->buffer_size = 0;
     }
     if ((ConfGetChildValueIntWithDefault(if_root, if_default, "ring-size", &value)) == 1) {
-        aconf->ring_size = value;
+        aconf->ring_size = (int)value;
     }
 
     if ((ConfGetChildValueIntWithDefault(if_root, if_default, "block-size", &value)) == 1) {
@@ -632,12 +632,12 @@ static void *ParseAFPConfig(const char *iface)
             SCLogWarning("%s: block-size %" PRIuMAX " must be a multiple of pagesize (%u).", iface,
                     value, getpagesize());
         } else {
-            aconf->block_size = value;
+            aconf->block_size = (int)value;
         }
     }
 
     if ((ConfGetChildValueIntWithDefault(if_root, if_default, "block-timeout", &value)) == 1) {
-        aconf->block_timeout = value;
+        aconf->block_timeout = (int)value;
     } else {
         aconf->block_timeout = 10;
     }

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -94,7 +94,7 @@ static void *ParsePcapConfig(const char *iface)
     if ((ConfGetInt("pcap.buffer-size", &value)) == 1) {
         if (value >= 0 && value <= INT_MAX) {
             SCLogInfo("Pcap will use %d buffer size", (int)value);
-            aconf->buffer_size = value;
+            aconf->buffer_size = (int)value;
         } else {
             SCLogWarning("pcap.buffer-size "
                          "value of %" PRIiMAX " is invalid. Valid range is "
@@ -212,8 +212,10 @@ static void *ParsePcapConfig(const char *iface)
     aconf->snaplen = 0;
     if (ConfGetChildValueIntWithDefault(if_root, if_default, "snaplen", &snaplen) != 1) {
         SCLogDebug("could not get snaplen or none specified");
+    } else if (snaplen < INT_MIN || snaplen > INT_MAX) {
+        SCLogDebug("snaplen value is not in the accepted range");
     } else {
-        aconf->snaplen = snaplen;
+        aconf->snaplen = (int)snaplen;
     }
 
     return aconf;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2678,7 +2678,7 @@ static void UpdateRawDataForVLANHdr(Packet *p)
 {
     if (p->afp_v.vlan_tci != 0) {
         uint8_t *pstart = GET_PKT_DATA(p) - VLAN_HEADER_LEN;
-        size_t plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
+        uint32_t plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
         /* move ethernet addresses */
         memmove(pstart, GET_PKT_DATA(p), 2 * ETH_ALEN);
         /* write vlan info */

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -158,7 +158,7 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     ErfFileThreadVars *etv = (ErfFileThreadVars *)data;
     DagRecord dr;
 
-    int r = fread(&dr, sizeof(DagRecord), 1, etv->erf);
+    size_t r = fread(&dr, sizeof(DagRecord), 1, etv->erf);
     if (r < 1) {
         if (feof(etv->erf)) {
             SCLogInfo("End of ERF file reached");

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -166,7 +166,7 @@ void TmModuleDecodePcapRegister (void)
 static inline void UpdatePcapStatsValue64(uint64_t *last, uint32_t current32)
 {
     /* uint64_t -> uint32_t is defined behaviour. It slices lower 32bits. */
-    uint32_t last32 = *last;
+    uint32_t last32 = (uint32_t)*last;
 
     /* Branchless code as wrap-around is defined for unsigned */
     *last += (uint32_t)(current32 - last32);

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -931,7 +931,8 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
     const uint64_t left_edge = GetLeftEdge(f, ssn, stream);
     SCLogDebug("buffer left_edge %" PRIu64, left_edge);
     if (left_edge && left_edge > STREAM_BASE_OFFSET(stream)) {
-        uint32_t slide = left_edge - STREAM_BASE_OFFSET(stream);
+        DEBUG_VALIDATE_BUG_ON(left_edge - STREAM_BASE_OFFSET(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(left_edge - STREAM_BASE_OFFSET(stream));
         SCLogDebug("buffer sliding %u to offset %"PRIu64, slide, left_edge);
 
         if (!(ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED)) {

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1111,9 +1111,9 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
                     "got data at %"PRIu64". GAP of size %"PRIu64,
                     offset, blk->offset, blk->offset - offset);
             *data = NULL;
-            *data_len = blk->offset - offset;
+            *data_len = (uint32_t)(blk->offset - offset);
 
-        /* block starts before offset, but ends after */
+            /* block starts before offset, but ends after */
         } else if (offset > blk->offset && offset <= (blk->offset + blk->len)) {
             SCLogDebug("get data from offset %"PRIu64". SBB %"PRIu64"/%u",
                     offset, blk->offset, blk->len);
@@ -1203,7 +1203,7 @@ static inline uint32_t AdjustToAcked(const Packet *p,
             /* see if the buffer contains unack'd data as well */
             if (app_progress <= last_ack_abs && app_progress + data_len > last_ack_abs) {
                 uint32_t check = data_len;
-                adjusted = last_ack_abs - app_progress;
+                adjusted = (uint32_t)(last_ack_abs - app_progress);
                 BUG_ON(adjusted > check);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", adjusted);
@@ -1436,7 +1436,7 @@ static int GetRawBuffer(TcpStream *stream, const uint8_t **data, uint32_t *data_
             uint64_t delta = offset - (*iter)->offset;
             if (delta < mydata_len) {
                 *data = mydata + delta;
-                *data_len = mydata_len - delta;
+                *data_len = (uint32_t)(mydata_len - delta);
                 *data_offset = offset;
             } else {
                 SCLogDebug("no data (yet)");
@@ -1520,7 +1520,8 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
     }
 
     if (progress > STREAM_RAW_PROGRESS(stream)) {
-        uint32_t slide = progress - STREAM_RAW_PROGRESS(stream);
+        DEBUG_VALIDATE_BUG_ON(progress - STREAM_RAW_PROGRESS(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(progress - STREAM_RAW_PROGRESS(stream));
         stream->raw_progress_rel += slide;
         stream->flags &= ~STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
 
@@ -1532,7 +1533,8 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
             target = GetAbsLastAck(stream);
         }
         if (target > STREAM_RAW_PROGRESS(stream)) {
-            uint32_t slide = target - STREAM_RAW_PROGRESS(stream);
+            DEBUG_VALIDATE_BUG_ON(target - STREAM_RAW_PROGRESS(stream) > UINT32_MAX);
+            uint32_t slide = (uint32_t)(target - STREAM_RAW_PROGRESS(stream));
             stream->raw_progress_rel += slide;
         }
         stream->flags &= ~STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
@@ -1801,7 +1803,7 @@ static int StreamReassembleRawDo(TcpSession *ssn, TcpStream *stream,
             /* see if the buffer contains unack'd data as well */
             if (progress + mydata_len > re) {
                 uint32_t check = mydata_len;
-                mydata_len = re - progress;
+                mydata_len = (uint32_t)(re - progress);
                 BUG_ON(check < mydata_len);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", mydata_len);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1032,7 +1032,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1138,7 +1138,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->server.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->server.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1191,7 +1191,7 @@ static int StreamTcpPacketStateNone(
             if (ssn->client.last_ts == 0)
                 ssn->client.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             ssn->client.flags |= STREAMTCP_STREAM_FLAG_TIMESTAMP;
         }
 
@@ -1297,7 +1297,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1331,7 +1331,7 @@ static inline void StreamTcp3whsSynAckToStateQueue(Packet *p, TcpStateQueue *q)
     q->win = TCP_GET_WINDOW(p);
     q->seq = TCP_GET_SEQ(p);
     q->ack = TCP_GET_ACK(p);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p) == 1)
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -1592,7 +1592,7 @@ static void TcpStateQueueInitFromPktSyn(const Packet *p, TcpStateQueue *q)
     memset(q, 0, sizeof(*q));
 
     q->win = TCP_GET_WINDOW(p);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p) == 1) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -1624,7 +1624,7 @@ static void TcpStateQueueInitFromPktSynAck(const Packet *p, TcpStateQueue *q)
     memset(q, 0, sizeof(*q));
 
     q->win = TCP_GET_WINDOW(p);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p) == 1) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -1862,7 +1862,7 @@ static int StreamTcpPacketStateSynSent(
                        "ssn->server.last_ts %" PRIu32 "",
                     ssn, ssn->client.last_ts, ssn->server.last_ts);
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->client.last_ts == 0)
                 ssn->client.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
         } else {
@@ -1967,7 +1967,7 @@ static int StreamTcpPacketStateSynSent(
 
                 if (ssn->server.last_ts == 0)
                     ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
-                ssn->server.last_pkt_ts = SCTIME_SECS(p->ts);
+                ssn->server.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_TIMESTAMP;
             }
 
@@ -2069,7 +2069,7 @@ static int StreamTcpPacketStateSynSent(
         {
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
             ssn->client.flags &= ~STREAMTCP_STREAM_FLAG_TIMESTAMP;
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
         } else {
             ssn->client.last_ts = 0;
             ssn->client.flags &= ~STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
@@ -6148,7 +6148,7 @@ static int StreamTcpValidateTimestamp (TcpSession *ssn, Packet *p)
             if (last_pkt_ts == 0 &&
                     (ssn->flags & STREAMTCP_FLAG_MIDSTREAM))
             {
-                last_pkt_ts = SCTIME_SECS(p->ts);
+                last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             }
 
             if (result < 0) {
@@ -6290,7 +6290,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
             if (sender_stream->last_pkt_ts == 0 &&
                     (ssn->flags & STREAMTCP_FLAG_MIDSTREAM))
             {
-                sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             }
 
             if (result < 0) {
@@ -6315,7 +6315,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
                 if (SEQ_EQ(sender_stream->next_seq, TCP_GET_SEQ(p)))
                     sender_stream->last_ts = ts;
 
-                sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
             } else if (ret == 0) {
                 /* if the timestamp of packet is not valid then, check if the
@@ -6325,7 +6325,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
                         (((uint32_t)SCTIME_SECS(p->ts) >
                                 (sender_stream->last_pkt_ts + PAWS_24DAYS)))) {
                     sender_stream->last_ts = ts;
-                    sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                    sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
                     SCLogDebug("timestamp considered valid anyway");
                 } else {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -517,7 +517,12 @@ static void SetBpfStringFromFile(char *filename)
         SCLogError("Failed to stat file %s", filename);
         exit(EXIT_FAILURE);
     }
-    bpf_len = st.st_size + 1;
+    // st.st_size is signed on Windows
+    if ((uint64_t)st.st_size >= UINT32_MAX) {
+        SCLogError("Cannot handle file %s because of its size", filename);
+        exit(EXIT_FAILURE);
+    }
+    bpf_len = (uint32_t)st.st_size + 1;
 
     bpf_filter = SCMalloc(bpf_len);
     if (unlikely(bpf_filter == NULL)) {

--- a/src/tests/detect-snmp-pdu_type.c
+++ b/src/tests/detect-snmp-pdu_type.c
@@ -26,10 +26,10 @@
  */
 static int SNMPValidityTestParse01 (void)
 {
-    DetectSNMPPduTypeData *dd = NULL;
-    dd = DetectSNMPPduTypeParse("2");
+    DetectU32Data *dd = NULL;
+    dd = DetectU32Parse("2");
     FAIL_IF_NULL(dd);
-    FAIL_IF_NOT(dd->pdu_type == 2);
+    FAIL_IF_NOT(dd->arg1 == 2);
     DetectSNMPPduTypeFree(NULL, dd);
     PASS;
 }

--- a/src/threads.h
+++ b/src/threads.h
@@ -252,12 +252,13 @@ enum {
 })
 
 #else
-#define SCGetThreadIdLong(...) ({ \
-   pid_t tmpthid; \
-   tmpthid = syscall(SYS_gettid); \
-   unsigned long _scgetthread_tid = (unsigned long)tmpthid; \
-   _scgetthread_tid; \
-})
+#define SCGetThreadIdLong(...)                                                                     \
+    ({                                                                                             \
+        pid_t tmpthid;                                                                             \
+        tmpthid = (pid_t)syscall(SYS_gettid);                                                      \
+        unsigned long _scgetthread_tid = (unsigned long)tmpthid;                                   \
+        _scgetthread_tid;                                                                          \
+    })
 #endif /* OS FREEBSD */
 
 extern thread_local char t_thread_name[THREAD_NAME_LEN + 1];

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -692,7 +692,7 @@ static int SetCPUAffinitySet(cpu_set_t *cs)
     int r = thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY,
                               (void*)cs, THREAD_AFFINITY_POLICY_COUNT);
 #else
-    pid_t tid = syscall(SYS_gettid);
+    pid_t tid = (pid_t)syscall(SYS_gettid);
     int r = sched_setaffinity(tid, sizeof(cpu_set_t), cs);
 #endif /* OS_FREEBSD */
 

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -161,7 +161,7 @@ static int UnixNew(UnixCommand * this)
     addr.sun_family = AF_UNIX;
     strlcpy(addr.sun_path, sockettarget, sizeof(addr.sun_path));
     addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
-    len = strlen(addr.sun_path) + sizeof(addr.sun_family) + 1;
+    len = (int)(strlen(addr.sun_path) + sizeof(addr.sun_family) + 1);
 
     /* create socket */
     this->socket = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -335,7 +335,7 @@ static int UnixCommandAccept(UnixCommand *this)
     json_error_t jerror;
     int client;
     int client_version;
-    int ret;
+    size_t ret;
     UnixClient *uclient = NULL;
 
     /* accept client socket */
@@ -351,12 +351,7 @@ static int UnixCommandAccept(UnixCommand *this)
 
     /* read client version */
     buffer[sizeof(buffer)-1] = 0;
-    ret = recv(client, buffer, sizeof(buffer)-1, 0);
-    if (ret < 0) {
-        SCLogInfo("Command server: client doesn't send version");
-        close(client);
-        return 0;
-    }
+    ret = recv(client, buffer, sizeof(buffer) - 1, 0);
     if (ret >= (int)(sizeof(buffer)-1)) {
         SCLogInfo("Command server: client message is too long, "
                   "disconnect him.");
@@ -537,7 +532,7 @@ error:
 static void UnixCommandRun(UnixCommand * this, UnixClient *client)
 {
     char buffer[4096];
-    int ret;
+    size_t ret;
     if (client->version <= UNIX_PROTO_V1) {
         ret = recv(client->fd, buffer, sizeof(buffer) - 1, 0);
         if (ret <= 0) {
@@ -570,7 +565,7 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
                 UnixCommandClose(this, client->fd);
                 return;
             }
-            if (ret >= (int)(sizeof(buffer)- offset - 1)) {
+            if (ret >= (sizeof(buffer) - offset - 1)) {
                 SCLogInfo("Command server: client command is too long, "
                         "disconnect him.");
                 UnixCommandClose(this, client->fd);
@@ -582,15 +577,16 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
                 struct timeval tv;
                 fd_set select_set;
                 offset += ret;
+                int rets = 0;
                 do {
                     FD_ZERO(&select_set);
                     FD_SET(client->fd, &select_set);
                     tv.tv_sec = 0;
                     tv.tv_usec = 200 * 1000;
                     try++;
-                    ret = select(client->fd, &select_set, NULL, NULL, &tv);
+                    rets = select(client->fd, &select_set, NULL, NULL, &tv);
                     /* catch select() error */
-                    if (ret == -1) {
+                    if (rets == -1) {
                         /* Signal was caught: just ignore it */
                         if (errno != EINTR) {
                             SCLogInfo("Unix socket: lost connection with client");
@@ -598,8 +594,8 @@ static void UnixCommandRun(UnixCommand * this, UnixClient *client)
                             return;
                         }
                     }
-                } while (ret == 0 && try < 3);
-                if (ret > 0) {
+                } while (rets == 0 && try < 3);
+                if (rets > 0) {
                     ret = recv(client->fd, buffer + offset,
                                sizeof(buffer) - offset - 1, 0);
                 }
@@ -695,7 +691,7 @@ static TmEcode UnixManagerUptimeCommand(json_t *cmd,
                                  json_t *server_msg, void *data)
 {
     SCEnter();
-    int uptime;
+    int64_t uptime;
     UnixCommand *ucmd = (UnixCommand *)data;
 
     uptime = time(NULL) - ucmd->start_timestamp;

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -102,7 +102,7 @@ void BuildCpusetWithCallback(const char *name, ConfNode *node,
     ConfNode *lnode;
     TAILQ_FOREACH(lnode, &node->head, next) {
         int i;
-        long int a,b;
+        int a, b;
         int stop = 0;
         int max = UtilCpuGetNumProcessorsOnline() - 1;
         if (!strcmp(lnode->val, "all")) {
@@ -112,12 +112,12 @@ void BuildCpusetWithCallback(const char *name, ConfNode *node,
         } else if (strchr(lnode->val, '-') != NULL) {
             char *sep = strchr(lnode->val, '-');
             char *end;
-            a = strtoul(lnode->val, &end, 10);
+            a = (int)strtoul(lnode->val, &end, 10);
             if (end != sep) {
                 SCLogError("%s: invalid cpu range (start invalid): \"%s\"", name, lnode->val);
                 exit(EXIT_FAILURE);
             }
-            b = strtol(sep + 1, &end, 10);
+            b = (int)strtol(sep + 1, &end, 10);
             if (end != sep + strlen(sep)) {
                 SCLogError("%s: invalid cpu range (end invalid): \"%s\"", name, lnode->val);
                 exit(EXIT_FAILURE);
@@ -127,12 +127,12 @@ void BuildCpusetWithCallback(const char *name, ConfNode *node,
                 exit(EXIT_FAILURE);
             }
             if (b > max) {
-                SCLogError("%s: upper bound (%ld) of cpu set is too high, only %d cpu(s)", name, b,
+                SCLogError("%s: upper bound (%d) of cpu set is too high, only %d cpu(s)", name, b,
                         max + 1);
             }
         } else {
             char *end;
-            a = strtoul(lnode->val, &end, 10);
+            a = (int)strtoul(lnode->val, &end, 10);
             if (end != lnode->val + strlen(lnode->val)) {
                 SCLogError("%s: invalid cpu range (not an integer): \"%s\"", name, lnode->val);
                 exit(EXIT_FAILURE);

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -228,7 +228,7 @@ int ByteExtractString(uint64_t *res, int base, size_t len, const char *str, bool
         return -1;
     }
 
-    return (endptr - ptr);
+    return (int)(endptr - ptr);
 }
 
 int ByteExtractStringUint64(uint64_t *res, int base, size_t len, const char *str)
@@ -531,7 +531,7 @@ int ByteExtractStringSigned(int64_t *res, int base, size_t len, const char *str,
 
     //fprintf(stderr, "ByteExtractStringSigned: Extracted base %d: 0x%" PRIx64 "\n", base, *res);
 
-    return (endptr - ptr);
+    return (int)(endptr - ptr);
 }
 
 int ByteExtractStringInt64(int64_t *res, int base, size_t len, const char *str)

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -450,9 +450,9 @@ uint32_t SCClassConfClasstypeHashFunc(HashTable *ht, void *data, uint16_t datale
 {
     SCClassConfClasstype *ct = (SCClassConfClasstype *)data;
     uint32_t hash = 0;
-    int i = 0;
+    size_t i = 0;
 
-    int len = strlen(ct->classtype);
+    size_t len = strlen(ct->classtype);
 
     for (i = 0; i < len; i++)
         hash += u8_tolower((unsigned char)(ct->classtype)[i]);
@@ -480,8 +480,8 @@ char SCClassConfClasstypeHashCompareFunc(void *data1, uint16_t datalen1,
 {
     SCClassConfClasstype *ct1 = (SCClassConfClasstype *)data1;
     SCClassConfClasstype *ct2 = (SCClassConfClasstype *)data2;
-    int len1 = 0;
-    int len2 = 0;
+    size_t len1 = 0;
+    size_t len2 = 0;
 
     if (ct1 == NULL || ct2 == NULL)
         return 0;

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -290,25 +290,25 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
      *        app-layer-*
      */
     if (strncmp("tm-", module_name, 3) == 0) {
-        *dn_len = strlen(module_name) - 3;
+        *dn_len = (int)strlen(module_name) - 3;
         return module_name + 3;
     } else if (strncmp("util-", module_name, 5) == 0) {
-        *dn_len = strlen(module_name) - 5;
+        *dn_len = (int)strlen(module_name) - 5;
         return module_name + 5;
     } else if (strncmp("source-pcap-file", module_name, 16) == 0) {
-        *dn_len = strlen("pcap");
+        *dn_len = (int)strlen("pcap");
         return "pcap";
     } else if (strncmp("source-", module_name, 7) == 0) {
-        *dn_len = strlen(module_name) - 7;
+        *dn_len = (int)strlen(module_name) - 7;
         return module_name + 7;
     } else if (strncmp("runmode-", module_name, 8) == 0) {
-        *dn_len = strlen(module_name) - 8;
+        *dn_len = (int)strlen(module_name) - 8;
         return module_name + 8;
     } else if (strncmp("app-layer-", module_name, 10) == 0) {
-        *dn_len = strlen(module_name);
+        *dn_len = (int)strlen(module_name);
         return module_name;
     } else if (strncmp("detect-engine", module_name, 13) == 0) {
-        *dn_len = strlen("detect");
+        *dn_len = (int)strlen("detect");
         return "detect";
     }
 
@@ -323,9 +323,9 @@ static const char *SCTransformModule(const char *module_name, int *dn_len)
     }
 
     if (seg_cnt < transform_max_segs)
-        *dn_len = strlen(module_name);
+        *dn_len = (int)strlen(module_name);
     else
-        *dn_len = last - module_name;
+        *dn_len = (int)(last - module_name);
 
     return module_name;
 }

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -707,7 +707,7 @@ static uint8_t * GetLine(uint8_t *buf, uint32_t blen, uint8_t **remainPtr,
     }
 
     /* Calculate token length */
-    *tokLen = (buf + i) - tok;
+    *tokLen = (uint32_t)((buf + i) - tok);
 
     return tok;
 }
@@ -774,7 +774,7 @@ static uint8_t * GetToken(uint8_t *buf, uint32_t blen, const char *delims,
         }
 
         /* Calculate token length */
-        *tokenLen = (buf + i) - tok;
+        *tokenLen = (uint32_t)((buf + i) - tok);
     }
 
     return tok;
@@ -844,7 +844,7 @@ static int StoreMimeHeader(MimeDecParseState *state)
 static int IsExeUrl(const uint8_t *url, uint32_t len)
 {
     int isExeUrl = 0;
-    uint32_t i, extLen;
+    size_t i, extLen;
     uint8_t *ext;
 
     /* Now check for executable extensions and if not found, cut off at first '/' */
@@ -1009,12 +1009,13 @@ static int FindUrlStrings(const uint8_t *line, uint32_t len,
             SCLogDebug("Looking for URL String starting with: %s", schemeStr);
 
             /* Check for token definition */
-            fptr = FindBuffer(remptr, len - (remptr - line), (uint8_t *)schemeStr, schemeStrLen);
+            fptr = FindBuffer(
+                    remptr, len - (uint32_t)(remptr - line), (uint8_t *)schemeStr, schemeStrLen);
             if (fptr != NULL) {
                 if (!mdcfg->log_url_scheme) {
                     fptr += schemeStrLen; /* Strip scheme from stored URL */
                 }
-                tok = GetToken(fptr, len - (fptr - line), " \"\'<>]\t", &remptr, &tokLen);
+                tok = GetToken(fptr, len - (uint32_t)(fptr - line), " \"\'<>]\t", &remptr, &tokLen);
                 if (tok == fptr) {
                     SCLogDebug("Found url string");
 
@@ -1117,8 +1118,8 @@ static int ProcessDecodedDataChunk(const uint8_t *chunk, uint32_t len,
                 /* Parse each line one by one */
                 remainPtr = (uint8_t *)chunk;
                 do {
-                    tok = GetLine(
-                            remainPtr, len - (remainPtr - (uint8_t *)chunk), &remainPtr, &tokLen);
+                    tok = GetLine(remainPtr, len - (uint32_t)(remainPtr - (uint8_t *)chunk),
+                            &remainPtr, &tokLen);
                     if (tok != remainPtr) {
                         /* Search line for URL */
                         ret = FindUrlStrings(tok, tokLen, state);
@@ -1807,7 +1808,7 @@ static int FindMimeHeader(const uint8_t *buf, uint32_t blen,
 
         if (hval != NULL) {
             /* If max header value exceeded, flag it */
-            vlen = blen - (hval - buf);
+            vlen = blen - (uint32_t)(hval - buf);
             if ((mdcfg != NULL) && (state->hvlen + vlen > mdcfg->header_value_depth)) {
                 SCLogDebug("Error: Header value of length (%u) is too long",
                         state->hvlen + vlen);
@@ -2613,7 +2614,7 @@ MimeDecEntity * MimeDecParseFullMsg(const uint8_t *buf, uint32_t blen, void *dat
     remainPtr = (uint8_t *) buf;
     uint8_t *line = NULL;
     do {
-        tok = GetLine(remainPtr, blen - (remainPtr - buf), &remainPtr, &tokLen);
+        tok = GetLine(remainPtr, blen - (uint32_t)(remainPtr - buf), &remainPtr, &tokLen);
         if (tok != remainPtr) {
 
             line = tok;

--- a/src/util-fmemopen.c
+++ b/src/util-fmemopen.c
@@ -117,20 +117,20 @@ static fpos_t SeekFn(void *handler, fpos_t offset, int whence)
  */
 static int ReadFn(void *handler, char *buf, int size)
 {
-    size_t count = 0;
+    int count = 0;
     SCFmem *mem = handler;
     size_t available = mem->size - mem->pos;
     int is_eof = 0;
 
     if (size < 0) return - 1;
 
-    if ((size_t)size > available) {
-        size = available;
+    if (size > (int)available) {
+        size = (int)available;
     } else {
         is_eof = 1;
     }
 
-    while (count < (size_t)size)
+    while (count < size)
         buf[count++] = mem->buffer[mem->pos++];
 
     if (is_eof == 1)
@@ -148,16 +148,16 @@ static int ReadFn(void *handler, char *buf, int size)
  */
 static int WriteFn(void *handler, const char *buf, int size)
 {
-    size_t count = 0;
+    int count = 0;
     SCFmem *mem = handler;
     size_t available = mem->size - mem->pos;
 
     if (size < 0) return - 1;
 
-    if ((size_t)size > available)
-        size = available;
+    if (size > (int)available)
+        size = (int)available;
 
-    while (count < (size_t)size)
+    while (count < size)
         mem->buffer[mem->pos++] = buf[count++];
 
     return count;

--- a/src/util-hash-string.c
+++ b/src/util-hash-string.c
@@ -38,8 +38,8 @@ uint32_t StringHashFunc(HashTable *ht, void *data, uint16_t datalen)
 char StringHashCompareFunc(void *data1, uint16_t datalen1,
                            void *data2, uint16_t datalen2)
 {
-    int len1 = strlen((char *)data1);
-    int len2 = strlen((char *)data2);
+    size_t len1 = strlen((char *)data1);
+    size_t len2 = strlen((char *)data2);
 
     if (len1 == len2 && memcmp(data1, data2, len1) == 0) {
         return 1;

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -40,8 +40,8 @@ bool IPv4AddressStringIsValid(const char *str)
 
     memset(&addr, 0, sizeof(addr));
 
-    uint32_t len = strlen(str);
-    uint32_t i = 0;
+    size_t len = strlen(str);
+    size_t i = 0;
     for (i = 0; i < len; i++) {
         if (!(str[i] == '.' || isdigit(str[i]))) {
             return false;
@@ -85,8 +85,8 @@ bool IPv6AddressStringIsValid(const char *str)
     int sep = 0;
     bool colon_seen = false;
 
-    uint32_t len = strlen(str);
-    uint32_t i = 0;
+    size_t len = strlen(str);
+    size_t i = 0;
     for (i = 0; i < len && str[i] != 0; i++) {
         if (!(str[i] == '.' || str[i] == ':' ||
             isxdigit(str[i])))

--- a/src/util-ja3.h
+++ b/src/util-ja3.h
@@ -30,8 +30,8 @@
 
 typedef struct JA3Buffer_ {
     char *data;
-    size_t size;
-    size_t used;
+    uint32_t size;
+    uint32_t used;
 } JA3Buffer;
 
 JA3Buffer *Ja3BufferInit(void);

--- a/src/util-landlock.c
+++ b/src/util-landlock.c
@@ -44,7 +44,7 @@ void LandlockSandboxing(SCInstance *suri)
 static inline int landlock_create_ruleset(
         const struct landlock_ruleset_attr *const attr, const size_t size, const __u32 flags)
 {
-    return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+    return (int)syscall(__NR_landlock_create_ruleset, attr, size, flags);
 }
 #endif
 
@@ -52,14 +52,14 @@ static inline int landlock_create_ruleset(
 static inline int landlock_add_rule(const int ruleset_fd, const enum landlock_rule_type rule_type,
         const void *const rule_attr, const __u32 flags)
 {
-    return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type, rule_attr, flags);
+    return (int)syscall(__NR_landlock_add_rule, ruleset_fd, rule_type, rule_attr, flags);
 }
 #endif
 
 #ifndef landlock_restrict_self
 static inline int landlock_restrict_self(const int ruleset_fd, const __u32 flags)
 {
-    return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+    return (int)syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
 }
 #endif
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -776,7 +776,7 @@ static bool LogFileThreadedName(
          * for update
          */
         dot = strrchr(original_name, '.');
-        int dotpos = dot - original_name;
+        long dotpos = dot - original_name;
         tname[dotpos] = '\0';
         char *ext = tname + dotpos + 1;
         if (strlen(tname) && strlen(ext)) {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -126,7 +126,7 @@ typedef struct LogFileCtx_ {
     /**< Used by some alert loggers like the unified ones that append
      * the date onto the end of files. */
     char *prefix;
-    size_t prefix_len;
+    uint32_t prefix_len;
 
     /** Generic size_limit and size_current
      * They must be common to the threads accessing the same file */

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -117,10 +117,9 @@ void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
     fprintf(fp, "%s", nbuf);
 }
 
-void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen,
-                    uint8_t *buf, uint32_t buflen)
+void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen, uint8_t *buf, size_t buflen)
 {
-    uint32_t u = 0;
+    size_t u = 0;
 
     for (u = 0; u < buflen; u++) {
         if (isprint(buf[u]) && buf[u] != '\"') {

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -43,8 +43,7 @@
 
 void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
 void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
-void PrintRawUriBuf(char *, uint32_t *, uint32_t,
-                    uint8_t *, uint32_t);
+void PrintRawUriBuf(char *, uint32_t *, uint32_t, uint8_t *, size_t);
 void PrintRawJsonFp(FILE *, uint8_t *, uint32_t);
 void PrintRawDataFp(FILE *, const uint8_t *, uint32_t);
 void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -361,7 +361,7 @@ static uint32_t ProtoNameHashFunc(HashTable *ht, void *data, uint16_t datalen)
      * as the proto number is not used for lookups
      */
     ProtoNameHashEntry *p = (ProtoNameHashEntry *)data;
-    return StringHashDjb2((uint8_t *)p->name, strlen(p->name)) % ht->array_size;
+    return StringHashDjb2((uint8_t *)p->name, (uint32_t)strlen(p->name)) % ht->array_size;
 }
 
 static char ProtoNameHashCompareFunc(void *data1, uint16_t datalen1, void *data2, uint16_t datalen2)
@@ -375,8 +375,8 @@ static char ProtoNameHashCompareFunc(void *data1, uint16_t datalen1, void *data2
     if (p1->name == NULL || p2->name == NULL)
         return 0;
 
-    int len1 = strlen(p1->name);
-    int len2 = strlen(p2->name);
+    size_t len1 = strlen(p1->name);
+    size_t len2 = strlen(p2->name);
 
     return len1 == len2 && memcmp(p1->name, p2->name, len1) == 0;
 }

--- a/src/util-random.c
+++ b/src/util-random.c
@@ -38,7 +38,7 @@ static long int RandomGetClock(void)
     clock_gettime(CLOCK_REALTIME, &ts);
 
     // coverity[dont_call : FALSE]
-    srandom(ts.tv_nsec ^ ts.tv_sec);
+    srandom((unsigned int)(ts.tv_nsec ^ ts.tv_sec));
     long int value = random();
     return value;
 }
@@ -103,7 +103,7 @@ long int RandomGet(void)
         return 0;
 
     long int value = 0;
-    int ret = getrandom(&value, sizeof(value), 0);
+    ssize_t ret = getrandom(&value, sizeof(value), 0);
     /* ret should be sizeof(value), but if it is > 0 and < sizeof(value)
      * it's still better than nothing so we return what we have */
     if (ret <= 0) {

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -413,9 +413,9 @@ uint32_t SCRConfReferenceHashFunc(HashTable *ht, void *data, uint16_t datalen)
 {
     SCRConfReference *ref = (SCRConfReference *)data;
     uint32_t hash = 0;
-    int i = 0;
+    size_t i = 0;
 
-    int len = strlen(ref->system);
+    size_t len = strlen(ref->system);
 
     for (i = 0; i < len; i++)
         hash += u8_tolower((unsigned char)ref->system[i]);
@@ -443,8 +443,8 @@ char SCRConfReferenceHashCompareFunc(void *data1, uint16_t datalen1,
 {
     SCRConfReference *ref1 = (SCRConfReference *)data1;
     SCRConfReference *ref2 = (SCRConfReference *)data2;
-    int len1 = 0;
-    int len2 = 0;
+    size_t len1 = 0;
+    size_t len2 = 0;
 
     if (ref1 == NULL || ref2 == NULL)
         return 0;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -442,7 +442,8 @@ static inline void ConsolidateFwd(StreamingBuffer *sb, const StreamingBufferConf
             if (sa->offset == region->stream_offset &&
                     sa_re > (region->stream_offset + region->buf_offset)) {
                 DEBUG_VALIDATE_BUG_ON(sa_re < region->stream_offset);
-                region->buf_offset = sa_re - region->stream_offset;
+                DEBUG_VALIDATE_BUG_ON(sa_re - region->stream_offset > UINT32_MAX);
+                region->buf_offset = (uint32_t)(sa_re - region->stream_offset);
                 SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
                            " bo %u sz %u BUF_OFFSET UPDATED",
                         sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
@@ -458,8 +459,10 @@ static inline void ConsolidateFwd(StreamingBuffer *sb, const StreamingBufferConf
                    sa_re >= tr->offset && sa_re < tr_re) // ends inside
         {
             // merge. sb->sbb_size includes both so we need to adjust that too.
-            uint32_t combined_len = sa->len + tr->len;
-            sa->len = tr_re - sa->offset;
+            DEBUG_VALIDATE_BUG_ON(sa->len + tr->len > UINT32_MAX);
+            uint32_t combined_len = (uint32_t)(sa->len + tr->len);
+            DEBUG_VALIDATE_BUG_ON(tr_re - sa->offset > UINT32_MAX);
+            sa->len = (uint32_t)(tr_re - sa->offset);
             sa_re = sa->offset + sa->len;
             SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u REMOVED MERGED", tr, tr->offset, tr->len);
             SBB_RB_REMOVE(tree, tr);
@@ -472,7 +475,8 @@ static inline void ConsolidateFwd(StreamingBuffer *sb, const StreamingBufferConf
             if (sa->offset == region->stream_offset &&
                     sa_re > (region->stream_offset + region->buf_offset)) {
                 DEBUG_VALIDATE_BUG_ON(sa_re < region->stream_offset);
-                region->buf_offset = sa_re - region->stream_offset;
+                DEBUG_VALIDATE_BUG_ON(sa_re - region->stream_offset > UINT32_MAX);
+                region->buf_offset = (uint32_t)(sa_re - region->stream_offset);
                 SCLogDebug("-> (fwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
                            " bo %u sz %u BUF_OFFSET UPDATED",
                         sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
@@ -539,7 +543,8 @@ static inline void ConsolidateBackward(StreamingBuffer *sb, const StreamingBuffe
             if (sa->offset == region->stream_offset &&
                     sa_re > (region->stream_offset + region->buf_offset)) {
                 DEBUG_VALIDATE_BUG_ON(sa_re < region->stream_offset);
-                region->buf_offset = sa_re - region->stream_offset;
+                DEBUG_VALIDATE_BUG_ON(sa_re - region->stream_offset > UINT32_MAX);
+                region->buf_offset = (uint32_t)(sa_re - region->stream_offset);
                 SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
                            " bo %u sz %u BUF_OFFSET UPDATED",
                         sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
@@ -554,8 +559,10 @@ static inline void ConsolidateBackward(StreamingBuffer *sb, const StreamingBuffe
             */
         } else if (sa->offset > tr->offset && sa_re > tr_re && sa->offset <= tr_re) {
             // merge. sb->sbb_size includes both so we need to adjust that too.
-            uint32_t combined_len = sa->len + tr->len;
-            sa->len = sa_re - tr->offset;
+            DEBUG_VALIDATE_BUG_ON(sa->len + tr->len > UINT32_MAX);
+            uint32_t combined_len = (uint32_t)(sa->len + tr->len);
+            DEBUG_VALIDATE_BUG_ON(sa_re - tr->offset > UINT32_MAX);
+            sa->len = (uint32_t)(sa_re - tr->offset);
             sa->offset = tr->offset;
             sa_re = sa->offset + sa->len;
             SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u REMOVED MERGED", tr, tr->offset, tr->len);
@@ -571,7 +578,8 @@ static inline void ConsolidateBackward(StreamingBuffer *sb, const StreamingBuffe
             if (sa->offset == region->stream_offset &&
                     sa_re > (region->stream_offset + region->buf_offset)) {
                 DEBUG_VALIDATE_BUG_ON(sa_re < region->stream_offset);
-                region->buf_offset = sa_re - region->stream_offset;
+                DEBUG_VALIDATE_BUG_ON(sa_re - region->stream_offset > UINT32_MAX);
+                region->buf_offset = (uint32_t)(sa_re - region->stream_offset);
                 SCLogDebug("-> (bwd) tr %p %" PRIu64 "/%u region %p so %" PRIu64
                            " bo %u sz %u BUF_OFFSET UPDATED",
                         sa, sa->offset, sa->len, region, region->stream_offset, region->buf_offset,
@@ -657,7 +665,8 @@ static void SBBPrune(StreamingBuffer *sb, const StreamingBufferConfig *cfg)
         /* partly before, partly beyond. Adjust */
         if (sbb->offset < sb->region.stream_offset &&
                 sbb->offset + sbb->len > sb->region.stream_offset) {
-            uint32_t shrink_by = sb->region.stream_offset - sbb->offset;
+            DEBUG_VALIDATE_BUG_ON(sb->region.stream_offset - sbb->offset > UINT32_MAX);
+            uint32_t shrink_by = (uint32_t)(sb->region.stream_offset - sbb->offset);
             DEBUG_VALIDATE_BUG_ON(shrink_by > sbb->len);
             if (sbb->len >= shrink_by) {
                 sbb->len -=  shrink_by;
@@ -868,7 +877,8 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
 
         // Do the shift. If new region is exactly at the slide offset we can skip this.
         DEBUG_VALIDATE_BUG_ON(to_shift->stream_offset > slide_offset);
-        const uint32_t s = slide_offset - to_shift->stream_offset;
+        DEBUG_VALIDATE_BUG_ON(slide_offset - to_shift->stream_offset > UINT32_MAX);
+        const uint32_t s = (uint32_t)(slide_offset - to_shift->stream_offset);
         if (s > 0) {
             const uint32_t new_data_size = to_shift->buf_size - s;
             uint32_t new_mem_size = ToNextMultipleOf(new_data_size, cfg->buf_size);
@@ -883,15 +893,21 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
                 StreamingBufferRegion *start = to_shift;
                 StreamingBufferRegion *next = start->next;
                 const uint64_t next_re = next->stream_offset + next->buf_size;
-                const uint32_t mem_size = ToNextMultipleOf(next_re - slide_offset, cfg->buf_size);
+                DEBUG_VALIDATE_BUG_ON(next_re - slide_offset > UINT32_MAX);
+                const uint32_t mem_size =
+                        ToNextMultipleOf((uint32_t)(next_re - slide_offset), cfg->buf_size);
 
                 /* using next as the new main */
                 if (start->buf_size < next->buf_size) {
                     SCLogDebug("replace main with the next bigger region");
 
-                    const uint32_t next_data_offset = next->stream_offset - slide_offset;
+                    DEBUG_VALIDATE_BUG_ON(next->stream_offset - slide_offset > UINT32_MAX);
+                    const uint32_t next_data_offset =
+                            (uint32_t)(next->stream_offset - slide_offset);
                     const uint32_t prev_buf_size = next->buf_size;
-                    const uint32_t start_data_offset = slide_offset - start->stream_offset;
+                    DEBUG_VALIDATE_BUG_ON(slide_offset - start->stream_offset > UINT32_MAX);
+                    const uint32_t start_data_offset =
+                            (uint32_t)(slide_offset - start->stream_offset);
                     DEBUG_VALIDATE_BUG_ON(start_data_offset > start->buf_size);
                     if (start_data_offset > start->buf_size) {
                         new_mem_size = new_data_size;
@@ -1021,7 +1037,8 @@ void StreamingBufferSlideToOffset(
     }
 
     if (offset > sb->region.stream_offset) {
-        const uint32_t slide = offset - sb->region.stream_offset;
+        DEBUG_VALIDATE_BUG_ON(offset - sb->region.stream_offset > UINT32_MAX);
+        const uint32_t slide = (uint32_t)(offset - sb->region.stream_offset);
         if (sb->head != NULL) {
             /* have sbb's, so can't rely on buf_offset for the slide */
             if (slide < sb->region.buf_size) {
@@ -1232,7 +1249,8 @@ static StreamingBufferRegion *BufferInsertAtRegionConsolidate(StreamingBuffer *s
 
     // 2. resize dst
     const uint32_t old_size = dst->buf_size;
-    const uint32_t dst_copy_offset = dst->stream_offset - dst_offset;
+    DEBUG_VALIDATE_BUG_ON(dst->stream_offset - dst_offset > UINT32_MAX);
+    const uint32_t dst_copy_offset = (uint32_t)(dst->stream_offset - dst_offset);
 #ifdef DEBUG
     const uint32_t old_offset = dst->buf_offset;
     SCLogDebug("old_size %u, old_offset %u, dst_copy_offset %u", old_size, old_offset,
@@ -1289,7 +1307,8 @@ static StreamingBufferRegion *BufferInsertAtRegionConsolidate(StreamingBuffer *s
             r = r->next;
             continue;
         }
-        const uint32_t target_offset = r->stream_offset - dst_offset;
+        DEBUG_VALIDATE_BUG_ON(r->stream_offset - dst_offset > UINT32_MAX);
+        const uint32_t target_offset = (uint32_t)(r->stream_offset - dst_offset);
         SCLogDebug("r %p: target_offset %u", r, target_offset);
         DEBUG_VALIDATE_BUG_ON(target_offset > dst->buf_size);
         DEBUG_VALIDATE_BUG_ON(target_offset + r->buf_size > dst->buf_size);
@@ -1368,8 +1387,9 @@ static StreamingBufferRegion *BufferInsertAtRegionDo(StreamingBuffer *sb,
         }
         insert_adjusted_re = MAX(insert_adjusted_re, (end->stream_offset + end->buf_size));
 
-        uint32_t new_buf_size =
-                ToNextMultipleOf(insert_adjusted_re - insert_start_offset, cfg->buf_size);
+        DEBUG_VALIDATE_BUG_ON(insert_adjusted_re - insert_start_offset > UINT32_MAX);
+        uint32_t new_buf_size = ToNextMultipleOf(
+                (uint32_t)(insert_adjusted_re - insert_start_offset), cfg->buf_size);
         SCLogDebug("new_buf_size %u", new_buf_size);
 
         /* see if our new buf size + cfg->buf_size margin leads to an overlap with the next region.
@@ -1378,8 +1398,9 @@ static StreamingBufferRegion *BufferInsertAtRegionDo(StreamingBuffer *sb,
             SCLogDebug("adjusted end from %p to %p", end, end->next);
             end = end->next;
             insert_adjusted_re = MAX(insert_adjusted_re, (end->stream_offset + end->buf_size));
-            new_buf_size =
-                    ToNextMultipleOf(insert_adjusted_re - insert_start_offset, cfg->buf_size);
+            DEBUG_VALIDATE_BUG_ON(insert_adjusted_re - insert_start_offset > UINT32_MAX);
+            new_buf_size = ToNextMultipleOf(
+                    (uint32_t)(insert_adjusted_re - insert_start_offset), cfg->buf_size);
             SCLogDebug("new_buf_size %u", new_buf_size);
         }
 
@@ -1492,7 +1513,8 @@ int StreamingBufferInsertAt(StreamingBuffer *sb, const StreamingBufferConfig *cf
     SCLogDebug("inserting %" PRIu64 "/%u using %s region %p", offset, data_len,
             region == &sb->region ? "main" : "aux", region);
 
-    uint32_t rel_offset = offset - region->stream_offset;
+    DEBUG_VALIDATE_BUG_ON(offset - region->stream_offset > UINT32_MAX);
+    uint32_t rel_offset = (uint32_t)(offset - region->stream_offset);
     if (!DATA_FITS_AT_OFFSET(region, data_len, rel_offset)) {
         if ((r = GrowToSize(sb, cfg, (rel_offset + data_len))) != SC_OK)
             return r;
@@ -1644,7 +1666,8 @@ void StreamingBufferSBBGetData(const StreamingBuffer *sb,
             uint64_t offset = region->stream_offset - sbb->offset;
             if (offset < sbb->len) {
                 *data = region->buf;
-                *data_len = sbb->len - offset;
+                DEBUG_VALIDATE_BUG_ON(sbb->len - offset > UINT32_MAX);
+                *data_len = (uint32_t)(sbb->len - offset);
                 return;
             }
             SCLogDebug("3");
@@ -1671,22 +1694,26 @@ void StreamingBufferSBBGetDataAtOffset(const StreamingBuffer *sb,
 
     const StreamingBufferRegion *region = GetRegionForOffset(sb, offset);
     if (region) {
-        uint32_t sbblen = sbb->len - (offset - sbb->offset);
+        DEBUG_VALIDATE_BUG_ON(sbb->len - (offset - sbb->offset) > UINT32_MAX);
+        uint32_t sbblen = (uint32_t)(sbb->len - (offset - sbb->offset));
 
         if (offset >= region->stream_offset) {
             uint64_t data_offset = offset - region->stream_offset;
             *data = region->buf + data_offset;
-            if (data_offset + sbblen > region->buf_size)
-                *data_len = region->buf_size - data_offset;
-            else
+            if (data_offset + sbblen > region->buf_size) {
+                DEBUG_VALIDATE_BUG_ON(region->buf_size - data_offset > UINT32_MAX);
+                *data_len = (uint32_t)(region->buf_size - data_offset);
+            } else {
                 *data_len = sbblen;
+            }
             DEBUG_VALIDATE_BUG_ON(*data_len > sbblen);
             return;
         } else {
             uint64_t data_offset = region->stream_offset - sbb->offset;
             if (data_offset < sbblen) {
                 *data = region->buf;
-                *data_len = sbblen - data_offset;
+                DEBUG_VALIDATE_BUG_ON(sbblen - data_offset > UINT32_MAX);
+                *data_len = (uint32_t)(sbblen - data_offset);
                 DEBUG_VALIDATE_BUG_ON(*data_len > sbblen);
                 return;
             }
@@ -1707,17 +1734,20 @@ void StreamingBufferSegmentGetData(const StreamingBuffer *sb,
         if (seg->stream_offset >= region->stream_offset) {
             uint64_t offset = seg->stream_offset - region->stream_offset;
             *data = region->buf + offset;
-            if (offset + seg->segment_len > region->buf_size)
-                *data_len = region->buf_size - offset;
-            else
+            if (offset + seg->segment_len > region->buf_size) {
+                DEBUG_VALIDATE_BUG_ON(region->buf_size - offset > UINT32_MAX);
+                *data_len = (uint32_t)(region->buf_size - offset);
+            } else {
                 *data_len = seg->segment_len;
+            }
             SCLogDebug("*data_len %u", *data_len);
             return;
         } else {
             uint64_t offset = region->stream_offset - seg->stream_offset;
             if (offset < seg->segment_len) {
                 *data = region->buf;
-                *data_len = seg->segment_len - offset;
+                DEBUG_VALIDATE_BUG_ON(seg->segment_len - offset > UINT32_MAX);
+                *data_len = (uint32_t)(seg->segment_len - offset);
                 SCLogDebug("*data_len %u", *data_len);
                 return;
             }
@@ -1772,7 +1802,8 @@ int StreamingBufferGetDataAtOffset (const StreamingBuffer *sb,
     const StreamingBufferRegion *region = GetRegionForOffset(sb, offset);
     if (region != NULL && region->buf != NULL && offset >= region->stream_offset &&
             offset < (region->stream_offset + region->buf_offset)) {
-        uint32_t skip = offset - region->stream_offset;
+        DEBUG_VALIDATE_BUG_ON(offset - region->stream_offset > UINT32_MAX);
+        uint32_t skip = (uint32_t)(offset - region->stream_offset);
         *data = region->buf + skip;
         *data_len = region->buf_offset - skip;
         return 1;

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -299,7 +299,8 @@ THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
 
-    ctx->config.data_size = data_size;
+    BUG_ON(data_size > UINT32_MAX);
+    ctx->config.data_size = (uint32_t)data_size;
     ctx->config.DataSet = DataSet;
     ctx->config.DataFree = DataFree;
     ctx->config.DataHash = DataHash;

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -992,12 +992,12 @@ static int SCThresholdConfLineIsMultiline(char *line)
 {
     int flag = 0;
     char *rline = line;
-    int len = strlen(line);
+    size_t len = strlen(line);
 
     while (line < rline + len && *line != '\n') {
         /* we have a comment */
         if (*line == '\\')
-            flag = line - rline;
+            flag = (int)(line - rline);
         else
             if (!isspace((unsigned char)*line))
                 flag = 0;

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -549,7 +549,7 @@ int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str, size_t 
         return 1;
     }
 
-    int r = strftime(buffer, sizeof(buffer), pattern, tp);
+    size_t r = strftime(buffer, sizeof(buffer), pattern, tp);
     if (r == 0) {
         return 1;
     }

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -53,8 +53,8 @@ typedef struct {
     {                                                                                              \
         .secs = 0, .usecs = 0                                                                      \
     }
-#define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
-#define SCTIME_SECS(t)           ((uint64_t)(t).secs)
+#define SCTIME_USECS(t)          ((t).usecs)
+#define SCTIME_SECS(t)           ((t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
 #define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
 #define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))

--- a/src/util-var-name.c
+++ b/src/util-var-name.c
@@ -336,7 +336,8 @@ uint32_t VarNameStoreLookupByName(const char *name, const enum VarTypes type)
 static uint32_t VariableNameHash(HashListTable *ht, void *buf, uint16_t buflen)
 {
     VariableName *vn = (VariableName *)buf;
-    uint32_t hash = StringHashDjb2((const uint8_t *)vn->name, strlen(vn->name)) + vn->type;
+    uint32_t hash =
+            StringHashDjb2((const uint8_t *)vn->name, (uint32_t)strlen(vn->name)) + vn->type;
     return (hash % VARNAME_HASHSIZE);
 }
 


### PR DESCRIPTION
[Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix `-Wshorten-64-to-32` warnings for some files
- Add CI build with this warning

```
LIBHTP_BRANCH=pr/399
```
https://github.com/OISF/libhtp/pull/399

#9512 with fixed compilation with different flags

There must be some stuff to review more carefully
