### PR TITLE
stats: Track stream reassembly drops

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -794,6 +794,8 @@ const char *PacketDropReasonToString(enum PacketDropReason r)
             return "stream memcap";
         case PKT_DROP_REASON_STREAM_MIDSTREAM:
             return "stream midstream";
+        case PKT_DROP_REASON_STREAM_REASSEMBLY:
+            return "stream reassembly";
         case PKT_DROP_REASON_APPLAYER_ERROR:
             return "applayer error";
         case PKT_DROP_REASON_APPLAYER_MEMCAP:

--- a/src/decode.h
+++ b/src/decode.h
@@ -411,6 +411,8 @@ enum PacketDropReason {
     PKT_DROP_REASON_STREAM_ERROR,
     PKT_DROP_REASON_STREAM_MEMCAP,
     PKT_DROP_REASON_STREAM_MIDSTREAM,
+    PKT_DROP_REASON_STREAM_REASSEMBLY,
+    PKT_DROP_REASON_MAX,
 };
 
 /* forward declaration since Packet struct definition requires this */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1903,7 +1903,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             SCLogDebug("StreamTcpReassembleHandleSegmentHandleData error");
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
-                    p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+                    p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_REASSEMBLY);
             SCReturnInt(-1);
         }
 


### PR DESCRIPTION
Continuation of #9505 

Issue: 6235
(cherry picked from commit 904f0ddeeeb1bdb4a686f991cf090a47dd84249e)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6364](https://redmine.openinfosecfoundation.org/issues/6364)

Describe changes:
- Cherry-pick of fix for 6235

Updates:
- Removed `PKT_DROP_REASON_MAX` (erroneously added)

### Provide values to any of the below to override the defaults.


```
SV_REPO=
SV_BRANCH=pr/1391
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
