### PR TITLE
Draft: reduce the number of fflush calls

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -30,6 +30,12 @@ Output types::
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
+      # Control for calls to flush file contents:
+      # - 0 Flush after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -295,7 +301,7 @@ The example above adds epoch time to the filename. All the date modifiers from t
 C library should be supported. See the man page for ``strftime`` for all supported
 modifiers.
 
-.. _output_eve_rotate:
+.. _output_eve_threaded:
 
 Threaded file output
 ~~~~~~~~~~~~~~~~~~~~
@@ -316,6 +322,32 @@ the aggregate of each file's contents must be treated together.
 This example will cause each Suricata thread to write to its own "eve.json" file. Filenames are constructed
 by adding a unique identifier to the filename.  For example, ``eve.7.json``.
 
+
+.. _output_eve_flush:
+
+Flushing file contents
+--~~~~~~~~~~~~~~~~~~~~
+
+By default, Suricata will call ``flush`` each time the file is written. ``flush-threshold``
+can be set to a byte-count to reduce the number of ``fflush`` calls. When non-zero, ``fflush`` is called
+when the bytes written to the file are equal to or exceed the value; subsequent calls to ``fflush`` occur.
+
+Reducing the number of ``fflush`` calls can reduce write overhead at the expense of risk of leaving
+up to ``flush-threshold`` bytes unbuffered/unwritten should Suricata unexpectedly terminate.
+
+The default value is ``0``.
+
+::
+
+   outputs:
+     - eve-log:
+         filename: eve.json
+         flush-threshold: 4096
+
+This example will cause Suricata to call ``fflush`` every time 4096 bytes have been written to ``eve.json``.
+
+
+.. _output_eve_rotate:
 
 Rotate log file
 ~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -7,6 +7,12 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json
       #threaded: false
+      # Control for calls to flush file contents:
+      # - 0 Flush contents after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/detect.h
+++ b/src/detect.h
@@ -332,9 +332,7 @@ typedef struct IPOnlyCIDRItem_ {
 /** \brief Used to start a pointer to SigMatch context
  * Should never be dereferenced without casting to something else.
  */
-typedef struct SigMatchCtx_ {
-    int foo;
-} SigMatchCtx;
+typedef void SigMatchCtx;
 
 /** \brief a single match condition for a signature */
 typedef struct SigMatch_ {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -949,6 +949,10 @@ static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 
 static int JsonAlertLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
 {
+    if (PKT_IS_PSEUDOPKT(p)) {
+        JsonAlertLogThread *aft = thread_data;
+        LogFileFlush(aft->json_output_ctx->file_ctx);
+    }
     if (p->alerts.cnt || (p->flags & PKT_HAS_TAG)) {
         return TRUE;
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -95,6 +95,12 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
+      # Control for calls to flush file contents:
+      # - 0 Flush contents after each write
+      # - <byte-count> Flush periodically. Track bytes written; when bytes
+      #   written is equal to or greater, flush file contents. The next
+      #   flush occurs when the bytes written meets or exceeds this value.
+      #flush-threshold: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"


### PR DESCRIPTION
DRAFT:

@victorjulien @jasonish  This is a poc for 
- Reducing the number of fflush calls
- Ensuring the file is flushed when closing
- (Temporary) Flush on pseudo-packets (in the alert log; this is done in the *wrong* function but demonstrates an action on pseudo packets in the output path).


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
