### PR TITLE
Napatech: fixed SCTIME_ADD_USECS from util-time.h to allow correct pa…

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -946,19 +946,19 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
          */
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts / 100000000),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts / 100000000),
                         ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts >> 32), pkt_ts & 0xFFFFFFFF);
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts >> 32), pkt_ts & 0xFFFFFFFF);
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts >> 32),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts >> 32),
                         ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS((pkt_ts / 100000000) - 11644473600),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS((pkt_ts / 100000000) - 11644473600),
                         ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             default:

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -57,7 +57,11 @@ typedef struct {
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
 #define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
-#define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))
+#define SCTIME_ADD_USECS(ts, us)                                                                   \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = (ts).secs + ((ts).usecs + (us)) / 1000000, .usecs = ((ts).usecs + (us)) % 1000000  \
+    }
 #define SCTIME_FROM_SECS(s)                                                                        \
     (SCTime_t)                                                                                     \
     {                                                                                              \


### PR DESCRIPTION
…cket timestamp calculation

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:[6372](https://redmine.openinfosecfoundation.org/issues/6372)

Describe changes:
The SCTIME_ADD_USECS code is updated and timestamp timestamp-related code in source-napatech is fixed.
It seems the software was never tested with real hardware. Current 7.0.1 and master versions generate timestamps with seconds == 0.
The SV test is impossible since the code is only reachable when the card is available.
Technically it's possible to prepare unit test if it's required.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
