### PR TITLE
doc/code-submission: add commit sign guide

### DIFF
--- a/doc/userguide/devguide/codebase/contributing/code-submission-process.rst
+++ b/doc/userguide/devguide/codebase/contributing/code-submission-process.rst
@@ -19,6 +19,7 @@ Commits
     * Description, wrapped at ~72 characters
 #. Commits should be individually compilable, starting with the oldest commit. Make sure that
    each commit can be built if it and the preceding commits in the PR are used.
+#. Commits should be authored with the format: "FirstName LastName <name@example.com>"
 
 Information that needs to be part of a commit (if applicable):
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/9510

Changes since v1:
- say "authored by" instead of "signed by"