### PR TITLE
napatech: Ensure usecs field is valid

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -946,8 +946,9 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
          */
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts / 100000000),
-                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
+                pkt_ts += 50;
+                p->ts = SCTIME_ADD_USECS(
+                        SCTIME_FROM_USECS(pkt_ts / 100000000), ((pkt_ts % 100000000) / 100));
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
                 p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts >> 32), pkt_ts & 0xFFFFFFFF);
@@ -958,8 +959,9 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
+                pkt_ts += 50;
                 p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS((pkt_ts / 100000000) - 11644473600),
-                        ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
+                        ((pkt_ts % 100000000) / 100));
                 break;
             default:
                 SCLogError("Packet from Napatech Stream: %u does not have a supported timestamp "


### PR DESCRIPTION
This commit prevents the microseconds field from containing a value greater than 999,999

Issue: 6372

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Round up the pkt ts to ensure the microsecond field doesn't overflow.
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
