### PR TITLE
detect: remove code writing unused values

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1289,7 +1289,6 @@ int DetectAddressTestConfVars(void)
         }
 
         DetectAddressHeadFree(gh);
-        gh = NULL;
         DetectAddressHeadFree(ghn);
         ghn = NULL;
     }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1645,8 +1645,6 @@ int CreateGroupedPortList(DetectEngineCtx *de_ctx, DetectPort *port_list, Detect
             /* when a group's sigs are added to the joingr, we can free it */
             gr->next = NULL;
             DetectPortFree(de_ctx, gr);
-            gr = NULL;
-
         /* append */
         } else {
             gr->next = NULL;

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -510,7 +510,6 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 if (sm != NULL) {
                     SigMatchRemoveSMFromList(s, sm, DETECT_SM_LIST_THRESHOLD);
                     SigMatchFree(de_ctx, sm);
-                    sm = NULL;
                 }
             }
 


### PR DESCRIPTION
Describe changes:
- remove code writing value that is unused

Coveridy ID 1546822 1546823 and 1546824

Looks like they introduced a new rule