### PR TITLE
Draft: JA4 for TLS and QUIC

### DIFF
--- a/rust/src/quic/frames.rs
+++ b/rust/src/quic/frames.rs
@@ -16,6 +16,7 @@
  */
 
 use super::error::QuicError;
+use super::ja4::*;
 use crate::quic::parser::quic_var_uint;
 use nom7::bytes::complete::take;
 use nom7::combinator::{all_consuming, complete};
@@ -29,7 +30,7 @@ use tls_parser::TlsMessage::Handshake;
 use tls_parser::TlsMessageHandshake::{ClientHello, ServerHello};
 use tls_parser::{
     parse_tls_extensions, parse_tls_message_handshake, TlsCipherSuiteID, TlsExtension,
-    TlsExtensionType, TlsMessage,
+    TlsExtensionType, TlsMessage, TlsVersion,
 };
 
 /// Tuple of StreamTag and offset
@@ -137,6 +138,7 @@ pub(crate) struct Crypto {
     // the lifetime of TlsExtension due to references to the slice used for parsing
     pub extv: Vec<QuicTlsExtension>,
     pub ja3: String,
+    pub ja4: Option<JA4>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -235,7 +237,7 @@ fn quic_tls_ja3_client_extends(ja3: &mut String, exts: Vec<TlsExtension>) {
 
 // get interesting stuff out of parsed tls extensions
 fn quic_get_tls_extensions(
-    input: Option<&[u8]>, ja3: &mut String, client: bool,
+    input: Option<&[u8]>, ja3: &mut String, ja4: Option<&JA4>, client: bool,
 ) -> Vec<QuicTlsExtension> {
     let mut extv = Vec::new();
     if let Some(extr) = input {
@@ -249,8 +251,25 @@ fn quic_get_tls_extensions(
                     dash = true;
                 }
                 ja3.push_str(&u16::from(etype).to_string());
+                if let Some(ja4) = ja4 {
+                    ja4.add_extension(etype)
+                }
                 let mut values = Vec::new();
                 match e {
+                    TlsExtension::SupportedVersions(x) => {
+                        let mut max: TlsVersion = TlsVersion::Ssl30;
+                        for version in x {
+                            if u16::from(*version) > u16::from(max) {
+                                max = *version;
+                            }
+                            let mut value = Vec::new();
+                            value.extend_from_slice(version.to_string().as_bytes());
+                            values.push(value);
+                        }
+                        if let Some(ja4) = ja4 {
+                            ja4.set_tls_version(max);
+                        }
+                    }
                     TlsExtension::SNI(x) => {
                         for sni in x {
                             let mut value = Vec::new();
@@ -258,11 +277,28 @@ fn quic_get_tls_extensions(
                             values.push(value);
                         }
                     }
+                    TlsExtension::SignatureAlgorithms(x) => {
+                        for sigalgo in x {
+                            let mut value = Vec::new();
+                            value.extend_from_slice(sigalgo.to_string().as_bytes());
+                            values.push(value);
+                            if let Some(ja4) = ja4 {
+                                ja4.add_signature_algorithm(*sigalgo)
+                            }
+                        }
+                    }
                     TlsExtension::ALPN(x) => {
+                        let mut first = true;
                         for alpn in x {
                             let mut value = Vec::new();
                             value.extend_from_slice(alpn);
                             values.push(value);
+                            if first {
+                                if let Some(ja4) = ja4 {
+                                    ja4.set_alpn(alpn, alpn.len());
+                                }
+                                first = false;
+                            }
                         }
                     }
                     _ => {}
@@ -282,6 +318,7 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
         match hs {
             ClientHello(ch) => {
                 let mut ja3 = String::with_capacity(256);
+                let ja4 = JA4::new();
                 ja3.push_str(&u16::from(ch.version).to_string());
                 ja3.push(',');
                 let mut dash = false;
@@ -292,11 +329,12 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
                         dash = true;
                     }
                     ja3.push_str(&u16::from(*c).to_string());
+                    ja4.add_cipher_suite(*c);
                 }
                 ja3.push(',');
                 let ciphers = ch.ciphers;
-                let extv = quic_get_tls_extensions(ch.ext, &mut ja3, true);
-                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));
+                let extv = quic_get_tls_extensions(ch.ext, &mut ja3, Some(&ja4), true);
+                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3, ja4: Some(ja4) }));
             }
             ServerHello(sh) => {
                 let mut ja3 = String::with_capacity(256);
@@ -305,8 +343,8 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
                 ja3.push_str(&u16::from(sh.cipher).to_string());
                 ja3.push(',');
                 let ciphers = vec![sh.cipher];
-                let extv = quic_get_tls_extensions(sh.ext, &mut ja3, false);
-                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));
+                let extv = quic_get_tls_extensions(sh.ext, &mut ja3, None, false);
+                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3, ja4: None }));
             }
             _ => {}
         }

--- a/rust/src/quic/ja4.rs
+++ b/rust/src/quic/ja4.rs
@@ -1,0 +1,92 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+*/
+
+use std::{ffi::{CString,CStr}, os::raw::c_char};
+use tls_parser::{TlsCipherSuiteID, TlsExtensionType, TlsVersion};
+
+pub enum CJa4 {}
+
+extern {
+    pub fn Ja4Init() -> *mut CJa4;
+    pub fn Ja4SetQUIC(j: *mut CJa4);
+    pub fn Ja4SetTLSVersion(j: *mut CJa4, version: u16);
+    pub fn Ja4SetALPN(j: *mut CJa4, proto: *const c_char, len: u8);
+    pub fn Ja4AddCipher(j: *mut CJa4, cipher: u16);
+    pub fn Ja4AddExtension(j: *mut CJa4, ext: u16);
+    pub fn Ja4AddSigAlgo(j: *mut CJa4, sigalgo: u16);
+    pub fn Ja4GetHash(j: *mut CJa4) -> *const c_char;
+    pub fn Ja4Free(j: *mut *mut CJa4);
+}
+
+#[derive(Debug, PartialEq)]
+pub struct JA4 {
+    pub ptr: *mut CJa4,
+}
+
+impl JA4 {
+    pub fn new() -> Self {
+        let new_ptr = unsafe { Ja4Init() };
+        unsafe { Ja4SetQUIC(new_ptr) };
+        Self { ptr: new_ptr }
+    }
+    
+    pub fn set_tls_version(&self, version: TlsVersion) {
+        unsafe {
+            Ja4SetTLSVersion(self.ptr, u16::from(version));
+        }
+    }
+    
+    pub fn set_alpn(&self, alpn: &[u8], len: usize) {
+        unsafe {
+            // allowing this since the pointer will not
+            // be used further after the call to the C code
+            #[allow(temporary_cstring_as_ptr)]
+            Ja4SetALPN(self.ptr, CString::new(alpn).unwrap().as_ptr(), len as u8)
+        }
+    }
+    
+    pub fn add_cipher_suite(&self, cipher: TlsCipherSuiteID) {
+        unsafe {
+            Ja4AddCipher(self.ptr, u16::from(cipher));
+        }
+    }
+    
+    pub fn add_extension(&self, ext: TlsExtensionType) {
+        unsafe {
+            Ja4AddExtension(self.ptr, u16::from(ext));
+        }
+    }
+    
+    pub fn add_signature_algorithm(&self, sigalgo: u16) {
+        unsafe {
+            Ja4AddSigAlgo(self.ptr, sigalgo);
+        }
+    }
+
+    pub fn get_hash(&self) -> Result<String, std::str::Utf8Error> {
+        let c_str = unsafe { CStr::from_ptr(Ja4GetHash(self.ptr)) };
+        Ok(String::from_utf8_lossy(c_str.to_bytes()).to_string())
+    }
+}
+
+impl Drop for JA4 {
+    fn drop(&mut self) {
+        unsafe {
+            Ja4Free(&mut self.ptr as *mut *mut CJa4);
+        }
+    }
+}

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -122,6 +122,11 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
         js.set_string("string", ja3)?;
         js.close()?;
     }
+
+    if let Some(ref ja4) =  &tx.ja4 {
+            js.set_string("ja4", ja4)?;
+    }
+
     if !tx.extv.is_empty() {
         js.open_array("extensions")?;
         for e in &tx.extv {

--- a/rust/src/quic/mod.rs
+++ b/rust/src/quic/mod.rs
@@ -20,6 +20,7 @@ mod cyu;
 pub mod detect;
 mod error;
 mod frames;
+mod ja4;
 mod logger;
 mod parser;
 pub mod quic;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -551,6 +551,7 @@ noinst_HEADERS = \
 	util-ioctl.h \
 	util-ip.h \
 	util-ja3.h \
+	util-ja4.h \
 	util-landlock.h \
 	util-logopenfile.h \
 	util-log-redis.h \
@@ -1146,6 +1147,7 @@ libsuricata_c_a_SOURCES = \
 	util-ioctl.c \
 	util-ip.c \
 	util-ja3.c \
+	util-ja4.c \
 	util-landlock.c \
 	util-logopenfile.c \
 	util-log-redis.c \

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -50,6 +50,7 @@
 #include "util-pool.h"
 #include "util-byte.h"
 #include "util-ja3.h"
+#include "util-ja4.h"
 #include "util-enum.h"
 #include "flow-util.h"
 #include "flow-private.h"
@@ -143,8 +144,9 @@ enum {
     ERR_EXTRACT_VALIDITY,
 };
 
-/* JA3 fingerprints are disabled by default */
+/* JA3 and JA4 fingerprints are disabled by default */
 #define SSL_CONFIG_DEFAULT_JA3 0
+#define SSL_CONFIG_DEFAULT_JA4 0
 
 enum SslConfigEncryptHandling {
     SSL_CNF_ENC_HANDLE_DEFAULT = 0, /**< disable raw content, continue tracking */
@@ -154,10 +156,12 @@ enum SslConfigEncryptHandling {
 
 typedef struct SslConfig_ {
     enum SslConfigEncryptHandling encrypt_mode;
-    /** dynamic setting for ja3: can be enabled on demand if not explicitly
-     *  disabled. */
+    /** dynamic setting for ja3 and ja4: can be enabled on demand if not
+     *  explicitly disabled. */
     SC_ATOMIC_DECLARE(int, enable_ja3);
     bool disable_ja3; /**< ja3 explicitly disabled. Don't enable on demand. */
+    SC_ATOMIC_DECLARE(int, enable_ja4);
+    bool disable_ja4; /**< ja4 explicitly disabled. Don't enable on demand. */
 } SslConfig;
 
 SslConfig ssl_config;
@@ -691,6 +695,10 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
     uint16_t version = (uint16_t)(*input << 8) | *(input + 1);
     ssl_state->curr_connp->version = version;
 
+    if (SC_ATOMIC_GET(ssl_config.enable_ja4) && ssl_state->curr_connp->ja4 != NULL) {
+        Ja4SetTLSVersion(ssl_state->curr_connp->ja4, version);
+    }
+
     /* TLSv1.3 draft1 to draft21 use the version field as earlier TLS
        versions, instead of using the supported versions extension. */
     if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
@@ -834,37 +842,48 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         goto invalid_length;
     }
 
-    if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
-        JA3Buffer *ja3_cipher_suites = Ja3BufferInit();
-        if (ja3_cipher_suites == NULL)
-            return -1;
+    if (SC_ATOMIC_GET(ssl_config.enable_ja3) || SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        JA3Buffer *ja3_cipher_suites = NULL;
+
+        if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+            ja3_cipher_suites = Ja3BufferInit();
+            if (ja3_cipher_suites == NULL)
+                return -1;
+        }
 
         uint16_t processed_len = 0;
         /* coverity[tainted_data] */
         while (processed_len < cipher_suites_length)
         {
-            if (!(HAS_SPACE(2))) {
-                Ja3BufferFree(&ja3_cipher_suites);
-                goto invalid_length;
+            if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+                if (!(HAS_SPACE(2))) {
+                    Ja3BufferFree(&ja3_cipher_suites);
+                    goto invalid_length;
+                }
             }
 
             uint16_t cipher_suite = (uint16_t)(*input << 8) | *(input + 1);
             input += 2;
 
             if (TLSDecodeValueIsGREASE(cipher_suite) != 1) {
-                int rc = Ja3BufferAddValue(&ja3_cipher_suites, cipher_suite);
-                if (rc != 0) {
-                    return -1;
+                if (SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+                    Ja4AddCipher(ssl_state->curr_connp->ja4, cipher_suite);
+                }
+                if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+                    int rc = Ja3BufferAddValue(&ja3_cipher_suites, cipher_suite);
+                    if (rc != 0) {
+                        return -1;
+                    }
                 }
             }
-
             processed_len += 2;
         }
 
-        int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                   &ja3_cipher_suites);
-        if (rc == -1) {
-            return -1;
+        if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+            int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_cipher_suites);
+            if (rc == -1) {
+                return -1;
+            }
         }
 
     } else {
@@ -1025,6 +1044,9 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
             uint16_t ver = (uint16_t)(input[i] << 8) | input[i + 1];
             if (TLSVersionValid(ver)) {
                 ssl_state->curr_connp->version = ver;
+                if (ssl_state->curr_connp->ja4 != NULL) {
+                    Ja4SetTLSVersion(ssl_state->curr_connp->ja4, ver);
+                }
                 break;
             }
             i += 2;
@@ -1171,6 +1193,98 @@ invalid_length:
     return -1;
 }
 
+static inline int TLSDecodeHSHelloExtensionSigAlgorithms(
+        SSLState *ssl_state, const uint8_t *const initial_input, const uint32_t input_len)
+{
+    const uint8_t *input = initial_input;
+
+    /* Empty extension */
+    if (input_len == 0)
+        return 0;
+
+    if (!(HAS_SPACE(2)))
+        goto invalid_length;
+
+    uint16_t sigalgo_len = (uint16_t)(*input << 8) | *(input + 1);
+    input += 2;
+
+    if (!(HAS_SPACE(sigalgo_len)))
+        goto invalid_length;
+
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+            SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        uint16_t sigalgo_processed_len = 0;
+        /* coverity[tainted_data] */
+        while (sigalgo_processed_len < sigalgo_len) {
+            uint16_t sigalgo = (uint16_t)(*input << 8) | *(input + 1);
+            input += 2;
+            sigalgo_processed_len += 2;
+
+            Ja4AddSigAlgo(ssl_state->curr_connp->ja4, sigalgo);
+        }
+    } else {
+        /* Skip signature algorithms */
+        input += sigalgo_len;
+    }
+
+    return (input - initial_input);
+
+invalid_length:
+    SCLogDebug("Signature algorithm list invalid length");
+    SSLSetEvent(ssl_state, TLS_DECODER_EVENT_HANDSHAKE_INVALID_LENGTH);
+
+    return -1;
+}
+
+static inline int TLSDecodeHSHelloExtensionALPN(
+        SSLState *ssl_state, const uint8_t *const initial_input, const uint32_t input_len)
+{
+    const uint8_t *input = initial_input;
+
+    /* Empty extension */
+    if (input_len == 0)
+        return 0;
+
+    if (!(HAS_SPACE(2)))
+        goto invalid_length;
+
+    uint16_t alpn_len = (uint16_t)(*input << 8) | *(input + 1);
+    input += 2;
+
+    if (!(HAS_SPACE(alpn_len)))
+        goto invalid_length;
+
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+            SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        uint16_t alpn_processed_len = 0;
+        /* coverity[tainted_data] */
+        while (alpn_processed_len < alpn_len) {
+            uint8_t protolen = *input;
+            input += 1;
+            alpn_processed_len += 1;
+
+            /* we only want the first value for JA4 */
+            if (alpn_processed_len == 1) {
+                Ja4SetALPN(ssl_state->curr_connp->ja4, input, protolen);
+            }
+
+            alpn_processed_len += protolen;
+            input += protolen;
+        }
+    } else {
+        /* Skip ALPN protocols */
+        input += alpn_len;
+    }
+
+    return (input - initial_input);
+
+invalid_length:
+    SCLogDebug("ALPN list invalid length");
+    SSLSetEvent(ssl_state, TLS_DECODER_EVENT_HANDSHAKE_INVALID_LENGTH);
+
+    return -1;
+}
+
 static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                                          const uint8_t * const initial_input,
                                          const uint32_t input_len)
@@ -1180,6 +1294,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
     int ret;
     int rc;
     const bool ja3 = (SC_ATOMIC_GET(ssl_config.enable_ja3) == 1);
+    const bool ja4 = (SC_ATOMIC_GET(ssl_config.enable_ja4) == 1);
 
     JA3Buffer *ja3_extensions = NULL;
     JA3Buffer *ja3_elliptic_curves = NULL;
@@ -1272,6 +1387,28 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 break;
             }
 
+            case SSL_EXTENSION_SIGNATURE_ALGORITHMS: {
+                /* coverity[tainted_data] */
+                ret = TLSDecodeHSHelloExtensionSigAlgorithms(ssl_state, input, ext_len);
+                if (ret < 0)
+                    goto end;
+
+                input += ret;
+
+                break;
+            }
+
+            case SSL_EXTENSION_ALPN: {
+                /* coverity[tainted_data] */
+                ret = TLSDecodeHSHelloExtensionALPN(ssl_state, input, ext_len);
+                if (ret < 0)
+                    goto end;
+
+                input += ret;
+
+                break;
+            }
+
             case SSL_EXTENSION_EARLY_DATA:
             {
                 if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
@@ -1325,6 +1462,12 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
             }
         }
 
+        if (ja4) {
+            if (TLSDecodeValueIsGREASE(ext_type) != 1) {
+                Ja4AddExtension(ssl_state->curr_connp->ja4, ext_type);
+            }
+        }
+
         processed_len += ext_len + 4;
     }
 
@@ -1372,6 +1515,10 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 {
     int ret;
     uint32_t parsed = 0;
+
+    if (SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        ssl_state->curr_connp->ja4 = Ja4Init();
+    }
 
     ret = TLSDecodeHSHelloVersion(ssl_state, input, input_len);
     if (ret < 0)
@@ -2697,6 +2844,8 @@ static void SSLStateFree(void *p)
     if (ssl_state->server_connp.session_id)
         SCFree(ssl_state->server_connp.session_id);
 
+    if (ssl_state->client_connp.ja4)
+        Ja4Free(&ssl_state->client_connp.ja4);
     if (ssl_state->client_connp.ja3_str)
         Ja3BufferFree(&ssl_state->client_connp.ja3_str);
     if (ssl_state->client_connp.ja3_hash)
@@ -3063,6 +3212,20 @@ void RegisterSSLParsers(void)
             enable_ja3 = true;
         }
         SC_ATOMIC_SET(ssl_config.enable_ja3, enable_ja3);
+
+        /* Check if we should generate JA4 fingerprints */
+        int enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        if (ConfGet("app-layer.protocols.tls.ja4-fingerprints", &strval) != 1) {
+            enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        } else if (strcmp(strval, "auto") == 0) {
+            enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        } else if (ConfValIsFalse(strval)) {
+            enable_ja4 = 0;
+            ssl_config.disable_ja4 = true;
+        } else if (ConfValIsTrue(strval)) {
+            enable_ja4 = true;
+        }
+        SC_ATOMIC_SET(ssl_config.enable_ja4, enable_ja4);
 
         if (g_disable_hashing) {
             if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -27,6 +27,7 @@
 #define __APP_LAYER_SSL_H__
 
 #include "util-ja3.h"
+#include "util-ja4.h"
 #include "rust.h"
 
 enum TlsFrameTypes {
@@ -141,6 +142,8 @@ enum {
 #define SSL_EXTENSION_SNI                       0x0000
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
+#define SSL_EXTENSION_SIGNATURE_ALGORITHMS      0x000d
+#define SSL_EXTENSION_ALPN                      0x0010
 #define SSL_EXTENSION_SESSION_TICKET            0x0023
 #define SSL_EXTENSION_EARLY_DATA                0x002a
 #define SSL_EXTENSION_SUPPORTED_VERSIONS        0x002b
@@ -266,6 +269,8 @@ typedef struct SSLStateConnp_ {
 
     JA3Buffer *ja3_str;
     char *ja3_hash;
+
+    JA4 *ja4;
 
     /* handshake tls fragmentation buffer. Handshake messages can be fragmented over multiple
      * TLS records. */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -76,6 +76,7 @@ SC_ATOMIC_EXTERN(unsigned int, cert_id);
 #define LOG_TLS_FIELD_CLIENT            (1 << 13) /**< client fields (issuer, subject, etc) */
 #define LOG_TLS_FIELD_CLIENT_CERT       (1 << 14)
 #define LOG_TLS_FIELD_CLIENT_CHAIN      (1 << 15)
+#define LOG_TLS_FIELD_JA4               (1 << 16)
 
 typedef struct {
     const char *name;
@@ -90,7 +91,7 @@ TlsFields tls_fields[] = { { "version", LOG_TLS_FIELD_VERSION },
     { "chain", LOG_TLS_FIELD_CHAIN }, { "session_resumed", LOG_TLS_FIELD_SESSION_RESUMED },
     { "ja3", LOG_TLS_FIELD_JA3 }, { "ja3s", LOG_TLS_FIELD_JA3S },
     { "client", LOG_TLS_FIELD_CLIENT }, { "client_certificate", LOG_TLS_FIELD_CLIENT_CERT },
-    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN }, { NULL, -1 } };
+    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN }, { "ja4", LOG_TLS_FIELD_JA4 }, { NULL, -1 } };
 
 typedef struct OutputTlsCtx_ {
     uint32_t flags;  /** Store mode */
@@ -207,6 +208,13 @@ static void JsonTlsLogJa3(JsonBuilder *js, SSLState *ssl_state)
         JsonTlsLogJa3String(js, ssl_state);
 
         jb_close(js);
+    }
+}
+
+static void JsonTlsLogJa4(JsonBuilder *js, SSLState *ssl_state)
+{
+    if (ssl_state->client_connp.ja4 != NULL) {
+        jb_set_string(js, "ja4", Ja4GetHash(ssl_state->client_connp.ja4));
     }
 }
 
@@ -381,6 +389,10 @@ static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
     if (tls_ctx->fields & LOG_TLS_FIELD_JA3S)
         JsonTlsLogJa3S(js, ssl_state);
 
+    /* tls ja4 */
+    if (tls_ctx->fields & LOG_TLS_FIELD_JA4)
+        JsonTlsLogJa4(js, ssl_state);
+
     if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT) {
         const bool log_cert = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CERT) != 0;
         const bool log_chain = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CHAIN) != 0;
@@ -419,6 +431,9 @@ void JsonTlsLogJSONExtended(JsonBuilder *tjs, SSLState * state)
 
     /* tls ja3s */
     JsonTlsLogJa3S(tjs, state);
+
+    /* tls ja4 */
+    JsonTlsLogJa4(tjs, state);
 
     if (HasClientCert(&state->client_connp)) {
         jb_open_object(tjs, "client");

--- a/src/util-ja4.c
+++ b/src/util-ja4.c
@@ -1,0 +1,296 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha@steinbiss.name>
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect-engine.h"
+#include "util-ja4.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "util-validate.h"
+#include <stdlib.h>
+#include <string.h>
+#include "rust.h"
+
+struct JA4_ {
+    bool finalized;
+    const char *tls_version;
+    char proto, alpn[2], sni, ja4[37];
+    uint16_t nof_ciphers, nof_exts;
+    size_t len_cipher, len_ext, len_sigs, cap_cipher, cap_ext, cap_sigs;
+    char *exts, *ciphers, *sigs;
+};
+
+#define JA4_INITIAL_BUFSIZE 64
+
+static int Ja4HexCompare(const void *a, const void *b)
+{
+    return strncmp((const char *)a, (const char *)b, 4 * sizeof(char));
+}
+
+static inline int JA4ExtendBuffer(char **buf, size_t *cap)
+{
+    size_t newcap = *cap * 2;
+    char *new = SCRealloc(*buf, newcap);
+    if (new == NULL) {
+        SCLogError("Error resizing JA4 buffer");
+        return -1;
+    }
+    *buf = new;
+    *cap = newcap;
+    return 0;
+}
+
+static inline bool JA4IsGREASE(const uint16_t value)
+{
+    switch (value) {
+        case 0x0a0a:
+        case 0x1a1a:
+        case 0x2a2a:
+        case 0x3a3a:
+        case 0x4a4a:
+        case 0x5a5a:
+        case 0x6a6a:
+        case 0x7a7a:
+        case 0x8a8a:
+        case 0x9a9a:
+        case 0xaaaa:
+        case 0xbaba:
+        case 0xcaca:
+        case 0xdada:
+        case 0xeaea:
+        case 0xfafa:
+            return true;
+        default:
+            return false;
+    }
+}
+
+JA4 *Ja4Init(void)
+{
+    JA4 *j = NULL;
+    j = SCCalloc(1, sizeof(*j));
+    if (unlikely(j == NULL)) {
+        SCLogError("Unable to allocate JA4 memory");
+        return NULL;
+    }
+    j->cap_cipher = j->cap_ext = j->cap_sigs = JA4_INITIAL_BUFSIZE;
+    j->ciphers = SCCalloc(j->cap_cipher, sizeof(char));
+    j->exts = SCCalloc(j->cap_ext, sizeof(char));
+    j->sigs = SCCalloc(j->cap_sigs, sizeof(char));
+    Ja4Reset(j);
+    return j;
+}
+
+void Ja4SetQUIC(JA4 *j)
+{
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    j->proto = 'q';
+}
+
+void Ja4SetTLSVersion(JA4 *j, uint16_t v)
+{
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (JA4IsGREASE(v))
+        return;
+    switch (v) {
+        case 0x0304:
+            j->tls_version = "13";
+            break;
+        case 0x0303:
+            j->tls_version = "12";
+            break;
+        case 0x0302:
+            j->tls_version = "11";
+            break;
+        case 0x0301:
+            j->tls_version = "10";
+            break;
+        case 0x0300:
+            j->tls_version = "s3";
+            break;
+        case 0x0200:
+            j->tls_version = "s2";
+            break;
+        case 0x0100:
+            j->tls_version = "s1";
+            break;
+        default:
+            j->tls_version = "00";
+    }
+}
+
+void Ja4SetALPN(JA4 *j, const uint8_t *val, uint8_t len)
+{
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (len > 1) {
+        uint16_t testval = (val[0] << 8) | val[1];
+        if (JA4IsGREASE(testval))
+            return;
+        j->alpn[0] = val[0];
+        j->alpn[1] = val[len - 1];
+    }
+}
+
+void Ja4AddCipher(JA4 *j, const uint16_t cipher)
+{
+    int ret;
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (JA4IsGREASE(cipher))
+        return;
+    if (j->len_cipher + 4 > j->cap_cipher) {
+        ret = JA4ExtendBuffer(&(j->ciphers), &(j->cap_cipher));
+        if (ret < 0) {
+            /* XXX TODO Handle */
+            return;
+        }
+    }
+    (void)sprintf(j->ciphers + j->len_cipher, "%04x", cipher);
+    j->len_cipher += 4;
+    j->nof_ciphers++;
+}
+
+void Ja4AddExtension(JA4 *j, const uint16_t ext)
+{
+    int ret;
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (JA4IsGREASE(ext))
+        return;
+    /* skip SNI and ALPN */
+    if (ext == 0x0000) {
+        j->sni = 'd';
+        j->nof_exts++;
+        return;
+    }
+    if (ext == 0x0010) {
+        j->nof_exts++;
+        return;
+    }
+    if (j->len_ext + 4 > j->cap_ext) {
+        ret = JA4ExtendBuffer(&(j->exts), &(j->cap_ext));
+        if (ret < 0) {
+            /* XXX TODO Handle */
+            return;
+        }
+    }
+    (void)sprintf(j->exts + j->len_ext, "%04x", ext);
+    j->len_ext += 4;
+    j->nof_exts++;
+}
+
+void Ja4AddSigAlgo(JA4 *j, const uint16_t sigalgo)
+{
+    int ret;
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (JA4IsGREASE(sigalgo))
+        return;
+    if (j->len_sigs + 4 > j->cap_sigs) {
+        ret = JA4ExtendBuffer(&(j->sigs), &(j->cap_sigs));
+        if (ret < 0) {
+            /* XXX TODO Handle */
+            return;
+        }
+    }
+    (void)sprintf(j->sigs + j->len_sigs, "%04x", sigalgo);
+    j->len_sigs += 4;
+}
+
+static inline void Ja4BuildHash(JA4 *j)
+{
+    uint16_t i;
+    char ja4_a[32];
+    char buf[10];
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    (void)snprintf(ja4_a, 32, "%c%s%c%02u%02u%c%c", j->proto, j->tls_version, j->sni,
+            j->nof_ciphers > 99 ? 99 : j->nof_ciphers, j->nof_exts > 99 ? 99 : j->nof_exts,
+            j->alpn[0], j->alpn[1]);
+    SCLogDebug("JA4_a: %s", ja4_a);
+
+    DEBUG_VALIDATE_BUG_ON(j->len_cipher % 4 != 0);
+    (void)qsort(j->ciphers, j->len_cipher / 4, 4, Ja4HexCompare);
+    SCSha256 *sha256_ctx = SCSha256New();
+    for (i = 0; i < j->len_cipher; i += 4) {
+        (void)snprintf(buf, 10, "%.4s%s", j->ciphers + i, i == j->len_cipher - 4 ? "" : ",");
+        SCLogDebug("%d/%lu: updating with cipher %s", i, j->len_cipher, buf);
+        SCSha256Update(sha256_ctx, (unsigned char *)buf, strlen(buf));
+    }
+    char ja4_b_full[65];
+    SCSha256FinalizeToHex(sha256_ctx, ja4_b_full, 65);
+    SCLogDebug("JA4_b: %.12s", ja4_b_full);
+
+    sha256_ctx = SCSha256New();
+    DEBUG_VALIDATE_BUG_ON(j->len_ext % 4 != 0);
+    (void)qsort(j->exts, j->len_ext / 4, 4, Ja4HexCompare);
+    for (i = 0; i < j->len_ext; i += 4) {
+        (void)snprintf(buf, 10, "%.4s%s", j->exts + i, i == j->len_ext - 4 ? "" : ",");
+        SCLogDebug("%d/%lu: updating with ext %s", i, j->len_ext, buf);
+        SCSha256Update(sha256_ctx, (unsigned char *)buf, strlen(buf));
+    }
+    SCSha256Update(sha256_ctx, (const uint8_t *)"_", 1);
+    DEBUG_VALIDATE_BUG_ON(j->len_sigs % 4 != 0);
+    for (i = 0; i < j->len_sigs; i += 4) {
+        (void)snprintf(buf, 10, "%.4s%s", j->sigs + i, i == j->len_sigs - 4 ? "" : ",");
+        SCLogDebug("%d/%lu: updating with sig %s", i, j->len_sigs, buf);
+        SCSha256Update(sha256_ctx, (unsigned char *)buf, strlen(buf));
+    }
+    char ja4_c_full[65];
+    SCSha256FinalizeToHex(sha256_ctx, ja4_c_full, 65);
+    SCLogDebug("JA4_c: %.12s", ja4_c_full);
+
+    (void)snprintf(j->ja4, 37, "%.10s_%.12s_%.12s", ja4_a, ja4_b_full, ja4_c_full);
+    SCLogDebug("JA4: %s", j->ja4);
+    j->finalized = true;
+}
+
+const char *Ja4GetHash(JA4 *j)
+{
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    if (!j->finalized)
+        Ja4BuildHash(j);
+    return (const char *)j->ja4;
+}
+
+void Ja4Reset(JA4 *j)
+{
+    DEBUG_VALIDATE_BUG_ON(j == NULL);
+    j->finalized = false;
+    j->proto = 't';
+    j->sni = 'i';
+    j->tls_version = "00";
+    j->len_cipher = j->len_ext = j->len_sigs = 0;
+    j->nof_ciphers = j->nof_exts = 0;
+    j->alpn[0] = j->alpn[1] = '0';
+}
+
+void Ja4Free(JA4 **j)
+{
+    if (j == NULL)
+        return;
+    if (*j == NULL)
+        return;
+    SCFree((*j)->sigs);
+    SCFree((*j)->ciphers);
+    SCFree((*j)->exts);
+    SCFree(*j);
+    *j = NULL;
+}

--- a/src/util-ja4.h
+++ b/src/util-ja4.h
@@ -1,0 +1,46 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Sascha Steinbiss <sascha@steinbiss.name>
+ */
+
+#ifndef __UTIL_JA4_H__
+#define __UTIL_JA4_H__
+
+typedef struct JA4_ JA4;
+
+JA4 *Ja4Init(void);
+void Ja4SetQUIC(JA4 *);
+void Ja4SetTLSVersion(JA4 *, const uint16_t);
+void Ja4SetALPN(JA4 *, const uint8_t *, uint8_t);
+void Ja4AddCipher(JA4 *, const uint16_t);
+void Ja4AddExtension(JA4 *, const uint16_t);
+void Ja4AddSigAlgo(JA4 *, const uint16_t);
+const char *Ja4GetHash(JA4 *);
+void Ja4Reset(JA4 *);
+void Ja4Free(JA4 **);
+/* TODO */
+void Ja4RegisterTests(void);
+
+InspectionBuffer *Ja4DetectGetHash(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+        const int list_id);
+
+#endif /* __UTIL_JA4_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -252,7 +252,7 @@ outputs:
             # session id
             #session-resumption: no
             # custom controls which TLS fields that are included in eve-log
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s]
+            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,
@@ -892,9 +892,10 @@ app-layer:
       detection-ports:
         dp: 443
 
-      # Generate JA3 fingerprint from client hello. If not specified it
+      # Generate JA3/JA4 fingerprints from client hello. If not specified it
       # will be disabled by default, but enabled if rules require it.
       #ja3-fingerprints: auto
+      #ja4-fingerprints: auto
 
       # What to do when the encrypted communications start:
       # - default: keep tracking TLS session, check for protocol anomalies,


### PR DESCRIPTION
Just a PoC demonstrating JA4 support for TLS and QUIC. Will also add tests and some more error checking if the core team is fine with the general approach.

Results match the reference implementation (https://github.com/FoxIO-LLC/ja4) for some self-made QUIC pcaps ([quic.zip](https://github.com/OISF/suricata/files/12778249/quic.zip)) and TLS pcaps from suricata-verify:

```
$ rm -f eve.json; ./src/suricata -vvv -c suricata.yaml --set app-layer.protocols.tls.ja4-fingerprints=yes -k none -r ../suricata-verify/tests/tls/tls-random/input.pcap -l . 2&>1 > /dev/null
$ jq 'select(.event_type == "tls")' eve.json | grep ja4
    "ja4": "t12i1810s1_27d4652c4487_06a4338d0495"
$ ../ja4/binaries/linux/ja4 ../suricata-verify/tests/tls/tls-random/input.pcap | grep ja4:
  ja4: t12i1810s1_27d4652c4487_06a4338d0495
```

```
$ rm -f eve.json; ./src/suricata -vvv -c suricata.yaml -k none -r out.pcap -l . 2&>1 > /dev/null
$ jq 'select(.event_type == "quic")' eve.json | grep ja4
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
    "ja4": "q13d0310h3_55b375c5d22e_cd85d2d88918",
$ ../ja4/binaries/linux/ja4 -r out.pcap | grep ja4:
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
  ja4: q13d0310h3_55b375c5d22e_cd85d2d88918
```

It would be easy to also provide JA4_r, JA4_ro and JA4_o.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
