### PR TITLE
detect: update packet action on protocol change

### DIFF
--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -430,6 +430,10 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
             TmqhOutputPacketpool(tv, x);
         }
     }
+    if (FlowChangeProto(p->flow) && p->flow->flags & FLOW_ACTION_DROP) {
+        // in case f->flags & FLOW_ACTION_DROP was set by one of the dequeued packets
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+    }
 }
 
 static void FlowWorkerFlowTimeout(ThreadVars *tv, Packet *p, FlowWorkerThreadData *fw,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6305

Describe changes:
- detect: update packet action on protocol change

I am not sure the patch is complete.
Without a protocol change, can you craft a packet whose pseudo packets will set drop to the flow, but the packet itself does not ?