### PR TITLE
output/email: reset custom fields during init

### DIFF
--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -391,6 +391,7 @@ bool EveEmailAddMetadata(const Flow *f, uint32_t tx_id, JsonBuilder *js)
 
 void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx)
 {
+    email_ctx->fields = 0;
     if (conf) {
         const char *extended = ConfNodeLookupChildValue(conf, "extended");
 
@@ -400,7 +401,6 @@ void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx)
             }
         }
 
-        email_ctx->fields  = 0;
         ConfNode *custom;
         if ((custom = ConfNodeLookupChild(conf, "custom")) != NULL) {
             ConfNode *field;


### PR DESCRIPTION
Redmine ticket: None yet. Need somebody to confirm if the analysis is correct and this is a bug. This purely came from "works on my machine" case of https://github.com/OISF/suricata-verify/pull/1405 after I spent way too much time figuring the difference in behaviors and finally tried to check the code.

I believe (and tested) that the **alternate** solution for this problem is:
```C
diff --git a/src/output-json-smtp.c b/src/output-json-smtp.c
index cc3003907..f7674687c 100644
--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -122,7 +122,7 @@ static OutputInitResult OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_c
     OutputInitResult result = { NULL, false };
     OutputJsonCtx *ojc = parent_ctx->data;
 
-    OutputJsonEmailCtx *email_ctx = SCMalloc(sizeof(OutputJsonEmailCtx));
+    OutputJsonEmailCtx *email_ctx = SCCalloc(1, sizeof(OutputJsonEmailCtx));
     if (unlikely(email_ctx == NULL))
         return result;
```
I'm not sure which one is more ideal.