### PR TITLE
Draft: JA4 for TLS and QUIC -- v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3035,6 +3035,9 @@
                     },
                     "additionalProperties": false
                 },
+                "ja4": {
+                    "type": "string"
+                },
                 "sni": {
                     "type": "string"
                 },
@@ -5419,6 +5422,9 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "ja4": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/rust/src/quic/frames.rs
+++ b/rust/src/quic/frames.rs
@@ -16,6 +16,7 @@
  */
 
 use super::error::QuicError;
+use super::ja4::*;
 use crate::quic::parser::quic_var_uint;
 use nom7::bytes::complete::take;
 use nom7::combinator::{all_consuming, complete};
@@ -29,7 +30,7 @@ use tls_parser::TlsMessage::Handshake;
 use tls_parser::TlsMessageHandshake::{ClientHello, ServerHello};
 use tls_parser::{
     parse_tls_extensions, parse_tls_message_handshake, TlsCipherSuiteID, TlsExtension,
-    TlsExtensionType, TlsMessage,
+    TlsExtensionType, TlsMessage, TlsVersion,
 };
 
 /// Tuple of StreamTag and offset
@@ -137,6 +138,7 @@ pub(crate) struct Crypto {
     // the lifetime of TlsExtension due to references to the slice used for parsing
     pub extv: Vec<QuicTlsExtension>,
     pub ja3: String,
+    pub ja4: Option<JA4>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -235,7 +237,7 @@ fn quic_tls_ja3_client_extends(ja3: &mut String, exts: Vec<TlsExtension>) {
 
 // get interesting stuff out of parsed tls extensions
 fn quic_get_tls_extensions(
-    input: Option<&[u8]>, ja3: &mut String, client: bool,
+    input: Option<&[u8]>, ja3: &mut String, mut ja4: Option<&mut JA4>, client: bool,
 ) -> Vec<QuicTlsExtension> {
     let mut extv = Vec::new();
     if let Some(extr) = input {
@@ -249,8 +251,25 @@ fn quic_get_tls_extensions(
                     dash = true;
                 }
                 ja3.push_str(&u16::from(etype).to_string());
+                if let Some(ref mut ja4) = ja4 {
+                    ja4.add_extension(etype)
+                }
                 let mut values = Vec::new();
                 match e {
+                    TlsExtension::SupportedVersions(x) => {
+                        let mut max: TlsVersion = TlsVersion::Ssl30;
+                        for version in x {
+                            if u16::from(*version) > u16::from(max) {
+                                max = *version;
+                            }
+                            let mut value = Vec::new();
+                            value.extend_from_slice(version.to_string().as_bytes());
+                            values.push(value);
+                        }
+                        if let Some(ref mut ja4) = ja4 {
+                            ja4.set_tls_version(max);
+                        }
+                    }
                     TlsExtension::SNI(x) => {
                         for sni in x {
                             let mut value = Vec::new();
@@ -258,11 +277,28 @@ fn quic_get_tls_extensions(
                             values.push(value);
                         }
                     }
+                    TlsExtension::SignatureAlgorithms(x) => {
+                        for sigalgo in x {
+                            let mut value = Vec::new();
+                            value.extend_from_slice(sigalgo.to_string().as_bytes());
+                            values.push(value);
+                            if let Some(ref mut  ja4) = ja4 {
+                                ja4.add_signature_algorithm(*sigalgo)
+                            }
+                        }
+                    }
                     TlsExtension::ALPN(x) => {
+                        let mut first = true;
                         for alpn in x {
                             let mut value = Vec::new();
                             value.extend_from_slice(alpn);
                             values.push(value);
+                            if first {
+                                if let Some(ref mut ja4) = ja4 {
+                                    ja4.set_alpn(alpn, alpn.len());
+                                }
+                                first = false;
+                            }
                         }
                     }
                     _ => {}
@@ -284,6 +320,8 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
                 let mut ja3 = String::with_capacity(256);
                 ja3.push_str(&u16::from(ch.version).to_string());
                 ja3.push(',');
+                let mut ja4 = JA4::new();
+                ja4.set_quic();
                 let mut dash = false;
                 for c in &ch.ciphers {
                     if dash {
@@ -292,11 +330,12 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
                         dash = true;
                     }
                     ja3.push_str(&u16::from(*c).to_string());
+                    ja4.add_cipher_suite(*c);
                 }
                 ja3.push(',');
                 let ciphers = ch.ciphers;
-                let extv = quic_get_tls_extensions(ch.ext, &mut ja3, true);
-                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));
+                let extv = quic_get_tls_extensions(ch.ext, &mut ja3, Some(&mut ja4), true);
+                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3, ja4: Some(ja4) }));
             }
             ServerHello(sh) => {
                 let mut ja3 = String::with_capacity(256);
@@ -305,8 +344,8 @@ fn parse_quic_handshake(msg: TlsMessage) -> Option<Frame> {
                 ja3.push_str(&u16::from(sh.cipher).to_string());
                 ja3.push(',');
                 let ciphers = vec![sh.cipher];
-                let extv = quic_get_tls_extensions(sh.ext, &mut ja3, false);
-                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3 }));
+                let extv = quic_get_tls_extensions(sh.ext, &mut ja3, None, false);
+                return Some(Frame::Crypto(Crypto { ciphers, extv, ja3, ja4: None }));
             }
             _ => {}
         }

--- a/rust/src/quic/ja4.rs
+++ b/rust/src/quic/ja4.rs
@@ -119,7 +119,7 @@ impl JA4 {
     }
 
     pub fn add_signature_algorithm(&mut self, sigalgo: u16) {
-        if JA4::is_grease(u16::from(sigalgo)) {
+        if JA4::is_grease(sigalgo) {
             return;
         }
         self.signature_algorithms.push(sigalgo);
@@ -170,7 +170,7 @@ impl JA4 {
         let unsorted_sigalgostrings: Vec<String> = self
             .signature_algorithms
             .iter()
-            .map(|v| format!("{:04x}", u16::from(*v)))
+            .map(|v| format!("{:04x}", (*v)))
             .collect();
         let ja4_c2_raw = unsorted_sigalgostrings.join(",");
         let ja4_c_raw = format!("{}_{}", ja4_c1_raw, ja4_c2_raw);
@@ -241,12 +241,12 @@ mod tests {
         let mut alpn = "foobar".as_bytes();
         let mut len = alpn.len();
         let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
-        assert_eq!(JA4::is_grease(v), false);
+        assert!(!JA4::is_grease(v));
 
         alpn = &[0x0a, 0x00, 0x0a];
         len = alpn.len();
         let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
-        assert_eq!(JA4::is_grease(v), true);
+        assert!(JA4::is_grease(v));
     }
 
     #[test]

--- a/rust/src/quic/ja4.rs
+++ b/rust/src/quic/ja4.rs
@@ -1,0 +1,301 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+*
+* You can copy, redistribute or modify this Program under the terms of
+* the GNU General Public License version 2 as published by the Free
+* Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* version 2 along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+* 02110-1301, USA.
+
+// Author: Sascha Steinbiss <sascha@steinbiss.name>
+
+*/
+
+use digest::Digest;
+use sha2::Sha256;
+use std::{ffi::CStr, os::raw::c_char};
+use tls_parser::{TlsCipherSuiteID, TlsExtensionType, TlsVersion};
+
+#[derive(Debug, PartialEq)]
+pub struct JA4 {
+    tls_version: Option<TlsVersion>,
+    ciphersuites: Vec<TlsCipherSuiteID>,
+    extensions: Vec<TlsExtensionType>,
+    signature_algorithms: Vec<u16>,
+    domain: bool,
+    alpn: [char; 2],
+    quic: bool,
+    nof_exts: u16,
+    nof_ciphers: u16,
+}
+
+impl JA4 {
+    #[inline]
+    fn is_grease(val: u16) -> bool {
+        match val {
+            0x0a0a | 0x1a1a | 0x2a2a | 0x3a3a | 0x4a4a | 0x5a5a | 0x6a6a | 0x7a7a | 0x8a8a
+            | 0x9a9a | 0xaaaa | 0xbaba | 0xcaca | 0xdada | 0xeaea | 0xfafa => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn version_to_ja4code(val: Option<TlsVersion>) -> &'static str {
+        match val {
+            Some(TlsVersion::Tls13) => "13",
+            Some(TlsVersion::Tls12) => "12",
+            Some(TlsVersion::Tls11) => "11",
+            Some(TlsVersion::Tls10) => "10",
+            Some(TlsVersion::Ssl30) => "s3",
+            // the TLS parser does not support SSL 1.0 and 2.0 hence no
+            // support for "s1"/"s2"
+            _ => "00",
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            tls_version: None,
+            ciphersuites: Vec::with_capacity(20),
+            extensions: Vec::with_capacity(20),
+            signature_algorithms: Vec::with_capacity(20),
+            domain: false,
+            alpn: ['0', '0'],
+            quic: false,
+            nof_exts: 0,
+            nof_ciphers: 0,
+        }
+    }
+
+    pub fn set_quic(&mut self) {
+        self.quic = true;
+    }
+
+    pub fn set_tls_version(&mut self, version: TlsVersion) {
+        if JA4::is_grease(u16::from(version)) {
+            return;
+        }
+        self.tls_version = Some(version);
+    }
+
+    pub fn set_alpn(&mut self, alpn: &[u8], len: usize) {
+        if len > 1 && alpn.len() > 1 {
+            let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
+            if JA4::is_grease(v) {
+                return;
+            }
+            self.alpn[0] = char::from(alpn[0]);
+            self.alpn[1] = char::from(alpn[len - 1]);
+        }
+    }
+
+    pub fn add_cipher_suite(&mut self, cipher: TlsCipherSuiteID) {
+        if JA4::is_grease(u16::from(cipher)) {
+            return;
+        }
+        self.ciphersuites.push(cipher);
+        self.nof_ciphers += 1;
+    }
+
+    pub fn add_extension(&mut self, ext: TlsExtensionType) {
+        if JA4::is_grease(u16::from(ext)) {
+            return;
+        }
+        if ext != TlsExtensionType::ApplicationLayerProtocolNegotiation
+            && ext != TlsExtensionType::ServerName
+        {
+            self.extensions.push(ext);
+        } else if ext == TlsExtensionType::ServerName {
+            self.domain = true;
+        }
+        self.nof_exts += 1;
+    }
+
+    pub fn add_signature_algorithm(&mut self, sigalgo: u16) {
+        if JA4::is_grease(u16::from(sigalgo)) {
+            return;
+        }
+        self.signature_algorithms.push(sigalgo);
+    }
+
+    pub fn get_hash(&self) -> String {
+        // Calculate JA4_a
+        let ja4_a = format!(
+            "{proto}{version}{sni}{nof_c:02}{nof_e:02}{al1}{al2}",
+            proto = if self.quic { "q" } else { "t" },
+            version = JA4::version_to_ja4code(self.tls_version),
+            sni = if self.domain { "d" } else { "i" },
+            nof_c = if self.nof_ciphers > 99 {
+                99
+            } else {
+                self.nof_ciphers
+            },
+            nof_e = if self.nof_exts > 99 {
+                99
+            } else {
+                self.nof_exts
+            },
+            al1 = self.alpn[0],
+            al2 = self.alpn[1]
+        );
+
+        // Calculate JA4_b
+        let mut sorted_ciphers = self.ciphersuites.to_vec();
+        sorted_ciphers.sort_by(|a, b| u16::from(*a).cmp(&u16::from(*b)));
+        let sorted_cipherstrings: Vec<String> = sorted_ciphers
+            .iter()
+            .map(|v| format!("{:04x}", u16::from(*v)))
+            .collect();
+        let mut sha = Sha256::new();
+        let ja4_b_raw = sorted_cipherstrings.join(",");
+        sha.update(&ja4_b_raw);
+        let mut ja4_b = format!("{:x}", sha.finalize_reset());
+        ja4_b.truncate(12);
+
+        // Calculate JA4_c
+        let mut sorted_exts = self.extensions.to_vec();
+        sorted_exts.sort_by(|a, b| u16::from(*a).cmp(&u16::from(*b)));
+        let sorted_extstrings: Vec<String> = sorted_exts
+            .iter()
+            .map(|v| format!("{:04x}", u16::from(*v)))
+            .collect();
+        let ja4_c1_raw = sorted_extstrings.join(",");
+        let unsorted_sigalgostrings: Vec<String> = self
+            .signature_algorithms
+            .iter()
+            .map(|v| format!("{:04x}", u16::from(*v)))
+            .collect();
+        let ja4_c2_raw = unsorted_sigalgostrings.join(",");
+        let ja4_c_raw = format!("{}_{}", ja4_c1_raw, ja4_c2_raw);
+        sha.update(&ja4_c_raw);
+        let mut ja4_c = format!("{:x}", sha.finalize());
+        ja4_c.truncate(12);
+
+        return format!("{}_{}_{}", ja4_a, ja4_b, ja4_c);
+    }
+}
+
+pub struct SCJA4(JA4);
+
+#[no_mangle]
+pub extern "C" fn SCJA4New() -> *mut SCJA4 {
+    let j = Box::new(SCJA4(JA4::new()));
+    Box::into_raw(j)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4SetTLSVersion(j: &mut SCJA4, version: u16) {
+    j.0.set_tls_version(TlsVersion(version));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4AddCipher(j: &mut SCJA4, cipher: u16) {
+    j.0.add_cipher_suite(TlsCipherSuiteID(cipher));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4AddExtension(j: &mut SCJA4, ext: u16) {
+    j.0.add_extension(TlsExtensionType(ext));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4AddSigAlgo(j: &mut SCJA4, sigalgo: u16) {
+    j.0.add_signature_algorithm(sigalgo);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4SetALPN(j: &mut SCJA4, proto: *const c_char, len: u16) {
+    let c_str = CStr::from_ptr(proto);
+    j.0.set_alpn(c_str.to_bytes(), len as usize);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4GetHash(j: &mut SCJA4, out: *mut c_char, len: u8) -> i32 {
+    let hash = j.0.get_hash();
+    if crate::ffi::strings::copy_to_c_char(hash, out, len as usize) {
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4Free(j: &mut SCJA4) {
+    let _ja4: Box<SCJA4> = Box::from_raw(j);
+    // this should now be dropped when it goes out of scope
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ja4_is_grease() {
+        let mut alpn = "foobar".as_bytes();
+        let mut len = alpn.len();
+        let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
+        assert_eq!(JA4::is_grease(v), false);
+
+        alpn = &[0x0a, 0x00, 0x0a];
+        len = alpn.len();
+        let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
+        assert_eq!(JA4::is_grease(v), true);
+    }
+
+    #[test]
+    fn test_gethash() {
+        let mut j = JA4::new();
+
+        // the empty JA4 hash
+        let s = j.get_hash();
+        assert_eq!(s, "t00i000000_e3b0c44298fc_d2e2adf7177b");
+
+        // set TLS version
+        j.set_tls_version(TlsVersion::Tls12);
+        let s = j.get_hash();
+        assert_eq!(s, "t12i000000_e3b0c44298fc_d2e2adf7177b");
+
+        // set QUIC
+        j.set_quic();
+        let s = j.get_hash();
+        assert_eq!(s, "q12i000000_e3b0c44298fc_d2e2adf7177b");
+
+        // set GREASE extension, should be ignored
+        j.add_extension(TlsExtensionType(0x0a0a));
+        let s = j.get_hash();
+        assert_eq!(s, "q12i000000_e3b0c44298fc_d2e2adf7177b");
+
+        // set SNI extension, should only increase count and change i->d
+        j.add_extension(TlsExtensionType(0x0000));
+        let s = j.get_hash();
+        assert_eq!(s, "q12d000100_e3b0c44298fc_d2e2adf7177b");
+
+        // set ALPN extension, should only increase count and set end of JA4_a
+        j.set_alpn(b"h3-16", 5);
+        j.add_extension(TlsExtensionType::ApplicationLayerProtocolNegotiation);
+        let s = j.get_hash();
+        assert_eq!(s, "q12d0002h6_e3b0c44298fc_d2e2adf7177b");
+
+        // set some ciphers
+        j.add_cipher_suite(TlsCipherSuiteID(0x1111));
+        j.add_cipher_suite(TlsCipherSuiteID(0x0a20));
+        j.add_cipher_suite(TlsCipherSuiteID(0xbada));
+        let s = j.get_hash();
+        assert_eq!(s, "q12d0302h6_f500716053f9_d2e2adf7177b");
+
+        // set some extensions and signature algorithms
+        j.add_extension(TlsExtensionType(0xface));
+        j.add_extension(TlsExtensionType(0x0121));
+        j.add_extension(TlsExtensionType(0x1234));
+        j.add_signature_algorithm(0x6666);
+        let s = j.get_hash();
+        assert_eq!(s, "q12d0305h6_f500716053f9_2debc8880bae");
+    }
+}

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -122,6 +122,11 @@ fn log_template(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonEr
         js.set_string("string", ja3)?;
         js.close()?;
     }
+
+    if let Some(ref ja4) =  &tx.ja4 {
+            js.set_string("ja4", ja4)?;
+    }
+
     if !tx.extv.is_empty() {
         js.open_array("extensions")?;
         for e in &tx.extv {

--- a/rust/src/quic/mod.rs
+++ b/rust/src/quic/mod.rs
@@ -20,6 +20,7 @@ mod cyu;
 pub mod detect;
 mod error;
 mod frames;
+mod ja4;
 mod logger;
 mod parser;
 pub mod quic;

--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::applayer::{self, *};
 use crate::core::{AppProto, Flow, ALPROTO_FAILED, ALPROTO_UNKNOWN, IPPROTO_UDP, Direction};
-use std::collections::VecDeque;
+use std::{collections::VecDeque};
 use std::ffi::CString;
 use tls_parser::TlsExtensionType;
 
@@ -48,6 +48,7 @@ pub struct QuicTransaction {
     pub ua: Option<Vec<u8>>,
     pub extv: Vec<QuicTlsExtension>,
     pub ja3: Option<String>,
+    pub ja4: Option<String>,
     pub client: bool,
     tx_data: AppLayerTxData,
 }
@@ -55,7 +56,7 @@ pub struct QuicTransaction {
 impl QuicTransaction {
     fn new(
         header: QuicHeader, data: QuicData, sni: Option<Vec<u8>>, ua: Option<Vec<u8>>,
-        extv: Vec<QuicTlsExtension>, ja3: Option<String>, client: bool,
+        extv: Vec<QuicTlsExtension>, ja3: Option<String>, ja4: Option<String>, client: bool,
     ) -> Self {
 	let direction = if client { Direction::ToServer } else { Direction::ToClient };
         let cyu = Cyu::generate(&header, &data.frames);
@@ -67,6 +68,7 @@ impl QuicTransaction {
             ua,
             extv,
             ja3,
+            ja4,
             client,
             tx_data: AppLayerTxData::for_direction(direction),
         }
@@ -82,6 +84,7 @@ impl QuicTransaction {
             ua: None,
             extv: Vec::new(),
             ja3: None,
+            ja4: None,
             client,
             tx_data: AppLayerTxData::for_direction(direction),
         }
@@ -132,9 +135,9 @@ impl QuicState {
 
     fn new_tx(
         &mut self, header: QuicHeader, data: QuicData, sni: Option<Vec<u8>>, ua: Option<Vec<u8>>,
-        extb: Vec<QuicTlsExtension>, ja3: Option<String>, client: bool,
+        extb: Vec<QuicTlsExtension>, ja3: Option<String>, ja4: Option<String>, client: bool,
     ) {
-        let mut tx = QuicTransaction::new(header, data, sni, ua, extb, ja3, client);
+        let mut tx = QuicTransaction::new(header, data, sni, ua, extb, ja3, ja4, client);
         self.max_tx_id += 1;
         tx.tx_id = self.max_tx_id;
         self.transactions.push_back(tx);
@@ -212,6 +215,7 @@ impl QuicState {
         let mut sni: Option<Vec<u8>> = None;
         let mut ua: Option<Vec<u8>> = None;
         let mut ja3: Option<String> = None;
+        let mut ja4: Option<String> = None;
         let mut extv: Vec<QuicTlsExtension> = Vec::new();
         for frame in &data.frames {
             match frame {
@@ -231,6 +235,14 @@ impl QuicState {
                 }
                 Frame::Crypto(c) => {
                     ja3 = Some(c.ja3.clone());
+                    // we only do client fingerprints for now
+                    if to_server {
+                        // our hash is complete, let's only use strings from
+                        // now on
+                        if let Some(ref rja4) = c.ja4 {
+                            ja4 = Some(rja4.get_hash());
+                        }
+                    }
                     for e in &c.extv {
                         if e.etype == TlsExtensionType::ServerName && !e.values.is_empty() {
                             sni = Some(e.values[0].to_vec());
@@ -246,7 +258,7 @@ impl QuicState {
                 _ => {}
             }
         }
-        self.new_tx(header, data, sni, ua, extv, ja3, to_server);
+        self.new_tx(header, data, sni, ua, extv, ja3, ja4, to_server);
     }
 
     fn set_event_notx(&mut self, event: QuicEvent, header: QuicHeader, client: bool) {
@@ -302,6 +314,7 @@ impl QuicState {
                             None,
                             None,
                             Vec::new(),
+                            None,
                             None,
                             to_server,
                         );

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -143,8 +143,9 @@ enum {
     ERR_EXTRACT_VALIDITY,
 };
 
-/* JA3 fingerprints are disabled by default */
+/* JA3 and JA4 fingerprints are disabled by default */
 #define SSL_CONFIG_DEFAULT_JA3 0
+#define SSL_CONFIG_DEFAULT_JA4 0
 
 enum SslConfigEncryptHandling {
     SSL_CNF_ENC_HANDLE_DEFAULT = 0, /**< disable raw content, continue tracking */
@@ -154,10 +155,12 @@ enum SslConfigEncryptHandling {
 
 typedef struct SslConfig_ {
     enum SslConfigEncryptHandling encrypt_mode;
-    /** dynamic setting for ja3: can be enabled on demand if not explicitly
-     *  disabled. */
+    /** dynamic setting for ja3 and ja4: can be enabled on demand if not
+     *  explicitly disabled. */
     SC_ATOMIC_DECLARE(int, enable_ja3);
     bool disable_ja3; /**< ja3 explicitly disabled. Don't enable on demand. */
+    SC_ATOMIC_DECLARE(int, enable_ja4);
+    bool disable_ja4; /**< ja4 explicitly disabled. Don't enable on demand. */
 } SslConfig;
 
 SslConfig ssl_config;
@@ -691,6 +694,10 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
     uint16_t version = (uint16_t)(*input << 8) | *(input + 1);
     ssl_state->curr_connp->version = version;
 
+    if (SC_ATOMIC_GET(ssl_config.enable_ja4) && ssl_state->curr_connp->ja4 != NULL) {
+        SCJA4SetTLSVersion(ssl_state->curr_connp->ja4, version);
+    }
+
     /* TLSv1.3 draft1 to draft21 use the version field as earlier TLS
        versions, instead of using the supported versions extension. */
     if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
@@ -834,37 +841,48 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
         goto invalid_length;
     }
 
-    if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
-        JA3Buffer *ja3_cipher_suites = Ja3BufferInit();
-        if (ja3_cipher_suites == NULL)
-            return -1;
+    if (SC_ATOMIC_GET(ssl_config.enable_ja3) || SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        JA3Buffer *ja3_cipher_suites = NULL;
+
+        if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+            ja3_cipher_suites = Ja3BufferInit();
+            if (ja3_cipher_suites == NULL)
+                return -1;
+        }
 
         uint16_t processed_len = 0;
         /* coverity[tainted_data] */
         while (processed_len < cipher_suites_length)
         {
-            if (!(HAS_SPACE(2))) {
-                Ja3BufferFree(&ja3_cipher_suites);
-                goto invalid_length;
+            if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+                if (!(HAS_SPACE(2))) {
+                    Ja3BufferFree(&ja3_cipher_suites);
+                    goto invalid_length;
+                }
             }
 
             uint16_t cipher_suite = (uint16_t)(*input << 8) | *(input + 1);
             input += 2;
 
             if (TLSDecodeValueIsGREASE(cipher_suite) != 1) {
-                int rc = Ja3BufferAddValue(&ja3_cipher_suites, cipher_suite);
-                if (rc != 0) {
-                    return -1;
+                if (SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+                    SCJA4AddCipher(ssl_state->curr_connp->ja4, cipher_suite);
+                }
+                if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+                    int rc = Ja3BufferAddValue(&ja3_cipher_suites, cipher_suite);
+                    if (rc != 0) {
+                        return -1;
+                    }
                 }
             }
-
             processed_len += 2;
         }
 
-        int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                   &ja3_cipher_suites);
-        if (rc == -1) {
-            return -1;
+        if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+            int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_cipher_suites);
+            if (rc == -1) {
+                return -1;
+            }
         }
 
     } else {
@@ -1025,6 +1043,9 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
             uint16_t ver = (uint16_t)(input[i] << 8) | input[i + 1];
             if (TLSVersionValid(ver)) {
                 ssl_state->curr_connp->version = ver;
+                if (ssl_state->curr_connp->ja4 != NULL) {
+                    SCJA4SetTLSVersion(ssl_state->curr_connp->ja4, ver);
+                }
                 break;
             }
             i += 2;
@@ -1171,6 +1192,98 @@ invalid_length:
     return -1;
 }
 
+static inline int TLSDecodeHSHelloExtensionSigAlgorithms(
+        SSLState *ssl_state, const uint8_t *const initial_input, const uint32_t input_len)
+{
+    const uint8_t *input = initial_input;
+
+    /* Empty extension */
+    if (input_len == 0)
+        return 0;
+
+    if (!(HAS_SPACE(2)))
+        goto invalid_length;
+
+    uint16_t sigalgo_len = (uint16_t)(*input << 8) | *(input + 1);
+    input += 2;
+
+    if (!(HAS_SPACE(sigalgo_len)))
+        goto invalid_length;
+
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+            SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        uint16_t sigalgo_processed_len = 0;
+        /* coverity[tainted_data] */
+        while (sigalgo_processed_len < sigalgo_len) {
+            uint16_t sigalgo = (uint16_t)(*input << 8) | *(input + 1);
+            input += 2;
+            sigalgo_processed_len += 2;
+
+            SCJA4AddSigAlgo(ssl_state->curr_connp->ja4, sigalgo);
+        }
+    } else {
+        /* Skip signature algorithms */
+        input += sigalgo_len;
+    }
+
+    return (input - initial_input);
+
+invalid_length:
+    SCLogDebug("Signature algorithm list invalid length");
+    SSLSetEvent(ssl_state, TLS_DECODER_EVENT_HANDSHAKE_INVALID_LENGTH);
+
+    return -1;
+}
+
+static inline int TLSDecodeHSHelloExtensionALPN(
+        SSLState *ssl_state, const uint8_t *const initial_input, const uint32_t input_len)
+{
+    const uint8_t *input = initial_input;
+
+    /* Empty extension */
+    if (input_len == 0)
+        return 0;
+
+    if (!(HAS_SPACE(2)))
+        goto invalid_length;
+
+    uint16_t alpn_len = (uint16_t)(*input << 8) | *(input + 1);
+    input += 2;
+
+    if (!(HAS_SPACE(alpn_len)))
+        goto invalid_length;
+
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
+            SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        uint16_t alpn_processed_len = 0;
+        /* coverity[tainted_data] */
+        while (alpn_processed_len < alpn_len) {
+            uint8_t protolen = *input;
+            input += 1;
+            alpn_processed_len += 1;
+
+            /* we only want the first value for JA4 */
+            if (alpn_processed_len == 1) {
+                SCJA4SetALPN(ssl_state->curr_connp->ja4, (const char *)input, protolen);
+            }
+
+            alpn_processed_len += protolen;
+            input += protolen;
+        }
+    } else {
+        /* Skip ALPN protocols */
+        input += alpn_len;
+    }
+
+    return (input - initial_input);
+
+invalid_length:
+    SCLogDebug("ALPN list invalid length");
+    SSLSetEvent(ssl_state, TLS_DECODER_EVENT_HANDSHAKE_INVALID_LENGTH);
+
+    return -1;
+}
+
 static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                                          const uint8_t * const initial_input,
                                          const uint32_t input_len)
@@ -1180,6 +1293,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
     int ret;
     int rc;
     const bool ja3 = (SC_ATOMIC_GET(ssl_config.enable_ja3) == 1);
+    const bool ja4 = (SC_ATOMIC_GET(ssl_config.enable_ja4) == 1);
 
     JA3Buffer *ja3_extensions = NULL;
     JA3Buffer *ja3_elliptic_curves = NULL;
@@ -1272,6 +1386,28 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
                 break;
             }
 
+            case SSL_EXTENSION_SIGNATURE_ALGORITHMS: {
+                /* coverity[tainted_data] */
+                ret = TLSDecodeHSHelloExtensionSigAlgorithms(ssl_state, input, ext_len);
+                if (ret < 0)
+                    goto end;
+
+                input += ret;
+
+                break;
+            }
+
+            case SSL_EXTENSION_ALPN: {
+                /* coverity[tainted_data] */
+                ret = TLSDecodeHSHelloExtensionALPN(ssl_state, input, ext_len);
+                if (ret < 0)
+                    goto end;
+
+                input += ret;
+
+                break;
+            }
+
             case SSL_EXTENSION_EARLY_DATA:
             {
                 if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
@@ -1325,6 +1461,12 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
             }
         }
 
+        if (ja4) {
+            if (TLSDecodeValueIsGREASE(ext_type) != 1) {
+                SCJA4AddExtension(ssl_state->curr_connp->ja4, ext_type);
+            }
+        }
+
         processed_len += ext_len + 4;
     }
 
@@ -1372,6 +1514,10 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
 {
     int ret;
     uint32_t parsed = 0;
+
+    if (SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+        ssl_state->curr_connp->ja4 = SCJA4New();
+    }
 
     ret = TLSDecodeHSHelloVersion(ssl_state, input, input_len);
     if (ret < 0)
@@ -2697,6 +2843,8 @@ static void SSLStateFree(void *p)
     if (ssl_state->server_connp.session_id)
         SCFree(ssl_state->server_connp.session_id);
 
+    if (ssl_state->client_connp.ja4)
+        SCJA4Free(ssl_state->client_connp.ja4);
     if (ssl_state->client_connp.ja3_str)
         Ja3BufferFree(&ssl_state->client_connp.ja3_str);
     if (ssl_state->client_connp.ja3_hash)
@@ -3063,6 +3211,20 @@ void RegisterSSLParsers(void)
             enable_ja3 = true;
         }
         SC_ATOMIC_SET(ssl_config.enable_ja3, enable_ja3);
+
+        /* Check if we should generate JA4 fingerprints */
+        int enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        if (ConfGet("app-layer.protocols.tls.ja4-fingerprints", &strval) != 1) {
+            enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        } else if (strcmp(strval, "auto") == 0) {
+            enable_ja4 = SSL_CONFIG_DEFAULT_JA4;
+        } else if (ConfValIsFalse(strval)) {
+            enable_ja4 = 0;
+            ssl_config.disable_ja4 = true;
+        } else if (ConfValIsTrue(strval)) {
+            enable_ja4 = true;
+        }
+        SC_ATOMIC_SET(ssl_config.enable_ja4, enable_ja4);
 
         if (g_disable_hashing) {
             if (SC_ATOMIC_GET(ssl_config.enable_ja3)) {

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -141,6 +141,8 @@ enum {
 #define SSL_EXTENSION_SNI                       0x0000
 #define SSL_EXTENSION_ELLIPTIC_CURVES           0x000a
 #define SSL_EXTENSION_EC_POINT_FORMATS          0x000b
+#define SSL_EXTENSION_SIGNATURE_ALGORITHMS      0x000d
+#define SSL_EXTENSION_ALPN                      0x0010
 #define SSL_EXTENSION_SESSION_TICKET            0x0023
 #define SSL_EXTENSION_EARLY_DATA                0x002a
 #define SSL_EXTENSION_SUPPORTED_VERSIONS        0x002b
@@ -266,6 +268,8 @@ typedef struct SSLStateConnp_ {
 
     JA3Buffer *ja3_str;
     char *ja3_hash;
+
+    SCJA4 *ja4;
 
     /* handshake tls fragmentation buffer. Handshake messages can be fragmented over multiple
      * TLS records. */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -76,6 +76,7 @@ SC_ATOMIC_EXTERN(unsigned int, cert_id);
 #define LOG_TLS_FIELD_CLIENT            (1 << 13) /**< client fields (issuer, subject, etc) */
 #define LOG_TLS_FIELD_CLIENT_CERT       (1 << 14)
 #define LOG_TLS_FIELD_CLIENT_CHAIN      (1 << 15)
+#define LOG_TLS_FIELD_JA4               (1 << 16)
 
 typedef struct {
     const char *name;
@@ -90,7 +91,7 @@ TlsFields tls_fields[] = { { "version", LOG_TLS_FIELD_VERSION },
     { "chain", LOG_TLS_FIELD_CHAIN }, { "session_resumed", LOG_TLS_FIELD_SESSION_RESUMED },
     { "ja3", LOG_TLS_FIELD_JA3 }, { "ja3s", LOG_TLS_FIELD_JA3S },
     { "client", LOG_TLS_FIELD_CLIENT }, { "client_certificate", LOG_TLS_FIELD_CLIENT_CERT },
-    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN }, { NULL, -1 } };
+    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN }, { "ja4", LOG_TLS_FIELD_JA4 }, { NULL, -1 } };
 
 typedef struct OutputTlsCtx_ {
     uint32_t flags;  /** Store mode */
@@ -207,6 +208,17 @@ static void JsonTlsLogJa3(JsonBuilder *js, SSLState *ssl_state)
         JsonTlsLogJa3String(js, ssl_state);
 
         jb_close(js);
+    }
+}
+
+static void JsonTlsLogSCJA4(JsonBuilder *js, SSLState *ssl_state)
+{
+    if (ssl_state->client_connp.ja4 != NULL) {
+        char buffer[37];
+        SCJA4GetHash(ssl_state->client_connp.ja4, buffer, 37);
+        buffer[36] = '\0';
+        /* JA4 hash has 36 characters */
+        jb_set_string(js, "ja4", buffer);
     }
 }
 
@@ -381,6 +393,10 @@ static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
     if (tls_ctx->fields & LOG_TLS_FIELD_JA3S)
         JsonTlsLogJa3S(js, ssl_state);
 
+    /* tls ja4 */
+    if (tls_ctx->fields & LOG_TLS_FIELD_JA4)
+        JsonTlsLogSCJA4(js, ssl_state);
+
     if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT) {
         const bool log_cert = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CERT) != 0;
         const bool log_chain = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CHAIN) != 0;
@@ -419,6 +435,9 @@ void JsonTlsLogJSONExtended(JsonBuilder *tjs, SSLState * state)
 
     /* tls ja3s */
     JsonTlsLogJa3S(tjs, state);
+
+    /* tls ja4 */
+    JsonTlsLogSCJA4(tjs, state);
 
     if (HasClientCert(&state->client_connp)) {
         jb_open_object(tjs, "client");

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -252,7 +252,7 @@ outputs:
             # session id
             #session-resumption: no
             # custom controls which TLS fields that are included in eve-log
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s]
+            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,
@@ -892,9 +892,10 @@ app-layer:
       detection-ports:
         dp: 443
 
-      # Generate JA3 fingerprint from client hello. If not specified it
+      # Generate JA3/JA4 fingerprints from client hello. If not specified it
       # will be disabled by default, but enabled if rules require it.
       #ja3-fingerprints: auto
+      #ja4-fingerprints: auto
 
       # What to do when the encrypted communications start:
       # - default: keep tracking TLS session, check for protocol anomalies,


### PR DESCRIPTION
Previous PR: #9536 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6379

Changes to previous PR:
- Rewrite JA4 calculation in Rust, eliminating the C implementation and re-enabling Rust unit tests.
- Add C bindings for the Rust functions to be used in the TLS parser.
- Add JA4 fields to schema.

```
SV_BRANCH=pr/1407
```
