### PR TITLE
docs: update advanced install & quickstart - v1

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -364,5 +364,9 @@ Suricata packages.
 Advanced Installation
 ---------------------
 
-Various installation guides for installing from GIT and for other operating systems are maintained at:
+If you are using Ubuntu, you can follow
+:doc:`devguide/codebase/contributing/installation-from-git`.
+
+For other various installation guides for installing from GIT and for other operating
+systems, please check (bear in mind that those may be somewhat outdated):
 https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Suricata_Installation

--- a/doc/userguide/quickstart.rst
+++ b/doc/userguide/quickstart.rst
@@ -11,6 +11,7 @@ It's assumed that you run a recent Ubuntu release as the official PPA can then
 be used for the installation. To install the latest stable Suricata version, follow
 the steps::
 
+    sudo apt-get install software-properties-common
     sudo add-apt-repository ppa:oisf/suricata-stable
     sudo apt update
     sudo apt install suricata jq


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none, minor updates

Changes that I noticed would be welcome, after some interactions with newcomers

Describe changes:
- link to our DevGuide's Installation from GitHub instructions
- add instruction to install software-properties-common to the quickstart section, too, just in case someone is not only new to Suri, but also to Ubuntu, when they arrive there

Split them into two commits in case we want to drop any of the changes.