### PR TITLE
detect: frees SigMatch when too many buffers

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -474,6 +474,8 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
             if (SignatureInitDataBufferCheckExpand(s) < 0) {
                 SCLogError("failed to expand rule buffer array");
                 s->init_data->init_flags |= SIG_FLAG_INIT_OVERFLOW;
+                SigMatchFree(de_ctx, new);
+                sigmatch_table[new->type].Free(de_ctx, new->ctx);
                 return;
             }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6104

Describe changes:
- detect: frees SigMatch when too many buffers

But now, instead of leaking memory, we risk use after free, as the caller is not aware these structures have been freed (see dsize for instance which will use `sm`)
But this is the only central place before some of the pointers get out of scope... 