### PR TITLE
Napatech: remove deprecated Hostbuffer Allowance (HBA) support

### DIFF
--- a/doc/userguide/capture-hardware/napatech.rst
+++ b/doc/userguide/capture-hardware/napatech.rst
@@ -391,14 +391,6 @@ that is being processed, the following counters will be output in stats.log:
 This is useful for fine-grain debugging to determine if a specific CPU core or
 thread is falling behind resulting in dropped packets.
 
-If hba is enabled the following counter will also be provided:
-
-- napa<streamid>.hba_drop: the number of packets dropped because the host buffer allowance high-water mark was reached.
-
-In addition to counters host buffer utilization is tracked and logged. This is also useful for
-debugging. Log messages are output for both Host and On-Board buffers when reach 25, 50, 75
-percent of utilization. Corresponding messages are output when utilization decreases.
-
 Debugging:
 
 For debugging configurations it is useful to see what traffic is flowing as well as what streams are
@@ -419,15 +411,6 @@ Napatech configuration options:
 These are the Napatech options available in the Suricata configuration file::
 
   napatech:
-    # The Host Buffer Allowance for all streams
-    # (-1 = OFF, 1 - 100 = percentage of the host buffer that can be held back)
-    # This may be enabled when sharing streams with another application.
-    # Otherwise, it should be turned off.
-    #
-    # Note: hba will be deprecated in Suricata 7
-    #
-    #hba: -1
-
     # When use_all_streams is set to "yes" the initialization code will query
     # the Napatech service for all configured streams and listen on all of them.
     # When set to "no" the streams config array will be used.
@@ -515,12 +498,6 @@ These are the Napatech options available in the Suricata configuration file::
     # This parameter has no effect if auto-config is disabled.
     #
     hashmode: hash5tuplesorted
-
-*Note: hba is useful only when a stream is shared with another application. When hba is enabled packets will be dropped
-(i.e. not delivered to Suricata) when the host-buffer utilization reaches the high-water mark indicated by the hba value.
-This insures that, should Suricata get behind in its packet processing, the other application will still receive all
-of the packets. If this is enabled without another application sharing the stream it will result in sub-optimal packet
-buffering.*
 
 Make sure that there are enough host-buffers declared in ``ntservice.ini`` to
 accommodate the number of cores/streams being used.

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -194,14 +194,6 @@ static void *NapatechConfigParser(const char *device)
         return NULL;
     }
 
-    /* Set the host buffer allowance for this stream
-     * Right now we just look at the global default - there is no per-stream hba configuration
-     */
-    if (ConfGetInt("napatech.hba", &conf->hba) == 0) {
-        conf->hba = -1;
-    } else {
-        SCLogWarning("Napatech Host Buffer Allocation (hba) will be deprecated in Suricata v7.0.");
-    }
     return (void *) conf;
 }
 
@@ -233,10 +225,6 @@ static int NapatechInit(int runmode)
                             SCCalloc(1, sizeof (struct NapatechStreamDevConf));
     if (unlikely(conf == NULL)) {
         FatalError("Failed to allocate memory for NAPATECH device.");
-    }
-
-    if ((ConfGetInt("napatech.hba", &conf->hba) != 0) && (conf->hba > 0)) {
-        SCLogInfo("Host Buffer Allowance: %d", (int) conf->hba);
     }
 
     if (use_hw_bypass) {

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -797,7 +797,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
     char error_buffer[100];
     uint64_t pkt_ts;
     NtNetBuf_t packet_buffer;
-    NapatechThreadVars *ntv = (NapatechThreadVars *) data;
+    NapatechThreadVars *ntv = (NapatechThreadVars *)data;
     int numa_node = -1;
     int set_cpu_affinity = 0;
     int closer = 0;
@@ -877,8 +877,8 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
 
     SCLogDebug("Opening NAPATECH Stream: %u for processing", ntv->stream_id);
 
-    if ((status = NT_NetRxOpen(&(ntv->rx_stream), "SuricataStream",
-            NT_NET_INTERFACE_PACKET, ntv->stream_id, -1)) != NT_SUCCESS) {
+    if ((status = NT_NetRxOpen(&(ntv->rx_stream), "SuricataStream", NT_NET_INTERFACE_PACKET,
+                 ntv->stream_id, -1)) != NT_SUCCESS) {
 
         NAPATECH_ERROR(status);
         SCFree(ntv);

--- a/src/source-napatech.h
+++ b/src/source-napatech.h
@@ -34,7 +34,6 @@ void TmModuleNapatechDecodeRegister(void);
 struct NapatechStreamDevConf
 {
     uint16_t stream_id;
-    intmax_t hba;
 };
 
 int NapatechSetPortmap(int port, int peer);


### PR DESCRIPTION
- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Remove deprecated Hostbuffer Allowance (HBA) support from Napatech plugin