### PR TITLE
docs: update readthedocs config to new options - v1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,9 @@
 # Required by Read The Docs
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 formats: all
-
-python:
-  version: "3.8"
-
-  # Use an empty install section to avoid RTD from picking up a non-python
-  # requirements.txt file.
-  install: []


### PR DESCRIPTION
Our documentation was failing to build (https://readthedocs.org/projects/suricata/builds/22112658/), seems connected to the new way of indicating build options (cf
https://readthedocs.org/projects/suricata/builds/22112658/, https://docs.readthedocs.io/en/stable/config-file/v2.html#build, and https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os).

Describe changes:
- Added the build.os required new field 
- adjusted the way python version is passed