### PR TITLE
docs: update readthedocs config to new options - v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,21 @@
 # Required by Read The Docs
 version: 2
 
-formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 
 python:
-  version: "3.8"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - sphinx-rtd-theme
 
-  # Use an empty install section to avoid RTD from picking up a non-python
-  # requirements.txt file.
-  install: []
+sphinx:
+  builder: html
+  configuration: doc/userguide/conf.py
+  fail_on_warning: false
+
+formats: all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,10 +8,7 @@ build:
 
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - sphinx-rtd-theme
+    - requirements: doc/userguide/requirements.txt
 
 sphinx:
   builder: html

--- a/doc/userguide/requirements.txt
+++ b/doc/userguide/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Previous PR: #9564 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: none

Describe changes from last PR:
- (re)add requirements.txt file for our userguide, as that seems to be one of the ways to pass extra dependencies to read the docs, now
- add sphinx configurations to `readthedocs.yaml`

Checked with my own instance of rtd and seems to work, this time: https://suri-rtd-test.readthedocs.io/en/rtd-yaml-update-v2/

Leaving this as draft, as I don't know if this is the style we want to follow...