### PR TITLE
docs: update readthedocs config to new options - v3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,18 @@
 # Required by Read The Docs
 version: 2
 
-formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 python:
-  version: "3.8"
+  install:
+    - requirements: doc/userguide/requirements.txt
 
-  # Use an empty install section to avoid RTD from picking up a non-python
-  # requirements.txt file.
-  install: []
+sphinx:
+  builder: html
+  configuration: doc/userguide/conf.py
+  fail_on_warning: false
+
+formats: all

--- a/doc/userguide/requirements.txt
+++ b/doc/userguide/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Our documentation was failing to build, seems connected to the new way of indicating build options (cf
https://readthedocs.org/projects/suricata/builds/22112658/, https://docs.readthedocs.io/en/stable/config-file/v2.html#build, and https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os).

Added the build.os required new field, and adjusted the way python version is passed.

For the new configuration style for read the docs, one of the ways to pass extra configuration for python is having a requirements file.

Previous PR: #9566 

Describe changes:
- Squash commits, 
- bump python version for RtD to 3.11
