### PR TITLE
detect-ssh-proto-version: use FAIL macros in tests

### DIFF
--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -286,12 +286,10 @@ static int DetectSshVersionTestParse01 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "1.0");
-    if (ssh != NULL && strncmp((char *) ssh->ver, "1.0", 3) == 0) {
-        DetectSshVersionFree(NULL, ssh);
-        return 1;
-    }
+    FAIL_IF_NOT(ssh != NULL && strncmp((char *) ssh->ver, "1.0", 3) == 0);
+    DetectSshVersionFree(NULL, ssh);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -302,12 +300,10 @@ static int DetectSshVersionTestParse02 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "2_compat");
-    if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
-        DetectSshVersionFree(NULL, ssh);
-        return 1;
-    }
+    FAIL_IF_NOT(ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT);
+    DetectSshVersionFree(NULL, ssh);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -318,27 +314,19 @@ static int DetectSshVersionTestParse03 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "2_com");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, "");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, ".1");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, "lalala");
+    FAIL_IF_NOT_NULL(ssh);
+
     if (ssh != NULL) {
         DetectSshVersionFree(NULL, ssh);
-        return 0;
     }
 
-    return 1;
+    PASS;
 }
 
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6337](https://redmine.openinfosecfoundation.org/issues/6337)

Describe changes:
- Updated the detect-ssh-proto-version tests to use new FAIL/PASS API
