### PR TITLE
Rust doc: add docstring to rust module files - v1

### DIFF
--- a/rust/src/applayertemplate/mod.rs
+++ b/rust/src/applayertemplate/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Application Layer template parser and logger.
+
 mod parser;
 pub mod template;
 /* TEMPLATE_START_REMOVE */

--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! ASN.1 Parser.
+
 use der_parser::ber::{parse_ber_recursive, BerObject, BerObjectContent, Tag};
 use nom7::Err;
 use std::convert::TryFrom;

--- a/rust/src/bittorrent_dht/mod.rs
+++ b/rust/src/bittorrent_dht/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! BitTorrent DHT Application Layer and Parser.
+
 pub mod bittorrent_dht;
 pub mod logger;
 pub mod parser;

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -1,3 +1,5 @@
+//! Utility Library for handling strings, hexadecimals and bytes.
+
 use super::build_slice;
 use crate::jsonbuilder::HEX;
 use std::ffi::CString;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Retrieves configuration details.
+
 use std::os::raw::c_char;
 use std::os::raw::c_void;
 use std::os::raw::c_int;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-// This file exposes items from the core "C" code to Rust.
+//! This file exposes items from the core "C" code to Rust.
 
 use std;
 use crate::filecontainer::*;

--- a/rust/src/dcerpc/mod.rs
+++ b/rust/src/dcerpc/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! DCE/RPC protocol Parser.
+
 pub mod dcerpc;
 pub mod dcerpc_udp;
 pub mod parser;

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Module for Rule parsing.
+
 pub mod byte_math;
 pub mod error;
 pub mod iprep;

--- a/rust/src/dhcp/mod.rs
+++ b/rust/src/dhcp/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! DHCP parser, decoder and logger.
+
 pub mod dhcp;
 pub mod parser;
 pub mod logger;

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! DNS parser and Application layer.
+
 pub mod detect;
 pub mod dns;
 pub mod log;

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Foreign Function Interface module for hashes(sha256, sha1, md5), base64 and strings.
+
 pub mod hashing;
 pub mod base64;
 pub mod strings;

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! This file handles File--related operations(Open, Append, Close).
+
 use std::ptr;
 use std::os::raw::{c_void};
 

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -28,6 +28,8 @@
  * The tracker does continue to follow the file.
  */
 
+//! Gap handling and Chunk-based file transfer tracker.
+
 use crate::core::*;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Rust API Implementation with C.
+
 use crate::applayer::StreamSlice;
 use crate::core::Flow;
 #[cfg(not(test))]

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! FTP parser and Application Layer.
+
 use nom7::bytes::complete::{tag, take_until};
 use nom7::character::complete::{digit1, multispace0};
 use nom7::combinator::{complete, map_res, opt, verify};

--- a/rust/src/http2/mod.rs
+++ b/rust/src/http2/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! HTTP/2 parser and Application Layer.
+
 #![allow(clippy::result_unit_err)]
 
 mod decompression;

--- a/rust/src/ike/mod.rs
+++ b/rust/src/ike/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! IKE parser and Application Layer.
+
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 extern crate ipsec_parser;

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+ //! JSON logger utility library.
+
 #![allow(clippy::missing_safety_doc)]
 
 use std::cmp::max;

--- a/rust/src/kerberos.rs
+++ b/rust/src/kerberos.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Kerberos Parser.
+
 use nom7::IResult;
 use nom7::error::{ErrorKind, ParseError};
 use nom7::number::streaming::le_u16;

--- a/rust/src/krb/mod.rs
+++ b/rust/src/krb/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Kerberos-v5 Application Layer.
+
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 pub mod krb5;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Library tree.
+
 #![cfg_attr(feature = "strict", deny(warnings))]
 
 // Allow these patterns as its a style we like.

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Logging utility.
+
 use std;
 use std::ffi::CString;
 use std::path::Path;

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Lua wrapper.
+
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::os::raw::c_long;

--- a/rust/src/lzma.rs
+++ b/rust/src/lzma.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! lzma decompression utility.
+
 use lzma_rs::decompress::{Options, Stream};
 use lzma_rs::error::Error;
 use std::io::{Cursor, Write};

--- a/rust/src/mime/mod.rs
+++ b/rust/src/mime/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! File mime parser.
+
 use crate::common::nom7::take_until_and_consume;
 use nom7::branch::alt;
 use nom7::bytes::streaming::{tag, take_until, take_while};

--- a/rust/src/modbus/mod.rs
+++ b/rust/src/modbus/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! modbus application layer parser and detection module.
+
 pub mod detect;
 pub mod log;
 pub mod modbus;

--- a/rust/src/mqtt/mod.rs
+++ b/rust/src/mqtt/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! MQQT Application layer parser.
+
 pub mod detect;
 pub mod logger;
 pub mod mqtt;

--- a/rust/src/nfs/mod.rs
+++ b/rust/src/nfs/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! NFS Application layer parsing, logging and detection module.
+
 pub mod types;
 pub mod rpc_records;
 pub mod nfs_records;

--- a/rust/src/ntp/mod.rs
+++ b/rust/src/ntp/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! NTP Application layer parser.
+
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 pub mod ntp;

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Bootstrap plugin utility module.
+
 pub fn init() {
     unsafe {
         let context = super::core::SCGetContext();

--- a/rust/src/quic/mod.rs
+++ b/rust/src/quic/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! QUIC Application layer parser and logging module.
+
 mod crypto;
 mod cyu;
 pub mod detect;

--- a/rust/src/rfb/mod.rs
+++ b/rust/src/rfb/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! RFB protocol parser.
+
 // Author: Frank Honza <frank.honza@dcso.de>
 
 pub mod detect;

--- a/rust/src/sip/mod.rs
+++ b/rust/src/sip/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! SIP protocol parsing and logging module.
+
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
 pub mod detect;

--- a/rust/src/smb/mod.rs
+++ b/rust/src/smb/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! SMB Application layer and parser.
+
 pub mod error;
 pub mod smb_records;
 pub mod smb_status;

--- a/rust/src/snmp/mod.rs
+++ b/rust/src/snmp/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! SNMP Application Layer, parser and logger.
+
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 extern crate snmp_parser;

--- a/rust/src/ssh/mod.rs
+++ b/rust/src/ssh/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! SSH Application Layer, logger and Parser.
+
 pub mod detect;
 pub mod logger;
 mod parser;

--- a/rust/src/telnet/mod.rs
+++ b/rust/src/telnet/mod.rs
@@ -15,5 +15,7 @@
  * 02110-1301, USA.
  */
 
+//! telnet application layer and parser.
+
 pub mod telnet;
 mod parser;

--- a/rust/src/tftp/mod.rs
+++ b/rust/src/tftp/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! TFTP Parser, logger and application layer.
+
 // written by Clément Galland <clement.galland@epita.fr>
 
 pub mod tftp;

--- a/rust/src/util.rs
+++ b/rust/src/util.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! Utility to test strings for valid UTF-8.
+
 use std::ffi::CStr;
 use std::os::raw::c_char;
 

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+//! X.509 certificates parser and decoder for SSL/TLS.
+
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::common::rust_string_to_c;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/4584

Describe changes:

- Added docstrings for the short descriptions of Rust module files.