### PR TITLE
dpdk: add interrupt (power-saving) mode v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -111,6 +111,7 @@ static void *ParseDpdkConfigAndConfigureDevice(const char *iface);
 static void DPDKDerefConfig(void *conf);
 
 #define DPDK_CONFIG_DEFAULT_THREADS                     "auto"
+#define DPDK_CONFIG_DEFAULT_POWER_SAVING_MODE           0
 #define DPDK_CONFIG_DEFAULT_MEMPOOL_SIZE                65535
 #define DPDK_CONFIG_DEFAULT_MEMPOOL_CACHE_SIZE          "auto"
 #define DPDK_CONFIG_DEFAULT_RX_DESCRIPTORS              1024
@@ -126,6 +127,7 @@ static void DPDKDerefConfig(void *conf);
 
 DPDKIfaceConfigAttributes dpdk_yaml = {
     .threads = "threads",
+    .power_saving = "power-saving",
     .promisc = "promisc",
     .multicast = "multicast",
     .checksum_checks = "checksum-checks",
@@ -434,6 +436,15 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
     SCReturnInt(0);
 }
 
+static bool ConfigSetPowerSavingMode(DPDKIfaceConfig *iconf, int entry_bool)
+{
+    SCEnter();
+    if (entry_bool)
+        iconf->flags |= DPDK_POWER_SAVE;
+
+    SCReturnBool(true);
+}
+
 static int ConfigSetRxQueues(DPDKIfaceConfig *iconf, uint16_t nb_queues)
 {
     SCEnter();
@@ -694,6 +705,13 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
                      : ConfigSetThreads(iconf, entry_str);
     if (retval < 0)
         SCReturnInt(retval);
+
+    retval = ConfGetChildValueBoolWithDefault(
+                     if_root, if_default, dpdk_yaml.power_saving, &entry_bool) != 1
+                     ? ConfigSetPowerSavingMode(iconf, DPDK_CONFIG_DEFAULT_POWER_SAVING_MODE)
+                     : ConfigSetPowerSavingMode(iconf, entry_bool);
+    if (retval != true)
+        SCReturnInt(-EINVAL);
 
     // currently only mapping "1 thread == 1 RX (and 1 TX queue in IPS mode)" is supported
     retval = ConfigSetRxQueues(iconf, (uint16_t)iconf->threads);
@@ -1105,6 +1123,11 @@ static void DeviceInitPortConf(const DPDKIfaceConfig *iconf,
                     .offloads = 0,
             },
     };
+
+    if (iconf->flags & DPDK_POWER_SAVE) {
+        SCLogConfig("Switching to interrupt (power-saving) mode");
+        port_conf->intr_conf.rxq = 1;
+    }
 
     // configure RX offloads
     if (dev_info->rx_offload_capa & RTE_ETH_RX_OFFLOAD_RSS_HASH) {

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -25,6 +25,7 @@
 
 typedef struct DPDKIfaceConfigAttributes_ {
     const char *threads;
+    const char *power_saving;
     const char *promisc;
     const char *multicast;
     const char *checksum_checks;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -36,8 +36,9 @@ typedef enum { DPDK_COPY_MODE_NONE, DPDK_COPY_MODE_TAP, DPDK_COPY_MODE_IPS } Dpd
 
 /* DPDK Flags */
 // General flags
-#define DPDK_PROMISC   (1 << 0) /**< Promiscuous mode */
-#define DPDK_MULTICAST (1 << 1) /**< Enable multicast packets */
+#define DPDK_PROMISC    (1 << 0) /**< Promiscuous mode */
+#define DPDK_MULTICAST  (1 << 1) /**< Enable multicast packets */
+#define DPDK_POWER_SAVE (1 << 2) /**< Power-saving mode */
 // Offloads
 #define DPDK_RX_CHECKSUM_OFFLOAD (1 << 4) /**< Enable chsum offload */
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -753,6 +753,7 @@ dpdk:
       # - auto takes all cores
       # in IPS mode it is required to specify the number of cores and the numbers on both interfaces must match
       threads: auto
+      power-saving: no # yes to switch to interrupt mode 
       promisc: true # promiscuous mode - capture all packets
       multicast: true # enables also detection on multicast packets
       checksum-checks: true # if Suricata should validate checksums


### PR DESCRIPTION
When the packet load is low, Suricata can run in interrupt mode. This resembles the classic approach of processing packets - CPU cores run low and only fetch packets on interrupt.

Ticket: #5839

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5839) ticket:

Describe changes:
- add interrupt mode 

Works in both IDS and IPS runmode. Also, it is possible to run one interface in polling mode and the other in interrupt mode. 