### PR TITLE
Filestore master6 6388 v1 (no backport)

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -22,7 +22,7 @@ decompression = ["flate2", "brotli"]
 [dependencies]
 nom = "~ 5.1.3"
 bitflags = "~1.2.1"
-byteorder = "1.3"
+byteorder = "~1.3"
 uuid = "0.8"
 crc = "1.8"
 memchr = "~ 2.3"

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -107,7 +107,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
                 ((s->flags & HTP_FLAG_STORE_FILES_TX_TC) && txid == s->store_tx_id)) {
             flags |= FILE_STORE;
             flags &= ~FILE_NOSTORE;
-        } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TC)) {
+        } else if (s->f->file_flags & FLOWFILE_NO_STORE_TC) {
             flags |= FILE_NOSTORE;
         }
 
@@ -129,7 +129,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
                 ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
             flags |= FILE_STORE;
             flags &= ~FILE_NOSTORE;
-        } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TS)) {
+        } else if (s->f->file_flags & FLOWFILE_NO_STORE_TS) {
             flags |= FILE_NOSTORE;
         }
 

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -103,8 +103,8 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
 
         flags = FileFlowToFlags(s->f, STREAM_TOCLIENT);
 
-        if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
-                ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
+        if ((s->flags & HTP_FLAG_STORE_FILES_TC) ||
+                ((s->flags & HTP_FLAG_STORE_FILES_TX_TC) && txid == s->store_tx_id)) {
             flags |= FILE_STORE;
             flags &= ~FILE_NOSTORE;
         } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TC)) {
@@ -125,8 +125,8 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
         files = s->files_ts;
 
         flags = FileFlowToFlags(s->f, STREAM_TOSERVER);
-        if ((s->flags & HTP_FLAG_STORE_FILES_TC) ||
-                ((s->flags & HTP_FLAG_STORE_FILES_TX_TC) && txid == s->store_tx_id)) {
+        if ((s->flags & HTP_FLAG_STORE_FILES_TS) ||
+                ((s->flags & HTP_FLAG_STORE_FILES_TX_TS) && txid == s->store_tx_id)) {
             flags |= FILE_STORE;
             flags &= ~FILE_NOSTORE;
         } else if (!(flags & FILE_STORE) && (s->f->file_flags & FLOWFILE_NO_STORE_TS)) {

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -635,7 +635,11 @@ void SigGroupHeadSetFilestoreCount(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             continue;
 
         if (SignatureIsFilestoring(s)) {
-            sgh->filestore_cnt++;
+            if (sgh->filestore_cnt == UINT16_MAX) {
+                SCLogError(SC_ERR_NOT_SUPPORTED, "Too many filestore in signature group head");
+            } else {
+                sgh->filestore_cnt++;
+            }
         }
     }
 

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -167,6 +167,7 @@ static void OutputFiledataLogFfc(ThreadVars *tv, OutputLoggerThreadData *td,
                 SCLogDebug("ff FILE_STORE not set");
                 continue;
             }
+            DEBUG_VALIDATE_BUG_ON(ff->flags & FILE_NOSTORE);
 
             /* if we have no data chunks left to log, we should still
              * close the logger(s) */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1109,7 +1109,13 @@ void FileUpdateFlowFileFlags(Flow *f, uint16_t set_file_flags, uint8_t direction
         FileContainer *ffc = AppLayerParserGetFiles(f, direction);
         if (ffc != NULL) {
             for (File *ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
-                ptr->flags |= per_file_flags;
+                if ((per_file_flags & FILE_NOSTORE) && (ptr->flags & FILE_STORE)) {
+                    // if a rule reload removes a rule storing file
+                    // but a file was being stored...
+                    ptr->flags |= per_file_flags & (~FILE_NOSTORE);
+                } else {
+                    ptr->flags |= per_file_flags;
+                }
 
 #ifdef HAVE_NSS
                 /* destroy any ctx we may have so far */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1226,7 +1226,12 @@ void FileStoreAllFilesForTx(FileContainer *fc, uint64_t tx_id)
     if (fc != NULL) {
         for (ptr = fc->head; ptr != NULL; ptr = ptr->next) {
             if (ptr->txid == tx_id) {
-                FileStore(ptr);
+                // Checks if an already opened file has already set
+                // FILE_NOSTORE, and thus not saved the content
+                // it the streaming buffer
+                if ((ptr->flags & FILE_NOSTORE) == 0) {
+                    FileStore(ptr);
+                }
             }
         }
     }
@@ -1240,7 +1245,9 @@ void FileStoreAllFiles(FileContainer *fc)
 
     if (fc != NULL) {
         for (ptr = fc->head; ptr != NULL; ptr = ptr->next) {
-            FileStore(ptr);
+            if ((ptr->flags & FILE_NOSTORE) == 0) {
+                FileStore(ptr);
+            }
         }
     }
 }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -553,6 +553,7 @@ void FileContainerAdd(FileContainer *ffc, File *ff)
  */
 int FileStore(File *ff)
 {
+    DEBUG_VALIDATE_BUG_ON(ff->flags & FILE_NOSTORE);
     ff->flags |= FILE_STORE;
     SCReturnInt(0);
 }
@@ -985,6 +986,7 @@ int FileCloseFilePtr(File *ff, const uint8_t *data,
         if (flags & FILE_NOSTORE) {
             SCLogDebug("not storing this file");
             ff->flags |= FILE_NOSTORE;
+            ff->flags &= ~FILE_STORE;
         } else {
 #ifdef HAVE_NSS
             if (g_file_force_sha256 && ff->sha256_ctx) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6388

Describe changes:
- Make sure we do not store a file if we do not have its full contents (and thus the naming does not match the hash)
- Adds some debug assertions
- Fixes behavior of keyword `filestore:request,flow` with a unidirectional scope
- Logs an error if a `SigGroupHead` has more than `UINT16_MAX` filestores (and thus its count overflow, leading to bad detection)

The commit [http: remove tautological check](https://github.com/OISF/suricata/commit/30c256da2d79c78db7f57184d184efc029dad0a3) may be removed as it is an optimization, not a fix (done trying to understand when `FILE_STORE` and `FILE_NOSTORE` were set)

> Make sure we do not store a file if we do not have its full contents (and thus the naming does not match the hash)

This happens when both flags `FILE_STORE` and  `FILE_NOSTORE` are set (even if they should not be set together) because `FileAppendDataDo` checks this with `FileStoreNoStoreCheck`(so after the 512 first bytes) to not store the content (just stream it into the hashes)

These flags are set by
- FileOpen (either one, or none)
- FileStore (setting `FILE_STORE` basically when a rule with the keyword matches)
- FileUpdateFlowFileFlags which, (if I am right) is called only on the first packet of the flow for each direction (+ at each rules reload) and may set `FILE_NOSTORE` if the flow+direction results in a Signature group not having any filestore