### PR TITLE
detect-ssh-proto-version: use FAIL macros in tests - v3

### DIFF
--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -286,12 +286,11 @@ static int DetectSshVersionTestParse01 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "1.0");
-    if (ssh != NULL && strncmp((char *) ssh->ver, "1.0", 3) == 0) {
-        DetectSshVersionFree(NULL, ssh);
-        return 1;
-    }
+    FAIL_IF_NULL(ssh);
+    FAIL_IF_NOT(strncmp((char *)ssh->ver, "1.0", 3) == 0);
+    DetectSshVersionFree(NULL, ssh);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -302,12 +301,10 @@ static int DetectSshVersionTestParse02 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "2_compat");
-    if (ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT) {
-        DetectSshVersionFree(NULL, ssh);
-        return 1;
-    }
+    FAIL_IF_NOT(ssh->flags & SSH_FLAG_PROTOVERSION_2_COMPAT);
+    DetectSshVersionFree(NULL, ssh);
 
-    return 0;
+    PASS;
 }
 
 /**
@@ -318,27 +315,15 @@ static int DetectSshVersionTestParse03 (void)
 {
     DetectSshVersionData *ssh = NULL;
     ssh = DetectSshVersionParse(NULL, "2_com");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, "");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, ".1");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
     ssh = DetectSshVersionParse(NULL, "lalala");
-    if (ssh != NULL) {
-        DetectSshVersionFree(NULL, ssh);
-        return 0;
-    }
+    FAIL_IF_NOT_NULL(ssh);
 
-    return 1;
+    PASS;
 }
 
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6337](https://redmine.openinfosecfoundation.org/issues/6337)

Previous PR: #9578

Describe changes:
- Updated the detect-ssh-proto-version tests to use new FAIL/PASS API
- Fixed clang-format error from the previous PR