### PR TITLE
detect/analyzer: add more details for the tcp ack keyword - v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -861,6 +861,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_close(js);
                 break;
             }
+            case DETECT_ACK: {
+                const DetectAckData *cd = (const DetectAckData *)smd->ctx;
+
+                jb_open_object(js, "ack");
+                jb_set_uint(js, cd);
+                jb_close(js);
+                break;
+            }
         }
         jb_close(js);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6354

Describe changes:
- Added the DETECT_ACK case to detect-engine-analyzer.c

Request Feedback:
- Am I on the right track?
- I tried writing test.rules and test.yaml, but the test fails, so I know I'm not getting it right, I just wanted to try.

test.rules:
```
alert tcp any any -> any any (msg:"SURICATA STREAM 3way handshake ACK"; ack:=>0; sid:1)
```

test.yaml:
```
requires:
    min-version: 7.0.0

args:
    - --engine-analysis

checks:
- filter:
    filename: rules.json
    count: 1
    match:
      id: 1
      lists.packet.matches[0].name: "tcp.ack"
```
