### PR TITLE
detect/analyzer: add more details for the tcp ack keyword - v2

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -45,6 +45,7 @@
 #include "util-time.h"
 #include "util-validate.h"
 #include "util-conf.h"
+#include "detect-tcp-ack.h"
 
 static int rule_warnings_only = 0;
 
@@ -858,6 +859,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_ACK: {
+                const DetectAckData *cd = (const DetectAckData *)smd->ctx;
+
+                jb_open_object(js, "ack");
+                jb_set_uint(js, "ack", cd->ack);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6354

Previous PR: https://github.com/OISF/suricata/pull/9605

Describe changes:
- Added the `detect-tcp-ack.h` header to the file.
- Modified the code to properly handle the DETECT_ACK case; pass the int value of `ack` to the JsonBuilder.
- Corrected the `test.rules` signature.

`test.rules`:
```
alert tcp any any -> any any (msg:"SURICATA STREAM 3way handshake ACK"; ack:0; sid:1;)
alert tcp any any -> any any (msg:"SURICATA STREAM 3way handshake ACK"; ack:1; sid:2;)
alert tcp any any -> any any (msg:"SURICATA STREAM 3way handshake ACK"; ack:2; sid:3;)
```

`test.yaml`:
```
requires:
    min-version: 7.0.0
args:
    - --engine-analysis

checks:
- filter:
    filename: rules.json
    count: 1
    match:
      id: 1
      lists.packet.matches[0].name: "tcp.ack"
```

`output`:
```
{
  "raw":"alert tcp any any -> any any (msg:\"SURICATA STREAM 3way handshake ACK\"; ack:0; sid:1;)",
  "id":1,
  "gid":1,
  "rev":0,
  "msg":"SURICATA STREAM 3way handshake ACK",
  "app_proto":"unknown",
  "requirements": [],
  "type":"pkt",
  "flags": [
    "src_any",
    "dst_any",
    "sp_any",
    "dp_any",
    "need_packet",
    "toserver",
    "toclient"
  ],
  "pkt_engines": [
    {
      "name":"packet",
      "is_mpm":false
    }
  ],
  "frame_engines":[],
  "lists": {
    "packet":{
      "matches": [
        {
          "name":"tcp.ack"
        }
      ]
    }
  }
}
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1423