### PR TITLE
output: Add the nullsink output type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1678,6 +1678,14 @@
     ;;
     esac
 
+    AC_ARG_ENABLE(nulloutput,
+	        AS_HELP_STRING([--enable-nulloutput],[Enable null output support]),
+	        [ enable_nulloutput="$enableval"],
+	        [ enable_nulloutput="no"])
+    if test "x$enable_nulloutput" == "xyes"; then
+        AC_DEFINE([HAVE_NULL_LOGOUTPUT],[1],[null output support])
+    fi
+
     AC_CHECK_LIB(unwind,unw_backtrace,,LIBUNW="no")
     if test "$LIBUNW" = "no"; then
         echo
@@ -2672,6 +2680,7 @@ Development settings:
   Debug output enabled:                    ${enable_debug}
   Debug validation enabled:                ${enable_debug_validation}
   Fuzz targets enabled:                    ${enable_fuzztargets}
+  Null output device enabled:              ${enable_nulloutput}
 
 Generic build parameters:
   Installation prefix:                     ${prefix}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -385,6 +385,7 @@ noinst_HEADERS = \
 	log-tlslog.h \
 	log-tlsstore.h \
 	output-eve-stream.h \
+	output-eve-null.h \
 	output-filedata.h \
 	output-file.h \
 	output-filestore.h \
@@ -1037,6 +1038,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-tftp.c \
 	output-json-tls.c \
 	output-eve-syslog.c \
+	output-eve-null.c \
 	output-lua.c \
 	output-packet.c \
 	output-stats.c \

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -1,0 +1,87 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ *
+ * File-like output for logging: null/discard device
+ */
+
+#include "suricata-common.h" /* errno.h, string.h, etc. */
+
+#if HAVE_NULL_LOGOUTPUT
+#include "output.h" /* DEFAULT_LOG_* */
+#include "output-eve-null.h"
+
+#ifdef OS_WIN32
+void NullLogInitialize(void)
+{
+}
+#else /* !OS_WIN32 */
+
+#define OUTPUT_NAME "nullsink"
+
+static int NullLogInit(ConfNode *conf, bool threaded, void **init_data)
+{
+    *init_data = NULL;
+    return 0;
+}
+
+static int NullLogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+{
+    return 0;
+}
+
+static int NullLogThreadInit(void *init_data, int thread_id, void **thread_data)
+{
+    return 0;
+}
+
+static int NullLogThreadDeInit(void *init_data, void *thread_data)
+{
+    return 0;
+}
+
+static void NullLogDeInit(void *init_data)
+{
+}
+
+void NullLogInitialize(void)
+{
+    SCLogDebug("Registering the %s logger", OUTPUT_NAME);
+
+    SCEveFileType *file_type = SCCalloc(1, sizeof(SCEveFileType));
+
+    if (file_type == NULL) {
+        FatalError("Unable to allocate memory for eve file type %s", OUTPUT_NAME);
+    }
+
+    file_type->name = OUTPUT_NAME;
+    file_type->Init = NullLogInit;
+    file_type->Deinit = NullLogDeInit;
+    file_type->Write = NullLogWrite;
+    file_type->ThreadInit = NullLogThreadInit;
+    file_type->ThreadDeinit = NullLogThreadDeInit;
+    if (!SCRegisterEveFileType(file_type)) {
+        FatalError("Failed to register EVE file type: %s", OUTPUT_NAME);
+    }
+}
+#endif /* !OS_WIN32 */
+#endif /* HAVE_NULL_LOGOUTPUT */

--- a/src/output-eve-null.h
+++ b/src/output-eve-null.h
@@ -1,0 +1,28 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ *
+ * File-like output for logging: null/discard device
+ */
+#if HAVE_NULL_LOGOUTPUT
+void NullLogInitialize(void);
+#endif /* HAVE_NULL_LOGOUTPUT */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -48,6 +48,7 @@
 #include "util-classification-config.h"
 #include "util-syslog.h"
 #include "output-eve-syslog.h"
+#include "output-eve-null.h"
 
 #include "output.h"
 #include "output-json.h"
@@ -98,6 +99,9 @@ void OutputJsonRegister (void)
     // Register output file types that use the new eve filetype registration
     // API.
     SyslogInitialize();
+#if HAVE_NULL_LOGOUTPUT
+    NullLogInitialize();
+#endif
 }
 
 json_t *SCJsonString(const char *val)


### PR DESCRIPTION
Continuation of #9617 

This PR adds an output type that discards output for situations where performance is monitored or persisted data is not needed.

This must be configured with `--enable-nulloutput` before Suricata is built. Use `nullsink` for the `filetype` value in each output.

Note that Suricata will continue to generate and prepare values (logs, alerts, etc) for output; `nullsink` eliminates persisting the values.

Describe changes:
- Configuration changes to support `--enable-output`
- NULL output plugin

Updates:
- Add missing header file to src/Makefile.am

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
