### PR TITLE
detect: error early when too many buffers

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -474,16 +474,18 @@ void SigMatchAppendSMToList(Signature *s, SigMatch *new, const int list)
             if (SignatureInitDataBufferCheckExpand(s) < 0) {
                 SCLogError("failed to expand rule buffer array");
                 s->init_data->init_flags |= SIG_FLAG_INIT_OVERFLOW;
-                return;
+                // SignatureInitDataBufferCheckExpand should not fail in this case
+                DEBUG_VALIDATE_BUG_ON(s->init_data->curbuf == NULL);
+                // keep curbuf even with wrong id as we error on this signature
+            } else {
+                /* initialize new buffer */
+                s->init_data->curbuf = &s->init_data->buffers[s->init_data->buffer_index++];
+                s->init_data->curbuf->id = list;
+                /* buffer set up by sigmatch is tracked in case we add a stickybuffer for the
+                 * same list. */
+                s->init_data->curbuf->sm_init = true;
+                SCLogDebug("s->init_data->buffer_index %u", s->init_data->buffer_index);
             }
-
-            /* initialize new buffer */
-            s->init_data->curbuf = &s->init_data->buffers[s->init_data->buffer_index++];
-            s->init_data->curbuf->id = list;
-            /* buffer set up by sigmatch is tracked in case we add a stickybuffer for the
-             * same list. */
-            s->init_data->curbuf->sm_init = true;
-            SCLogDebug("s->init_data->buffer_index %u", s->init_data->buffer_index);
         }
         BUG_ON(s->init_data->curbuf == NULL);
 
@@ -990,8 +992,11 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
         /* setup may or may not add a new SigMatch to the list */
         setup_ret = st->Setup(de_ctx, s, NULL);
     }
-    if (setup_ret < 0) {
+    if (setup_ret < 0 || (s->init_data->init_flags & SIG_FLAG_INIT_OVERFLOW)) {
         SCLogDebug("\"%s\" failed to setup", st->name);
+        if (s->init_data->init_flags & SIG_FLAG_INIT_OVERFLOW) {
+            SCLogError("rule %u tries to use too many buffers", s->id);
+        }
 
         /* handle 'silent' error case */
         if (setup_ret == -2) {
@@ -1902,11 +1907,6 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     if (s->init_data->curbuf && s->init_data->curbuf->head == NULL) {
         SCLogError("rule %u setup buffer %s but didn't add matches to it", s->id,
                 DetectEngineBufferTypeGetNameById(de_ctx, s->init_data->curbuf->id));
-        SCReturnInt(0);
-    }
-
-    if (s->init_data->init_flags & SIG_FLAG_INIT_OVERFLOW) {
-        SCLogError("rule %u tries to use too many buffers", s->id);
         SCReturnInt(0);
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6104

Describe changes:
- detect: frees SigMatch when too many buffers and do not leak memory

#9622 with another proposal