### PR TITLE
Be more user-friendly with non-existing user

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2157,16 +2157,14 @@ static int InitRunAs(SCInstance *suri)
     if (suri->do_setuid == TRUE) {
         if (SCGetUserID(suri->user_name, suri->group_name,
                         &suri->userid, &suri->groupid) != 0) {
-            SCLogError("failed in getting user ID");
-            return TM_ECODE_FAILED;
+            FatalError("failed in getting user ID");
         }
 
         sc_set_caps = TRUE;
     /* Get the suricata group ID to given group ID */
     } else if (suri->do_setgid == TRUE) {
         if (SCGetGroupID(suri->group_name, &suri->groupid) != 0) {
-            SCLogError("failed in getting group ID");
-            return TM_ECODE_FAILED;
+            FatalError("failed in getting group ID");
         }
 
         sc_set_caps = TRUE;

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -153,6 +153,11 @@ int SCGetUserID(const char *user_name, const char *group_name, uint32_t *uid, ui
     uint32_t groupid = 0;
     struct passwd *pw;
 
+    if (user_name == NULL || strlen(user_name) == 0) {
+        FatalError("no user name was provided - ensure it is specified either in the configuration "
+                   "file or in command-line arguments");
+    }
+
     /* Get the user ID */
     if (isdigit((unsigned char)user_name[0]) != 0) {
         if (ByteExtractStringUint32(&userid, 10, 0, (const char *)user_name) < 0) {
@@ -215,6 +220,11 @@ int SCGetGroupID(const char *group_name, uint32_t *gid)
 {
     uint32_t grpid = 0;
     struct group *gp;
+
+    if (group_name == NULL || strlen(group_name) == 0) {
+        FatalError("no group name was provided - ensure it is specified either in the "
+                   "configuration file or in command-line arguments");
+    }
 
     /* Get the group ID */
     if (isdigit((unsigned char)group_name[0]) != 0) {


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/9596

Redmine ticket:

https://redmine.openinfosecfoundation.org/issues/6278

Describe changes:
- Previous PR split into sub-PRs

To use a pull request use a branch name like pr/N where N is the
pull request number.

Alternatively, SV_BRANCH may also be a link to an
OISF/suricata-verify pull-request.

SV_REPO=
SV_BRANCH=pr/1417
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=