### PR TITLE
Update calls to DPDK Bonding API and update versions of DPDK builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1961,7 +1961,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.1, 21.11.3, 20.11.7, 19.11.14 ]
+        dpdk_version: [ 22.11.3, 21.11.5, 20.11.9, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/src/util-dpdk-bonding.c
+++ b/src/util-dpdk-bonding.c
@@ -54,7 +54,12 @@ uint16_t BondingMemberDevicesGet(
         uint16_t bond_pid, uint16_t bonded_devs[], uint16_t bonded_devs_length)
 {
 #ifdef HAVE_DPDK_BOND
+#if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+    int32_t len = rte_eth_bond_members_get(bond_pid, bonded_devs, bonded_devs_length);
+#else
     int32_t len = rte_eth_bond_slaves_get(bond_pid, bonded_devs, bonded_devs_length);
+#endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */
+
     if (len == 0)
         FatalError("%s: no bonded devices found", DPDKGetPortNameByPortID(bond_pid));
     else if (len < 0)


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/9596

Redmine ticket:

https://redmine.openinfosecfoundation.org/issues/6381

Describe changes:
- Previous PR split into sub-PRs

PR contains updated calls to DPDK Bonding API - DPDK 23.11 makes calls with "slave" term obsolete and replaces that with a "member" term. 
The other commit updates versions of DPDK builds in Github Actions. 