### PR TITLE
rule: Don't drop flow if rule matches on packet properties.

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -22,7 +22,7 @@ decompression = ["flate2", "brotli"]
 [dependencies]
 nom = "~ 5.1.3"
 bitflags = "~1.2.1"
-byteorder = "1.3"
+byteorder = "~1.3"
 uuid = "0.8"
 crc = "1.8"
 memchr = "~ 2.3"

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -326,6 +326,13 @@ static inline void FlowApplySignatureActions(
         if ((pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
                 (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_LIKE_IPONLY | SIG_FLAG_PDONLY |
                                     SIG_FLAG_APPLAYER))) {
+
+            /* No action when the signature doesn't require a stream */
+            if ((s->flags &
+                        (SIG_FLAG_APPLAYER | SIG_FLAG_REQUIRE_PACKET | SIG_FLAG_REQUIRE_STREAM)) ==
+                    (SIG_FLAG_APPLAYER | SIG_FLAG_REQUIRE_PACKET))
+                return;
+
             pa->flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
             SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
                        "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",


### PR DESCRIPTION
Continuation of #9618 
This commit modifies the logic used to determine the disposition of a flow/packet.

If the rule contains packet match properties, the flow shouldn't be dropped.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5578](https://redmine.openinfosecfoundation.org/issues/5578)

Describe changes:
- When deciding how to handle the `drop` action, check if the rule applies to packet properties.

Updates:
- Cherry-pick of in-flight byteorder crate version update
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1424