### PR TITLE
detect/analyzer: add more details for the tcp ack keyword - v3

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -861,6 +861,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_close(js);
                 break;
             }
+            case DETECT_ACK: {
+                const DetectAckData *cd = (const DetectAckData *)smd->ctx;
+
+                jb_open_object(js, "ack");
+                jb_set_uint(js, "number", cd->ack);
+                jb_close(js);
+                break;
+            }
         }
         jb_close(js);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6354

Previous PR: https://github.com/OISF/suricata/pull/9608

Describe changes:
- Modified the code to properly handle the DETECT_ACK case; corrected the variable used to represent the Acknowledgement number.


Output:

```
{
  "raw": "alert tcp any any -> any any (msg:\"Testing ack\"; ack:782; sid:1;)",
  "id": 1,
  "gid": 1,
  "rev": 0,
  "msg": "Testing ack",
  "app_proto": "unknown",
  "requirements": [],
  "type": "pkt",
  "flags": [
    "src_any",
    "dst_any",
    "sp_any",
    "dp_any",
    "need_packet",
    "toserver",
    "toclient"
  ],
  "pkt_engines" : [
    {
      "name": "packet",
      "is_mpm": false
    }
  ],
  "frame_engines": [],
  "lists": {
    "packet": {
      "matches": [
        {
          "name": "tcp.ack",
          "ack": {
            "number": 782
          }
        }
      ]
    }
   }
}
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1430