### PR TITLE
docs: adjust readthedocs config to new options (60x backport) - v1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,18 @@
 # Required by Read The Docs
 version: 2
 
-formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 python:
-  version: "3.8"
+  install:
+    - requirements: doc/userguide/requirements.txt
 
-  # Use an empty install section to avoid RTD from picking up a non-python
-  # requirements.txt file.
-  install: []
+sphinx:
+  builder: html
+  configuration: doc/userguide/conf.py
+  fail_on_warning: false
+
+formats: all

--- a/doc/userguide/requirements.txt
+++ b/doc/userguide/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
Backport from the changes we added to rtd config as docs for 6 are also not building.