### PR TITLE
detect/analyzer: add more details for the tcp.mss keyword - v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -32,6 +32,7 @@
 #include "detect-engine.h"
 #include "detect-engine-analyzer.h"
 #include "detect-engine-mpm.h"
+#include "detect-engine-uint.h"
 #include "conf.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
@@ -39,6 +40,7 @@
 #include "detect-bytetest.h"
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
+#include "detect-tcpmss.h"
 #include "detect-ipopts.h"
 #include "feature.h"
 #include "util-print.h"
@@ -858,6 +860,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_TCPMSS: {
+                const DetectU16Data *cd = (const DetectU16Data *)smd->ctx;
+
+                jb_open_object(js, "mss");
+                jb_set_uint(js, "size", cd->arg1);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6355

Describe changes:
- Added the `DETECT_TCPMSS` case to the `detect-engine-analyzer.c` file.
- Added `detect-tcpmss.h` and `detect-engine-uint.h` as headers to the file.

I need feedback on this; test still does not work, even the test for `lists.packet.matches[0].name: "tcp.mss"` does not work either. I checked the `detect-engine-register.h` file if `DETECT_TCPMSS` is present, and it was. I really do not know where to look anymore.


```
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1433
```
