### PR TITLE
runmodes: suricata hint missing runmode -v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2369,6 +2369,7 @@ static int FinalizeRunMode(SCInstance *suri, char **argv)
 {
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
+            SCLogError("Error: Missing run mode. Please specify a capture runmode.");
             PrintUsage(argv[0]);
             return TM_ECODE_FAILED;
         default:

--- a/src/tests/test_runmode.c
+++ b/src/tests/test_runmode.c
@@ -1,0 +1,19 @@
+#include "suricata-common.h"
+#include "util-running-modes.h"
+#include "util-conf.h"
+#include "runmodes.h"
+#include "util-unittest.h"
+
+void test_missing_run_mode(void) {
+    // Simulate missing run mode and check error message
+    SCInstance suri;
+    char *argv[] = {"suricata", NULL};
+    
+    int result = FinalizeRunMode(&suri, argv);
+    
+    FAIL_IF(result != TM_ECODE_FAILED);
+    // Add checks to verify the error message, if possible
+    PASS;
+}
+
+UtRegisterTest("RunModeTest", test_missing_run_mode);


### PR DESCRIPTION
Ticket: 5711

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5711) ticket:

Describe changes:
-Suricata when run does not provide feedback when the runmode is missing, leading to confusion for users
-Added missing runmode error


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1434

