### PR TITLE
detect/tenants: Add tenant context to rule loads

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1496,11 +1496,17 @@ int SigAddressPrepareStage1(DetectEngineCtx *de_ctx)
     }
 
     if (!(de_ctx->flags & DE_QUIET)) {
-        SCLogInfo("%" PRIu32 " signatures processed. %" PRIu32 " are IP-only "
-                "rules, %" PRIu32 " are inspecting packet payload, %"PRIu32
-                " inspect application layer, %"PRIu32" are decoder event only",
-                de_ctx->sig_cnt, cnt_iponly, cnt_payload, cnt_applayer,
-                cnt_deonly);
+        if (strlen(de_ctx->config_prefix) > 0)
+            SCLogInfo("tenant id %d: %" PRIu32 " signatures processed. %" PRIu32 " are IP-only "
+                      "rules, %" PRIu32 " are inspecting packet payload, %" PRIu32
+                      " inspect application layer, %" PRIu32 " are decoder event only",
+                    de_ctx->tenant_id, de_ctx->sig_cnt, cnt_iponly, cnt_payload, cnt_applayer,
+                    cnt_deonly);
+        else
+            SCLogInfo("%" PRIu32 " signatures processed. %" PRIu32 " are IP-only "
+                      "rules, %" PRIu32 " are inspecting packet payload, %" PRIu32
+                      " inspect application layer, %" PRIu32 " are decoder event only",
+                    de_ctx->sig_cnt, cnt_iponly, cnt_payload, cnt_applayer, cnt_deonly);
 
         SCLogConfig("building signature grouping structure, stage 1: "
                "preprocessing rules... complete");

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -245,7 +245,11 @@ static int ProcessSigFiles(DetectEngineCtx *de_ctx, char *pattern,
         if (strcmp("/dev/null", fname) == 0)
             return 0;
 #endif
-        SCLogConfig("Loading rule file: %s", fname);
+        if (strlen(de_ctx->config_prefix) > 0) {
+            SCLogConfig("tenant id %d: Loading rule file: %s", de_ctx->tenant_id, fname);
+        } else {
+            SCLogConfig("Loading rule file: %s", fname);
+        }
         r = DetectLoadSigFile(de_ctx, fname, good_sigs, bad_sigs);
         if (r < 0) {
             ++(st->bad_files);
@@ -347,8 +351,15 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
         }
     } else {
         /* we report the total of files and rules successfully loaded and failed */
-        SCLogInfo("%" PRId32 " rule files processed. %" PRId32 " rules successfully loaded, %" PRId32 " rules failed",
-            sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
+        if (strlen(de_ctx->config_prefix) > 0)
+            SCLogInfo("tenant id %d:  %" PRId32 " rule files processed. %" PRId32
+                      " rules successfully loaded, %" PRId32 " rules failed",
+                    de_ctx->tenant_id, sig_stat->total_files, sig_stat->good_sigs_total,
+                    sig_stat->bad_sigs_total);
+        else
+            SCLogInfo("%" PRId32 " rule files processed. %" PRId32
+                      " rules successfully loaded, %" PRId32 " rules failed",
+                    sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
     }
 
     if ((sig_stat->bad_sigs_total || sig_stat->bad_files) && de_ctx->failure_fatal) {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -88,7 +88,7 @@ void DetectEngineBufferTypeSupportsMpm(DetectEngineCtx *de_ctx, const char *name
 void DetectEngineBufferTypeSupportsTransformations(DetectEngineCtx *de_ctx, const char *name);
 
 /* prototypes */
-DetectEngineCtx *DetectEngineCtxInitWithPrefix(const char *prefix);
+DetectEngineCtx *DetectEngineCtxInitWithPrefix(const char *prefix, uint32_t tenant_id);
 DetectEngineCtx *DetectEngineCtxInit(void);
 DetectEngineCtx *DetectEngineCtxInitStubForDD(void);
 DetectEngineCtx *DetectEngineCtxInitStubForMT(void);

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -363,8 +363,12 @@ static bool SCClassConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
     }
 
 #ifdef UNITTESTS
-    SCLogInfo("Added \"%d\" classification types from the classification file",
-              de_ctx->class_conf_ht->count);
+    if (strlen(de_ctx->config_prefix) > 0)
+        SCLogInfo("tenant id %d: Added \"%d\" classification types from the classification file",
+                de_ctx->tenant_id, de_ctx->class_conf_ht->count);
+    else
+        SCLogInfo("Added \"%d\" classification types from the classification file",
+                de_ctx->class_conf_ht->count);
 #endif
 
     return errors == 0;

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -335,8 +335,12 @@ static bool SCRConfParseFile(DetectEngineCtx *de_ctx, FILE *fd)
     }
 
 #ifdef UNITTESTS
-    SCLogInfo("Added \"%d\" reference types from the reference.config file",
-              de_ctx->reference_conf_ht->count);
+    if (strlen(de_ctx->config_prefix) > 0)
+        SCLogInfo("tenant id %d: Added \"%d\" reference types from the reference.config file",
+                de_ctx->tenant_id, de_ctx->reference_conf_ht->count);
+    else
+        SCLogInfo("Added \"%d\" reference types from the reference.config file",
+                de_ctx->reference_conf_ht->count);
 #endif /* UNITTESTS */
     return true;
 }

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1042,7 +1042,11 @@ int SCThresholdConfParseFile(DetectEngineCtx *de_ctx, FILE *fp)
         }
     }
 
-    SCLogInfo("Threshold config parsed: %d rule(s) found", rule_num);
+    if (strlen(de_ctx->config_prefix) > 0)
+        SCLogInfo("tenant id %d: Threshold config parsed: %d rule(s) found", de_ctx->tenant_id,
+                rule_num);
+    else
+        SCLogInfo("Threshold config parsed: %d rule(s) found", rule_num);
     return 0;
 }
 


### PR DESCRIPTION
Issue: 1520

This commit adds the tenant id for context to rule and .config file loads.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [1520](https://redmine.openinfosecfoundation.org/issues/1520)

Describe changes:
- Put tenant id into the detect engine context before loading conf files
- Include tenant id in log messages for context

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
