### PR TITLE
detect/analyzer: add more details for the tcp seq keyword - v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -40,6 +40,7 @@
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
 #include "detect-ipopts.h"
+#include "detect-tcp-seq.h"
 #include "feature.h"
 #include "util-print.h"
 #include "util-time.h"
@@ -858,6 +859,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_SEQ: {
+                const DetectSeqData *cd = (const DetectSeqData *)smd->ctx;
+
+                jb_open_object(js, "seq");
+                jb_set_uint(js, "number", cd->seq);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6353

Describe changes:
- Added the `DETECT_SEQ` case to the `detect-engine-analyzer.c` `DumpMatches` function.
- Included `detect-tcp-seq.h` as header file.

```
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1435
```
