### PR TITLE
detect/analyzer: add more details for tcp_seq - v2

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -40,6 +40,7 @@
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
 #include "detect-ipopts.h"
+#include "detect-tcp-seq.h"
 #include "feature.h"
 #include "util-print.h"
 #include "util-time.h"
@@ -858,6 +859,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_SEQ: {
+                const DetectSeqData *cd = (const DetectSeqData *)smd->ctx;
+
+                jb_open_object(js, "seq");
+                jb_set_uint(js, "number", cd->seq);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6353

Previous PR: https://github.com/OISF/suricata/pull/9676

Describe changes:
- Modify the commit message subject to comply with project's 50 character limit.

Output:
```
{
    "raw":"alert tcp any any -> any any (msg:\"Testing seq\"; seq:723833; sid:2;)",
    "id":2,
    "gid":1,
    "rev":0,
    "msg":"Testing seq",
    "app_proto":"unknown",
    "requirements":[],
    "type":"pkt",
    "flags": [
        "src_any",
        "dst_any",
        "sp_any",
        "dp_any",
        "need_packet",
        "toserver",
        "toclient"
    ],
    "pkt_engines": [
        {
            "name":"packet",
            "is_mpm":false
        }
    ],
    "frame_engines": [],
    "lists": {
        "packet": {
            "matches": [
                {
                    "name":"tcp.seq",
                    "seq": {
                        "number":723833
                    }
                }
            ]
        }
    }
}
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1435

