### PR TITLE
detect/analyzer: add more details for the tcp.mss keyword - v2

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -32,6 +32,7 @@
 #include "detect-engine.h"
 #include "detect-engine-analyzer.h"
 #include "detect-engine-mpm.h"
+#include "detect-engine-uint.h"
 #include "conf.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
@@ -39,6 +40,7 @@
 #include "detect-bytetest.h"
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
+#include "detect-tcpmss.h"
 #include "detect-ipopts.h"
 #include "feature.h"
 #include "util-print.h"
@@ -858,6 +860,17 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_TCPMSS: {
+                const DetectU16Data *cd = (const DetectU16Data *)smd->ctx;
+
+                jb_open_object(js, "tcp_mss");
+                const char *flag = TcpmssModeToString(cd->mode);
+                jb_set_string(js, "mode", flag);
+                jb_set_uint(js, "value1", cd->arg1);
+                jb_set_uint(js, "value2", cd->arg2);
                 jb_close(js);
                 break;
             }

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -63,6 +63,25 @@ void DetectTcpmssRegister(void)
 }
 
 /**
+ * \brief Return human readable value for tcp.mss mode
+ *
+ * \param mode uint8_t DetectU16Data tcp.mss mode value
+ */
+const char *TcpmssModeToString(uint8_t mode)
+{
+    switch (mode) {
+        case 1:
+            return "less than";
+        case 3:
+            return "greater than";
+        case 5:
+            return "range";
+        default:
+            return NULL;
+    }
+}
+
+/**
  * \brief This function is used to match TCPMSS rule option on a packet with those passed via
  * tcpmss:
  *

--- a/src/detect-tcpmss.h
+++ b/src/detect-tcpmss.h
@@ -26,4 +26,6 @@
 
 void DetectTcpmssRegister(void);
 
+const char *TcpmssModeToString(uint8_t mode);
+
 #endif	/* _DETECT_TCPMSS_H */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6355

Previous PR: https://github.com/OISF/suricata/pull/9673

Describe changes:
- Included the options to be logged that were not included in the last PR; `mode` and `arg2`.
- Added `TcpmssModeToString` function into `detect-tcpmss.c` file to convert the `mode` bit to a human readable value.
- Included `TcpmssModeToString` to `detect-tcpmss.h` file.

Suggestion:
- In the outputs, whenever the rule does not provide for `value2`, I personally feel it should then not be logged, just like the `mode` value is not logged when not provided in the rule. I traced it to `rust/src/detect/uint.rs`; `line 67` where `arg2` can be equated to NULL.

Output for id-1:
```json
{
    "raw":"alert tcp any any -> any any (msg:\"Testing mss\"; tcp.mss:50; sid:1;)",
    "id":1,
    "gid":1,
    "rev":0,
    "msg":"Testing mss",
    "app_proto":"unknown",
    "requirements": [],
    "type":"pkt",
    "flags": [
        "src_any",
        "dst_any",
        "sp_any",
        "dp_any",
        "need_packet",
        "toserver",
        "toclient"
    ],
    "pkt_engines": [
        {
            "name":"packet",
            "is_mpm":false
        }
    ],
    "frame_engines": [],
    "lists": {
        "packet": {
            "matches": [
                {
                    "name":"tcp.mss",
                    "tcp_mss": {
                        "value1":50,
                        "value2":0
                    }
                }
            ]
        }
    }
}
```

Output for id-4:
```json
{
    "raw":"alert tcp any any -> any any (msg:\"Testing mss\"; tcp.mss:123-456; sid:4;)",
    "id":4,
    "gid":1,
    "rev":0,
    "msg":"Testing mss",
    "app_proto":"unknown",
    "requirements":[],
    "type":"pkt",
    "flags":[
        "src_any",
        "dst_any",
        "sp_any",
        "dp_any",
        "need_packet",
        "toserver",
        "toclient"
    ],
    "pkt_engines":[
        {
            "name":"packet",
            "is_mpm":false
        }
    ],
    "frame_engines":[],
    "lists":{
        "packet":{
            "matches":[
                {
                    "name":"tcp.mss",
                    "tcp_mss":{
                        "mode":"range",
                        "value1":123,
                        "value2":456
                    }
                }
            ]
        }
    }
}
```


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1436
