### PR TITLE
misc: docs - add reference to RPM packages section, improve PR template - v1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 Make sure these boxes are signed before submitting your Pull Request -- thank you.
 
-- [ ] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
-- [ ] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
+- [ ] I have read the contributing guide lines at
+   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
+- [ ] I have signed the Open Information Security Foundation contribution agreement at
+   https://suricata.io/about/contribution-agreement/ (obs.: this is only required once)
 - [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
 
 Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -298,6 +298,8 @@ For Debian 10 (buster), for instance, run the following as ``root``::
     apt-get update
     apt-get install suricata -t buster-backports
 
+.. _RPM packages:
+
 CentOS, AlmaLinux, RockyLinux, Fedora, etc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Describe changes:
- add a proper anchor for RPM packages section, so we can add that to our Downloads and Features pages
- add a small note to the CLA requirement in our PR template, since some contributors thought they had to sign that up for every new PR
