### PR TITLE
detect/analyzer: add more details for the flowbits keyword v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -45,6 +45,7 @@
 #include "util-time.h"
 #include "util-validate.h"
 #include "util-conf.h"
+#include "detect-flowbits.h"
 
 static int rule_warnings_only = 0;
 
@@ -858,6 +859,33 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_open_object(js, "ipopts");
                 const char *flag = IpOptsFlagToString(cd->ipopt);
                 jb_set_string(js, "option", flag);
+                jb_close(js);
+                break;
+            }
+            case DETECT_FLOWBITS: {
+                const DetectFlowbitsData *cd = (const DetectFlowbitsData *)smd->ctx;
+
+                jb_open_object(js, "flowbits");
+                switch (cd->cmd) {
+                    case DETECT_FLOWBITS_CMD_NOALERT:
+                        jb_set_string(js, "cmd", "noalert");
+                        break;
+                    case DETECT_FLOWBITS_CMD_ISSET:
+                        jb_set_string(js, "cmd", "isset");
+                        break;
+                    case DETECT_FLOWBITS_CMD_ISNOTSET:
+                        jb_set_string(js, "cmd", "isnotset");
+                        break;
+                    case DETECT_FLOWBITS_CMD_SET:
+                        jb_set_string(js, "cmd", "set");
+                        break;
+                    case DETECT_FLOWBITS_CMD_UNSET:
+                        jb_set_string(js, "cmd", "unset");
+                        break;
+                    case DETECT_FLOWBITS_CMD_TOGGLE:
+                        jb_set_string(js, "cmd", "toggle");
+                        break;
+                }
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Task #6309

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/6309) ticket:

Describe changes:
- Added the DETECT_FLOWBITS case to detect-engine-analyzer.c

Request Feedback:
- Am I on the right track?
- The tests I wrote are failing but I've shared my code to see how I can change it.

test.rules:
```
alert ip any any -> any any (msg:"isset rule need an option"; flowbits:isset; sid:1;)
alert ip any any -> any any (msg:"isnotset rule need an option"; flowbits:isnotset; sid:2)
alert ip any any -> any any (msg:"set rule need an option"; flowbits:set; sid:3;)
alert ip any any -> any any (msg:"unset rule need an option"; flowbits:unset; sid:4;)
alert ip any any -> any any (msg:"toggle rule need an option"; flowbits:toggle; sid:5;)
```
test.yaml
```
requires:
    min-version: 7.0.0
    pcap: false

args:
    - --engine-analysis

checks:
- filter:
    filename: rules.json
    count: 1
    match:
      id: 1
      lists.packet.matches[0].name: "flowbits"
      lists.packet.matches[0].flowbits.option: "isset"
- filter:
    filename: rules.json
    count: 1
    match:
      id: 2
      lists.packet.matches[0].name: "flowbits"
      lists.packet.matches[0].flowbits.option: "isnotset"
- filter:
    filename: rules.json
    count: 1
    match:
      id: 3
      lists.packet.matches[0].name: "flowbits"
      lists.packet.matches[0].flowbits.option: "set"
- filter:
    filename: rules.json
    count: 1
    match:
      id: 4
      lists.packet.matches[0].name: "flowbits"
      lists.packet.matches[0].flowbits.option: "unset"
- filter:
    filename: rules.json
    count: 1
    match:
      id: 5
      lists.packet.matches[0].name: "flowbits"
      lists.packet.matches[0].flowbits.option: "toggle"

```
