### PR TITLE
configure: Move configure.ac setup to autogen

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -10,6 +10,9 @@ else
   echo "Failed to find libtoolize or glibtoolize, please ensure it is installed and accessible via your PATH env variable"
   exit 1
 fi;
+PRODUCT_NAME=${PRODUCT_NAME:-suricata}
+PRODUCT_VERSION=${PRODUCT_VERSION:-7.0.3-dev}
+sed -e "s/@PRODUCT_NAME@/$PRODUCT_NAME/" -e "s/@PRODUCT_VERSION@/$PRODUCT_VERSION/"  configure.ac.in > configure.ac
 autoreconf -fv --install || exit 1
 if which cargo > /dev/null; then
     if [ -f rust/Cargo.lock ] ; then

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -1,4 +1,4 @@
-    AC_INIT([suricata],[7.0.3-dev])
+    AC_INIT([@PRODUCT_NAME@],[@PRODUCT_VERSION@])
     m4_ifndef([AM_SILENT_RULES], [m4_define([AM_SILENT_RULES],[])])AM_SILENT_RULES([yes])
     AC_CONFIG_HEADERS([src/autoconf.h])
     AC_CONFIG_SRCDIR([src/suricata.c])


### PR DESCRIPTION
This commit changes how the product name and product version values for autoconf's 'AC_INIT' are populated.

With this change, a 3rd party can specify a unique product name and product version by setting environment variables before running autogen.sh

$ PRODUCT_NAME="my_suricata" PRODUCT_VERSION="7.0.3-my_suricata" ./autogen.sh

The default name and version are unchanged if the environment variables are not defined:
- suricata
- 7.0.3-dev

Future version updates should take place in 'autogen.sh'

Describe changes:
- Remove configure.ac; add configure.ac.in
- Pre-process configure.ac.in during autogen.sh to populate name/version values


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
