### PR TITLE
runmodes: clear hint for missing runmode v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2369,6 +2369,7 @@ static int FinalizeRunMode(SCInstance *suri, char **argv)
 {
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
+            SCLogError("Missing run mode. Please specify a capture runmode.");
             PrintUsage(argv[0]);
             return TM_ECODE_FAILED;
         default:


### PR DESCRIPTION
Ticket: 5711

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5711) ticket:

Describe changes:
-Suricata when run does not provide feedback when the runmode is missing, leading to confusion for users
-Added missing runmode error
-Incoporated previous feedback

Previous PR; https://github.com/OISF/suricata/pull/9674
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1442

