### PR TITLE
detect/bytejump: Improve end-of-buffer edge case.

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -166,23 +166,18 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     /* Calculate the ptr value for the bytejump and length remaining in
      * the packet from that point.
      */
-    ptr = payload;
-    len = payload_len;
+    ptr = payload + offset;
+    len = payload_len - offset;
     if (flags & DETECT_BYTEJUMP_RELATIVE) {
         ptr += det_ctx->buffer_offset;
         len -= det_ctx->buffer_offset;
 
-        ptr += offset;
-        len -= offset;
+        SCLogDebug("[relative] after: ptr %p [len %d]", ptr, len);
 
         /* No match if there is no relative base */
-        if (ptr == NULL || len <= 0) {
+        if (ptr == NULL || (nbytes && len <= 0)) {
             SCReturnBool(false);
         }
-    }
-    else {
-        ptr += offset;
-        len -= offset;
     }
 
     /* Verify the to-be-extracted data is within the packet */
@@ -243,7 +238,7 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     if (jumpptr < payload) {
         jumpptr = payload;
         SCLogDebug("jump location is before buffer start; resetting to buffer start");
-    } else if (jumpptr >= (payload + payload_len)) {
+    } else if (jumpptr > (payload + payload_len)) {
         SCLogDebug("Jump location (%" PRIu64 ") is not within payload (%" PRIu32 ")",
                 payload_len + val, payload_len);
         SCReturnBool(false);


### PR DESCRIPTION
Improve byte-jump behavior when the jump value points to the end of the buffer.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4623](https://redmine.openinfosecfoundation.org/issues/4623)

Describe changes:
- 0 length check should only occur when there are bytes to extract
- Off by one comparison with end of buffer.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1445
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
