### PR TITLE
detect/bytejump: Convert unittest to FAIL/PASS API -v 1

### DIFF
--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -751,15 +751,12 @@ static int g_dce_stub_data_buffer_id = 0;
  */
 static int DetectBytejumpTestParse01(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL, "4,0", NULL, NULL);
-    if (data != NULL) {
-        DetectBytejumpFree(NULL, data);
-        result = 1;
-    }
-
-    return result;
+    FAIL_IF_NULL(data);
+    
+    DetectBytejumpFree(NULL, data);
+    PASS;
 }
 
 /**
@@ -767,23 +764,18 @@ static int DetectBytejumpTestParse01(void)
  */
 static int DetectBytejumpTestParse02(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL, "4, 0", NULL, NULL);
-    if (data != NULL) {
-        if (   (data->nbytes == 4)
-            && (data->offset == 0)
-            && (data->multiplier == 1)
-            && (data->post_offset == 0)
-            && (data->flags == 0)
-            && (data->base == DETECT_BYTEJUMP_BASE_UNSET))
-        {
-            result = 1;
-        }
-        DetectBytejumpFree(NULL, data);
-    }
-
-    return result;
+    FAIL_IF_NULL(data);
+    FAIL_IF_NOT(data->nbytes == 4);
+    FAIL_IF_NOT(data->offset == 0);
+    FAIL_IF_NOT(data->multiplier == 1);
+    FAIL_IF_NOT(data->post_offset == 0);
+    FAIL_IF_NOT(data->flags == 0);
+    FAIL_IF_NOT(data->base == DETECT_BYTEJUMP_BASE_UNSET);
+    
+    DetectBytejumpFree(NULL, data);
+    PASS;
 }
 
 /**
@@ -791,30 +783,25 @@ static int DetectBytejumpTestParse02(void)
  */
 static int DetectBytejumpTestParse03(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL,
             " 4,0 , relative , little, string, "
             "dec, align, from_beginning",
             NULL, NULL);
-    if (data != NULL) {
-        if (   (data->nbytes == 4)
-            && (data->offset == 0)
-            && (data->multiplier == 1)
-            && (data->post_offset == 0)
-            && (data->flags == ( DETECT_BYTEJUMP_RELATIVE
+    FAIL_IF_NULL(data);
+    FAIL_IF_NOT(data->nbytes == 4);
+    FAIL_IF_NOT(data->offset == 0);
+    FAIL_IF_NOT(data->multiplier == 1);
+    FAIL_IF_NOT(data->post_offset == 0);
+    FAIL_IF_NOT(data->flags == ( DETECT_BYTEJUMP_RELATIVE
                                 |DETECT_BYTEJUMP_LITTLE
                                 |DETECT_BYTEJUMP_STRING
                                 |DETECT_BYTEJUMP_ALIGN
-                                |DETECT_BYTEJUMP_BEGIN))
-            && (data->base == DETECT_BYTEJUMP_BASE_DEC))
-        {
-            result = 1;
-        }
-        DetectBytejumpFree(NULL, data);
-    }
+                                |DETECT_BYTEJUMP_BEGIN));
+    FAIL_IF_NOT(data->base == DETECT_BYTEJUMP_BASE_DEC);
 
-    return result;
+    DetectBytejumpFree(NULL, data);
+    PASS;
 }
 
 /**
@@ -825,31 +812,26 @@ static int DetectBytejumpTestParse03(void)
  */
 static int DetectBytejumpTestParse04(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL,
             " 4,0 , relative , little, string, "
             "dec, align, from_beginning , "
             "multiplier 2 , post_offset -16 ",
             NULL, NULL);
-    if (data != NULL) {
-        if (   (data->nbytes == 4)
-            && (data->offset == 0)
-            && (data->multiplier == 2)
-            && (data->post_offset == -16)
-            && (data->flags == ( DETECT_BYTEJUMP_RELATIVE
+    FAIL_IF_NULL(data);
+    FAIL_IF_NOT(data->nbytes == 4);
+    FAIL_IF_NOT(data->offset == 0);
+    FAIL_IF_NOT(data->multiplier == 2);
+    FAIL_IF_NOT(data->post_offset == -16);
+    FAIL_IF_NOT(data->flags == ( DETECT_BYTEJUMP_RELATIVE
                                 |DETECT_BYTEJUMP_LITTLE
                                 |DETECT_BYTEJUMP_ALIGN
                                 |DETECT_BYTEJUMP_STRING
-                                |DETECT_BYTEJUMP_BEGIN))
-            && (data->base == DETECT_BYTEJUMP_BASE_DEC))
-        {
-            result = 1;
-        }
-        DetectBytejumpFree(NULL, data);
-    }
+                                |DETECT_BYTEJUMP_BEGIN));
+    FAIL_IF_NOT(data->base == DETECT_BYTEJUMP_BASE_DEC);
 
-    return result;
+    DetectBytejumpFree(NULL, data);
+    PASS;
 }
 
 /**
@@ -857,17 +839,14 @@ static int DetectBytejumpTestParse04(void)
  */
 static int DetectBytejumpTestParse05(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL,
             " 4,0 , relative , little, dec, "
             "align, from_beginning",
             NULL, NULL);
-    if (data == NULL) {
-        result = 1;
-    }
+    FAIL_IF_NOT_NULL(data);
 
-    return result;
+    PASS;
 }
 
 /**
@@ -875,14 +854,11 @@ static int DetectBytejumpTestParse05(void)
  */
 static int DetectBytejumpTestParse06(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL, "9, 0", NULL, NULL);
-    if (data == NULL) {
-        result = 1;
-    }
+    FAIL_IF_NOT_NULL(data);
 
-    return result;
+    PASS;
 }
 
 /**
@@ -890,14 +866,11 @@ static int DetectBytejumpTestParse06(void)
  */
 static int DetectBytejumpTestParse07(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL, "24, 0, string, dec", NULL, NULL);
-    if (data == NULL) {
-        result = 1;
-    }
+    FAIL_IF_NOT_NULL(data);
 
-    return result;
+    PASS;
 }
 
 /**
@@ -905,14 +878,11 @@ static int DetectBytejumpTestParse07(void)
  */
 static int DetectBytejumpTestParse08(void)
 {
-    int result = 0;
     DetectBytejumpData *data = NULL;
     data = DetectBytejumpParse(NULL, "4, 0xffffffffffffffff", NULL, NULL);
-    if (data == NULL) {
-        result = 1;
-    }
+    FAIL_IF_NOT_NULL(data);
 
-    return result;
+    PASS;
 }
 
 /**
@@ -975,11 +945,12 @@ static int DetectBytejumpTestParse10(void)
     FAIL_IF_NOT(sm->type == DETECT_BYTEJUMP);
 
     DetectBytejumpData *bd = (DetectBytejumpData *)sm->ctx;
-    if (!(bd->flags & DETECT_BYTEJUMP_DCE) && !(bd->flags & DETECT_BYTEJUMP_RELATIVE) &&
-            (bd->flags & DETECT_BYTEJUMP_STRING) && (bd->flags & DETECT_BYTEJUMP_BIG) &&
-            (bd->flags & DETECT_BYTEJUMP_LITTLE)) {
-        goto end;
-    }
+    FAIL_IF_NOT(bd->flags & DETECT_BYTEJUMP_DCE);
+    FAIL_IF_NOT(bd->flags & DETECT_BYTEJUMP_RELATIVE);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_STRING);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_BIG);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_LITTLE);
+
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
                                       "(msg:\"Testing bytejump_body\"; "
@@ -998,11 +969,11 @@ static int DetectBytejumpTestParse10(void)
     FAIL_IF_NOT(sm->type == DETECT_BYTEJUMP);
 
     bd = (DetectBytejumpData *)sm->ctx;
-    if (!(bd->flags & DETECT_BYTEJUMP_DCE) && !(bd->flags & DETECT_BYTEJUMP_RELATIVE) &&
-            (bd->flags & DETECT_BYTEJUMP_STRING) && (bd->flags & DETECT_BYTEJUMP_BIG) &&
-            (bd->flags & DETECT_BYTEJUMP_LITTLE)) {
-        goto end;
-    }
+    FAIL_IF_NOT(bd->flags & DETECT_BYTEJUMP_DCE);
+    FAIL_IF_NOT(bd->flags & DETECT_BYTEJUMP_RELATIVE);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_STRING);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_BIG);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_LITTLE);
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
                                       "(msg:\"Testing bytejump_body\"; "
@@ -1021,13 +992,12 @@ static int DetectBytejumpTestParse10(void)
     FAIL_IF_NOT(sm->type == DETECT_BYTEJUMP);
 
     bd = (DetectBytejumpData *)sm->ctx;
-    if ((bd->flags & DETECT_BYTEJUMP_DCE) && !(bd->flags & DETECT_BYTEJUMP_RELATIVE) &&
-            (bd->flags & DETECT_BYTEJUMP_STRING) && (bd->flags & DETECT_BYTEJUMP_BIG) &&
-            (bd->flags & DETECT_BYTEJUMP_LITTLE)) {
-        goto end;
-    }
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_DCE);
+    FAIL_IF_NOT(bd->flags & DETECT_BYTEJUMP_RELATIVE);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_STRING);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_BIG);
+    FAIL_IF(bd->flags & DETECT_BYTEJUMP_LITTLE);
 
-end:
     DetectEngineCtxFree(de_ctx);
     PASS;
 }
@@ -1038,12 +1008,10 @@ end:
 static int DetectBytejumpTestParse11(void)
 {
     DetectEngineCtx *de_ctx = NULL;
-    int result = 1;
     Signature *s = NULL;
 
     de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
     s = SigInit(de_ctx, "alert tcp any any -> any any "
@@ -1052,10 +1020,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,string,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1063,10 +1028,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_sub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,big,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1074,10 +1036,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,little,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1085,10 +1044,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,string,hex,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1096,10 +1052,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,string,dec,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1107,10 +1060,7 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,string,oct,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
     s = SigInit(de_ctx, "alert tcp any any -> any any "
                 "(msg:\"Testing bytejump_body\"; "
@@ -1118,17 +1068,12 @@ static int DetectBytejumpTestParse11(void)
                 "dce_stub_data; "
                 "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
                 "post_offset -16,from_beginning,dce; sid:1;)");
-    if (s != NULL) {
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NOT_NULL(s);
 
- end:
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
     DetectEngineCtxFree(de_ctx);
-
-    return result;
+    PASS;
 }
 
 /**
@@ -1192,7 +1137,6 @@ static int DetectBytejumpTestParse14(void)
  */
 static int DetectByteJumpTestPacket01 (void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"GET /AllWorkAndNoPlayMakesWillADullBoy HTTP/1.0"
                     "User-Agent: Wget/1.11.4"
                     "Accept: */*"
@@ -1203,18 +1147,16 @@ static int DetectByteJumpTestPacket01 (void)
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (msg:\"pcre + byte_test + "
     "relative\"; pcre:\"/AllWorkAndNoPlayMakesWillADullBoy/\"; byte_jump:1,6,"
     "relative,string,dec; content:\"0\"; sid:134; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig);
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig));
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 /**
@@ -1224,7 +1166,6 @@ end:
  */
 static int DetectByteJumpTestPacket02 (void)
 {
-    int result = 0;
     uint8_t buf[] = { 0x00, 0x00, 0x00, 0x77, 0xff, 0x53,
                     0x4d, 0x42, 0x2f, 0x00, 0x00, 0x00, 0x00, 0x18,
                     0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1236,23 +1177,20 @@ static int DetectByteJumpTestPacket02 (void)
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (msg:\"byte_jump with byte_jump"
                  " + relative\"; byte_jump:1,13; byte_jump:4,0,relative; "
                  "content:\"|48 00 00|\"; within:3; sid:144; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig);
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig));
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 static int DetectByteJumpTestPacket03(void)
 {
-    int result = 0;
     uint8_t *buf = NULL;
     uint16_t buflen = 0;
     buf = SCMalloc(4);
@@ -1266,20 +1204,18 @@ static int DetectByteJumpTestPacket03(void)
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (msg:\"byte_jump\"; "
         "byte_jump:1,214748364; sid:1; rev:1;)";
 
-    result = !UTHPacketMatchSig(p, sig);
+    FAIL_IF(UTHPacketMatchSig(p, sig));
 
     UTHFreePacket(p);
+    FAIL_IF_NULL(buf);
 
-end:
-    if (buf != NULL)
-        SCFree(buf);
-    return result;
+    SCFree(buf);
+    PASS;
 }
 
 /**
@@ -1287,22 +1223,19 @@ end:
  */
 static int DetectByteJumpTestPacket04 (void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"XYZ04abcdABCD";
     uint16_t buflen = strlen((char *)buf);
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (content:\"XYZ\"; byte_jump:2,0,relative,string,dec; content:\"ABCD\"; distance:0; within:4; sid:1; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig);
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig));
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 /**
@@ -1310,22 +1243,19 @@ end:
  */
 static int DetectByteJumpTestPacket05 (void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"XYZ04abcdABCD";
     uint16_t buflen = strlen((char *)buf);
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (content:\"XYZ\"; byte_jump:2,0,relative,string,dec; content:\"cdABCD\"; within:6; sid:1; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig) ? 0 : 1;
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig) ? 0 : 1);
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 /**
@@ -1333,22 +1263,19 @@ end:
  */
 static int DetectByteJumpTestPacket06 (void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"XX04abcdABCD";
     uint16_t buflen = strlen((char *)buf);
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (content:\"XX\"; byte_jump:2,0,relative,string,dec,from_beginning; content:\"ABCD\"; distance:4; within:4; sid:1; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig);
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig));
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 /**
@@ -1356,22 +1283,19 @@ end:
  */
 static int DetectByteJumpTestPacket07 (void)
 {
-    int result = 0;
     uint8_t *buf = (uint8_t *)"XX04abcdABCD";
     uint16_t buflen = strlen((char *)buf);
     Packet *p;
     p = UTHBuildPacket((uint8_t *)buf, buflen, IPPROTO_TCP);
 
-    if (p == NULL)
-        goto end;
+    FAIL_IF_NULL(p);
 
     char sig[] = "alert tcp any any -> any any (content:\"XX\"; byte_jump:2,0,relative,string,dec,from_beginning; content:\"abcdABCD\"; distance:0; within:8; sid:1; rev:1;)";
 
-    result = UTHPacketMatchSig(p, sig) ? 1 : 0;
+    FAIL_IF_NOT(UTHPacketMatchSig(p, sig) ? 1 : 0);
 
     UTHFreePacket(p);
-end:
-    return result;
+    PASS;
 }
 
 /**


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6328

Describe changes:
- Converted the bytejump unittest in the `detect-bytejump.c` file to the FAIL/PASS API.