### PR TITLE
dns/eve: use defaults formats if formats is empty

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -265,6 +265,7 @@ typedef struct LogDnsLogThread_ {
 
 JsonBuilder *JsonDNSLogQuery(void *txptr)
 {
+    SCLogNotice("JsonDNSLogQuery");
     JsonBuilder *queryjb = jb_new_array();
     if (queryjb == NULL) {
         return NULL;
@@ -512,14 +513,22 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
         if (dnslog_ctx->flags & LOG_ANSWERS) {
             ConfNode *format;
             if ((format = ConfNodeLookupChild(conf, "formats")) != NULL) {
-                dnslog_ctx->flags &= ~LOG_FORMAT_ALL;
+                uint64_t flags = 0;
                 ConfNode *field;
                 TAILQ_FOREACH (field, &format->head, next) {
                     if (strcasecmp(field->val, "detailed") == 0) {
-                        dnslog_ctx->flags |= LOG_FORMAT_DETAILED;
+                        flags |= LOG_FORMAT_DETAILED;
                     } else if (strcasecmp(field->val, "grouped") == 0) {
-                        dnslog_ctx->flags |= LOG_FORMAT_GROUPED;
+                        flags |= LOG_FORMAT_GROUPED;
+                    } else {
+                        SCLogError("Invalid JSON DNS log format: %s", field->val);
                     }
+                }
+                if (flags) {
+                    dnslog_ctx->flags &= ~LOG_FORMAT_ALL;
+                    dnslog_ctx->flags |= flags;
+                } else {
+                    SCLogWarning("Empty EVE DNS format array, using defaults");
                 }
             } else {
                 dnslog_ctx->flags |= LOG_FORMAT_ALL;


### PR DESCRIPTION
If the configuration field "formats" is empty, DNS response records do
not have any relevant information other than that there was a
response, but not much about the response.

I'm pretty sure the intention here was to log the response details if
no formats were provided, which is what happens when the field is
commented out.

So if no formats are specified, use the default of all.

Bug: https://redmine.openinfosecfoundation.org/issues/6420

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1446
