### PR TITLE
runmodes: remove obsolete references to pcap auto modes

### DIFF
--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -42,11 +42,8 @@ void RunModeFilePcapRegister(void)
     RunModeRegisterNewRunMode(RUNMODE_PCAP_FILE, "single", "Single threaded pcap file mode",
             RunModeFilePcapSingle, NULL);
     RunModeRegisterNewRunMode(RUNMODE_PCAP_FILE, "autofp",
-            "Multi threaded pcap file mode.  Packets from "
-            "each flow are assigned to a single detect thread, "
-            "unlike \"pcap-file-auto\" where packets from "
-            "the same flow can be processed by any detect "
-            "thread",
+            "Multi-threaded pcap file mode. Packets from each flow are assigned to a consistent "
+            "detection thread",
             RunModeFilePcapAutoFp, NULL);
 
     return;

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -41,11 +41,8 @@ void RunModeIdsPcapRegister(void)
     RunModeRegisterNewRunMode(RUNMODE_PCAP_DEV, "single", "Single threaded pcap live mode",
             RunModeIdsPcapSingle, NULL);
     RunModeRegisterNewRunMode(RUNMODE_PCAP_DEV, "autofp",
-            "Multi threaded pcap live mode.  Packets from "
-            "each flow are assigned to a single detect thread, "
-            "unlike \"pcap_live_auto\" where packets from "
-            "the same flow can be processed by any detect "
-            "thread",
+            "Multi-threaded pcap live mode. Packets from each flow are assigned to a consistent "
+            "detection thread",
             RunModeIdsPcapAutoFp, NULL);
     RunModeRegisterNewRunMode(RUNMODE_PCAP_DEV, "workers",
             "Workers pcap live mode, each thread does all"


### PR DESCRIPTION
These auto modes were remove many years ago. Also cleanup the wording
a little.

Task: https://redmine.openinfosecfoundation.org/issues/6427
