### PR TITLE
stats: Log packets/bytes per second in Suricata stats - V1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4120,6 +4120,9 @@
                         "bytes": {
                             "type": "integer"
                         },
+                        "bytes_per_sec": {
+                            "type": "integer"
+                        },
                         "chdlc": {
                             "type": "integer"
                         },
@@ -4187,6 +4190,9 @@
                             "type": "integer"
                         },
                         "pkts": {
+                            "type": "integer"
+                        },
+                        "pkts_per_sec": {
                             "type": "integer"
                         },
                         "ppp": {

--- a/src/counters.c
+++ b/src/counters.c
@@ -56,8 +56,9 @@ enum {
     STATS_TYPE_AVERAGE = 2,
     STATS_TYPE_MAXIMUM = 3,
     STATS_TYPE_FUNC = 4,
+    STATS_TYPE_TIMED = 5,
 
-    STATS_TYPE_MAX = 5,
+    STATS_TYPE_MAX = 6,
 };
 
 /**
@@ -778,6 +779,8 @@ static int StatsOutput(ThreadVars *tv)
             StatsRecord *r = &stats_table.tstats[offset];
             /* xfer previous value to pvalue and reset value */
             r->pvalue = r->value;
+            r->counter_pvalue = r->counter_value;
+            r->counter_value = e->value;
             r->value = 0;
             r->name = table[c].name;
             r->short_name = table[c].short_name;
@@ -788,6 +791,10 @@ static int StatsOutput(ThreadVars *tv)
                     if (e->value > 0 && e->updates > 0) {
                         r->value = (uint64_t)(e->value / e->updates);
                     }
+                    break;
+                case STATS_TYPE_TIMED:
+                    r->value = r->counter_value - r->counter_pvalue;
+                    r->value = (uint64_t)(r->value / stats_tts);
                     break;
                 default:
                     r->value = e->value;
@@ -801,12 +808,14 @@ static int StatsOutput(ThreadVars *tv)
 
     /* transfer 'merge table' to final stats table */
     for (uint16_t x = 0; x < max_id; x++) {
+        struct CountersMergeTable *m = &merge_table[x];
         /* xfer previous value to pvalue and reset value */
+        table[x].counter_pvalue = table[x].counter_value;
+        table[x].counter_value = m->value;
         table[x].pvalue = table[x].value;
         table[x].value = 0;
         table[x].tm_name = "Total";
 
-        struct CountersMergeTable *m = &merge_table[x];
         switch (m->type) {
             case STATS_TYPE_MAXIMUM:
                 if (m->value > table[x].value)
@@ -816,6 +825,10 @@ static int StatsOutput(ThreadVars *tv)
                 if (m->value > 0 && m->updates > 0) {
                     table[x].value = (uint64_t)(m->value / m->updates);
                 }
+                break;
+            case STATS_TYPE_TIMED:
+                table[x].value = table[x].counter_value - table[x].counter_pvalue;
+                table[x].value = (uint64_t)(table[x].value / stats_tts);
                 break;
             default:
                 table[x].value += m->value;
@@ -1004,6 +1017,25 @@ uint16_t StatsRegisterMaxCounter(const char *name, struct ThreadVars_ *tv)
             (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
             &tv->perf_public_ctx,
             STATS_TYPE_MAXIMUM, NULL);
+    return id;
+}
+
+/**
+ * \brief Registers a counter, whose value holds the value assigne to it
+ *        ,in a stat window, per second in a.
+ *
+ * \param name Name of the counter, to be registered
+ * \param tv    Pointer to the ThreadVars instance for which the counter would
+ *              be registered
+ *
+ * \retval id Counter id for the newly registered counter, or the already
+ *            present counter
+ */
+uint16_t StatsRegisterTmdCounter(const char *name, struct ThreadVars_ *tv)
+{
+    uint16_t id = StatsRegisterQualifiedCounter(name,
+            (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
+            &tv->perf_public_ctx, STATS_TYPE_TIMED, NULL);
     return id;
 }
 

--- a/src/counters.h
+++ b/src/counters.h
@@ -121,6 +121,7 @@ void StatsReleaseResources(void);
 uint16_t StatsRegisterCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterAvgCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterMaxCounter(const char *, struct ThreadVars_ *);
+uint16_t StatsRegisterTmdCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
 
 /* functions used to update local counter values */

--- a/src/decode.c
+++ b/src/decode.c
@@ -564,6 +564,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_mpls = StatsRegisterCounter("decoder.mpls", tv);
     dtv->counter_avg_pkt_size = StatsRegisterAvgCounter("decoder.avg_pkt_size", tv);
     dtv->counter_max_pkt_size = StatsRegisterMaxCounter("decoder.max_pkt_size", tv);
+    dtv->counter_pkts_per_sec = StatsRegisterTmdCounter("decoder.pkts_per_sec", tv);
+    dtv->counter_bytes_per_sec = StatsRegisterTmdCounter("decoder.bytes_per_sec", tv);
     dtv->counter_max_mac_addrs_src = StatsRegisterMaxCounter("decoder.max_mac_addrs_src", tv);
     dtv->counter_max_mac_addrs_dst = StatsRegisterMaxCounter("decoder.max_mac_addrs_dst", tv);
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
@@ -655,8 +657,9 @@ void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p)
 {
     StatsIncr(tv, dtv->counter_pkts);
-    //StatsIncr(tv, dtv->counter_pkts_per_sec);
+    StatsIncr(tv, dtv->counter_pkts_per_sec);
     StatsAddUI64(tv, dtv->counter_bytes, GET_PKT_LEN(p));
+    StatsAddUI64(tv, dtv->counter_bytes_per_sec, GET_PKT_LEN(p));
     StatsAddUI64(tv, dtv->counter_avg_pkt_size, GET_PKT_LEN(p));
     StatsSetUI64(tv, dtv->counter_max_pkt_size, GET_PKT_LEN(p));
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -674,6 +674,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_bytes;
     uint16_t counter_avg_pkt_size;
     uint16_t counter_max_pkt_size;
+    uint16_t counter_pkts_per_sec;
+    uint16_t counter_bytes_per_sec;
     uint16_t counter_max_mac_addrs_src;
     uint16_t counter_max_mac_addrs_dst;
 

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -34,6 +34,8 @@ typedef struct StatsRecord_ {
     const char *tm_name;
     int64_t value;  /**< total value */
     int64_t pvalue; /**< prev value (may be higher for memuse counters) */
+    int64_t counter_value;  /**< counter value used to calculate this stats */
+    int64_t counter_pvalue; /**< counter prev value used to calculate this stats */
 } StatsRecord;
 
 typedef struct StatsTable_ {


### PR DESCRIPTION
This commit aims to add packets/bytes per second to Suricata's statistics log. To achieve this, a new type of qualifier was created and two new fields were added to the Start Record structure.

Task OISF#6410

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6410