### PR TITLE
[6.0.x backport] bytejump + dns eve/v2

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -595,14 +595,24 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
             if (dnslog_ctx->flags & LOG_ANSWERS) {
                 ConfNode *format;
                 if ((format = ConfNodeLookupChild(conf, "formats")) != NULL) {
-                    dnslog_ctx->flags &= ~LOG_FORMAT_ALL;
+                    uint64_t flags = 0;
                     ConfNode *field;
                     TAILQ_FOREACH(field, &format->head, next) {
                         if (strcasecmp(field->val, "detailed") == 0) {
-                            dnslog_ctx->flags |= LOG_FORMAT_DETAILED;
+                            flags |= LOG_FORMAT_DETAILED;
                         } else if (strcasecmp(field->val, "grouped") == 0) {
-                            dnslog_ctx->flags |= LOG_FORMAT_GROUPED;
+                            flags |= LOG_FORMAT_GROUPED;
+                        } else {
+                            SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid JSON DNS log format: %s",
+                                    field->val);
                         }
+                    }
+                    if (flags) {
+                        dnslog_ctx->flags &= ~LOG_FORMAT_ALL;
+                        dnslog_ctx->flags |= flags;
+                    } else {
+                        SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                                "Empty EVE DNS format array, using defaults");
                     }
                 } else {
                     dnslog_ctx->flags |= LOG_FORMAT_ALL;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6378
https://redmine.openinfosecfoundation.org/issues/6421

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1450

Previous PR: https://github.com/OISF/suricata/pull/9717

Changes since v1:
- added fix for ticket 6421 to fix failing CI