### PR TITLE
macset: remove dead flow cleanup code

### DIFF
--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -115,12 +115,6 @@
         (f)->sgh_toclient = NULL;                                                                  \
         GenericVarFree((f)->flowvar);                                                              \
         (f)->flowvar = NULL;                                                                       \
-        if (MacSetFlowStorageEnabled()) {                                                          \
-            MacSet *ms = FlowGetStorageById((f), MacSetGetFlowStorageID());                        \
-            if (ms != NULL) {                                                                      \
-                MacSetReset(ms);                                                                   \
-            }                                                                                      \
-        }                                                                                          \
         RESET_COUNTERS((f));                                                                       \
     } while (0)
 


### PR DESCRIPTION
The only caller of `FLOW_RECYCLE` first calls `FlowFreeStorage()`, so the reset logic in `FLOW_RECYCLE` can never trigger.

@satta can  you have a look at this? Thanks!