### PR TITLE
detect/flow: optimize only_stream/no_stream options

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1970,6 +1970,10 @@ static int DetectEngineInspectRulePayloadMatches(
             if (!(s->flags & SIG_FLAG_REQUIRE_PACKET) && (p->flags & PKT_STREAM_ADD)) {
                 return false;
             }
+            if (s->flags & SIG_FLAG_REQUIRE_STREAM_ONLY) {
+                SCLogDebug("SIG_FLAG_REQUIRE_STREAM_ONLY, so no match");
+                return false;
+            }
             if (DetectEngineInspectPacketPayload(de_ctx, det_ctx, s, p->flow, p) != 1) {
                 return false;
             }

--- a/src/detect.h
+++ b/src/detect.h
@@ -246,6 +246,10 @@ typedef struct DetectPort_ {
 
 #define SIG_FLAG_FLUSH                  BIT_U32(12) /**< detection logic needs stream flush notification */
 
+#define SIG_FLAG_REQUIRE_STREAM_ONLY                                                               \
+    BIT_U32(13) /**< signature is requiring stream match. Stream match is not optional, so no      \
+                   fallback to packet payload. */
+
 // vacancies
 
 #define SIG_FLAG_REQUIRE_FLOWVAR        BIT_U32(17) /**< signature can only match if a flowbit, flowvar or flowint is available. */


### PR DESCRIPTION
Until now the implementation would scan the stream, fallback to the packet payload in exception cases, then keep track of where the match was and in the flow match logic reject the match if it was in the wrong buffer.

This patch simplifies this logic, by refusing to inspect the packet payload when `only_stream` is set.

To do this the `only_stream`/`no_stream` options are now translated to the pseudo protocols `tcp-stream` and `tcp-pkt` at parsing, so that the `flow` keyword doesn't have to evaluate these conditions anymore.
