### PR TITLE
config/mt: Add vlan-pair MT selector

### DIFF
--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -73,6 +73,11 @@ argsd = {
             "type": int,
             "required": 0,
         },
+        {
+            "name": "hargs_extra",
+            "type": int,
+            "required": 0,
+        },
     ],
     "register-tenant-handler": [
         {
@@ -86,6 +91,11 @@ argsd = {
         },
         {
             "name": "hargs",
+            "type": int,
+            "required": 0,
+        },
+        {
+            "name": "hargs_extra",
             "type": int,
             "required": 0,
         },

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -133,8 +133,14 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantRegisterVlanIdPair(
+        uint32_t tenant_id, uint16_t vlan_outer, uint16_t vlan_inner);
+int DetectEngineTenantUnregisterVlanIdPair(
+        uint32_t tenant_id, uint16_t vlan_outer, uint16_t vlan_inner);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1496,19 +1496,24 @@ typedef struct SigGroupHead_ {
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_VLAN_PAIR,   /**< map vlan pair to tenant id */
 };
+
+typedef union _traffic_id {
+    uint32_t id;
+    uint16_t vlan_pair[2];
+} TrafficId;
 
 typedef struct DetectEngineTenantMapping_ {
     uint32_t tenant_id;
 
     /* traffic id that maps to the tenant id */
-    uint32_t traffic_id;
+    TrafficId traffic_id;
 
     struct DetectEngineTenantMapping_ *next;
 } DetectEngineTenantMapping;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -881,22 +881,54 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         traffic_id = json_integer_value(hargs);
     }
 
+    /* 3.5 (vlan-pair only) Get optional hargs_extra (vlan-id-inner) */
+    int traffic_id_inner = -1;
+    if (0 == strcmp(htype, "vlan-pair")) {
+        hargs = json_object_get(cmd, "hargs_extra");
+        if (hargs != NULL) {
+            if (!json_is_integer(hargs)) {
+                SCLogInfo("error: hargs_extra not a number");
+                json_object_set_new(answer, "message", json_string("hargs_extra not a number"));
+                return TM_ECODE_FAILED;
+            }
+            traffic_id_inner = json_integer_value(hargs);
+        }
+    }
+
     /* 4 add to system */
     int r = -1;
     if (strcmp(htype, "pcap") == 0) {
         r = DetectEngineTenantRegisterPcapFile(tenant_id);
-    } else if (strcmp(htype, "vlan") == 0) {
+    } else if (strcmp(htype, "vlan") == 0 || strcmp(htype, "vlan-pair") == 0) {
         if (traffic_id < 0) {
             json_object_set_new(answer, "message", json_string("vlan requires argument"));
             return TM_ECODE_FAILED;
         }
-        if (traffic_id > USHRT_MAX) {
+        if (traffic_id > 4094) {
             json_object_set_new(answer, "message", json_string("vlan argument out of range"));
             return TM_ECODE_FAILED;
         }
+        if (strcmp(htype, "vlan-pair") == 0) {
+            if (traffic_id_inner < 0) {
+                json_object_set_new(answer, "message", json_string("vlan-pair requires argument"));
+                return TM_ECODE_FAILED;
+            }
+            if (traffic_id_inner > 4094) {
+                json_object_set_new(
+                        answer, "message", json_string("vlan-pair argument out of range"));
+                return TM_ECODE_FAILED;
+            }
+        }
 
-        SCLogInfo("VLAN handler: id %u maps to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTenantRegisterVlanId(tenant_id, (uint16_t)traffic_id);
+        if (strcmp(htype, "vlan") == 0) {
+            SCLogInfo("VLAN handler: id %u maps to tenant %u", (uint32_t)traffic_id, tenant_id);
+            r = DetectEngineTenantRegisterVlanId(tenant_id, (uint16_t)traffic_id);
+        } else {
+            SCLogInfo("VLAN-pair handler: id %u:%u maps to tenant %u", (uint32_t)traffic_id,
+                    (uint32_t)traffic_id_inner, tenant_id);
+            r = DetectEngineTenantRegisterVlanIdPair(
+                    tenant_id, (uint16_t)traffic_id, (uint16_t)traffic_id_inner);
+        }
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler setup failure"));
@@ -961,23 +993,55 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         }
         traffic_id = json_integer_value(hargs);
     }
+    /* 3.5 Get optional hargs_extra (only with vlan-pair) */
+    int traffic_id_inner = -1;
+    if (0 == strcmp(htype, "vlan-pair")) {
+        hargs = json_object_get(cmd, "hargs_extra");
+        if (hargs != NULL) {
+            if (!json_is_integer(hargs)) {
+                SCLogInfo("error: hargs_extra not a number");
+                json_object_set_new(answer, "message", json_string("hargs not a number"));
+                return TM_ECODE_FAILED;
+            }
+            traffic_id_inner = json_integer_value(hargs);
+        }
+    }
 
     /* 4 add to system */
     int r = -1;
     if (strcmp(htype, "pcap") == 0) {
         r = DetectEngineTenantUnregisterPcapFile(tenant_id);
-    } else if (strcmp(htype, "vlan") == 0) {
+    } else if (strcmp(htype, "vlan") == 0 || strcmp(htype, "vlan-pair") == 0) {
         if (traffic_id < 0) {
             json_object_set_new(answer, "message", json_string("vlan requires argument"));
             return TM_ECODE_FAILED;
         }
-        if (traffic_id > USHRT_MAX) {
+        if (traffic_id > 4094) {
             json_object_set_new(answer, "message", json_string("vlan argument out of range"));
             return TM_ECODE_FAILED;
         }
+        if (strcmp(htype, "vlan-pair") == 0) {
+            if (traffic_id_inner < 0) {
+                json_object_set_new(answer, "message", json_string("vlan-pair requires argument"));
+                return TM_ECODE_FAILED;
+            }
+            if (traffic_id_inner > 4094) {
+                json_object_set_new(
+                        answer, "message", json_string("vlan-pair argument out of range"));
+                return TM_ECODE_FAILED;
+            }
+        }
 
-        SCLogInfo("VLAN handler: removing mapping of %u to tenant %u", (uint32_t)traffic_id, tenant_id);
-        r = DetectEngineTenantUnregisterVlanId(tenant_id, (uint16_t)traffic_id);
+        if (strcmp(htype, "vlan") == 0) {
+            SCLogInfo("VLAN handler: removing mapping of %u to tenant %u", (uint32_t)traffic_id,
+                    tenant_id);
+            r = DetectEngineTenantUnregisterVlanId(tenant_id, (uint16_t)traffic_id);
+        } else {
+            SCLogInfo("VLAN handler: removing mapping of %u:%u to tenant %u", (uint32_t)traffic_id,
+                    (uint32_t)traffic_id_inner, tenant_id);
+            r = DetectEngineTenantUnregisterVlanIdPair(
+                    tenant_id, (uint16_t)traffic_id, (uint16_t)traffic_id_inner);
+        }
     }
     if (r != 0) {
         json_object_set_new(answer, "message", json_string("handler unregister failure"));


### PR DESCRIPTION
Continuation of #9401

Add a new MT selector type to support use cases where a VLAN pair should be used to determine the MT tenant.

Packets with one VLAN id will never match as `vlan-pair` requires at least QinQ

Tenants are selected by:
- The outer VLAN equals `vlan-id` or `vlan-id` is 0 (wildcard)
- The inner VLAN equals `vlan-id-inner` or `vlan-id-inner` is 0 (wildcard)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6237](https://redmine.openinfosecfoundation.org/issues/6237)

Describe changes:
- Add and document a new MT selector -- `vlan-pair` -- for use cases where a VLAN pair should determines the tenant.

Updates
- Reworked to support a pair of VLAN (outer, inner) determines the tenant.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1354
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
