### PR TITLE
macset: remove dead flow init/cleanup code

### DIFF
--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -200,13 +200,9 @@ void FlowInit(Flow *f, const Packet *p)
     f->timeout_at = timeout_at;
 
     if (MacSetFlowStorageEnabled()) {
-        MacSet *ms = FlowGetStorageById(f, MacSetGetFlowStorageID());
-        if (ms != NULL) {
-            MacSetReset(ms);
-        } else {
-            ms = MacSetInit(10);
-            FlowSetStorageById(f, MacSetGetFlowStorageID(), ms);
-        }
+        DEBUG_VALIDATE_BUG_ON(FlowGetStorageById(f, MacSetGetFlowStorageID()) != NULL);
+        MacSet *ms = MacSetInit(10);
+        FlowSetStorageById(f, MacSetGetFlowStorageID(), ms);
     }
 
     SCReturn;

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -115,12 +115,6 @@
         (f)->sgh_toclient = NULL;                                                                  \
         GenericVarFree((f)->flowvar);                                                              \
         (f)->flowvar = NULL;                                                                       \
-        if (MacSetFlowStorageEnabled()) {                                                          \
-            MacSet *ms = FlowGetStorageById((f), MacSetGetFlowStorageID());                        \
-            if (ms != NULL) {                                                                      \
-                MacSetReset(ms);                                                                   \
-            }                                                                                      \
-        }                                                                                          \
         RESET_COUNTERS((f));                                                                       \
     } while (0)
 

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -259,14 +259,6 @@ int MacSetSize(const MacSet *ms)
     return size;
 }
 
-void MacSetReset(MacSet *ms)
-{
-    if (ms == NULL)
-        return;
-    ms->state[MAC_SET_SRC] = ms->state[MAC_SET_DST] = EMPTY_SET;
-    ms->last[MAC_SET_SRC] = ms->last[MAC_SET_DST] = 0;
-}
-
 void MacSetFree(MacSet *ms)
 {
     size_t total_free = 0;
@@ -331,16 +323,6 @@ static int MacSetTest01(void)
     FAIL_IF_NOT(MacSetSize(ms) == 3);
 
     i = 0;
-    ret = MacSetForEach(ms, CheckTest1Membership, &i);
-    FAIL_IF_NOT(ret == 0);
-
-    MacSetReset(ms);
-    FAIL_IF_NOT(MacSetSize(ms) == 0);
-
-    MacSetAdd(ms, addr2, addr3);
-    FAIL_IF_NOT(MacSetSize(ms) == 2);
-
-    i = 1;
     ret = MacSetForEach(ms, CheckTest1Membership, &i);
     FAIL_IF_NOT(ret == 0);
 


### PR DESCRIPTION
FlowInit() will only be called on a newly allocated, or a fully cleaned up flow, so no existing storage will exist.

The only caller of `FLOW_RECYCLE` first calls `FlowFreeStorage()`, so the reset logic in `FLOW_RECYCLE` can never trigger.

Remove now unused MacSetReset logic.

replaces #9723 
cc @satta 