### PR TITLE
config/mt: Add vlan-tuple MT selector 

### DIFF
--- a/doc/userguide/configuration/multi-tenant.rst
+++ b/doc/userguide/configuration/multi-tenant.rst
@@ -18,7 +18,7 @@ Add a new section in the main ("master") Suricata configuration file -- ``surica
 Settings:
 
 * `enabled`: yes/no -> is multi-tenancy support enabled
-* `selector`: direct (for unix socket pcap processing, see below), VLAN or device
+* `selector`: direct (for unix socket pcap processing, see below), vlan, vlan-tuple or device
 * `loaders`: number of `loader` threads, for parallel tenant loading at startup
 * `tenants`: list of tenants
 * `config-path`: path from where the tenant yamls are loaded
@@ -27,15 +27,30 @@ Settings:
   * yaml: separate yaml file with the tenant specific settings
 
 * `mappings`:
+  * tenant id: tenant to associate with the VLAN id or device
+
+Tenant mappings depend on the type of selector used:
+
+* `vlan` or `device`
 
   * VLAN id or device: The outermost VLAN is used to match.
-  * tenant id: tenant to associate with the VLAN id or device
+
+* `vlan-tuple`
+
+  * VLAN tuple: Specify the VLAN identifiers -- outermost to innermost, e.g., `[3000, 1]` will match when the
+    outermost VLAN id is 3000 and the innermost VLAN id is 1. The special value of `0` means "any VLAN in that position" will match.
+    Note that there must the same number of layers of VLAN encapsulation as there are values in the tuple.
+
+
+    * `[0, 302]` will match any packet with an innermost VLAN id of `302` on packets that are QinQ..
+    * `[3000, 0]` will match any packet with an outermost VLAN id of `3000` on packets that are QinQ..
+    * `[3000, 1000, 40]` will match any packet with 3-VLAN identifiers of outermost `3000`, middle `1000` and innermost `40`.
 
 ::
 
   multi-detect:
     enabled: yes
-    #selector: direct # direct or vlan
+    #selector: direct # direct or vlan, vlan-tuple
     selector: vlan
     loaders: 3
 
@@ -54,6 +69,33 @@ Settings:
       tenant-id: 2
     - vlan-id: 1112
       tenant-id: 3
+
+
+This example uses the VLAN tuple selector for packets encapsulated with two VLAN ids:
+
+::
+
+  multi-detect:
+    enabled: yes
+    selector: vlan-tuple
+    loaders: 3
+
+    tenants:
+    - id: 1
+      yaml: tenant-1.yaml
+    - id: 2
+      yaml: tenant-2.yaml
+    - id: 3
+      yaml: tenant-3.yaml
+
+    mappings:
+    - vlan-tuple: [1000, 1]
+      tenant-id: 1
+    - vlan-tuple: [2000, 1]
+      tenant-id: 2
+    - vlan-tuple: [1112, 1]
+      tenant-id: 3
+
 
 The tenant-1.yaml, tenant-2.yaml, tenant-3.yaml each contain a partial
 configuration:
@@ -97,8 +139,11 @@ configuration:
 vlan-id
 ~~~~~~~
 
-Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value.
-Multiple VLANs can have the same tenant id. VLAN id values must be between 1 and 4094.
+Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value with
+the selector ``vlan`` (default); the selector ``vlan-tuple`` should be used if QinQ is deployed and requires both
+the inner and outer VLAN id values to match to determine the tenant.
+Multiple VLANs can have the same tenant id. VLAN id values must be between 1 and 4094 with the ``vlan`` selector.
+A wildcard value of ``00`` can be used with the ``vlan-tuple`` selector.
 
 Example of VLAN mapping::
 
@@ -108,6 +153,26 @@ Example of VLAN mapping::
     - vlan-id: 2000
       tenant-id: 2
     - vlan-id: 1112
+      tenant-id: 3
+
+The mappings can also be modified over the unix socket, see below.
+
+Note: can only be used if ``vlan.use-for-tracking`` is enabled.
+
+vlan-tuple
+~~~~~~~~~~
+
+The ``vlan-tuple`` tag can only used with the ``vlan-tuple`` selector. The value will be used
+to match with the innermost VLAN. Values of ``0`` will match any VLAN value.
+
+Example of VLAN mapping::
+
+    mappings:
+    - vlan-tuple: [1000, 0]
+      tenant-id: 1
+    - vlan-tuple: [2000, 3000]
+      tenant-id: 2
+    - vlan-tuple: [1112, 3112]
       tenant-id: 3
 
 The mappings can also be modified over the unix socket, see below.
@@ -195,25 +260,52 @@ Live traffic mode
 
 Multi-tenancy supports both VLAN and devices with live traffic.
 
-In the master configuration yaml file, specify ``device`` or ``vlan`` for the ``selector`` setting.
+In the master configuration yaml file, specify ``device``, ``vlan`` or ``vlan-tuple`` for the ``selector`` setting.
 
 Registration
 ~~~~~~~~~~~~
 
 Tenants can be mapped to vlan ids.
 
-``register-tenant-handler <tenant id> vlan <vlan id>``
+
+Examples using the ``vlan`` selector:
+
+::
+
+  register-tenant-handler <tenant id> vlan <vlan id>
 
 ::
 
   register-tenant-handler 1 vlan 1000
 
-``unregister-tenant-handler <tenant id> vlan <vlan id>``
+::
+
+  unregister-tenant-handler <tenant id> vlan <vlan id>
 
 ::
 
   unregister-tenant-handler 4 vlan 1111
   unregister-tenant-handler 1 vlan 1000
+
+
+Examples using the ``vlan-tuple`` selector:
+
+::
+
+  register-tenant-handler <tenant id> vlan-tuple <vlan outer id> <vlan inner id>
+
+::
+
+  register-tenant-handler 1 vlan-tuple 1000
+
+::
+
+  unregister-tenant-handler <tenant id> vlan-tuple <vlan outer id> <vlan inner id>
+
+::
+
+  unregister-tenant-handler 4 vlan-tuple 1111 1
+  unregister-tenant-handler 1 vlan-tuple 1000 2
 
 The registration of tenant and tenant handlers can be done on a
 running engine.

--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -73,6 +73,11 @@ argsd = {
             "type": int,
             "required": 0,
         },
+        {
+            "name": "hargs_extra",
+            "type": int,
+            "required": 0,
+        },
     ],
     "register-tenant-handler": [
         {
@@ -86,6 +91,11 @@ argsd = {
         },
         {
             "name": "hargs",
+            "type": int,
+            "required": 0,
+        },
+        {
+            "name": "hargs_extra",
             "type": int,
             "required": 0,
         },

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -101,6 +101,7 @@ static char TenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len
 static void TenantIdFree(void *d);
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
+static uint32_t DetectEngineTenantGetIdFromVlanIdTuple(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
 
 static DetectEngineAppInspectionEngine *g_app_inspect_engines = NULL;
@@ -3179,6 +3180,10 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanId;
             SCLogDebug("TENANT_SELECTOR_VLAN");
             break;
+        case TENANT_SELECTOR_VLAN_TUPLE:
+            det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanIdTuple;
+            SCLogDebug("TENANT_SELECTOR_VLAN_TUPLE");
+            break;
         case TENANT_SELECTOR_LIVEDEV:
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromLivedev;
             SCLogDebug("TENANT_SELECTOR_LIVEDEV");
@@ -4152,8 +4157,8 @@ error:
     return 0;
 }
 
-static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings_root_node,
-        bool failure_fatal)
+static int DetectEngineMultiTenantSetupLoadVlanMappings(enum DetectEngineTenantSelectors selector,
+        const ConfNode *mappings_root_node, bool failure_fatal)
 {
     ConfNode *mapping_node = NULL;
 
@@ -4162,9 +4167,6 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
         TAILQ_FOREACH(mapping_node, &mappings_root_node->head, next) {
             ConfNode *tenant_id_node = ConfNodeLookupChild(mapping_node, "tenant-id");
             if (tenant_id_node == NULL)
-                goto bad_mapping;
-            ConfNode *vlan_id_node = ConfNodeLookupChild(mapping_node, "vlan-id");
-            if (vlan_id_node == NULL)
                 goto bad_mapping;
 
             uint32_t tenant_id = 0;
@@ -4176,25 +4178,67 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
                 goto bad_mapping;
             }
 
-            uint16_t vlan_id = 0;
-            if (StringParseUint16(
-                        &vlan_id, 10, (uint16_t)strlen(vlan_id_node->val), vlan_id_node->val) < 0) {
-                SCLogError("vlan-id  "
-                           "of %s is invalid",
-                        vlan_id_node->val);
-                goto bad_mapping;
-            }
-            if (vlan_id == 0 || vlan_id >= 4095) {
-                SCLogError("vlan-id  "
-                           "of %s is invalid. Valid range 1-4094.",
-                        vlan_id_node->val);
-                goto bad_mapping;
-            }
+            if (selector == TENANT_SELECTOR_VLAN) {
+                ConfNode *vlan_id_node = ConfNodeLookupChild(mapping_node, "vlan-id");
+                if (vlan_id_node == NULL)
+                    goto bad_mapping;
 
-            if (DetectEngineTenantRegisterVlanId(tenant_id, vlan_id) != 0) {
-                goto error;
+                uint16_t vlan_id = 0;
+                if (StringParseU16RangeCheck(&vlan_id, 10, (uint16_t)strlen(vlan_id_node->val),
+                            vlan_id_node->val, 1, 4094) < 0) {
+                    SCLogError("vlan-id  "
+                               "of %s is invalid; must be %d-4094",
+                            vlan_id_node->val, 1);
+                    goto bad_mapping;
+                }
+                if (DetectEngineTenantRegisterVlanId(tenant_id, vlan_id) != 0) {
+                    goto error;
+                }
+                SCLogConfig("vlan %u connected to tenant-id %u", vlan_id, tenant_id);
+            } else if (selector == TENANT_SELECTOR_VLAN_TUPLE) {
+
+                ConfNode *vlan_tuple = ConfNodeLookupChild(mapping_node, "vlan-tuple");
+                ConfNode *field;
+                int idx = 0;
+                uint16_t vlan_id = 0;
+                TrafficId traffic_id = { 0 };
+                TAILQ_FOREACH (field, &vlan_tuple->head, next) {
+                    /* "0" is a wild card value (matches any vlan) so permit it */
+                    if (StringParseU16RangeCheck(&vlan_id, 10, (uint16_t)strlen(field->val),
+                                field->val, 0, 4094) < 0) {
+                        SCLogError("vlan value %s is invalid; must be 0-4094", field->val);
+                        goto bad_mapping;
+                    }
+                    traffic_id.vlan.tuple[idx++] = vlan_id;
+                }
+                traffic_id.vlan.count = idx;
+
+                /* Reject if all vlan ids have wildcard values */
+                bool all_wildcard = true;
+                for (int i = 0; i < traffic_id.vlan.count; i++) {
+                    if (traffic_id.vlan.tuple[i] != 0) {
+                        all_wildcard = false;
+                        break;
+                    }
+                }
+
+                if (all_wildcard) {
+                    SCLogError("Cannot use wild-card values for all vlan ids");
+                    goto error;
+                }
+
+                if (traffic_id.vlan.tuple[1] == 0) {
+                    SCLogNotice("tenant id: %d, Since the inner VLAN id value is the wildcard "
+                                "value (0); suggest the use of "
+                                "the selector \"vlan\" instead.",
+                            tenant_id);
+                }
+
+                if (DetectEngineTenantRegisterVlanIdTuple(tenant_id, traffic_id) != 0)
+                    goto error;
+                SCLogNotice("vlan-tuple %u:%u connected to tenant-id %u", traffic_id.vlan.tuple[0],
+                        traffic_id.vlan.tuple[1], tenant_id);
             }
-            SCLogConfig("vlan %u connected to tenant-id %u", vlan_id, tenant_id);
             mapping_cnt++;
             continue;
 
@@ -4238,17 +4282,20 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         if (ConfGet("multi-detect.selector", &handler) == 1) {
             SCLogConfig("multi-tenant selector type %s", handler);
 
-            if (strcmp(handler, "vlan") == 0) {
-                tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
+            if (strcmp(handler, "vlan") == 0 || strcmp(handler, "vlan-tuple") == 0) {
+                if (strcmp(handler, "vlan") == 0)
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
+                else
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN_TUPLE;
 
                 int vlanbool = 0;
                 if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
                     SCLogError("vlan tracking is disabled, "
-                               "can't use multi-detect selector 'vlan'");
+                               "can't use multi-detect selector '%s'",
+                            handler);
                     SCMutexUnlock(&master->lock);
                     goto error;
                 }
-
             } else if (strcmp(handler, "direct") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_DIRECT;
             } else if (strcmp(handler, "device") == 0) {
@@ -4273,12 +4320,13 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         /* traffic -- tenant mappings */
         ConfNode *mappings_root_node = ConfGetNode("multi-detect.mappings");
 
-        if (tenant_selector == TENANT_SELECTOR_VLAN) {
-            int mapping_cnt = DetectEngineMultiTenantSetupLoadVlanMappings(mappings_root_node,
-                    failure_fatal);
+        if (tenant_selector == TENANT_SELECTOR_VLAN ||
+                tenant_selector == TENANT_SELECTOR_VLAN_TUPLE) {
+            int mapping_cnt = DetectEngineMultiTenantSetupLoadVlanMappings(
+                    tenant_selector, mappings_root_node, failure_fatal);
             if (mapping_cnt == 0) {
-                /* no mappings are valid when we're in unix socket mode,
-                 * they can be added on the fly. Otherwise warn/error
+                /* no mappings are valid only when in unix socket mode,
+                 * as they can be added on the fly. Otherwise warn/error
                  * depending on failure_fatal */
 
                 if (unix_socket) {
@@ -4385,23 +4433,64 @@ error:
 
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p)
 {
-    const DetectEngineThreadCtx *det_ctx = ctx;
-    uint32_t x = 0;
-    uint32_t vlan_id = 0;
-
     if (p->vlan_idx == 0)
         return 0;
 
-    vlan_id = p->vlan_id[0];
-
+    const DetectEngineThreadCtx *det_ctx = ctx;
     if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
         return 0;
 
     /* not very efficient, but for now we're targeting only limited amounts.
      * Can use hash/tree approach later. */
-    for (x = 0; x < det_ctx->tenant_array_size; x++) {
-        if (det_ctx->tenant_array[x].traffic_id == vlan_id)
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id.vlan.count != p->vlan_idx)
+            continue;
+        if (det_ctx->tenant_array[x].traffic_id.vlan.tuple[0] == p->vlan_id[0])
             return det_ctx->tenant_array[x].tenant_id;
+    }
+
+    return 0;
+}
+
+/* Match if the configured vlan match is a wildcard or the vlan ids match */
+#define VLAN_TUPLE_MATCH(tenant_val, traffic_val) ((tenant_val == 0) || (tenant_val == traffic_val))
+
+#define TRAFFIC_ID_VLAN_TUPLE_MATCH(tenant_val, traffic_id)                                        \
+    ({                                                                                             \
+        bool match = false;                                                                        \
+        if (tenant_val.vlan.count == traffic_id.vlan.count) {                                      \
+            match = true;                                                                          \
+            for (int i = 0; i < tenant_val.vlan.count; i++) {                                      \
+                if (tenant_val.vlan.tuple[i] != traffic_id.vlan.tuple[i]) {                        \
+                    match = false;                                                                 \
+                    break;                                                                         \
+                }                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+        match;                                                                                     \
+    })
+static uint32_t DetectEngineTenantGetIdFromVlanIdTuple(const void *ctx, const Packet *p)
+{
+    if (p->vlan_idx == 0)
+        return 0;
+
+    const DetectEngineThreadCtx *det_ctx = ctx;
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    TrafficId traffic_id = {
+        .vlan.count = p->vlan_idx, .vlan.tuple[0] = p->vlan_id[0], .vlan.tuple[1] = p->vlan_id[1]
+    };
+
+    /* not very efficient, but for now we're targeting only limited amounts.
+     * Can use hash/tree approach later. */
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id.vlan.count != p->vlan_idx)
+            continue;
+
+        if (TRAFFIC_ID_VLAN_TUPLE_MATCH(det_ctx->tenant_array[x].traffic_id, traffic_id)) {
+            return det_ctx->tenant_array[x].tenant_id;
+        }
     }
 
     return 0;
@@ -4420,7 +4509,7 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
 }
 
 static int DetectEngineTenantRegisterSelector(
-        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
+        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, TrafficId traffic_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);
@@ -4433,10 +4522,18 @@ static int DetectEngineTenantRegisterSelector(
 
     DetectEngineTenantMapping *m = master->tenant_mapping_list;
     while (m) {
-        if (m->traffic_id == traffic_id) {
-            SCLogInfo("traffic id already registered");
-            SCMutexUnlock(&master->lock);
-            return -1;
+        if (selector == TENANT_SELECTOR_VLAN_TUPLE) {
+            if (TRAFFIC_ID_VLAN_TUPLE_MATCH(m->traffic_id, traffic_id)) {
+                SCLogInfo("traffic id already registered");
+                SCMutexUnlock(&master->lock);
+                return -1;
+            }
+        } else {
+            if (m->traffic_id.id == traffic_id.id) {
+                SCLogInfo("traffic id already registered");
+                SCMutexUnlock(&master->lock);
+                return -1;
+            }
         }
         m = m->next;
     }
@@ -4461,7 +4558,7 @@ static int DetectEngineTenantRegisterSelector(
 }
 
 static int DetectEngineTenantUnregisterSelector(
-        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
+        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, TrafficId traffic_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);
@@ -4474,9 +4571,7 @@ static int DetectEngineTenantUnregisterSelector(
     DetectEngineTenantMapping *prev = NULL;
     DetectEngineTenantMapping *map = master->tenant_mapping_list;
     while (map) {
-        if (map->traffic_id == traffic_id &&
-            map->tenant_id == tenant_id)
-        {
+        if (map->traffic_id.id == traffic_id.id && map->tenant_id == tenant_id) {
             if (prev != NULL)
                 prev->next = map->next;
             else
@@ -4484,7 +4579,7 @@ static int DetectEngineTenantUnregisterSelector(
 
             map->next = NULL;
             SCFree(map);
-            SCLogInfo("tenant handler %u %u %u unregistered", selector, tenant_id, traffic_id);
+            SCLogInfo("tenant handler %u %u %u unregistered", selector, tenant_id, traffic_id.id);
             SCMutexUnlock(&master->lock);
             return 0;
         }
@@ -4498,30 +4593,44 @@ static int DetectEngineTenantUnregisterSelector(
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id)
 {
-    return DetectEngineTenantRegisterSelector(
-            TENANT_SELECTOR_LIVEDEV, tenant_id, (uint32_t)device_id);
+    TrafficId traffic_id = { .id = device_id };
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_LIVEDEV, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 {
-    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN, tenant_id, (uint32_t)vlan_id);
+    TrafficId traffic_id = { .vlan.tuple[0] = vlan_id, .vlan.count = 1 };
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 {
-    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN, tenant_id, (uint32_t)vlan_id);
+    TrafficId traffic_id = { .vlan.tuple[0] = vlan_id, .vlan.count = 1 };
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN, tenant_id, traffic_id);
+}
+
+int DetectEngineTenantRegisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id)
+{
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN_TUPLE, tenant_id, traffic_id);
+}
+
+int DetectEngineTenantUnregisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id)
+{
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN_TUPLE, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id)
 {
+    TrafficId traffic_id = { .id = 0 };
     SCLogInfo("registering %u %d 0", TENANT_SELECTOR_DIRECT, tenant_id);
-    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, 0);
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id)
 {
+    TrafficId traffic_id = { .id = 0 };
     SCLogInfo("unregistering %u %d 0", TENANT_SELECTOR_DIRECT, tenant_id);
-    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, 0);
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, traffic_id);
 }
 
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p)

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -133,8 +133,12 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantRegisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
+int DetectEngineTenantUnregisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1496,19 +1496,27 @@ typedef struct SigGroupHead_ {
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_VLAN_TUPLE,  /**< map vlan tuple to tenant id */
 };
+
+typedef union _traffic_id {
+    uint32_t id;
+    struct TrafficIdVlan_ {
+        uint16_t tuple[VLAN_MAX_LAYERS];
+        uint16_t count;
+    } vlan;
+} TrafficId;
 
 typedef struct DetectEngineTenantMapping_ {
     uint32_t tenant_id;
 
     /* traffic id that maps to the tenant id */
-    uint32_t traffic_id;
+    TrafficId traffic_id;
 
     struct DetectEngineTenantMapping_ *next;
 } DetectEngineTenantMapping;


### PR DESCRIPTION
Continuation of #9729 

Add a new MT selector type to support use cases where a VLAN tuple should be used to determine the MT tenant.

Packets with one VLAN id will never match as `vlan-tuple` requires at least QinQ.

The tuple can hold up to 3 values -- this is the max supported by Suricata atm.

Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 5]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id is `5`

Wild card values are supported; values of 0 match 'any VLAN' value in the same position as expressed in the tuple:
Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 0]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id always matches since it's a wildcard value.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6237](https://redmine.openinfosecfoundation.org/issues/6237)

Describe changes:
- Add and document a new MT selector -- `vlan-pair` -- for use cases where a VLAN pair should determines the tenant.

Updates
- Reworked to support a tuple of VLAN values,(outer, center [,inner]) determines the tenant.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1354
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
