### PR TITLE
config/mt: Add vlan-tuple MT selector

### DIFF
--- a/doc/userguide/configuration/multi-tenant.rst
+++ b/doc/userguide/configuration/multi-tenant.rst
@@ -18,7 +18,7 @@ Add a new section in the main ("master") Suricata configuration file -- ``surica
 Settings:
 
 * `enabled`: yes/no -> is multi-tenancy support enabled
-* `selector`: direct (for unix socket pcap processing, see below), VLAN or device
+* `selector`: direct (for unix socket pcap processing, see below), vlan, vlan-tuple or device
 * `loaders`: number of `loader` threads, for parallel tenant loading at startup
 * `tenants`: list of tenants
 * `config-path`: path from where the tenant yamls are loaded
@@ -27,15 +27,30 @@ Settings:
   * yaml: separate yaml file with the tenant specific settings
 
 * `mappings`:
+  * tenant id: tenant to associate with the VLAN id or device
+
+Tenant mappings depend on the type of selector used:
+
+* `vlan` or `device`
 
   * VLAN id or device: The outermost VLAN is used to match.
-  * tenant id: tenant to associate with the VLAN id or device
+
+* `vlan-tuple`
+
+  * VLAN tuple: Specify the VLAN identifiers -- outermost to innermost, e.g., `[3000, 1]` will match when the
+    outermost VLAN id is 3000 and the innermost VLAN id is 1. The special value of `0` means "any VLAN in that position" will match.
+    Note that there must the same number of layers of VLAN encapsulation as there are values in the tuple.
+
+
+    * `[0, 302]` will match any packet with an innermost VLAN id of `302` on packets that are QinQ..
+    * `[3000, 0]` will match any packet with an outermost VLAN id of `3000` on packets that are QinQ..
+    * `[3000, 1000, 40]` will match any packet with 3-VLAN identifiers of outermost `3000`, middle `1000` and innermost `40`.
 
 ::
 
   multi-detect:
     enabled: yes
-    #selector: direct # direct or vlan
+    #selector: direct # direct or vlan, vlan-tuple
     selector: vlan
     loaders: 3
 
@@ -54,6 +69,33 @@ Settings:
       tenant-id: 2
     - vlan-id: 1112
       tenant-id: 3
+
+
+This example uses the VLAN tuple selector for packets encapsulated with two VLAN ids:
+
+::
+
+  multi-detect:
+    enabled: yes
+    selector: vlan-tuple
+    loaders: 3
+
+    tenants:
+    - id: 1
+      yaml: tenant-1.yaml
+    - id: 2
+      yaml: tenant-2.yaml
+    - id: 3
+      yaml: tenant-3.yaml
+
+    mappings:
+    - vlan-tuple: [1000, 1]
+      tenant-id: 1
+    - vlan-tuple: [2000, 1]
+      tenant-id: 2
+    - vlan-tuple: [1112, 1]
+      tenant-id: 3
+
 
 The tenant-1.yaml, tenant-2.yaml, tenant-3.yaml each contain a partial
 configuration:
@@ -97,8 +139,11 @@ configuration:
 vlan-id
 ~~~~~~~
 
-Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value.
-Multiple VLANs can have the same tenant id. VLAN id values must be between 1 and 4094.
+Assign tenants to VLAN ids. Suricata matches the outermost VLAN id with this value with
+the selector ``vlan`` (default); the selector ``vlan-tuple`` should be used if QinQ is deployed and requires both
+the inner and outer VLAN id values to match to determine the tenant.
+Multiple VLANs can have the same tenant id. VLAN id values must be between 1 and 4094 with the ``vlan`` selector.
+A wildcard value of ``00`` can be used with the ``vlan-tuple`` selector.
 
 Example of VLAN mapping::
 
@@ -108,6 +153,26 @@ Example of VLAN mapping::
     - vlan-id: 2000
       tenant-id: 2
     - vlan-id: 1112
+      tenant-id: 3
+
+The mappings can also be modified over the unix socket, see below.
+
+Note: can only be used if ``vlan.use-for-tracking`` is enabled.
+
+vlan-tuple
+~~~~~~~~~~
+
+The ``vlan-tuple`` tag can only used with the ``vlan-tuple`` selector. The value will be used
+to match with the innermost VLAN. Values of ``0`` will match any VLAN value.
+
+Example of VLAN mapping::
+
+    mappings:
+    - vlan-tuple: [1000, 0]
+      tenant-id: 1
+    - vlan-tuple: [2000, 3000]
+      tenant-id: 2
+    - vlan-tuple: [1112, 3112]
       tenant-id: 3
 
 The mappings can also be modified over the unix socket, see below.
@@ -195,25 +260,52 @@ Live traffic mode
 
 Multi-tenancy supports both VLAN and devices with live traffic.
 
-In the master configuration yaml file, specify ``device`` or ``vlan`` for the ``selector`` setting.
+In the master configuration yaml file, specify ``device``, ``vlan`` or ``vlan-tuple`` for the ``selector`` setting.
 
 Registration
 ~~~~~~~~~~~~
 
 Tenants can be mapped to vlan ids.
 
-``register-tenant-handler <tenant id> vlan <vlan id>``
+
+Examples using the ``vlan`` selector:
+
+::
+
+  register-tenant-handler <tenant id> vlan <vlan id>
 
 ::
 
   register-tenant-handler 1 vlan 1000
 
-``unregister-tenant-handler <tenant id> vlan <vlan id>``
+::
+
+  unregister-tenant-handler <tenant id> vlan <vlan id>
 
 ::
 
   unregister-tenant-handler 4 vlan 1111
   unregister-tenant-handler 1 vlan 1000
+
+
+Examples using the ``vlan-tuple`` selector:
+
+::
+
+  register-tenant-handler <tenant id> vlan-tuple <vlan outer id> <vlan inner id>
+
+::
+
+  register-tenant-handler 1 vlan-tuple 1000
+
+::
+
+  unregister-tenant-handler <tenant id> vlan-tuple <vlan outer id> <vlan inner id>
+
+::
+
+  unregister-tenant-handler 4 vlan-tuple 1111 1
+  unregister-tenant-handler 1 vlan-tuple 1000 2
 
 The registration of tenant and tenant handlers can be done on a
 running engine.

--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -73,6 +73,11 @@ argsd = {
             "type": int,
             "required": 0,
         },
+        {
+            "name": "hargs_extra",
+            "type": int,
+            "required": 0,
+        },
     ],
     "register-tenant-handler": [
         {
@@ -86,6 +91,11 @@ argsd = {
         },
         {
             "name": "hargs",
+            "type": int,
+            "required": 0,
+        },
+        {
+            "name": "hargs_extra",
             "type": int,
             "required": 0,
         },

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -133,8 +133,12 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantRegisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
+int DetectEngineTenantUnregisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1496,19 +1496,27 @@ typedef struct SigGroupHead_ {
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_VLAN_TUPLE,  /**< map vlan tuple to tenant id */
 };
+
+typedef union _traffic_id {
+    uint32_t id;
+    struct TrafficIdVlan_ {
+        uint16_t tuple[VLAN_MAX_LAYERS];
+        uint16_t count;
+    } vlan;
+} TrafficId;
 
 typedef struct DetectEngineTenantMapping_ {
     uint32_t tenant_id;
 
     /* traffic id that maps to the tenant id */
-    uint32_t traffic_id;
+    TrafficId traffic_id;
 
     struct DetectEngineTenantMapping_ *next;
 } DetectEngineTenantMapping;


### PR DESCRIPTION
Continuation of #9737

Add a new MT selector type to support use cases where a VLAN tuple should be used to determine the MT tenant.

Packets with one VLAN id will never match as `vlan-tuple` requires at least QinQ.

The tuple can hold up to 3 values -- this is the max supported by Suricata atm.

Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 5]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id is `5`

Wild card values are supported; values of 0 match 'any VLAN' value in the same position as expressed in the tuple:
Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 0]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id always matches since it's a wildcard value.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6237](https://redmine.openinfosecfoundation.org/issues/6237)

Describe changes:
- Add and document a new MT selector -- `vlan-pair` -- for use cases where a VLAN pair should determines the tenant.

Updates
- Fixed debug log message of tenant/traffic id

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1354
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
