### PR TITLE
stats: Log packets/bytes per second in stats - V2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4120,6 +4120,9 @@
                         "bytes": {
                             "type": "integer"
                         },
+                        "bytes_per_sec": {
+                            "type": "integer"
+                        },
                         "chdlc": {
                             "type": "integer"
                         },
@@ -4187,6 +4190,9 @@
                             "type": "integer"
                         },
                         "pkts": {
+                            "type": "integer"
+                        },
+                        "pkts_per_sec": {
                             "type": "integer"
                         },
                         "ppp": {

--- a/src/counters.h
+++ b/src/counters.h
@@ -121,6 +121,7 @@ void StatsReleaseResources(void);
 uint16_t StatsRegisterCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterAvgCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterMaxCounter(const char *, struct ThreadVars_ *);
+uint16_t StatsRegisterTmdCounter(const char *, struct ThreadVars_ *);
 uint16_t StatsRegisterGlobalCounter(const char *cname, uint64_t (*Func)(void));
 
 /* functions used to update local counter values */

--- a/src/decode.c
+++ b/src/decode.c
@@ -564,6 +564,8 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_mpls = StatsRegisterCounter("decoder.mpls", tv);
     dtv->counter_avg_pkt_size = StatsRegisterAvgCounter("decoder.avg_pkt_size", tv);
     dtv->counter_max_pkt_size = StatsRegisterMaxCounter("decoder.max_pkt_size", tv);
+    dtv->counter_pkts_per_sec = StatsRegisterTmdCounter("decoder.pkts_per_sec", tv);
+    dtv->counter_bytes_per_sec = StatsRegisterTmdCounter("decoder.bytes_per_sec", tv);
     dtv->counter_max_mac_addrs_src = StatsRegisterMaxCounter("decoder.max_mac_addrs_src", tv);
     dtv->counter_max_mac_addrs_dst = StatsRegisterMaxCounter("decoder.max_mac_addrs_dst", tv);
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
@@ -655,8 +657,9 @@ void DecodeUpdatePacketCounters(ThreadVars *tv,
                                 const DecodeThreadVars *dtv, const Packet *p)
 {
     StatsIncr(tv, dtv->counter_pkts);
-    //StatsIncr(tv, dtv->counter_pkts_per_sec);
+    StatsIncr(tv, dtv->counter_pkts_per_sec);
     StatsAddUI64(tv, dtv->counter_bytes, GET_PKT_LEN(p));
+    StatsAddUI64(tv, dtv->counter_bytes_per_sec, GET_PKT_LEN(p));
     StatsAddUI64(tv, dtv->counter_avg_pkt_size, GET_PKT_LEN(p));
     StatsSetUI64(tv, dtv->counter_max_pkt_size, GET_PKT_LEN(p));
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -674,6 +674,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_bytes;
     uint16_t counter_avg_pkt_size;
     uint16_t counter_max_pkt_size;
+    uint16_t counter_pkts_per_sec;
+    uint16_t counter_bytes_per_sec;
     uint16_t counter_max_mac_addrs_src;
     uint16_t counter_max_mac_addrs_dst;
 

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -34,6 +34,8 @@ typedef struct StatsRecord_ {
     const char *tm_name;
     int64_t value;  /**< total value */
     int64_t pvalue; /**< prev value (may be higher for memuse counters) */
+    int64_t counter_value;  /**< counter value used to calculate this stats */
+    int64_t counter_pvalue; /**< counter prev value used to calculate this stats */
 } StatsRecord;
 
 typedef struct StatsTable_ {


### PR DESCRIPTION
This commit aims to add packets/bytes per second to Suricata's statistics log. To achieve this, a new type of qualifier was created and two new fields were added to the StatsRecord struct.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6410](https://redmine.openinfosecfoundation.org/issues/6410)

Previous PR: #9711

Suricata-verify tests: https://github.com/OISF/suricata-verify/pull/1453

Describe changes:
- Fix StatsRegisterTmdCounter function description 
- Add tests to Suricata-verify

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1453
