### PR TITLE
Bugfix/flow keyword set error - v2

### DIFF
--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -227,6 +227,10 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
                 if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
                     SCLogError("DETECT_FLOW_FLAG_ESTABLISHED flag is already set");
                     goto error;
+                } else if (fd->flags & DETECT_FLOW_FLAG_NOT_ESTABLISHED) {
+                    SCLogError("cannot set DETECT_FLOW_FLAG_ESTABLISHED, "
+                               "DETECT_FLOW_FLAG_NOT_ESTABLISHED already set");
+                    goto error;
                 } else if (fd->flags & DETECT_FLOW_FLAG_STATELESS) {
                     SCLogError("DETECT_FLOW_FLAG_STATELESS already set");
                     goto error;
@@ -236,7 +240,7 @@ static DetectFlowData *DetectFlowParse (DetectEngineCtx *de_ctx, const char *flo
                 if (fd->flags & DETECT_FLOW_FLAG_NOT_ESTABLISHED) {
                     SCLogError("DETECT_FLOW_FLAG_NOT_ESTABLISHED flag is already set");
                     goto error;
-                } else if (fd->flags & DETECT_FLOW_FLAG_NOT_ESTABLISHED) {
+                } else if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
                     SCLogError("cannot set DETECT_FLOW_FLAG_NOT_ESTABLISHED, "
                                "DETECT_FLOW_FLAG_ESTABLISHED already set");
                     goto error;
@@ -946,6 +950,19 @@ static int DetectFlowTestParse21 (void)
     PASS;
 }
 
+/**
+ * \test DetectFlowTestParse22 is a test for setting the established,not_established flow opts both
+ */
+static int DetectFlowTestParse22(void)
+{
+    DetectFlowData *fd = NULL;
+    fd = DetectFlowParse(NULL, "established,not_established");
+    FAIL_IF_NOT_NULL(fd);
+    fd = DetectFlowParse(NULL, "not_established,established");
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
+}
+
 static int DetectFlowSigTest01(void)
 {
     uint8_t *buf = (uint8_t *)"supernovaduper";
@@ -1104,6 +1121,7 @@ static void DetectFlowRegisterTests(void)
     UtRegisterTest("DetectFlowTestParse20", DetectFlowTestParse20);
     UtRegisterTest("DetectFlowTestParseNocase20", DetectFlowTestParseNocase20);
     UtRegisterTest("DetectFlowTestParse21", DetectFlowTestParse21);
+    UtRegisterTest("DetectFlowTestParse22", DetectFlowTestParse22);
     UtRegisterTest("DetectFlowTestParseNotEstablished",
         DetectFlowTestParseNotEstablished);
     UtRegisterTest("DetectFlowTestParseNoFrag", DetectFlowTestParseNoFrag);


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- fix the flag test
- write an unit test
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
