### PR TITLE
rule-reload: Release excess memory freed during engine reload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,13 @@
             #include <sys/random.h> 
             ])
 
+    AC_CHECK_HEADERS([malloc.h])
+    AC_CHECK_DECL([malloc_trim],
+        AC_DEFINE([HAVE_MALLOC_TRIM], [1], [Use malloc_trim]),
+        [], [
+            #include <malloc.h> 
+            ])
+
     OCFLAGS=$CFLAGS
     CFLAGS=""
     AC_CHECK_FUNCS([strlcpy strlcat])

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4796,6 +4796,15 @@ int DetectEngineReload(const SCInstance *suri)
     SCLogDebug("old_de_ctx should have been freed");
 
     SCLogNotice("rule reload complete");
+
+#ifdef HAVE_MALLOC_TRIM
+    /* The reload process potentially frees up large amounts of memory.
+     * Encourage the memory management system to reclaim as much as it
+     * can.
+     */
+    malloc_trim(0);
+#endif
+
     return 0;
 }
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -215,6 +215,10 @@ typedef unsigned char u_char;
 #include <netdb.h>
 #endif
 
+#if HAVE_MALLOC_H
+#include <malloc.h>
+#endif
+
 #if __CYGWIN__
 #if !defined _X86_ && !defined __x86_64
 #define _X86_


### PR DESCRIPTION
The hot reload results in large chunks of memory being freed as the as the old signature tables are discarded. Help the memory management system along by telling to release as much memory as it can at this point.

Bug: #6454.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6454

Describe changes:
We had issue on an embedded device of low memory on rule-reload.
We found that while the memory has been freed, the kernel needs a kick to properly report this.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
