### PR TITLE
detect: Inline default pkt inspect engines

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1918,8 +1918,6 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
             SigMatch *sm = s->init_data->smlists[type];
             s->sm_arrays[type] = SigMatchList2DataArray(sm);
         }
-        /* set up the pkt inspection engines */
-        DetectEnginePktInspectionSetup(s);
 
         if (rule_engine_analysis_set) {
             EngineAnalysisAddAllRulePatterns(de_ctx, s);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1910,11 +1910,9 @@ int DetectEngineBufferTypeGetByIdTransforms(
 }
 
 /* returns false if no match, true if match */
-static int DetectEngineInspectRulePacketMatches(
-    DetectEngineThreadCtx *det_ctx,
-    const DetectEnginePktInspectionEngine *engine,
-    const Signature *s,
-    Packet *p, uint8_t *_alert_flags)
+static inline int DetectEngineInspectRulePacketMatches(DetectEngineThreadCtx *det_ctx,
+        const DetectEnginePktInspectionEngine *engine, const Signature *s, Packet *p,
+        uint8_t *_alert_flags)
 {
     SCEnter();
 
@@ -1940,10 +1938,9 @@ static int DetectEngineInspectRulePacketMatches(
     return true;
 }
 
-static int DetectEngineInspectRulePayloadMatches(
-     DetectEngineThreadCtx *det_ctx,
-     const DetectEnginePktInspectionEngine *engine,
-     const Signature *s, Packet *p, uint8_t *alert_flags)
+static inline int DetectEngineInspectRulePayloadMatches(DetectEngineThreadCtx *det_ctx,
+        const DetectEnginePktInspectionEngine *engine, const Signature *s, Packet *p,
+        uint8_t *alert_flags)
 {
     SCEnter();
 
@@ -1982,12 +1979,22 @@ static int DetectEngineInspectRulePayloadMatches(
     return true;
 }
 
-bool DetectEnginePktInspectionRun(ThreadVars *tv,
-        DetectEngineThreadCtx *det_ctx, const Signature *s,
-        Flow *f, Packet *p,
-        uint8_t *alert_flags)
+inline bool DetectEnginePktInspectionRun(ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
+        const Signature *s, Flow *f, Packet *p, uint8_t *alert_flags)
 {
     SCEnter();
+
+    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
+        if (DetectEngineInspectRulePayloadMatches(det_ctx, NULL, s, p, alert_flags) == false) {
+            return false;
+        }
+    }
+
+    if (s->sm_arrays[DETECT_SM_LIST_MATCH]) {
+        if (DetectEngineInspectRulePacketMatches(det_ctx, NULL, s, p, alert_flags) == false) {
+            return false;
+        }
+    }
 
     for (DetectEnginePktInspectionEngine *e = s->pkt_inspect; e != NULL; e = e->next) {
         if (e->v1.Callback(det_ctx, e, s, p, alert_flags) == false) {
@@ -2027,26 +2034,6 @@ static int DetectEnginePktInspectionAppend(Signature *s, InspectionBufferPktInsp
         }
         a->next = e;
     }
-    return 0;
-}
-
-int DetectEnginePktInspectionSetup(Signature *s)
-{
-    /* only handle PMATCH here if we're not an app inspect rule */
-    if (s->sm_arrays[DETECT_SM_LIST_PMATCH] && (s->init_data->init_flags & SIG_FLAG_INIT_STATE_MATCH) == 0) {
-        if (DetectEnginePktInspectionAppend(
-                    s, DetectEngineInspectRulePayloadMatches, NULL, DETECT_SM_LIST_PMATCH) < 0)
-            return -1;
-        SCLogDebug("sid %u: DetectEngineInspectRulePayloadMatches appended", s->id);
-    }
-
-    if (s->sm_arrays[DETECT_SM_LIST_MATCH]) {
-        if (DetectEnginePktInspectionAppend(
-                    s, DetectEngineInspectRulePacketMatches, NULL, DETECT_SM_LIST_MATCH) < 0)
-            return -1;
-        SCLogDebug("sid %u: DetectEngineInspectRulePacketMatches appended", s->id);
-    }
-
     return 0;
 }
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -182,7 +182,6 @@ bool DetectEnginePktInspectionRun(ThreadVars *tv,
         DetectEngineThreadCtx *det_ctx, const Signature *s,
         Flow *f, Packet *p,
         uint8_t *alert_flags);
-int DetectEnginePktInspectionSetup(Signature *s);
 
 void DetectEngineSetParseMetadata(void);
 void DetectEngineUnsetParseMetadata(void);


### PR DESCRIPTION
Scenarios with a small number of rules, no MPM-based rules, experienced a 6%-14% performance degradation from the commit 0965afd66 detect: pkt inspect engines
inwhich the default pkt inspect engines were converted to callbacks to simplify adding extra pkt inspect engines.

Avoid adding the default pkt inspect engines to the callback chain and instead call them directly in an inlined function within DetectRulePacketRules().

Bug: #6291

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [✓] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6291

Describe changes:
Updated from Suricata 4.0.6 to Suricata 7, this performance degradation was noticed on a setup with the following:
* 176 signatures
* 3 are inspecting packet payload
* 33 inspect application layer
* 83 are decoder event only
This performance impact was significant when running a small number of lightweight rules, but was not significant on larger (and more heavy-duty) rule sets.

The changes make the default packet inspection engines inline, like they were in Suricata 4 before extra packet inspection engines were supported.

### Provide values to any of the below to override the defaults.

No Suricata-verify test.