### PR TITLE
 plugins: fix file type plugins - v2

### DIFF
--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -61,7 +61,6 @@ typedef struct SCEveFileType_ {
     TAILQ_ENTRY(SCEveFileType_) entries;
 } SCEveFileType;
 
-bool SCPluginRegisterEveFileType(SCEveFileType *);
 bool SCRegisterEveFileType(SCEveFileType *);
 
 typedef struct SCCapturePlugin_ {

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -865,8 +865,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCReturnInt(0);
     }
 
-    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN) {
-        lf_ctx->plugin.plugin->Deinit(lf_ctx->plugin.init_data);
+    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN && lf_ctx->parent != NULL) {
+        lf_ctx->plugin.plugin->ThreadDeinit(lf_ctx->plugin.init_data, lf_ctx->plugin.thread_data);
     }
 
     if (lf_ctx->threaded) {
@@ -900,6 +900,13 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
     if (!lf_ctx->threaded) {
         OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);
+    }
+
+    /* Deinitialize output plugins. We only want to call this for the
+     * parent of threaded output, or always for non-threaded
+     * output. */
+    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN && lf_ctx->parent == NULL) {
+        lf_ctx->plugin.plugin->Deinit(lf_ctx->plugin.init_data);
     }
 
     memset(lf_ctx, 0, sizeof(*lf_ctx));

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -72,7 +72,6 @@ typedef struct LogFilePluginCtx_ {
 typedef struct LogFileCtx_ {
     union {
         FILE *fp;
-        void *plugin_data;
 #ifdef HAVE_LIBHIREDIS
         void *redis;
 #endif


### PR DESCRIPTION
7.0 with a change to threaded eve output mode broke filetype plugins.

Previous PR: https://github.com/OISF/suricata/pull/9772

Changes from previous PR:
- Remove example plugin

Ticket: https://redmine.openinfosecfoundation.org/issues/6438
