### PR TITLE
github-ci: suppress author names; cancel earlier builds - v1

### DIFF
--- a/.github/workflows/authors-done.yml
+++ b/.github/workflows/authors-done.yml
@@ -44,8 +44,7 @@ jobs:
           script: |
             let fs = require('fs');
             let issue_number = Number(fs.readFileSync('./pr-number.txt'));
-            let new_authors = String(fs.readFileSync('./new-authors.txt'));
-            let msg = 'NOTE: This PR may contain new authors:\n\n```\n' + new_authors + '```';
+            let msg = 'NOTE: This PR may contain new authors.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,6 +12,10 @@ on:
       SV_REPO:
       SV_BRANCH:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 env:


### PR DESCRIPTION
- Don't call out the new author names and emails in a PR comment, instead just
  add a comment that there may be an new author.  The author names are still in
  the artifact though. Example: https://github.com/jasonish/suricata/pull/192#issuecomment-1814469451

- For builds.yml, cancel the previous job on a push to the same branch.
