### PR TITLE
change value of rev

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -77,7 +77,7 @@ represents the version of the signature. If a signature is modified,
 the number of rev will be incremented by the signature writers. The
 format of rev is::
 
-  rev:123;
+  rev:1;
 
 
 Example of rev in a signature:


### PR DESCRIPTION
The previous value  of rev was exactly the sid value that caused the error.  The value of rev should be one, and when the value of sid is changed, the value of rev should also be added by one.

