### PR TITLE
output/eve: reduce fflush call count 

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -30,6 +30,10 @@ Output types::
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      #buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -7,6 +7,10 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json
       #threaded: false
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      #buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -381,6 +381,7 @@ noinst_HEADERS = \
 	ippair-storage.h \
 	ippair-timeout.h \
 	log-cf-common.h \
+	log-flush.h \
 	log-httplog.h \
 	log-pcap.h \
 	log-stats.h \
@@ -993,6 +994,7 @@ libsuricata_c_a_SOURCES = \
 	ippair-storage.c \
 	ippair-timeout.c \
 	log-cf-common.c \
+	log-flush.c \
 	log-httplog.c \
 	log-pcap.c \
 	log-stats.c \

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -485,7 +485,7 @@ static int AlertDebugLogLogger(ThreadVars *tv, void *thread_data, const Packet *
 
 void AlertDebugLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_ALERT_DEBUG, MODULE_NAME, "alert-debug",
-        AlertDebugLogInitCtx, AlertDebugLogLogger, AlertDebugLogCondition,
-        AlertDebugLogThreadInit, AlertDebugLogThreadDeinit, NULL);
+    OutputRegisterPacketModule(LOGGER_ALERT_DEBUG, MODULE_NAME, "alert-debug", AlertDebugLogInitCtx,
+            AlertDebugLogLogger, NULL, AlertDebugLogCondition, AlertDebugLogThreadInit,
+            AlertDebugLogThreadDeinit, NULL);
 }

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -485,7 +485,15 @@ static int AlertDebugLogLogger(ThreadVars *tv, void *thread_data, const Packet *
 
 void AlertDebugLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertDebugLogLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertDebugLogCondition,
+        .ThreadInitFunc = AlertDebugLogThreadInit,
+        .ThreadDeinitFunc = AlertDebugLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketModule(LOGGER_ALERT_DEBUG, MODULE_NAME, "alert-debug", AlertDebugLogInitCtx,
-            AlertDebugLogLogger, NULL, AlertDebugLogCondition, AlertDebugLogThreadInit,
-            AlertDebugLogThreadDeinit, NULL);
+            &output_logger_functions);
 }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -76,9 +76,9 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p);
 
 void AlertFastLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_ALERT_FAST, MODULE_NAME, "fast",
-        AlertFastLogInitCtx, AlertFastLogger, AlertFastLogCondition,
-        AlertFastLogThreadInit, AlertFastLogThreadDeinit, NULL);
+    OutputRegisterPacketModule(LOGGER_ALERT_FAST, MODULE_NAME, "fast", AlertFastLogInitCtx,
+            AlertFastLogger, NULL, AlertFastLogCondition, AlertFastLogThreadInit,
+            AlertFastLogThreadDeinit, NULL);
     AlertFastLogRegisterTests();
 }
 

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -76,9 +76,17 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p);
 
 void AlertFastLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_ALERT_FAST, MODULE_NAME, "fast", AlertFastLogInitCtx,
-            AlertFastLogger, NULL, AlertFastLogCondition, AlertFastLogThreadInit,
-            AlertFastLogThreadDeinit, NULL);
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertFastLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertFastLogCondition,
+        .ThreadInitFunc = AlertFastLogThreadInit,
+        .ThreadDeinitFunc = AlertFastLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
+    OutputRegisterPacketModule(
+            LOGGER_ALERT_FAST, MODULE_NAME, "fast", AlertFastLogInitCtx, &output_logger_functions);
     AlertFastLogRegisterTests();
 }
 

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -391,8 +391,8 @@ static int AlertSyslogLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 void AlertSyslogRegister (void)
 {
 #ifndef OS_WIN32
-    OutputRegisterPacketModule(LOGGER_ALERT_SYSLOG, MODULE_NAME, "syslog",
-        AlertSyslogInitCtx, AlertSyslogLogger, AlertSyslogCondition,
-        AlertSyslogThreadInit, AlertSyslogThreadDeinit, NULL);
+    OutputRegisterPacketModule(LOGGER_ALERT_SYSLOG, MODULE_NAME, "syslog", AlertSyslogInitCtx,
+            AlertSyslogLogger, NULL, AlertSyslogCondition, AlertSyslogThreadInit,
+            AlertSyslogThreadDeinit, NULL);
 #endif /* !OS_WIN32 */
 }

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -391,8 +391,15 @@ static int AlertSyslogLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 void AlertSyslogRegister (void)
 {
 #ifndef OS_WIN32
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertSyslogLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertSyslogCondition,
+        .ThreadInitFunc = AlertSyslogThreadInit,
+        .ThreadDeinitFunc = AlertSyslogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
     OutputRegisterPacketModule(LOGGER_ALERT_SYSLOG, MODULE_NAME, "syslog", AlertSyslogInitCtx,
-            AlertSyslogLogger, NULL, AlertSyslogCondition, AlertSyslogThreadInit,
-            AlertSyslogThreadDeinit, NULL);
+            &output_logger_functions);
 #endif /* !OS_WIN32 */
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -1049,9 +1049,12 @@ void DecodeUnregisterCounters(void);
 #define PKT_FIRST_ALERTS BIT_U32(29)
 #define PKT_FIRST_TAG    BIT_U32(30)
 
+#define PKT_PSEUDO_LOG_FLUSH BIT_U32(31) /**< Detect/log flush for protocol upgrade */
+
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) \
     ((p)->flags & (PKT_PSEUDO_STREAM_END|PKT_PSEUDO_DETECTLOG_FLUSH))
+#define PKT_IS_FLUSHPKT(p) ((p)->flags & (PKT_PSEUDO_LOG_FLUSH))
 
 #define PKT_SET_SRC(p, src_val) ((p)->pkt_src = src_val)
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2283,21 +2283,26 @@ int DetectEngineInspectPktBufferGeneric(
 }
 
 /** \internal
- *  \brief inject a pseudo packet into each detect thread that doesn't use the
- *         new det_ctx yet
+ *  \brief inject a pseudo packet into each detect thread
+ *      -that doesn't use the new det_ctx yet
+ *      -*or*, if the thread should flush its output logs.
  */
-static void InjectPackets(ThreadVars **detect_tvs,
-                          DetectEngineThreadCtx **new_det_ctx,
-                          int no_of_detect_tvs)
+static void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx,
+        int no_of_detect_tvs, bool flush_logs)
 {
-    /* inject a fake packet if the detect thread isn't using the new ctx yet,
-     * this speeds up the process */
+    /* inject a fake packet if the detect thread that needs it. This function
+     * is called if
+     *  - A thread isn't using a DE ctx and should
+     *  - Or, it should process a pseudo packet and flush its output logs.
+     * to speed the process. */
     for (int i = 0; i < no_of_detect_tvs; i++) {
-        if (SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) != 1) {
+        if (flush_logs || SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) != 1) {
             if (detect_tvs[i]->inq != NULL) {
                 Packet *p = PacketGetFromAlloc();
                 if (p != NULL) {
                     p->flags |= PKT_PSEUDO_STREAM_END;
+                    if (flush_logs)
+                        p->flags |= PKT_PSEUDO_LOG_FLUSH;
                     PKT_SET_SRC(p, PKT_SRC_DETECT_RELOAD_FLUSH);
                     PacketQueue *q = detect_tvs[i]->inq->pq;
                     SCMutexLock(&q->mutex_q);
@@ -2308,6 +2313,111 @@ static void InjectPackets(ThreadVars **detect_tvs,
             }
         }
     }
+}
+
+/**
+ * \brief Trigger detect threads to flush their output logs
+ *
+ * This function is intended to be called at regular intervals to force
+ * buffered log data to be persisted
+ */
+void WorkerFlushLogs(void)
+{
+    SCEnter();
+    uint32_t i = 0;
+
+    /* count detect threads in use */
+    uint32_t no_of_detect_tvs = TmThreadCountThreadsByTmmFlags(TM_FLAG_DETECT_TM);
+    /* can be zero in unix socket mode */
+    if (no_of_detect_tvs == 0) {
+        return;
+    }
+
+    /* prepare swap structures */
+    DetectEngineThreadCtx *det_ctx[no_of_detect_tvs];
+    ThreadVars *detect_tvs[no_of_detect_tvs];
+    memset(det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx *)));
+    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars *)));
+
+    /* start the process of swapping detect threads ctxs */
+
+    /* get reference to tv's and setup new_det_ctx array */
+    SCMutexLock(&tv_root_lock);
+    for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
+        if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
+            continue;
+        }
+        for (TmSlot *s = tv->tm_slots; s != NULL; s = s->slot_next) {
+            TmModule *tm = TmModuleGetById(s->tm_id);
+            if (!(tm->flags & TM_FLAG_DETECT_TM)) {
+                continue;
+            }
+
+            if (suricata_ctl_flags != 0) {
+                SCMutexUnlock(&tv_root_lock);
+                goto error;
+            }
+
+            det_ctx[i] = FlowWorkerGetDetectCtxPtr(SC_ATOMIC_GET(s->slot_data));
+            SC_ATOMIC_SET(det_ctx[i]->flush_ack, 0);
+            detect_tvs[i] = tv;
+
+            i++;
+            break;
+        }
+    }
+    BUG_ON(i != no_of_detect_tvs);
+
+    SCMutexUnlock(&tv_root_lock);
+
+    SCLogDebug("Creating flush pseudo packets for %d threads", no_of_detect_tvs);
+    InjectPackets(detect_tvs, det_ctx, no_of_detect_tvs, true);
+
+    uint32_t threads_done = 0;
+retry:
+    for (i = 0; i < no_of_detect_tvs; i++) {
+        if (suricata_ctl_flags != 0) {
+            threads_done = no_of_detect_tvs;
+            break;
+        }
+        usleep(1000);
+        if (SC_ATOMIC_GET(det_ctx[i]->flush_ack) == 1) {
+            SCLogDebug("thread slot %d has ack'd flush request", i);
+            threads_done++;
+        } else {
+            SCLogDebug("thread slot %d not yet ack'd flush request", i);
+            TmThreadsCaptureBreakLoop(detect_tvs[i]);
+        }
+    }
+    if (threads_done < no_of_detect_tvs) {
+        threads_done = 0;
+        SleepMsec(250);
+        goto retry;
+    }
+
+    /* this is to make sure that if someone initiated shutdown during
+     * this process
+     *
+     * TODO: needed?
+     *
+     * .rule swap, the live rule swap won't clean up the old det_ctx and
+     * de_ctx, till all detect threads have stopped working and sitting
+     * silently after setting RUNNING_DONE flag and while waiting for
+     * THV_DEINIT flag */
+    if (i != no_of_detect_tvs) { // not all threads we swapped
+        for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
+            if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
+                continue;
+            }
+
+            while (!TmThreadsCheckFlag(tv, THV_RUNNING_DONE)) {
+                usleep(100);
+            }
+        }
+    }
+
+error:
+    return;
 }
 
 /** \internal
@@ -2405,7 +2515,7 @@ static int DetectEngineReloadThreads(DetectEngineCtx *new_de_ctx)
     SCLogDebug("Live rule swap has swapped %d old det_ctx's with new ones, "
                "along with the new de_ctx", no_of_detect_tvs);
 
-    InjectPackets(detect_tvs, new_det_ctx, no_of_detect_tvs);
+    InjectPackets(detect_tvs, new_det_ctx, no_of_detect_tvs, false);
 
     /* loop waiting for detect threads to switch to the new det_ctx. Try to
      * wake up capture if needed (break loop). */

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2296,8 +2296,9 @@ void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx,
      *  - Or, it should process a pseudo packet and flush its output logs.
      * to speed the process. */
     for (int i = 0; i < no_of_detect_tvs; i++) {
-        if (flush_logs || SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) != 1) {
-            if (detect_tvs[i]->inq != NULL) {
+        if (flush_logs ||
+                (new_det_ctx[i] && SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) != 1)) {
+            if (detect_tvs[i] && detect_tvs[i]->inq != NULL) {
                 Packet *p = PacketGetFromAlloc();
                 if (p != NULL) {
                     p->flags |= PKT_PSEUDO_STREAM_END;
@@ -2425,7 +2426,7 @@ retry:
         if (SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) == 1) {
             SCLogDebug("new_det_ctx - %p used by detect engine", new_det_ctx[i]);
             threads_done++;
-        } else {
+        } else if (detect_tvs[i]) {
             TmThreadsCaptureBreakLoop(detect_tvs[i]);
         }
     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2287,7 +2287,7 @@ int DetectEngineInspectPktBufferGeneric(
  *      -that doesn't use the new det_ctx yet
  *      -*or*, if the thread should flush its output logs.
  */
-static void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx,
+void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx,
         int no_of_detect_tvs, bool flush_logs)
 {
     /* inject a fake packet if the detect thread that needs it. This function
@@ -2313,111 +2313,6 @@ static void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_d
             }
         }
     }
-}
-
-/**
- * \brief Trigger detect threads to flush their output logs
- *
- * This function is intended to be called at regular intervals to force
- * buffered log data to be persisted
- */
-void WorkerFlushLogs(void)
-{
-    SCEnter();
-    uint32_t i = 0;
-
-    /* count detect threads in use */
-    uint32_t no_of_detect_tvs = TmThreadCountThreadsByTmmFlags(TM_FLAG_DETECT_TM);
-    /* can be zero in unix socket mode */
-    if (no_of_detect_tvs == 0) {
-        return;
-    }
-
-    /* prepare swap structures */
-    DetectEngineThreadCtx *det_ctx[no_of_detect_tvs];
-    ThreadVars *detect_tvs[no_of_detect_tvs];
-    memset(det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx *)));
-    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars *)));
-
-    /* start the process of swapping detect threads ctxs */
-
-    /* get reference to tv's and setup new_det_ctx array */
-    SCMutexLock(&tv_root_lock);
-    for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
-        if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
-            continue;
-        }
-        for (TmSlot *s = tv->tm_slots; s != NULL; s = s->slot_next) {
-            TmModule *tm = TmModuleGetById(s->tm_id);
-            if (!(tm->flags & TM_FLAG_DETECT_TM)) {
-                continue;
-            }
-
-            if (suricata_ctl_flags != 0) {
-                SCMutexUnlock(&tv_root_lock);
-                goto error;
-            }
-
-            det_ctx[i] = FlowWorkerGetDetectCtxPtr(SC_ATOMIC_GET(s->slot_data));
-            SC_ATOMIC_SET(det_ctx[i]->flush_ack, 0);
-            detect_tvs[i] = tv;
-
-            i++;
-            break;
-        }
-    }
-    BUG_ON(i != no_of_detect_tvs);
-
-    SCMutexUnlock(&tv_root_lock);
-
-    SCLogDebug("Creating flush pseudo packets for %d threads", no_of_detect_tvs);
-    InjectPackets(detect_tvs, det_ctx, no_of_detect_tvs, true);
-
-    uint32_t threads_done = 0;
-retry:
-    for (i = 0; i < no_of_detect_tvs; i++) {
-        if (suricata_ctl_flags != 0) {
-            threads_done = no_of_detect_tvs;
-            break;
-        }
-        usleep(1000);
-        if (SC_ATOMIC_GET(det_ctx[i]->flush_ack) == 1) {
-            SCLogDebug("thread slot %d has ack'd flush request", i);
-            threads_done++;
-        } else {
-            SCLogDebug("thread slot %d not yet ack'd flush request", i);
-            TmThreadsCaptureBreakLoop(detect_tvs[i]);
-        }
-    }
-    if (threads_done < no_of_detect_tvs) {
-        threads_done = 0;
-        SleepMsec(250);
-        goto retry;
-    }
-
-    /* this is to make sure that if someone initiated shutdown during
-     * this process
-     *
-     * TODO: needed?
-     *
-     * .rule swap, the live rule swap won't clean up the old det_ctx and
-     * de_ctx, till all detect threads have stopped working and sitting
-     * silently after setting RUNNING_DONE flag and while waiting for
-     * THV_DEINIT flag */
-    if (i != no_of_detect_tvs) { // not all threads we swapped
-        for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
-            if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
-                continue;
-            }
-
-            while (!TmThreadsCheckFlag(tv, THV_RUNNING_DONE)) {
-                usleep(100);
-            }
-        }
-    }
-
-error:
-    return;
 }
 
 /** \internal

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -206,6 +206,8 @@ void DetectRunStoreStateTx(const SigGroupHead *sgh, Flow *f, void *tx, uint64_t 
 
 void DetectEngineStateResetTxs(Flow *f);
 
+void WorkerFlushLogs(void);
+
 void DeStateRegisterTests(void);
 
 #endif /* __DETECT_ENGINE_H__ */

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -206,8 +206,9 @@ void DetectRunStoreStateTx(const SigGroupHead *sgh, Flow *f, void *tx, uint64_t 
 
 void DetectEngineStateResetTxs(Flow *f);
 
-void WorkerFlushLogs(void);
-
 void DeStateRegisterTests(void);
 
+/* packet injection */
+void InjectPackets(ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx,
+        int no_of_detect_tvs, bool flush_logs);
 #endif /* __DETECT_ENGINE_H__ */

--- a/src/detect.c
+++ b/src/detect.c
@@ -1761,6 +1761,10 @@ TmEcode Detect(ThreadVars *tv, Packet *p, void *data)
                   det_ctx);
     }
 
+    /* Ack if a flush was requested */
+    int notset = 0;
+    SC_ATOMIC_CAS(&det_ctx->flush_ack, notset, 1);
+
     /* if in MT mode _and_ we have tenants registered, use
      * MT logic. */
     if (det_ctx->mt_det_ctxs_cnt > 0 && det_ctx->TenantGetId != NULL)

--- a/src/detect.h
+++ b/src/detect.h
@@ -1160,6 +1160,7 @@ typedef struct DetectEngineThreadCtx_ {
     PacketAlert *alert_queue;
 
     SC_ATOMIC_DECLARE(int, so_far_used_by_detect);
+    SC_ATOMIC_DECLARE(int, flush_ack);
 
     /* holds the current recursion depth on content inspection */
     int inspection_recursion_counter;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1177,8 +1177,8 @@ typedef struct DetectEngineThreadCtx_ {
     RuleMatchCandidateTx *tx_candidates;
     uint32_t tx_candidates_size;
 
-    SignatureNonPrefilterStore *non_pf_store_ptr;
     uint32_t non_pf_store_cnt;
+    SignatureNonPrefilterStore *non_pf_store_ptr;
 
     MpmThreadCtx mtc; /**< thread ctx for the mpm */
     PrefilterRuleStore pmq;

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -561,8 +561,11 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
     SCLogDebug("packet %"PRIu64, p->pcap_cnt);
 
     /* update time */
-    if (!(PKT_IS_PSEUDOPKT(p))) {
+    if (!(PKT_IS_PSEUDOPKT(p) || PKT_IS_FLUSHPKT(p))) {
         TimeSetByThread(tv->id, p->ts);
+    }
+    if ((PKT_IS_FLUSHPKT(p))) {
+        OutputLoggerFlush(tv, p, fw->output_thread);
     }
 
     /* handle Flow */

--- a/src/log-flush.c
+++ b/src/log-flush.c
@@ -1,0 +1,208 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect.h"
+#include "detect-engine.h"
+#include "flow-worker.h"
+#include "log-flush.h"
+#include "tm-threads.h"
+#include "conf.h"
+#include "conf-yaml-loader.h"
+#include "util-privs.h"
+
+/**
+ * \brief Trigger detect threads to flush their output logs
+ *
+ * This function is intended to be called at regular intervals to force
+ * buffered log data to be persisted
+ */
+static void WorkerFlushLogs(void)
+{
+    SCEnter();
+    /* count detect threads in use */
+    uint32_t no_of_detect_tvs = TmThreadCountThreadsByTmmFlags(TM_FLAG_DETECT_TM);
+    /* can be zero in unix socket mode */
+    if (no_of_detect_tvs == 0) {
+        return;
+    }
+
+    /* prepare swap structures */
+    DetectEngineThreadCtx *det_ctx[no_of_detect_tvs];
+    ThreadVars *detect_tvs[no_of_detect_tvs];
+    memset(det_ctx, 0x00, (no_of_detect_tvs * sizeof(DetectEngineThreadCtx *)));
+    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars *)));
+
+    /* start the process of swapping detect threads ctxs */
+
+    uint32_t i = 0;
+    /* get reference to tv's and setup new_det_ctx array */
+    SCMutexLock(&tv_root_lock);
+    for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
+        if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
+            continue;
+        }
+        for (TmSlot *s = tv->tm_slots; s != NULL; s = s->slot_next) {
+            TmModule *tm = TmModuleGetById(s->tm_id);
+            if (!(tm->flags & TM_FLAG_DETECT_TM)) {
+                continue;
+            }
+
+            if (suricata_ctl_flags != 0) {
+                SCMutexUnlock(&tv_root_lock);
+                goto error;
+            }
+
+            det_ctx[i] = FlowWorkerGetDetectCtxPtr(SC_ATOMIC_GET(s->slot_data));
+            SC_ATOMIC_SET(det_ctx[i]->flush_ack, 0);
+            detect_tvs[i] = tv;
+
+            i++;
+            break;
+        }
+    }
+    BUG_ON(i != no_of_detect_tvs);
+
+    SCMutexUnlock(&tv_root_lock);
+
+    SCLogDebug("Creating flush pseudo packets for %d threads", no_of_detect_tvs);
+    InjectPackets(detect_tvs, det_ctx, no_of_detect_tvs, true);
+
+    uint32_t threads_done = 0;
+retry:
+    for (i = 0; i < no_of_detect_tvs; i++) {
+        if (suricata_ctl_flags != 0) {
+            threads_done = no_of_detect_tvs;
+            break;
+        }
+        usleep(1000);
+        if (SC_ATOMIC_GET(det_ctx[i]->flush_ack) == 1) {
+            SCLogDebug("thread slot %d has ack'd flush request", i);
+            threads_done++;
+        } else {
+            SCLogDebug("thread slot %d not yet ack'd flush request", i);
+            TmThreadsCaptureBreakLoop(detect_tvs[i]);
+        }
+    }
+    if (threads_done < no_of_detect_tvs) {
+        threads_done = 0;
+        SleepMsec(250);
+        goto retry;
+    }
+
+    /* this is to make sure that if someone initiated shutdown during
+     * this process
+     *
+     * TODO: needed?
+     *
+     * .rule swap, the live rule swap won't clean up the old det_ctx and
+     * de_ctx, till all detect threads have stopped working and sitting
+     * silently after setting RUNNING_DONE flag and while waiting for
+     * THV_DEINIT flag */
+    if (i != no_of_detect_tvs) { // not all threads we swapped
+        for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
+            if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
+                continue;
+            }
+
+            while (!TmThreadsCheckFlag(tv, THV_RUNNING_DONE)) {
+                usleep(100);
+            }
+        }
+    }
+
+error:
+    return;
+}
+
+static void *LogFlusherWakeupThread(void *arg)
+{
+    ThreadVars *tv_local = (ThreadVars *)arg;
+
+    intmax_t output_flush_interval = 0;
+    if (ConfGetInt("logging.flush-interval", &output_flush_interval) == 0) {
+        output_flush_interval = 0;
+    }
+    if (output_flush_interval < 0 || output_flush_interval > 60) {
+        SCLogConfig("flush_interval must be 0 or less than 60; using 0");
+        output_flush_interval = 0;
+    }
+    SCLogNotice("Using flush-interval of %d seconds", (int)output_flush_interval);
+
+    SCSetThreadName(tv_local->name);
+
+    if (tv_local->thread_setup_flags != 0)
+        TmThreadSetupOptions(tv_local);
+
+    /* Set the threads capability */
+    tv_local->cap_flags = 0;
+    SCDropCaps(tv_local);
+
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
+
+    while (1) {
+        if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
+            TmThreadsSetFlag(tv_local, THV_PAUSED);
+            TmThreadTestThreadUnPaused(tv_local);
+            TmThreadsUnsetFlag(tv_local, THV_PAUSED);
+        }
+
+        WorkerFlushLogs();
+        sleep(output_flush_interval);
+
+        if (TmThreadsCheckFlag(tv_local, THV_KILL)) {
+            break;
+        }
+    }
+
+    TmThreadsSetFlag(tv_local, THV_RUNNING_DONE);
+    TmThreadWaitForFlag(tv_local, THV_DEINIT);
+    TmThreadsSetFlag(tv_local, THV_CLOSED);
+    return NULL;
+}
+
+void LogFlushThreads(void)
+{
+    intmax_t output_flush_interval = 0;
+    if (ConfGetInt("logging.flush-interval", &output_flush_interval) == 0) {
+        output_flush_interval = 0;
+    }
+    if (output_flush_interval < 0 || output_flush_interval > 60) {
+        output_flush_interval = 0;
+    }
+
+    if (output_flush_interval) {
+        ThreadVars *tv_log_flush =
+                TmThreadCreateMgmtThread(thread_name_log_flusher, LogFlusherWakeupThread, 1);
+        if (tv_log_flush == NULL) {
+            FatalError("Unable to create log flush thread");
+        }
+        if (TmThreadSpawn(tv_log_flush) != 0) {
+            FatalError("Unable to spawn log flush thread");
+        }
+    } else {
+        SCLogConfig("log flusher thread not started since flush-interval is %d",
+                (int)output_flush_interval);
+    }
+}

--- a/src/log-flush.h
+++ b/src/log-flush.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ */
+#ifndef __LOG_FLUSH_H__
+#define __LOG_FLUSH_H__
+void LogFlushThreads(void);
+#endif /* __LOG_FLUSH_H__ */

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -210,8 +210,16 @@ static bool PcapLogCondition(ThreadVars *, void *, const Packet *);
 
 void PcapLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_PCAP, MODULE_NAME, "pcap-log", PcapLogInitCtx, PcapLog, NULL,
-            PcapLogCondition, PcapLogDataInit, PcapLogDataDeinit, NULL);
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = PcapLog,
+        .FlushFunc = NULL,
+        .ConditionFunc = PcapLogCondition,
+        .ThreadInitFunc = PcapLogDataInit,
+        .ThreadDeinitFunc = PcapLogDataDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+    OutputRegisterPacketModule(
+            LOGGER_PCAP, MODULE_NAME, "pcap-log", PcapLogInitCtx, &output_logger_functions);
     PcapLogProfileSetup();
     SC_ATOMIC_INIT(thread_cnt);
     SC_ATOMIC_SET(thread_cnt, 1); /* first id is 1 */

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -210,9 +210,8 @@ static bool PcapLogCondition(ThreadVars *, void *, const Packet *);
 
 void PcapLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_PCAP, MODULE_NAME, "pcap-log",
-        PcapLogInitCtx, PcapLog, PcapLogCondition, PcapLogDataInit,
-        PcapLogDataDeinit, NULL);
+    OutputRegisterPacketModule(LOGGER_PCAP, MODULE_NAME, "pcap-log", PcapLogInitCtx, PcapLog, NULL,
+            PcapLogCondition, PcapLogDataInit, PcapLogDataDeinit, NULL);
     PcapLogProfileSetup();
     SC_ATOMIC_INIT(thread_cnt);
     SC_ATOMIC_SET(thread_cnt, 1); /* first id is 1 */

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -437,6 +437,6 @@ static bool EveStreamLogCondition(ThreadVars *tv, void *data, const Packet *p)
 void EveStreamLogRegister(void)
 {
     OutputRegisterPacketSubModule(LOGGER_JSON_STREAM, "eve-log", MODULE_NAME, "eve-log.stream",
-            EveStreamLogInitCtxSub, EveStreamLogger, EveStreamLogCondition, EveStreamLogThreadInit,
-            EveStreamLogThreadDeinit, NULL);
+            EveStreamLogInitCtxSub, EveStreamLogger, OutputJsonLogFlush, EveStreamLogCondition,
+            EveStreamLogThreadInit, EveStreamLogThreadDeinit, NULL);
 }

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -436,7 +436,15 @@ static bool EveStreamLogCondition(ThreadVars *tv, void *data, const Packet *p)
 
 void EveStreamLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = EveStreamLogger,
+        .FlushFunc = OutputJsonLogFlush,
+        .ConditionFunc = EveStreamLogCondition,
+        .ThreadInitFunc = EveStreamLogThreadInit,
+        .ThreadDeinitFunc = EveStreamLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_STREAM, "eve-log", MODULE_NAME, "eve-log.stream",
-            EveStreamLogInitCtxSub, EveStreamLogger, OutputJsonLogFlush, EveStreamLogCondition,
-            EveStreamLogThreadInit, EveStreamLogThreadDeinit, NULL);
+            EveStreamLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -935,6 +935,14 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
     return TM_ECODE_OK;
 }
 
+static int JsonAlertFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    JsonAlertLogThread *aft = thread_data;
+    SCLogDebug("%s flushing %s", tv->name, ((LogFileCtx *)(aft->ctx->file_ctx))->filename);
+    OutputJsonFlush(aft->ctx);
+    return 0;
+}
+
 static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonAlertLogThread *aft = thread_data;
@@ -1177,8 +1185,7 @@ error:
 
 void JsonAlertLogRegister (void)
 {
-    OutputRegisterPacketSubModule(LOGGER_JSON_ALERT, "eve-log", MODULE_NAME,
-        "eve-log.alert", JsonAlertLogInitCtxSub, JsonAlertLogger,
-        JsonAlertLogCondition, JsonAlertLogThreadInit, JsonAlertLogThreadDeinit,
-        NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_ALERT, "eve-log", MODULE_NAME, "eve-log.alert",
+            JsonAlertLogInitCtxSub, JsonAlertLogger, JsonAlertFlush, JsonAlertLogCondition,
+            JsonAlertLogThreadInit, JsonAlertLogThreadDeinit, NULL);
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1185,7 +1185,15 @@ error:
 
 void JsonAlertLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonAlertLogger,
+        .FlushFunc = JsonAlertFlush,
+        .ConditionFunc = JsonAlertLogCondition,
+        .ThreadInitFunc = JsonAlertLogThreadInit,
+        .ThreadDeinitFunc = JsonAlertLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_ALERT, "eve-log", MODULE_NAME, "eve-log.alert",
-            JsonAlertLogInitCtxSub, JsonAlertLogger, JsonAlertFlush, JsonAlertLogCondition,
-            JsonAlertLogThreadInit, JsonAlertLogThreadDeinit, NULL);
+            JsonAlertLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -273,6 +273,14 @@ static int AnomalyJson(ThreadVars *tv, JsonAnomalyLogThread *aft, const Packet *
     return rc;
 }
 
+static int JsonAnomalyFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    JsonAnomalyLogThread *aft = thread_data;
+    SCLogDebug("%s flushing %s", tv->name, ((LogFileCtx *)(aft->ctx->file_ctx))->filename);
+    OutputJsonFlush(aft->ctx);
+    return 0;
+}
+
 static int JsonAnomalyLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonAnomalyLogThread *aft = thread_data;
@@ -451,10 +459,9 @@ static OutputInitResult JsonAnomalyLogInitCtxSub(ConfNode *conf, OutputCtx *pare
 
 void JsonAnomalyLogRegister (void)
 {
-    OutputRegisterPacketSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME,
-        "eve-log.anomaly", JsonAnomalyLogInitCtxSub, JsonAnomalyLogger,
-        JsonAnomalyLogCondition, JsonAnomalyLogThreadInit, JsonAnomalyLogThreadDeinit,
-        NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME, "eve-log.anomaly",
+            JsonAnomalyLogInitCtxSub, JsonAnomalyLogger, JsonAnomalyFlush, JsonAnomalyLogCondition,
+            JsonAnomalyLogThreadInit, JsonAnomalyLogThreadDeinit, NULL);
 
     OutputRegisterTxSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME,
         "eve-log.anomaly", JsonAnomalyLogInitCtxHelper, ALPROTO_UNKNOWN,

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -459,9 +459,17 @@ static OutputInitResult JsonAnomalyLogInitCtxSub(ConfNode *conf, OutputCtx *pare
 
 void JsonAnomalyLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonAnomalyLogger,
+        .FlushFunc = JsonAnomalyFlush,
+        .ConditionFunc = JsonAnomalyLogCondition,
+        .ThreadInitFunc = JsonAnomalyLogThreadInit,
+        .ThreadDeinitFunc = JsonAnomalyLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME, "eve-log.anomaly",
-            JsonAnomalyLogInitCtxSub, JsonAnomalyLogger, JsonAnomalyFlush, JsonAnomalyLogCondition,
-            JsonAnomalyLogThreadInit, JsonAnomalyLogThreadDeinit, NULL);
+            JsonAnomalyLogInitCtxSub, &output_logger_functions);
 
     OutputRegisterTxSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME,
         "eve-log.anomaly", JsonAnomalyLogInitCtxHelper, ALPROTO_UNKNOWN,

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -70,6 +70,15 @@ static void OutputJsonLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
+int OutputJsonLogFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    OutputJsonThreadCtx *aft = thread_data;
+    LogFileCtx *file_ctx = aft->ctx->file_ctx;
+    SCLogDebug("%s flushing %s", tv->name, file_ctx->filename);
+    LogFileFlush(file_ctx);
+    return 0;
+}
+
 OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -386,8 +386,7 @@ static bool JsonDropLogCondition(ThreadVars *tv, void *data, const Packet *p)
 
 void JsonDropLogRegister (void)
 {
-    OutputRegisterPacketSubModule(LOGGER_JSON_DROP, "eve-log", MODULE_NAME,
-        "eve-log.drop", JsonDropLogInitCtxSub, JsonDropLogger,
-        JsonDropLogCondition, JsonDropLogThreadInit, JsonDropLogThreadDeinit,
-        NULL);
+    OutputRegisterPacketSubModule(LOGGER_JSON_DROP, "eve-log", MODULE_NAME, "eve-log.drop",
+            JsonDropLogInitCtxSub, JsonDropLogger, OutputJsonLogFlush, JsonDropLogCondition,
+            JsonDropLogThreadInit, JsonDropLogThreadDeinit, NULL);
 }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -386,7 +386,15 @@ static bool JsonDropLogCondition(ThreadVars *tv, void *data, const Packet *p)
 
 void JsonDropLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonDropLogger,
+        .FlushFunc = OutputJsonLogFlush,
+        .ConditionFunc = JsonDropLogCondition,
+        .ThreadInitFunc = JsonDropLogThreadInit,
+        .ThreadDeinitFunc = JsonDropLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_DROP, "eve-log", MODULE_NAME, "eve-log.drop",
-            JsonDropLogInitCtxSub, JsonDropLogger, OutputJsonLogFlush, JsonDropLogCondition,
-            JsonDropLogThreadInit, JsonDropLogThreadDeinit, NULL);
+            JsonDropLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -508,7 +508,15 @@ error:
 
 void JsonFrameLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonFrameLogger,
+        .FlushFunc = OutputJsonLogFlush,
+        .ConditionFunc = JsonFrameLogCondition,
+        .ThreadInitFunc = JsonFrameLogThreadInit,
+        .ThreadDeinitFunc = JsonFrameLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_FRAME, "eve-log", MODULE_NAME, "eve-log.frame",
-            JsonFrameLogInitCtxSub, JsonFrameLogger, OutputJsonLogFlush, JsonFrameLogCondition,
-            JsonFrameLogThreadInit, JsonFrameLogThreadDeinit, NULL);
+            JsonFrameLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -509,6 +509,6 @@ error:
 void JsonFrameLogRegister(void)
 {
     OutputRegisterPacketSubModule(LOGGER_JSON_FRAME, "eve-log", MODULE_NAME, "eve-log.frame",
-            JsonFrameLogInitCtxSub, JsonFrameLogger, JsonFrameLogCondition, JsonFrameLogThreadInit,
-            JsonFrameLogThreadDeinit, NULL);
+            JsonFrameLogInitCtxSub, JsonFrameLogger, OutputJsonLogFlush, JsonFrameLogCondition,
+            JsonFrameLogThreadInit, JsonFrameLogThreadDeinit, NULL);
 }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -95,11 +95,11 @@ static bool JsonMetadataLogCondition(ThreadVars *tv, void *data, const Packet *p
 void JsonMetadataLogRegister (void)
 {
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.metadata",
-            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
-            JsonLogThreadDeinit, NULL);
+            OutputJsonLogInitSub, JsonMetadataLogger, OutputJsonLogFlush, JsonMetadataLogCondition,
+            JsonLogThreadInit, JsonLogThreadDeinit, NULL);
 
     /* Kept for compatibility. */
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.vars",
-            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
-            JsonLogThreadDeinit, NULL);
+            OutputJsonLogInitSub, JsonMetadataLogger, OutputJsonLogFlush, JsonMetadataLogCondition,
+            JsonLogThreadInit, JsonLogThreadDeinit, NULL);
 }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -94,12 +94,19 @@ static bool JsonMetadataLogCondition(ThreadVars *tv, void *data, const Packet *p
 
 void JsonMetadataLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonMetadataLogger,
+        .FlushFunc = OutputJsonLogFlush,
+        .ConditionFunc = JsonMetadataLogCondition,
+        .ThreadInitFunc = JsonLogThreadInit,
+        .ThreadDeinitFunc = JsonLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.metadata",
-            OutputJsonLogInitSub, JsonMetadataLogger, OutputJsonLogFlush, JsonMetadataLogCondition,
-            JsonLogThreadInit, JsonLogThreadDeinit, NULL);
+            OutputJsonLogInitSub, &output_logger_functions);
 
     /* Kept for compatibility. */
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.vars",
-            OutputJsonLogInitSub, JsonMetadataLogger, OutputJsonLogFlush, JsonMetadataLogCondition,
-            JsonLogThreadInit, JsonLogThreadDeinit, NULL);
+            OutputJsonLogInitSub, &output_logger_functions);
 }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -928,6 +928,12 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     return 0;
 }
 
+void OutputJsonFlush(OutputJsonThreadCtx *ctx)
+{
+    LogFileCtx *file_ctx = ctx->file_ctx;
+    LogFileFlush(file_ctx);
+}
+
 int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
 {
     LogFileCtx *file_ctx = ctx->file_ctx;

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -105,6 +105,7 @@ JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirectio
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx);
 OutputInitResult OutputJsonInitCtx(ConfNode *);
+int OutputJsonLogFlush(ThreadVars *tv, void *thread_data, const Packet *p);
 
 OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
 TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
@@ -118,5 +119,6 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
 void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
+void OutputJsonFlush(OutputJsonThreadCtx *ctx);
 
 #endif /* __OUTPUT_JSON_H__ */

--- a/src/output-packet.c
+++ b/src/output-packet.c
@@ -250,9 +250,13 @@ static uint32_t OutputPacketLoggerGetActiveCount(void)
 
 void OutputPacketLoggerRegister(void)
 {
-    OutputRegisterRootLogger(OutputPacketLogThreadInit, OutputPacketLogThreadDeinit,
-            OutputPacketLogExitPrintStats, OutputPacketLog, OutputPacketFlush,
-            OutputPacketLoggerGetActiveCount);
+    OutputRootLoggerFunctions root_logger_functions = { .ThreadInitFunc = OutputPacketLogThreadInit,
+        .ThreadDeinitFunc = OutputPacketLogThreadDeinit,
+        .LogFunc = OutputPacketLog,
+        .FlushFunc = OutputPacketFlush,
+        .ThreadExitPrintStatsFunc = OutputPacketLogExitPrintStats,
+        .ActiveCntFunc = OutputPacketLoggerGetActiveCount };
+    OutputRegisterRootLogger(&root_logger_functions);
 }
 
 void OutputPacketShutdown(void)

--- a/src/output-packet.h
+++ b/src/output-packet.h
@@ -34,9 +34,9 @@ typedef int (*PacketLogger)(ThreadVars *, void *thread_data, const Packet *);
  */
 typedef bool (*PacketLogCondition)(ThreadVars *, void *thread_data, const Packet *);
 
-int OutputRegisterPacketLogger(LoggerId logger_id, const char *name,
-    PacketLogger LogFunc, PacketLogCondition ConditionFunc, OutputCtx *,
-    ThreadInitFunc, ThreadDeinitFunc, ThreadExitPrintStatsFunc);
+int OutputRegisterPacketLogger(LoggerId logger_id, const char *name, PacketLogger LogFunc,
+        PacketLogger FlushFunc, PacketLogCondition ConditionFunc, OutputCtx *, ThreadInitFunc,
+        ThreadDeinitFunc, ThreadExitPrintStatsFunc);
 
 void OutputPacketLoggerRegister(void);
 

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -454,9 +454,9 @@ static uint32_t OutputStreamingLoggerGetActiveCount(void)
 }
 
 void OutputStreamingLoggerRegister(void) {
-    OutputRegisterRootLogger(OutputStreamingLogThreadInit,
-        OutputStreamingLogThreadDeinit, OutputStreamingLogExitPrintStats,
-        OutputStreamingLog, OutputStreamingLoggerGetActiveCount);
+    OutputRegisterRootLogger(OutputStreamingLogThreadInit, OutputStreamingLogThreadDeinit,
+            OutputStreamingLogExitPrintStats, OutputStreamingLog, NULL,
+            OutputStreamingLoggerGetActiveCount);
 }
 
 void OutputStreamingShutdown(void)

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -454,9 +454,14 @@ static uint32_t OutputStreamingLoggerGetActiveCount(void)
 }
 
 void OutputStreamingLoggerRegister(void) {
-    OutputRegisterRootLogger(OutputStreamingLogThreadInit, OutputStreamingLogThreadDeinit,
-            OutputStreamingLogExitPrintStats, OutputStreamingLog, NULL,
-            OutputStreamingLoggerGetActiveCount);
+    OutputRootLoggerFunctions root_logger_functions = { .ThreadInitFunc =
+                                                                OutputStreamingLogThreadInit,
+        .ThreadDeinitFunc = OutputStreamingLogThreadDeinit,
+        .LogFunc = OutputStreamingLog,
+        .FlushFunc = NULL,
+        .ThreadExitPrintStatsFunc = OutputStreamingLogExitPrintStats,
+        .ActiveCntFunc = OutputStreamingLoggerGetActiveCount };
+    OutputRegisterRootLogger(&root_logger_functions);
 }
 
 void OutputStreamingShutdown(void)

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -669,7 +669,7 @@ static uint32_t OutputTxLoggerGetActiveCount(void)
 void OutputTxLoggerRegister (void)
 {
     OutputRegisterRootLogger(OutputTxLogThreadInit, OutputTxLogThreadDeinit,
-        OutputTxLogExitPrintStats, OutputTxLog, OutputTxLoggerGetActiveCount);
+            OutputTxLogExitPrintStats, OutputTxLog, NULL, OutputTxLoggerGetActiveCount);
 }
 
 void OutputTxShutdown(void)

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -668,8 +668,13 @@ static uint32_t OutputTxLoggerGetActiveCount(void)
 
 void OutputTxLoggerRegister (void)
 {
-    OutputRegisterRootLogger(OutputTxLogThreadInit, OutputTxLogThreadDeinit,
-            OutputTxLogExitPrintStats, OutputTxLog, NULL, OutputTxLoggerGetActiveCount);
+    OutputRootLoggerFunctions root_logger_functions = { .ThreadInitFunc = OutputTxLogThreadInit,
+        .ThreadDeinitFunc = OutputTxLogThreadDeinit,
+        .LogFunc = OutputTxLog,
+        .FlushFunc = NULL,
+        .ThreadExitPrintStatsFunc = OutputTxLogExitPrintStats,
+        .ActiveCntFunc = OutputTxLoggerGetActiveCount };
+    OutputRegisterRootLogger(&root_logger_functions);
 }
 
 void OutputTxShutdown(void)

--- a/src/output.h
+++ b/src/output.h
@@ -89,14 +89,30 @@ extern OutputModuleList output_modules;
 
 void OutputRegisterModule(const char *, const char *, OutputInitFunc);
 
+/* struct for packet module and packet sub-module registration */
+typedef struct OutputPacketLoggerFunctions_ {
+    PacketLogger LogFunc;
+    PacketLogger FlushFunc;
+    PacketLogCondition ConditionFunc;
+    ThreadInitFunc ThreadInitFunc;
+    ThreadDeinitFunc ThreadDeinitFunc;
+    ThreadExitPrintStatsFunc ThreadExitPrintStatsFunc;
+} OutputPacketLoggerFunctions;
+
+/* struct for root logger registration */
+typedef struct OutputRootLoggerFunctions_ {
+    ThreadInitFunc ThreadInitFunc;
+    ThreadDeinitFunc ThreadDeinitFunc;
+    ThreadExitPrintStatsFunc ThreadExitPrintStatsFunc;
+    OutputLogFunc LogFunc;
+    OutputFlushFunc FlushFunc;
+    OutputGetActiveCountFunc ActiveCntFunc;
+} OutputRootLoggerFunctions;
+
 void OutputRegisterPacketModule(LoggerId id, const char *name, const char *conf_name,
-        OutputInitFunc InitFunc, PacketLogger LogFunc, PacketLogger FlushFunc,
-        PacketLogCondition ConditionFunc, ThreadInitFunc, ThreadDeinitFunc,
-        ThreadExitPrintStatsFunc);
+        OutputInitFunc InitFunc, OutputPacketLoggerFunctions *);
 void OutputRegisterPacketSubModule(LoggerId id, const char *parent_name, const char *name,
-        const char *conf_name, OutputInitSubFunc InitFunc, PacketLogger LogFunc,
-        PacketLogger FlushFunc, PacketLogCondition ConditionFunc, ThreadInitFunc ThreadInit,
-        ThreadDeinitFunc ThreadDeinit, ThreadExitPrintStatsFunc ThreadExitPrintStats);
+        const char *conf_name, OutputInitSubFunc InitFunc, OutputPacketLoggerFunctions *);
 
 void OutputRegisterTxModule(LoggerId id, const char *name,
     const char *conf_name, OutputInitFunc InitFunc, AppProto alproto,
@@ -195,9 +211,7 @@ void OutputRegisterFileRotationFlag(int *flag);
 void OutputUnregisterFileRotationFlag(int *flag);
 void OutputNotifyFileRotation(void);
 
-void OutputRegisterRootLogger(ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-        ThreadExitPrintStatsFunc ThreadExitPrintStats, OutputLogFunc LogFunc,
-        OutputFlushFunc FlushFunc, OutputGetActiveCountFunc ActiveCntFunc);
+void OutputRegisterRootLogger(OutputRootLoggerFunctions *);
 void TmModuleLoggerRegister(void);
 
 TmEcode OutputLoggerLog(ThreadVars *, Packet *, void *);

--- a/src/output.h
+++ b/src/output.h
@@ -51,6 +51,7 @@ typedef struct OutputInitResult_ {
 typedef OutputInitResult (*OutputInitFunc)(ConfNode *);
 typedef OutputInitResult (*OutputInitSubFunc)(ConfNode *, OutputCtx *);
 typedef TmEcode (*OutputLogFunc)(ThreadVars *, Packet *, void *);
+typedef TmEcode (*OutputFlushFunc)(ThreadVars *, Packet *, void *);
 typedef uint32_t (*OutputGetActiveCountFunc)(void);
 
 typedef struct OutputModule_ {
@@ -66,6 +67,7 @@ typedef struct OutputModule_ {
     ThreadExitPrintStatsFunc ThreadExitPrintStats;
 
     PacketLogger PacketLogFunc;
+    PacketLogger PacketFlushFunc;
     PacketLogCondition PacketConditionFunc;
     TxLogger TxLogFunc;
     TxLoggerCondition TxLogCondition;
@@ -87,15 +89,14 @@ extern OutputModuleList output_modules;
 
 void OutputRegisterModule(const char *, const char *, OutputInitFunc);
 
-void OutputRegisterPacketModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc, PacketLogger LogFunc,
-    PacketLogCondition ConditionFunc, ThreadInitFunc, ThreadDeinitFunc,
-    ThreadExitPrintStatsFunc);
-void OutputRegisterPacketSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    PacketLogger LogFunc, PacketLogCondition ConditionFunc,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
+void OutputRegisterPacketModule(LoggerId id, const char *name, const char *conf_name,
+        OutputInitFunc InitFunc, PacketLogger LogFunc, PacketLogger FlushFunc,
+        PacketLogCondition ConditionFunc, ThreadInitFunc, ThreadDeinitFunc,
+        ThreadExitPrintStatsFunc);
+void OutputRegisterPacketSubModule(LoggerId id, const char *parent_name, const char *name,
+        const char *conf_name, OutputInitSubFunc InitFunc, PacketLogger LogFunc,
+        PacketLogger FlushFunc, PacketLogCondition ConditionFunc, ThreadInitFunc ThreadInit,
+        ThreadDeinitFunc ThreadDeinit, ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
 void OutputRegisterTxModule(LoggerId id, const char *name,
     const char *conf_name, OutputInitFunc InitFunc, AppProto alproto,
@@ -194,13 +195,13 @@ void OutputRegisterFileRotationFlag(int *flag);
 void OutputUnregisterFileRotationFlag(int *flag);
 void OutputNotifyFileRotation(void);
 
-void OutputRegisterRootLogger(ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats,
-    OutputLogFunc LogFunc, OutputGetActiveCountFunc ActiveCntFunc);
+void OutputRegisterRootLogger(ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
+        ThreadExitPrintStatsFunc ThreadExitPrintStats, OutputLogFunc LogFunc,
+        OutputFlushFunc FlushFunc, OutputGetActiveCountFunc ActiveCntFunc);
 void TmModuleLoggerRegister(void);
 
 TmEcode OutputLoggerLog(ThreadVars *, Packet *, void *);
+TmEcode OutputLoggerFlush(ThreadVars *, Packet *, void *);
 TmEcode OutputLoggerThreadInit(ThreadVars *, const void *, void **);
 TmEcode OutputLoggerThreadDeinit(ThreadVars *, void *);
 void OutputLoggerExitPrintStats(ThreadVars *, void *);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -645,10 +645,9 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
 
     if (module->PacketLogFunc) {
         SCLogDebug("%s is a packet logger", module->name);
-        OutputRegisterPacketLogger(module->logger_id, module->name,
-            module->PacketLogFunc, module->PacketConditionFunc, output_ctx,
-            module->ThreadInit, module->ThreadDeinit,
-            module->ThreadExitPrintStats);
+        OutputRegisterPacketLogger(module->logger_id, module->name, module->PacketLogFunc,
+                module->PacketFlushFunc, module->PacketConditionFunc, output_ctx,
+                module->ThreadInit, module->ThreadDeinit, module->ThreadExitPrintStats);
     } else if (module->TxLogFunc) {
         SCLogDebug("%s is a tx logger", module->name);
         OutputRegisterTxLogger(module->logger_id, module->name, module->alproto,

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -34,6 +34,7 @@
 #include "util-byte.h"
 #include "util-affinity.h"
 #include "conf.h"
+#include "log-flush.h"
 #include "queue.h"
 #include "runmodes.h"
 #include "runmode-af-packet.h"
@@ -87,6 +88,7 @@ const char *thread_name_unix_socket = "US";
 const char *thread_name_detect_loader = "DL";
 const char *thread_name_counter_stats = "CS";
 const char *thread_name_counter_wakeup = "CW";
+const char *thread_name_log_flusher = "LF";
 
 /**
  * \brief Holds description for a runmode.
@@ -462,6 +464,7 @@ void RunModeDispatch(int runmode, const char *custom_mode, const char *capture_p
             BypassedFlowManagerThreadSpawn();
         }
         StatsSpawnThreads();
+        LogFlushThreads();
     }
 }
 

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -75,6 +75,7 @@ extern const char *thread_name_unix_socket;
 extern const char *thread_name_detect_loader;
 extern const char *thread_name_counter_stats;
 extern const char *thread_name_counter_wakeup;
+extern const char *thread_name_log_flusher;
 
 char *RunmodeGetActive(void);
 const char *RunModeGetMainMode(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2798,13 +2798,6 @@ int PostConfLoadedSetup(SCInstance *suri)
 
 static void SuricataMainLoop(SCInstance *suri)
 {
-    /*
-     * Use the flush interval to determine how many iterations through the
-     * loop constitute a flush_interval.
-     * The sleep interval is 10ms.
-     */
-    const int flush_wait_count = (suri->output_flush_interval * 1000) / 10;
-    int wait_count = 0;
     while(1) {
         if (sigterm_count || sigint_count) {
             suricata_ctl_flags |= SURICATA_STOP;
@@ -2833,14 +2826,6 @@ static void SuricataMainLoop(SCInstance *suri)
         } else if (DetectEngineReloadIsStart()) {
             DetectEngineReload(suri);
             DetectEngineReloadSetIdle();
-        }
-
-        if (flush_wait_count) {
-            if (++wait_count == flush_wait_count) {
-                SCLogDebug("Sending flush packet to threads");
-                WorkerFlushLogs();
-                wait_count = 0;
-            }
         }
 
         usleep(10* 1000);
@@ -3002,17 +2987,6 @@ int SuricataMain(int argc, char **argv)
     if (ConfGetBool("security.limit-noproc", &limit_nproc) == 0) {
         limit_nproc = 0;
     }
-
-    intmax_t flush_interval = 0;
-    if (ConfGetInt("logging.flush-interval", &flush_interval) == 0) {
-        flush_interval = 0;
-    }
-    if (flush_interval < 0 || flush_interval > 60) {
-        SCLogConfig("flush_interval must be 0 or less than 60; using 0");
-        flush_interval = 0;
-    }
-    suricata.output_flush_interval = flush_interval;
-    SCLogConfig("Using flush-interval of %d seconds", (int)flush_interval);
 
 #if defined(SC_ADDRESS_SANITIZER)
     if (limit_nproc) {

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -152,6 +152,7 @@ typedef struct SCInstance_ {
     int offline;
     int verbose;
     int checksum_validation;
+    int output_flush_interval;
 
     struct timeval start_time;
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -152,7 +152,6 @@ typedef struct SCInstance_ {
     int offline;
     int verbose;
     int checksum_validation;
-    int output_flush_interval;
 
     struct timeval start_time;
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -31,6 +31,7 @@
 #include "util-byte.h"
 #include "util-conf.h"
 #include "util-path.h"
+#include "util-misc.h"
 #include "util-time.h"
 
 #if defined(HAVE_SYS_UN_H) && defined(HAVE_SYS_SOCKET_H) && defined(HAVE_SYS_TYPES_H)
@@ -223,7 +224,7 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
                         log_ctx->filename);
             }
             log_ctx->output_errors++;
-        } else {
+        } else if (log_ctx->buffer_size) {
             SCFflushUnlocked(log_ctx->fp);
         }
     }
@@ -307,8 +308,11 @@ static char *SCLogFilenameFromPattern(const char *pattern)
 static void SCLogFileCloseNoLock(LogFileCtx *log_ctx)
 {
     SCLogDebug("Closing %s", log_ctx->filename);
-    if (log_ctx->fp)
+    if (log_ctx->fp) {
+        if (log_ctx->buffer_size)
+            SCFflushUnlocked(log_ctx->fp);
         fclose(log_ctx->fp);
+    }
 
     if (log_ctx->output_errors) {
         SCLogError("There were %" PRIu64 " output errors to %s", log_ctx->output_errors,
@@ -399,8 +403,8 @@ error_exit:
  *  \retval FILE* on success
  *  \retval NULL on error
  */
-static FILE *
-SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
+static FILE *SCLogOpenFileFp(
+        const char *path, const char *append_setting, uint32_t mode, const uint32_t buffer_size)
 {
     FILE *ret = NULL;
 
@@ -436,7 +440,18 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
         }
     }
 
+    /* Set buffering behavior */
+    if (buffer_size == 0) {
+        setbuf(ret, NULL);
+        SCLogNotice("Setting output to %s non-buffered", filename);
+    } else {
+        if (setvbuf(ret, NULL, _IOFBF, buffer_size) < 0)
+            FatalError("unable to set %s to buffered: %d", filename, buffer_size);
+        SCLogConfig("Setting output to %s buffered [%d]", filename, buffer_size);
+    }
+
     SCFree(filename);
+
     return ret;
 }
 
@@ -516,6 +531,22 @@ SCConfLogOpenGeneric(ConfNode *conf,
     if (filetype == NULL)
         filetype = DEFAULT_LOG_FILETYPE;
 
+    /* Determine the buffering for this output device; a value of 0 means to not buffer;
+     * any other value must be a multiple of 4096
+     */
+    uint32_t buffer_size = LOGFILE_EVE_BUFFER_SIZE;
+    const char *buffer_size_value = ConfNodeLookupChildValue(conf, "buffer-size");
+    if (buffer_size_value != NULL) {
+        uint32_t value;
+        if (ParseSizeStringU32(buffer_size_value, &value) < 0) {
+            FatalError("Error parsing "
+                       "buffer-size - %s. Killing engine",
+                    buffer_size_value);
+        }
+        buffer_size = value;
+    }
+
+    SCLogNotice("buffering: %s -> %d", buffer_size_value, buffer_size);
     const char *filemode = ConfNodeLookupChildValue(conf, "filemode");
     uint32_t mode = 0;
     if (filemode != NULL && StringParseUint32(&mode, 8, (uint16_t)strlen(filemode), filemode) > 0) {
@@ -560,6 +591,10 @@ SCConfLogOpenGeneric(ConfNode *conf,
         }
     }
 #endif
+    if (!(strcasecmp(filetype, DEFAULT_LOG_FILETYPE) == 0 || strcasecmp(filetype, "file") == 0)) {
+        SCLogConfig("buffering setting ignored for %s output types", filetype);
+    }
+
     // Now, what have we been asked to open?
     if (strcasecmp(filetype, "unix_stream") == 0) {
 #ifdef BUILD_WITH_UNIXSOCKET
@@ -582,8 +617,10 @@ SCConfLogOpenGeneric(ConfNode *conf,
     } else if (strcasecmp(filetype, DEFAULT_LOG_FILETYPE) == 0 ||
                strcasecmp(filetype, "file") == 0) {
         log_ctx->is_regular = 1;
+        log_ctx->buffer_size = buffer_size;
         if (!log_ctx->threaded) {
-            log_ctx->fp = SCLogOpenFileFp(log_path, append, log_ctx->filemode);
+            log_ctx->fp =
+                    SCLogOpenFileFp(log_path, append, log_ctx->filemode, log_ctx->buffer_size);
             if (log_ctx->fp == NULL)
                 return -1; // Error already logged by Open...Fp routine
         } else {
@@ -645,7 +682,8 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
     /* Reopen the file. Append is forced in case the file was not
      * moved as part of a rotation process. */
     SCLogDebug("Reopening log file %s.", log_ctx->filename);
-    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "yes", log_ctx->filemode);
+    log_ctx->fp =
+            SCLogOpenFileFp(log_ctx->filename, "yes", log_ctx->filemode, log_ctx->buffer_size);
     if (log_ctx->fp == NULL) {
         return -1; // Already logged by Open..Fp routine.
     }
@@ -815,7 +853,7 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
             goto error;
         }
         SCLogDebug("Thread open -- using name %s [replaces %s]", fname, log_path);
-        thread->fp = SCLogOpenFileFp(fname, append, thread->filemode);
+        thread->fp = SCLogOpenFileFp(fname, append, thread->filemode, parent_ctx->buffer_size);
         if (thread->fp == NULL) {
             goto error;
         }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -160,6 +160,9 @@ typedef struct LogFileCtx_ {
     uint64_t dropped;
 
     uint64_t output_errors;
+
+    /* Track buffered content */
+    uint64_t bytes_since_last_flush;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -86,6 +86,7 @@ typedef struct LogFileCtx_ {
 
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
+    void (*Flush)(struct LogFileCtx_ *fp);
 
     LogFilePluginCtx plugin;
 
@@ -173,6 +174,7 @@ typedef struct LogFileCtx_ {
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
+void LogFileFlush(LogFileCtx *file_ctx);
 
 LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -107,6 +107,9 @@ typedef struct LogFileCtx_ {
     /** File permissions */
     uint32_t filemode;
 
+    /** File buffering */
+    uint32_t buffer_size;
+
     /** Suricata sensor name */
     char *sensor_name;
 
@@ -163,6 +166,9 @@ typedef struct LogFileCtx_ {
 
 /* flags for LogFileCtx */
 #define LOGFILE_ROTATE_INTERVAL 0x04
+
+/* Default EVE output buffering size */
+#define LOGFILE_EVE_BUFFER_SIZE (8 * 1024)
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -95,6 +95,10 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -556,6 +560,17 @@ outputs:
 # Logging configuration.  This is not about logging IDS alerts/events, but
 # output about what Suricata is doing, like startup messages, errors, etc.
 logging:
+
+  # The flush-interval governs how often Suricata will instruct the detection
+  # threads to flush their EVE output. Specify the value in seconds [1-60]
+  # and Suricata will initiate EVE log output flushes at that interval. A value
+  # of 0 means no EVE log output flushes are initiated. When the EVE output
+  # buffer-size value is non-zero, some EVE output that was written may remain
+  # buffered. The flush-interval governs how much buffered data exists.
+  #
+  # The default value is: 0 (never instruct detection threads to flush output)
+  #flush-interval: 0
+
   # The default log level: can be overridden in an output section.
   # Note that debug level logging will only be emitted if Suricata was
   # compiled with the --enable-debug configure option.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -557,19 +557,20 @@ outputs:
       scripts:
       #   - script1.lua
 
-# Logging configuration.  This is not about logging IDS alerts/events, but
-# output about what Suricata is doing, like startup messages, errors, etc.
-logging:
-
-  # The flush-interval governs how often Suricata will instruct the detection
+heartbeat:
+  # The outputflush-interval governs how often Suricata will instruct the detection
   # threads to flush their EVE output. Specify the value in seconds [1-60]
   # and Suricata will initiate EVE log output flushes at that interval. A value
   # of 0 means no EVE log output flushes are initiated. When the EVE output
   # buffer-size value is non-zero, some EVE output that was written may remain
-  # buffered. The flush-interval governs how much buffered data exists.
+  # buffered. The output-flush-interval governs how much buffered data exists.
   #
   # The default value is: 0 (never instruct detection threads to flush output)
-  #flush-interval: 0
+  #output-flush-interval: 0
+
+# Logging configuration.  This is not about logging IDS alerts/events, but
+# output about what Suricata is doing, like startup messages, errors, etc.
+logging:
 
   # The default log level: can be overridden in an output section.
   # Note that debug level logging will only be emitted if Suricata was


### PR DESCRIPTION
Continuation of #9802

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3449](https://redmine.openinfosecfoundation.org/issues/3449)

Describe changes:
- Add EVE configuration parameter to control buffering: `buffer-size`. When 0, unbuffered I/O is used; other values are used to set the stdio buffer size. The value is `outputs.eve-log.buffer-size`
- Add Suricata configuration parameter -- `flush-interval` -- to set cadence for Suricata periodically directing detect threads to flush EVE output. To be used in conjunction with `buffer-size`. Set `logging.flush-interval` to the number of seconds Suricata should periodically cause the EVE output to be flushed. The default value is `0` which instructs Suricata to never cause the EVE output to be flushed.
- Add mechanism to periodically send pseudo packets to detect threads as a way to trigger flush. Controlled by `flush-interval`
- Add "log flusher" thread when flushing is configured (`logging.flush-interval` is between 1 and 69).

Updates:
- Added file missing from git
- Modified log-flush thread to sleep in a series of 500ms increments to respond better to shutdown scenarios
- Checked detection context pointers that could possibly become state in flush and packet injection functions.

## `hyperfine` results
## Suricata configurations
### Threaded output *off*
- suricata.yaml (default values)
- suricata-buffer-flush.yaml (flush every 2 seconds with 16kb buffer)
- suricata-buffering.yaml (16kb buffer)
### Threaded output
- suricata.yaml
- suricata-buffer-flush.yaml
- suricata-buffering.yaml

```
Benchmark 1: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     411.279 s ±  2.769 s    [User: 1375.083 s, System: 135.731 s]
  Range (min … max):   409.550 s … 414.473 s    3 runs

  Warning: The first benchmarking run for this command was significantly slower than the rest (414.473 s). This could be caused by (filesystem) caches that were not filled until after the first run. You should consider using the '--warmup' option to fill those caches before the actual benchmark. Alternatively, use the '--prepare' option to clear the caches before each timing run.

Benchmark 2: ./src/suricata -c suricata-buffer-flush.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     413.066 s ±  6.341 s    [User: 1377.730 s, System: 122.352 s]
  Range (min … max):   406.132 s … 418.569 s    3 runs

Benchmark 3: ./src/suricata -c suricata-buffering.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     407.890 s ±  4.460 s    [User: 1370.222 s, System: 121.522 s]
  Range (min … max):   403.176 s … 412.042 s    3 runs

Benchmark 4: ./src/suricata -c suricata-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     397.753 s ± 28.644 s    [User: 1363.991 s, System: 132.469 s]
  Range (min … max):   366.626 s … 423.003 s    3 runs

Benchmark 5: ./src/suricata -c suricata-buffer-flush-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     414.763 s ± 12.046 s    [User: 1380.227 s, System: 121.760 s]
  Range (min … max):   401.456 s … 424.925 s    3 runs

Benchmark 6: ./src/suricata -c suricata-buffering-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll
  Time (mean ± σ):     418.456 s ±  2.223 s    [User: 1379.530 s, System: 122.226 s]
  Range (min … max):   417.039 s … 421.019 s    3 runs

Summary
  './src/suricata -c suricata-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll' ran
    1.03 ± 0.07 times faster than './src/suricata -c suricata-buffering.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll'
    1.03 ± 0.07 times faster than './src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll'
    1.04 ± 0.08 times faster than './src/suricata -c suricata-buffer-flush.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll'
    1.04 ± 0.08 times faster than './src/suricata -c suricata-buffer-flush-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll'
    1.05 ± 0.08 times faster than './src/suricata -c suricata-buffering-threaded.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll'
```
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
