### PR TITLE
Pop3 protocol detection 6366 v2

### DIFF
--- a/doc/userguide/rules/differences-from-snort.rst
+++ b/doc/userguide/rules/differences-from-snort.rst
@@ -19,6 +19,7 @@ Automatic Protocol Detection
    -  dns
    -  http
    -  imap (detection only by default; no parsing)
+   -  pop3 (detection only by default; no parsing)
    -  ftp
    -  modbus (disabled by default; minimalist probe parser; can lead to false positives)
    -  smb

--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -96,6 +96,7 @@ you can pick from. These are:
 * ssh
 * smtp
 * imap
+* pop3
 * modbus (disabled by default)
 * dnp3 (disabled by default)
 * enip (disabled by default)

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3791,6 +3791,9 @@
                                 "pgsql": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
+                                "pop3": {
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
                                 "quic": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
@@ -3908,6 +3911,9 @@
                                 "pgsql": {
                                     "type": "integer"
                                 },
+                                "pop3": {
+                                    "type": "integer"
+                                },
                                 "quic": {
                                     "type": "integer"
                                 },
@@ -4017,6 +4023,9 @@
                                     "type": "integer"
                                 },
                                 "pgsql": {
+                                    "type": "integer"
+                                },
+                                "pop3": {
                                     "type": "integer"
                                 },
                                 "quic": {

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -951,6 +951,15 @@ static int FTPGetAlstateProgress(void *vtx, uint8_t direction)
     return FTP_STATE_FINISHED;
 }
 
+static AppProto FTPUserProbingParser(
+        Flow *f, uint8_t direction, const uint8_t *input, uint32_t len, uint8_t *rdir)
+{
+    if (f->alproto_tc == ALPROTO_POP3) {
+        // POP traffic begins by same "USER" pattern as FTP
+        return ALPROTO_FAILED;
+    }
+    return ALPROTO_FTP;
+}
 
 static int FTPRegisterPatternsForProtocolDetection(void)
 {
@@ -962,8 +971,8 @@ static int FTPRegisterPatternsForProtocolDetection(void)
                 IPPROTO_TCP, ALPROTO_FTP, "FEAT", 4, 0, STREAM_TOSERVER) < 0) {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCI(
-                IPPROTO_TCP, ALPROTO_FTP, "USER ", 5, 0, STREAM_TOSERVER) < 0) {
+    if (AppLayerProtoDetectPMRegisterPatternCSwPP(IPPROTO_TCP, ALPROTO_FTP, "USER ", 5, 0,
+                STREAM_TOSERVER, FTPUserProbingParser, 5, 5) < 0) {
         return -1;
     }
     if (AppLayerProtoDetectPMRegisterPatternCI(

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1779,12 +1779,22 @@ void AppLayerParserRegisterProtocolParsers(void)
         if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_IMAP,
                                   "1|20|capability", 12, 0, STREAM_TOSERVER) < 0)
         {
-            SCLogInfo("imap proto registration failure");
-            exit(EXIT_FAILURE);
+            FatalError("imap proto registration failure");
         }
     } else {
         SCLogInfo("Protocol detection and parser disabled for %s protocol.",
                   "imap");
+    }
+
+    /** POP3 */
+    AppLayerProtoDetectRegisterProtocol(ALPROTO_POP3, "pop3");
+    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", "pop3")) {
+        if (AppLayerProtoDetectPMRegisterPatternCS(
+                    IPPROTO_TCP, ALPROTO_POP3, "+OK ", 4, 0, STREAM_TOCLIENT) < 0) {
+            FatalError("pop3 proto registration failure");
+        }
+    } else {
+        SCLogInfo("Protocol detection and parser disabled for pop3 protocol.");
     }
 
     ValidateParsers();

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -64,6 +64,7 @@ const AppProtoStringTuple AppProtoStrings[ALPROTO_MAX] = {
     { ALPROTO_RDP, "rdp" },
     { ALPROTO_HTTP2, "http2" },
     { ALPROTO_BITTORRENT_DHT, "bittorrent-dht" },
+    { ALPROTO_POP3, "pop3" },
     { ALPROTO_HTTP, "http" },
     { ALPROTO_FAILED, "failed" },
 #ifdef UNITTESTS

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -60,6 +60,7 @@ enum AppProtoEnum {
     ALPROTO_RDP,
     ALPROTO_HTTP2,
     ALPROTO_BITTORRENT_DHT,
+    ALPROTO_POP3,
 
     // signature-only (ie not seen in flow)
     // HTTP for any version (ALPROTO_HTTP1 (version 1) or ALPROTO_HTTP2)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -971,6 +971,8 @@ app-layer:
         content-inspect-window: 4096
     imap:
       enabled: detection-only
+    pop3:
+      enabled: detection-only
     smb:
       enabled: yes
       detection-ports:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6366

Describe changes:
- pop3 protocol detection

### Provide values to any of the below to override the defaults.

https://github.com/OISF/suricata-verify/pull/1481
```
SV_BRANCH=pr/1481
```

Rebase of #9500 to rerun QA

First preliminary part for https://github.com/OISF/suricata/pull/8892 and https://redmine.openinfosecfoundation.org/issues/1125

This will require a QA rebaseline

After that :
- QA baseline is wrong because of counting IRC flows on port 5432 as pgsql because pgsql probing parser to client accepts anything
- See first commits of #8892 about generic protocol detection and see if we can craft tests to identify these bugs
- Make eve.json stats field about flows match the count of flow with app_proto because of so many corner cases
- Add FTP and SMTP server side detection