### PR TITLE
detect: SigMatchAppendSMToList can fail

### DIFF
--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -278,20 +278,19 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
     }
     SCLogDebug("data->event_id %u", data->event_id);
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_APP_LAYER_EVENT;
-    sm->ctx = (SigMatchCtx *)data;
-
     if (event_type == APP_LAYER_EVENT_TYPE_PACKET) {
-        SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+        if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_APP_LAYER_EVENT, (SigMatchCtx *)data,
+                    DETECT_SM_LIST_MATCH) == NULL) {
+            goto error;
+        }
     } else {
         if (DetectSignatureSetAppProto(s, data->alproto) != 0)
             goto error;
 
-        SigMatchAppendSMToList(s, sm, g_applayer_events_list_id);
+        if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_APP_LAYER_EVENT, (SigMatchCtx *)data,
+                    g_applayer_events_list_id) == NULL) {
+            goto error;
+        }
         s->flags |= SIG_FLAG_APPLAYER;
     }
 
@@ -300,10 +299,6 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
 error:
     if (data) {
         DetectAppLayerEventFree(de_ctx, data);
-    }
-    if (sm) {
-        sm->ctx = NULL;
-        SigMatchFree(de_ctx, sm);
     }
     return -1;
 }

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -141,7 +141,6 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
         Signature *s, const char *arg)
 {
     DetectAppLayerProtocolData *data = NULL;
-    SigMatch *sm = NULL;
 
     if (s->alproto != ALPROTO_UNKNOWN) {
         SCLogError("Either we already "
@@ -169,14 +168,10 @@ static int DetectAppLayerProtocolSetup(DetectEngineCtx *de_ctx,
         }
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_APP_LAYER_PROTOCOL, (SigMatchCtx *)data,
+                DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_APP_LAYER_PROTOCOL;
-    sm->ctx = (void *)data;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     return 0;
 
 error:

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -127,18 +127,11 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
     if (ad == NULL)
         return -1;
 
-    /* Okay so far so good, lets get this into a SigMatch
-     * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ASN1, (SigMatchCtx *)ad, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         DetectAsn1Free(de_ctx, ad);
         return -1;
     }
-
-    sm->type = DETECT_ASN1;
-    sm->ctx = (SigMatchCtx *)ad;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
 
     return 0;
 }

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -191,7 +191,6 @@ static int DetectBase64DecodeSetup(DetectEngineCtx *de_ctx, Signature *s,
     uint8_t relative = 0;
     DetectBase64Decode *data = NULL;
     int sm_list;
-    SigMatch *sm = NULL;
     SigMatch *pm = NULL;
 
     if (str != NULL) {
@@ -226,13 +225,10 @@ static int DetectBase64DecodeSetup(DetectEngineCtx *de_ctx, Signature *s,
         }
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BASE64_DECODE, (SigMatchCtx *)data, sm_list) ==
+            NULL) {
         goto error;
     }
-    sm->type = DETECT_BASE64_DECODE;
-    sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
 
     if (!data->bytes) {
         data->bytes = BASE64_DECODE_MAX;

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -199,7 +199,6 @@ static int SigParseGetMaxBsize(DetectU64Data *bsz)
 static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *sizestr)
 {
     SCEnter();
-    SigMatch *sm = NULL;
 
     if (DetectBufferGetActiveList(de_ctx, s) == -1)
         SCReturnInt(-1);
@@ -212,13 +211,9 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     if (bsz == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BSIZE, (SigMatchCtx *)bsz, list) == NULL) {
         goto error;
-    sm->type = DETECT_BSIZE;
-    sm->ctx = (void *)bsz;
-
-    SigMatchAppendSMToList(s, sm, list);
+    }
 
     SCReturnInt(0);
 

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -69,7 +69,6 @@ void DetectBypassRegister(void)
 
 static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    SigMatch *sm = NULL;
 
     if (s->flags & SIG_FLAG_FILESTORE) {
         SCLogError("bypass can't work with filestore keyword");
@@ -77,13 +76,9 @@ static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     }
     s->flags |= SIG_FLAG_BYPASS;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BYPASS, NULL, DETECT_SM_LIST_POSTMATCH) == NULL) {
         return -1;
-
-    sm->type = DETECT_BYPASS;
-    sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    }
 
     return 0;
 }

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -531,7 +531,6 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
  */
 static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
-    SigMatch *sm = NULL;
     SigMatch *prev_pm = NULL;
     DetectByteExtractData *data = NULL;
     int ret = -1;
@@ -609,14 +608,10 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     if (data->local_id > de_ctx->byte_extract_max_local_id)
         de_ctx->byte_extract_max_local_id = data->local_id;
 
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BYTE_EXTRACT, (SigMatchCtx *)data, sm_list) ==
+            NULL) {
         goto error;
-    sm->type = DETECT_BYTE_EXTRACT;
-    sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
-
+    }
 
     if (!(data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE))
         goto okay;
@@ -638,7 +633,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
  error:
     DetectByteExtractFree(de_ctx, data);
     return ret;
-}
+ }
 
 /**
  * \brief Used to free instances of DetectByteExtractData.

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -469,7 +469,6 @@ error:
 
 static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
-    SigMatch *sm = NULL;
     SigMatch *prev_pm = NULL;
     DetectBytejumpData *data = NULL;
     char *offset = NULL;
@@ -569,12 +568,9 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         offset = NULL;
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BYTEJUMP, (SigMatchCtx *)data, sm_list) == NULL) {
         goto error;
-    sm->type = DETECT_BYTEJUMP;
-    sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     if (!(data->flags & DETECT_BYTEJUMP_RELATIVE))
         goto okay;
@@ -603,7 +599,7 @@ static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     }
     DetectBytejumpFree(de_ctx, data);
     return ret;
-}
+ }
 
 /**
  * \brief this function will free memory associated with DetectBytejumpData

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -279,7 +279,6 @@ static DetectByteMathData *DetectByteMathParse(
  */
 static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
-    SigMatch *sm = NULL;
     SigMatch *prev_pm = NULL;
     DetectByteMathData *data;
     char *rvalue = NULL;
@@ -393,12 +392,9 @@ static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         de_ctx->byte_extract_max_local_id = data->local_id;
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BYTEMATH, (SigMatchCtx *)data, sm_list) == NULL) {
         goto error;
-    sm->type = DETECT_BYTEMATH;
-    sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     if (!(data->flags & DETECT_BYTEMATH_FLAG_RELATIVE))
         goto okay;
@@ -424,7 +420,7 @@ static int DetectByteMathSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         SCFree(nbytes);
     DetectByteMathFree(de_ctx, data);
     return ret;
-}
+ }
 
 /**
  * \brief Used to free instances of DetectByteMathractData.

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -582,7 +582,6 @@ error:
 
 static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
-    SigMatch *sm = NULL;
     SigMatch *prev_pm = NULL;
     char *value = NULL;
     char *offset = NULL;
@@ -696,12 +695,9 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         nbytes = NULL;
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_BYTETEST, (SigMatchCtx *)data, sm_list) == NULL) {
         goto error;
-    sm->type = DETECT_BYTETEST;
-    sm->ctx = (SigMatchCtx *)data;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     if (!(data->flags & DETECT_BYTETEST_RELATIVE))
         goto okay;
@@ -728,7 +724,7 @@ static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         SCFree(nbytes);
     DetectBytetestFree(de_ctx, data);
     return ret;
-}
+ }
 
 /**
  * \brief this function will free memory associated with DetectBytetestData

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -208,7 +208,6 @@ static int DetectCipServiceSetup(DetectEngineCtx *de_ctx, Signature *s,
     SCEnter();
 
     DetectCipServiceData *cipserviced = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0)
         return -1;
@@ -217,21 +216,15 @@ static int DetectCipServiceSetup(DetectEngineCtx *de_ctx, Signature *s,
     if (cipserviced == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_CIPSERVICE, (SigMatchCtx *)cipserviced,
+                g_cip_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_CIPSERVICE;
-    sm->ctx = (void *) cipserviced;
-
-    SigMatchAppendSMToList(s, sm, g_cip_buffer_id);
+    }
     SCReturnInt(0);
 
 error:
     if (cipserviced != NULL)
         DetectCipServiceFree(de_ctx, cipserviced);
-    if (sm != NULL)
-        SCFree(sm);
     SCReturnInt(-1);
 }
 
@@ -378,7 +371,6 @@ static int DetectEnipCommandSetup(DetectEngineCtx *de_ctx, Signature *s,
         const char *rulestr)
 {
     DetectEnipCommandData *enipcmdd = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_ENIP) != 0)
         return -1;
@@ -387,21 +379,15 @@ static int DetectEnipCommandSetup(DetectEngineCtx *de_ctx, Signature *s,
     if (enipcmdd == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_ENIPCOMMAND, (SigMatchCtx *)enipcmdd, g_enip_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_ENIPCOMMAND;
-    sm->ctx = (void *) enipcmdd;
-
-    SigMatchAppendSMToList(s, sm, g_enip_buffer_id);
+    }
     SCReturnInt(0);
 
 error:
     if (enipcmdd != NULL)
         DetectEnipCommandFree(de_ctx, enipcmdd);
-    if (sm != NULL)
-        SCFree(sm);
     SCReturnInt(-1);
 }
 

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -170,7 +170,6 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     SCEnter();
 
     DetectConfigData *fd = NULL;
-    SigMatch *sm = NULL;
     int res = 0;
     size_t pcre2len;
 #if 0
@@ -182,10 +181,6 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     }
 #endif
     pcre2_match_data *match = NULL;
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-    sm->type = DETECT_CONFIG;
 
     if (str == NULL || strlen(str) == 0) {
         SCLogError("config keywords need arguments");
@@ -297,8 +292,10 @@ static int DetectConfigSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
         s->flags |= SIG_FLAG_APPLAYER;
     }
 
-    sm->ctx = (SigMatchCtx*)fd;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_CONFIG, (SigMatchCtx *)fd, DETECT_SM_LIST_POSTMATCH) == NULL) {
+        goto error;
+    }
 
     pcre2_match_data_free(match);
     return 0;
@@ -307,8 +304,6 @@ error:
     if (match) {
         pcre2_match_data_free(match);
     }
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -353,12 +353,9 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
         }
     }
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_CONTENT, (SigMatchCtx *)cd, sm_list) == NULL) {
         goto error;
-    sm->ctx = (void *)cd;
-    sm->type = DETECT_CONTENT;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     return 0;
 

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -274,15 +274,8 @@ static int DetectIPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectIPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_IPV4_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -291,15 +284,16 @@ static int DetectIPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_IPV4_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectIPV4CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectIPV4CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -371,15 +365,8 @@ static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectTCPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_TCPV4_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -388,15 +375,16 @@ static int DetectTCPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_TCPV4_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectTCPV4CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectTCPV4CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -468,15 +456,8 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectTCPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_TCPV6_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -485,15 +466,16 @@ static int DetectTCPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_TCPV6_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectTCPV6CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectTCPV6CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -565,15 +547,8 @@ static int DetectUDPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectUDPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_UDPV4_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -582,15 +557,16 @@ static int DetectUDPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_UDPV4_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectUDPV4CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectUDPV4CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -662,15 +638,8 @@ static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectUDPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_UDPV6_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -679,15 +648,16 @@ static int DetectUDPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (void *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_UDPV6_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectUDPV6CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectUDPV6CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -757,15 +727,8 @@ static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectICMPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
 
     //printf("DetectCsumSetup: \'%s\'\n", csum_str);
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_ICMPV4_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -774,15 +737,16 @@ static int DetectICMPV4CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_ICMPV4_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectICMPV4CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectICMPV4CsumFree(de_ctx, cd);
 
     return -1;
 }
@@ -857,13 +821,6 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectICMPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const char *csum_str)
 {
     DetectCsumData *cd = NULL;
-    SigMatch *sm = NULL;
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_ICMPV6_CSUM;
 
     if ( (cd = SCMalloc(sizeof(DetectCsumData))) == NULL)
         goto error;
@@ -872,15 +829,16 @@ static int DetectICMPV6CsumSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
     if (DetectCsumParseArg(csum_str, cd) == 0)
         goto error;
 
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_ICMPV6_CSUM, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (cd != NULL) DetectICMPV6CsumFree(de_ctx, cd);
-    if (sm != NULL) SCFree(sm);
+    if (cd != NULL)
+        DetectICMPV6CsumFree(de_ctx, cd);
 
     return -1;
 }

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -292,7 +292,6 @@ static int SetupLoadPath(const DetectEngineCtx *de_ctx,
 
 static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    SigMatch *sm = NULL;
     char cmd_str[16] = "", name[64] = "";
     enum DatasetTypes type = DATASET_TYPE_NOTSET;
     char load[PATH_MAX] = "";
@@ -352,20 +351,15 @@ static int DetectDatarepSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
 
-    sm->type = DETECT_DATAREP;
-    sm->ctx = (SigMatchCtx *)cd;
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_DATAREP, (SigMatchCtx *)cd, list) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:
     if (cd != NULL)
         SCFree(cd);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -344,7 +344,6 @@ static int SetupSavePath(const DetectEngineCtx *de_ctx,
 int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectDatasetData *cd = NULL;
-    SigMatch *sm = NULL;
     uint8_t cmd = 0;
     uint64_t memcap = 0;
     uint32_t hashsize = 0;
@@ -424,20 +423,15 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
 
-    sm->type = DETECT_DATASET;
-    sm->ctx = (SigMatchCtx *)cd;
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_DATASET, (SigMatchCtx *)cd, list) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:
     if (cd != NULL)
         SCFree(cd);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -154,15 +154,10 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_DCE_IFACE, did, g_dce_generic_list_id) == NULL) {
+        DetectDceIfaceFree(de_ctx, did);
         return -1;
     }
-
-    sm->type = DETECT_DCE_IFACE;
-    sm->ctx = did;
-
-    SigMatchAppendSMToList(s, sm, g_dce_generic_list_id);
     return 0;
 }
 

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -142,16 +142,11 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
         return -1;
     }
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_DCE_OPNUM, (SigMatchCtx *)dod, g_dce_generic_list_id) == NULL) {
         DetectDceOpnumFree(de_ctx, dod);
         return -1;
     }
-
-    sm->type = DETECT_DCE_OPNUM;
-    sm->ctx = (void *)dod;
-
-    SigMatchAppendSMToList(s, sm, g_dce_generic_list_id);
     return 0;
 }
 

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -220,7 +220,6 @@ static int DetectDetectionFilterSetup(DetectEngineCtx *de_ctx, Signature *s, con
 {
     SCEnter();
     DetectThresholdData *df = NULL;
-    SigMatch *sm = NULL;
     SigMatch *tmpm = NULL;
 
     /* checks if there's a previous instance of threshold */
@@ -240,22 +239,16 @@ static int DetectDetectionFilterSetup(DetectEngineCtx *de_ctx, Signature *s, con
     if (df == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_DETECTION_FILTER, (SigMatchCtx *)df,
+                DETECT_SM_LIST_THRESHOLD) == NULL) {
         goto error;
-
-    sm->type = DETECT_DETECTION_FILTER;
-    sm->ctx = (SigMatchCtx *)df;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+    }
 
     return 0;
 
 error:
     if (df)
         SCFree(df);
-    if (sm)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-dhcp-leasetime.c
+++ b/src/detect-dhcp-leasetime.c
@@ -93,14 +93,11 @@ static int DetectDHCPLeaseTimeSetup(DetectEngineCtx *de_ctx, Signature *s, const
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_DHCP_LEASETIME, (SigMatchCtx *)dd, g_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_DHCP_LEASETIME;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-dhcp-rebinding-time.c
+++ b/src/detect-dhcp-rebinding-time.c
@@ -93,14 +93,11 @@ static int DetectDHCPRebindingTimeSetup(DetectEngineCtx *de_ctx, Signature *s, c
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_DHCP_REBINDING_TIME, (SigMatchCtx *)dd, g_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_DHCP_REBINDING_TIME;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-dhcp-renewal-time.c
+++ b/src/detect-dhcp-renewal-time.c
@@ -93,14 +93,11 @@ static int DetectDHCPRenewalTimeSetup(DetectEngineCtx *de_ctx, Signature *s, con
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_DHCP_RENEWAL_TIME, (SigMatchCtx *)dd, g_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_DHCP_RENEWAL_TIME;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -205,7 +205,6 @@ static int DetectDNP3FuncSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 {
     SCEnter();
     DetectDNP3 *dnp3 = NULL;
-    SigMatch *sm = NULL;
     uint8_t function_code;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_DNP3) != 0)
@@ -222,22 +221,15 @@ static int DetectDNP3FuncSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     }
     dnp3->function_code = function_code;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_DNP3FUNC, (SigMatchCtx *)dnp3,
+                g_dnp3_match_buffer_id) == NULL) {
         goto error;
     }
-    sm->type = DETECT_AL_DNP3FUNC;
-    sm->ctx = (void *)dnp3;
-
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
 
     SCReturnInt(0);
 error:
     if (dnp3 != NULL) {
         SCFree(dnp3);
-    }
-    if (sm != NULL) {
-        SCFree(sm);
     }
     SCReturnInt(-1);
 }
@@ -291,7 +283,6 @@ static int DetectDNP3IndSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 {
     SCEnter();
     DetectDNP3 *detect = NULL;
-    SigMatch *sm = NULL;
     uint16_t flags;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_DNP3) != 0)
@@ -308,21 +299,15 @@ static int DetectDNP3IndSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     }
     detect->ind_flags = flags;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_DNP3IND, (SigMatchCtx *)detect,
+                g_dnp3_match_buffer_id) == NULL) {
         goto error;
     }
-    sm->type = DETECT_AL_DNP3IND;
-    sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
 
     SCReturnInt(0);
 error:
     if (detect != NULL) {
         SCFree(detect);
-    }
-    if (sm != NULL) {
-        SCFree(sm);
     }
     SCReturnInt(-1);
 }
@@ -366,7 +351,6 @@ static int DetectDNP3ObjSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     uint8_t group;
     uint8_t variation;
     DetectDNP3 *detect = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_DNP3) != 0)
         return -1;
@@ -382,21 +366,15 @@ static int DetectDNP3ObjSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     detect->obj_group = group;
     detect->obj_variation = variation;
 
-    sm = SigMatchAlloc();
-    if (unlikely(sm == NULL)) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_DNP3OBJ, (SigMatchCtx *)detect,
+                g_dnp3_match_buffer_id) == NULL) {
         goto fail;
     }
-    sm->type = DETECT_AL_DNP3OBJ;
-    sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, g_dnp3_match_buffer_id);
 
     SCReturnInt(1);
 fail:
     if (detect != NULL) {
         SCFree(detect);
-    }
-    if (sm != NULL) {
-        SCFree(sm);
     }
     SCReturnInt(0);
 }

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -41,15 +41,11 @@ static int DetectDnsOpcodeSetup(DetectEngineCtx *de_ctx, Signature *s,
         return -1;
     }
 
-    SigMatch *sm = SigMatchAlloc();
-    if (unlikely(sm == NULL)) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_DNS_OPCODE, (SigMatchCtx *)detect,
+                dns_opcode_list_id) == NULL) {
         goto error;
     }
 
-    sm->type = DETECT_AL_DNS_OPCODE;
-    sm->ctx = (void *)detect;
-    SigMatchAppendSMToList(s, sm, dns_opcode_list_id);
-    
     SCReturnInt(0);
 
 error:

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -119,7 +119,6 @@ static int DetectDsizeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectU16Data *dd = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectGetLastSMFromLists(s, DETECT_DSIZE, -1)) {
         SCLogError("Can't use 2 or more dsizes in "
@@ -137,17 +136,12 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL){
-        SCLogError("Failed to allocate memory for SigMatch");
+    SigMatch *sm = SigMatchAppendSMToList(
+            de_ctx, s, DETECT_DSIZE, (SigMatchCtx *)dd, DETECT_SM_LIST_MATCH);
+    if (sm == NULL) {
         rs_detect_u16_free(dd);
         goto error;
     }
-
-    sm->type = DETECT_DSIZE;
-    sm->ctx = (SigMatchCtx *)dd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
 
     SCLogDebug("dd->arg1 %" PRIu16 ", dd->arg2 %" PRIu16 ", dd->mode %" PRIu8 "", dd->arg1,
             dd->arg2, dd->mode);

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -211,16 +211,11 @@ static int DetectEngineEventSetupDo(
 
     SCLogDebug("rawstr %s %u", rawstr, de->event);
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, smtype, (SigMatchCtx *)de, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         SCFree(de);
         return -1;
     }
-
-    sm->type = smtype;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     return 0;
 }
 

--- a/src/detect-file-hash-common.c
+++ b/src/detect-file-hash-common.c
@@ -321,7 +321,6 @@ int DetectFileHashSetup(
         DetectEngineCtx *de_ctx, Signature *s, const char *str, uint16_t type, int list)
 {
     DetectFileHashData *filehash = NULL;
-    SigMatch *sm = NULL;
 
     filehash = DetectFileHashParse(de_ctx, str, type);
     if (filehash == NULL)
@@ -329,14 +328,10 @@ int DetectFileHashSetup(
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, type, (SigMatchCtx *)filehash, list) == NULL) {
         goto error;
-
-    sm->type = type;
-    sm->ctx = (void *)filehash;
-
-    SigMatchAppendSMToList(s, sm, list);
+    }
 
     s->file_flags |= FILE_SIG_NEED_FILE;
 
@@ -355,8 +350,6 @@ int DetectFileHashSetup(
 error:
     if (filehash != NULL)
         DetectFileHashFree(de_ctx, filehash);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -123,20 +123,15 @@ static int DetectFilesizeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 {
     SCEnter();
     DetectU64Data *fsd = NULL;
-    SigMatch *sm = NULL;
 
     fsd = DetectU64Parse(str);
     if (fsd == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FILESIZE, (SigMatchCtx *)fsd, g_file_match_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_FILESIZE;
-    sm->ctx = (SigMatchCtx *)fsd;
-
-    SigMatchAppendSMToList(s, sm, g_file_match_list_id);
+    }
 
     s->file_flags |= (FILE_SIG_NEED_FILE|FILE_SIG_NEED_SIZE);
     SCReturnInt(0);
@@ -144,8 +139,6 @@ static int DetectFilesizeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 error:
     if (fsd != NULL)
         DetectFilesizeFree(de_ctx, fsd);
-    if (sm != NULL)
-        SCFree(sm);
     SCReturnInt(-1);
 }
 

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -349,7 +349,6 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     }
 
     DetectFilestoreData *fd = NULL;
-    SigMatch *sm = NULL;
     char *args[3] = {NULL,NULL,NULL};
     int res = 0;
     size_t pcre2len;
@@ -360,12 +359,6 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
         SCLogError("filestore can't work with bypass keyword");
         return -1;
     }
-
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_FILESTORE;
 
     if (str != NULL && strlen(str) > 0) {
         char str_0[32];
@@ -455,25 +448,22 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
             if (fd->scope == 0)
                 fd->scope = FILESTORE_SCOPE_DEFAULT;
         }
-
-        sm->ctx = (SigMatchCtx*)fd;
-    } else {
-        sm->ctx = (SigMatchCtx*)NULL;
     }
 
     if (s->alproto == ALPROTO_HTTP1 || s->alproto == ALPROTO_HTTP) {
         AppLayerHtpNeedFileInspection();
     }
 
-    SigMatchAppendSMToList(s, sm, g_file_match_list_id);
-    s->filestore_ctx = (const DetectFilestoreData *)sm->ctx;
-
-    sm = SigMatchAlloc();
-    if (unlikely(sm == NULL))
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FILESTORE, (SigMatchCtx *)fd, g_file_match_list_id) == NULL) {
         goto error;
-    sm->type = DETECT_FILESTORE_POSTMATCH;
-    sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    }
+    s->filestore_ctx = fd;
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FILESTORE_POSTMATCH, NULL, DETECT_SM_LIST_POSTMATCH) == NULL) {
+        goto error;
+    }
 
     s->flags |= SIG_FLAG_FILESTORE;
 
@@ -486,8 +476,6 @@ error:
     if (match) {
         pcre2_match_data_free(match);
     }
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -46,16 +46,11 @@ static int DetectFlowAgeSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     if (du32 == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FLOW_AGE, (SigMatchCtx *)du32, DETECT_SM_LIST_MATCH) == NULL) {
         DetectFlowAgeFree(de_ctx, du32);
         return -1;
     }
-
-    sm->type = DETECT_FLOW_AGE;
-    sm->ctx = (SigMatchCtx *)du32;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-flow-pkts.c
+++ b/src/detect-flow-pkts.c
@@ -46,16 +46,11 @@ static int DetectFlowPktsToClientSetup(DetectEngineCtx *de_ctx, Signature *s, co
     if (du32 == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLOW_PKTS_TO_CLIENT, (SigMatchCtx *)du32,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectFlowPktsToClientFree(de_ctx, du32);
         return -1;
     }
-
-    sm->type = DETECT_FLOW_PKTS_TO_CLIENT;
-    sm->ctx = (SigMatchCtx *)du32;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -124,16 +119,11 @@ static int DetectFlowPktsToServerSetup(DetectEngineCtx *de_ctx, Signature *s, co
     if (du32 == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLOW_PKTS_TO_SERVER, (SigMatchCtx *)du32,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectFlowPktsToServerFree(de_ctx, du32);
         return -1;
     }
-
-    sm->type = DETECT_FLOW_PKTS_TO_SERVER;
-    sm->ctx = (SigMatchCtx *)du32;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -202,16 +192,11 @@ static int DetectFlowBytesToClientSetup(DetectEngineCtx *de_ctx, Signature *s, c
     if (du64 == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLOW_BYTES_TO_CLIENT, (SigMatchCtx *)du64,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectFlowBytesToClientFree(de_ctx, du64);
         return -1;
     }
-
-    sm->type = DETECT_FLOW_BYTES_TO_CLIENT;
-    sm->ctx = (SigMatchCtx *)du64;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -251,16 +236,11 @@ static int DetectFlowBytesToServerSetup(DetectEngineCtx *de_ctx, Signature *s, c
     if (du64 == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLOW_BYTES_TO_SERVER, (SigMatchCtx *)du64,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectFlowBytesToServerFree(de_ctx, du64);
         return -1;
     }
-
-    sm->type = DETECT_FLOW_BYTES_TO_SERVER;
-    sm->ctx = (SigMatchCtx *)du64;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -388,13 +388,7 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     if (fd == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_FLOW;
-    sm->ctx = (SigMatchCtx *)fd;
-
+    bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
         s->flags |= SIG_FLAG_TOSERVER;
@@ -408,14 +402,18 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
             fd->flags == DETECT_FLOW_FLAG_TOCLIENT) {
         /* no direct flow is needed for just direction,
          * no sigmatch is needed either. */
-        SigMatchFree(de_ctx, sm);
-        sm = NULL;
+        appendsm = false;
     } else {
         s->init_data->init_flags |= SIG_FLAG_INIT_FLOW;
     }
 
-    if (sm != NULL) {
-        SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (appendsm) {
+        if (SigMatchAppendSMToList(
+                    de_ctx, s, DETECT_FLOW, (SigMatchCtx *)fd, DETECT_SM_LIST_MATCH) == NULL) {
+            goto error;
+        }
+    } else if (fd != NULL) {
+        DetectFlowFree(de_ctx, fd);
     }
 
     if (parse_flags & DETECT_FLOW_FLAG_ONLYSTREAM) {

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -117,7 +117,6 @@ int DetectFlowvarMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectFlowvarData *fd = NULL;
-    SigMatch *sm = NULL;
     char varname[64], varcontent[64];
     int res = 0;
     size_t pcre2len;
@@ -184,14 +183,11 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (unlikely(sm == NULL))
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FLOWVAR, (SigMatchCtx *)fd, DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_FLOWVAR;
-    sm->ctx = (SigMatchCtx *)fd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
 
     SCFree(content);
     return 0;
@@ -199,8 +195,6 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char
 error:
     if (fd != NULL)
         DetectFlowvarDataFree(de_ctx, fd);
-    if (sm != NULL)
-        SCFree(sm);
     if (content != NULL)
         SCFree(content);
     return -1;
@@ -265,7 +259,6 @@ int DetectVarStoreMatch(DetectEngineThreadCtx *det_ctx,
  */
 int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t idx)
 {
-    SigMatch *sm = NULL;
     DetectFlowvarData *fv = NULL;
 
     fv = SCMalloc(sizeof(DetectFlowvarData));
@@ -277,14 +270,10 @@ int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t 
     fv->idx = idx;
     fv->post_match = true;
 
-    sm = SigMatchAlloc();
-    if (unlikely(sm == NULL))
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLOWVAR_POSTMATCH, (SigMatchCtx *)fv,
+                DETECT_SM_LIST_POSTMATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_FLOWVAR_POSTMATCH;
-    sm->ctx = (SigMatchCtx *)fv;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    }
     return 0;
 error:
     if (fv != NULL)

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -287,20 +287,15 @@ error:
 static int DetectFragBitsSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectFragBitsData *de = NULL;
-    SigMatch *sm = NULL;
 
     de = DetectFragBitsParse(rawstr);
     if (de == NULL)
         return -1;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_FRAGBITS, (SigMatchCtx *)de, DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_FRAGBITS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -230,25 +230,21 @@ error:
 static int DetectFragOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *fragoffsetstr)
 {
     DetectFragOffsetData *fragoff = NULL;
-    SigMatch *sm = NULL;
 
     fragoff = DetectFragOffsetParse(de_ctx, fragoffsetstr);
     if (fragoff == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) goto error;
-
-    sm->type = DETECT_FRAGOFFSET;
-    sm->ctx = (SigMatchCtx *)fragoff;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FRAGOFFSET, (SigMatchCtx *)fragoff,
+                DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (fragoff != NULL) DetectFragOffsetFree(de_ctx, fragoff);
-    if (sm != NULL) SCFree(sm);
+    if (fragoff != NULL)
+        DetectFragOffsetFree(de_ctx, fragoff);
     return -1;
 
 }

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -207,17 +207,8 @@ int DetectFtpbounceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *ftpb
 {
     SCEnter();
 
-    SigMatch *sm = NULL;
-
     if (DetectSignatureSetAppProto(s, ALPROTO_FTP) != 0)
         return -1;
-
-    sm = SigMatchAlloc();
-    if (sm == NULL) {
-        return -1;
-    }
-
-    sm->type = DETECT_FTPBOUNCE;
 
     /* We don't need to allocate any data for ftpbounce here.
      *
@@ -228,8 +219,9 @@ int DetectFtpbounceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *ftpb
      * without breaking the connection, so I guess we can make it a bit faster
      * with a flow flag set lookup in the Match function.
      */
-    sm->ctx = NULL;
 
-    SigMatchAppendSMToList(s, sm, g_ftp_request_list_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FTPBOUNCE, NULL, g_ftp_request_list_id) == NULL) {
+        return -1;
+    }
     SCReturnInt(0);
 }

--- a/src/detect-ftpdata.c
+++ b/src/detect-ftpdata.c
@@ -191,15 +191,11 @@ static int DetectFtpdataSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     if (ftpcommandd == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FTPDATA, (SigMatchCtx *)ftpcommandd,
+                g_ftpdata_buffer_id) == NULL) {
         DetectFtpdataFree(de_ctx, ftpcommandd);
         return -1;
     }
-    sm->type = DETECT_FTPDATA;
-    sm->ctx = (void *)ftpcommandd;
-
-    SigMatchAppendSMToList(s, sm, g_ftpdata_buffer_id);
     return 0;
 }
 

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -409,21 +409,17 @@ error:
 static int DetectGeoipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
     DetectGeoipData *geoipdata = NULL;
-    SigMatch *sm = NULL;
 
     geoipdata = DetectGeoipDataParse(de_ctx, optstr);
     if (geoipdata == NULL)
         goto error;
 
     /* Get this into a SigMatch and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_GEOIP, (SigMatchCtx *)geoipdata, DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_GEOIP;
-    sm->ctx = (SigMatchCtx *)geoipdata;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -431,8 +427,6 @@ static int DetectGeoipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *o
 error:
     if (geoipdata != NULL)
         DetectGeoipDataFree(de_ctx, geoipdata);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -331,7 +331,6 @@ error:
 int DetectHostbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectXbitsData *cd = NULL;
-    SigMatch *sm = NULL;
     uint8_t fb_cmd = 0;
     uint8_t hb_dir = 0;
     char fb_cmd_str[16] = "", fb_name[256] = "";
@@ -406,12 +405,6 @@ int DetectHostbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_HOSTBITS;
-    sm->ctx = (void *)cd;
 
     switch (fb_cmd) {
         /* case DETECT_XBITS_CMD_NOALERT can't happen here */
@@ -419,14 +412,20 @@ int DetectHostbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         case DETECT_XBITS_CMD_ISNOTSET:
         case DETECT_XBITS_CMD_ISSET:
             /* checks, so packet list */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_HOSTBITS, (SigMatchCtx *)cd,
+                        DETECT_SM_LIST_MATCH) == NULL) {
+                goto error;
+            }
             break;
 
         case DETECT_XBITS_CMD_SET:
         case DETECT_XBITS_CMD_UNSET:
         case DETECT_XBITS_CMD_TOGGLE:
             /* modifiers, only run when entire sig has matched */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_HOSTBITS, (SigMatchCtx *)cd,
+                        DETECT_SM_LIST_POSTMATCH) == NULL) {
+                goto error;
+            }
             break;
 
         // suppress coverity warning as scan-build-7 warns w/o this.
@@ -440,8 +439,6 @@ int DetectHostbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
 error:
     if (cd != NULL)
         SCFree(cd);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -263,16 +263,11 @@ static int DetectHTTP2frametypeSetup (DetectEngineCtx *de_ctx, Signature *s, con
         return -1;
     *http2ft = frame_type;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_FRAMETYPE, (SigMatchCtx *)http2ft,
+                g_http2_match_buffer_id) == NULL) {
         DetectHTTP2frametypeFree(NULL, http2ft);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_FRAMETYPE;
-    sm->ctx = (SigMatchCtx *)http2ft;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }
@@ -348,16 +343,11 @@ static int DetectHTTP2errorcodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
         return -1;
     *http2ec = error_code;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_ERRORCODE, (SigMatchCtx *)http2ec,
+                g_http2_match_buffer_id) == NULL) {
         DetectHTTP2errorcodeFree(NULL, http2ec);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_ERRORCODE;
-    sm->ctx = (SigMatchCtx *)http2ec;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }
@@ -415,16 +405,11 @@ static int DetectHTTP2prioritySetup (DetectEngineCtx *de_ctx, Signature *s, cons
     if (prio == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_PRIORITY, (SigMatchCtx *)prio,
+                g_http2_match_buffer_id) == NULL) {
         rs_detect_u8_free(prio);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_PRIORITY;
-    sm->ctx = (SigMatchCtx *)prio;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }
@@ -482,16 +467,11 @@ static int DetectHTTP2windowSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     if (wu == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_WINDOW, (SigMatchCtx *)wu,
+                g_http2_match_buffer_id) == NULL) {
         rs_detect_u32_free(wu);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_WINDOW;
-    sm->ctx = (SigMatchCtx *)wu;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }
@@ -539,16 +519,11 @@ static int DetectHTTP2sizeUpdateSetup (DetectEngineCtx *de_ctx, Signature *s, co
     if (su == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_SIZEUPDATE, (SigMatchCtx *)su,
+                g_http2_match_buffer_id) == NULL) {
         DetectHTTP2settingsFree(NULL, su);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_SIZEUPDATE;
-    sm->ctx = (SigMatchCtx *)su;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }
@@ -596,16 +571,11 @@ static int DetectHTTP2settingsSetup (DetectEngineCtx *de_ctx, Signature *s, cons
     if (http2set == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_HTTP2_SETTINGS, (SigMatchCtx *)http2set,
+                g_http2_match_buffer_id) == NULL) {
         DetectHTTP2settingsFree(NULL, http2set);
         return -1;
     }
-
-    sm->type = DETECT_HTTP2_SETTINGS;
-    sm->ctx = (SigMatchCtx *)http2set;
-
-    SigMatchAppendSMToList(s, sm, g_http2_match_buffer_id);
 
     return 0;
 }

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -241,25 +241,21 @@ error:
 static int DetectIcmpIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *icmpidstr)
 {
     DetectIcmpIdData *iid = NULL;
-    SigMatch *sm = NULL;
 
     iid = DetectIcmpIdParse(de_ctx, icmpidstr);
     if (iid == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) goto error;
-
-    sm->type = DETECT_ICMP_ID;
-    sm->ctx = (SigMatchCtx *)iid;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_ICMP_ID, (SigMatchCtx *)iid, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (iid != NULL) DetectIcmpIdFree(de_ctx, iid);
-    if (sm != NULL) SCFree(sm);
+    if (iid != NULL)
+        DetectIcmpIdFree(de_ctx, iid);
     return -1;
 
 }

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -244,24 +244,20 @@ error:
 static int DetectIcmpSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char *icmpseqstr)
 {
     DetectIcmpSeqData *iseq = NULL;
-    SigMatch *sm = NULL;
 
     iseq = DetectIcmpSeqParse(de_ctx, icmpseqstr);
     if (iseq == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) goto error;
-
-    sm->type = DETECT_ICMP_SEQ;
-    sm->ctx = (SigMatchCtx *)iseq;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_ICMP_SEQ, (SigMatchCtx *)iseq, DETECT_SM_LIST_MATCH) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
-    if (iseq != NULL) DetectIcmpSeqFree(de_ctx, iseq);
-    if (sm != NULL) SCFree(sm);
+    if (iseq != NULL)
+        DetectIcmpSeqFree(de_ctx, iseq);
     return -1;
 
 }

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -114,16 +114,11 @@ static int DetectICMPv6mtuSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     if (icmpv6mtud == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ICMPV6MTU, (SigMatchCtx *)icmpv6mtud,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectICMPv6mtuFree(de_ctx, icmpv6mtud);
         return -1;
     }
-
-    sm->type = DETECT_ICMPV6MTU;
-    sm->ctx = (SigMatchCtx *)icmpv6mtud;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     s->proto.flags |= DETECT_PROTO_IPV6;
 

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -118,18 +118,14 @@ static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
 {
 
     DetectU8Data *icd = NULL;
-    SigMatch *sm = NULL;
 
     icd = DetectU8Parse(icodestr);
     if (icd == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) goto error;
-
-    sm->type = DETECT_ICODE;
-    sm->ctx = (SigMatchCtx *)icd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ICODE, (SigMatchCtx *)icd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -137,7 +133,6 @@ static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
 error:
     if (icd != NULL)
         rs_detect_u8_free(icd);
-    if (sm != NULL) SCFree(sm);
     return -1;
 }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -191,7 +191,6 @@ error:
 int DetectIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *idstr)
 {
     DetectIdData *id_d = NULL;
-    SigMatch *sm = NULL;
 
     id_d = DetectIdParse(idstr);
     if (id_d == NULL)
@@ -199,16 +198,11 @@ int DetectIdSetup (DetectEngineCtx *de_ctx, Signature *s, const char *idstr)
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ID, (SigMatchCtx *)id_d, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         DetectIdFree(de_ctx, id_d);
         return -1;
     }
-
-    sm->type = DETECT_ID;
-    sm->ctx = (SigMatchCtx *)id_d;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -211,14 +211,11 @@ static int DetectIkeChosenSaSetup(DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_IKE_CHOSEN_SA, (SigMatchCtx *)dd,
+                g_ike_chosen_sa_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_IKE_CHOSEN_SA;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_ike_chosen_sa_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-ike-exch-type.c
+++ b/src/detect-ike-exch-type.c
@@ -115,14 +115,11 @@ static int DetectIkeExchTypeSetup(DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_IKE_EXCH_TYPE, (SigMatchCtx *)ike_exch_type,
+                g_ike_exch_type_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_IKE_EXCH_TYPE;
-    sm->ctx = (SigMatchCtx *)ike_exch_type;
-
-    SigMatchAppendSMToList(s, sm, g_ike_exch_type_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-ike-key-exchange-payload-length.c
+++ b/src/detect-ike-key-exchange-payload-length.c
@@ -121,14 +121,12 @@ static int DetectIkeKeyExchangePayloadLengthSetup(
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_IKE_KEY_EXCHANGE_PAYLOAD_LENGTH,
+                (SigMatchCtx *)key_exchange_payload_length,
+                g_ike_key_exch_payload_length_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_IKE_KEY_EXCHANGE_PAYLOAD_LENGTH;
-    sm->ctx = (SigMatchCtx *)key_exchange_payload_length;
-
-    SigMatchAppendSMToList(s, sm, g_ike_key_exch_payload_length_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-ike-nonce-payload-length.c
+++ b/src/detect-ike-nonce-payload-length.c
@@ -115,14 +115,12 @@ static int DetectIkeNoncePayloadLengthSetup(
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_IKE_NONCE_PAYLOAD_LENGTH,
+                (SigMatchCtx *)nonce_payload_length,
+                g_ike_nonce_payload_length_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_IKE_NONCE_PAYLOAD_LENGTH;
-    sm->ctx = (SigMatchCtx *)nonce_payload_length;
-
-    SigMatchAppendSMToList(s, sm, g_ike_nonce_payload_length_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -243,27 +243,22 @@ error:
 static int DetectIpOptsSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectIpOptsData *de = NULL;
-    SigMatch *sm = NULL;
 
     de = DetectIpOptsParse(rawstr);
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_IPOPTS, (SigMatchCtx *)de, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_IPOPTS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (de) SCFree(de);
-    if (sm) SCFree(sm);
+    if (de)
+        SCFree(de);
     return -1;
 }
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -188,7 +188,6 @@ static int DetectIPProtoTypePresentForOP(Signature *s, uint8_t op)
  */
 static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
-    SigMatch *sm = NULL;
     int i;
 
     DetectIPProtoData *data = DetectIPProtoParse(optstr);
@@ -414,12 +413,10 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
             break;
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_IPPROTO, (SigMatchCtx *)data, DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-    sm->type = DETECT_IPPROTO;
-    sm->ctx = (void *)data;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -428,8 +425,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
 
     DetectIPProtoFree(de_ctx, data);
     return -1;
-}
-
+ }
 
 void DetectIPProtoRemoveAllSMs(DetectEngineCtx *de_ctx, Signature *s)
 {

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -213,7 +213,6 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
 int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    SigMatch *sm = NULL;
 
     DetectIPRepData *cd = rs_detect_iprep_parse(rawstr);
     if (cd == NULL) {
@@ -225,22 +224,17 @@ int DetectIPRepSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_IPREP, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_IPREP;
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
 
     return 0;
 
 error:
     if (cd != NULL)
         DetectIPRepFree(de_ctx, cd);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -211,7 +211,6 @@ error:
  */
 int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, const char *isdataatstr)
 {
-    SigMatch *sm = NULL;
     SigMatch *prev_pm = NULL;
     DetectIsdataatData *idad = NULL;
     char *offset = NULL;
@@ -273,12 +272,9 @@ int DetectIsdataatSetup (DetectEngineCtx *de_ctx, Signature *s, const char *isda
         goto end;
     }
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ISDATAAT, (SigMatchCtx *)idad, sm_list) == NULL) {
         goto end;
-    sm->type = DETECT_ISDATAAT;
-    sm->ctx = (SigMatchCtx *)idad;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     if (!(idad->flags & ISDATAAT_RELATIVE)) {
         ret = 0;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -129,25 +129,21 @@ static int DetectITypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
 {
 
     DetectU8Data *itd = NULL;
-    SigMatch *sm = NULL;
 
     itd = DetectITypeParse(de_ctx, itypestr);
     if (itd == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL) goto error;
-
-    sm->type = DETECT_ITYPE;
-    sm->ctx = (SigMatchCtx *)itd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ITYPE, (SigMatchCtx *)itd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (itd != NULL) DetectITypeFree(de_ctx, itd);
-    if (sm != NULL) SCFree(sm);
+    if (itd != NULL)
+        DetectITypeFree(de_ctx, itd);
     return -1;
 }
 

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -176,7 +176,6 @@ error:
 static int DetectKrb5ErrCodeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *krb5str)
 {
     DetectKrb5ErrCodeData *krb5d = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_KRB5) != 0)
         return -1;
@@ -185,22 +184,16 @@ static int DetectKrb5ErrCodeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     if (krb5d == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_KRB5_ERRCODE, (SigMatchCtx *)krb5d,
+                g_krb5_err_code_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_KRB5_ERRCODE;
-    sm->ctx = (void *)krb5d;
-
-    SigMatchAppendSMToList(s, sm, g_krb5_err_code_list_id);
+    }
 
     return 0;
 
 error:
     if (krb5d != NULL)
         DetectKrb5ErrCodeFree(de_ctx, krb5d);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -173,7 +173,6 @@ error:
 static int DetectKrb5MsgTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *krb5str)
 {
     DetectKrb5MsgTypeData *krb5d = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_KRB5) != 0)
         return -1;
@@ -182,22 +181,16 @@ static int DetectKrb5MsgTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const 
     if (krb5d == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_KRB5_MSGTYPE, (SigMatchCtx *)krb5d,
+                g_krb5_msg_type_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_KRB5_MSGTYPE;
-    sm->ctx = (void *)krb5d;
-
-    SigMatchAppendSMToList(s, sm, g_krb5_msg_type_list_id);
+    }
 
     return 0;
 
 error:
     if (krb5d != NULL)
         DetectKrb5MsgTypeFree(de_ctx, krb5d);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-krb5-ticket-encryption.c
+++ b/src/detect-krb5-ticket-encryption.c
@@ -44,7 +44,6 @@ static int DetectKrb5TicketEncryptionSetup(
         DetectEngineCtx *de_ctx, Signature *s, const char *krb5str)
 {
     DetectKrb5TicketEncryptionData *krb5d = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_KRB5) != 0)
         return -1;
@@ -53,22 +52,16 @@ static int DetectKrb5TicketEncryptionSetup(
     if (krb5d == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_KRB5_TICKET_ENCRYPTION, (SigMatchCtx *)krb5d,
+                g_krb5_ticket_encryption_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_KRB5_TICKET_ENCRYPTION;
-    sm->ctx = (void *)krb5d;
-
-    SigMatchAppendSMToList(s, sm, g_krb5_ticket_encryption_list_id);
+    }
 
     return 0;
 
 error:
     if (krb5d != NULL)
         DetectKrb5TicketEncryptionFree(de_ctx, krb5d);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -1013,7 +1013,6 @@ error:
 static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectLuaData *lua = NULL;
-    SigMatch *sm = NULL;
 
     /* First check if Lua rules are enabled, by default Lua in rules
      * is disabled. */
@@ -1047,12 +1046,6 @@ static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *st
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_LUA;
-    sm->ctx = (SigMatchCtx *)lua;
 
     int list = -1;
     if (lua->alproto == ALPROTO_UNKNOWN) {
@@ -1118,15 +1111,15 @@ static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *st
         goto error;
     }
 
-    SigMatchAppendSMToList(s, sm, list);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_LUA, (SigMatchCtx *)lua, list) == NULL) {
+        goto error;
+    }
 
     return 0;
 
 error:
     if (lua != NULL)
         DetectLuaFree(de_ctx, lua);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mark.c
+++ b/src/detect-mark.c
@@ -203,18 +203,14 @@ static int DetectMarkSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     if (data == NULL) {
         return -1;
     }
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
-        DetectMarkDataFree(de_ctx, data);
-        return -1;
-    }
-
-    sm->type = DETECT_MARK;
-    sm->ctx = (SigMatchCtx *)data;
 
     /* Append it to the list of post match, so the mark is set if the
      * full signature matches. */
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_MARK, (SigMatchCtx *)data, DETECT_SM_LIST_POSTMATCH) == NULL) {
+        DetectMarkDataFree(de_ctx, data);
+        return -1;
+    }
     return 0;
 #endif
 }

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -85,7 +85,6 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
 {
     SCEnter();
     DetectModbusRust *modbus = NULL;
-    SigMatch        *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0)
         return -1;
@@ -96,22 +95,16 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     }
 
     /* Okay so far so good, lets get this into a SigMatch and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_MODBUS, (SigMatchCtx *)modbus, g_modbus_buffer_id) == NULL) {
         goto error;
-
-    sm->type    = DETECT_AL_MODBUS;
-    sm->ctx     = (void *) modbus;
-
-    SigMatchAppendSMToList(s, sm, g_modbus_buffer_id);
+    }
 
     SCReturnInt(0);
 
 error:
     if (modbus != NULL)
         DetectModbusFree(de_ctx, modbus);
-    if (sm != NULL)
-        SCFree(sm);
     SCReturnInt(-1);
 }
 

--- a/src/detect-mqtt-connack-sessionpresent.c
+++ b/src/detect-mqtt-connack-sessionpresent.c
@@ -156,7 +156,6 @@ error:
 static int DetectMQTTConnackSessionPresentSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     bool *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -165,22 +164,16 @@ static int DetectMQTTConnackSessionPresentSetup (DetectEngineCtx *de_ctx, Signat
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_CONNACK_SESSION_PRESENT, (SigMatchCtx *)de,
+                mqtt_connack_session_present_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_CONNACK_SESSION_PRESENT;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_connack_session_present_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-connect-flags.c
+++ b/src/detect-mqtt-connect-flags.c
@@ -214,7 +214,6 @@ error:
 static int DetectMQTTConnectFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectMQTTConnectFlagsData *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -223,22 +222,16 @@ static int DetectMQTTConnectFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, co
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_CONNECT_FLAGS, (SigMatchCtx *)de,
+                mqtt_connect_flags_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_CONNECT_FLAGS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_connect_flags_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-flags.c
+++ b/src/detect-mqtt-flags.c
@@ -198,7 +198,6 @@ error:
 static int DetectMQTTFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectMQTTFlagsData *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -207,22 +206,16 @@ static int DetectMQTTFlagsSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_FLAGS, (SigMatchCtx *)de, mqtt_flags_id) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_FLAGS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_flags_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-protocol-version.c
+++ b/src/detect-mqtt-protocol-version.c
@@ -106,7 +106,6 @@ static int DetectMQTTProtocolVersionMatch(DetectEngineThreadCtx *det_ctx,
  */
 static int DetectMQTTProtocolVersionSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    SigMatch *sm = NULL;
     DetectU8Data *de = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
@@ -116,22 +115,16 @@ static int DetectMQTTProtocolVersionSetup(DetectEngineCtx *de_ctx, Signature *s,
     if (de == NULL)
         return -1;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_PROTOCOL_VERSION, (SigMatchCtx *)de,
+                mqtt_protocol_version_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_PROTOCOL_VERSION;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_protocol_version_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         rs_detect_u8_free(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-qos.c
+++ b/src/detect-mqtt-qos.c
@@ -135,7 +135,6 @@ static uint8_t *DetectMQTTQosParse(const char *rawstr)
 static int DetectMQTTQosSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     uint8_t *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -144,22 +143,16 @@ static int DetectMQTTQosSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_QOS, (SigMatchCtx *)de, mqtt_qos_id) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_QOS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_qos_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-reason-code.c
+++ b/src/detect-mqtt-reason-code.c
@@ -151,7 +151,6 @@ static uint8_t *DetectMQTTReasonCodeParse(const char *rawstr)
 static int DetectMQTTReasonCodeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     uint8_t *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -160,22 +159,16 @@ static int DetectMQTTReasonCodeSetup (DetectEngineCtx *de_ctx, Signature *s, con
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_REASON_CODE, (SigMatchCtx *)de,
+                mqtt_reason_code_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_REASON_CODE;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_reason_code_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-mqtt-type.c
+++ b/src/detect-mqtt-type.c
@@ -140,7 +140,6 @@ error:
 static int DetectMQTTTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     uint8_t *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_MQTT) < 0)
         return -1;
@@ -149,22 +148,16 @@ static int DetectMQTTTypeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_MQTT_TYPE, (SigMatchCtx *)de, mqtt_type_id) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_AL_MQTT_TYPE;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, mqtt_type_id);
+    }
 
     return 0;
 
 error:
     if (de != NULL)
         SCFree(de);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-nfs-procedure.c
+++ b/src/detect-nfs-procedure.c
@@ -153,7 +153,6 @@ static int DetectNfsProcedureSetup (DetectEngineCtx *de_ctx, Signature *s,
                                    const char *rawstr)
 {
     DetectU32Data *dd = NULL;
-    SigMatch *sm = NULL;
 
     SCLogDebug("\'%s\'", rawstr);
 
@@ -168,15 +167,12 @@ static int DetectNfsProcedureSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_NFS_PROCEDURE;
-    sm->ctx = (void *)dd;
 
     SCLogDebug("low %u hi %u", dd->arg1, dd->arg2);
-    SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_NFS_PROCEDURE, (SigMatchCtx *)dd,
+                g_nfs_request_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-nfs-version.c
+++ b/src/detect-nfs-version.c
@@ -152,15 +152,12 @@ static int DetectNfsVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_NFS_VERSION;
-    sm->ctx = (void *)dd;
 
     SCLogDebug("low %u hi %u", dd->arg1, dd->arg2);
-    SigMatchAppendSMToList(s, sm, g_nfs_request_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_NFS_VERSION, (SigMatchCtx *)dd,
+                g_nfs_request_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -75,7 +75,7 @@ SigMatchData* SigMatchList2DataArray(SigMatch *head);
 void SigParseRegisterTests(void);
 Signature *DetectEngineAppendSig(DetectEngineCtx *, const char *);
 
-void SigMatchAppendSMToList(Signature *, SigMatch *, int);
+SigMatch *SigMatchAppendSMToList(DetectEngineCtx *, Signature *, uint16_t, SigMatchCtx *, int);
 void SigMatchRemoveSMFromList(Signature *, SigMatch *, int);
 int SigMatchListSMBelongsTo(const Signature *, const SigMatch *);
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -865,7 +865,6 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
 {
     SCEnter();
     DetectPcreData *pd = NULL;
-    SigMatch *sm = NULL;
     int parsed_sm_list = DETECT_SM_LIST_NOTSET;
     char capture_names[1024] = "";
     AppProto alproto = ALPROTO_UNKNOWN;
@@ -918,12 +917,10 @@ static int DetectPcreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *r
     if (sm_list == -1)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    SigMatch *sm = SigMatchAppendSMToList(de_ctx, s, DETECT_PCRE, (SigMatchCtx *)pd, sm_list);
+    if (sm == NULL) {
         goto error;
-    sm->type = DETECT_PCRE;
-    sm->ctx = (void *)pd;
-    SigMatchAppendSMToList(s, sm, sm_list);
+    }
 
     for (uint8_t x = 0; x < pd->idx; x++) {
         if (DetectFlowvarPostMatchSetup(de_ctx, s, pd->capids[x]) < 0)

--- a/src/detect-pktvar.c
+++ b/src/detect-pktvar.c
@@ -152,15 +152,10 @@ static int DetectPktvarSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (unlikely(sm == NULL)) {
-        DetectPktvarFree(de_ctx, cd);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_PKTVAR, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
     }
-    sm->type = DETECT_PKTVAR;
-    sm->ctx = (SigMatchCtx *)cd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
 
     pcre2_match_data_free(match);
     return 0;

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -156,15 +156,9 @@ int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char *replac
     SCFree(content);
     content = NULL;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (unlikely(sm == NULL)) {
-        SCFree(ud->replace);
-        ud->replace = NULL;
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_REPLACE, NULL, DETECT_SM_LIST_POSTMATCH) == NULL) {
         goto error;
     }
-    sm->type = DETECT_REPLACE;
-    sm->ctx = NULL;
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
     return 0;
 
 error:

--- a/src/detect-rfb-secresult.c
+++ b/src/detect-rfb-secresult.c
@@ -210,7 +210,6 @@ error:
 static int DetectRfbSecresultSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectRfbSecresultData *de = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_RFB) < 0)
         return -1;
@@ -219,20 +218,16 @@ static int DetectRfbSecresultSetup (DetectEngineCtx *de_ctx, Signature *s, const
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_RFB_SECRESULT, (SigMatchCtx *)de, rfb_secresult_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_RFB_SECRESULT;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, rfb_secresult_id);
+    }
 
     return 0;
 
 error:
-    if (de) SCFree(de);
-    if (sm) SCFree(sm);
+    if (de)
+        SCFree(de);
     return -1;
 }
 

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -127,14 +127,11 @@ static int DetectRfbSectypeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_RFB_SECTYPE, (SigMatchCtx *)dd,
+                g_rfb_sectype_buffer_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_RFB_SECTYPE;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_rfb_sectype_buffer_id);
+    }
     return 0;
 
 error:

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -266,26 +266,21 @@ error:
 int DetectRpcSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rpcstr)
 {
     DetectRpcData *rd = NULL;
-    SigMatch *sm = NULL;
 
     rd = DetectRpcParse(de_ctx, rpcstr);
     if (rd == NULL) goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_RPC, (SigMatchCtx *)rd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_RPC;
-    sm->ctx = (SigMatchCtx *)rd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (rd != NULL) DetectRpcFree(de_ctx, rd);
-    if (sm != NULL) SCFree(sm);
+    if (rd != NULL)
+        DetectRpcFree(de_ctx, rd);
     return -1;
 
 }

--- a/src/detect-sameip.c
+++ b/src/detect-sameip.c
@@ -92,26 +92,18 @@ static int DetectSameipMatch(DetectEngineThreadCtx *det_ctx,
  */
 static int DetectSameipSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
-    SigMatch *sm = NULL;
 
     /* Get this into a SigMatch and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_SAMEIP, NULL, DETECT_SM_LIST_MATCH) == NULL) {
         goto error;
-
-    sm->type = DETECT_SAMEIP;
-    sm->ctx = NULL;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
-
 }
 
 #ifdef UNITTESTS

--- a/src/detect-snmp-pdu_type.c
+++ b/src/detect-snmp-pdu_type.c
@@ -180,7 +180,6 @@ static int DetectSNMPPduTypeSetup (DetectEngineCtx *de_ctx, Signature *s,
                                    const char *rawstr)
 {
     DetectSNMPPduTypeData *dd = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0)
         return -1;
@@ -193,15 +192,12 @@ static int DetectSNMPPduTypeSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_SNMP_PDU_TYPE;
-    sm->ctx = (void *)dd;
 
     SCLogDebug("snmp.pdu_type %d", dd->pdu_type);
-    SigMatchAppendSMToList(s, sm, g_snmp_pdu_type_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SNMP_PDU_TYPE, (SigMatchCtx *)dd,
+                g_snmp_pdu_type_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -132,7 +132,6 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
                                    const char *rawstr)
 {
     DetectU32Data *dd = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SNMP) != 0)
         return -1;
@@ -145,15 +144,12 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_AL_SNMP_VERSION;
-    sm->ctx = (void *)dd;
 
     SCLogDebug("snmp.version %d", dd->arg1);
-    SigMatchAppendSMToList(s, sm, g_snmp_version_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SNMP_VERSION, (SigMatchCtx *)dd,
+                g_snmp_version_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -233,7 +233,6 @@ error:
 static int DetectSshVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectSshVersionData *ssh = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SSH) != 0)
         return -1;
@@ -244,21 +243,16 @@ static int DetectSshVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SSH_PROTOVERSION, (SigMatchCtx *)ssh,
+                g_ssh_banner_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_SSH_PROTOVERSION;
-    sm->ctx = (void *)ssh;
-
-    SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id);
+    }
     return 0;
 
 error:
     if (ssh != NULL)
         DetectSshVersionFree(de_ctx, ssh);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -220,7 +220,6 @@ error:
 static int DetectSshSoftwareVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectSshSoftwareVersionData *ssh = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_SSH) != 0)
         return -1;
@@ -231,21 +230,16 @@ static int DetectSshSoftwareVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SSH_SOFTWAREVERSION, (SigMatchCtx *)ssh,
+                g_ssh_banner_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_SSH_SOFTWAREVERSION;
-    sm->ctx = (void *)ssh;
-
-    SigMatchAppendSMToList(s, sm, g_ssh_banner_list_id);
+    }
     return 0;
 
 error:
     if (ssh != NULL)
         DetectSshSoftwareVersionFree(de_ctx, ssh);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -303,7 +303,6 @@ error:
 static int DetectSslStateSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
     DetectSslStateData *ssd = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
@@ -312,21 +311,15 @@ static int DetectSslStateSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     if (ssd == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SSL_STATE, (SigMatchCtx *)ssd,
+                g_tls_generic_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_SSL_STATE;
-    sm->ctx = (SigMatchCtx*)ssd;
-
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    }
     return 0;
 
 error:
     if (ssd != NULL)
         DetectSslStateFree(de_ctx, ssd);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -290,7 +290,6 @@ error:
 static int DetectSslVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectSslVersionData *ssl = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
@@ -301,21 +300,16 @@ static int DetectSslVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_SSL_VERSION, (SigMatchCtx *)ssl,
+                g_tls_generic_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_SSL_VERSION;
-    sm->ctx = (void *)ssl;
-
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    }
     return 0;
 
 error:
     if (ssl != NULL)
         DetectSslVersionFree(de_ctx, ssl);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -146,16 +146,11 @@ static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (sd == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_STREAM_SIZE, (SigMatchCtx *)sd, DETECT_SM_LIST_MATCH) == NULL) {
         DetectStreamSizeFree(de_ctx, sd);
         return -1;
     }
-
-    sm->type = DETECT_STREAM_SIZE;
-    sm->ctx = (SigMatchCtx *)sd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     return 0;
 }
 

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -303,17 +303,12 @@ int DetectTagSetup(DetectEngineCtx *de_ctx, Signature *s, const char *tagstr)
     if (td == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    /* Append it to the list of tags */
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_TAG, (SigMatchCtx *)td, DETECT_SM_LIST_TMATCH) ==
+            NULL) {
         DetectTagDataFree(de_ctx, td);
         return -1;
     }
-
-    sm->type = DETECT_TAG;
-    sm->ctx = (SigMatchCtx *)td;
-
-    /* Append it to the list of tags */
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_TMATCH);
     return 0;
 }
 

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -110,24 +110,19 @@ static int DetectAckMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectAckSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
     DetectAckData *data = NULL;
-    SigMatch *sm = NULL;
 
     data = SCMalloc(sizeof(DetectAckData));
     if (unlikely(data == NULL))
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_ACK;
-
     if (StringParseUint32(&data->ack, 10, 0, optstr) < 0) {
         goto error;
     }
-    sm->ctx = (SigMatchCtx*)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ACK, (SigMatchCtx *)data, DETECT_SM_LIST_MATCH) ==
+            NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -135,8 +130,6 @@ static int DetectAckSetup(DetectEngineCtx *de_ctx, Signature *s, const char *opt
 error:
     if (data)
         SCFree(data);
-    if (sm)
-        SigMatchFree(de_ctx, sm);
     return -1;
 
 }

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -480,27 +480,22 @@ error:
 static int DetectFlagsSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectFlagsData *de = NULL;
-    SigMatch *sm = NULL;
 
     de = DetectFlagsParse(rawstr);
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_FLAGS, (SigMatchCtx *)de, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_FLAGS;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (de) SCFree(de);
-    if (sm) SCFree(sm);
+    if (de)
+        SCFree(de);
     return -1;
 }
 

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -105,24 +105,19 @@ static int DetectSeqMatch(DetectEngineThreadCtx *det_ctx,
 static int DetectSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char *optstr)
 {
     DetectSeqData *data = NULL;
-    SigMatch *sm = NULL;
 
     data = SCMalloc(sizeof(DetectSeqData));
     if (unlikely(data == NULL))
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_SEQ;
-
     if (StringParseUint32(&data->seq, 10, 0, optstr) < 0) {
         goto error;
     }
-    sm->ctx = (SigMatchCtx*)data;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_SEQ, (SigMatchCtx *)data, DETECT_SM_LIST_MATCH) ==
+            NULL) {
+        goto error;
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
@@ -130,8 +125,6 @@ static int DetectSeqSetup (DetectEngineCtx *de_ctx, Signature *s, const char *op
 error:
     if (data)
         SCFree(data);
-    if (sm)
-        SigMatchFree(de_ctx, sm);
     return -1;
 
 }

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -181,28 +181,24 @@ error:
 static int DetectWindowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *windowstr)
 {
     DetectWindowData *wd = NULL;
-    SigMatch *sm = NULL;
 
     wd = DetectWindowParse(de_ctx, windowstr);
     if (wd == NULL) goto error;
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_WINDOW, (SigMatchCtx *)wd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         goto error;
-
-    sm->type = DETECT_WINDOW;
-    sm->ctx = (SigMatchCtx *)wd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+    }
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;
 
 error:
-    if (wd != NULL) DetectWindowFree(de_ctx, wd);
-    if (sm != NULL) SCFree(sm);
+    if (wd != NULL)
+        DetectWindowFree(de_ctx, wd);
     return -1;
 
 }

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -105,16 +105,11 @@ static int DetectTcpmssSetup (DetectEngineCtx *de_ctx, Signature *s, const char 
     if (tcpmssd == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_TCPMSS, (SigMatchCtx *)tcpmssd, DETECT_SM_LIST_MATCH) == NULL) {
         DetectTcpmssFree(de_ctx, tcpmssd);
         return -1;
     }
-
-    sm->type = DETECT_TCPMSS;
-    sm->ctx = (SigMatchCtx *)tcpmssd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -192,16 +192,11 @@ static int DetectTemplateSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
     if (templated == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_TEMPLATE, (SigMatchCtx *)templated,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectTemplateFree(de_ctx, templated);
         return -1;
     }
-
-    sm->type = DETECT_TEMPLATE;
-    sm->ctx = (void *)templated;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -112,16 +112,11 @@ static int DetectTemplate2Setup (DetectEngineCtx *de_ctx, Signature *s, const ch
     if (template2d == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_TEMPLATE2, (SigMatchCtx *)template2d,
+                DETECT_SM_LIST_MATCH) == NULL) {
         DetectTemplate2Free(de_ctx, template2d);
         return -1;
     }
-
-    sm->type = DETECT_TEMPLATE2;
-    sm->ctx = (SigMatchCtx *)template2d;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
 
     return 0;

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -239,7 +239,6 @@ error:
 static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
     DetectThresholdData *de = NULL;
-    SigMatch *sm = NULL;
     SigMatch *tmpm = NULL;
 
     /* checks if there is a previous instance of detection_filter */
@@ -259,20 +258,16 @@ static int DetectThresholdSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     if (de == NULL)
         goto error;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_THRESHOLD, (SigMatchCtx *)de, DETECT_SM_LIST_THRESHOLD) == NULL) {
         goto error;
-
-    sm->type = DETECT_THRESHOLD;
-    sm->ctx = (SigMatchCtx *)de;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
+    }
 
     return 0;
 
 error:
-    if (de) SCFree(de);
-    if (sm) SCFree(sm);
+    if (de)
+        SCFree(de);
     return -1;
 }
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -414,7 +414,6 @@ static int DetectTlsExpiredSetup (DetectEngineCtx *de_ctx, Signature *s,
                                   const char *rawstr)
 {
     DetectTlsValidityData *dd = NULL;
-    SigMatch *sm = NULL;
 
     SCLogDebug("\'%s\'", rawstr);
 
@@ -429,25 +428,20 @@ static int DetectTlsExpiredSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
 
     dd->mode = DETECT_TLS_VALIDITY_EX;
     dd->type = DETECT_TLS_TYPE_NOTAFTER;
     dd->epoch = 0;
     dd->epoch2 = 0;
 
-    sm->type = DETECT_AL_TLS_EXPIRED;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_EXPIRED, (SigMatchCtx *)dd,
+                g_tls_validity_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:
     DetectTlsValidityFree(de_ctx, dd);
-    if (sm)
-        SCFree(sm);
     return -1;
 }
 
@@ -465,7 +459,6 @@ static int DetectTlsValidSetup (DetectEngineCtx *de_ctx, Signature *s,
                                 const char *rawstr)
 {
     DetectTlsValidityData *dd = NULL;
-    SigMatch *sm = NULL;
 
     SCLogDebug("\'%s\'", rawstr);
 
@@ -480,25 +473,20 @@ static int DetectTlsValidSetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
 
     dd->mode = DETECT_TLS_VALIDITY_VA;
     dd->type = DETECT_TLS_TYPE_NOTAFTER;
     dd->epoch = 0;
     dd->epoch2 = 0;
 
-    sm->type = DETECT_AL_TLS_VALID;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_VALID, (SigMatchCtx *)dd,
+                g_tls_validity_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:
     DetectTlsValidityFree(de_ctx, dd);
-    if (sm)
-        SCFree(sm);
     return -1;
 }
 
@@ -555,7 +543,6 @@ static int DetectTlsValiditySetup (DetectEngineCtx *de_ctx, Signature *s,
                                    const char *rawstr, uint8_t type)
 {
     DetectTlsValidityData *dd = NULL;
-    SigMatch *sm = NULL;
 
     SCLogDebug("\'%s\'", rawstr);
 
@@ -570,31 +557,25 @@ static int DetectTlsValiditySetup (DetectEngineCtx *de_ctx, Signature *s,
 
     /* okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
 
     if (type == DETECT_TLS_TYPE_NOTBEFORE) {
         dd->type = DETECT_TLS_TYPE_NOTBEFORE;
-        sm->type = DETECT_AL_TLS_NOTBEFORE;
     }
     else if (type == DETECT_TLS_TYPE_NOTAFTER) {
         dd->type = DETECT_TLS_TYPE_NOTAFTER;
-        sm->type = DETECT_AL_TLS_NOTAFTER;
     }
     else {
         goto error;
     }
 
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_tls_validity_buffer_id);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_NOTAFTER, (SigMatchCtx *)dd,
+                g_tls_validity_buffer_id) == NULL) {
+        goto error;
+    }
     return 0;
 
 error:
     DetectTlsValidityFree(de_ctx, dd);
-    if (sm)
-        SCFree(sm);
     return -1;
 }
 

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -341,15 +341,11 @@ static int DetectTLSCertChainLenSetup(DetectEngineCtx *de_ctx, Signature *s, con
         return -1;
     }
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, KEYWORD_ID, (SigMatchCtx *)dd, g_tls_cert_buffer_id) ==
+            NULL) {
         rs_detect_u32_free(dd);
         return -1;
     }
-    sm->type = KEYWORD_ID;
-    sm->ctx = (void *)dd;
-
-    SigMatchAppendSMToList(s, sm, g_tls_cert_buffer_id);
     return 0;
 }
 

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -232,7 +232,6 @@ error:
 static int DetectTlsVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectTlsVersionData *tls = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
@@ -243,22 +242,17 @@ static int DetectTlsVersionSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_VERSION, (SigMatchCtx *)tls,
+                g_tls_generic_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_TLS_VERSION;
-    sm->ctx = (void *)tls;
-
-    SigMatchAppendSMToList(s, sm, g_tls_generic_list_id);
+    }
 
     return 0;
 
 error:
     if (tls != NULL)
         DetectTlsVersionFree(de_ctx, tls);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -298,7 +298,6 @@ error:
 static int DetectTlsSubjectSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectTlsData *tls = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
@@ -309,21 +308,16 @@ static int DetectTlsSubjectSetup (DetectEngineCtx *de_ctx, Signature *s, const c
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(
+                de_ctx, s, DETECT_AL_TLS_SUBJECT, (SigMatchCtx *)tls, g_tls_cert_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_TLS_SUBJECT;
-    sm->ctx = (void *)tls;
-
-    SigMatchAppendSMToList(s, sm, g_tls_cert_list_id);
+    }
     return 0;
 
 error:
     if (tls != NULL)
         DetectTlsSubjectFree(de_ctx, tls);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }
@@ -494,7 +488,6 @@ error:
 static int DetectTlsIssuerDNSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     DetectTlsData *tls = NULL;
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
@@ -505,21 +498,16 @@ static int DetectTlsIssuerDNSetup (DetectEngineCtx *de_ctx, Signature *s, const 
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_ISSUERDN, (SigMatchCtx *)tls,
+                g_tls_cert_list_id) == NULL) {
         goto error;
-
-    sm->type = DETECT_AL_TLS_ISSUERDN;
-    sm->ctx = (void *)tls;
-
-    SigMatchAppendSMToList(s, sm, g_tls_cert_list_id);
+    }
     return 0;
 
 error:
     if (tls != NULL)
         DetectTlsIssuerDNFree(de_ctx, tls);
-    if (sm != NULL)
-        SCFree(sm);
     return -1;
 
 }
@@ -594,19 +582,16 @@ static void DetectTlsFingerprintFree(DetectEngineCtx *de_ctx, void *ptr)
  */
 static int DetectTlsStoreSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    SigMatch *sm = NULL;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_TLS) != 0)
         return -1;
 
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        return -1;
-
-    sm->type = DETECT_AL_TLS_STORE;
     s->flags |= SIG_FLAG_TLSSTORE;
 
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_AL_TLS_STORE, NULL, DETECT_SM_LIST_POSTMATCH) ==
+            NULL) {
+        return -1;
+    }
     return 0;
 }
 

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -185,16 +185,11 @@ static int DetectTosSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg
     if (tosd == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_TOS, (SigMatchCtx *)tosd, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         DetectTosFree(de_ctx, tosd);
         return -1;
     }
-
-    sm->type = DETECT_TOS;
-    sm->ctx = (SigMatchCtx *)tosd;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -116,16 +116,11 @@ static int DetectTtlSetup (DetectEngineCtx *de_ctx, Signature *s, const char *tt
     if (ttld == NULL)
         return -1;
 
-    SigMatch *sm = SigMatchAlloc();
-    if (sm == NULL) {
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_TTL, (SigMatchCtx *)ttld, DETECT_SM_LIST_MATCH) ==
+            NULL) {
         DetectTtlFree(de_ctx, ttld);
         return -1;
     }
-
-    sm->type = DETECT_TTL;
-    sm->ctx = (SigMatchCtx *)ttld;
-
-    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
     s->flags |= SIG_FLAG_REQUIRE_PACKET;
     return 0;
 }

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -335,7 +335,6 @@ static int DetectXbitParse(DetectEngineCtx *de_ctx,
 
 int DetectXbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    SigMatch *sm = NULL;
     DetectXbitsData *cd = NULL;
 
     int result = DetectXbitParse(de_ctx, rawstr, &cd);
@@ -349,12 +348,6 @@ int DetectXbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 
     /* Okay so far so good, lets get this into a SigMatch
      * and put it in the Signature. */
-    sm = SigMatchAlloc();
-    if (sm == NULL)
-        goto error;
-
-    sm->type = DETECT_XBITS;
-    sm->ctx = (void *)cd;
 
     switch (cd->cmd) {
         /* case DETECT_XBITS_CMD_NOALERT can't happen here */
@@ -362,14 +355,20 @@ int DetectXbitSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
         case DETECT_XBITS_CMD_ISNOTSET:
         case DETECT_XBITS_CMD_ISSET:
             /* checks, so packet list */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+            if (SigMatchAppendSMToList(
+                        de_ctx, s, DETECT_XBITS, (SigMatchCtx *)cd, DETECT_SM_LIST_MATCH) == NULL) {
+                goto error;
+            }
             break;
 
         case DETECT_XBITS_CMD_SET:
         case DETECT_XBITS_CMD_UNSET:
         case DETECT_XBITS_CMD_TOGGLE:
             /* modifiers, only run when entire sig has matched */
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_XBITS, (SigMatchCtx *)cd,
+                        DETECT_SM_LIST_POSTMATCH) == NULL) {
+                goto error;
+            }
             break;
     }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -287,7 +287,6 @@ typedef struct DetectPort_ {
     BIT_U32(8) /**< priority is explicitly set by the priority keyword */
 #define SIG_FLAG_INIT_FILEDATA              BIT_U32(9)  /**< signature has filedata keyword */
 #define SIG_FLAG_INIT_JA3                   BIT_U32(10) /**< signature has ja3 keyword */
-#define SIG_FLAG_INIT_OVERFLOW              BIT_U32(11) /**< signature has overflown buffers */
 
 /* signature mask flags */
 /** \note: additions should be added to the rule analyzer as well */

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -224,7 +224,6 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
         const char *th_ip)
 {
     Signature *s = NULL;
-    SigMatch *sm = NULL;
     DetectThresholdData *de = NULL;
 
     BUG_ON(parsed_type != TYPE_SUPPRESS);
@@ -266,15 +265,10 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
             if (unlikely(de == NULL))
                 goto error;
 
-            sm = SigMatchAlloc();
-            if (sm == NULL) {
-                SCLogError("Error allocating SigMatch");
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_THRESHOLD, (SigMatchCtx *)de,
+                        DETECT_SM_LIST_SUPPRESS) == NULL) {
                 goto error;
             }
-
-            sm->type = DETECT_THRESHOLD;
-            sm->ctx = (void *)de;
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
         }
     } else if (id == 0 && gid > 0)    {
         if (parsed_track == TRACK_RULE) {
@@ -295,16 +289,10 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
             if (unlikely(de == NULL))
                 goto error;
 
-            sm = SigMatchAlloc();
-            if (sm == NULL) {
-                SCLogError("Error allocating SigMatch");
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_THRESHOLD, (SigMatchCtx *)de,
+                        DETECT_SM_LIST_SUPPRESS) == NULL) {
                 goto error;
             }
-
-            sm->type = DETECT_THRESHOLD;
-            sm->ctx = (void *)de;
-
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
         }
     } else if (id > 0 && gid == 0) {
         SCLogError("Can't use a event config that has "
@@ -327,16 +315,10 @@ static int SetupSuppressRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid,
             if (unlikely(de == NULL))
                 goto error;
 
-            sm = SigMatchAlloc();
-            if (sm == NULL) {
-                SCLogError("Error allocating SigMatch");
+            if (SigMatchAppendSMToList(de_ctx, s, DETECT_THRESHOLD, (SigMatchCtx *)de,
+                        DETECT_SM_LIST_SUPPRESS) == NULL) {
                 goto error;
             }
-
-            sm->type = DETECT_THRESHOLD;
-            sm->ctx = (void *)de;
-
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_SUPPRESS);
         }
     }
 
@@ -377,8 +359,7 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
     /* Install it */
     if (id == 0 && gid == 0) {
         for (s = de_ctx->sig_list; s != NULL; s = s->next) {
-            sm = DetectGetLastSMByListId(s,
-                    DETECT_SM_LIST_THRESHOLD, DETECT_THRESHOLD, -1);
+            sm = DetectGetLastSMByListId(s, DETECT_SM_LIST_THRESHOLD, DETECT_THRESHOLD, -1);
             if (sm != NULL) {
                 SCLogWarning("signature sid:%" PRIu32 " has "
                              "an event var set.  The signature event var is "
@@ -411,19 +392,14 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             de->new_action = parsed_new_action;
             de->timeout = parsed_timeout;
 
-            sm = SigMatchAlloc();
-            if (sm == NULL) {
-                SCLogError("Error allocating SigMatch");
+            uint16_t smtype = DETECT_THRESHOLD;
+            if (parsed_type == TYPE_RATE)
+                smtype = DETECT_DETECTION_FILTER;
+
+            if (SigMatchAppendSMToList(
+                        de_ctx, s, smtype, (SigMatchCtx *)de, DETECT_SM_LIST_THRESHOLD) == NULL) {
                 goto error;
             }
-
-            if (parsed_type == TYPE_RATE)
-                sm->type = DETECT_DETECTION_FILTER;
-            else
-                sm->type = DETECT_THRESHOLD;
-            sm->ctx = (void *)de;
-
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
         }
 
     } else if (id == 0 && gid > 0) {
@@ -452,19 +428,14 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
                 de->new_action = parsed_new_action;
                 de->timeout = parsed_timeout;
 
-                sm = SigMatchAlloc();
-                if (sm == NULL) {
-                    SCLogError("Error allocating SigMatch");
+                uint16_t smtype = DETECT_THRESHOLD;
+                if (parsed_type == TYPE_RATE)
+                    smtype = DETECT_DETECTION_FILTER;
+
+                if (SigMatchAppendSMToList(de_ctx, s, smtype, (SigMatchCtx *)de,
+                            DETECT_SM_LIST_THRESHOLD) == NULL) {
                     goto error;
                 }
-
-                if (parsed_type == TYPE_RATE)
-                    sm->type = DETECT_DETECTION_FILTER;
-                else
-                    sm->type = DETECT_THRESHOLD;
-                sm->ctx = (void *)de;
-
-                SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
             }
         }
     } else if (id > 0 && gid == 0) {
@@ -525,19 +496,14 @@ static int SetupThresholdRule(DetectEngineCtx *de_ctx, uint32_t id, uint32_t gid
             de->new_action = parsed_new_action;
             de->timeout = parsed_timeout;
 
-            sm = SigMatchAlloc();
-            if (sm == NULL) {
-                SCLogError("Error allocating SigMatch");
+            uint16_t smtype = DETECT_THRESHOLD;
+            if (parsed_type == TYPE_RATE)
+                smtype = DETECT_DETECTION_FILTER;
+
+            if (SigMatchAppendSMToList(
+                        de_ctx, s, smtype, (SigMatchCtx *)de, DETECT_SM_LIST_THRESHOLD) == NULL) {
                 goto error;
             }
-
-            if (parsed_type == TYPE_RATE)
-                sm->type = DETECT_DETECTION_FILTER;
-            else
-                sm->type = DETECT_THRESHOLD;
-            sm->ctx = (void *)de;
-
-            SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_THRESHOLD);
         }
     }
 end:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6104

Describe changes:
- fixes buffer overflow in rules parsing
- fixes memory leak in parsing `dcerpc.iface` on OOM condition (if `SigMatchAlloc` returns NULL)

Replaces #9662 with needed rebase
