### PR TITLE
general/cppcheck: Address cppcheck memory related errors

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1377,7 +1377,12 @@ static int DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
     map->address = address;
     map->contains_negation = contains_negation;
 
-    BUG_ON(HashListTableAdd(de_ctx->address_table, (void *)map, 0) != 0);
+    if (HashListTableAdd(de_ctx->address_table, (void *)map, 0) != 0) {
+        if (map->string)
+            SCFree(map->string);
+        SCFree(map);
+        BUG_ON(true);
+    }
     return 0;
 }
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -842,6 +842,28 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
             r = next;
         }
         SCLogDebug("to_shift %p", to_shift);
+
+        // this region is main, or will xfer its buffer to main
+        if (to_shift) {
+            SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", to_shift->stream_offset,
+                    to_shift->buf, to_shift->buf_size, to_shift->buf_offset);
+            if (to_shift != &sb->region) {
+                DEBUG_VALIDATE_BUG_ON(sb->region.buf != NULL);
+
+                sb->region.buf = to_shift->buf;
+                sb->region.stream_offset = to_shift->stream_offset;
+                sb->region.buf_offset = to_shift->buf_offset;
+                sb->region.buf_size = to_shift->buf_size;
+                sb->region.next = to_shift->next;
+
+                assert(to_shift != &sb->region);
+                FREE(cfg, to_shift, sizeof(*to_shift));
+                to_shift = &sb->region;
+                sb->regions--;
+                DEBUG_VALIDATE_BUG_ON(sb->regions == 0);
+            }
+        }
+
     } else {
         to_shift = &sb->region;
         SCLogDebug("shift start region %p", to_shift);
@@ -849,23 +871,6 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
 
     // this region is main, or will xfer its buffer to main
     if (to_shift) {
-        SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", to_shift->stream_offset,
-                to_shift->buf, to_shift->buf_size, to_shift->buf_offset);
-        if (to_shift != &sb->region) {
-            DEBUG_VALIDATE_BUG_ON(sb->region.buf != NULL);
-
-            sb->region.buf = to_shift->buf;
-            sb->region.stream_offset = to_shift->stream_offset;
-            sb->region.buf_offset = to_shift->buf_offset;
-            sb->region.buf_size = to_shift->buf_size;
-            sb->region.next = to_shift->next;
-
-            FREE(cfg, to_shift, sizeof(*to_shift));
-            to_shift = &sb->region;
-            sb->regions--;
-            DEBUG_VALIDATE_BUG_ON(sb->regions == 0);
-        }
-
         // Do the shift. If new region is exactly at the slide offset we can skip this.
         DEBUG_VALIDATE_BUG_ON(to_shift->stream_offset > slide_offset);
         const uint32_t s = slide_offset - to_shift->stream_offset;


### PR DESCRIPTION
Address cppcheck reported memory leak/misuse errors. See the redmine issue for the cppcheck command that uncovered the issues.

Issue: 6527

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6527](https://redmine.openinfosecfoundation.org/issues/6527)

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
