### PR TITLE
userguide: update tls not_after/not_before mentions (6.0.x backport) - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -690,8 +690,8 @@ If extended logging is enabled the following fields are also included:
 * "fingerprint": The (SHA1) fingerprint of the TLS certificate
 * "sni": The Server Name Indication (SNI) extension sent by the client
 * "version": The SSL/TLS version used
-* "not_before": The NotBefore field from the TLS certificate
-* "not_after": The NotAfter field from the TLS certificate
+* "notbefore": The NotBefore field from the TLS certificate
+* "notafter": The NotAfter field from the TLS certificate
 * "ja3": The JA3 fingerprint consisting of both a JA3 hash and a JA3 string
 * "ja3s": The JA3S fingerprint consisting of both a JA3 hash and a JA3 string
 


### PR DESCRIPTION
Our tls fields not_after and not_before are actually logged as `notafter` and `notbefore`, but were documented with the underscore.

Update the documentation, since updating the log format itself would be a breaking change.

Task #5494

(cherry picked from commit a649a92afd4ed71b264ee1df408875322d9dfaf9)

Backport ticket: https://redmine.openinfosecfoundation.org/issues/6512