### PR TITLE
scripts: helper script to install dependencies - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1744,55 +1744,14 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
-      - name: Install dependencies
-        run: |
-          apt update
-          apt -y install \
-                libpcre2-dev \
-                build-essential \
-                autoconf \
-                automake \
-                cargo \
-                git \
-                jq \
-                libtool \
-                libpcap-dev \
-                libnet1-dev \
-                libyaml-0-2 \
-                libyaml-dev \
-                libcap-ng-dev \
-                libcap-ng0 \
-                libmagic-dev \
-                libnetfilter-queue-dev \
-                libnetfilter-queue1 \
-                libnfnetlink-dev \
-                libnfnetlink0 \
-                libhiredis-dev \
-                libjansson-dev \
-                libevent-dev \
-                libevent-pthreads-2.1-7 \
-                libjansson-dev \
-                libpython2.7 \
-                make \
-                parallel \
-                python3-yaml \
-                rustc \
-                software-properties-common \
-                zlib1g \
-                zlib1g-dev \
-                exuberant-ctags
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
+      - name: Install dependencies
+        run: ./scripts/install-deps.sh --developer
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
       - run: ./configure --enable-debug-validation
         env:
@@ -1822,52 +1781,18 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
+      - uses: actions/checkout@v3.5.3
       - name: Install dependencies
         run: |
-          apt update
+          ./scripts/install-deps.sh --developer
           apt -y install \
-                afl \
-                afl-clang \
-                libpcre2-dev \
-                build-essential \
-                autoconf \
-                automake \
-                cargo \
-                git \
-                libtool \
-                libpcap-dev \
-                libnet1-dev \
-                libyaml-0-2 \
-                libyaml-dev \
-                libcap-ng-dev \
-                libcap-ng0 \
-                libmagic-dev \
-                libnetfilter-queue-dev \
-                libnetfilter-queue1 \
-                libnfnetlink-dev \
-                libnfnetlink0 \
-                libhiredis-dev \
-                libjansson-dev \
-                libjansson-dev \
-                libpython2.7 \
-                make \
-                rustc \
-                software-properties-common \
-                zlib1g \
-                zlib1g-dev
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
+            afl \
+            afl-clang
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ LDFLAGS="-fsanitize=address" ./configure --enable-fuzztargets --disable-shared
       - run: AFL_HARDEN=1 make -j2
@@ -1884,48 +1809,13 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry
 
-      - name: Install dependencies
-        run: |
-            sudo apt update
-            sudo apt -y install \
-                  libpcre2-dev \
-                  build-essential \
-                  autoconf \
-                  automake \
-                  cargo \
-                  git \
-                  jq \
-                  libtool \
-                  libpcap-dev \
-                  libnet1-dev \
-                  libyaml-0-2 \
-                  libyaml-dev \
-                  libcap-ng-dev \
-                  libcap-ng0 \
-                  libmagic-dev \
-                  libnetfilter-queue-dev \
-                  libnetfilter-queue1 \
-                  libnfnetlink-dev \
-                  libnfnetlink0 \
-                  libhiredis-dev \
-                  libjansson-dev \
-                  libevent-dev \
-                  libevent-pthreads-2.1-7 \
-                  libjansson-dev \
-                  libpython2.7 \
-                  make \
-                  parallel \
-                  python3-yaml \
-                  rustc \
-                  software-properties-common \
-                  zlib1g \
-                  zlib1g-dev \
-                  exuberant-ctags
+      - uses: actions/checkout@v3.5.3
 
+      - name: Install dependencies
+        run: sudo ./scripts/install-deps.sh --developer
       - name: Install Netmap dependencies
         run: |
           sudo apt -y install \
-                build-essential \
                 git \
                 linux-headers-$(uname -r)
 
@@ -1943,18 +1833,11 @@ jobs:
           make -j2
           sudo make install
 
-      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-netmap
       - run: make -j2
@@ -1977,43 +1860,10 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry
 
+      - uses: actions/checkout@v3.5.3
+
       - name: Install dependencies
-        run: |
-          apt update
-          apt -y install \
-                libpcre2-dev \
-                build-essential \
-                autoconf \
-                automake \
-                cargo \
-                git \
-                jq \
-                libtool \
-                libpcap-dev \
-                libnet1-dev \
-                libyaml-0-2 \
-                libyaml-dev \
-                libcap-ng-dev \
-                libcap-ng0 \
-                libmagic-dev \
-                libnetfilter-queue-dev \
-                libnetfilter-queue1 \
-                libnfnetlink-dev \
-                libnfnetlink0 \
-                libhiredis-dev \
-                libjansson-dev \
-                libevent-dev \
-                libevent-pthreads-2.1-7 \
-                libjansson-dev \
-                libpython2.7 \
-                make \
-                parallel \
-                python3-yaml \
-                rustc \
-                software-properties-common \
-                zlib1g \
-                zlib1g-dev \
-                exuberant-ctags
+        run: ./scripts/install-deps.sh --developer
       - name: Install DPDK dependencies
         run: |
           apt update
@@ -2041,18 +1891,11 @@ jobs:
           ninja -C build install
           ldconfig
           cd $HOME
-      - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-dpdk
       - run: make -j2

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              $(SURICATA_UPDATE_DIR) \
 	     lua \
 	     acsite.m4 \
-	     scripts/generate-images.sh
+	     scripts/generate-images.sh \
+	     scripts/install-deps.sh
 SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib etc python ebpf \
           $(SURICATA_UPDATE_DIR)
 DIST_SUBDIRS = examples/plugins/c-json-filetype $(SUBDIRS)

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,238 @@
+#! /bin/sh
+#
+# This is a helper script to install dependencies for building
+# Suricata from source. By default it will install a set of
+# dependencies suitable for users of Suricata.  Add the --developer
+# option to install extra dependencies suitable for developers such as
+# ASAN and documentation build tools.
+
+set -e
+
+for arg in $@; do
+    case $arg in
+	--developer)
+	    DEVELOPER="yes"
+	    ;;
+	*)
+	    echo "error: bad argument: $arg"
+	    exit 1
+	    ;;
+    esac
+done
+
+if ! test -e /etc/os-release; then
+    echo "error: unable to determine OS (no /etc/os-release)"
+    exit 1
+fi
+
+. /etc/os-release
+
+if [ "${ID}" = "" ]; then
+    echo "error: no os-release id"
+    exit 1
+fi
+
+install_deps_debian() {
+    if [ "${VERSION_ID}" -lt "11" ]; then
+	echo "error: only Debian 11 and newer supported at this time"
+	exit 1
+    fi
+
+    apt update
+    apt -y install \
+        build-essential \
+        dpdk-dev \
+        libcap-ng-dev \
+        libcap-ng0 \
+        libjansson-dev \
+        libjansson4 \
+        liblua5.1-dev \
+        liblz4-dev \
+        liblzma-dev \
+        libmagic-dev \
+        libmaxminddb-dev \
+        libnet1-dev \
+        libnspr4-dev \
+        libnuma-dev \
+        libpcap-dev \
+        libpcre2-dev \
+        libssl-dev \
+        libtool \
+        libyaml-0-2 \
+        libyaml-dev \
+        make \
+        pkg-config \
+        python3 \
+        python3-yaml \
+        zlib1g \
+        zlib1g-dev
+
+    if [ "${DEVELOPER}" = "yes" ]; then
+	echo "===> Installing extra developer packages"
+	apt -y install \
+	    autoconf \
+	    automake \
+            jq \
+            sphinx-doc \
+            sphinx-common \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-latex-base \
+            texlive-latex-extra
+    fi
+
+    # Only install Rust if not found, as it may already be installed
+    # from Rustup.
+    if ! rustc --version > /dev/null 2>&1; then
+	apt -y install cargo rustc
+    fi
+
+    # Same for cbindgen, it may already have been installed with
+    # cargo.
+    if ! cbindgen --version > /dev/null 2>&1; then
+	apt -y install cbindgen
+    fi
+}
+
+install_deps_fedora() {
+    dnf -y install \
+	dpdk-devel \
+	hyperscan-devel \
+        diffutils \
+        file-devel \
+        gcc \
+        gcc-c++ \
+        hiredis-devel \
+        jansson-devel \
+        libcap-ng-devel \
+        libevent-devel \
+        libmaxminddb-devel \
+        libnet-devel \
+        libnetfilter_queue-devel \
+        libnfnetlink-devel \
+        libpcap-devel \
+        libtool \
+        libtool \
+        libyaml-devel \
+        lua-devel \
+        lz4-devel \
+        make \
+        pcre2-devel \
+        pkgconfig \
+        python3-yaml \
+        which \
+        zlib-devel
+
+    if [ "${DEVELOPER}" = "yes" ]; then
+	echo "===> Installing extra developer packages"
+	dnf -y install \
+	    autoconf \
+	    automake \
+	    jq \
+	    libasan \
+            python3-sphinx \
+            texlive-capt-of \
+            texlive-cmap \
+            texlive-collection-latexrecommended \
+            texlive-fncychap \
+            texlive-framed \
+            texlive-latex \
+            texlive-needspace \
+            texlive-tabulary \
+            texlive-titlesec \
+            texlive-upquote \
+            texlive-wrapfig
+    fi
+    
+    # Only install Rust if not found, as it may already be installed
+    # from Rustup.
+    if ! rustc --version > /dev/null 2>&1; then
+	dnf -y install cargo rustc
+    fi
+
+    # Same for cbindgen, it may already have been installed with
+    # cargo.
+    if ! cbindgen --version > /dev/null 2>&1; then
+	dnf -y install cbindgen
+    fi
+}
+
+install_deps_ubuntu() {
+    if [ "${VERSION_ID}" != "22.04x" ]; then
+	echo "===> WARNING: this script is for Ubuntu 22.04 and may not work"
+	echo "===>          correctly on ${PRETTY_NAME}"
+    fi
+
+    apt -y update
+    apt -y install \
+        build-essential \
+        libcap-ng-dev \
+        libcap-ng0 \
+        libevent-dev \
+        libevent-pthreads-2.1-7 \
+        libhiredis-dev \
+        libjansson-dev \
+        libjansson-dev \
+        libmagic-dev \
+        libnet1-dev \
+        libnetfilter-queue-dev \
+        libnetfilter-queue1 \
+        libnfnetlink-dev \
+        libnfnetlink0 \
+        libpcap-dev \
+        libpcre2-dev \
+        libpython2.7 \
+        libtool \
+        libyaml-0-2 \
+        libyaml-dev \
+        make \
+        python3-yaml \
+        software-properties-common \
+        zlib1g \
+        zlib1g-dev
+
+    # TODO:
+    # - asan
+    if [ "${DEVELOPER}" = "yes" ]; then
+	echo "===> Installing extra developer packages"
+	apt -y install \
+	    autoconf \
+	    automake \
+	    git \
+            jq \
+            sphinx-common \
+            sphinx-doc \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-latex-base \
+            texlive-latex-extra
+    fi
+    
+    # Only install Rust if not found, as it may already be installed
+    # from Rustup.
+    if ! rustc --version > /dev/null 2>&1; then
+	apt -y install cargo rustc
+    fi
+
+    # Same for cbindgen, it may already have been installed with
+    # cargo.
+    if ! cbindgen --version > /dev/null 2>&1; then
+	apt -y install cbindgen
+    fi
+}
+
+case "${ID}" in
+    debian)
+	install_deps_debian
+	;;
+    fedora)
+	install_deps_fedora
+	;;
+    ubuntu)
+	install_deps_ubuntu
+	;;
+    *)
+	echo "error: ${ID} not supported by this script"
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Just trying an idea to help bootstrap a development environment. A script,
install-deps.sh that knows how to install dependencies on a handful of common
distributions.

It currently handle Debian, Ubuntu and Fedora.

To show it in use, update the Ubuntu GitHub CI jobs to use this script.
