### PR TITLE
pgsql: improve probing function - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -185,12 +185,11 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
         }
         PgsqlBEMessage::UnknownMessageType(RegularPacket {
             identifier: _,
-            length,
-            payload,
+            length: _,
+            payload: _,
         }) => {
-            // jb.set_string_from_bytes("identifier", identifier.to_vec())?;
-            jb.set_uint("length", (*length).into())?;
-            jb.set_string_from_bytes("payload", payload)?;
+            // We don't expect to log these, as the probing function won't recognize them as pgsql
+            // traffic
         }
         PgsqlBEMessage::AuthenticationOk(_)
         | PgsqlBEMessage::AuthenticationCleartextPassword(_)

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -102,6 +102,14 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             js.set_string("message", req.to_str())?;
         }
+        PgsqlFEMessage::UnknownMessageType(RegularPacket {
+            identifier: _,
+            length: _,
+            payload: _,
+        }) => {
+            // We don't expect to log this, as the probing function will fail the proto if we see
+            // such a message
+        }
     }
     js.close()?;
     Ok(js)

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -284,6 +284,11 @@ impl PgsqlState {
                 SCLogDebug!("Match: Terminate message");
                 Some(PgsqlStateProgress::ConnectionTerminated)
             }
+            PgsqlFEMessage::UnknownMessageType(_) => {
+                SCLogDebug!("Match: Unknown message type");
+                // Not changing state when we don't know the message
+                None
+            }
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6080

Describe changes:
- add UnknownMessageType for pgsql client messages
- improve pgsql probing functions to return `ALPROTO_UNKNOWN` when an unknown message type is seen/parsed - thought that this might make more sense than `ALPROTO_FAILED` @catenacyber, but will change if you think otherwise
- clean-up logger code a bit

Didn't add SV tests as this was triggered by a TLPR pcap and I wasn't able to easily reproduce a pcap, but created SV tests locally and it looks fixed.