### PR TITLE
general/cppcheck: Address cppcheck memory related errors

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1362,23 +1362,28 @@ void DetectAddressMapFree(DetectEngineCtx *de_ctx)
     return;
 }
 
-static int DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
-                        DetectAddressHead *address, bool contains_negation)
+static bool DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
+        DetectAddressHead *address, bool contains_negation)
 {
     DetectAddressMap *map = SCCalloc(1, sizeof(*map));
     if (map == NULL)
-        return -1;
+        return false;
 
     map->string = SCStrdup(string);
     if (map->string == NULL) {
         SCFree(map);
-        return -1;
+        return false;
     }
     map->address = address;
     map->contains_negation = contains_negation;
 
-    BUG_ON(HashListTableAdd(de_ctx->address_table, (void *)map, 0) != 0);
-    return 0;
+    if (HashListTableAdd(de_ctx->address_table, (void *)map, 0) != 0) {
+        SCFree(map->string);
+        SCFree(map);
+        return false;
+    }
+
+    return true;
 }
 
 static const DetectAddressMap *DetectAddressMapLookup(DetectEngineCtx *de_ctx,
@@ -1471,8 +1476,10 @@ const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
         *contains_negation = false;
     }
 
-    DetectAddressMapAdd((DetectEngineCtx *)de_ctx, string, head,
-            *contains_negation);
+    if (!DetectAddressMapAdd((DetectEngineCtx *)de_ctx, string, head, *contains_negation)) {
+        DetectAddressHeadFree(head);
+        head = NULL;
+    }
     return head;
 }
 

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -842,6 +842,28 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
             r = next;
         }
         SCLogDebug("to_shift %p", to_shift);
+
+        // this region is main, or will xfer its buffer to main
+        if (to_shift) {
+            SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", to_shift->stream_offset,
+                    to_shift->buf, to_shift->buf_size, to_shift->buf_offset);
+            if (to_shift != &sb->region) {
+                DEBUG_VALIDATE_BUG_ON(sb->region.buf != NULL);
+
+                sb->region.buf = to_shift->buf;
+                sb->region.stream_offset = to_shift->stream_offset;
+                sb->region.buf_offset = to_shift->buf_offset;
+                sb->region.buf_size = to_shift->buf_size;
+                sb->region.next = to_shift->next;
+
+                BUG_ON(to_shift == &sb->region);
+                FREE(cfg, to_shift, sizeof(*to_shift));
+                to_shift = &sb->region;
+                sb->regions--;
+                DEBUG_VALIDATE_BUG_ON(sb->regions == 0);
+            }
+        }
+
     } else {
         to_shift = &sb->region;
         SCLogDebug("shift start region %p", to_shift);
@@ -849,23 +871,6 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
 
     // this region is main, or will xfer its buffer to main
     if (to_shift) {
-        SCLogDebug("main: offset %" PRIu64 " buf %p size %u offset %u", to_shift->stream_offset,
-                to_shift->buf, to_shift->buf_size, to_shift->buf_offset);
-        if (to_shift != &sb->region) {
-            DEBUG_VALIDATE_BUG_ON(sb->region.buf != NULL);
-
-            sb->region.buf = to_shift->buf;
-            sb->region.stream_offset = to_shift->stream_offset;
-            sb->region.buf_offset = to_shift->buf_offset;
-            sb->region.buf_size = to_shift->buf_size;
-            sb->region.next = to_shift->next;
-
-            FREE(cfg, to_shift, sizeof(*to_shift));
-            to_shift = &sb->region;
-            sb->regions--;
-            DEBUG_VALIDATE_BUG_ON(sb->regions == 0);
-        }
-
         // Do the shift. If new region is exactly at the slide offset we can skip this.
         DEBUG_VALIDATE_BUG_ON(to_shift->stream_offset > slide_offset);
         const uint32_t s = slide_offset - to_shift->stream_offset;


### PR DESCRIPTION
Continuation of #9866 

Address cppcheck reported memory leak/misuse errors. See the redmine issue for the cppcheck command that uncovered the issues.

Issue: 6527

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6527](https://redmine.openinfosecfoundation.org/issues/6527)

Updates:
- Fix issue with using `assert`; converted to `BUG_ON`
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
