### PR TITLE
detect/filestore: fix memory leak on sig parsing

### DIFF
--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -455,6 +455,7 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
 
     if (SigMatchAppendSMToList(
                 de_ctx, s, DETECT_FILESTORE, (SigMatchCtx *)fd, g_file_match_list_id) == NULL) {
+        SCFree(fd);
         goto error;
     }
     s->filestore_ctx = fd;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6574

Describe changes:
- detect/filestore: fix memory leak on sig parsing introduced by commit c272a646c5ae739d18901776cc5a940afd3d3d38
