### PR TITLE
pgsql: improve probing function - v4

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -184,12 +184,10 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
         }
         PgsqlBEMessage::UnknownMessageType(RegularPacket {
             identifier: _,
-            length,
-            payload,
+            length: _,
+            payload: _,
         }) => {
-            // jb.set_string_from_bytes("identifier", identifier.to_vec())?;
-            jb.set_uint("length", (*length).into())?;
-            jb.set_string_from_bytes("payload", payload)?;
+            // We don't want to log these, for now. Cf redmine: #6576
         }
         PgsqlBEMessage::AuthenticationOk(_)
         | PgsqlBEMessage::AuthenticationCleartextPassword(_)

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -102,6 +102,13 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             js.set_string("message", req.to_str())?;
         }
+        PgsqlFEMessage::UnknownMessageType(RegularPacket {
+            identifier: _,
+            length: _,
+            payload: _,
+        }) => {
+            // We don't want to log these, for now. Cf redmine: #6576
+        }
     }
     js.close()?;
     Ok(js)

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -1056,7 +1056,6 @@ pub fn pgsql_parse_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
                 b'T' => parse_row_description(i)?,
                 b'A' => parse_notification_response(i)?,
                 b'D' => parse_consolidated_data_row(i)?,
-                // _ => return Err(Err::Error(make_error(i, ErrorKind::Switch))),
                 _ => {
                     let (i, payload) = rest(i)?;
                     let unknown = PgsqlBEMessage::UnknownMessageType (RegularPacket{

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -320,6 +320,7 @@ pub enum PgsqlFEMessage {
     SASLResponse(RegularPacket),
     SimpleQuery(RegularPacket),
     Terminate(TerminationMessage),
+    UnknownMessageType(RegularPacket),
 }
 
 impl PgsqlFEMessage {
@@ -332,6 +333,7 @@ impl PgsqlFEMessage {
             PgsqlFEMessage::SASLResponse(_) => "sasl_response",
             PgsqlFEMessage::SimpleQuery(_) => "simple_query",
             PgsqlFEMessage::Terminate(_) => "termination_message",
+            PgsqlFEMessage::UnknownMessageType(_) => "unknown_message_type",
         }
     }
 }
@@ -673,7 +675,17 @@ pub fn parse_request(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
         b'\0' => pgsql_parse_startup_packet(i)?,
         b'Q' => parse_simple_query(i)?,
         b'X' => parse_terminate_message(i)?,
-        _ => return Err(Err::Error(make_error(i, ErrorKind::Switch))),
+        _ => {
+            let (i, identifier) = be_u8(i)?;
+            let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+            let (i, payload) = take(length - PGSQL_LENGTH_FIELD)(i)?;
+            let unknown = PgsqlFEMessage::UnknownMessageType (RegularPacket{
+                identifier,
+                length,
+                payload: payload.to_vec(),
+            });
+            (i, unknown)
+        }
     };
     Ok((i, message))
 }

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -151,7 +151,7 @@ impl Default for PgsqlState {
         Self::new()
     }
 }
-    
+
 impl PgsqlState {
     pub fn new() -> Self {
         Self {
@@ -563,8 +563,20 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
     if input_len >= 1 && !input.is_null() {
 
         let slice: &[u8] = build_slice!(input, input_len as usize);
-        if probe_ts(slice) {
-            return ALPROTO_PGSQL;
+
+        match parser::parse_request(slice) {
+            Ok((_, request)) => {
+                if let PgsqlFEMessage::UnknownMessageType(_) = request {
+                    return ALPROTO_FAILED;
+                }
+                return ALPROTO_PGSQL;
+            }
+            Err(Err::Incomplete(_)) => {
+                return ALPROTO_UNKNOWN;
+            }
+            Err(_e) => {
+                return ALPROTO_FAILED;
+            }
         }
     }
     return ALPROTO_UNKNOWN;
@@ -584,7 +596,10 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
         }
 
         match parser::pgsql_parse_response(slice) {
-            Ok((_, _response)) => {
+            Ok((_, response)) => {
+                if let PgsqlBEMessage::UnknownMessageType(_) = response {
+                    return ALPROTO_FAILED;
+                }
                 return ALPROTO_PGSQL;
             }
             Err(Err::Incomplete(_)) => {

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -284,6 +284,11 @@ impl PgsqlState {
                 SCLogDebug!("Match: Terminate message");
                 Some(PgsqlStateProgress::ConnectionTerminated)
             }
+            PgsqlFEMessage::UnknownMessageType(_) => {
+                SCLogDebug!("Match: Unknown message type");
+                // Not changing state when we don't know the message
+                None
+            }
         }
     }
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/9917

Changes from previous PR:
- remove unittests still calling `probe_ts` function, causing CI check failures (thankfully)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6080

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1506