### PR TITLE
detect: negated content matches on absent buffer

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2192,6 +2192,12 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
     const InspectionBuffer *buffer = engine->v2.GetData(det_ctx, transforms,
             f, flags, txv, list_id);
     if (unlikely(buffer == NULL)) {
+        if (engine->smd->type == DETECT_CONTENT) {
+            DetectContentData *cd = (DetectContentData *)engine->smd->ctx;
+            if (cd->flags & DETECT_CONTENT_NEGATED) {
+                return DETECT_ENGINE_INSPECT_SIG_MATCH;
+            }
+        }
         return eof ? DETECT_ENGINE_INSPECT_SIG_CANT_MATCH :
                      DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2224

Describe changes:
- detect: negated content matches on absent buffer

```
SV_BRANCH=pr/1503
```
