### PR TITLE
detect/asn1: handle in PMATCH

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -218,7 +218,7 @@ fn asn1_decode<'a>(
 /// pointer must be freed using `rs_asn1_free`
 #[no_mangle]
 pub unsafe extern "C" fn rs_asn1_decode(
-    input: *const u8, input_len: u16, buffer_offset: u32, ad_ptr: *const DetectAsn1Data,
+    input: *const u8, input_len: u32, buffer_offset: u32, ad_ptr: *const DetectAsn1Data,
 ) -> *mut Asn1<'static> {
     if input.is_null() || input_len == 0 || ad_ptr.is_null() {
         return std::ptr::null_mut();

--- a/src/detect-asn1.h
+++ b/src/detect-asn1.h
@@ -26,4 +26,7 @@
 /* prototypes */
 void DetectAsn1Register (void);
 
+bool DetectAsn1Match(const SigMatchData *smd, const uint8_t *buffer, const uint32_t buffer_len,
+        const uint32_t offset);
+
 #endif /* __DETECT_ASN1_H__ */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -31,6 +31,7 @@
 #include "detect.h"
 #include "detect-engine.h"
 #include "detect-parse.h"
+#include "detect-asn1.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
 #include "detect-isdataat.h"
@@ -683,6 +684,13 @@ uint8_t DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThrea
                 }
             }
         }
+    } else if (smd->type == DETECT_ASN1) {
+        if (!DetectAsn1Match(smd, buffer, buffer_len, det_ctx->buffer_offset)) {
+            SCLogDebug("asn1 no_match");
+            goto no_match;
+        }
+        SCLogDebug("asn1 match");
+        goto match;
     } else {
         SCLogDebug("sm->type %u", smd->type);
 #ifdef DEBUG


### PR DESCRIPTION
Since the asn1 keyword is processing payload data, move the handling of the keyword into the PMATCH with content inspection.

Use u32 as buffer length in the Rust FFI

replaces #9922