### PR TITLE
userguide: fix css for readthedocs hosted userguide - v1

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -137,20 +137,15 @@ if not on_rtd:
         html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     except:
         html_theme = 'default'
-    def setup(app):
-        if hasattr(app, 'add_css_file'):
-            app.add_css_file('css/suricata.css')
-        else:
-            app.add_stylesheet('css/suricata.css')
 else:
     html_theme = 'sphinx_rtd_theme'
-    html_context = {
-        'css_files': [
-            'https://media.readthedocs.org/css/sphinx_rtd_theme.css',
-            'https://media.readthedocs.org/css/readthedocs-doc-embed.css',
-            '_static/css/suricata.css',
-        ],
-    }
+
+# Add in our own stylesheet.
+def setup(app):
+    if hasattr(app, 'add_css_file'):
+        app.add_css_file('css/suricata.css')
+    else:
+        app.add_stylesheet('css/suricata.css')
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Looks like we were just using outdated CSS files, so instead, don't manually
bring in any ReadTheDocs CSS files.

Bug: https://redmine.openinfosecfoundation.org/issues/6589

Example of current broken output (note the actions list without bullets):
  https://docs.suricata.io/en/suricata-7.0.2/rules/intro.html#action

And with this patch:
  https://jasonish-suricata.readthedocs.io/en/latest/rules/intro.html#action

There will be other changes as well by using newer CSS, one appears to be extra spacing in the main TOC as can be seen here:
  https://jasonish-suricata.readthedocs.io/en/latest/index.html
