### PR TITLE
Stats udp prefix 6304 v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3776,6 +3776,9 @@
                                 "krb5_udp": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
+                                "modbus": {
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
                                 "mqtt": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1063,14 +1063,17 @@ void AppLayerSetupCounters(void)
         const uint8_t ipproto_map = FlowGetProtoMapping(ipproto);
         const uint8_t other_ipproto = ipproto == IPPROTO_TCP ? IPPROTO_UDP : IPPROTO_TCP;
         const char *ipproto_suffix = (ipproto == IPPROTO_TCP) ? "_tcp" : "_udp";
+        uint8_t ipprotos[256 / 8];
 
         for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
             if (alprotos[alproto] == 1) {
                 const char *tx_str = "app_layer.tx.";
                 const char *alproto_str = AppLayerGetProtoName(alproto);
 
-                if (AppLayerParserProtoIsRegistered(ipproto, alproto) &&
-                        AppLayerParserProtoIsRegistered(other_ipproto, alproto)) {
+                memset(ipprotos, 0, sizeof(ipprotos));
+                AppLayerProtoDetectSupportedIpprotos(alproto, ipprotos);
+                if ((ipprotos[IPPROTO_TCP / 8] & (1 << (IPPROTO_TCP % 8))) &&
+                        (ipprotos[IPPROTO_UDP / 8] & (1 << (IPPROTO_UDP % 8)))) {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
                             "%s%s%s", str, alproto_str, ipproto_suffix);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6304

Describe changes:
- fix missing _udp or _tcp suffix in stats for protocols on both

#9934 with S-V test + different fix reusing `AppLayerProtoDetectSupportedIpprotos` instead of `AppLayerParserProtoIsRegistered` (that will also work for detection-only)


```
SV_BRANCH=pr/1504
```
https://github.com/OISF/suricata-verify/pull/1504