### PR TITLE
Stats udp prefix 6304 v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3776,6 +3776,9 @@
                                 "krb5_udp": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
+                                "modbus": {
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
                                 "mqtt": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6304

Describe changes:
- fix missing _udp or _tcp suffix in stats for protocols on both

#9942 removing now unused variable and the warning for it

```
SV_BRANCH=pr/1504
```
https://github.com/OISF/suricata-verify/pull/1504