### PR TITLE
time: Retain usecs from in new value

### DIFF
--- a/src/util-time.h
+++ b/src/util-time.h
@@ -56,7 +56,11 @@ typedef struct {
 #define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
-#define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
+#define SCTIME_ADD_SECS(ts, s)                                                                     \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = (ts).secs + (s), .usecs = (ts).usecs                                               \
+    }
 #define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))
 #define SCTIME_FROM_SECS(s)                                                                        \
     (SCTime_t)                                                                                     \


### PR DESCRIPTION
Issue: 6584

Retain the useconds portion of the timestamp when creating the new structure

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6584](https://redmine.openinfosecfoundation.org/issues/6584)

Describe changes:
- Retain `usecs` from existing time structure

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
