### PR TITLE
config/mt: Add vlan-tuple MT selector

### DIFF
--- a/python/suricata/sc/specs.py
+++ b/python/suricata/sc/specs.py
@@ -69,8 +69,9 @@ argsd = {
             "required": 1,
         },
         {
-            "name": "hargs",
+            "name": "hargs_tuple",
             "type": int,
+            "variable": 1,
             "required": 0,
         },
     ],
@@ -85,8 +86,9 @@ argsd = {
             "required": 1,
         },
         {
-            "name": "hargs",
+            "name": "hargs_tuple",
             "type": int,
+            "variable": 1,
             "required": 0,
         },
     ],

--- a/python/suricata/sc/suricatasc.py
+++ b/python/suricata/sc/suricatasc.py
@@ -220,6 +220,7 @@ class SuricataSC:
         arguments = dict()
         for c, spec in enumerate(cmd_specs, 1):
             spec_type = str if "type" not in spec else spec["type"]
+            variable =  False if "variable" not in spec else spec["variable"]
             if spec["required"]:
                 if spec.get("val"):
                     arguments[spec["name"]] = spec_type(spec["val"])
@@ -233,7 +234,12 @@ class SuricataSC:
                 except ValueError as ve:
                     raise SuricataCommandException("L{}: Erroneous arguments: {}".format(get_linenumber(), ve))
             elif c < len(full_cmd):
-                arguments[spec["name"]] = spec_type(full_cmd[c])
+                if variable:
+                    arguments[spec["name"]] = []
+                    for var in full_cmd[c:]:
+                        arguments[spec["name"]].append(spec_type(var))
+                else:
+                    arguments[spec["name"]] = spec_type(full_cmd[c])
         return cmd, arguments
 
     def parse_command(self, command):
@@ -279,7 +285,7 @@ class SuricataSC:
                         continue
                     cmdret = self.send_command(cmd, arguments)
                 except (SuricataCommandException, SuricataReturnException) as err:
-                    print("An exception occured: " + str(err.value))
+                    print("An exception occurred: " + str(err.value))
                     continue
                 #decode json message
                 if cmdret["return"] == "NOK":

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -101,6 +101,7 @@ static char TenantIdCompare(void *d1, uint16_t d1_len, void *d2, uint16_t d2_len
 static void TenantIdFree(void *d);
 static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
+static uint32_t DetectEngineTenantGetIdFromVlanIdTuple(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
 
 static DetectEngineAppInspectionEngine *g_app_inspect_engines = NULL;
@@ -3182,6 +3183,10 @@ static TmEcode DetectEngineThreadCtxInitForMT(ThreadVars *tv, DetectEngineThread
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanId;
             SCLogDebug("TENANT_SELECTOR_VLAN");
             break;
+        case TENANT_SELECTOR_VLAN_TUPLE:
+            det_ctx->TenantGetId = DetectEngineTenantGetIdFromVlanIdTuple;
+            SCLogDebug("TENANT_SELECTOR_VLAN_TUPLE");
+            break;
         case TENANT_SELECTOR_LIVEDEV:
             det_ctx->TenantGetId = DetectEngineTenantGetIdFromLivedev;
             SCLogDebug("TENANT_SELECTOR_LIVEDEV");
@@ -4146,8 +4151,8 @@ error:
     return 0;
 }
 
-static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings_root_node,
-        bool failure_fatal)
+static int DetectEngineMultiTenantSetupLoadVlanMappings(enum DetectEngineTenantSelectors selector,
+        const ConfNode *mappings_root_node, bool failure_fatal)
 {
     ConfNode *mapping_node = NULL;
 
@@ -4156,9 +4161,6 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
         TAILQ_FOREACH(mapping_node, &mappings_root_node->head, next) {
             ConfNode *tenant_id_node = ConfNodeLookupChild(mapping_node, "tenant-id");
             if (tenant_id_node == NULL)
-                goto bad_mapping;
-            ConfNode *vlan_id_node = ConfNodeLookupChild(mapping_node, "vlan-id");
-            if (vlan_id_node == NULL)
                 goto bad_mapping;
 
             uint32_t tenant_id = 0;
@@ -4170,25 +4172,67 @@ static int DetectEngineMultiTenantSetupLoadVlanMappings(const ConfNode *mappings
                 goto bad_mapping;
             }
 
-            uint16_t vlan_id = 0;
-            if (StringParseUint16(
-                        &vlan_id, 10, (uint16_t)strlen(vlan_id_node->val), vlan_id_node->val) < 0) {
-                SCLogError("vlan-id  "
-                           "of %s is invalid",
-                        vlan_id_node->val);
-                goto bad_mapping;
-            }
-            if (vlan_id == 0 || vlan_id >= 4095) {
-                SCLogError("vlan-id  "
-                           "of %s is invalid. Valid range 1-4094.",
-                        vlan_id_node->val);
-                goto bad_mapping;
-            }
+            if (selector == TENANT_SELECTOR_VLAN) {
+                ConfNode *vlan_id_node = ConfNodeLookupChild(mapping_node, "vlan-id");
+                if (vlan_id_node == NULL)
+                    goto bad_mapping;
 
-            if (DetectEngineTenantRegisterVlanId(tenant_id, vlan_id) != 0) {
-                goto error;
+                uint16_t vlan_id = 0;
+                if (StringParseU16RangeCheck(&vlan_id, 10, (uint16_t)strlen(vlan_id_node->val),
+                            vlan_id_node->val, 1, 4094) < 0) {
+                    SCLogError("vlan-id  "
+                               "of %s is invalid; must be %d-4094",
+                            vlan_id_node->val, 1);
+                    goto bad_mapping;
+                }
+                if (DetectEngineTenantRegisterVlanId(tenant_id, vlan_id) != 0) {
+                    goto error;
+                }
+                SCLogConfig("vlan %u connected to tenant-id %u", vlan_id, tenant_id);
+            } else if (selector == TENANT_SELECTOR_VLAN_TUPLE) {
+
+                ConfNode *vlan_tuple = ConfNodeLookupChild(mapping_node, "vlan-tuple");
+                ConfNode *field;
+                int16_t idx = 0;
+                uint16_t vlan_id = 0;
+                TrafficId traffic_id = { 0 };
+                TAILQ_FOREACH (field, &vlan_tuple->head, next) {
+                    /* "0" is a wild card value (matches any vlan) so permit it */
+                    if (StringParseU16RangeCheck(&vlan_id, 10, (uint16_t)strlen(field->val),
+                                field->val, 0, 4094) < 0) {
+                        SCLogError("vlan value %s is invalid; must be 0-4094", field->val);
+                        goto bad_mapping;
+                    }
+                    traffic_id.vlan.tuple[idx++] = vlan_id;
+                }
+                traffic_id.vlan.count = idx;
+
+                /* Reject if all vlan ids have wildcard values */
+                bool all_wildcard = true;
+                for (int i = 0; i < traffic_id.vlan.count; i++) {
+                    if (traffic_id.vlan.tuple[i] != 0) {
+                        all_wildcard = false;
+                        break;
+                    }
+                }
+
+                if (all_wildcard) {
+                    SCLogError("Cannot use wild-card values for all vlan ids");
+                    goto error;
+                }
+
+                if (traffic_id.vlan.tuple[1] == 0) {
+                    SCLogConfig("tenant id: %d, Since the inner VLAN id value is the wildcard "
+                                "value (0); suggest the use of "
+                                "the selector \"vlan\" instead.",
+                            tenant_id);
+                }
+
+                if (DetectEngineTenantRegisterVlanIdTuple(tenant_id, traffic_id) != 0)
+                    goto error;
+                SCLogConfig("vlan-tuple %u:%u connected to tenant-id %u", traffic_id.vlan.tuple[0],
+                        traffic_id.vlan.tuple[1], tenant_id);
             }
-            SCLogConfig("vlan %u connected to tenant-id %u", vlan_id, tenant_id);
             mapping_cnt++;
             continue;
 
@@ -4232,17 +4276,20 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         if (ConfGet("multi-detect.selector", &handler) == 1) {
             SCLogConfig("multi-tenant selector type %s", handler);
 
-            if (strcmp(handler, "vlan") == 0) {
-                tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
+            if (strcmp(handler, "vlan") == 0 || strcmp(handler, "vlan-tuple") == 0) {
+                if (strcmp(handler, "vlan") == 0)
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN;
+                else
+                    tenant_selector = master->tenant_selector = TENANT_SELECTOR_VLAN_TUPLE;
 
                 int vlanbool = 0;
                 if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
                     SCLogError("vlan tracking is disabled, "
-                               "can't use multi-detect selector 'vlan'");
+                               "can't use multi-detect selector '%s'",
+                            handler);
                     SCMutexUnlock(&master->lock);
                     goto error;
                 }
-
             } else if (strcmp(handler, "direct") == 0) {
                 tenant_selector = master->tenant_selector = TENANT_SELECTOR_DIRECT;
             } else if (strcmp(handler, "device") == 0) {
@@ -4267,12 +4314,13 @@ int DetectEngineMultiTenantSetup(const bool unix_socket)
         /* traffic -- tenant mappings */
         ConfNode *mappings_root_node = ConfGetNode("multi-detect.mappings");
 
-        if (tenant_selector == TENANT_SELECTOR_VLAN) {
-            int mapping_cnt = DetectEngineMultiTenantSetupLoadVlanMappings(mappings_root_node,
-                    failure_fatal);
+        if (tenant_selector == TENANT_SELECTOR_VLAN ||
+                tenant_selector == TENANT_SELECTOR_VLAN_TUPLE) {
+            int mapping_cnt = DetectEngineMultiTenantSetupLoadVlanMappings(
+                    tenant_selector, mappings_root_node, failure_fatal);
             if (mapping_cnt == 0) {
-                /* no mappings are valid when we're in unix socket mode,
-                 * they can be added on the fly. Otherwise warn/error
+                /* no mappings are valid only when in unix socket mode,
+                 * as they can be added on the fly. Otherwise warn/error
                  * depending on failure_fatal */
 
                 if (unix_socket) {
@@ -4379,23 +4427,64 @@ error:
 
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p)
 {
-    const DetectEngineThreadCtx *det_ctx = ctx;
-    uint32_t x = 0;
-    uint32_t vlan_id = 0;
-
     if (p->vlan_idx == 0)
         return 0;
 
-    vlan_id = p->vlan_id[0];
-
+    const DetectEngineThreadCtx *det_ctx = ctx;
     if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
         return 0;
 
     /* not very efficient, but for now we're targeting only limited amounts.
      * Can use hash/tree approach later. */
-    for (x = 0; x < det_ctx->tenant_array_size; x++) {
-        if (det_ctx->tenant_array[x].traffic_id == vlan_id)
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id.vlan.count != p->vlan_idx)
+            continue;
+        if (det_ctx->tenant_array[x].traffic_id.vlan.tuple[0] == p->vlan_id[0])
             return det_ctx->tenant_array[x].tenant_id;
+    }
+
+    return 0;
+}
+
+/* Match if the configured vlan match is a wildcard or the vlan ids match */
+#define VLAN_TUPLE_MATCH(tenant_val, traffic_val) ((tenant_val == 0) || (tenant_val == traffic_val))
+
+#define TRAFFIC_ID_VLAN_TUPLE_MATCH(tenant_val, traffic_id)                                        \
+    ({                                                                                             \
+        bool match = false;                                                                        \
+        if (tenant_val.vlan.count == traffic_id.vlan.count) {                                      \
+            match = true;                                                                          \
+            for (int i = 0; i < tenant_val.vlan.count; i++) {                                      \
+                if (tenant_val.vlan.tuple[i] != traffic_id.vlan.tuple[i]) {                        \
+                    match = false;                                                                 \
+                    break;                                                                         \
+                }                                                                                  \
+            }                                                                                      \
+        }                                                                                          \
+        match;                                                                                     \
+    })
+static uint32_t DetectEngineTenantGetIdFromVlanIdTuple(const void *ctx, const Packet *p)
+{
+    if (p->vlan_idx == 0)
+        return 0;
+
+    const DetectEngineThreadCtx *det_ctx = ctx;
+    if (det_ctx == NULL || det_ctx->tenant_array == NULL || det_ctx->tenant_array_size == 0)
+        return 0;
+
+    TrafficId traffic_id = {
+        .vlan.count = p->vlan_idx, .vlan.tuple[0] = p->vlan_id[0], .vlan.tuple[1] = p->vlan_id[1]
+    };
+
+    /* not very efficient, but for now we're targeting only limited amounts.
+     * Can use hash/tree approach later. */
+    for (uint32_t x = 0; x < det_ctx->tenant_array_size; x++) {
+        if (det_ctx->tenant_array[x].traffic_id.vlan.count != p->vlan_idx)
+            continue;
+
+        if (TRAFFIC_ID_VLAN_TUPLE_MATCH(det_ctx->tenant_array[x].traffic_id, traffic_id)) {
+            return det_ctx->tenant_array[x].tenant_id;
+        }
     }
 
     return 0;
@@ -4414,7 +4503,7 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
 }
 
 static int DetectEngineTenantRegisterSelector(
-        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
+        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, TrafficId traffic_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);
@@ -4427,10 +4516,18 @@ static int DetectEngineTenantRegisterSelector(
 
     DetectEngineTenantMapping *m = master->tenant_mapping_list;
     while (m) {
-        if (m->traffic_id == traffic_id) {
-            SCLogInfo("traffic id already registered");
-            SCMutexUnlock(&master->lock);
-            return -1;
+        if (selector == TENANT_SELECTOR_VLAN_TUPLE) {
+            if (TRAFFIC_ID_VLAN_TUPLE_MATCH(m->traffic_id, traffic_id)) {
+                SCLogInfo("traffic id already registered");
+                SCMutexUnlock(&master->lock);
+                return -1;
+            }
+        } else {
+            if (m->traffic_id.id == traffic_id.id) {
+                SCLogInfo("traffic id already registered");
+                SCMutexUnlock(&master->lock);
+                return -1;
+            }
         }
         m = m->next;
     }
@@ -4449,13 +4546,24 @@ static int DetectEngineTenantRegisterSelector(
 
     master->tenant_selector = selector;
 
-    SCLogDebug("tenant handler %u %u %u registered", selector, tenant_id, traffic_id);
+    if (sc_log_global_log_level >= SC_LOG_DEBUG) {
+        if (selector == TENANT_SELECTOR_VLAN) {
+            SCLogDebug("tenant handler %u %u %u registered", selector, tenant_id,
+                    traffic_id.vlan.tuple[0]);
+        } else if (selector == TENANT_SELECTOR_VLAN_TUPLE) {
+            SCLogDebug("tenant handler %u %u [%u, %u, %u] registered", selector, tenant_id,
+                    traffic_id.vlan.tuple[0], traffic_id.vlan.tuple[1], traffic_id.vlan.tuple[2]);
+        } else {
+            SCLogDebug("tenant handler %u %u %u registered", selector, tenant_id, traffic_id.id);
+        }
+    }
+
     SCMutexUnlock(&master->lock);
     return 0;
 }
 
 static int DetectEngineTenantUnregisterSelector(
-        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, uint32_t traffic_id)
+        enum DetectEngineTenantSelectors selector, uint32_t tenant_id, TrafficId traffic_id)
 {
     DetectEngineMasterCtx *master = &g_master_de_ctx;
     SCMutexLock(&master->lock);
@@ -4468,9 +4576,7 @@ static int DetectEngineTenantUnregisterSelector(
     DetectEngineTenantMapping *prev = NULL;
     DetectEngineTenantMapping *map = master->tenant_mapping_list;
     while (map) {
-        if (map->traffic_id == traffic_id &&
-            map->tenant_id == tenant_id)
-        {
+        if (map->traffic_id.id == traffic_id.id && map->tenant_id == tenant_id) {
             if (prev != NULL)
                 prev->next = map->next;
             else
@@ -4478,7 +4584,7 @@ static int DetectEngineTenantUnregisterSelector(
 
             map->next = NULL;
             SCFree(map);
-            SCLogInfo("tenant handler %u %u %u unregistered", selector, tenant_id, traffic_id);
+            SCLogInfo("tenant handler %u %u %u unregistered", selector, tenant_id, traffic_id.id);
             SCMutexUnlock(&master->lock);
             return 0;
         }
@@ -4492,30 +4598,44 @@ static int DetectEngineTenantUnregisterSelector(
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id)
 {
-    return DetectEngineTenantRegisterSelector(
-            TENANT_SELECTOR_LIVEDEV, tenant_id, (uint32_t)device_id);
+    TrafficId traffic_id = { .id = device_id };
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_LIVEDEV, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 {
-    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN, tenant_id, (uint32_t)vlan_id);
+    TrafficId traffic_id = { .vlan.tuple[0] = vlan_id, .vlan.count = 1 };
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id)
 {
-    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN, tenant_id, (uint32_t)vlan_id);
+    TrafficId traffic_id = { .vlan.tuple[0] = vlan_id, .vlan.count = 1 };
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN, tenant_id, traffic_id);
+}
+
+int DetectEngineTenantRegisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id)
+{
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_VLAN_TUPLE, tenant_id, traffic_id);
+}
+
+int DetectEngineTenantUnregisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id)
+{
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_VLAN_TUPLE, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id)
 {
+    TrafficId traffic_id = { .id = 0 };
     SCLogInfo("registering %u %d 0", TENANT_SELECTOR_DIRECT, tenant_id);
-    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, 0);
+    return DetectEngineTenantRegisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, traffic_id);
 }
 
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id)
 {
+    TrafficId traffic_id = { .id = 0 };
     SCLogInfo("unregistering %u %d 0", TENANT_SELECTOR_DIRECT, tenant_id);
-    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, 0);
+    return DetectEngineTenantUnregisterSelector(TENANT_SELECTOR_DIRECT, tenant_id, traffic_id);
 }
 
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p)

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -133,8 +133,12 @@ int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int r
 int DetectEngineReloadTenantsBlocking(const int reload_cnt);
 
 int DetectEngineTenantRegisterLivedev(uint32_t tenant_id, int device_id);
+int DetectEngineTenantRegisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantUnregisterVlanIdInner(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantRegisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
 int DetectEngineTenantUnregisterVlanId(uint32_t tenant_id, uint16_t vlan_id);
+int DetectEngineTenantRegisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
+int DetectEngineTenantUnregisterVlanIdTuple(uint32_t tenant_id, TrafficId traffic_id);
 int DetectEngineTenantRegisterPcapFile(uint32_t tenant_id);
 int DetectEngineTenantUnregisterPcapFile(uint32_t tenant_id);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1494,19 +1494,27 @@ typedef struct SigGroupHead_ {
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 
-enum DetectEngineTenantSelectors
-{
-    TENANT_SELECTOR_UNKNOWN = 0,    /**< not set */
-    TENANT_SELECTOR_DIRECT,         /**< method provides direct tenant id */
-    TENANT_SELECTOR_VLAN,           /**< map vlan to tenant id */
-    TENANT_SELECTOR_LIVEDEV,        /**< map livedev to tenant id */
+enum DetectEngineTenantSelectors {
+    TENANT_SELECTOR_UNKNOWN = 0, /**< not set */
+    TENANT_SELECTOR_DIRECT,      /**< method provides direct tenant id */
+    TENANT_SELECTOR_VLAN,        /**< map vlan to tenant id */
+    TENANT_SELECTOR_LIVEDEV,     /**< map livedev to tenant id */
+    TENANT_SELECTOR_VLAN_TUPLE,  /**< map vlan tuple to tenant id */
 };
+
+typedef union _traffic_id {
+    uint32_t id;
+    struct TrafficIdVlan_ {
+        uint16_t tuple[VLAN_MAX_LAYERS];
+        uint16_t count;
+    } vlan;
+} TrafficId;
 
 typedef struct DetectEngineTenantMapping_ {
     uint32_t tenant_id;
 
     /* traffic id that maps to the tenant id */
-    uint32_t traffic_id;
+    TrafficId traffic_id;
 
     struct DetectEngineTenantMapping_ *next;
 } DetectEngineTenantMapping;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1283,10 +1283,11 @@ host-mode: auto
 # or trigger some modifications of the engine. Set enabled to yes
 # to activate the feature. In auto mode, the feature will only be
 # activated in live capture mode. You can use the filename variable to set
-# the file name of the socket.
+# the file name of the socket. The default socket filename is
+# suricata-command.socket
 unix-command:
   enabled: auto
-  #filename: custom.socket
+  #filename: suricata-command.socket
 
 # Magic file. The extension .mgc is added to the value here.
 #magic-file: /usr/share/file/magic


### PR DESCRIPTION
Continuation of #9747

Add a new MT selector type to support use cases where a VLAN tuple should be used to determine the MT tenant.

Packets with one VLAN id will never match as `vlan-tuple` requires at least QinQ.

The tuple can hold up to 3 values -- this is the max supported by Suricata atm.

Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 5]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id is `5`

Wild card values are supported; values of 0 match 'any VLAN' value in the same position as expressed in the tuple:
Tenants are selected by specifying a VLAN tuple, e.g., `[1010, 0]`. A packet matches when:
- It has double VLAN encapsulation
- The outer VLAN id is `1015`
- The inner VLAN id always matches since it's a wildcard value.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6237](https://redmine.openinfosecfoundation.org/issues/6237)

Describe changes:
- Add and document a new MT selector -- `vlan-tuple` -- for use cases where a VLAN pair should determines the tenant.

Updates
- Documentation fixups per @jufajardini 
- Document default unix command socket filename.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1354
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
