### PR TITLE
util/time: Improve usecs handling in time macros

### DIFF
--- a/src/util-time.h
+++ b/src/util-time.h
@@ -56,7 +56,11 @@ typedef struct {
 #define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
-#define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
+#define SCTIME_ADD_SECS(ts, s)                                                                     \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = (ts).secs + (s), .usecs = (ts).usecs                                               \
+    }
 #define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))
 #define SCTIME_FROM_SECS(s)                                                                        \
     (SCTime_t)                                                                                     \
@@ -83,7 +87,7 @@ typedef struct {
 #define SCTIME_FROM_TIMESPEC(ts)                                                                   \
     (SCTime_t)                                                                                     \
     {                                                                                              \
-        .secs = (ts)->tv_sec, .usecs = (ts)->tv_nsec * 1000                                        \
+        .secs = (ts)->tv_sec, .usecs = (ts)->tv_nsec / 1000                                        \
     }
 
 #define SCTIME_TO_TIMEVAL(tv, t)                                                                   \


### PR DESCRIPTION
Fix SCTIME_ADD_SECS zeroing subsecond part

When adding s seconds to SCtime_t ts, don't zero out the ts.usecs field.

Fixes Redmine Bug #6584

Fix SCTIME_FROM_TIMESPEC garbage microseconds part

When converting nanosecond to microseconds divide by 1000 instead of multiplying by 1000.

Fixes Redmine bug #6585

- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
