### PR TITLE
detect: flush when setting no_inspection

### DIFF
--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -371,8 +371,19 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
     StreamTcp(tv, p, fw->stream_thread, &fw->pq);
     FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_STREAM);
 
-    if (FlowChangeProto(p->flow)) {
+    // this is the first packet that sets no payload inspection
+    bool setting_nopayload =
+            (p->flow->flags & FLOW_NOPAYLOAD_INSPECTION) && !(p->flags & PKT_NOPAYLOAD_INSPECTION);
+    if (FlowChangeProto(p->flow) || setting_nopayload) {
+        if (setting_nopayload) {
+            // We still need to flush detection on previous packets.
+            // The pseudo packets should not have NOPAYLOAD_INSPECTION set yet.
+            p->flow->flags &= ~FLOW_NOPAYLOAD_INSPECTION;
+        }
         StreamTcpDetectLogFlush(tv, fw->stream_thread, p->flow, p, &fw->pq);
+        if (setting_nopayload) {
+            p->flow->flags |= FLOW_NOPAYLOAD_INSPECTION;
+        }
         AppLayerParserStateSetFlag(p->flow->alparser, APP_LAYER_PARSER_EOF_TS);
         AppLayerParserStateSetFlag(p->flow->alparser, APP_LAYER_PARSER_EOF_TC);
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6578

Describe changes:
- detect: flush when setting no_inspection

So that we can run detection on the clear text of ssh new keys packet

```
SV_BRANCH=pr/1507
```
https://github.com/OISF/suricata-verify/pull/1507

#9903 rebased with newer S-V PR to get green CI