### PR TITLE
pgsql: use static str for log & remove whitespaces - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -79,7 +79,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
             if flags & PGSQL_LOG_PASSWORDS != 0 {
                 js.set_string_from_bytes("password", payload)?;
             } else {
-                js.set_string(req.to_str(), "password log disabled")?;
+                js.set_string("password_message", "password_log_disabled")?;
             }
         }
         PgsqlFEMessage::SASLResponse(RegularPacket {


### PR DESCRIPTION
Removing the white spaces from the password message, as these can cause issues with grepping commands querying log results, and also doesn't show a consistent behavior among different environments.

Also replace function call with static str, as it wasn't needed there.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None yet, will create one if we decide we want to merge and backport this

Describe changes:
- replace call to `to_str()` with static string in logging call
- replace whitespaces in pgsql password not enabled message with `_` as it's more query friendly


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1511
