### PR TITLE
doc: add file name details 5088 v2 

### DIFF
--- a/doc/userguide/rules/ftp-keywords.rst
+++ b/doc/userguide/rules/ftp-keywords.rst
@@ -29,3 +29,15 @@ Detect FTP bounce attacks.
 Syntax::
 
   ftpbounce
+
+file.name
+---------
+
+The ``file.name`` keyword can be used at the FTP application level.
+
+Example::
+
+alert ftp-data any any -> any any (msg:"ftp layer file.name keyword usage"; \
+file.name; content:"file.txt"; classtype:bad-unknown; sid:1; rev:1;)
+
+For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.

--- a/doc/userguide/rules/ftp-keywords.rst
+++ b/doc/userguide/rules/ftp-keywords.rst
@@ -1,6 +1,8 @@
 FTP/FTP-DATA Keywords
 =====================
 
+.. role:: example-rule-options
+
 ftpdata_command
 ---------------
 
@@ -12,14 +14,13 @@ Syntax::
 
   ftpdata_command:(retr|stor)
 
-Examples::
+Signature Example:
 
-  ftpdata_command:retr
-  ftpdata_command:stor
+.. container:: example-rule
 
-Signature example::
-
- alert ftp-data any any -> any any (msg:"FTP store password"; filestore; filename:"password"; ftpdata_command:stor; sid:3; rev:1;)
+  alert ftp-data any any -> any any (msg:"FTP store password"; \
+  filestore; filename:"password"; \
+  :example-rule-options:`ftpdata_command:stor;` sid:3; rev:1;)
 
 ftpbounce
 ---------
@@ -35,9 +36,12 @@ file.name
 
 The ``file.name`` keyword can be used at the FTP application level.
 
-Example::
+Signature Example:
 
-alert ftp-data any any -> any any (msg:"ftp layer file.name keyword usage"; \
-file.name; content:"file.txt"; classtype:bad-unknown; sid:1; rev:1;)
+.. container:: example-rule
+
+  alert ftp-data any any -> any any (msg:"FTP file.name usage"; \
+  :example-rule-options:`file.name; content:"file.txt";` \
+  classtype:bad-unknown; sid:1; rev:1;)
 
 For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -44,6 +44,7 @@ http.accept_enc                http_accept_enc (*)      Request
 http.referer                   http_referer (*)         Request
 http.connection                http_connection (*)      Both
 file.data                      file_data (*)            Both
+file.name                      filename (*)             Request
 http.content_type              http_content_type (*)    Both
 http.content_len               http_content_len (*)     Both
 http.start                     http_start (*)           Both
@@ -670,7 +671,6 @@ Example::
     alert http any any -> any any (flow:to_client; \
             http.location; content:"http://www.google.com"; sid:1;)
 
-
 http.host and http.host.raw
 ---------------------------
 
@@ -844,3 +844,15 @@ Multiple Buffer Matching
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``file.data`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+file.name
+---------
+
+The ``file.name`` keyword can be used at the HTTP application level.
+
+Example::
+
+  alert http any any -> any any (msg:"http layer file.name keyword usage"; \
+  file.name; content:"picture.jpg"; classtype:bad-unknown; sid:1; rev:1;)
+
+For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -34,6 +34,7 @@ Suricata Rules
    http2-keywords
    quic-keywords
    nfs-keywords
+   smtp-keywords
    app-layer
    xbits
    thresholding

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -33,6 +33,7 @@ Suricata Rules
    ike-keywords
    http2-keywords
    quic-keywords
+   nfs-keywords
    app-layer
    xbits
    thresholding

--- a/doc/userguide/rules/nfs-keywords.rst
+++ b/doc/userguide/rules/nfs-keywords.rst
@@ -1,0 +1,19 @@
+NFS Keywords
+============
+
+.. role:: example-rule-options
+
+file.name
+---------
+
+The ``file.name`` keyword can be used at the NFS application level. 
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert nfs any any -> any any (msg:"NFS file.name usage"; \
+  :example-rule-options:`file.name; content:"file.txt";` \
+  classtype:bad-unknown; sid:1; rev:1;)
+
+For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.

--- a/doc/userguide/rules/smb-keywords.rst
+++ b/doc/userguide/rules/smb-keywords.rst
@@ -1,6 +1,8 @@
 SMB Keywords
 ==============
 
+.. role:: example-rule-options
+
 SMB keywords used in both SMB1 and SMB2 protocols.
 
 smb.named_pipe
@@ -58,3 +60,18 @@ Examples::
 ``smb.ntlmssp_domain`` is a 'sticky buffer'.
 
 ``smb.ntlmssp_domain`` can be used as ``fast_pattern``.
+
+file.name
+---------
+
+The ``file.name`` keyword can be used at the SMB application level. 
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert smb any any -> any any (msg:"SMB file.name usage"; \
+  :example-rule-options:`file.name; content:"file.txt";` \
+  classtype:bad-unknown; sid:1; rev:1;)
+
+For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.

--- a/doc/userguide/rules/smtp-keywords.rst
+++ b/doc/userguide/rules/smtp-keywords.rst
@@ -1,0 +1,19 @@
+SMTP Keywords
+=============
+
+.. role:: example-rule-options
+
+file.name
+---------
+
+The ``file.name`` keyword can be used at the SMTP application level. 
+
+Signature Example:
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"SMTP file.name usage"; \
+  :example-rule-options:`file.name; content:"winmail.dat";` \
+  classtype:bad-unknown; sid:1; rev:1;)
+
+For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5088

Describe changes:
- updated signature examples to use rule container
- added asterisk to denote sticky buffer for http keyword table
- HTTP2 does not currently support file name keyword usage so that was left out of docs

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
