### PR TITLE
configure: fix llc detection on recent Ubuntu/Debian

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,7 +450,7 @@
           [
             AS_IF([test "$CLANG" != no],
                   [
-                    llc_candidates=$($CLANG --version | \
+                    llc_candidates=$($CLANG --version | sed -e 's/.*clang version/clang version/' | \
                       awk '/^clang version/ {
                              split($3, v, ".");
                              printf("llc-%s.%s llc-%s llc", v[[1]], v[[2]], v[[1]])


### PR DESCRIPTION
Cherry-pick of 37b1595c20959353ec438860dc5a49bcae227aa8 
Redmine Ticket: #4262
https://redmine.openinfosecfoundation.org/issues/4262


Where clang --version was returning:

clang version 9.0.1-15+b1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

Newer version like clang-10 on Debian are returning:

Debian clang version 10.0.1-8+b1
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

As a result, the parsing was failing to determine which llc was available on the system.
