### PR TITLE
pgsql: don't log password msg if password logging disabled - v2

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -78,8 +78,6 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             if flags & PGSQL_LOG_PASSWORDS != 0 {
                 js.set_string_from_bytes("password", payload)?;
-            } else {
-                js.set_string(req.to_str(), "password log disabled")?;
             }
         }
         PgsqlFEMessage::SASLResponse(RegularPacket {


### PR DESCRIPTION
If the logging of the password is disabled, there isn't much point in
logging the password message itself.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6603

Previous PR: https://github.com/OISF/suricata/pull/9968

Describe changes:
- don't log the password message at all if this is disabled in the config.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1514