### PR TITLE
util/time: Improve SCTIME macro handling of seconds and useconds

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -931,19 +931,19 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
          */
         switch (NT_NET_GET_PKT_TIMESTAMP_TYPE(packet_buffer)) {
             case NT_TIMESTAMP_TYPE_NATIVE_UNIX:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts / 100000000),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts / 100000000),
                         ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_PCAP:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts >> 32), pkt_ts & 0xFFFFFFFF);
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts >> 32), pkt_ts & 0xFFFFFFFF);
                 break;
             case NT_TIMESTAMP_TYPE_PCAP_NANOTIME:
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS(pkt_ts >> 32),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS(pkt_ts >> 32),
                         ((pkt_ts & 0xFFFFFFFF) / 1000) + ((pkt_ts % 1000) > 500 ? 1 : 0));
                 break;
             case NT_TIMESTAMP_TYPE_NATIVE_NDIS:
                 /* number of seconds between 1/1/1601 and 1/1/1970 */
-                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_USECS((pkt_ts / 100000000) - 11644473600),
+                p->ts = SCTIME_ADD_USECS(SCTIME_FROM_SECS((pkt_ts / 100000000) - 11644473600),
                         ((pkt_ts % 100000000) / 100) + ((pkt_ts % 100) > 50 ? 1 : 0));
                 break;
             default:

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -57,7 +57,11 @@ typedef struct {
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
 #define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
-#define SCTIME_ADD_USECS(ts, us) SCTIME_FROM_USECS((ts).usecs + (us))
+#define SCTIME_ADD_USECS(ts, us)                                                                   \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = (ts).secs + ((ts).usecs + (us)) / 1000000, .usecs = ((ts).usecs + (us)) % 1000000  \
+    }
 #define SCTIME_FROM_SECS(s)                                                                        \
     (SCTime_t)                                                                                     \
     {                                                                                              \

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -56,11 +56,15 @@ typedef struct {
 #define SCTIME_USECS(t)          ((uint64_t)(t).usecs)
 #define SCTIME_SECS(t)           ((uint64_t)(t).secs)
 #define SCTIME_MSECS(t)          (SCTIME_SECS(t) * 1000 + SCTIME_USECS(t) / 1000)
-#define SCTIME_ADD_SECS(ts, s)   SCTIME_FROM_SECS((ts).secs + (s))
 #define SCTIME_ADD_USECS(ts, us)                                                                   \
     (SCTime_t)                                                                                     \
     {                                                                                              \
         .secs = (ts).secs + ((ts).usecs + (us)) / 1000000, .usecs = ((ts).usecs + (us)) % 1000000  \
+    }
+#define SCTIME_ADD_SECS(ts, s)                                                                     \
+    (SCTime_t)                                                                                     \
+    {                                                                                              \
+        .secs = (ts).secs + (s), .usecs = (ts).usecs                                               \
     }
 #define SCTIME_FROM_SECS(s)                                                                        \
     (SCTime_t)                                                                                     \
@@ -87,7 +91,7 @@ typedef struct {
 #define SCTIME_FROM_TIMESPEC(ts)                                                                   \
     (SCTime_t)                                                                                     \
     {                                                                                              \
-        .secs = (ts)->tv_sec, .usecs = (ts)->tv_nsec * 1000                                        \
+        .secs = (ts)->tv_sec, .usecs = (ts)->tv_nsec / 1000                                        \
     }
 
 #define SCTIME_TO_TIMEVAL(tv, t)                                                                   \


### PR DESCRIPTION
Continuation of #9966 

Merging the PRs to simplify backporting as they are related and affect the same source code files.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) tickets:
- [6372](https://redmine.openinfosecfoundation.org/issues/6372)
- [6584](https://redmine.openinfosecfoundation.org/issues/6584)
- [6585](https://redmine.openinfosecfoundation.org/issues/6585)

Describe changes:
- Fix issues with `SCTIME` macros to retain seconds, prevent useconds from overflow
- Correct timestamp initialization in Napatech packet source

Updates:
- Adjust commit messages
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
