### PR TITLE
detect: negated content matches on absent buffer

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -89,6 +89,9 @@ generated if the used version of Firefox is not 3.6.13.
 .. note:: The following characters must be escaped inside the content:
              ``;`` ``\`` ``"``
 
+A negated content on an absent buffer will match.
+`http.referer; content:!"example";` will match on a request without any referer.
+
 nocase
 ------
 
@@ -271,6 +274,7 @@ of the payload. The second example illustrates a signature searching
 for byte 50 after the last match.
 
 You can also use the negation (!) before isdataat.
+A negated isdataat on an absent buffer will match any value.
 
 .. image:: payload-keywords/isdataat1.png
 
@@ -287,6 +291,8 @@ the bsize value will be compared using the relational operator. Ranges are inclu
 If one or more ``content`` keywords precedes ``bsize``, each occurrence of ``content``
 will be inspected and an error will be raised if the content length and the bsize
 value prevent a match.
+
+bsize will not match if a sticky buffer is absent.
 
 Format::
 
@@ -433,6 +439,7 @@ Example::
   alert tcp any any -> any any (msg:"Byte_Test Example - Compare to String"; \
  	 content:"foobar"; byte_test:4,=,1337,1,relative,string,dec;)
 
+A negated operation will match on absent buffers.
 
 byte_math
 ---------
@@ -711,6 +718,12 @@ Example of pcre in a signature:
 .. container:: example-rule
 
     drop tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"ET TROJAN Likely Bot Nick in IRC (USA +..)"; flow:established,to_server; flowbits:isset,is_proto_irc; content:"NICK "; :example-rule-emphasis:`pcre:"/NICK .*USA.*[0-9]{3,}/i";` reference:url,doc.emergingthreats.net/2008124; classtype:trojan-activity; sid:2008124; rev:2;)
+
+You can also use the negation (!) before pcre::
+
+  pcre:!"/example/";
+
+A negated pcre on an absent buffer will always match.
 
 There are a few qualities of pcre which can be modified:
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -38,6 +38,11 @@ Upgrading 7.0 to 8.0
 --------------------
 .. note:: ``stats.whitelist`` has been renamed to ``stats.score`` in ``eve.json``
 
+Major changes
+~~~~~~~~~~~~~
+- Negated content matches on absent buffers.
+  `http.referer; content:!"example";` will match on a request without any referer.
+
 Upgrading 6.0 to 7.0
 --------------------
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2224

Describe changes:
- detect: negated content matches on absent buffer

```
SV_BRANCH=pr/1516
```
https://github.com/OISF/suricata-verify/pull/1516

#9944 with
- handling all keywords (with debug assertion to check) 
- new S-V test
- doc

@jufajardini could you help me in the docs wording ? do you have something clearer than "absent" ?