### PR TITLE
clang-format: prefer clang-format-14

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -21,9 +21,9 @@ jobs:
 
   # Checking for correct formatting of branch for C code changes
   check-formatting:
-    name: Formatting Check (clang 9)
-    runs-on: ubuntu-20.04
-    container: ubuntu:20.04
+    name: Formatting Check (clang 14)
+    runs-on: ubuntu-22.04
+    container: ubuntu:22.04
     continue-on-error: false
     steps:
 
@@ -43,6 +43,8 @@ jobs:
                 autoconf \
                 automake \
                 cargo \
+                cbindgen \
+                clang-format-14 \
                 git \
                 libtool \
                 libpcap-dev \
@@ -58,21 +60,14 @@ jobs:
                 libnfnetlink0 \
                 libhiredis-dev \
                 libjansson-dev \
-                libpython2.7 \
                 make \
-                python \
                 rustc \
+                python-is-python3 \
+                python3 \
                 software-properties-common \
                 wget \
                 zlib1g \
                 zlib1g-dev
-      - name: Install packages for clang-format 9
-        run: |
-          # no need to install full clang
-          apt-get install -y clang-format-9
-      - name: Install cbindgen
-        run: cargo install --force --debug --version 0.24.3 cbindgen
-      - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       # Checking out the branch is not as simple as "checking out".
       #
       # In case master has any new commits since we branched off, github will

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -560,9 +560,13 @@ SetTopLevelDir
 
 RequireProgram GIT git
 # ubuntu uses clang-format-{version} name for newer versions. fedora not.
-RequireProgram GIT_CLANG_FORMAT git-clang-format-11 git-clang-format-10 git-clang-format-9 git-clang-format
+RequireProgram GIT_CLANG_FORMAT git-clang-format-14 git-clang-format-11 git-clang-format-10 git-clang-format-9 git-clang-format
 GIT_CLANG_FORMAT_BINARY=clang-format
-if [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-11$ ]]; then
+if [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-14$ ]]; then
+    # default binary is clang-format, specify the correct version.
+    # Alternative: git config clangformat.binary "clang-format-14"
+    GIT_CLANG_FORMAT_BINARY="clang-format-14"
+elif [[ $GIT_CLANG_FORMAT =~ .*git-clang-format-11$ ]]; then
     # default binary is clang-format, specify the correct version.
     # Alternative: git config clangformat.binary "clang-format-11"
     GIT_CLANG_FORMAT_BINARY="clang-format-11"


### PR DESCRIPTION
If reformatting all the code, move to a newer version of clang-format.