### PR TITLE
detect: log warning when too many filestore

### DIFF
--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -630,7 +630,11 @@ void SigGroupHeadSetFilestoreCount(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             continue;
 
         if (SignatureIsFilestoring(s)) {
-            sgh->filestore_cnt++;
+            if (sgh->filestore_cnt == UINT16_MAX) {
+                SCLogWarning("Too many filestore in signature group head");
+            } else {
+                sgh->filestore_cnt++;
+            }
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6393

Describe changes:
- detect: log error when too many filestores

#9994 with warning instead of error