### PR TITLE
detect: flush when setting no_inspection

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1441,7 +1441,6 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* set the packets to no inspection and reassembly if required */
     if (pstate->flags & APP_LAYER_PARSER_NO_INSPECTION) {
         AppLayerParserSetEOF(pstate);
-        FlowSetNoPayloadInspectionFlag(f);
 
         if (f->proto == IPPROTO_TCP) {
             StreamTcpDisableAppLayer(f);
@@ -1463,6 +1462,9 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
                     StreamTcpSetSessionBypassFlag(ssn);
                 }
             }
+        } else {
+            // for TCP, this is set after flushing
+            FlowSetNoPayloadInspectionFlag(f);
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6578

Describe changes:
- detect: flush when setting no_inspection

So that we can run detection on the clear text of ssh new keys packet

```
SV_BRANCH=pr/1507
```
https://github.com/OISF/suricata-verify/pull/1507

#9961 with code review taken into account