### PR TITLE
pgsql: don't log passsword msg if password disabled (7.0.x backport) - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -78,8 +78,6 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             if flags & PGSQL_LOG_PASSWORDS != 0 {
                 js.set_string_from_bytes("password", payload)?;
-            } else {
-                js.set_string(req.to_str(), "password log disabled")?;
             }
         }
         PgsqlFEMessage::SASLResponse(RegularPacket {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
backport - https://redmine.openinfosecfoundation.org/issues/6604
original - https://redmine.openinfosecfoundation.org/issues/6603

Describe changes:
- clean cherry-pick from original work from PR https://github.com/OISF/suricata/pull/9979