### PR TITLE
github-ci: add DPDK 23.11 to the builds workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1967,7 +1967,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.3, 21.11.5, 20.11.9, 19.11.14 ]
+        dpdk_version: [ 23.11, 22.11.3, 21.11.5, 20.11.9, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/6382) ticket: https://redmine.openinfosecfoundation.org/issues/6382

Describe changes:
- added a new DPDK version to build