### PR TITLE
http2: do not have leading space for response line

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -545,7 +545,7 @@ fn http2_tx_get_resp_line(tx: &mut HTTP2Transaction) {
         } else {
             &empty
         };
-    resp_line.extend(b" HTTP/2 ");
+    resp_line.extend(b"HTTP/2 ");
     resp_line.extend(status);
     resp_line.extend(b"\r\n");
     tx.resp_line.extend(resp_line)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6558

Describe changes:
- Backport of #9872 

```
SV_BRANCH=pr/1543
```
https://github.com/OISF/suricata-verify/pull/1543