### PR TITLE
doc: install guide cleanups; meta cleanups - v1

### DIFF
--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -109,39 +109,44 @@ CentOS, AlmaLinux, RockyLinux, Fedora, etc
 
 .. note:: The following instructions require ``sudo`` to be installed.
 
-To install all minimal dependencies, it is required to enable extra package
-repository in most distros. You can enable it possibly by
-one of the following ways::
+Some of these distributions require extra package repositories to be
+enabled.
 
-    sudo dnf -y update
-    sudo dnf -y install dnf-plugins-core
-    # AlmaLinux 8
-    sudo dnf config-manager --set-enabled powertools
-    # AlmaLinux 9
-    sudo dnf config-manager --set-enable crb
-    # Oracle Linux 8
-    sudo dnf config-manager --set-enable ol8_codeready_builder
-    # Oracle Linux 9
-    sudo dnf config-manager --set-enable ol9_codeready_builder
+* AlmaLinux 8
 
-Minimal::
+  ::
 
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y gcc gcc-c++ git jansson-devel libpcap-devel libtool \
-                   libyaml-devel make pcre2-devel which zlib-devel
-    cargo install --force cbindgen
+     sudo dnf -y install dnf-plugins-core epel-release
+     sudo dnf config-manager --set-enabled powertools
 
-Recommended::
+* AlmaLinux 9
 
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y autoconf automake diffutils file-devel gcc gcc-c++ git \
-                   jansson-devel jq libcap-ng-devel libevent-devel \
-                   libmaxminddb-devel libnet-devel libnetfilter_queue-devel \
-                   libnfnetlink-devel libpcap-devel libtool libyaml-devel \
-                   lua-devel lz4-devel make nss-devel pcre2-devel pkgconfig \
-                   python3-devel python3-sphinx python3-yaml sudo which \
-                   zlib-devel
-    cargo install --force cbindgen
+  ::
+
+     sudo dnf -y install dnf-plugins-core epel-release
+     sudo dnf config-manager --set-enable crb
+
+* Oracle Linux 8
+
+  ::
+
+     sudo dnf -y install dnf-plugins-core epel-release
+     sudo dnf config-manager --set-enable ol8_codeready_builder
+
+* Oracle Linux 9
+
+  ::
+
+     sudo dnf -y install dnf-plugins-core epel-release
+     sudo dnf config-manager --set-enable ol9_codeready_builder
+
+Recommended Dependencies::
+
+    sudo dnf -y install cargo diffutils file-devel gcc gcc-c++
+        hyperscan-devel jansson-devel libcap-ng-devel libnet-devel
+        libnetfilter_queue-devel libpcap-devel libtool libyaml-devel lua-devel
+        lz4-devel make pcre2-devel pkgconfig python3-yaml rust which
+        zlib-devel
 
 Compilation
 ^^^^^^^^^^^

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -78,20 +78,14 @@ The following tools are required::
 
   make gcc (or clang) pkg-config rustc cargo
 
-Rust support::
+.. note::
 
-  rustc, cargo
+   While most current operating systems and Linux distributions have a
+   recent enough version of Rust, some do not. In which case Rust may
+   need to be manually installed.
 
-  Some distros don't provide or provide outdated Rust packages.
-  Rust can also be installed directly from the Rust project itself::
-
-    1) Install Rust https://www.rust-lang.org/en-US/install.html
-    2) Install cbindgen - if the cbindgen is not found in the repository
-       or the cbindgen version is lower than required, it can be
-       alternatively installed as: cargo install --force cbindgen
-    3) Make sure the cargo path is within your PATH environment
-        e.g. echo 'export PATH=”${PATH}:~/.cargo/bin”' >> ~/.bashrc
-        e.g. export PATH="${PATH}:/root/.cargo/bin"
+   See https://www.rust-lang.org/tools/install for instructions on
+   installing Rust.
 
 Ubuntu/Debian
 """""""""""""

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -18,8 +18,8 @@ Installing from the source distribution files gives the most control over the Su
 
 Basic steps::
 
-    tar xzvf suricata-6.0.0.tar.gz
-    cd suricata-6.0.0
+    tar xzvf suricata-7.0.0.tar.gz
+    cd suricata-7.0.0
     ./configure
     make
     make install
@@ -28,6 +28,7 @@ This will install Suricata into ``/usr/local/bin/``, use the default
 configuration in ``/usr/local/etc/suricata/`` and will output to
 ``/usr/local/var/log/suricata``
 
+You can obtain the source code for the latest release from our [downloads page](https://suricata.io/download/).
 
 Common configure options
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,8 +163,6 @@ Compilation
 
 Follow these steps from your Suricata directory::
 
-    ./scripts/bundle.sh
-    ./autogen.sh
     ./configure # you may want to add additional parameters here
     # ./configure --help to get all available parameters
     make -j8 # j is for paralleling, you may de/increase depending on your CPU

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -11,6 +11,11 @@ recommended.
 
 Advanced users can check the advanced guides, see :ref:`install-advanced`.
 
+.. note::
+
+   If installing from a git checkout please see :ref:`Installation
+   from GIT`.
+
 Source
 ------
 

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -92,31 +92,17 @@ Ubuntu/Debian
 
 .. note:: The following instructions require ``sudo`` to be installed.
 
-Minimal::
+::
 
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install build-essential git libjansson-dev libpcap-dev \
-                    libpcre2-dev libtool libyaml-dev make pkg-config zlib1g-dev
-    # On most distros installing cbindgen with package manager should be enough
-    sudo apt-get install cbindgen # alternative: cargo install --force cbindgen
+   sudo apt-get update
 
-Recommended::
+   sudo apt-get install build-essential libcap-ng-dev libgeoip-dev \
+        libhyperscan-dev libjansson-dev liblz4-dev libmagic-dev \
+        libnet1-dev libnetfilter-queue-dev libpcap-dev libpcre2-dev \
+        libtool libunwind-dev libyaml-dev make pkg-config python3-yaml \
+        zlib1g-dev
 
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install autoconf automake build-essential ccache clang curl git \
-                    gosu jq libbpf-dev libcap-ng0 libcap-ng-dev libelf-dev \
-                    libevent-dev libgeoip-dev libhiredis-dev libjansson-dev \
-                    liblua5.1-dev libmagic-dev libnet1-dev libpcap-dev \
-                    libpcre2-dev libtool libyaml-0-2 libyaml-dev m4 make \
-                    pkg-config python3 python3-dev python3-yaml sudo zlib1g \
-                    zlib1g-dev
-    cargo install --force cbindgen
-
-Extra for iptables/nftables IPS integration::
-
-    sudo apt-get install libnetfilter-queue-dev libnetfilter-queue1  \
-                    libnetfilter-log-dev libnetfilter-log1      \
-                    libnfnetlink-dev libnfnetlink0
+:sub:`Tested on Ubuntu 20.04, 22.04; Debian 11, 12.`
 
 CentOS, AlmaLinux, RockyLinux, Fedora, etc
 """"""""""""""""""""""""""""""""""""""""""

--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -9,18 +9,19 @@ they do have an effect on the way Suricata reports events/alerts.
 msg (message)
 -------------
 
-The keyword msg gives contextual information about the signature and the possible alert.
+The ``msg`` keyword gives contextual information about the signature
+and the possible alert.
 
-The format of msg is::
+The format of ``msg`` is::
 
-  msg: "some description";
+  msg:"some description";
 
 Examples::
 
   msg:"ET MALWARE Win32/RecordBreaker CnC Checkin";
   msg:"ET EXPLOIT SMB-DS DCERPC PnP bind attempt";
 
-To continue the example from the previous chapter, the msg component of the
+To continue the example from the previous chapter, the ``msg`` component of the
 signature is emphasized below:
 
 .. container:: example-rule
@@ -40,12 +41,12 @@ signature is emphasized below:
 sid (signature ID)
 ------------------
 
-The keyword sid gives every signature its own id. This id is stated with a number
-greater than zero. The format of sid is::
+The ``sid`` keyword gives every signature its own id. This id is
+stated with a number greater than zero. The format of ``sid`` is::
 
-  sid:123;
+  sid:2260005;
 
-Example of sid in a signature:
+Example of ``sid`` in a signature:
 
 .. container:: example-rule
 
@@ -72,15 +73,14 @@ Example of sid in a signature:
 rev (revision)
 --------------
 
-The sid keyword is commonly accompanied by the rev keyword. Rev
-represents the version of the signature. If a signature is modified,
-the number of rev will be incremented by the signature writers. The
-format of rev is::
+The ``sid`` keyword is commonly accompanied by the ``rev``
+keyword. ``rev`` represents the revision of the signature. If a
+signature is modified, the number of ``rev`` will be incremented by
+the signature writers. The format of ``rev`` is::
 
-  rev:123;
+  rev:3;
 
-
-Example of rev in a signature:
+Example of ``rev`` in a signature:
 
 .. container:: example-rule
 
@@ -88,23 +88,25 @@ Example of rev in a signature:
 
 .. tip::
 
-    It is a standard practice in rule writing that the rev keyword
-    is expressed after the sid keyword. The sid and rev keywords
-    are commonly put as the last two keywords in a signature.
+    It is a standard practice in rule writing that the ``rev`` keyword
+    is expressed after the ``sid`` keyword. The ``sid`` and ``rev``
+    keywords are commonly put as the last two keywords in a signature.
 
 .. _gid:
 
 gid (group ID)
 --------------
 
-The gid keyword can be used to give different groups of
-signatures another id value (like in sid). Suricata by default uses gid 1.
-It is possible to modify the default value. In most cases, it will be
-unnecessary to change the default gid value. Changing the gid value
-has no technical implications, the value is only noted in alert data.
+The ``gid`` keyword can be used to give different groups of signatures
+another id value (like in ``sid``). Suricata by default uses
+``gid`` 1.  It is possible to modify the default value. In most cases,
+it will be unnecessary to change the default ``gid`` value. Changing
+the ``gid`` value has no technical implications, the value is only
+noted in alert data.
 
-Example of the gid value in an alert entry in the fast.log file.
-In the part [1:123], the first 1 is the gid (123 is the sid and 1 is the rev).
+Example of the ``gid`` value in an alert entry in the fast.log file.
+In the part [1:123], the first 1 is the ``gid`` (123 is the ``sid``
+and 1 is the ``rev``).
 
 .. container:: example-rule
 
@@ -114,21 +116,21 @@ In the part [1:123], the first 1 is the gid (123 is the sid and 1 is the rev).
 classtype
 ---------
 
-The classtype keyword gives information about the classification of
-rules and alerts. It consists of a short name, a long name and a
+The ``classtype`` keyword gives information about the classification
+of rules and alerts. It consists of a short name, a long name and a
 priority. It can tell for example whether a rule is just informational
-or is about a CVE. For each classtype, the classification.config has a
-priority that will be used in the rule.
+or is about a CVE. For each ``classtype``, the classification.config
+has a priority that will be used in the rule.
 
 Example classtype definition::
 
   config classification: web-application-attack,Web Application Attack,1
   config classification: not-suspicious,Not Suspicious Traffic,3
 
-Once we have defined the classification in the configuration file,
-we can use the classtypes in our rules. A rule with classtype web-application-attack
-will be assigned a priority of 1 and the alert will contain 'Web Application Attack'
-in the Suricata logs:
+Once we have defined the classification in the configuration file, we
+can use the classtypes in our rules. A rule with ``classtype``
+web-application-attack will be assigned a priority of 1 and the alert
+will contain 'Web Application Attack' in the Suricata logs:
 
 =======================  ======================  ===========
 classtype                Alert                   Priority
@@ -137,7 +139,7 @@ web-application-attack   Web Application Attack  1
 not-suspicious           Not Suspicious Traffic  3
 =======================  ======================  ===========
 
-Our continuing example also has a classtype: bad-unknown:
+Our continuing example also has a ``classtype``: bad-unknown:
 
 .. container:: example-rule
 
@@ -146,16 +148,19 @@ Our continuing example also has a classtype: bad-unknown:
 
 .. tip::
 
-    It is a standard practice in rule writing that the classtype keyword comes
-    before the sid and rev keywords (as shown in the example rule).
+    It is a standard practice in rule writing that the ``classtype``
+    keyword comes before the ``sid`` and ``rev`` keywords (as shown in
+    the example rule).
 
 reference
 ---------
-The reference keyword is used to document where information about the
-signature and about the problem the signature tries to address can be
-found. The reference keyword can appear multiple times in a signature.
-This keyword is meant for signature-writers and analysts who
-investigate why a signature has matched. It has the following format::
+
+The ``reference`` keyword is used to document where information about
+the signature and about the problem the signature tries to address can
+be found. The ``reference`` keyword can appear multiple times in a
+signature.  This keyword is meant for signature-writers and analysts
+who investigate why a signature has matched. It has the following
+format::
 
   reference:type,reference
 
@@ -177,22 +182,23 @@ All the reference types are defined in the reference.config configuration file.
 priority
 --------
 
-The priority keyword comes with a mandatory numeric value which can
-range from 1 to 255. The values 1 through 4 are commonly used.
-The highest priority is 1. Signatures with a higher priority will
-be examined first. Normally signatures have a priority determined through
-a classtype definition. The classtype definition can be overridden
-by defining the priority keyword in the signature.
-The format of priority is::
+The ``priority`` keyword comes with a mandatory numeric value which
+can range from 1 to 255. The values 1 through 4 are commonly used.
+The highest priority is 1. Signatures with a higher priority will be
+examined first. Normally signatures have a priority determined through
+a classtype definition. The classtype definition can be overridden by
+defining the priority keyword in the signature.  The format of
+priority is::
 
   priority:1;
 
 metadata
 --------
-The metadata keyword allows additional, non-functional, information to
-be added to the signature. While the format is free-form, it is
-recommended to stick to `[key, value]` pairs as Suricata can include these
-in eve alerts. The format is::
+
+The ``metadata`` keyword allows additional, non-functional,
+information to be added to the signature. While the format is
+free-form, it is recommended to stick to `[key, value]` pairs as
+Suricata can include these in eve alerts. The format is::
 
   metadata: key value;
   metadata: key value, key value;
@@ -200,14 +206,15 @@ in eve alerts. The format is::
 target
 ------
 
-The target keyword allows the rules writer to specify which side of the
-alert is the target of the attack. If specified, the alert event is enhanced
-to contain information about source and target.
+The ``target`` keyword allows the rules writer to specify which side
+of the alert is the target of the attack. If specified, the alert
+event is enhanced to contain information about source and target.
 
 The format is::
 
    target:[src_ip|dest_ip]
 
-If the value is src_ip then the source IP in the generated event (src_ip
-field in JSON) is the target of the attack. If target is set to dest_ip
-then the target is the destination IP in the generated event.
+If the value is ``src_ip`` then the source IP in the generated event
+(src_ip field in JSON) is the target of the attack. If ``target`` is
+set to ``dest_ip`` then the target is the destination IP in the
+generated event.


### PR DESCRIPTION
Includes:
- https://github.com/OISF/suricata/pull/9670
- Variation on: https://github.com/OISF/suricata/pull/9827

For the Ubuntu, Debian, EL install documentation:
- Drop mention of cbindgen, this install guide is for release users, cbindgen is not needed
- Add a note for users installing from git to head over to the git installation directions (devguide)
- Provide one set of dependency installation directions instead of multiple to simplify the process for the majority of users.
