### PR TITLE
pgsql: add cancel message (7.0.x backports) - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2432,13 +2432,17 @@ Example of HTTP2 logging, of a request and response:
 Event type: PGSQL
 -----------------
 
-PGSQL eve-logs reflect the bidirectional nature of the protocol transactions. Each PGSQL event lists at most one
-"Request" message field and one or more "Response" messages.
+PGSQL eve-logs reflect the bidirectional nature of the protocol transactions.
+Each PGSQL event lists at most one "Request" message field and one or more
+"Response" messages.
 
-The PGSQL parser merges individual messages into one EVE output item if they belong to the same transaction. In such cases, the source and destination information (IP/port) reflect the direction of the initial request, but contain messages from both sides.
+The PGSQL parser merges individual messages into one EVE output item if they
+belong to the same transaction. In such cases, the source and destination
+information (IP/port) reflect the direction of the initial request, but contain
+messages from both sides.
 
-
-Example of ``pgsql`` event for a SimpleQuery transaction complete with request with a ``SELECT`` statement and its response::
+Example of ``pgsql`` event for a SimpleQuery transaction complete with request
+with a ``SELECT`` statement and its response::
 
   {
     "timestamp": "2021-11-24T16:56:24.403417+0000",
@@ -2464,51 +2468,74 @@ Example of ``pgsql`` event for a SimpleQuery transaction complete with request w
     }
   }
 
-While on the wire PGSQL messages follow basically two types (startup messages and regular messages), those may have different subfields and/or meanings, based on the message type. Messages are logged based on their type and relevant fields.
+While on the wire PGSQL messages follow basically two types (startup messages
+and regular messages), those may have different subfields and/or meanings, based
+on the message type. Messages are logged based on their type and relevant fields.
 
-We list a few possible message types and what they mean in Suricata. For more details on message types and formats as well as what each message and field mean for PGSQL, check  `PostgreSQL's official documentation <https://www.postgresql.org/docs/14/protocol-message-formats.html>`_.
+We list a few possible message types and what they mean in Suricata. For more
+details on message types and formats as well as what each message and field mean
+for PGSQL, check `PostgreSQL's official documentation <https://www.postgresql.org
+/docs/14/protocol-message-formats.html>`_.
 
 Fields
 ~~~~~~
 
 * "tx_id": internal transaction id.
-* "request":  each PGSQL transaction may have up to one request message. The possible messages will be described in another section.
-* "response": even when there are several "Response" messages, there is one ``response`` field that summarizes all responses for that transaction. The possible messages will be described in another section.
+* "request":  each PGSQL transaction may have up to one request message. The
+  possible messages will be described in another section.
+* "response": even when there are several "Response" messages, there is one
+  ``response`` field that summarizes all responses for that transaction. The
+  possible messages will be described in another section.
 
 Request Messages
 ~~~~~~~~~~~~~~~~
 
 Some of the possible request messages are:
 
-* "startup_message": message sent by a frontend/client process to start a new PostgreSQL connection
-* "password_message": if password output for PGSQL is enabled in suricata.yaml, carries the password sent during Authentication phase
-* "simple_query": issued SQL command during simple query subprotocol. PostgreSQL identifies specific sets of commands that change the set of expected messages to be exchanged as subprotocols.
-* "message": frontend responses which do not have meaningful payloads are logged like this, where the field value is the message type
+* "startup_message": message sent by a frontend/client process to start a new
+  PostgreSQL connection
+* "password_message": if password output for PGSQL is enabled in suricata.yaml,
+  carries the password sent during Authentication phase
+* "simple_query": issued SQL command during simple query subprotocol. PostgreSQL
+  identifies specific sets of commands that change the set of expected messages
+  to be exchanged as subprotocols.
+* "message": frontend responses which do not have meaningful payloads are logged
+  like this, where the field value is the message type
 
-There are several different authentication messages possible, based on selected authentication method. (e.g. the SASL authentication will have a set of authentication messages different from when ``md5`` authentication is chosen).
+There are several different authentication messages possible, based on selected
+authentication method. (e.g. the SASL authentication will have a set of
+authentication messages different from when ``md5`` authentication is chosen).
 
 Response Messages
 ~~~~~~~~~~~~~~~~~
 
 Some of the possible request messages are:
 
-* "authentication_sasl_final": final SCRAM ``server-final-message``, as explained at https://www.postgresql.org/docs/14/sasl-authentication.html#SASL-SCRAM-SHA-256
-* "message": Backend responses which do not have meaningful payloads are logged like this, where the field value is the message type
+* "authentication_sasl_final": final SCRAM ``server-final-message``, as explained
+  at https://www.postgresql.org/docs/14/sasl-authentication.html#SASL-SCRAM-SHA-256
+* "message": Backend responses which do not have meaningful payloads are logged
+  like this, where the field value is the message type
 * "error_response"
 * "notice_response"
 * "notification_response"
 * "authentication_md5_password": a string with the ``md5`` salt value
 * "parameter_status": logged as an array
 * "backend_key_data"
-* "data_rows": integer. When one or many ``DataRow`` messages are parsed, the total returned rows
-* "data_size": in bytes. When one or many ``DataRow`` messages are parsed, the total size in bytes of the data returned
+* "data_rows": integer. When one or many ``DataRow`` messages are parsed, the
+  total returned rows
+* "data_size": in bytes. When one or many ``DataRow`` messages are parsed, the
+  total size in bytes of the data returned
 * "command_completed": string. Informs the command just completed by the backend
-* "ssl_accepted": bool. With this event, the initial PGSQL SSL Handshake negotiation is complete in terms of tracking and logging. The session will be upgraded to use TLS encryption
+* "ssl_accepted": bool. With this event, the initial PGSQL SSL Handshake
+  negotiation is complete in terms of tracking and logging. The session will be
+  upgraded to use TLS encryption
 
 Examples
 ~~~~~~~~
 
-The two ``pgsql`` events in this example represent a rejected ``SSL handshake`` and a following connection request where the authentication method indicated by the backend was ``md5``::
+The two ``pgsql`` events in this example represent a rejected ``SSL handshake``
+and a following connection request where the authentication method indicated by
+the backend was ``md5``::
 
   {
     "timestamp": "2021-11-24T16:56:19.435242+0000",

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2490,22 +2490,22 @@ Fields
 Request Messages
 ~~~~~~~~~~~~~~~~
 
-Some of the possible request messages are:
+Requests are sent by the frontend (client), which would be the source of a pgsql
+flow. Some of the possible request messages are:
 
-* "startup_message": message sent by a frontend/client process to start a new
-  PostgreSQL connection
+* "startup_message": message sent to start a new PostgreSQL connection
 * "password_message": if password output for PGSQL is enabled in suricata.yaml,
   carries the password sent during Authentication phase
 * "simple_query": issued SQL command during simple query subprotocol. PostgreSQL
   identifies specific sets of commands that change the set of expected messages
   to be exchanged as subprotocols.
-* "message": frontend responses which do not have meaningful payloads are logged
-  like this, where the field value is the message type
 * ``"message": "cancel_request"``: sent after a query, when the frontend
   attempts to cancel said query. This message is sent over a different port,
   thus bring shown as a different flow. It has no direct answer from the
   backend, but if successful will lead to an ``ErrorResponse`` in the
   transaction where the query was sent.
+* "message": requests which do not have meaningful payloads are logged like this,
+  where the field value is the message type
 
 There are several different authentication messages possible, based on selected
 authentication method. (e.g. the SASL authentication will have a set of
@@ -2514,7 +2514,8 @@ authentication messages different from when ``md5`` authentication is chosen).
 Response Messages
 ~~~~~~~~~~~~~~~~~
 
-Some of the possible request messages are:
+Responses are sent by the backend (server), which would be the destination of a
+pgsql flow. Some of the possible request messages are:
 
 * "authentication_sasl_final": final SCRAM ``server-final-message``, as explained
   at https://www.postgresql.org/docs/14/sasl-authentication.html#SASL-SCRAM-SHA-256

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2805,6 +2805,9 @@
                         "password_message": {
                             "type": "string"
                         },
+                        "process_id": {
+                            "type": "integer"
+                        },
                         "protocol_version": {
                             "type": "string"
                         },
@@ -2816,6 +2819,9 @@
                         },
                         "sasl_response": {
                             "type": "string"
+                        },
+                        "secret_key": {
+                            "type": "integer"
                         },
                         "simple_query": {
                             "type": "string"

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -94,6 +94,14 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             js.set_string_from_bytes(req.to_str(), payload)?;
         }
+        PgsqlFEMessage::CancelRequest(CancelRequestMessage {
+            pid,
+            backend_key,
+        }) => {
+            js.set_string("message", "cancel_request")?;
+            js.set_uint("process_id", (*pid).into())?;
+            js.set_uint("secret_key", (*backend_key).into())?;
+        }
         PgsqlFEMessage::Terminate(TerminationMessage {
             identifier: _,
             length: _,

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -34,6 +34,7 @@ use nom7::{Err, IResult};
 pub const PGSQL_LENGTH_FIELD: u32 = 4;
 
 pub const PGSQL_DUMMY_PROTO_MAJOR: u16 = 1234; // 0x04d2
+pub const PGSQL_DUMMY_PROTO_CANCEL_REQUEST: u16 = 5678; // 0x162e
 pub const PGSQL_DUMMY_PROTO_MINOR_SSL: u16 = 5679; //0x162f
 pub const _PGSQL_DUMMY_PROTO_MINOR_GSSAPI: u16 = 5680; // 0x1630
 
@@ -316,6 +317,12 @@ pub struct TerminationMessage {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct CancelRequestMessage {
+    pub pid: u32,
+    pub backend_key: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum PgsqlFEMessage {
     SSLRequest(DummyStartupPacket),
     StartupMessage(StartupPacket),
@@ -323,6 +330,7 @@ pub enum PgsqlFEMessage {
     SASLInitialResponse(SASLInitialResponsePacket),
     SASLResponse(RegularPacket),
     SimpleQuery(RegularPacket),
+    CancelRequest(CancelRequestMessage),
     Terminate(TerminationMessage),
     UnknownMessageType(RegularPacket),
 }
@@ -336,6 +344,7 @@ impl PgsqlFEMessage {
             PgsqlFEMessage::SASLInitialResponse(_) => "sasl_initial_response",
             PgsqlFEMessage::SASLResponse(_) => "sasl_response",
             PgsqlFEMessage::SimpleQuery(_) => "simple_query",
+            PgsqlFEMessage::CancelRequest(_) => "cancel_request",
             PgsqlFEMessage::Terminate(_) => "termination_message",
             PgsqlFEMessage::UnknownMessageType(_) => "unknown_message_type",
         }
@@ -611,16 +620,20 @@ pub fn pgsql_parse_startup_packet(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
             },
             PGSQL_DUMMY_PROTO_MAJOR => {
                 let (b, proto_major) = be_u16(b)?;
-                let (b, proto_minor) = all_consuming(be_u16)(b)?;
-                let _message = match proto_minor {
-                    PGSQL_DUMMY_PROTO_MINOR_SSL => (len, proto_major, proto_minor),
+                let (b, proto_minor) = be_u16(b)?;
+                let (b, message) = match proto_minor {
+                    PGSQL_DUMMY_PROTO_CANCEL_REQUEST => {
+                        parse_cancel_request(b)?
+                    },
+                    PGSQL_DUMMY_PROTO_MINOR_SSL => (b, PgsqlFEMessage::SSLRequest(DummyStartupPacket{
+                        length: len,
+                        proto_major,
+                        proto_minor
+                    })),
                     _ => return Err(Err::Error(make_error(b, ErrorKind::Switch))),
                 };
 
-                (b, PgsqlFEMessage::SSLRequest(DummyStartupPacket{
-                    length: len,
-                    proto_major,
-                    proto_minor}))
+                (b, message)
             }
             _ => return Err(Err::Error(make_error(b, ErrorKind::Switch))),
         };
@@ -663,6 +676,15 @@ fn parse_simple_query(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
         identifier,
         length,
         payload: query.to_vec(),
+    })))
+}
+
+fn parse_cancel_request(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
+    let (i, pid) = be_u32(i)?;
+    let (i, backend_key) = be_u32(i)?;
+    Ok((i, PgsqlFEMessage::CancelRequest(CancelRequestMessage {
+        pid,
+        backend_key,
     })))
 }
 
@@ -1262,8 +1284,36 @@ mod tests {
         let result = parse_request(&buf[0..3]);
         assert!(result.is_err());
 
-        // TODO add other messages
     }
+
+    #[test]
+    fn test_cancel_request_message() {
+        // A cancel request message
+        let buf: &[u8] = &[
+            0x00, 0x00, 0x00, 0x10, // length: 16 (fixed)
+            0x04, 0xd2, 0x16, 0x2e, // 1234.5678 - identifies a cancel request
+            0x00, 0x00, 0x76, 0x31, // PID: 30257
+            0x23, 0x84, 0xf7, 0x2d]; // Backend key: 595916589
+        let result = parse_cancel_request(buf);
+        assert!(result.is_ok());
+
+        let result = parse_cancel_request(&buf[0..3]);
+        assert!(result.is_err());
+
+        let result = pgsql_parse_startup_packet(buf);
+        assert!(result.is_ok());
+
+        let fail_result = pgsql_parse_startup_packet(&buf[0..3]);
+        assert!(fail_result.is_err());
+
+        let result = parse_request(buf);
+        assert!(result.is_ok());
+
+        let fail_result = parse_request(&buf[0..3]);
+        assert!(fail_result.is_err());
+    }
+
+
 
     #[test]
     fn test_parse_error_response_code() {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -37,6 +37,10 @@ pub const PGSQL_DUMMY_PROTO_MAJOR: u16 = 1234; // 0x04d2
 pub const PGSQL_DUMMY_PROTO_MINOR_SSL: u16 = 5679; //0x162f
 pub const _PGSQL_DUMMY_PROTO_MINOR_GSSAPI: u16 = 5680; // 0x1630
 
+fn parse_length(i: &[u8]) -> IResult<&[u8], u32> {
+    verify(be_u32, |&x| x >= PGSQL_LENGTH_FIELD)(i)
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum PgsqlParameters {
     // startup parameters
@@ -564,7 +568,7 @@ fn parse_sasl_initial_response_payload(i: &[u8]) -> IResult<&[u8], (SASLAuthenti
 
 pub fn parse_sasl_initial_response(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'p')(i)?;
-    let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, payload) = map_parser(take(length - PGSQL_LENGTH_FIELD), parse_sasl_initial_response_payload)(i)?;
     Ok((i, PgsqlFEMessage::SASLInitialResponse(
                 SASLInitialResponsePacket {
@@ -578,7 +582,7 @@ pub fn parse_sasl_initial_response(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
 
 pub fn parse_sasl_response(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'p')(i)?;
-    let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, payload) = take(length - PGSQL_LENGTH_FIELD)(i)?;
     let resp = PgsqlFEMessage::SASLResponse(
         RegularPacket {
@@ -638,7 +642,7 @@ pub fn pgsql_parse_startup_packet(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
 // Password can be encrypted or in cleartext
 pub fn parse_password_message(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'p')(i)?;
-    let (i, length) = verify(be_u32, |&x| x >= PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, password) = map_parser(
         take(length - PGSQL_LENGTH_FIELD),
         take_until1("\x00")
@@ -653,7 +657,7 @@ pub fn parse_password_message(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
 
 fn parse_simple_query(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'Q')(i)?;
-    let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, query) = map_parser(take(length - PGSQL_LENGTH_FIELD), take_until1("\x00"))(i)?;
     Ok((i, PgsqlFEMessage::SimpleQuery(RegularPacket {
         identifier,
@@ -664,7 +668,7 @@ fn parse_simple_query(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
 
 fn parse_terminate_message(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'X')(i)?;
-    let (i, length) = verify(be_u32, |&x| x == PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     Ok((i, PgsqlFEMessage::Terminate(TerminationMessage { identifier, length })))
 }
 
@@ -772,7 +776,7 @@ fn pgsql_parse_authentication_message<'a>(i: &'a [u8]) -> IResult<&'a [u8], Pgsq
 
 fn parse_parameter_status_message(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'S')(i)?;
-    let (i, length) = verify(be_u32, |&x| x >= PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, param) = map_parser(take(length - PGSQL_LENGTH_FIELD), pgsql_parse_generic_parameter)(i)?;
     Ok((i, PgsqlBEMessage::ParameterStatus(ParameterStatusMessage {
         identifier,
@@ -803,7 +807,7 @@ fn parse_backend_key_data_message(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
 
 fn parse_command_complete(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
     let (i, identifier) = verify(be_u8, |&x| x == b'C')(i)?;
-    let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+    let (i, length) = parse_length(i)?;
     let (i, payload) = map_parser(take(length - PGSQL_LENGTH_FIELD), take_until("\x00"))(i)?;
     Ok((i, PgsqlBEMessage::CommandComplete(RegularPacket {
         identifier,

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -117,6 +117,7 @@ pub enum PgsqlStateProgress {
     DataRowReceived,
     CommandCompletedReceived,
     ErrorMessageReceived,
+    CancelRequestReceived,
     ConnectionTerminated,
     #[cfg(test)]
     UnknownState,
@@ -229,6 +230,7 @@ impl PgsqlState {
             || self.state_progress == PgsqlStateProgress::SimpleQueryReceived
             || self.state_progress == PgsqlStateProgress::SSLRequestReceived
             || self.state_progress == PgsqlStateProgress::ConnectionTerminated
+            || self.state_progress == PgsqlStateProgress::CancelRequestReceived
         {
             let tx = self.new_tx();
             self.transactions.push_back(tx);
@@ -280,6 +282,7 @@ impl PgsqlState {
 
                 // Important to keep in mind that: "In simple Query mode, the format of retrieved values is always text, except when the given command is a FETCH from a cursor declared with the BINARY option. In that case, the retrieved values are in binary format. The format codes given in the RowDescription message tell which format is being used." (from pgsql official documentation)
             }
+            PgsqlFEMessage::CancelRequest(_) => Some(PgsqlStateProgress::CancelRequestReceived),
             PgsqlFEMessage::Terminate(_) => {
                 SCLogDebug!("Match: Terminate message");
                 Some(PgsqlStateProgress::ConnectionTerminated)


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
original: https://redmine.openinfosecfoundation.org/issues/6577
backport: https://redmine.openinfosecfoundation.org/issues/6581

Describe changes:
- Backports from https://github.com/OISF/suricata/pull/10054, except for the clang format commit for `schema.json`

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1553