### PR TITLE
detect/profiling: improve pcap reading performance

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1797,9 +1797,11 @@ TmEcode Detect(ThreadVars *tv, Packet *p, void *data)
 
 #ifdef PROFILE_RULES
     /* aggregate statistics */
-    if (SCTIME_SECS(p->ts) != det_ctx->rule_perf_last_sync) {
+    struct timeval ts;
+    gettimeofday(&ts, NULL);
+    if (ts.tv_sec != det_ctx->rule_perf_last_sync) {
         SCProfilingRuleThreatAggregate(det_ctx);
-        det_ctx->rule_perf_last_sync = SCTIME_SECS(p->ts);
+        det_ctx->rule_perf_last_sync = ts.tv_sec;
     }
 #endif
 


### PR DESCRIPTION
When reading a pcap, packet time can move much faster than wall clock time. This would trigger many more profile syncs than before.

As the sync is using a lock to synchronize with other threads, this is an expensive operation.

Bug: #6619.

Fixes: b591813b8690 ("profiling/rules: reduce sync logic scope")

https://redmine.openinfosecfoundation.org/issues/6619