### PR TITLE
[draft] doc: http keyword updates 3025 v1

### DIFF
--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -55,6 +55,7 @@ Example signature that would alert on the above response.
   classtype:bad-unknown; sid:30; rev:1;)
 
 Request Keywords:
+ * :ref:`http.uri`
  * :ref:`http.uri.raw`
  * :ref:`http.method`
  * :ref:`http.request_line`
@@ -118,43 +119,81 @@ Example HTTP Request::
   flow:established,to_server; :example-rule-options:`http.method; \
   content:"GET";` classtype:bad-unknown; sid:2; rev:1;)
 
-
 .. _rules-http-uri-normalization:
 
 .. _http.uri:
 
+http.uri 
+--------
+
+Matching on the HTTP URI buffer has two options in Suricata, the ``http.uri``
+and the ``http.uri.raw`` sticky buffers.
+
+It is possible to use any of the :doc:`payload-keywords` with the ``http.uri``
+keywords.
+
+
+The ``http.uri`` keyword normalizes the URI buffer. For example if a URI has two
+leading ``//`` in Suricata will normalize the URI to a single leading ``/``.
+
+Normalization Example::
+
+  GET //index.html HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
+
+In this case :example-rule-emphasis:`//index.html` would be normalized to 
+:example-rule-emphasis:`/index.html`.
+
+Example HTTP Request::
+
+  GET /index.html HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
+
+.. container:: example-rule
+
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP URI Example"; \
+  flow:established,to_server; :example-rule-options:`http.uri; \
+  content:"/index.html";` bsize:11; classtype:bad-unknown; sid:3; rev:1;)
+
+
 .. _http.uri.raw:
 
-http.uri and http.uri.raw
--------------------------
+http.uri.raw
+------------
 
-With the ``http.uri`` and the ``http.uri.raw`` sticky buffers, it
-is possible to match specifically and only on the request URI
-buffer. The keyword can be used in combination with all previously
-mentioned content modifiers like ``depth``, ``distance``, ``offset``,
-``nocase`` and ``within``.
+The ``http.uri.raw`` buffer matches on HTTP URI content but does not have any
+normalization (see :ref:`rules-http-uri-normalization`) performed on the buffer
+contents.
 
-The uri has two appearances in Suricata: the uri.raw and the
-normalized uri. The space for example can be indicated with the
-heximal notation %20. To convert this notation in a space, means
-normalizing it. It is possible though to match specific on the
-characters %20 in a uri. This means matching on the uri.raw. The
-uri.raw and the normalized uri are separate buffers. So, the uri.raw
-inspects the uri.raw buffer and can not inspect the normalized buffer.
+Abnormal HTTP Request Example::
 
-.. note:: uri.raw never has any spaces in it.
-          With this request line ``GET /uid=0(root) gid=0(root) HTTP/1.1``,
-          the ``http.uri.raw`` will match ``/uid=0(root)``
-          and ``http.protocol`` will match ``gid=0(root) HTTP/1.1``
-          Reference: `https://redmine.openinfosecfoundation.org/issues/2881 <https://redmine.openinfosecfoundation.org/issues/2881>`_
+  GET //index.html HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
 
-Example of the URI in a HTTP request:
+.. container:: example-rule
 
-.. image:: http-keywords/uri1.png
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP URI Raw Example"; \
+  flow:established,to_server; :example-rule-options:`http.uri.raw; \
+  content:"//index.html";` bsize:12; classtype:bad-unknown; sid:4; rev:1;)
 
-Example of the purpose of ``http.uri``:
+.. note:: The ``http.uri.raw`` keyword/buffer does not allow for spaces.
 
-.. image:: http-keywords/uri.png
+Example Request::
+
+  GET /example spaces HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
+
+Suricata would organize/populate the data in the as follows:
+
+``http.uri.raw`` would be populated with :example-rule-header:`/example`
+
+:ref:`http.protocol` would be populated with :example-rule-header:`spaces HTTP/1.1`
+
+Reference: `https://redmine.openinfosecfoundation.org/issues/2881 <https://redmine.openinfosecfoundation.org/issues/2881>`_
 
 
 urilen

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -17,7 +17,7 @@ requests resources from a server and a server responds to the request.
 
 In versions of HTTP prior to version 2 a client request could look like:
 
-Example::
+Example HTTP Request::
 
   GET /index.html HTTP/1.1
   User-Agent: Mozilla/5.0
@@ -36,12 +36,14 @@ Example signature that would alert on the above request.
 
 In versions of HTTP prior to version 2 a server response could look like:
 
-HTTP/1.1 200 OK
-Content-Type: text/html
-Content-Length: 258
-Date: Thu, 14 Dec 2023 20:22:41 GMT
-Server: nginx/0.8.54
-Connection: Close
+Example HTTP Response::
+
+  HTTP/1.1 200 OK
+  Content-Type: text/html
+  Content-Length: 258
+  Date: Thu, 14 Dec 2023 20:22:41 GMT
+  Server: nginx/0.8.54
+  Connection: Close
 
 Example signature that would alert on the above response.
 
@@ -87,46 +89,38 @@ Request or Response Keywords:
  * :ref:`http.header.raw`
  * :ref:`http.cookie`
 
-
-Although cookies are sent in an HTTP header, you can not match on them
-with the ``http.header`` keyword. Cookies are matched with their own
-keyword, namely ``http.cookie``.
-
-Each part of the table belongs to a so-called *buffer*. The HTTP
-method belongs to the method buffer, HTTP headers to the header buffer
-etc. A buffer is a specific portion of the request or response that
-Suricata extracts in memory for inspection.
-
-All previous described keywords can be used in combination with a
-buffer in a signature. The keywords ``distance`` and ``within`` are
-relative modifiers, so they may only be used within the same
-buffer. You can not relate content matches against different buffers
-with relative modifiers.
-
 .. _http.method:
 
 http.method
 -----------
 
-With the ``http.method`` sticky buffer, it is possible to match
-specifically and only on the HTTP method buffer. The keyword can be
-used in combination with all previously mentioned content modifiers
-such as: ``depth``, ``distance``, ``offset``, ``nocase`` and ``within``.
+The ``http.method`` keyword matches on the method/verb used in an HTTP request.
+HTTP request methods can be any of the following:
 
-Examples of methods are: **GET**, **POST**, **PUT**, **HEAD**,
-**DELETE**, **TRACE**, **OPTIONS**, **CONNECT** and **PATCH**.
+* GET
+* POST
+* HEAD
+* OPTIONS
+* PUT
+* DELETE
+* TRACE
+* CONNECT
+* PATCH
 
-Example of a method in a HTTP request:
+It is possible to use any of the :doc:`payload-keywords` with the ``http.method`` keyword.
 
-.. image:: http-keywords/method2.png
+Example HTTP Request::
 
-Example of the purpose of method:
+  GET /index.html HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
 
-.. image:: http-keywords/method.png
+.. container:: example-rule
 
-.. image:: http-keywords/Legenda_rules.png
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP Request Example"; \
+  flow:established,to_server; :example-rule-options:`http.method; \
+  content:"GET";`classtype:bad-unknown; sid:2; rev:1;)
 
-.. image:: http-keywords/method1.png
 
 .. _rules-http-uri-normalization:
 
@@ -258,6 +252,9 @@ Example of a header in a HTTP request:
 Example of the purpose of ``http.header``:
 
 .. image:: http-keywords/header1.png
+
+Although cookies are sent in an HTTP header, you can not match on them with the ``http.header`` keyword. Cookies are matched with their own keyword, namely ``http.cookie``.
+
 
 .. _http.cookie:
 

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -119,7 +119,7 @@ Example HTTP Request::
 
   alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP Request Example"; \
   flow:established,to_server; :example-rule-options:`http.method; \
-  content:"GET";`classtype:bad-unknown; sid:2; rev:1;)
+  content:"GET";` classtype:bad-unknown; sid:2; rev:1;)
 
 
 .. _rules-http-uri-normalization:
@@ -641,8 +641,8 @@ header value. The \\r\\n after the header are not part of the buffer.
 
 Example::
 
-    alert http any any -> any any (flow:to_client; \
-            http.location; content:"http://www.google.com"; sid:1;)
+  alert http any any -> any any (flow:to_client; \
+  http.location; content:"http://www.google.com"; sid:1;)
 
 .. _http.host:
 

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -53,39 +53,39 @@ Example signature that would alert on the above response.
   classtype:bad-unknown; sid:30; rev:1;)
 
 Request Keywords:
- * http.uri
- * http.uri.raw
+ * :ref:`http.uri`
+ * :ref:`http.uri.raw`
  * :ref:`http.method`
- * http.request_line
- * http.request_body
- * http.cookie
- * http.user_agent
- * http.host
- * http.host.raw
- * http.accept
- * http.accept_lang
- * http.accept_enc
- * http.referer
- * file.name
+ * :ref:`http.request_line`
+ * :ref:`http.request_body`
+ * :ref:`http.cookie`
+ * :ref:`http.user_agent`
+ * :ref:`http.host`
+ * :ref:`http.host.raw`
+ * :ref:`http.accept`
+ * :ref:`http.accept_lang`
+ * :ref:`http.accept_enc`
+ * :ref:`http.referer`
+ * :ref:`file.name`
 
 Response Keywords:
- * http.stat_msg
- * http.stat_code 
- * http.response_line
- * http.response_body
- * http.server
- * http.location
+ * :ref:`http.stat_msg`
+ * :ref:`http.stat_code`
+ * :ref:`http.response_line`
+ * :ref:`http.response_body`
+ * :ref:`http.server`
+ * :ref:`http.location`
 
 Request or Response Keywords:
- * file.data
- * http.content_type
- * http.content_len
- * http.start
- * http.protocol
- * http.header_names
- * http.header
- * http.header.raw
- * http.cookie
+ * :ref:`file.data`
+ * :ref:`http.content_type`
+ * :ref:`http.content_len`
+ * :ref:`http.start`
+ * :ref:`http.protocol`
+ * :ref:`http.header_names`
+ * :ref:`http.header`
+ * :ref:`http.header.raw`
+ * :ref:`http.cookie`
 
 
 Although cookies are sent in an HTTP header, you can not match on them
@@ -130,6 +130,10 @@ Example of the purpose of method:
 
 .. _rules-http-uri-normalization:
 
+.. _http.uri:
+
+.. _http.uri.raw:
+
 http.uri and http.uri.raw
 -------------------------
 
@@ -161,29 +165,6 @@ Example of the purpose of ``http.uri``:
 
 .. image:: http-keywords/uri.png
 
-uricontent
-----------
-
-The ``uricontent`` keyword has the exact same effect as the
-``http.uri`` sticky buffer. ``uricontent`` is a deprecated
-(although still supported) way to match specifically and only on the
-request URI buffer.
-
-Example of ``uricontent``:
-
-.. container:: example-rule
-
-    alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"ET TROJAN Possible Vundo Trojan Variant reporting to Controller"; flow:established,to_server; content:"POST "; depth:5; :example-rule-emphasis:`uricontent:"/frame.html?";` urilen: > 80; classtype:trojan-activity; reference:url,doc.emergingthreats.net/2009173; reference:url,www.emergingthreats.net/cgi-bin/cvsweb.cgi/sigs/VIRUS/TROJAN_Vundo; sid:2009173; rev:2;)
-
-The difference between ``http.uri`` and ``uricontent`` is the syntax:
-
-.. image:: http-keywords/uricontent1.png
-
-.. image:: http-keywords/http_uri.png
-
-When authoring new rules, it is recommended that the ``http.uri``
-content sticky buffer be used rather than the deprecated ``uricontent``
-keyword.
 
 urilen
 ------
@@ -216,6 +197,8 @@ Example of ``urilen`` in a signature:
 You can also append ``norm`` or ``raw`` to define what sort of buffer you want
 to use (normalized or raw buffer).
 
+.. _http.protocol:
+
 http.protocol
 -------------
 
@@ -233,6 +216,8 @@ Example::
 
     alert http any any -> any any (flow:to_server; http.protocol; content:"HTTP/1.0"; sid:1;)
 
+.. _http.request_line:
+
 http.request_line
 -----------------
 
@@ -241,6 +226,10 @@ The ``http.request_line`` forces the whole HTTP request line to be inspected.
 Example::
 
     alert http any any -> any any (http.request_line; content:"GET / HTTP/1.0"; sid:1;)
+
+.. _http.header:
+
+.. _http.header.raw:
 
 http.header and http.header.raw
 -------------------------------
@@ -269,6 +258,8 @@ Example of a header in a HTTP request:
 Example of the purpose of ``http.header``:
 
 .. image:: http-keywords/header1.png
+
+.. _http.cookie:
 
 http.cookie
 -----------
@@ -301,6 +292,8 @@ Example ``http.cookie`` keyword in a signature:
     http.uri; content:"/"; fast_pattern; :example-rule-emphasis:`http.cookie;
     content:"PHPSESSIONID="; startswith;` classtype:bad-unknown; sid:123;
     rev:1;)
+
+.. _http.user_agent:
 
 http.user_agent
 ---------------
@@ -361,6 +354,8 @@ Notes
 
 -  `https://blog.inliniac.net/2012/07/09/suricata-http\_user\_agent-vs-http\_header/ <https://blog.inliniac.net/2012/07/09/suricata-http_user_agent-vs-http_header/>`_
 
+.. _http.accept:
+
 http.accept
 -----------
 
@@ -370,6 +365,8 @@ value. The \\r\\n after the header are not part of the buffer.
 Example::
 
     alert http any any -> any any (http.accept; content:"image/gif"; sid:1;)
+
+.. _http.accept_enc:
 
 http.accept_enc
 ---------------
@@ -381,6 +378,7 @@ Example::
 
     alert http any any -> any any (http.accept_enc; content:"gzip"; sid:1;)
 
+.. _http.accept_lang:
 
 http.accept_lang
 ----------------
@@ -392,6 +390,7 @@ Example::
 
     alert http any any -> any any (http.accept_lang; content:"en-us"; sid:1;)
 
+.. _http.connection:
 
 http.connection
 ---------------
@@ -403,6 +402,7 @@ Example::
 
     alert http any any -> any any (http.connection; content:"keep-alive"; sid:1;)
 
+.. _http.content_type:
 
 http.content_type
 -----------------
@@ -420,6 +420,7 @@ Examples::
     alert http any any -> any any (flow:to_client; \
             http.content_type; content:"text/javascript"; sid:2;)
 
+.. _http.content_len:
 
 http.content_len
 ----------------
@@ -444,8 +445,10 @@ Example, match if C-L is equal to or bigger than 8079::
     alert http any any -> any any (flow:to_client; \
             http.content_len; byte_test:0,>=,8079,0,string,dec; sid:3;)
 
+.. _http.referer:
+
 http.referer
----------------
+-------------
 
 Sticky buffer to match on the HTTP Referer header. Only contains the
 header value. The \\r\\n after the header are not part of the buffer.
@@ -453,6 +456,8 @@ header value. The \\r\\n after the header are not part of the buffer.
 Example::
 
     alert http any any -> any any (http.referer; content:".php"; sid:1;)
+
+.. _http.start:
 
 http.start
 ----------
@@ -467,6 +472,8 @@ Example::
 
 The buffer contains the normalized headers and is terminated by an extra
 \\r\\n to indicate the end of the headers.
+
+.. _http.header_names:
 
 http.header_names
 -----------------
@@ -501,6 +508,8 @@ Example to make sure *User-Agent* is after *Host*, but not necessarily directly 
             content:"|0d 0a|Host|0d 0a|"; content:"|0a 0d|User-Agent|0d 0a|"; \
             distance:-2; sid:1;)
 
+.. _http.request_body:
+
 http.request_body
 -----------------
 
@@ -526,6 +535,8 @@ setting.
 +to use the previous name, but it's recommended that rules be converted to use
 +the new name.
 
+.. _http.stat_code:
+
 http.stat_code
 --------------
 
@@ -541,6 +552,8 @@ Example of ``http.stat_code`` in a HTTP response:
 Example of the purpose of ``http.stat_code``:
 
 .. image:: http-keywords/stat-code1.png
+
+.. _http.stat_msg:
 
 http.stat_msg
 -------------
@@ -559,6 +572,8 @@ Example of the purpose of ``http.stat_msg``:
 
 .. image:: http-keywords/stat_msg_1.png
 
+.. _http.response_line:
+
 http.response_line
 ------------------
 
@@ -567,6 +582,8 @@ The ``http.response_line`` forces the whole HTTP response line to be inspected.
 Example::
 
     alert http any any -> any any (http.response_line; content:"HTTP/1.0 200 OK"; sid:1;)
+
+.. _http.response_body:
 
 http.response_body
 ------------------
@@ -604,6 +621,8 @@ Notes
 +to use the previous name, but it's recommended that rules be converted to use
 +the new name.
 
+.. _http.server:
+
 http.server
 -----------
 
@@ -615,6 +634,8 @@ Example::
     alert http any any -> any any (flow:to_client; \
             http.server; content:"Microsoft-IIS/6.0"; sid:1;)
 
+.. _http.location:
+
 http.location
 -------------
 
@@ -625,6 +646,10 @@ Example::
 
     alert http any any -> any any (flow:to_client; \
             http.location; content:"http://www.google.com"; sid:1;)
+
+.. _http.host:
+
+.. _http.host.raw:
 
 http.host and http.host.raw
 ---------------------------
@@ -638,6 +663,8 @@ like ``distance``, ``offset``, ``within``, etc.
 
 The ``nocase`` keyword is not allowed anymore. Keep in mind that you need
 to specify a lowercase pattern.
+
+.. _http.request_header:
 
 http.request_header
 -------------------
@@ -657,6 +684,7 @@ Examples::
 
 ``http.request_header`` can be used as ``fast_pattern``.
 
+.. _http.response_header:
 
 http.response_header
 --------------------
@@ -727,6 +755,8 @@ Notes
 
 -  Corresponding PCRE modifier (``http_host``): ``W``
 -  Corresponding PCRE modifier (``http_raw_host``): ``Z``
+
+.. _file.data:
 
 file.data
 ---------
@@ -799,6 +829,8 @@ Multiple Buffer Matching
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``file.data`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+.. _file.name:
 
 file.name
 ---------

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -199,33 +199,44 @@ Reference: `https://redmine.openinfosecfoundation.org/issues/2881 <https://redmi
 urilen
 ------
 
-The ``urilen`` keyword is used to match on the length of the request
+The ``urilen`` keyword is used to match on the length of the normalized request
 URI. It is possible to use the ``<`` and ``>`` operators, which
-indicate respectively *smaller than* and *larger than*.
+indicate respectively *less than* and *larger than*.
 
-The format of ``urilen`` is::
+The ``urilen`` keyword does not require a content match on the :ref:`http.uri`
+buffer or the :ref:`http.uri.raw` buffer.
 
-  urilen:3;
+Example HTTP Request::
 
-Other possibilities are::
-
-  urilen:1;
-  urilen:>1;
-  urilen:<10;
-  urilen:10<>20;	(bigger than 10, smaller than 20)
-
-Example:
-
-.. image:: http-keywords/urilen.png
-
-Example of ``urilen`` in a signature:
+  GET /index.html HTTP/1.1
+  User-Agent: Mozilla/5.0
+  Host: suricata.io
 
 .. container:: example-rule
 
-    alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"ET TROJAN Possible Vundo Trojan Variant reporting to Controller"; flow:established,to_server; content:"POST "; depth:5; uricontent:"/frame.html?"; :example-rule-emphasis:`urilen: > 80;` classtype:trojan-activity; reference:url,doc.emergingthreats.net/2009173; reference:url,www.emergingthreats.net/cgi-bin/cvsweb.cgi/sigs/VIRUS/TROJAN_Vundo; sid:2009173; rev:2;)
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"HTTP Request"; \
+  flow:established,to_server; :example-rule-options:`urilen:11;` \
+  http.method; content:"GET"; classtype:bad-unknown; sid:40; rev:1;)
 
-You can also append ``norm`` or ``raw`` to define what sort of buffer you want
-to use (normalized or raw buffer).
+The above signature would match on any HTTP GET request that has a URI
+length of 11, regardless of the content or structure of the URI.
+
+The following signatures would all alert on the example request above as well
+and show the different ``urilen`` options.
+
+.. container:: example-rule
+
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"urilen greater than 10"; \
+  flow:established,to_server; :example-rule-options:`urilen:>10;` \
+  classtype:bad-unknown; sid:41; rev:1;)
+
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"urilen less than 12"; \
+  flow:established,to_server; :example-rule-options:`urilen:<12;` \
+  classtype:bad-unknown; sid:42; rev:1;)
+
+  alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"urilen greater/less than \
+  example"; flow:established,to_server; :example-rule-options:`urilen:10<>12;` \
+  classtype:bad-unknown; sid:43; rev:1;)
 
 .. _http.protocol:
 

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -55,14 +55,12 @@ Example signature that would alert on the above response.
   classtype:bad-unknown; sid:30; rev:1;)
 
 Request Keywords:
- * :ref:`http.uri`
  * :ref:`http.uri.raw`
  * :ref:`http.method`
  * :ref:`http.request_line`
  * :ref:`http.request_body`
  * :ref:`http.cookie`
  * :ref:`http.user_agent`
- * :ref:`http.host`
  * :ref:`http.host.raw`
  * :ref:`http.accept`
  * :ref:`http.accept_lang`
@@ -85,7 +83,6 @@ Request or Response Keywords:
  * :ref:`http.start`
  * :ref:`http.protocol`
  * :ref:`http.header_names`
- * :ref:`http.header`
  * :ref:`http.header.raw`
  * :ref:`http.cookie`
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/3025

Describe changes:
- as discussed in various other doc update tickets, giving this page an update and wanted to get some feedback before going too far with changes
- removed the legacy keywords and sticky buffer table as that was/is confusing
- reformatted keyword list and made list links
- updated http.method keyword with the idea of using that same format for the remaining keywords.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
