### PR TITLE
Detect dns opcode range 5446 v4

### DIFF
--- a/doc/userguide/rules/dns-keywords.rst
+++ b/doc/userguide/rules/dns-keywords.rst
@@ -27,6 +27,7 @@ dns.opcode
 ----------
 
 This keyword matches on the **opcode** found in the DNS header flags.
+It uses a 8-bit unsigned integer as value.
 
 Syntax
 ~~~~~~
@@ -34,6 +35,7 @@ Syntax
 ::
 
    dns.opcode:[!]<number>
+   dns.opcode:[!]<number1>-<number2>
 
 Examples
 ~~~~~~~~
@@ -45,6 +47,14 @@ Match on DNS requests and responses with **opcode** 4::
 Match on DNS requests where the **opcode** is NOT 0::
 
   dns.opcode:!0;
+
+Match on DNS requests where the **opcode** is between 7 and 15, exclusively:
+
+  dns.opcode:7-15;
+
+Match on DNS requests where the **opcode** is not between 7 and 15:
+
+  dns.opcode:!7-15;
 
 dns.query
 ---------

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -37,7 +37,7 @@ pub enum DetectUintMode {
     DetectUintModeNe,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[repr(C)]
 pub struct DetectUintData<T> {
     pub arg1: T,

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -81,6 +81,22 @@ mod test {
                 arg2: 0,
             }
         );
+        assert_eq!(
+            detect_parse_uint::<u8>("7-15").unwrap().1,
+            DetectUintData {
+                mode: DetectUintMode::DetectUintModeRange,
+                arg1: 7,
+                arg2: 15,
+            }
+        );
+        assert_eq!(
+            detect_parse_uint::<u8>("!1-6").unwrap().1,
+            DetectUintData {
+                mode: DetectUintMode::DetectUintModeNegRg,
+                arg1: 1,
+                arg2: 6,
+            }
+        );
         assert!(detect_parse_uint::<u8>("").is_err());
         assert!(detect_parse_uint::<u8>("!").is_err());
         assert!(detect_parse_uint::<u8>("!   ").is_err());

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -19,6 +19,7 @@
 
 #include "detect-parse.h"
 #include "detect-engine.h"
+#include "detect-engine-uint.h"
 #include "detect-dns-opcode.h"
 #include "rust.h"
 
@@ -35,7 +36,7 @@ static int DetectDnsOpcodeSetup(DetectEngineCtx *de_ctx, Signature *s,
         return -1;
     }
 
-    void *detect = rs_detect_dns_opcode_parse(str);
+    void *detect = DetectU8Parse(str);
     if (detect == NULL) {
         SCLogError("failed to parse dns.opcode: %s", str);
         return -1;
@@ -57,7 +58,7 @@ static void DetectDnsOpcodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     if (ptr != NULL) {
-        rs_dns_detect_opcode_free(ptr);
+        rs_detect_u8_free(ptr);
     }
     SCReturn;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5446

Describe changes:
- make keyword dns.opcode use helper for integers so that they can have all features such as range
- integer keywords now accept negated range

#9945 with needed rebase