### PR TITLE
pgsql: remove unused msg field (7.0.x backport) - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -234,7 +234,6 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
         }
         PgsqlBEMessage::ConsolidatedDataRow(ConsolidatedDataRowPacket {
             identifier: _,
-            length: _,
             row_cnt,
             data_size,
         }) => {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -210,7 +210,6 @@ pub struct BackendKeyDataMessage {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConsolidatedDataRowPacket {
     pub identifier: u8,
-    pub length: u32,
     pub row_cnt: u16,
     pub data_size: u64,
 }
@@ -924,7 +923,6 @@ pub fn parse_consolidated_data_row(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
     Ok((i, PgsqlBEMessage::ConsolidatedDataRow(
                 ConsolidatedDataRowPacket {
                     identifier,
-                    length,
                     row_cnt: 1,
                     data_size: add_up_data_size(rows),
                 }

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -487,7 +487,6 @@ impl PgsqlState {
                             let dummy_resp =
                                 PgsqlBEMessage::ConsolidatedDataRow(ConsolidatedDataRowPacket {
                                     identifier: b'D',
-                                    length: tx.get_row_cnt() as u32, // TODO this is ugly. We can probably get rid of `length` field altogether...
                                     row_cnt: tx.get_row_cnt(),
                                     data_size: tx.data_size, // total byte count of all data_row messages combined
                                 });


### PR DESCRIPTION
The `ConsolidatedDataRow` struct had a `length` field that wasn't truly used.

Related to
Bug #6389

(cherry-picked from commit 1afb485dfa253f4b409fa1acf0b7790cf1d2f09b)



Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- backport ticket: https://redmine.openinfosecfoundation.org/issues/6521
- original ticket: https://redmine.openinfosecfoundation.org/issues/6389

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/10062 with clean cherry-pick

