### PR TITLE
src: remove unused headers-exported functions

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1366,17 +1366,6 @@ void RegisterFTPParsers(void)
 #endif
 }
 
-void FTPAtExitPrintStats(void)
-{
-#ifdef DEBUG
-    SCMutexLock(&ftp_state_mem_lock);
-    SCLogDebug("ftp_state_memcnt %"PRIu64", ftp_state_memuse %"PRIu64"",
-               ftp_state_memcnt, ftp_state_memuse);
-    SCMutexUnlock(&ftp_state_mem_lock);
-#endif
-}
-
-
 /*
  * \brief Returns the ending offset of the next line from a multi-line buffer.
  *

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -184,7 +184,6 @@ typedef struct FtpDataState_ {
 
 void RegisterFTPParsers(void);
 void FTPParserRegisterTests(void);
-void FTPAtExitPrintStats(void);
 void FTPParserCleanup(void);
 uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -91,28 +91,6 @@ int HtpBodyAppendChunk(const HTPCfgDir *hcfg, HtpBody *body,
  * \param body pointer to the HtpBody holding the list
  * \retval none
  */
-void HtpBodyPrint(HtpBody *body)
-{
-    if (SCLogDebugEnabled()||1) {
-        SCEnter();
-
-        if (body->first == NULL)
-            return;
-
-        HtpBodyChunk *cur = NULL;
-        SCLogDebug("--- Start body chunks at %p ---", body);
-        printf("--- Start body chunks at %p ---\n", body);
-        for (cur = body->first; cur != NULL; cur = cur->next) {
-            const uint8_t *data = NULL;
-            uint32_t data_len = 0;
-            StreamingBufferSegmentGetData(body->sb, &cur->sbseg, &data, &data_len);
-            SCLogDebug("Body %p; data %p, len %"PRIu32, body, data, data_len);
-            printf("Body %p; data %p, len %"PRIu32"\n", body, data, data_len);
-            PrintRawDataFp(stdout, data, data_len);
-        }
-        SCLogDebug("--- End body chunks at %p ---", body);
-    }
-}
 
 /**
  * \brief Free the information held in the request body

--- a/src/app-layer-htp-body.h
+++ b/src/app-layer-htp-body.h
@@ -29,7 +29,6 @@
 #define __APP_LAYER_HTP_BODY_H__
 
 int HtpBodyAppendChunk(const HTPCfgDir *, HtpBody *, const uint8_t *, uint32_t);
-void HtpBodyPrint(HtpBody *);
 void HtpBodyFree(const HTPCfgDir *, HtpBody *);
 void HtpBodyPrune(HtpState *, HtpBody *, int);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -421,12 +421,6 @@ void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
-uint32_t AppLayerParserGetOptionFlags(uint8_t protomap, AppProto alproto)
-{
-    SCEnter();
-    SCReturnUInt(alp_ctx.ctxs[protomap][alproto].option_flags);
-}
-
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
         void *(*StateAlloc)(void *, AppProto), void (*StateFree)(void *))
 {
@@ -863,11 +857,6 @@ AppLayerDecoderEvents *AppLayerParserGetDecoderEvents(AppLayerParserState *pstat
 
     SCReturnPtr(pstate->decoder_events,
                 "AppLayerDecoderEvents *");
-}
-
-void AppLayerParserSetDecoderEvents(AppLayerParserState *pstate, AppLayerDecoderEvents *devents)
-{
-    pstate->decoder_events = devents;
 }
 
 AppLayerDecoderEvents *AppLayerParserGetEventsByTx(uint8_t ipproto, AppProto alproto,
@@ -1823,27 +1812,6 @@ static inline void AppLayerParserStreamTruncated(AppLayerParserState *pstate, co
 
     SCReturn;
 }
-
-#ifdef DEBUG
-void AppLayerParserStatePrintDetails(AppLayerParserState *pstate)
-{
-    SCEnter();
-
-    if (pstate == NULL)
-        SCReturn;
-
-    AppLayerParserState *p = pstate;
-    SCLogDebug("AppLayerParser parser state information for parser state p(%p). "
-               "p->inspect_id[0](%"PRIu64"), "
-               "p->inspect_id[1](%"PRIu64"), "
-               "p->log_id(%"PRIu64"), "
-               "p->decoder_events(%p).",
-               pstate, p->inspect_id[0], p->inspect_id[1], p->log_id,
-               p->decoder_events);
-
-    SCReturn;
-}
-#endif
 
 /***** Unittests *****/
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -218,7 +218,6 @@ void AppLayerParserRegisterStateDataFunc(
 
 /***** Get and transaction functions *****/
 
-uint32_t AppLayerParserGetOptionFlags(uint8_t protomap, AppProto alproto);
 AppLayerGetTxIteratorFunc AppLayerGetTxIterator(const uint8_t ipproto,
          const AppProto alproto);
 
@@ -235,7 +234,6 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
                                 void *alstate, const uint8_t flags, bool tag_txs_as_inspected);
 
 AppLayerDecoderEvents *AppLayerParserGetDecoderEvents(AppLayerParserState *pstate);
-void AppLayerParserSetDecoderEvents(AppLayerParserState *pstate, AppLayerDecoderEvents *devents);
 AppLayerDecoderEvents *AppLayerParserGetEventsByTx(uint8_t ipproto, AppProto alproto, void *tx);
 AppLayerGetFileState AppLayerParserGetTxFiles(
         const Flow *f, void *state, void *tx, const uint8_t direction);
@@ -314,11 +312,6 @@ AppLayerParserState *AppLayerParserStateAlloc(void);
 void AppLayerParserStateFree(AppLayerParserState *pstate);
 
 void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir);
-
-#ifdef DEBUG
-void AppLayerParserStatePrintDetails(AppLayerParserState *pstate);
-#endif
-
 
 /***** Unittests *****/
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -583,25 +583,6 @@ int ConfValIsFalse(const char *val)
  * \retval 1 will be returned if the name is found and was properly
  * converted to a double, otherwise 0 will be returned.
  */
-int ConfGetDouble(const char *name, double *val)
-{
-    const char *strval = NULL;
-    double tmpdo;
-    char *endptr;
-
-    if (ConfGet(name, &strval) == 0)
-        return 0;
-
-    errno = 0;
-    tmpdo = strtod(strval, &endptr);
-    if (strval[0] == '\0' || *endptr != '\0')
-        return 0;
-    if (errno == ERANGE)
-        return 0;
-
-    *val = tmpdo;
-    return 1;
-}
 
 /**
  * \brief Retrieve a configuration value as a float
@@ -870,36 +851,6 @@ int ConfNodeChildValueIsTrue(const ConfNode *node, const char *key)
  *  \param file The name of the file
  *  \retval str Pointer to the string path + sig_file
  */
-char *ConfLoadCompleteIncludePath(const char *file)
-{
-    const char *defaultpath = NULL;
-    char *path = NULL;
-
-    /* Path not specified */
-    if (PathIsRelative(file)) {
-        if (ConfGet("include-path", &defaultpath) == 1) {
-            SCLogDebug("Default path: %s", defaultpath);
-            size_t path_len = sizeof(char) * (strlen(defaultpath) +
-                          strlen(file) + 2);
-            path = SCMalloc(path_len);
-            if (unlikely(path == NULL))
-                return NULL;
-            strlcpy(path, defaultpath, path_len);
-            if (path[strlen(path) - 1] != '/')
-                strlcat(path, "/", path_len);
-            strlcat(path, file, path_len);
-       } else {
-            path = SCStrdup(file);
-            if (unlikely(path == NULL))
-                return NULL;
-        }
-    } else {
-        path = SCStrdup(file);
-        if (unlikely(path == NULL))
-            return NULL;
-    }
-    return path;
-}
 
 /**
  * \brief Prune a configuration node.

--- a/src/conf.h
+++ b/src/conf.h
@@ -61,7 +61,6 @@ ConfNode *ConfGetRootNode(void);
 int ConfGet(const char *name, const char **vptr);
 int ConfGetInt(const char *name, intmax_t *val);
 int ConfGetBool(const char *name, int *val);
-int ConfGetDouble(const char *name, double *val);
 int ConfGetFloat(const char *name, float *val);
 int ConfSet(const char *name, const char *val);
 int ConfSetFromString(const char *input, int final);
@@ -91,8 +90,8 @@ int ConfGetChildValueInt(const ConfNode *base, const char *name, intmax_t *val);
 int ConfGetChildValueBool(const ConfNode *base, const char *name, int *val);
 int ConfGetChildValueWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, const char **vptr);
 int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, intmax_t *val);
-int ConfGetChildValueBoolWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, int *val);
-char *ConfLoadCompleteIncludePath(const char *);
+int ConfGetChildValueBoolWithDefault(
+        const ConfNode *base, const ConfNode *dflt, const char *name, int *val);
 int ConfNodeIsSequence(const ConfNode *node);
 ConfNode *ConfSetIfaceNode(const char *ifaces_node_name, const char *iface);
 int ConfSetRootAndDefaultNodes(

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -74,11 +74,6 @@ uint64_t DefragTrackerGetMemuse(void)
     return memusecopy;
 }
 
-uint32_t DefragTrackerSpareQueueGetSize(void)
-{
-    return DefragTrackerQueueLen(&defragtracker_spare_q);
-}
-
 void DefragTrackerMoveToSpare(DefragTracker *h)
 {
     DefragTrackerEnqueue(&defragtracker_spare_q, h);

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -96,7 +96,6 @@ DefragTracker *DefragGetTrackerFromHash (Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);
-uint32_t DefragTrackerSpareQueueGetSize(void);
 
 int DefragTrackerSetMemcap(uint64_t);
 uint64_t DefragTrackerGetMemcap(void);

--- a/src/defrag-queue.c
+++ b/src/defrag-queue.c
@@ -130,13 +130,3 @@ DefragTracker *DefragTrackerDequeue (DefragTrackerQueue *q)
     DQLOCK_UNLOCK(q);
     return dt;
 }
-
-uint32_t DefragTrackerQueueLen(DefragTrackerQueue *q)
-{
-    uint32_t len;
-    DQLOCK_LOCK(q);
-    len = q->len;
-    DQLOCK_UNLOCK(q);
-    return len;
-}
-

--- a/src/defrag-queue.h
+++ b/src/defrag-queue.h
@@ -77,8 +77,7 @@ DefragTrackerQueue *DefragTrackerQueueInit(DefragTrackerQueue *);
 void DefragTrackerQueueDestroy (DefragTrackerQueue *);
 
 void DefragTrackerEnqueue (DefragTrackerQueue *, DefragTracker *);
-DefragTracker *DefragTrackerDequeue (DefragTrackerQueue *);
-uint32_t DefragTrackerQueueLen(DefragTrackerQueue *);
+DefragTracker *DefragTrackerDequeue(DefragTrackerQueue *);
 
 #endif /* __DEFRAG_QUEUE_H__ */
 

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -137,23 +137,6 @@ DetectAddress *DetectAddressCopy(DetectAddress *orig)
     return ag;
 }
 
-#ifdef DEBUG
-/**
- * \brief Prints the address data information for all the DetectAddress
- *        instances in the DetectAddress list sent as the argument.
- *
- * \param head Pointer to a list of DetectAddress instances.
- */
-void DetectAddressPrintList(DetectAddress *head)
-{
-    SCLogInfo("list:");
-    for (DetectAddress *cur = head; cur != NULL; cur = cur->next) {
-        DetectAddressPrint(cur);
-    }
-    SCLogInfo("endlist");
-}
-#endif
-
 /**
  * \internal
  * \brief Frees a list of DetectAddress instances.

--- a/src/detect-engine-address.h
+++ b/src/detect-engine-address.h
@@ -50,8 +50,4 @@ void DetectAddressMapFree(DetectEngineCtx *de_ctx);
 const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
         const char *string, bool *contains_negation);
 
-#ifdef DEBUG
-void DetectAddressPrintList(DetectAddress *);
-#endif
-
 #endif /* __DETECT_ADDRESS_H__ */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -890,11 +890,6 @@ void PatternMatchDestroy(MpmCtx *mpm_ctx, uint16_t mpm_matcher)
     mpm_table[mpm_matcher].DestroyCtx(mpm_ctx);
 }
 
-void PatternMatchThreadPrint(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
-{
-    SCLogDebug("mpm_thread_ctx %p, mpm_matcher %"PRIu16" defunct", mpm_thread_ctx, mpm_matcher);
-    //mpm_table[mpm_matcher].PrintThreadCtx(mpm_thread_ctx);
-}
 void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t mpm_matcher)
 {
     SCLogDebug("mpm_thread_ctx %p, mpm_matcher %"PRIu16"", mpm_thread_ctx, mpm_matcher);

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -46,10 +46,8 @@ void PatternMatchThreadPrepare(MpmThreadCtx *, uint16_t type);
 
 void PatternMatchDestroy(MpmCtx *, uint16_t);
 void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t);
-void PatternMatchThreadPrint(MpmThreadCtx *, uint16_t);
 
 int PatternMatchPrepareGroup(DetectEngineCtx *, SigGroupHead *);
-void DetectEngineThreadCtxInfo(ThreadVars *, DetectEngineThreadCtx *);
 
 TmEcode DetectEngineThreadCtxInit(ThreadVars *, void *, void **);
 TmEcode DetectEngineThreadCtxDeinit(ThreadVars *, void *);

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -279,11 +279,6 @@ int SigGroupHeadHashAdd(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
     return ret;
 }
 
-int SigGroupHeadHashRemove(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
-{
-    return HashListTableRemove(de_ctx->sgh_hash_table, (void *)sgh, 0);
-}
-
 /**
  * \brief Used to lookup a SigGroupHead hash from the detection engine context
  *        SigGroupHead hash table.

--- a/src/detect-engine-siggroup.h
+++ b/src/detect-engine-siggroup.h
@@ -38,8 +38,6 @@ void SigGroupHeadHashFree(DetectEngineCtx *);
 
 int SigGroupHeadHashInit(DetectEngineCtx *);
 
-int SigGroupHeadHashRemove(DetectEngineCtx *, SigGroupHead *);
-
 void SigGroupHeadInitDataFree(SigGroupHeadInitData *sghid);
 void SigGroupHeadSetSigCnt(SigGroupHead *sgh, uint32_t max_idx);
 void SigGroupHeadSetProtoAndDirection(SigGroupHead *sgh,

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -76,14 +76,6 @@ void TagDestroyCtx(void)
 #endif
 }
 
-/** \brief Reset the tagging engine context
- */
-void TagRestartCtx(void)
-{
-    TagDestroyCtx();
-    TagInitCtx();
-}
-
 int TagHostHasTag(Host *host)
 {
     return HostGetStorageById(host, host_tag_id) ? 1 : 0;

--- a/src/detect-engine-tag.h
+++ b/src/detect-engine-tag.h
@@ -48,7 +48,6 @@ void TagHandlePacket(DetectEngineCtx *, DetectEngineThreadCtx *, Packet *);
 
 void TagInitCtx(void);
 void TagDestroyCtx(void);
-void TagRestartCtx(void);
 
 int TagTimeoutCheck(Host *, SCTime_t);
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -83,7 +83,6 @@ bool DetectEngineBufferRunValidateCallback(
 bool DetectEngineBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_list,
         const uint8_t *content, uint16_t content_len, const char **namestr);
 void DetectEngineBufferTypeSupportsFrames(DetectEngineCtx *de_ctx, const char *name);
-void DetectEngineBufferTypeSupportsPacket(DetectEngineCtx *de_ctx, const char *name);
 void DetectEngineBufferTypeSupportsMpm(DetectEngineCtx *de_ctx, const char *name);
 void DetectEngineBufferTypeSupportsTransformations(DetectEngineCtx *de_ctx, const char *name);
 
@@ -168,8 +167,6 @@ void DetectPktInspectEngineRegister(const char *name,
         InspectionBufferGetPktDataPtr GetPktData,
         InspectionBufferPktInspectFunc Callback);
 
-void DetectFrameInspectEngineRegister(const char *name, int dir,
-        InspectionBufferFrameInspectFunc Callback, AppProto alproto, uint8_t type);
 void DetectEngineFrameInspectEngineRegister(DetectEngineCtx *de_ctx, const char *name, int dir,
         InspectionBufferFrameInspectFunc Callback, AppProto alproto, uint8_t type);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1590,7 +1590,6 @@ void DetectMetadataHashFree(DetectEngineCtx *de_ctx);
 
 /* events */
 void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e);
-AppLayerDecoderEvents *DetectEngineGetEvents(DetectEngineThreadCtx *det_ctx);
 
 void DumpPatterns(DetectEngineCtx *de_ctx);
 

--- a/src/device-storage.c
+++ b/src/device-storage.c
@@ -97,16 +97,6 @@ void *LiveDevGetStorageById(LiveDevice *d, LiveDevStorageId id)
 
 /* Start of "private" function */
 
-void *LiveDevAllocStorageById(LiveDevice *d, LiveDevStorageId id)
-{
-    return StorageAllocByIdPrealloc(d->storage, STORAGE_DEVICE, id.id);
-}
-
-void LiveDevFreeStorageById(LiveDevice *d, LiveDevStorageId id)
-{
-    StorageFreeById(d->storage, STORAGE_DEVICE, id.id);
-}
-
 void LiveDevFreeStorage(LiveDevice *d)
 {
     if (LiveDevStorageSize() > 0)

--- a/src/device-storage.h
+++ b/src/device-storage.h
@@ -36,9 +36,7 @@ unsigned int LiveDevStorageSize(void);
 
 void *LiveDevGetStorageById(LiveDevice *d, LiveDevStorageId id);
 int LiveDevSetStorageById(LiveDevice *d, LiveDevStorageId id, void *ptr);
-void *LiveDevAllocStorageById(LiveDevice *d, LiveDevStorageId id);
 
-void LiveDevFreeStorageById(LiveDevice *d, LiveDevStorageId id);
 void LiveDevFreeStorage(LiveDevice *d);
 
 LiveDevStorageId LiveDevStorageRegister(const char *name, const unsigned int size,

--- a/src/flow.c
+++ b/src/flow.c
@@ -190,23 +190,6 @@ int FlowHasAlerts(const Flow *f)
     return 0;
 }
 
-bool FlowHasGaps(const Flow *f, uint8_t way)
-{
-    if (f->proto == IPPROTO_TCP) {
-        TcpSession *ssn = (TcpSession *)f->protoctx;
-        if (ssn != NULL) {
-            if (way == STREAM_TOCLIENT) {
-                if (ssn->server.flags & STREAMTCP_STREAM_FLAG_HAS_GAP)
-                    return 1;
-            } else {
-                if (ssn->client.flags & STREAMTCP_STREAM_FLAG_HAS_GAP)
-                    return 1;
-            }
-        }
-    }
-    return 0;
-}
-
 /** \brief Set flag to indicate to change proto for the flow
  *
  * \param f flow

--- a/src/flow.h
+++ b/src/flow.h
@@ -554,7 +554,6 @@ void FlowShutdown(void);
 void FlowSetIPOnlyFlag(Flow *, int);
 void FlowSetHasAlertsFlag(Flow *);
 int FlowHasAlerts(const Flow *);
-bool FlowHasGaps(const Flow *, uint8_t way);
 void FlowSetChangeProtoFlag(Flow *);
 void FlowUnsetChangeProtoFlag(Flow *);
 int FlowChangeProto(Flow *);

--- a/src/host-queue.c
+++ b/src/host-queue.c
@@ -131,13 +131,3 @@ Host *HostDequeue (HostQueue *q)
     HQLOCK_UNLOCK(q);
     return h;
 }
-
-uint32_t HostQueueLen(HostQueue *q)
-{
-    uint32_t len;
-    HQLOCK_LOCK(q);
-    len = q->len;
-    HQLOCK_UNLOCK(q);
-    return len;
-}
-

--- a/src/host-queue.h
+++ b/src/host-queue.h
@@ -77,8 +77,7 @@ HostQueue *HostQueueInit(HostQueue *);
 void HostQueueDestroy (HostQueue *);
 
 void HostEnqueue (HostQueue *, Host *);
-Host *HostDequeue (HostQueue *);
-uint32_t HostQueueLen(HostQueue *);
+Host *HostDequeue(HostQueue *);
 
 #endif /* __HOST_QUEUE_H__ */
 

--- a/src/host-storage.c
+++ b/src/host-storage.c
@@ -101,11 +101,6 @@ void *HostAllocStorageById(Host *h, HostStorageId id)
     return StorageAllocByIdPrealloc(h->storage, STORAGE_HOST, id.id);
 }
 
-void HostFreeStorageById(Host *h, HostStorageId id)
-{
-    StorageFreeById(h->storage, STORAGE_HOST, id.id);
-}
-
 void HostFreeStorage(Host *h)
 {
     if (HostStorageSize() > 0)

--- a/src/host-storage.h
+++ b/src/host-storage.h
@@ -38,7 +38,6 @@ void *HostGetStorageById(Host *h, HostStorageId id);
 int HostSetStorageById(Host *h, HostStorageId id, void *ptr);
 void *HostAllocStorageById(Host *h, HostStorageId id);
 
-void HostFreeStorageById(Host *h, HostStorageId id);
 void HostFreeStorage(Host *h);
 
 void RegisterHostStorageTests(void);

--- a/src/host-timeout.c
+++ b/src/host-timeout.c
@@ -32,16 +32,6 @@
 
 #include "reputation.h"
 
-uint32_t HostGetSpareCount(void)
-{
-    return HostSpareQueueGetSize();
-}
-
-uint32_t HostGetActiveCount(void)
-{
-    return SC_ATOMIC_GET(host_counter);
-}
-
 /** \internal
  *  \brief See if we can really discard this host. Check use_cnt reference.
  *

--- a/src/host-timeout.h
+++ b/src/host-timeout.h
@@ -26,8 +26,5 @@
 
 uint32_t HostTimeoutHash(SCTime_t ts);
 
-uint32_t HostGetSpareCount(void);
-uint32_t HostGetActiveCount(void);
-
 #endif
 

--- a/src/host.c
+++ b/src/host.c
@@ -97,11 +97,6 @@ uint64_t HostGetMemuse(void)
     return memuse;
 }
 
-uint32_t HostSpareQueueGetSize(void)
-{
-    return HostQueueLen(&host_spare_q);
-}
-
 void HostMoveToSpare(Host *h)
 {
     HostEnqueue(&host_spare_q, h);

--- a/src/host.h
+++ b/src/host.h
@@ -143,7 +143,6 @@ void HostRelease(Host *);
 void HostLock(Host *);
 void HostClearMemory(Host *);
 void HostMoveToSpare(Host *);
-uint32_t HostSpareQueueGetSize(void);
 void HostPrintStats (void);
 
 void HostRegisterUnittests(void);

--- a/src/ippair-queue.c
+++ b/src/ippair-queue.c
@@ -131,12 +131,3 @@ IPPair *IPPairDequeue (IPPairQueue *q)
     HQLOCK_UNLOCK(q);
     return h;
 }
-
-uint32_t IPPairQueueLen(IPPairQueue *q)
-{
-    uint32_t len;
-    HQLOCK_LOCK(q);
-    len = q->len;
-    HQLOCK_UNLOCK(q);
-    return len;
-}

--- a/src/ippair-queue.h
+++ b/src/ippair-queue.h
@@ -77,7 +77,6 @@ IPPairQueue *IPPairQueueInit(IPPairQueue *);
 void IPPairQueueDestroy (IPPairQueue *);
 
 void IPPairEnqueue (IPPairQueue *, IPPair *);
-IPPair *IPPairDequeue (IPPairQueue *);
-uint32_t IPPairQueueLen(IPPairQueue *);
+IPPair *IPPairDequeue(IPPairQueue *);
 
 #endif /* __IPPAIR_QUEUE_H__ */

--- a/src/ippair-storage.c
+++ b/src/ippair-storage.c
@@ -47,11 +47,6 @@ void *IPPairAllocStorageById(IPPair *h, IPPairStorageId id)
     return StorageAllocByIdPrealloc(h->storage, STORAGE_IPPAIR, id.id);
 }
 
-void IPPairFreeStorageById(IPPair *h, IPPairStorageId id)
-{
-    StorageFreeById(h->storage, STORAGE_IPPAIR, id.id);
-}
-
 void IPPairFreeStorage(IPPair *h)
 {
     if (IPPairStorageSize() > 0)

--- a/src/ippair-storage.h
+++ b/src/ippair-storage.h
@@ -38,7 +38,6 @@ void *IPPairGetStorageById(IPPair *h, IPPairStorageId id);
 int IPPairSetStorageById(IPPair *h, IPPairStorageId id, void *ptr);
 void *IPPairAllocStorageById(IPPair *h, IPPairStorageId id);
 
-void IPPairFreeStorageById(IPPair *h, IPPairStorageId id);
 void IPPairFreeStorage(IPPair *h);
 
 void RegisterIPPairStorageTests(void);

--- a/src/ippair-timeout.c
+++ b/src/ippair-timeout.c
@@ -27,16 +27,6 @@
 #include "ippair-timeout.h"
 #include "detect-engine-threshold.h"
 
-uint32_t IPPairGetSpareCount(void)
-{
-    return IPPairSpareQueueGetSize();
-}
-
-uint32_t IPPairGetActiveCount(void)
-{
-    return SC_ATOMIC_GET(ippair_counter);
-}
-
 /** \internal
  *  \brief See if we can really discard this ippair. Check use_cnt reference.
  *

--- a/src/ippair-timeout.h
+++ b/src/ippair-timeout.h
@@ -26,7 +26,4 @@
 
 uint32_t IPPairTimeoutHash(SCTime_t ts);
 
-uint32_t IPPairGetSpareCount(void);
-uint32_t IPPairGetActiveCount(void);
-
 #endif

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -95,11 +95,6 @@ uint64_t IPPairGetMemuse(void)
     return memusecopy;
 }
 
-uint32_t IPPairSpareQueueGetSize(void)
-{
-    return IPPairQueueLen(&ippair_spare_q);
-}
-
 void IPPairMoveToSpare(IPPair *h)
 {
     IPPairEnqueue(&ippair_spare_q, h);
@@ -517,11 +512,6 @@ void IPPairRelease(IPPair *h)
 {
     (void) IPPairDecrUsecnt(h);
     SCMutexUnlock(&h->m);
-}
-
-void IPPairLock(IPPair *h)
-{
-    SCMutexLock(&h->m);
 }
 
 void IPPairUnlock(IPPair *h)

--- a/src/ippair.h
+++ b/src/ippair.h
@@ -122,10 +122,8 @@ void IPPairCleanup(void);
 IPPair *IPPairLookupIPPairFromHash (Address *, Address *);
 IPPair *IPPairGetIPPairFromHash (Address *, Address *);
 void IPPairRelease(IPPair *);
-void IPPairLock(IPPair *);
 void IPPairClearMemory(IPPair *);
 void IPPairMoveToSpare(IPPair *);
-uint32_t IPPairSpareQueueGetSize(void);
 void IPPairPrintStats (void);
 
 void IPPairRegisterUnittests(void);
@@ -133,7 +131,6 @@ void IPPairRegisterUnittests(void);
 IPPair *IPPairAlloc(void);
 void IPPairFree(IPPair *);
 
-void IPPairLock(IPPair *);
 void IPPairUnlock(IPPair *);
 
 int IPPairSetMemcap(uint64_t size);

--- a/src/output-flow.c
+++ b/src/output-flow.c
@@ -184,22 +184,6 @@ TmEcode OutputFlowLogThreadDeinit(ThreadVars *tv, void *thread_data)
     return TM_ECODE_OK;
 }
 
-void OutputFlowLogExitPrintStats(ThreadVars *tv, void *thread_data)
-{
-    OutputFlowLoggerThreadData *op_thread_data = (OutputFlowLoggerThreadData *)thread_data;
-    OutputLoggerThreadStore *store = op_thread_data->store;
-    OutputFlowLogger *logger = list;
-
-    while (logger && store) {
-        if (logger->ThreadExitPrintStats) {
-            logger->ThreadExitPrintStats(tv, store->thread_data);
-        }
-
-        logger = logger->next;
-        store = store->next;
-    }
-}
-
 void OutputFlowShutdown(void)
 {
     OutputFlowLogger *logger = list;

--- a/src/output-flow.h
+++ b/src/output-flow.h
@@ -40,6 +40,5 @@ void OutputFlowShutdown(void);
 TmEcode OutputFlowLog(ThreadVars *tv, void *thread_data, Flow *f);
 TmEcode OutputFlowLogThreadInit(ThreadVars *tv, void *initdata, void **data);
 TmEcode OutputFlowLogThreadDeinit(ThreadVars *tv, void *thread_data);
-void OutputFlowLogExitPrintStats(ThreadVars *tv, void *thread_data);
 
 #endif /* __OUTPUT_FLOW_H__ */

--- a/src/output.c
+++ b/src/output.c
@@ -422,44 +422,6 @@ void OutputRegisterTxSubModule(LoggerId id, const char *parent_name,
 }
 
 /**
- * \brief Register a file output module.
- *
- * This function will register an output module so it can be
- * configured with the configuration file.
- *
- * \retval Returns 0 on success, -1 on failure.
- */
-void OutputRegisterFileModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc, FileLogger FileLogFunc,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats)
-{
-    if (unlikely(FileLogFunc == NULL)) {
-        goto error;
-    }
-
-    OutputModule *module = SCCalloc(1, sizeof(*module));
-    if (unlikely(module == NULL)) {
-        goto error;
-    }
-
-    module->logger_id = id;
-    module->name = name;
-    module->conf_name = conf_name;
-    module->InitFunc = InitFunc;
-    module->FileLogFunc = FileLogFunc;
-    module->ThreadInit = ThreadInit;
-    module->ThreadDeinit = ThreadDeinit;
-    module->ThreadExitPrintStats = ThreadExitPrintStats;
-    TAILQ_INSERT_TAIL(&output_modules, module, entries);
-
-    SCLogDebug("File logger \"%s\" registered.", name);
-    return;
-error:
-    FatalError("Fatal error encountered. Exiting...");
-}
-
-/**
  * \brief Register a file output sub-module.
  *
  * This function will register an output module so it can be
@@ -526,46 +488,6 @@ void OutputRegisterFiledataModule(LoggerId id, const char *name,
     module->name = name;
     module->conf_name = conf_name;
     module->InitFunc = InitFunc;
-    module->FiledataLogFunc = FiledataLogFunc;
-    module->ThreadInit = ThreadInit;
-    module->ThreadDeinit = ThreadDeinit;
-    module->ThreadExitPrintStats = ThreadExitPrintStats;
-    TAILQ_INSERT_TAIL(&output_modules, module, entries);
-
-    SCLogDebug("Filedata logger \"%s\" registered.", name);
-    return;
-error:
-    FatalError("Fatal error encountered. Exiting...");
-}
-
-/**
- * \brief Register a file data output sub-module.
- *
- * This function will register an output module so it can be
- * configured with the configuration file.
- *
- * \retval Returns 0 on success, -1 on failure.
- */
-void OutputRegisterFiledataSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    FiledataLogger FiledataLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats)
-{
-    if (unlikely(FiledataLogFunc == NULL)) {
-        goto error;
-    }
-
-    OutputModule *module = SCCalloc(1, sizeof(*module));
-    if (unlikely(module == NULL)) {
-        goto error;
-    }
-
-    module->logger_id = id;
-    module->name = name;
-    module->conf_name = conf_name;
-    module->parent_name = parent_name;
-    module->InitSubFunc = InitFunc;
     module->FiledataLogFunc = FiledataLogFunc;
     module->ThreadInit = ThreadInit;
     module->ThreadDeinit = ThreadDeinit;
@@ -646,47 +568,6 @@ void OutputRegisterStreamingModule(LoggerId id, const char *name,
     module->name = name;
     module->conf_name = conf_name;
     module->InitFunc = InitFunc;
-    module->StreamingLogFunc = StreamingLogFunc;
-    module->stream_type = stream_type;
-    module->ThreadInit = ThreadInit;
-    module->ThreadDeinit = ThreadDeinit;
-    module->ThreadExitPrintStats = ThreadExitPrintStats;
-    TAILQ_INSERT_TAIL(&output_modules, module, entries);
-
-    SCLogDebug("Streaming logger \"%s\" registered.", name);
-    return;
-error:
-    FatalError("Fatal error encountered. Exiting...");
-}
-
-/**
- * \brief Register a streaming data output sub-module.
- *
- * This function will register an output module so it can be
- * configured with the configuration file.
- *
- * \retval Returns 0 on success, -1 on failure.
- */
-void OutputRegisterStreamingSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    StreamingLogger StreamingLogFunc, enum OutputStreamingType stream_type,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats)
-{
-    if (unlikely(StreamingLogFunc == NULL)) {
-        goto error;
-    }
-
-    OutputModule *module = SCCalloc(1, sizeof(*module));
-    if (unlikely(module == NULL)) {
-        goto error;
-    }
-
-    module->logger_id = id;
-    module->name = name;
-    module->conf_name = conf_name;
-    module->parent_name = parent_name;
-    module->InitSubFunc = InitFunc;
     module->StreamingLogFunc = StreamingLogFunc;
     module->stream_type = stream_type;
     module->ThreadInit = ThreadInit;

--- a/src/output.h
+++ b/src/output.h
@@ -132,27 +132,15 @@ void OutputRegisterTxSubModuleWithProgress(LoggerId id, const char *parent_name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
-void OutputRegisterFileModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc,
-    FileLogger FileLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
 void OutputRegisterFileSubModule(LoggerId id, const char *parent_name,
     const char *name, const char *conf_name,
     OutputInitSubFunc InitFunc, FileLogger FileLogFunc,
     ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
-void OutputRegisterFiledataModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc,
-    FiledataLogger FiledataLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
-void OutputRegisterFiledataSubModule(LoggerId, const char *parent_name,
-    const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
-    FiledataLogger FiledataLogFunc, ThreadInitFunc ThreadInit,
-    ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
+void OutputRegisterFiledataModule(LoggerId id, const char *name, const char *conf_name,
+        OutputInitFunc InitFunc, FiledataLogger FiledataLogFunc, ThreadInitFunc ThreadInit,
+        ThreadDeinitFunc ThreadDeinit, ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
 void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
     const char *name, const char *conf_name, OutputInitSubFunc InitFunc,
@@ -160,17 +148,10 @@ void OutputRegisterFlowSubModule(LoggerId id, const char *parent_name,
     ThreadDeinitFunc ThreadDeinit,
     ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
-void OutputRegisterStreamingModule(LoggerId id, const char *name,
-    const char *conf_name, OutputInitFunc InitFunc,
-    StreamingLogger StreamingLogFunc, enum OutputStreamingType stream_type,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
-void OutputRegisterStreamingSubModule(LoggerId id, const char *parent_name,
-    const char *name, const char *conf_name,
-    OutputInitSubFunc InitFunc, StreamingLogger StreamingLogFunc,
-    enum OutputStreamingType stream_type,
-    ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit,
-    ThreadExitPrintStatsFunc ThreadExitPrintStats);
+void OutputRegisterStreamingModule(LoggerId id, const char *name, const char *conf_name,
+        OutputInitFunc InitFunc, StreamingLogger StreamingLogFunc,
+        enum OutputStreamingType stream_type, ThreadInitFunc ThreadInit,
+        ThreadDeinitFunc ThreadDeinit, ThreadExitPrintStatsFunc ThreadExitPrintStats);
 
 void OutputRegisterStatsModule(LoggerId id, const char *name,
     const char *conf_name, OutputInitFunc InitFunc,

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -261,11 +261,6 @@ static int NapatechInit(int runmode)
     return 0;
 }
 
-int RunModeNapatechAutoFp(void)
-{
-    return NapatechInit(NT_RUNMODE_AUTOFP);
-}
-
 int RunModeNapatechWorkers(void)
 {
     return NapatechInit(NT_RUNMODE_WORKERS);

--- a/src/runmode-napatech.h
+++ b/src/runmode-napatech.h
@@ -30,7 +30,6 @@
 #include <nt.h>
 #endif /* HAVE_NAPATECH */
 
-int RunModeNapatechAutoFp(void);
 int RunModeNapatechWorkers(void);
 void RunModeNapatechRegister(void);
 const char *RunModeNapatechGetDefaultMode(void);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -548,11 +548,6 @@ static int file_logger_count = 0;
 static int filedata_logger_count = 0;
 static LoggerId logger_bits[ALPROTO_MAX];
 
-int RunModeOutputFileEnabled(void)
-{
-    return file_logger_count > 0;
-}
-
 int RunModeOutputFiledataEnabled(void)
 {
     return filedata_logger_count > 0;

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -89,8 +89,6 @@ void RunModeInitializeThreadSettings(void);
 void RunModeInitializeOutputs(void);
 void RunModeShutDown(void);
 
-/* bool indicating if file logger is enabled */
-int RunModeOutputFileEnabled(void);
 /* bool indicating if filedata logger is enabled */
 int RunModeOutputFiledataEnabled(void);
 /** bool indicating if run mode is offline */

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -283,11 +283,6 @@ TmEcode AFXDPQueueProtectionInit(void)
     SCReturnInt(TM_ECODE_OK);
 }
 
-void AFXDPMutexClean(void)
-{
-    SCMutexDestroy(&xsk_protect.queue_protect);
-}
-
 static TmEcode AFXDPAssignQueueID(AFXDPThreadVars *ptv)
 {
     if (ptv->xsk.queue.assigned == false) {

--- a/src/source-af-xdp.h
+++ b/src/source-af-xdp.h
@@ -64,6 +64,5 @@ void TmModuleReceiveAFXDPRegister(void);
 void TmModuleDecodeAFXDPRegister(void);
 
 TmEcode AFXDPQueueProtectionInit(void);
-void AFXDPMutexClean(void);
 
 #endif /* __SOURCE_AFXDP_H__ */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -412,11 +412,6 @@ static inline uint64_t GetAbsLastAck(const TcpStream *stream)
     }
 }
 
-uint64_t StreamTcpGetAcked(const TcpStream *stream)
-{
-    return GetAbsLastAck(stream);
-}
-
 // may contain gaps
 uint64_t StreamDataRightEdge(const TcpStream *stream, const bool eof)
 {
@@ -2167,16 +2162,6 @@ void StreamTcpCreateTestPacket(uint8_t *payload, uint8_t value,
  *  \param  stream_policy   Predefined value of stream for different OS policies
  *  \param  stream          Reassembled stream returned from the reassembly functions
  */
-
-int StreamTcpCheckStreamContents(uint8_t *stream_policy, uint16_t sp_size, TcpStream *stream)
-{
-    if (StreamingBufferCompareRawData(&stream->sb, stream_policy,(uint32_t)sp_size) == 0)
-    {
-        //PrintRawDataFp(stdout, stream_policy, sp_size);
-        return 0;
-    }
-    return 1;
-}
 
 static int VALIDATE(TcpStream *stream, uint8_t *data, uint32_t data_len)
 {

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -128,10 +128,6 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 void StreamTcpDisableAppLayer(Flow *f);
 int StreamTcpAppLayerIsDisabled(Flow *f);
 
-#ifdef UNITTESTS
-int StreamTcpCheckStreamContents(uint8_t *, uint16_t , TcpStream *);
-#endif
-
 bool StreamReassembleRawHasDataReady(TcpSession *ssn, Packet *p);
 void StreamTcpReassemblySetMinInspectDepth(TcpSession *ssn, int direction, uint32_t depth);
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -198,7 +198,6 @@ int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn
 void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
         const uint32_t progress);
 
-uint64_t StreamTcpGetAcked(const TcpStream *stream);
 uint64_t StreamTcpGetUsable(const TcpStream *stream, const bool eof);
 uint64_t StreamDataRightEdge(const TcpStream *stream, const bool eof);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -231,12 +231,6 @@ int EngineModeIsIPS(void)
     return (g_engine_mode == ENGINE_MODE_IPS);
 }
 
-int EngineModeIsIDS(void)
-{
-    DEBUG_VALIDATE_BUG_ON(g_engine_mode == ENGINE_MODE_UNKNOWN);
-    return (g_engine_mode == ENGINE_MODE_IDS);
-}
-
 void EngineModeSetIPS(void)
 {
     g_engine_mode = ENGINE_MODE_IPS;

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -108,7 +108,6 @@ void EngineModeSetIPS(void);
 void EngineModeSetIDS(void);
 int EngineModeIsUnknown(void);
 int EngineModeIsIPS(void);
-int EngineModeIsIDS(void);
 
 /* Box is acting as router */
 enum {

--- a/src/tm-modules.c
+++ b/src/tm-modules.c
@@ -68,17 +68,6 @@ TmModule *TmModuleGetByName(const char *name)
     return NULL;
 }
 
-/** \brief get the id of a module from it's name
- *  \param name registered name of the module
- *  \retval id the id or -1 in case of error */
-int TmModuleGetIdByName(const char *name)
-{
-    TmModule *tm = TmModuleGetByName(name);
-    if (tm == NULL)
-        return -1;
-    return TmModuleGetIDForTM(tm);
-}
-
 /**
  * \brief Returns a TM Module by its id.
  *

--- a/src/tm-modules.h
+++ b/src/tm-modules.h
@@ -94,7 +94,6 @@ typedef struct OutputCtx_ {
 
 TmModule *TmModuleGetByName(const char *name);
 TmModule *TmModuleGetById(int id);
-int TmModuleGetIdByName(const char *name);
 int TmModuleGetIDForTM(TmModule *tm);
 TmEcode TmModuleRegister(char *name, int (*module_func)(ThreadVars *, Packet *, void *));
 void TmModuleDebugList(void);

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -243,22 +243,6 @@ void PacketPoolReturnPacket(Packet *p)
     }
 }
 
-void PacketPoolInitEmpty(void)
-{
-    PktPool *my_pool = GetThreadPacketPool();
-
-#ifdef DEBUG_VALIDATION
-    BUG_ON(my_pool->initialized);
-    my_pool->initialized = 1;
-    my_pool->destroyed = 0;
-#endif /* DEBUG_VALIDATION */
-
-    SCMutexInit(&my_pool->return_stack.mutex, NULL);
-    SCCondInit(&my_pool->return_stack.cond, NULL);
-    SC_ATOMIC_INIT(my_pool->return_stack.return_threshold);
-    SC_ATOMIC_SET(my_pool->return_stack.return_threshold, 32);
-}
-
 void PacketPoolInit(void)
 {
     PktPool *my_pool = GetThreadPacketPool();

--- a/src/tmqh-packetpool.h
+++ b/src/tmqh-packetpool.h
@@ -80,7 +80,6 @@ Packet *PacketPoolGetPacket(void);
 void PacketPoolWait(void);
 void PacketPoolReturnPacket(Packet *p);
 void PacketPoolInit(void);
-void PacketPoolInitEmpty(void);
 void PacketPoolDestroy(void);
 void PacketPoolPostRunmodes(void);
 

--- a/src/util-bloomfilter-counting.c
+++ b/src/util-bloomfilter-counting.c
@@ -83,17 +83,6 @@ void BloomFilterCountingFree(BloomFilterCounting *bf)
     }
 }
 
-void BloomFilterCountingPrint(BloomFilterCounting *bf)
-{
-    printf("\n------ Counting Bloom Filter Stats ------\n");
-    printf("Buckets:               %" PRIu32 "\n", bf->array_size);
-    printf("Counter size:          %" PRIu32 "\n", bf->type);
-    printf("Memory size:           %" PRIu32 " bytes\n", bf->array_size * bf->type);
-    printf("Hash function pointer: %p\n", bf->Hash);
-    printf("Hash functions:        %" PRIu32 "\n", bf->hash_iterations);
-    printf("-----------------------------------------\n");
-}
-
 int BloomFilterCountingAdd(BloomFilterCounting *bf, const void *data, uint16_t datalen)
 {
     uint8_t iter = 0;

--- a/src/util-bloomfilter-counting.h
+++ b/src/util-bloomfilter-counting.h
@@ -36,7 +36,6 @@ typedef struct BloomFilterCounting_ {
 /* prototypes */
 BloomFilterCounting *BloomFilterCountingInit(uint32_t, uint8_t, uint8_t, uint32_t (*Hash)(const void *, uint16_t, uint8_t, uint32_t));
 void BloomFilterCountingFree(BloomFilterCounting *);
-void BloomFilterCountingPrint(BloomFilterCounting *);
 int BloomFilterCountingAdd(BloomFilterCounting *, const void *, uint16_t);
 int BloomFilterCountingRemove(BloomFilterCounting *, const void *, uint16_t);
 int BloomFilterCountingTest(BloomFilterCounting *, const void *, uint16_t);

--- a/src/util-bloomfilter.c
+++ b/src/util-bloomfilter.c
@@ -74,16 +74,6 @@ void BloomFilterFree(BloomFilter *bf)
     }
 }
 
-void BloomFilterPrint(BloomFilter *bf)
-{
-    printf("\n---------- Bloom Filter Stats -----------\n");
-    printf("Buckets:               %" PRIu32 "\n", bf->bitarray_size);
-    printf("Memory size:           %" PRIu32 " bytes\n", bf->bitarray_size/8 + 1);
-    printf("Hash function pointer: %p\n", bf->Hash);
-    printf("Hash functions:        %" PRIu32 "\n", bf->hash_iterations);
-    printf("-----------------------------------------\n");
-}
-
 int BloomFilterAdd(BloomFilter *bf, const void *data, uint16_t datalen)
 {
     uint8_t iter = 0;
@@ -98,22 +88,6 @@ int BloomFilterAdd(BloomFilter *bf, const void *data, uint16_t datalen)
     }
 
     return 0;
-}
-
-uint32_t BloomFilterMemoryCnt(BloomFilter *bf)
-{
-     if (bf == NULL)
-         return 0;
-
-     return 2;
-}
-
-uint32_t BloomFilterMemorySize(BloomFilter *bf)
-{
-     if (bf == NULL)
-         return 0;
-
-     return (sizeof(BloomFilter) + (bf->bitarray_size/8) + 1);
 }
 
 /*

--- a/src/util-bloomfilter.h
+++ b/src/util-bloomfilter.h
@@ -35,10 +35,7 @@ typedef struct BloomFilter_ {
 /* prototypes */
 BloomFilter *BloomFilterInit(uint32_t, uint8_t, uint32_t (*Hash)(const void *, uint16_t, uint8_t, uint32_t));
 void BloomFilterFree(BloomFilter *);
-void BloomFilterPrint(BloomFilter *);
 int BloomFilterAdd(BloomFilter *, const void *, uint16_t);
-uint32_t BloomFilterMemoryCnt(BloomFilter *);
-uint32_t BloomFilterMemorySize(BloomFilter *);
 
 void BloomFilterRegisterTests(void);
 

--- a/src/util-byte.c
+++ b/src/util-byte.c
@@ -644,31 +644,6 @@ int StringParseInt32(int32_t *res, int base, size_t len, const char *str)
     return ret;
 }
 
-int StringParseInt16(int16_t *res, int base, size_t len, const char *str)
-{
-    int64_t i64;
-    int ret;
-
-    ret = ByteExtractStringSigned(&i64, base, len, str, true);
-    if (ret <= 0) {
-        return ret;
-    }
-    if (i64 < INT16_MIN || i64 > INT16_MAX) {
-        return -1;
-    }
-
-    *res = (int16_t)i64;
-
-    if ((int64_t)(*res) != i64) {
-        SCLogError("Numeric value out of range "
-                   "(%" PRIi64 " > %" PRIiMAX ")\n",
-                i64, (intmax_t)SHRT_MAX);
-        return -1;
-    }
-
-    return ret;
-}
-
 int StringParseInt8(int8_t *res, int base, size_t len, const char *str)
 {
     int64_t i64;

--- a/src/util-byte.h
+++ b/src/util-byte.h
@@ -345,7 +345,6 @@ int StringParseInt32(int32_t *res, int base, size_t len, const char *str);
  * \return n Number of bytes extracted on success
  * \return -1 On error
  */
-int StringParseInt16(int16_t *res, int base, size_t len, const char *str);
 
 /**
  * Extract signed integer value from a string as int8_t strictly.

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -135,39 +135,6 @@ uint16_t UtilCpuGetNumProcessorsOnline(void)
 }
 
 /**
- * \brief Get the maximum number of cpus allowed in the system
- *        This syscall is present on Solaris, but it's not on linux
- *        or macosx. Maybe you should look at UtilCpuGetNumProcessorsConfigured()
- * \retval 0 if the syscall is not available or we have an error;
- *           otherwise it will return the number of cpus allowed
- */
-uint16_t UtilCpuGetNumProcessorsMax(void)
-{
-#ifdef SYSCONF_NPROCESSORS_MAX_COMPAT
-    long nprocs = -1;
-    nprocs = sysconf(_SC_NPROCESSORS_MAX);
-    if (nprocs < 1) {
-        SCLogError("Couldn't retrieve the maximum number of cpus "
-                   "allowed by the system (%s)",
-                strerror(errno));
-        return 0;
-    }
-
-    if (nprocs > UINT16_MAX) {
-        SCLogDebug("It seems that the system support more that %"PRIu16" CPUs. You "
-                   "can modify util-cpu.{c,h} to use uint32_t to support it", UINT16_MAX);
-        return UINT16_MAX;
-    }
-
-    return (uint16_t)nprocs;
-#else
-    SCLogError("Couldn't retrieve the maximum number of cpus allowed by "
-               "the system, synconf macro unavailable");
-    return 0;
-#endif
-}
-
-/**
  * \brief Print a summary of CPUs detected (configured and online)
  */
 void UtilCpuPrintSummary(void)

--- a/src/util-cpu.h
+++ b/src/util-cpu.h
@@ -29,9 +29,6 @@ uint16_t UtilCpuGetNumProcessorsConfigured(void);
 /* Processors online: */
 uint16_t UtilCpuGetNumProcessorsOnline(void);
 
-/* Only on Solaris */
-uint16_t UtilCpuGetNumProcessorsMax(void);
-
 void UtilCpuPrintSummary(void);
 
 uint64_t UtilCpuGetTicks(void);

--- a/src/util-debug-filters.c
+++ b/src/util-debug-filters.c
@@ -315,27 +315,6 @@ int SCLogMatchFGFilterBL(const char *file, const char *function, int line)
 }
 
 /**
- * \brief Adds a Whitelist(WL) fine-grained(FG) filter.  A FG filter WL filter
- *        allows messages that match this filter, to be logged, while the filter
- *        is defined using a file_name, function_name and line_number.
- *
- *        If a particular parameter in the fg-filter(file, function and line),
- *        shouldn't be considered while logging the message, one can supply
- *        NULL for the file_name or function_name and a negative line_no.
- *
- * \param file     File_name of the filter
- * \param function Function_name of the filter
- * \param line     Line number of the filter
- *
- * \retval  0 on successfully adding the filter;
- * \retval -1 on failure
- */
-int SCLogAddFGFilterWL(const char *file, const char *function, int line)
-{
-    return SCLogAddFGFilter(file, function, line, SC_LOG_FILTER_WL);
-}
-
-/**
  * \brief Adds a Blacklist(BL) fine-grained(FG) filter.  A FG filter BL filter
  *        allows messages that don't match this filter, to be logged, while the
  *        filter is defined using a file_name, function_name and line_number

--- a/src/util-debug-filters.h
+++ b/src/util-debug-filters.h
@@ -91,9 +91,6 @@ extern int sc_log_fg_filters_present;
 
 extern int sc_log_fd_filters_present;
 
-
-int SCLogAddFGFilterWL(const char *, const char *, int);
-
 int SCLogAddFGFilterBL(const char *, const char *, int);
 
 int SCLogMatchFGFilterBL(const char *, const char *, int);

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -487,25 +487,6 @@ int LiveDevUseBypass(LiveDevice *dev)
 }
 
 /**
- * Set number of currently bypassed flows for a protocol family
- *
- * \param dev pointer to LiveDevice to set stats for
- * \param cnt number of currently bypassed flows
- * \param family AF_INET to set IPv4 count or AF_INET6 to set IPv6 count
- */
-void LiveDevSetBypassStats(LiveDevice *dev, uint64_t cnt, int family)
-{
-    BypassInfo *bpfdata = LiveDevGetStorageById(dev, g_bypass_storage_id);
-    if (bpfdata) {
-        if (family == AF_INET) {
-            SC_ATOMIC_SET(bpfdata->ipv4_hash_count, cnt);
-        } else if (family == AF_INET6) {
-            SC_ATOMIC_SET(bpfdata->ipv6_hash_count, cnt);
-        }
-    }
-}
-
-/**
  * Increase number of currently bypassed flows for a protocol family
  *
  * \param dev pointer to LiveDevice to set stats for

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -81,7 +81,6 @@ void LiveDevRegisterExtension(void);
 int LiveRegisterDeviceName(const char *dev);
 int LiveRegisterDevice(const char *dev);
 int LiveDevUseBypass(LiveDevice *dev);
-void LiveDevSetBypassStats(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevAddBypassStats(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevSubBypassStats(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevAddBypassFail(LiveDevice *dev, uint64_t cnt, int family);

--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -101,14 +101,6 @@ void HashTableFree(HashTable *ht)
     SCFree(ht);
 }
 
-void HashTablePrint(HashTable *ht)
-{
-    printf("\n----------- Hash Table Stats ------------\n");
-    printf("Buckets:               %" PRIu32 "\n", ht->array_size);
-    printf("Hash function pointer: %p\n", ht->Hash);
-    printf("-----------------------------------------\n");
-}
-
 int HashTableAdd(HashTable *ht, void *data, uint16_t datalen)
 {
     if (ht == NULL || data == NULL)

--- a/src/util-hash.h
+++ b/src/util-hash.h
@@ -48,7 +48,6 @@ typedef struct HashTable_ {
 /* prototypes */
 HashTable* HashTableInit(uint32_t, uint32_t (*Hash)(struct HashTable_ *, void *, uint16_t), char (*Compare)(void *, uint16_t, void *, uint16_t), void (*Free)(void *));
 void HashTableFree(HashTable *);
-void HashTablePrint(HashTable *);
 int HashTableAdd(HashTable *, void *, uint16_t);
 int HashTableRemove(HashTable *, void *, uint16_t);
 void *HashTableLookup(HashTable *, void *, uint16_t);

--- a/src/util-hashlist.c
+++ b/src/util-hashlist.c
@@ -111,14 +111,6 @@ void HashListTableFree(HashListTable *ht)
     SCFree(ht);
 }
 
-void HashListTablePrint(HashListTable *ht)
-{
-    printf("\n----------- Hash Table Stats ------------\n");
-    printf("Buckets:               %" PRIu32 "\n", ht->array_size);
-    printf("Hash function pointer: %p\n", ht->Hash);
-    printf("-----------------------------------------\n");
-}
-
 int HashListTableAdd(HashListTable *ht, void *data, uint16_t datalen)
 {
     if (ht == NULL || data == NULL)

--- a/src/util-hashlist.h
+++ b/src/util-hashlist.h
@@ -47,7 +47,6 @@ typedef struct HashListTable_ {
 /* prototypes */
 HashListTable* HashListTableInit(uint32_t, uint32_t (*Hash)(struct HashListTable_ *, void *, uint16_t), char (*Compare)(void *, uint16_t, void *, uint16_t), void (*Free)(void *));
 void HashListTableFree(HashListTable *);
-void HashListTablePrint(HashListTable *);
 int HashListTableAdd(HashListTable *, void *, uint16_t);
 int HashListTableRemove(HashListTable *, void *, uint16_t);
 void *HashListTableLookup(HashListTable *, void *, uint16_t);

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -89,19 +89,6 @@ void LuaPushTableKeyValueInt(lua_State *luastate, const char *key, int value)
  *
  *  If value is NULL, string "(null")" will be put on the stack.
  */
-void LuaPushTableKeyValueString(lua_State *luastate, const char *key, const char *value)
-{
-    lua_pushstring(luastate, key);
-    lua_pushstring(luastate, value ? value : "(null)");
-    lua_settable(luastate, -3);
-}
-
-void LuaPushTableKeyValueArray(lua_State *luastate, const char *key, const uint8_t *value, size_t len)
-{
-    lua_pushstring(luastate, key);
-    LuaPushStringBuffer(luastate, value, len);
-    lua_settable(luastate, -3);
-}
 
 /** \internal
  *  \brief fill lua stack with payload

--- a/src/util-lua-common.h
+++ b/src/util-lua-common.h
@@ -30,8 +30,6 @@ int LuaCallbackError(lua_State *luastate, const char *msg);
 const char *LuaGetStringArgument(lua_State *luastate, int argc);
 
 void LuaPushTableKeyValueInt(lua_State *luastate, const char *key, int value);
-void LuaPushTableKeyValueString(lua_State *luastate, const char *key, const char *value);
-void LuaPushTableKeyValueArray(lua_State *luastate, const char *key, const uint8_t *value, size_t len);
 
 int LuaRegisterFunctions(lua_State *luastate);
 

--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -144,23 +144,6 @@ end:
     return retval;
 }
 
-int ParseSizeStringU8(const char *size, uint8_t *res)
-{
-    double temp_res = 0;
-
-    *res = 0;
-    int r = ParseSizeString(size, &temp_res);
-    if (r < 0)
-        return r;
-
-    if (temp_res > UINT8_MAX)
-        return -1;
-
-    *res = temp_res;
-
-    return 0;
-}
-
 int ParseSizeStringU16(const char *size, uint16_t *res)
 {
     double temp_res = 0;

--- a/src/util-misc.h
+++ b/src/util-misc.h
@@ -42,7 +42,6 @@
 
 /* size string parsing API */
 
-int ParseSizeStringU8(const char *, uint8_t *);
 int ParseSizeStringU16(const char *, uint16_t *);
 int ParseSizeStringU32(const char *, uint32_t *);
 int ParseSizeStringU64(const char *, uint64_t *);

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -118,42 +118,6 @@ char *PathMergeAlloc(const char *const dir, const char *const fname)
 }
 
 /**
- * \brief Wrapper to join a directory and filename and resolve using realpath
- *   _fullpath is used for WIN32
- *
- * \param out_buf output buffer.  Up to PATH_MAX will be written.  Unchanged on exit failure.
- * \param buf_size length of output buffer, must be PATH_MAX
- * \param dir the directory
- * \param fname the filename
- *
- * \retval 0 on success
- * \retval -1 on failure
- */
-int PathJoin(char *out_buf, size_t buf_size, const char *const dir, const char *const fname)
-{
-    SCEnter();
-    if (buf_size != PATH_MAX) {
-        return -1;
-    }
-    if (PathMerge(out_buf, buf_size, dir, fname) != 0) {
-        SCLogError("Could not join filename to path");
-        return -1;
-    }
-    char *tmp_buf = SCRealPath(out_buf, NULL);
-    if (tmp_buf == NULL) {
-        SCLogError("Error resolving path: %s", strerror(errno));
-        return -1;
-    }
-    memset(out_buf, 0, buf_size);
-    size_t ret = strlcpy(out_buf, tmp_buf, buf_size);
-    free(tmp_buf);
-    if (ret >= buf_size) {
-        return -1;
-    }
-    return 0;
-}
-
-/**
  * \brief Wrapper around SCMkDir with default mode arguments.
  */
 int SCDefaultMkDir(const char *path)
@@ -223,57 +187,6 @@ bool SCPathExists(const char *path)
         return true;
     }
     return false;
-}
-
-/**
- * \brief OS independent wrapper for directory check
- *
- * \param dir_entry object to check
- *
- * \retval True if the object is a regular directory, otherwise false.  This directory
- *          and parent directory will return false.
- */
-bool SCIsRegularDirectory(const struct dirent *const dir_entry)
-{
-#ifndef OS_WIN32
-    if ((dir_entry->d_type == DT_DIR) &&
-        (strcmp(dir_entry->d_name, ".") != 0) &&
-        (strcmp(dir_entry->d_name, "..") != 0)) {
-        return true;
-    }
-#endif
-    return false;
-}
-/**
- * \brief OS independent to check for regular file
- *
- * \param dir_entry object to check
- *
- * \retval True if the object is a regular file.  Otherwise false.
- */
-bool SCIsRegularFile(const struct dirent *const dir_entry)
-{
-#ifndef OS_WIN32
-    return dir_entry->d_type == DT_REG;
-#endif
-    return false;
-}
-
-/**
- * \brief OS independent wrapper for realpath
- *
- * \param path the path to resolve
- * \param resolved_path the resolved path; if null, a buffer will be allocated
- *
- * \retval the resolved_path; or a pointer to a new resolved_path buffer
- */
-char *SCRealPath(const char *path, char *resolved_path)
-{
-#ifdef OS_WIN32
-    return _fullpath(resolved_path, path, PATH_MAX);
-#else
-    return realpath(path, resolved_path);
-#endif
 }
 
 /*

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -51,13 +51,9 @@ int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
 int PathMerge(char *out_buf, size_t buf_size, const char *const dir, const char *const fname);
 char *PathMergeAlloc(const char *const dir, const char *const fname);
-int PathJoin(char *out_buf, size_t buf_len, const char *const dir, const char *const fname);
 int SCDefaultMkDir(const char *path);
 int SCCreateDirectoryTree(const char *path, const bool final);
 bool SCPathExists(const char *path);
-bool SCIsRegularDirectory(const struct dirent *const dir_entry);
-bool SCIsRegularFile(const struct dirent *const dir_entry);
-char *SCRealPath(const char *path, char *resolved_path);
 const char *SCBasename(const char *path);
 bool SCPathContainsTraversal(const char *path);
 

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -268,13 +268,6 @@ void PoolFree(Pool *p)
     SCFree(p);
 }
 
-void PoolPrint(Pool *p)
-{
-    printf("\n----------- Hash Table Stats ------------\n");
-    printf("Buckets:               %" PRIu32 "\n", p->empty_stack_size + p->alloc_stack_size);
-    printf("-----------------------------------------\n");
-}
-
 void *PoolGet(Pool *p)
 {
     SCEnter();
@@ -371,18 +364,6 @@ void PoolReturn(Pool *p, void *data)
     pb->data = data;
     p->outstanding--;
     SCReturn;
-}
-
-void PoolPrintSaturation(Pool *p)
-{
-    if (p->max_buckets > 0) {
-        SCLogDebug("pool %p is using %" PRIu32 " out of %" PRIu32 " items (%02.1f%%), max %" PRIu32
-                   " (%02.1f%%): pool struct memory %" PRIu64 ".",
-                p, p->outstanding, p->max_buckets,
-                (float)(p->outstanding) / (float)(p->max_buckets) * 100, p->max_outstanding,
-                (float)(p->max_outstanding) / (float)(p->max_buckets) * 100,
-                (uint64_t)(p->max_buckets * sizeof(PoolBucket)));
-    }
 }
 
 /*

--- a/src/util-pool.h
+++ b/src/util-pool.h
@@ -74,8 +74,6 @@ typedef struct Pool_ {
 /* prototypes */
 Pool* PoolInit(uint32_t, uint32_t, uint32_t, void *(*Alloc)(void), int (*Init)(void *, void *), void *, void (*Cleanup)(void *), void (*Free)(void *));
 void PoolFree(Pool *);
-void PoolPrint(Pool *);
-void PoolPrintSaturation(Pool *p);
 
 void *PoolGet(Pool *);
 void PoolReturn(Pool *, void *);

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -66,27 +66,6 @@ void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, const uint8_t *buf, ui
     }
 }
 
-void PrintRawJsonFp(FILE *fp, uint8_t *buf, uint32_t buflen)
-{
-#define BUFFER_LENGTH 2048
-    char nbuf[BUFFER_LENGTH] = "";
-    uint32_t offset = 0;
-
-    for (uint32_t u = 0; u < buflen; u++) {
-        if (buf[u] == '\\' || buf[u] == '/' || buf[u] == '\"') {
-            PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
-                             "\\%c", buf[u]);
-        } else if (isprint(buf[u])) {
-            PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
-                             "%c", buf[u]);
-        } else {
-            PrintBufferData(nbuf, &offset, BUFFER_LENGTH,
-                            "\\\\x%02X", buf[u]);
-        }
-    }
-    fprintf(fp, "%s", nbuf);
-}
-
 void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
 {
 #define BUFFER_LENGTH 2048

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -43,9 +43,7 @@
 
 void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
 void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
-void PrintRawUriBuf(char *, uint32_t *, uint32_t,
-                    uint8_t *, uint32_t);
-void PrintRawJsonFp(FILE *, uint8_t *, uint32_t);
+void PrintRawUriBuf(char *, uint32_t *, uint32_t, uint8_t *, uint32_t);
 void PrintRawDataFp(FILE *, const uint8_t *, uint32_t);
 void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           const uint8_t *src_buf, uint32_t src_buf_len);

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -1356,21 +1356,6 @@ static void SCRadixRemoveKey(uint8_t *key_stream, uint16_t key_bitlen,
 }
 
 /**
- * \brief Removes a key from the Radix tree
- *
- * \param key_stream Data that has to be removed from the Radix tree
- * \param key_bitlen The bitlen of the above stream.
- * \param tree       Pointer to the Radix tree from which the key has to be
- *                   removed
- */
-void SCRadixRemoveKeyGeneric(uint8_t *key_stream, uint16_t key_bitlen,
-                             SCRadixTree *tree)
-{
-    SCRadixRemoveKey(key_stream, key_bitlen, tree, 255);
-    return;
-}
-
-/**
  * \brief Removes an IPV4 address netblock key from the Radix tree.
  *
  * \param key_stream Data that has to be removed from the Radix tree.  In this

--- a/src/util-radix-tree.h
+++ b/src/util-radix-tree.h
@@ -105,7 +105,6 @@ SCRadixNode *SCRadixAddKeyIPV6Netblock(uint8_t *, SCRadixTree *, void *,
 bool SCRadixAddKeyIPV4String(const char *, SCRadixTree *, void *);
 bool SCRadixAddKeyIPV6String(const char *, SCRadixTree *, void *);
 
-void SCRadixRemoveKeyGeneric(uint8_t *, uint16_t, SCRadixTree *);
 void SCRadixRemoveKeyIPV4Netblock(uint8_t *, SCRadixTree *, uint8_t);
 void SCRadixRemoveKeyIPV4(uint8_t *, SCRadixTree *);
 void SCRadixRemoveKeyIPV6Netblock(uint8_t *, SCRadixTree *, uint8_t);

--- a/src/util-signal.c
+++ b/src/util-signal.c
@@ -74,15 +74,3 @@ void UtilSignalHandlerSetup(int sig, void (*handler)(int))
 
     return;
 }
-
-#if 0
-int UtilSignalIsHandler(int sig, void (*handler)(int))
-{
-    struct sigaction action;
-    memset(&action, 0x00, sizeof(struct sigaction));
-
-    sigaction(sig, NULL, &action);
-
-    return (action.sa_handler == handler);
-}
-#endif

--- a/src/util-signal.h
+++ b/src/util-signal.h
@@ -27,7 +27,4 @@
 int UtilSignalBlock(int);
 int UtilSignalUnblock(int);
 void UtilSignalHandlerSetup(int, void (*handler)(int));
-#if 0
-int UtilSignalIsHandler(int sig, void (*handler)(int));
-#endif
 #endif /* __UTIL_SIGNAL_H__ */

--- a/src/util-spm-bs.c
+++ b/src/util-spm-bs.c
@@ -130,9 +130,3 @@ uint8_t *BasicSearchNocase(const uint8_t *haystack, uint32_t haystack_len, const
 
     return NULL;
 }
-
-void BasicSearchInit (void)
-{
-    /* nothing no more */
-}
-

--- a/src/util-spm-bs.h
+++ b/src/util-spm-bs.h
@@ -29,7 +29,6 @@
 
 uint8_t *BasicSearch(const uint8_t *, uint32_t, const uint8_t *, uint16_t);
 uint8_t *BasicSearchNocase(const uint8_t *, uint32_t, const uint8_t *, uint16_t);
-void BasicSearchInit (void);
 
 #endif /* __UTIL_SPM_BS__ */
 

--- a/src/util-spm-bs2bm.c
+++ b/src/util-spm-bs2bm.c
@@ -54,29 +54,6 @@ void Bs2BmBadchars(const uint8_t *needle, uint16_t needle_len, uint8_t *badchars
 }
 
 /**
- * \brief Array setup function for Bs2BmNocase of bad characters index (not found at the needle)
- *
- * \param needle pointer to the pattern we ar searching for
- * \param needle_len length limit of the needle
- * \param badchars pointer to an empty array of bachars. The array prepared contains
- *                 characters that can't be inside the needle_len. So the skips can be
- *                 faster
- */
-void Bs2BmBadcharsNocase(const uint8_t *needle, uint16_t needle_len, uint8_t *badchars)
-{
-    uint32_t i;
-    for (i = 0; i < ALPHABET_SIZE; i++)
-        badchars[i] = 1;
-
-    /* set to 0 the values where index as ascii is present
-     * because they are not badchars
-     */
-    for (i = 0; i < needle_len; i++) {
-        badchars[u8_tolower(needle[i])] = 0;
-    }
-}
-
-/**
  * \brief Basic search with a bad characters array. The array badchars contains
  *        flags at character's ascii index that can't be inside the needle. So the skips can be
  *        faster

--- a/src/util-spm-bs2bm.h
+++ b/src/util-spm-bs2bm.h
@@ -29,7 +29,6 @@
 #define ALPHABET_SIZE 256
 
 void Bs2BmBadchars(const uint8_t *, uint16_t, uint8_t *);
-void Bs2BmBadcharsNocase(const uint8_t *, uint16_t, uint8_t *);
 uint8_t *Bs2Bm(const uint8_t *, uint32_t, const uint8_t *, uint16_t, const uint8_t[]);
 uint8_t *Bs2BmNocase(const uint8_t *, uint32_t, const uint8_t *, uint16_t, const uint8_t[]);
 

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -221,23 +221,6 @@ uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen,
 }
 
 /**
- * \brief Search a pattern in the text using the Bs2Bm nocase algorithm (build a bad characters array)
- *
- * \param text Text to search in
- * \param textlen length of the text
- * \param needle pattern to search for
- * \param needlelen length of the pattern
- */
-uint8_t *Bs2bmNocaseSearch(const uint8_t *text, uint32_t textlen,
-        const uint8_t *needle, uint16_t needlelen)
-{
-    uint8_t badchars[ALPHABET_SIZE];
-    Bs2BmBadchars(needle, needlelen, badchars);
-
-    return Bs2BmNocase(text, textlen, needle, needlelen, badchars);
-}
-
-/**
  * \brief Search a pattern in the text using Boyer Moore algorithm
  *        (build a bad character shifts array and good prefixes shift array)
  *

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -90,8 +90,8 @@ uint8_t *SpmScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
                  const uint8_t *haystack, uint32_t haystack_len);
 
 /** Default algorithm to use: Boyer Moore */
-uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
-uint8_t *Bs2bmNocaseSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
+uint8_t *Bs2bmSearch(
+        const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *BoyerMooreSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *BoyerMooreNocaseSearch(const uint8_t *text, uint32_t textlen, uint8_t *needle, uint16_t needlelen);
 

--- a/src/util-storage.h
+++ b/src/util-storage.h
@@ -71,5 +71,4 @@ void *StorageAllocByIdPrealloc(Storage *storage, StorageEnum type, int id);
 void StorageFreeById(Storage *storage, const StorageEnum type, const int id);
 void StorageFreeAll(Storage *storage, const StorageEnum type);
 
-void StorageRegisterTests(void);
 #endif

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -343,46 +343,6 @@ Packet *UTHBuildPacket(uint8_t *payload, uint16_t payload_len,
 }
 
 /**
- * \brief UTHBuildPacketArrayFromEth is a wrapper that build a packets from an array of
- *        packets in ethernet rawbytes. Hint: It also share the flows.
- *
- * \param raw_eth pointer to the array of ethernet packets in rawbytes
- * \param pktsize pointer to the array of sizes corresponding to each buffer pointed
- *                from pktsize.
- * \param numpkts number of packets in the array
- *
- * \retval Packet pointer to the array of built in packets; NULL if something fail
- */
-Packet **UTHBuildPacketArrayFromEth(uint8_t *raw_eth[], int *pktsize, int numpkts)
-{
-    DecodeThreadVars dtv;
-    ThreadVars th_v;
-    if (raw_eth == NULL || pktsize == NULL || numpkts <= 0) {
-        SCLogError("The arrays cant be null, and the number"
-                   " of packets should be grater thatn zero");
-        return NULL;
-    }
-    Packet **p = NULL;
-    p = SCMalloc(sizeof(Packet *) * numpkts);
-    if (unlikely(p == NULL))
-        return NULL;
-
-    memset(&dtv, 0, sizeof(DecodeThreadVars));
-    memset(&th_v, 0, sizeof(th_v));
-
-    int i = 0;
-    for (; i < numpkts; i++) {
-        p[i] = PacketGetFromAlloc();
-        if (p[i] == NULL) {
-            SCFree(p);
-            return NULL;
-        }
-        DecodeEthernet(&th_v, &dtv, p[i], raw_eth[i], pktsize[i]);
-    }
-    return p;
-}
-
-/**
  * \brief UTHBuildPacketFromEth is a wrapper that build a packet for the rawbytes
  *
  * \param raw_eth pointer to the rawbytes containing an ethernet packet

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -46,7 +46,6 @@ Packet *UTHBuildPacketSrcDstPorts(uint8_t *, uint16_t, uint8_t ipproto, uint16_t
 Packet *UTHBuildPacketIPV6SrcDst(uint8_t *, uint16_t, uint8_t ipproto, const char *, const char *);
 
 int UTHPacketMatchSigMpm(Packet *, char *, uint16_t);
-Packet **UTHBuildPacketArrayFromEth(uint8_t **, int *, int);
 Packet *UTHBuildPacketFromEth(uint8_t *, uint16_t);
 
 void UTHFreePacket(Packet *);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None : generic cleaning
https://redmine.openinfosecfoundation.org/issues/4083

Describe changes:
- remove functions defined in a header and never used (debug, api-completeness, and others)
- remove double definition of IPPairLock

Python helper script to do this in previous PR

Needed rebase of #9835