### PR TITLE
mqtt: Move conf code to rust

### DIFF
--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2022 Open Information Security Foundation
+/* Copyright (C) 2020-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -21,7 +21,7 @@ use super::mqtt_message::*;
 use super::parser::*;
 use crate::applayer::*;
 use crate::applayer::{self, LoggerFlags};
-use crate::conf::conf_get;
+use crate::conf::{conf_get, get_memval};
 use crate::core::*;
 use crate::frames::*;
 use nom7::Err;
@@ -112,7 +112,7 @@ pub struct MQTTState {
     connected: bool,
     skip_request: usize,
     skip_response: usize,
-    max_msg_len: usize,
+    max_msg_len: u32,
     tx_index_completed: usize,
 }
 
@@ -142,7 +142,7 @@ impl MQTTState {
             connected: false,
             skip_request: 0,
             skip_response: 0,
-            max_msg_len: unsafe { MAX_MSG_LEN as usize },
+            max_msg_len: unsafe { MAX_MSG_LEN},
             tx_index_completed: 0,
         }
     }
@@ -778,10 +778,8 @@ export_tx_data_get!(rs_mqtt_get_tx_data, MQTTTransaction);
 export_state_data_get!(rs_mqtt_get_state_data, MQTTState);
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_mqtt_register_parser(cfg_max_msg_len: u32) {
+pub unsafe extern "C" fn rs_mqtt_register_parser() {
     let default_port = CString::new("[1883]").unwrap();
-    let max_msg_len = &mut MAX_MSG_LEN;
-    *max_msg_len = cfg_max_msg_len;
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),
@@ -828,6 +826,13 @@ pub unsafe extern "C" fn rs_mqtt_register_parser(cfg_max_msg_len: u32) {
                 MQTT_MAX_TX = v;
             } else {
                 SCLogError!("Invalid value for mqtt.max-tx");
+            }
+        }
+        if let Some(val) = conf_get("app-layer.protocols.mqtt.max-msg-length") {
+            if let Ok(v) = get_memval(val) {
+                MAX_MSG_LEN = v as u32;
+            } else {
+                SCLogError!("Invalid value for mqtt.max-msg-length: {}", val);
             }
         }
     } else {

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -634,7 +634,7 @@ fn parse_remaining_message<'a>(
 pub fn parse_message(
     input: &[u8],
     protocol_version: u8,
-    max_msg_size: usize,
+    max_msg_size: u32,
 ) -> IResult<&[u8], MQTTMessage> {
     // Parse the fixed header first. This is identical across versions and can
     // be between 2 and 5 bytes long.
@@ -652,7 +652,7 @@ pub fn parse_message(
             // limit, we return a special truncation message type, containing
             // no parsed metadata but just the skipped length and the message
             // type.
-            if len > max_msg_size {
+            if len > max_msg_size as usize {
                 let msg = MQTTMessage {
                     header,
                     op: MQTTOperation::TRUNCATED(MQTTTruncatedData {

--- a/src/app-layer-mqtt.c
+++ b/src/app-layer-mqtt.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -22,13 +22,7 @@
  */
 
 #include "suricata-common.h"
-#include "stream.h"
-#include "conf.h"
 
-#include "util-misc.h"
-#include "util-unittest.h"
-
-#include "app-layer-detect-proto.h"
 #include "app-layer-parser.h"
 
 #include "app-layer-mqtt.h"
@@ -37,20 +31,9 @@
 void RegisterMQTTParsers(void)
 {
     SCLogDebug("Registering Rust mqtt parser.");
-    uint32_t max_msg_len = 1048576; /* default: 1MB */
 
-    if (AppLayerParserConfParserEnabled("tcp", "mqtt")) {
-        ConfNode *p = ConfGetNode("app-layer.protocols.mqtt.max-msg-length");
-        if (p != NULL) {
-            uint32_t value;
-            if (ParseSizeStringU32(p->val, &value) < 0) {
-                SCLogError("invalid value for max-msg-length: %s", p->val);
-            } else {
-                max_msg_len = value;
-            }
-        }
-        rs_mqtt_register_parser(max_msg_len);
-    }
+    rs_mqtt_register_parser();
+
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_MQTT,
         MQTTParserRegisterTests);


### PR DESCRIPTION
Issue: 6387

This commit moves the configuration logic to Rust.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6387](https://redmine.openinfosecfoundation.org/issues/6387)

Describe changes:
- Move configuration file code to rust
- Make max_msg_size a u32 (was usize)
- Removed extraneous #includes from C module.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
