### PR TITLE
Backport: endace: Fix source-dag timestamps

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -186,12 +186,10 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ErfDagThreadVars *ewtn = SCMalloc(sizeof(ErfDagThreadVars));
+    ErfDagThreadVars *ewtn = SCCalloc(1, sizeof(ErfDagThreadVars));
     if (unlikely(ewtn == NULL)) {
         FatalError("Failed to allocate memory for ERF DAG thread vars.");
     }
-
-    memset(ewtn, 0, sizeof(*ewtn));
 
     /* dag_parse_name will return a DAG device name and stream number
      * to open for this thread.
@@ -508,17 +506,13 @@ ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    /* Convert ERF time to timeval - from libpcap. */
+    /* Convert ERF time to SCTime_t */
     uint64_t ts = dr->ts;
     p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
     uint64_t usecs = ts >> 32;
-    if (usecs >= 1000000) {
-        usecs -= 1000000;
-        p->ts += SCTIME_FROM_SECS(1);
-    }
-    p->ts += SCTIME_FROM_USECS(usecs);
+    p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     StatsIncr(ewtn->tv, ewtn->packets);
     ewtn->bytes += wlen;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -195,17 +195,12 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     GET_PKT_LEN(p) = wlen;
     p->datalink = LINKTYPE_ETHERNET;
 
-    /* Convert ERF time to timeval - from libpcap. */
+    /* Convert ERF time to SCTime_t */
     uint64_t ts = dr.ts;
     p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
     uint64_t usecs = (ts >> 32);
-    if (usecs >= 1000000) {
-        usecs -= 1000000;
-        p->ts = SCTIME_ADD_SECS(p->ts, 1);
-        usecs++;
-    }
     p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     etv->pkts++;


### PR DESCRIPTION
Bug: [#6618](https://redmine.openinfosecfoundation.org/issues/6620)

Fix Endace ERF to SCTime_t timestamp conversion

Fix typo preventing compilation with --enable-dag

(cherry picked from commit 879db3dbc3e93912c784375c85d88404a9371f31)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6620](https://redmine.openinfosecfoundation.org/issues/6620)

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
