### PR TITLE
Detect cleanups/v12

### DIFF
--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -40,7 +40,7 @@
 /*prototypes*/
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectBsizeFree (DetectEngineCtx *, void *);
-static int SigParseGetMaxBsize(DetectU64Data *bsz);
+static int SigParseGetMaxBsize(const DetectU64Data *bsz);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
@@ -48,10 +48,10 @@ static void DetectBsizeRegisterTests (void);
 bool DetectBsizeValidateContentCallback(Signature *s, const SignatureInitDataBuffer *b)
 {
     int bsize = -1;
-    DetectU64Data *bsz;
+    const DetectU64Data *bsz;
     for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
         if (sm->type == DETECT_BSIZE) {
-            bsz = (DetectU64Data *)sm->ctx;
+            bsz = (const DetectU64Data *)sm->ctx;
             bsize = SigParseGetMaxBsize(bsz);
             break;
         }
@@ -171,7 +171,7 @@ static DetectU64Data *DetectBsizeParse(const char *str)
     return DetectU64Parse(str);
 }
 
-static int SigParseGetMaxBsize(DetectU64Data *bsz)
+static int SigParseGetMaxBsize(const DetectU64Data *bsz)
 {
     switch (bsz->mode) {
         case DETECT_UINT_LT:

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -68,8 +68,6 @@
 
 static DetectParseRegex parse_regex;
 
-static int DetectBytetestMatch(DetectEngineThreadCtx *det_ctx,
-                        Packet *p, const Signature *s, const SigMatchCtx *ctx);
 static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr);
 static void DetectBytetestFree(DetectEngineCtx *, void *ptr);
 #ifdef UNITTESTS
@@ -81,7 +79,6 @@ void DetectBytetestRegister (void)
     sigmatch_table[DETECT_BYTETEST].name = "byte_test";
     sigmatch_table[DETECT_BYTETEST].desc = "extract <num of bytes> and perform an operation selected with <operator> against the value in <test value> at a particular <offset>";
     sigmatch_table[DETECT_BYTETEST].url = "/rules/payload-keywords.html#byte-test";
-    sigmatch_table[DETECT_BYTETEST].Match = DetectBytetestMatch;
     sigmatch_table[DETECT_BYTETEST].Setup = DetectBytetestSetup;
     sigmatch_table[DETECT_BYTETEST].Free  = DetectBytetestFree;
 #ifdef UNITTESTS
@@ -311,13 +308,6 @@ int DetectBytetestDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
     SCLogDebug("NO MATCH");
     SCReturnInt(0);
 
-}
-
-static int DetectBytetestMatch(DetectEngineThreadCtx *det_ctx,
-                        Packet *p, const Signature *s, const SigMatchCtx *ctx)
-{
-    return DetectBytetestDoMatch(det_ctx, s, ctx, p->payload, p->payload_len,
-            ((DetectBytetestData *)ctx)->flags, 0, 0, 0);
 }
 
 static DetectBytetestData *DetectBytetestParse(

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -383,9 +383,9 @@ void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
     SCReturn;
 }
 
-/*
+/**
  *  \brief Determine the size needed to accommodate the content
- *  elements of a signature
+ *         elements of a signature
  *  \param s signature to get dsize value from
  *  \param max_size Maximum buffer/data size allowed.
  *  \param list signature match list.

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -571,10 +571,21 @@ static void PropagateLimits(Signature *s, SigMatch *sm_head)
                 SCLogDebug("stored: offset %u depth %u offset_plus_pat %u "
                            "has_active_depth_chain %s",
                         offset, depth, offset_plus_pat, has_active_depth_chain ? "true" : "false");
-                if (cd->flags & DETECT_CONTENT_DISTANCE && cd->distance >= 0) {
-                    VALIDATE((uint32_t)offset_plus_pat + cd->distance <= UINT16_MAX);
-                    offset = cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
-                    SCLogDebug("updated content to have offset %u", cd->offset);
+                if (cd->flags & DETECT_CONTENT_DISTANCE) {
+                    if (cd->distance >= 0) {
+                        VALIDATE((uint32_t)offset_plus_pat + cd->distance <= UINT16_MAX);
+                        offset = cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
+                        SCLogDebug("distance %d: updated content to have offset %u", cd->distance,
+                                cd->offset);
+                    } else {
+                        if (abs(cd->distance) > offset_plus_pat)
+                            offset = cd->offset = 0;
+                        else
+                            offset = cd->offset = (uint16_t)(offset_plus_pat + cd->distance);
+                        offset_plus_pat = offset + cd->content_len;
+                        SCLogDebug("distance %d: updated content to have offset %u", cd->distance,
+                                cd->offset);
+                    }
                 }
                 if (has_active_depth_chain) {
                     if (offset_plus_pat && cd->flags & DETECT_CONTENT_WITHIN && cd->within >= 0) {

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -243,7 +243,7 @@ int SigParseGetMaxDsize(const Signature *s)
 void SigParseSetDsizePair(Signature *s)
 {
     if (s->flags & SIG_FLAG_DSIZE && s->init_data->dsize_sm != NULL) {
-        DetectU16Data *dd = (DetectU16Data *)s->init_data->dsize_sm->ctx;
+        const DetectU16Data *dd = (const DetectU16Data *)s->init_data->dsize_sm->ctx;
 
         uint16_t low = 0;
         uint16_t high = 65535;

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1371,6 +1371,7 @@ void SignatureSetType(DetectEngineCtx *de_ctx, Signature *s)
     }
 }
 
+extern int g_skip_prefilter;
 /**
  * \brief Preprocess signature, classify ip-only, etc, build sig array
  *
@@ -1459,9 +1460,8 @@ int SigPrepareStage1(DetectEngineCtx *de_ctx)
         RuleSetWhitelist(s);
 
         /* if keyword engines are enabled in the config, handle them here */
-        if (de_ctx->prefilter_setting == DETECT_PREFILTER_AUTO &&
-                !(s->flags & SIG_FLAG_PREFILTER))
-        {
+        if (!g_skip_prefilter && de_ctx->prefilter_setting == DETECT_PREFILTER_AUTO &&
+                !(s->flags & SIG_FLAG_PREFILTER)) {
             int prefilter_list = DETECT_TBLSIZE;
 
             // TODO buffers?

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -594,8 +594,7 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
             nbytes = bmd->nbytes;
         }
 
-        DEBUG_VALIDATE_BUG_ON(buffer_len > UINT16_MAX);
-        if (DetectByteMathDoMatch(det_ctx, bmd, s, buffer, (uint16_t)buffer_len, nbytes, rvalue,
+        if (DetectByteMathDoMatch(det_ctx, bmd, s, buffer, buffer_len, nbytes, rvalue,
                     &det_ctx->byte_values[bmd->local_id], endian) != 1) {
             goto no_match;
         }

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -337,7 +337,7 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
 
             if ((cd->flags & DETECT_CONTENT_ENDS_WITH) == 0 || match_offset == buffer_len) {
                 /* Match branch, add replace to the list if needed */
-                if (cd->flags & DETECT_CONTENT_REPLACE) {
+                if (unlikely(cd->flags & DETECT_CONTENT_REPLACE)) {
                     if (inspection_mode == DETECT_ENGINE_CONTENT_INSPECTION_MODE_PAYLOAD) {
                         /* we will need to replace content if match is confirmed
                          * cast to non-const as replace writes to it. */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1066,8 +1066,13 @@ static SigMatch *GetMpmForList(const Signature *s, SigMatch *list, SigMatch *mpm
     return mpm_sm;
 }
 
+int g_skip_prefilter = 0;
+
 void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
 {
+    if (g_skip_prefilter)
+        return;
+
     if (s->init_data->mpm_sm != NULL)
         return;
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2710,9 +2710,6 @@ void DetectParseFreeRegex(DetectParseRegex *r)
     if (r->context) {
         pcre2_match_context_free(r->context);
     }
-    if (r->match) {
-        pcre2_match_data_free(r->match);
-    }
 }
 
 void DetectParseFreeRegexes(void)
@@ -2738,7 +2735,6 @@ void DetectParseRegexAddToFreeList(DetectParseRegex *detect_parse)
         FatalError("failed to alloc memory for pcre free list");
     }
     r->regex = detect_parse->regex;
-    r->match = detect_parse->match;
     r->next = g_detect_parse_regex_list;
     g_detect_parse_regex_list = r;
 }
@@ -2758,8 +2754,6 @@ bool DetectSetupParseRegexesOpts(const char *parse_str, DetectParseRegex *detect
                 parse_str, en, errbuffer);
         return false;
     }
-    detect_parse->match = pcre2_match_data_create_from_pattern(detect_parse->regex, NULL);
-
     DetectParseRegexAddToFreeList(detect_parse);
 
     return true;
@@ -2785,7 +2779,6 @@ DetectParseRegex *DetectSetupPCRE2(const char *parse_str, int opts)
         SCFree(detect_parse);
         return NULL;
     }
-    detect_parse->match = pcre2_match_data_create_from_pattern(detect_parse->regex, NULL);
 
     detect_parse->next = g_detect_parse_regex_list;
     g_detect_parse_regex_list = detect_parse;

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -62,7 +62,6 @@ enum {
 typedef struct DetectParseRegex {
     pcre2_code *regex;
     pcre2_match_context *context;
-    pcre2_match_data *match;
     struct DetectParseRegex *next;
 } DetectParseRegex;
 

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -678,7 +678,6 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         SCLogError("pcre2 could not create match context");
         goto error;
     }
-    pd->parse_regex.match = pcre2_match_data_create_from_pattern(pd->parse_regex.regex, NULL);
 
     if (apply_match_limit) {
         if (pcre_match_limit >= -1) {

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -360,6 +360,8 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
     int check_host_header = 0;
     char op_str[64] = "";
 
+    bool apply_match_limit = false;
+
     int cut_capture = 0;
     char *fcap = strstr(regexstr, "flow:");
     char *pcap = strstr(regexstr, "pkt:");
@@ -472,7 +474,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
                     break;
 
                 case 'O':
-                    pd->flags |= DETECT_PCRE_MATCH_LIMIT;
+                    apply_match_limit = true;
                     break;
 
                 case 'B': /* snort's option */
@@ -678,7 +680,7 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
     }
     pd->parse_regex.match = pcre2_match_data_create_from_pattern(pd->parse_regex.regex, NULL);
 
-    if (pd->flags & DETECT_PCRE_MATCH_LIMIT) {
+    if (apply_match_limit) {
         if (pcre_match_limit >= -1) {
             pcre2_set_match_limit(pd->parse_regex.context, pcre_match_limit);
         }

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -41,15 +41,14 @@
 #define SC_MATCH_LIMIT_RECURSION_DEFAULT 1500
 
 typedef struct DetectPcreData_ {
-    /* pcre options */
     DetectParseRegex parse_regex;
+    int thread_ctx_id;
 
     int opts;
     uint16_t flags;
     uint8_t idx;
     uint8_t captypes[DETECT_PCRE_CAPTURE_MAX];
     uint32_t capids[DETECT_PCRE_CAPTURE_MAX];
-    int thread_ctx_id;
 } DetectPcreData;
 
 /* prototypes */

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -44,7 +44,6 @@ typedef struct DetectPcreData_ {
     DetectParseRegex parse_regex;
     int thread_ctx_id;
 
-    int opts;
     uint16_t flags;
     uint8_t idx;
     uint8_t captypes[DETECT_PCRE_CAPTURE_MAX];

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -31,7 +31,6 @@
 #define DETECT_PCRE_RAWBYTES            0x00002
 #define DETECT_PCRE_CASELESS            0x00004
 
-#define DETECT_PCRE_MATCH_LIMIT         0x00020
 #define DETECT_PCRE_RELATIVE_NEXT       0x00040
 #define DETECT_PCRE_NEGATE              0x00080
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1097,7 +1097,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     }
 
     const DetectEngineAppInspectionEngine *engine = s->app_inspect;
-    while (engine != NULL) { // TODO could be do {} while as s->app_inspect cannot be null
+    do {
         TRACE_SID_TXS(s->id, tx, "engine %p inspect_flags %x", engine, inspect_flags);
         if (!(inspect_flags & BIT_U32(engine->id)) &&
                 direction == engine->dir)
@@ -1178,7 +1178,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             break;
         }
         engine = engine->next;
-    }
+    } while (engine != NULL);
     TRACE_SID_TXS(s->id, tx, "inspect_flags %x, total_matches %u, engine %p",
             inspect_flags, total_matches, engine);
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1797,9 +1797,11 @@ TmEcode Detect(ThreadVars *tv, Packet *p, void *data)
 
 #ifdef PROFILE_RULES
     /* aggregate statistics */
-    if (SCTIME_SECS(p->ts) != det_ctx->rule_perf_last_sync) {
+    struct timeval ts;
+    gettimeofday(&ts, NULL);
+    if (ts.tv_sec != det_ctx->rule_perf_last_sync) {
         SCProfilingRuleThreatAggregate(det_ctx);
-        det_ctx->rule_perf_last_sync = SCTIME_SECS(p->ts);
+        det_ctx->rule_perf_last_sync = ts.tv_sec;
     }
 #endif
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1302,6 +1302,8 @@ static bool IsLogDirectoryWritable(const char* str)
     return false;
 }
 
+extern int g_skip_prefilter;
+
 static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 {
     int opt;
@@ -1396,6 +1398,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"simulate-packet-tcp-ssn-memcap", required_argument, 0, 0},
         {"simulate-packet-defrag-memcap", required_argument, 0, 0},
         {"simulate-alert-queue-realloc-failure", 0, 0, 0},
+
+        {"qa-skip-prefilter", 0, &g_skip_prefilter, 1 },
+
         {"include", required_argument, 0, 0},
 
         {NULL, 0, NULL, 0}

--- a/src/tests/detect-engine-content-inspection.c
+++ b/src/tests/detect-engine-content-inspection.c
@@ -289,6 +289,20 @@ static int DetectEngineContentInspectionTest13(void) {
     TEST_FOOTER;
 }
 
+static int DetectEngineContentInspectionTest14(void)
+{
+    TEST_HEADER;
+    TEST_RUN("XYZ_klm_1234abcd_XYZ_klm_5678abcd", 33,
+            "content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; "
+            "byte_test:4,=,1234,-8,relative,string;",
+            true, 4);
+    TEST_RUN("XYZ_klm_1234abcd_XYZ_klm_5678abcd", 33,
+            "content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; "
+            "byte_test:4,=,5678,-8,relative,string;",
+            true, 5);
+    TEST_FOOTER;
+}
+
 void DetectEngineContentInspectionRegisterTests(void)
 {
     UtRegisterTest("DetectEngineContentInspectionTest01",
@@ -317,6 +331,8 @@ void DetectEngineContentInspectionRegisterTests(void)
                    DetectEngineContentInspectionTest12);
     UtRegisterTest("DetectEngineContentInspectionTest13 mix startswith/endswith",
                    DetectEngineContentInspectionTest13);
+    UtRegisterTest("DetectEngineContentInspectionTest14 byte_test negative offset",
+            DetectEngineContentInspectionTest14);
 }
 
 #undef TEST_HEADER

--- a/src/tests/detect-engine-content-inspection.c
+++ b/src/tests/detect-engine-content-inspection.c
@@ -303,6 +303,17 @@ static int DetectEngineContentInspectionTest14(void)
     TEST_FOOTER;
 }
 
+/** \brief negative distance */
+static int DetectEngineContentInspectionTest17(void)
+{
+    TEST_HEADER;
+    TEST_RUN("aaabbbcccdddee", 14,
+            "content:\"aaa\"; content:\"ee\"; within:2; distance:9; content:\"bbb\"; within:3; "
+            "distance:-11; content:\"ccc\"; within:3; distance:0;",
+            true, 4);
+    TEST_FOOTER;
+}
+
 void DetectEngineContentInspectionRegisterTests(void)
 {
     UtRegisterTest("DetectEngineContentInspectionTest01",
@@ -333,6 +344,8 @@ void DetectEngineContentInspectionRegisterTests(void)
                    DetectEngineContentInspectionTest13);
     UtRegisterTest("DetectEngineContentInspectionTest14 byte_test negative offset",
             DetectEngineContentInspectionTest14);
+    UtRegisterTest("DetectEngineContentInspectionTest17 negative distance",
+            DetectEngineContentInspectionTest17);
 }
 
 #undef TEST_HEADER

--- a/src/tests/detect-engine-content-inspection.c
+++ b/src/tests/detect-engine-content-inspection.c
@@ -202,6 +202,12 @@ static int DetectEngineContentInspectionTest08(void) {
     TEST_RUN("abcdefghy", 9,
             "content:\"a\"; content:!\"x\"; content:!\"c\"; distance:2; within:1; ", true, 3);
 
+    TEST_RUN("aaabbbccc", 9, "content:\"ccc\"; endswith; content:!\"bccc\"; endswith; ", false, 2);
+    TEST_RUN("aaabbbccc", 9, "content:\"ccc\"; endswith; content:!\"accc\"; endswith; ", true, 2);
+    TEST_RUN("aaabbbccc", 9, "content:\"ccc\"; endswith; content:!\"bccc\"; endswith; depth:4; ",
+            true, 2);
+    TEST_RUN("aaabbbccc", 9, "content:\"ccc\"; endswith; content:!\"bccc\"; endswith; depth:9; ",
+            false, 2);
     TEST_FOOTER;
 }
 

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -1989,11 +1989,9 @@ libhtp:\n\
     Packet *p1 = NULL;
     Packet *p2 = NULL;
     ThreadVars th_v;
-    DetectEngineCtx *de_ctx = NULL;
     DetectEngineThreadCtx *det_ctx = NULL;
     HtpState *http_state = NULL;
     Flow f;
-    int result = 0;
     uint8_t http_buf1[] =
         "GET /index.html HTTP/1.0\r\n"
         "Host: www.openinfosecfoundation.org\r\n"
@@ -2036,94 +2034,52 @@ libhtp:\n\
 
     StreamTcpInitConfig(true);
 
-    de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL)
-        goto end;
-
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"890\"; within:3; http_server_body; "
-                               "sid:1;)");
-    if (de_ctx->sig_list == NULL)
-        goto end;
+    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any ("
+                                                 "content:\"890\"; within:3; http_server_body; "
+                                                 "sid:1;)");
+    FAIL_IF_NULL(s);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     int r = AppLayerParserParse(
             NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOSERVER, http_buf1, http_len1);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(r != 0);
 
     http_state = f.alstate;
-    if (http_state == NULL) {
-        printf("no http state: \n");
-        result = 0;
-        goto end;
-    }
+    FAIL_IF_NULL(http_state);
 
-    /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
-
-    if (PacketAlertCheck(p1, 1)) {
-        printf("sid 1 matched but shouldn't have\n");
-        goto end;
-    }
+    FAIL_IF(PacketAlertCheck(p1, 1));
 
     r = AppLayerParserParse(
             NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOCLIENT, http_buf2, http_len2);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(r != 0);
 
-    /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
-
-    if (PacketAlertCheck(p2, 1)) {
-        printf("sid 1 matched but shouldn't have\n");
-        goto end;
-    }
+    FAIL_IF(PacketAlertCheck(p2, 1));
 
     r = AppLayerParserParse(
             NULL, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOCLIENT, http_buf3, http_len3);
-    if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(r != 0);
 
-    /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+    FAIL_IF(PacketAlertCheck(p2, 1));
 
-    if (PacketAlertCheck(p2, 1)) {
-        printf("sid 1 matched but shouldn't have\n");
-        goto end;
-    }
-
-    result = 1;
-
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
+    AppLayerParserThreadCtxFree(alp_tctx);
     HTPFreeConfig();
     HtpConfigRestoreBackup();
     ConfRestoreContextBackup();
-
-    if (de_ctx != NULL)
-        DetectEngineCtxFree(de_ctx);
-
+    DetectEngineCtxFree(de_ctx);
     StreamTcpFreeConfig(true);
     FLOW_DESTROY(&f);
     UTHFreePackets(&p1, 1);
     UTHFreePackets(&p2, 1);
-    return result;
+    PASS;
 }
 
 static int DetectEngineHttpServerBodyTest17(void)

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -95,7 +95,9 @@ uint32_t SCACTileSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                         PrefilterRuleStore *pmq, const uint8_t *buf,
                         uint32_t buflen);
 void SCACTilePrintInfo(MpmCtx *mpm_ctx);
-void SCACTileRegisterTests(void);
+#ifdef UNITTESTS
+static void SCACTileRegisterTests(void);
+#endif
 
 uint32_t SCACTileSearchLarge(const SCACTileSearchCtx *ctx, MpmThreadCtx *mpm_thread_ctx,
                              PrefilterRuleStore *pmq,
@@ -1403,7 +1405,9 @@ void MpmACTileRegister(void)
     mpm_table[MPM_AC_KS].Prepare = SCACTilePreparePatterns;
     mpm_table[MPM_AC_KS].Search = SCACTileSearch;
     mpm_table[MPM_AC_KS].PrintCtx = SCACTilePrintInfo;
+#ifdef UNITTESTS
     mpm_table[MPM_AC_KS].RegisterUnittests = SCACTileRegisterTests;
+#endif
 }
 
 
@@ -2384,12 +2388,8 @@ end:
     return result;
 }
 
-#endif /* UNITTESTS */
-
 void SCACTileRegisterTests(void)
 {
-
-#ifdef UNITTESTS
     UtRegisterTest("SCACTileTest01", SCACTileTest01);
     UtRegisterTest("SCACTileTest02", SCACTileTest02);
     UtRegisterTest("SCACTileTest03", SCACTileTest03);
@@ -2419,8 +2419,8 @@ void SCACTileRegisterTests(void)
     UtRegisterTest("SCACTileTest27", SCACTileTest27);
     UtRegisterTest("SCACTileTest28", SCACTileTest28);
     UtRegisterTest("SCACTileTest29", SCACTileTest29);
-#endif
 }
+#endif
 
 #else /* we're big endian */
 

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -72,7 +72,9 @@ int SCACPreparePatterns(MpmCtx *mpm_ctx);
 uint32_t SCACSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                     PrefilterRuleStore *pmq, const uint8_t *buf, uint32_t buflen);
 void SCACPrintInfo(MpmCtx *mpm_ctx);
-void SCACRegisterTests(void);
+#ifdef UNITTESTS
+static void SCACRegisterTests(void);
+#endif
 
 /* a placeholder to denote a failure transition in the goto table */
 #define SC_AC_FAIL (-1)
@@ -1139,8 +1141,9 @@ void MpmACRegister(void)
     mpm_table[MPM_AC].Prepare = SCACPreparePatterns;
     mpm_table[MPM_AC].Search = SCACSearch;
     mpm_table[MPM_AC].PrintCtx = SCACPrintInfo;
+#ifdef UNITTESTS
     mpm_table[MPM_AC].RegisterUnittests = SCACRegisterTests;
-
+#endif
     return;
 }
 
@@ -2121,12 +2124,8 @@ end:
     return result;
 }
 
-#endif /* UNITTESTS */
-
 void SCACRegisterTests(void)
 {
-
-#ifdef UNITTESTS
     UtRegisterTest("SCACTest01", SCACTest01);
     UtRegisterTest("SCACTest02", SCACTest02);
     UtRegisterTest("SCACTest03", SCACTest03);
@@ -2156,7 +2155,5 @@ void SCACRegisterTests(void)
     UtRegisterTest("SCACTest27", SCACTest27);
     UtRegisterTest("SCACTest28", SCACTest28);
     UtRegisterTest("SCACTest29", SCACTest29);
-#endif
-
-    return;
 }
+#endif /* UNITTESTS */

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -60,7 +60,9 @@ uint32_t SCHSSearch(const MpmCtx *mpm_ctx, MpmThreadCtx *mpm_thread_ctx,
                     PrefilterRuleStore *pmq, const uint8_t *buf, const uint32_t buflen);
 void SCHSPrintInfo(MpmCtx *mpm_ctx);
 void SCHSPrintSearchStats(MpmThreadCtx *mpm_thread_ctx);
-void SCHSRegisterTests(void);
+#ifdef UNITTESTS
+static void SCHSRegisterTests(void);
+#endif
 
 /* size of the hash table used to speed up pattern insertions initially */
 #define INIT_HASH_SIZE 65536
@@ -1049,8 +1051,9 @@ void MpmHSRegister(void)
     mpm_table[MPM_HS].Search = SCHSSearch;
     mpm_table[MPM_HS].PrintCtx = SCHSPrintInfo;
     mpm_table[MPM_HS].PrintThreadCtx = SCHSPrintSearchStats;
+#ifdef UNITTESTS
     mpm_table[MPM_HS].RegisterUnittests = SCHSRegisterTests;
-
+#endif
     /* Set Hyperscan memory allocators */
     SCHSSetAllocators();
 }
@@ -2132,11 +2135,8 @@ end:
     return result;
 }
 
-#endif /* UNITTESTS */
-
-void SCHSRegisterTests(void)
+static void SCHSRegisterTests(void)
 {
-#ifdef UNITTESTS
     UtRegisterTest("SCHSTest01", SCHSTest01);
     UtRegisterTest("SCHSTest02", SCHSTest02);
     UtRegisterTest("SCHSTest03", SCHSTest03);
@@ -2166,9 +2166,6 @@ void SCHSRegisterTests(void)
     UtRegisterTest("SCHSTest27", SCHSTest27);
     UtRegisterTest("SCHSTest28", SCHSTest28);
     UtRegisterTest("SCHSTest29", SCHSTest29);
-#endif
-
-    return;
 }
-
+#endif /* UNITTESTS */
 #endif /* BUILD_HYPERSCAN */

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -163,7 +163,9 @@ typedef struct MpmTableElmt_ {
     uint32_t (*Search)(const struct MpmCtx_ *, struct MpmThreadCtx_ *, PrefilterRuleStore *, const uint8_t *, uint32_t);
     void (*PrintCtx)(struct MpmCtx_ *);
     void (*PrintThreadCtx)(struct MpmThreadCtx_ *);
+#ifdef UNITTESTS
     void (*RegisterUnittests)(void);
+#endif
 } MpmTableElmt;
 
 extern MpmTableElmt mpm_table[MPM_TABLE_SIZE];

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -164,7 +164,6 @@ typedef struct MpmTableElmt_ {
     void (*PrintCtx)(struct MpmCtx_ *);
     void (*PrintThreadCtx)(struct MpmThreadCtx_ *);
     void (*RegisterUnittests)(void);
-    uint8_t flags;
 } MpmTableElmt;
 
 extern MpmTableElmt mpm_table[MPM_TABLE_SIZE];

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -297,36 +297,23 @@ static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs)
  *
  * \retval ptr to start of the match; NULL if no match
  */
-uint8_t *BoyerMoore(const uint8_t *x, uint16_t m, const uint8_t *y, uint32_t n, BmCtx *bm_ctx)
+uint8_t *BoyerMoore(
+        const uint8_t *x, const uint16_t m, const uint8_t *y, const uint32_t n, const BmCtx *bm_ctx)
 {
-    uint16_t *bmGs = bm_ctx->bmGs;
-    uint16_t *bmBc = bm_ctx->bmBc;
+    const uint16_t *bmGs = bm_ctx->bmGs;
+    const uint16_t *bmBc = bm_ctx->bmBc;
 
     int i, j, m1, m2;
-    int32_t int_n;
-#if 0
-    printf("\nBad:\n");
-    for (i=0;i<ALPHABET_SIZE;i++)
-        printf("%c,%d ", i, bmBc[i]);
-
-    printf("\ngood:\n");
-    for (i=0;i<m;i++)
-        printf("%c, %d ", x[i],bmBc[i]);
-    printf("\n");
-#endif
     // force casting to int32_t (if possible)
-    int_n = unlikely(n > INT32_MAX) ? INT32_MAX : n;
+    const int32_t int_n = unlikely(n > INT32_MAX) ? INT32_MAX : n;
     j = 0;
     while (j <= int_n - m ) {
         for (i = m - 1; i >= 0 && x[i] == y[i + j]; --i);
 
         if (i < 0) {
             return (uint8_t *)(y + j);
-            //j += bmGs[0];
         } else {
-//          printf("%c", y[i+j]);
-            j += (m1 = bmGs[i]) > (m2 = bmBc[y[i + j]] - m + 1 + i)? m1: m2;
-//          printf("%d, %d\n", m1, m2);
+            j += (m1 = bmGs[i]) > (m2 = bmBc[y[i + j]] - m + 1 + i) ? m1 : m2;
         }
     }
     return NULL;
@@ -348,24 +335,14 @@ uint8_t *BoyerMoore(const uint8_t *x, uint16_t m, const uint8_t *y, uint32_t n, 
  *
  * \retval ptr to start of the match; NULL if no match
  */
-uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, uint32_t n, BmCtx *bm_ctx)
+uint8_t *BoyerMooreNocase(
+        const uint8_t *x, const uint16_t m, const uint8_t *y, const uint32_t n, const BmCtx *bm_ctx)
 {
-    uint16_t *bmGs = bm_ctx->bmGs;
-    uint16_t *bmBc = bm_ctx->bmBc;
+    const uint16_t *bmGs = bm_ctx->bmGs;
+    const uint16_t *bmBc = bm_ctx->bmBc;
     int i, j, m1, m2;
-    int32_t int_n;
-#if 0
-    printf("\nBad:\n");
-    for (i=0;i<ALPHABET_SIZE;i++)
-        printf("%c,%d ", i, bmBc[i]);
-
-    printf("\ngood:\n");
-    for (i=0;i<m;i++)
-        printf("%c, %d ", x[i],bmBc[i]);
-    printf("\n");
-#endif
     // force casting to int32_t (if possible)
-    int_n = unlikely(n > INT32_MAX) ? INT32_MAX : n;
+    const int32_t int_n = unlikely(n > INT32_MAX) ? INT32_MAX : n;
     j = 0;
     while (j <= int_n - m ) {
          /* x is stored in lowercase. */
@@ -374,8 +351,7 @@ uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, uint32
         if (i < 0) {
             return (uint8_t *)(y + j);
         } else {
-            j += (m1 = bmGs[i]) > (m2 = bmBc[y[i + j]] - m + 1 + i)?
-                m1: m2;
+            j += (m1 = bmGs[i]) > (m2 = bmBc[y[i + j]] - m + 1 + i) ? m1 : m2;
         }
     }
     return NULL;

--- a/src/util-spm-bm.h
+++ b/src/util-spm-bm.h
@@ -41,8 +41,10 @@ BmCtx *BoyerMooreCtxInit(const uint8_t *needle, uint16_t needle_len);
 BmCtx *BoyerMooreNocaseCtxInit(uint8_t *needle, uint16_t needle_len);
 
 void BoyerMooreCtxToNocase(BmCtx *, uint8_t *, uint16_t);
-uint8_t *BoyerMoore(const uint8_t *x, uint16_t m, const uint8_t *y, uint32_t n, BmCtx *bm_ctx);
-uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, uint32_t n, BmCtx *bm_ctx);
+uint8_t *BoyerMoore(const uint8_t *x, const uint16_t m, const uint8_t *y, const uint32_t n,
+        const BmCtx *bm_ctx);
+uint8_t *BoyerMooreNocase(const uint8_t *x, const uint16_t m, const uint8_t *y, const uint32_t n,
+        const BmCtx *bm_ctx);
 void BoyerMooreCtxDeInit(BmCtx *);
 
 void SpmBMRegister(void);


### PR DESCRIPTION
#10080 rebased. Fixes formatting and renames qa option to `--qa-skip-prefilter`.

Adds a few minor cleanups.

https://github.com/OISF/suricata/commit/c161a12729df3170190dcdbf566890ced21dabcb is a real fix, probably need a ticket for that