### PR TITLE
flow-bypass: Set bypass thread to running state

### DIFF
--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -93,7 +93,14 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
     if (!found)
         return TM_ECODE_OK;
 
+    TmThreadsSetFlag(th_v, THV_RUNNING);
+
     while (1) {
+        if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
+            TmThreadsSetFlag(th_v, THV_PAUSED);
+            TmThreadTestThreadUnPaused(th_v);
+            TmThreadsUnsetFlag(th_v, THV_PAUSED);
+        }
         SCLogDebug("Dumping the table");
         gettimeofday(&tv, NULL);
         TIMEVAL_TO_TIMESPEC(&tv, &curtime);


### PR DESCRIPTION
When running Suricata in XDP bypass mode (bypass: yes),

Suricata started up with error:
Error: threads: thread "FB" failed to start in time: flags 0003

"FB" thread does not transition from THV_INIT_DONE to THV_RUNNING.

Set "FB" thread THV_RUNNING state in BypassedFlowManager().

Bug: 6254

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues/6254) ticket: [6254](https://redmine.openinfosecfoundation.org/projects/suricata/issues/6254)

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
