### PR TITLE
detect: free all tenant detect engines

### DIFF
--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -95,6 +95,7 @@ DetectEngineCtx *DetectEngineGetCurrent(void);
 DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
+void DetectEngineClearMaster(void);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);
 void DetectEngineDeReference(DetectEngineCtx **de_ctx);
 int DetectEngineReload(const SCInstance *suri);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -402,7 +402,7 @@ static void GlobalsDestroy(SCInstance *suri)
         DetectEngineMoveToFreeList(de_ctx);
         DetectEngineDeReference(&de_ctx);
     }
-    DetectEnginePruneFreeList();
+    DetectEngineClearMaster();
 
     AppLayerDeSetup();
     DatasetsSave();


### PR DESCRIPTION
Free all tenants registered in the master.

(cherry picked from commit a4d80bc7c4910170aba950db0a497124712b330a)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6549](https://redmine.openinfosecfoundation.org/issues/6549)

Describe changes:
- Free all tenant detect engines (and indirect references)

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1562
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
