### PR TITLE
mqtt: Improve handling of multiple PDU parsing

### DIFF
--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -468,7 +468,7 @@ impl MQTTState {
                     let _pdu = Frame::new(
                         flow,
                         &stream_slice,
-                        input,
+                        current,
                         current.len() as i64,
                         MQTTFrameType::Pdu as u8,
                     );
@@ -553,8 +553,8 @@ impl MQTTState {
                     let _pdu = Frame::new(
                         flow,
                         &stream_slice,
-                        input,
-                        input.len() as i64,
+                        current,
+                        current.len() as i64,
                         MQTTFrameType::Pdu as u8,
                     );
 


### PR DESCRIPTION
Issue: 6592


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6592](https://redmine.openinfosecfoundation.org/issues/6592)

Describe changes:
- Parse PDU instead of entire stream

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
