### PR TITLE
rust: allow clippy::items_after_test_module

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,6 +27,9 @@
 #![allow(clippy::let_and_return)]
 #![allow(clippy::uninlined_format_args)]
 
+// We find this is beyond what the linter should flag.
+#![allow(clippy::items_after_test_module)]
+
 // We find this makes sense at time.
 #![allow(clippy::module_inception)]
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- rust: allow clippy::items_after_test_module

https://github.com/OISF/suricata/pull/10106 allowing the pattern instead of fixing it