### PR TITLE
detect: case-insensitive comparison for requires

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -902,7 +902,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
     /* Check for options that are only to be processed during the
      * first "requires" pass. */
-    bool requires_only = strcmp(optname, "requires") == 0 || strcmp(optname, "sid") == 0;
+    bool requires_only = strcasecmp(optname, "requires") == 0 || strcasecmp(optname, "sid") == 0;
     if ((requires && !requires_only) || (!requires && requires_only)) {
         goto finish;
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6656

Describe changes:
- detect: fix assertion failure by making case-insensitive comparison for requires
