### PR TITLE
Clippy fixes

### DIFF
--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -410,11 +410,8 @@ mod tests {
             0x1c, 0x7d, 0xcf, 0x11,
         ];
 
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((_rem, _header)) => {
-                { assert!(false); }
-            }
-            _ => {}
+        if parser::parse_dcerpc_udp_header(request).is_ok() {
+            panic!("Result shoud not be ok");
         }
     }
 
@@ -428,12 +425,11 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-            }
-            _ => { assert!(false); }
+        if let Ok((rem, header)) = parser::parse_dcerpc_udp_header(request) {
+            assert_eq!(4, header.rpc_vers);
+            assert_eq!(80, request.len() - rem.len());
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 
@@ -447,13 +443,12 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-                assert_eq!(0, rem.len());
-            }
-            _ => { assert!(false); }
+        if let Ok((rem, header)) = parser::parse_dcerpc_udp_header(request) {
+            assert_eq!(4, header.rpc_vers);
+            assert_eq!(80, request.len() - rem.len());
+            assert_eq!(0, rem.len());
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -517,13 +517,10 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(args) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath(args) {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 
@@ -623,51 +620,37 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string dec",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
         bmd.base = BASE_DEFAULT;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING;
         bmd.base = ByteMathBase::BaseHex;
-        match parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
         bmd.base = ByteMathBase::BaseOct;
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 
@@ -774,40 +757,34 @@ mod tests {
         };
 
         bmd.bitmask_val = 0x12345678;
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x12345678",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask ffff1234",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0Xffff1234",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
     }
     #[test]
     fn test_parser_endian_valid() {
@@ -824,49 +801,41 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
 
         bmd.endian = ByteMathEndian::LittleEndian;
-        match parse_bytemath(
+        if let Ok((_, val)) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian little",
         ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.endian = ByteMathEndian::EndianDCE;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
 
         bmd.endian = DETECT_BYTEMATH_ENDIAN_DEFAULT;
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
     }
 
     #[test]
@@ -920,61 +889,49 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
 
         bmd.oper = ByteMathOperator::Subtraction;
-        match parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.oper = ByteMathOperator::Multiplication;
-        match parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
         bmd.oper = ByteMathOperator::Division;
-        match parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
         bmd.oper = ByteMathOperator::RightShift;
-        match parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
         bmd.oper = ByteMathOperator::LeftShift;
-        match parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
     }
 
     #[test]
@@ -1013,33 +970,27 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.rvalue = 1;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
         bmd.rvalue = 0;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
     }
 
     #[test]
@@ -1064,24 +1015,20 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
 
+
         bmd.offset = 65535;
-        match parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo") {
+            assert_eq!(val, bmd);
+        } else {
+            panic!("Result shoud be ok");
         }
+
     }
 
     #[test]

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -409,27 +409,18 @@ mod tests {
 
     #[test]
     fn test_parse_uint_unit() {
-        match detect_parse_uint::<u64>(" 2kb") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 2048);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = detect_parse_uint::<u64>(" 2kb") {
+            assert_eq!(val.arg1, 2048);
+        } else {
+            panic!("Result shoud be ok");
         }
-        match detect_parse_uint::<u8>("2kb") {
-            Ok((_, _val)) => {
-                assert!(false);
-            }
-            Err(_) => {}
+        if detect_parse_uint::<u8>("2kb").is_ok() {
+            panic!("Result shoud not be ok");
         }
-        match detect_parse_uint::<u32>("3MB") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 3 * 1024 * 1024);
-            }
-            Err(_) => {
-                assert!(false);
-            }
+        if let Ok((_, val)) = detect_parse_uint::<u32>("3MB") {
+            assert_eq!(val.arg1, 3 * 1024 * 1024);
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 }

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -242,41 +242,38 @@ mod tests {
         let pcap = include_bytes!("discover.pcap");
         let payload = &pcap[24 + 16 + 42..];
 
-        match dhcp_parse(payload) {
-            Ok((_rem, message)) => {
-                let header = message.header;
-                assert_eq!(header.opcode, BOOTP_REQUEST);
-                assert_eq!(header.htype, 1);
-                assert_eq!(header.hlen, 6);
-                assert_eq!(header.hops, 0);
-                assert_eq!(header.txid, 0x00003d1d);
-                assert_eq!(header.seconds, 0);
-                assert_eq!(header.flags, 0);
-                assert_eq!(header.clientip, &[0, 0, 0, 0]);
-                assert_eq!(header.yourip, &[0, 0, 0, 0]);
-                assert_eq!(header.serverip, &[0, 0, 0, 0]);
-                assert_eq!(header.giaddr, &[0, 0, 0, 0]);
-                assert_eq!(
-                    &header.clienthw[..(header.hlen as usize)],
-                    &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
-                );
-                assert!(header.servername.iter().all(|&x| x == 0));
-                assert!(header.bootfilename.iter().all(|&x| x == 0));
-                assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
+        if let Ok((_rem, message)) = dhcp_parse(payload) {
+            let header = message.header;
+            assert_eq!(header.opcode, BOOTP_REQUEST);
+            assert_eq!(header.htype, 1);
+            assert_eq!(header.hlen, 6);
+            assert_eq!(header.hops, 0);
+            assert_eq!(header.txid, 0x00003d1d);
+            assert_eq!(header.seconds, 0);
+            assert_eq!(header.flags, 0);
+            assert_eq!(header.clientip, &[0, 0, 0, 0]);
+            assert_eq!(header.yourip, &[0, 0, 0, 0]);
+            assert_eq!(header.serverip, &[0, 0, 0, 0]);
+            assert_eq!(header.giaddr, &[0, 0, 0, 0]);
+            assert_eq!(
+                &header.clienthw[..(header.hlen as usize)],
+                &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
+            );
+            assert!(header.servername.iter().all(|&x| x == 0));
+            assert!(header.bootfilename.iter().all(|&x| x == 0));
+            assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
 
-                assert!(!message.malformed_options);
-                assert!(!message.truncated_options);
+            assert!(!message.malformed_options);
+            assert!(!message.truncated_options);
 
-                assert_eq!(message.options.len(), 5);
-                assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
-                assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
-                assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
-                assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
-                assert_eq!(message.options[4].code, DHCP_OPT_END);
-            }
-            _ => {
-                assert!(false);
-            }
+            assert_eq!(message.options.len(), 5);
+            assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
+            assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
+            assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
+            assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
+            assert_eq!(message.options[4].code, DHCP_OPT_END);
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -477,34 +477,31 @@ mod tests {
 
         let (body, header) = dns_parse_header(pkt).unwrap();
         let res = dns_parse_body(body, pkt, header);
-        match res {
-            Ok((rem, request)) => {
-                // For now we have some remainder data as there is an
-                // additional record type we don't parse yet.
-                assert!(!rem.is_empty());
+        if let Ok((rem, request)) = res {
+            // For now we have some remainder data as there is an
+            // additional record type we don't parse yet.
+            assert!(!rem.is_empty());
 
-                assert_eq!(
-                    request.header,
-                    DNSHeader {
-                        tx_id: 0x8d32,
-                        flags: 0x0120,
-                        questions: 1,
-                        answer_rr: 0,
-                        authority_rr: 0,
-                        additional_rr: 1,
-                    }
-                );
+            assert_eq!(
+                request.header,
+                DNSHeader {
+                    tx_id: 0x8d32,
+                    flags: 0x0120,
+                    questions: 1,
+                    answer_rr: 0,
+                    authority_rr: 0,
+                    additional_rr: 1,
+                }
+            );
 
-                assert_eq!(request.queries.len(), 1);
+            assert_eq!(request.queries.len(), 1);
 
-                let query = &request.queries[0];
-                assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
-                assert_eq!(query.rrtype, 1);
-                assert_eq!(query.rrclass, 1);
-            }
-            _ => {
-                assert!(false);
-            }
+            let query = &request.queries[0];
+            assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
+            assert_eq!(query.rrtype, 1);
+            assert_eq!(query.rrclass, 1);
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 
@@ -589,7 +586,7 @@ mod tests {
                 )
             }
             _ => {
-                assert!(false);
+                panic!("Result shoud be ok");
             }
         }
     }
@@ -657,7 +654,7 @@ mod tests {
                 );
             }
             _ => {
-                assert!(false);
+                panic!("Result shoud be ok");
             }
         }
     }
@@ -718,7 +715,7 @@ mod tests {
                 );
             }
             _ => {
-                assert!(false);
+                panic!("Result shoud be ok");
             }
         }
     }
@@ -740,19 +737,16 @@ mod tests {
                 // The data should be fully parsed.
                 assert_eq!(rem.len(), 0);
 
-                match rdata {
-                    DNSRData::SSHFP(sshfp) => {
-                        assert_eq!(sshfp.algo, 2);
-                        assert_eq!(sshfp.fp_type, 1);
-                        assert_eq!(sshfp.fingerprint, &data[2..]);
-                    }
-                    _ => {
-                        assert!(false);
-                    }
+                if let DNSRData::SSHFP(sshfp) = rdata {
+                    assert_eq!(sshfp.algo, 2);
+                    assert_eq!(sshfp.fp_type, 1);
+                    assert_eq!(sshfp.fingerprint, &data[2..]);
+                } else {
+                    panic!("Expected DNSRData::SSHFP");
                 }
             }
             _ => {
-                assert!(false);
+                panic!("Result shoud be ok");
             }
         }
     }
@@ -799,38 +793,32 @@ mod tests {
                 assert_eq!(response.answers.len(), 2);
 
                 let answer1 = &response.answers[0];
-                match &answer1.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 20);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target,
-                            "sip-anycast-2.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
+                if let DNSRData::SRV(srv) = &answer1.data {
+                    assert_eq!(srv.priority, 20);
+                    assert_eq!(srv.weight, 1);
+                    assert_eq!(srv.port, 5060);
+                    assert_eq!(
+                        srv.target,
+                        "sip-anycast-2.voice.google.com".as_bytes().to_vec()
+                    );
+                } else {
+                    panic!("Expected DNSRData::SRV");
                 }
                 let answer2 = &response.answers[1];
-                match &answer2.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 10);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target,
-                            "sip-anycast-1.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
+                if let DNSRData::SRV(srv) = &answer2.data {
+                    assert_eq!(srv.priority, 10);
+                    assert_eq!(srv.weight, 1);
+                    assert_eq!(srv.port, 5060);
+                    assert_eq!(
+                        srv.target,
+                        "sip-anycast-1.voice.google.com".as_bytes().to_vec()
+                    );
+                } else {
+                    panic!("Expected DNSRData::SRV");
                 }
             }
             _ => {
-                assert!(false);
+                panic!("Result shoud be ok");
             }
         }
     }

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -275,16 +275,13 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_request(buf) {
-            Ok((_, req)) => {
-                assert_eq!(req.method, "REGISTER");
-                assert_eq!(req.path, "sip:sip.cybercity.dk");
-                assert_eq!(req.version, "SIP/2.0");
-                assert_eq!(req.headers["Content-Length"], "0");
-            }
-            _ => {
-                assert!(false);
-            }
+        if let Ok((_, req)) = sip_parse_request(buf) {
+            assert_eq!(req.method, "REGISTER");
+            assert_eq!(req.path, "sip:sip.cybercity.dk");
+            assert_eq!(req.version, "SIP/2.0");
+            assert_eq!(req.headers["Content-Length"], "0");
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 
@@ -311,15 +308,12 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_response(buf) {
-            Ok((_, resp)) => {
-                assert_eq!(resp.version, "SIP/2.0");
-                assert_eq!(resp.code, "401");
-                assert_eq!(resp.reason, "Unauthorized");
-            }
-            _ => {
-                assert!(false);
-            }
+        if let Ok((_, resp)) = sip_parse_response(buf) {
+            assert_eq!(resp.version, "SIP/2.0");
+            assert_eq!(resp.code, "401");
+            assert_eq!(resp.reason, "Unauthorized");
+        } else {
+            panic!("Result shoud be ok");
         }
     }
 }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -225,13 +225,10 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&READ_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true);
-            }
+        if let Some(txp) = parse_tftp_request(&READ_REQUEST[..]) {
+            assert_eq!(tx, txp);
+        } else {
+            panic!("Result should not be None");
         }
     }
 
@@ -245,13 +242,10 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&WRITE_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true, "fadfasd");
-            }
+        if let Some(txp) = parse_tftp_request(&WRITE_REQUEST[..]) {
+            assert_eq!(tx, txp);
+        } else {
+            panic!("Result should not be None");
         }
     }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None 

Describe changes:
- rust: fix clippy warnings for assertions_on_constants

@jasonish why do I get these and CI is not red ?
Because I am using a newer clippy ?

I also have others like zero_prefixed_literal