### PR TITLE
Clippy fixes v3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,5 +83,5 @@ jobs:
               echo "::error ::Clippy --fix made changes, please fix"
               exit 1
           fi
-      - run: cargo clippy --all-features
+      - run: cargo clippy --all-features --all-targets
         working-directory: rust

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -89,8 +89,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -101,8 +101,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der-oid-macro"
@@ -296,9 +296,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.39",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -325,8 +325,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -380,9 +380,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac",
 ]
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kerberos-parser"
@@ -431,9 +431,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "lzma-rs"
@@ -503,8 +503,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -642,8 +642,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "907a61bd0f64c2f29cd1cf1dc34d05176426a3f504a78010f08416ddb7b13708"
 dependencies = [
  "unicode-ident",
 ]
@@ -766,11 +766,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.69",
+ "proc-macro2 1.0.75",
 ]
 
 [[package]]
@@ -860,8 +860,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a585d3c22887d23bb06dd602b8ce96c2a716e1fa89beec8bfb49e466f2d643"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -879,22 +879,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.39",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "suricata"
-version = "7.0.3-dev"
+version = "8.0.0-dev"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -991,11 +991,11 @@ dependencies = [
 
 [[package]]
 name = "suricata-derive"
-version = "7.0.3-dev"
+version = "8.0.0-dev"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
 ]
 
@@ -1016,19 +1016,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "unicode-ident",
 ]
 
@@ -1038,43 +1038,63 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
 
 [[package]]
 name = "test-case"
-version = "1.1.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956044ef122917dde830c19dec5f76d0670329fde4104836d62ebcb14f4865f1"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
- "version_check",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
+ "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 2.0.39",
+ "proc-macro2 1.0.75",
+ "quote 1.0.35",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -70,5 +70,5 @@ time = "=0.3.13"
 suricata-derive = { path = "./derive" }
 
 [dev-dependencies]
-test-case = "~1.1.0"
+test-case = "~3.3.1"
 hex = "~0.4.3"

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -410,12 +410,7 @@ mod tests {
             0x1c, 0x7d, 0xcf, 0x11,
         ];
 
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((_rem, _header)) => {
-                { assert!(false); }
-            }
-            _ => {}
-        }
+        assert!(parser::parse_dcerpc_udp_header(request).is_err());
     }
 
     #[test]
@@ -428,13 +423,9 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-            }
-            _ => { assert!(false); }
-        }
+        let (rem, header) = parser::parse_dcerpc_udp_header(request).unwrap();
+        assert_eq!(4, header.rpc_vers);
+        assert_eq!(80, request.len() - rem.len());
     }
 
     #[test]
@@ -447,14 +438,10 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-                assert_eq!(0, rem.len());
-            }
-            _ => { assert!(false); }
-        }
+        let (rem, header) = parser::parse_dcerpc_udp_header(request).unwrap();
+        assert_eq!(4, header.rpc_vers);
+        assert_eq!(80, request.len() - rem.len());
+        assert_eq!(0, rem.len());
     }
 
     #[test]

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -517,14 +517,8 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(args) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath(args).unwrap();
+        assert_eq!(val, bmd);
     }
 
     #[test]
@@ -623,52 +617,26 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string dec",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
         bmd.base = BASE_DEFAULT;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING;
         bmd.base = ByteMathBase::BaseHex;
-        match parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex").unwrap();
+        assert_eq!(val, bmd);
 
         bmd.base = ByteMathBase::BaseOct;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
     }
 
     #[test]
@@ -774,40 +742,25 @@ mod tests {
         };
 
         bmd.bitmask_val = 0x12345678;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x12345678",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask ffff1234",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0Xffff1234",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
     }
     #[test]
     fn test_parser_endian_valid() {
@@ -824,49 +777,29 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = ByteMathEndian::LittleEndian;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian little",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = ByteMathEndian::EndianDCE;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = DETECT_BYTEMATH_ENDIAN_DEFAULT;
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -920,61 +853,31 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.oper = ByteMathOperator::Subtraction;
-        match parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.oper = ByteMathOperator::Multiplication;
-        match parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::Division;
-        match parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::RightShift;
-        match parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::LeftShift;
-        match parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -1013,33 +916,18 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.rvalue = 1;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.rvalue = 0;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -1064,24 +952,14 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.offset = 65535;
-        match parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -409,27 +409,12 @@ mod tests {
 
     #[test]
     fn test_parse_uint_unit() {
-        match detect_parse_uint::<u64>(" 2kb") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 2048);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
-        match detect_parse_uint::<u8>("2kb") {
-            Ok((_, _val)) => {
-                assert!(false);
-            }
-            Err(_) => {}
-        }
-        match detect_parse_uint::<u32>("3MB") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 3 * 1024 * 1024);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = detect_parse_uint::<u64>(" 2kb").unwrap();
+        assert_eq!(val.arg1, 2048);
+
+        assert!(detect_parse_uint::<u8>("2kb").is_err());
+
+        let (_, val) = detect_parse_uint::<u32>("3MB").unwrap();
+        assert_eq!(val.arg1, 3 * 1024 * 1024);
     }
 }

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -242,42 +242,36 @@ mod tests {
         let pcap = include_bytes!("discover.pcap");
         let payload = &pcap[24 + 16 + 42..];
 
-        match dhcp_parse(payload) {
-            Ok((_rem, message)) => {
-                let header = message.header;
-                assert_eq!(header.opcode, BOOTP_REQUEST);
-                assert_eq!(header.htype, 1);
-                assert_eq!(header.hlen, 6);
-                assert_eq!(header.hops, 0);
-                assert_eq!(header.txid, 0x00003d1d);
-                assert_eq!(header.seconds, 0);
-                assert_eq!(header.flags, 0);
-                assert_eq!(header.clientip, &[0, 0, 0, 0]);
-                assert_eq!(header.yourip, &[0, 0, 0, 0]);
-                assert_eq!(header.serverip, &[0, 0, 0, 0]);
-                assert_eq!(header.giaddr, &[0, 0, 0, 0]);
-                assert_eq!(
-                    &header.clienthw[..(header.hlen as usize)],
-                    &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
-                );
-                assert!(header.servername.iter().all(|&x| x == 0));
-                assert!(header.bootfilename.iter().all(|&x| x == 0));
-                assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
+        let (_rem, message) = dhcp_parse(payload).unwrap();
+        let header = message.header;
+        assert_eq!(header.opcode, BOOTP_REQUEST);
+        assert_eq!(header.htype, 1);
+        assert_eq!(header.hlen, 6);
+        assert_eq!(header.hops, 0);
+        assert_eq!(header.txid, 0x00003d1d);
+        assert_eq!(header.seconds, 0);
+        assert_eq!(header.flags, 0);
+        assert_eq!(header.clientip, &[0, 0, 0, 0]);
+        assert_eq!(header.yourip, &[0, 0, 0, 0]);
+        assert_eq!(header.serverip, &[0, 0, 0, 0]);
+        assert_eq!(header.giaddr, &[0, 0, 0, 0]);
+        assert_eq!(
+            &header.clienthw[..(header.hlen as usize)],
+            &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
+        );
+        assert!(header.servername.iter().all(|&x| x == 0));
+        assert!(header.bootfilename.iter().all(|&x| x == 0));
+        assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
 
-                assert!(!message.malformed_options);
-                assert!(!message.truncated_options);
+        assert!(!message.malformed_options);
+        assert!(!message.truncated_options);
 
-                assert_eq!(message.options.len(), 5);
-                assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
-                assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
-                assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
-                assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
-                assert_eq!(message.options[4].code, DHCP_OPT_END);
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        assert_eq!(message.options.len(), 5);
+        assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
+        assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
+        assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
+        assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
+        assert_eq!(message.options[4].code, DHCP_OPT_END);
     }
 
     #[test]

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -477,35 +477,29 @@ mod tests {
 
         let (body, header) = dns_parse_header(pkt).unwrap();
         let res = dns_parse_body(body, pkt, header);
-        match res {
-            Ok((rem, request)) => {
-                // For now we have some remainder data as there is an
-                // additional record type we don't parse yet.
-                assert!(!rem.is_empty());
+        let (rem, request) = res.unwrap();
+        // For now we have some remainder data as there is an
+        // additional record type we don't parse yet.
+        assert!(!rem.is_empty());
 
-                assert_eq!(
-                    request.header,
-                    DNSHeader {
-                        tx_id: 0x8d32,
-                        flags: 0x0120,
-                        questions: 1,
-                        answer_rr: 0,
-                        authority_rr: 0,
-                        additional_rr: 1,
-                    }
-                );
-
-                assert_eq!(request.queries.len(), 1);
-
-                let query = &request.queries[0];
-                assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
-                assert_eq!(query.rrtype, 1);
-                assert_eq!(query.rrclass, 1);
+        assert_eq!(
+            request.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x0120,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 0,
+                additional_rr: 1,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(request.queries.len(), 1);
+
+        let query = &request.queries[0];
+        assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(query.rrtype, 1);
+        assert_eq!(query.rrclass, 1);
     }
 
     /// Parse a DNS response.
@@ -534,64 +528,57 @@ mod tests {
             0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, /* ....N. */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, response)) => {
-                // The response should be full parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, response) = dns_parse_response(pkt).unwrap();
+        // The response should be full parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x8d32,
-                        flags: 0x81a0,
-                        questions: 1,
-                        answer_rr: 3,
-                        authority_rr: 0,
-                        additional_rr: 0,
-                    }
-                );
-
-                assert_eq!(response.answers.len(), 3);
-
-                let answer1 = &response.answers[0];
-                assert_eq!(answer1.name, "www.suricata-ids.org".as_bytes().to_vec());
-                assert_eq!(answer1.rrtype, 5);
-                assert_eq!(answer1.rrclass, 1);
-                assert_eq!(answer1.ttl, 3544);
-                assert_eq!(
-                    answer1.data,
-                    DNSRData::CNAME("suricata-ids.org".as_bytes().to_vec())
-                );
-
-                let answer2 = &response.answers[1];
-                assert_eq!(
-                    answer2,
-                    &DNSAnswerEntry {
-                        name: "suricata-ids.org".as_bytes().to_vec(),
-                        rrtype: 1,
-                        rrclass: 1,
-                        ttl: 244,
-                        data: DNSRData::A([192, 0, 78, 24].to_vec()),
-                    }
-                );
-
-                let answer3 = &response.answers[2];
-                assert_eq!(
-                    answer3,
-                    &DNSAnswerEntry {
-                        name: "suricata-ids.org".as_bytes().to_vec(),
-                        rrtype: 1,
-                        rrclass: 1,
-                        ttl: 244,
-                        data: DNSRData::A([192, 0, 78, 25].to_vec()),
-                    }
-                )
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x81a0,
+                questions: 1,
+                answer_rr: 3,
+                authority_rr: 0,
+                additional_rr: 0,
             }
-            _ => {
-                assert!(false);
+        );
+
+        assert_eq!(response.answers.len(), 3);
+
+        let answer1 = &response.answers[0];
+        assert_eq!(answer1.name, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(answer1.rrtype, 5);
+        assert_eq!(answer1.rrclass, 1);
+        assert_eq!(answer1.ttl, 3544);
+        assert_eq!(
+            answer1.data,
+            DNSRData::CNAME("suricata-ids.org".as_bytes().to_vec())
+        );
+
+        let answer2 = &response.answers[1];
+        assert_eq!(
+            answer2,
+            &DNSAnswerEntry {
+                name: "suricata-ids.org".as_bytes().to_vec(),
+                rrtype: 1,
+                rrclass: 1,
+                ttl: 244,
+                data: DNSRData::A([192, 0, 78, 24].to_vec()),
             }
-        }
+        );
+
+        let answer3 = &response.answers[2];
+        assert_eq!(
+            answer3,
+            &DNSAnswerEntry {
+                name: "suricata-ids.org".as_bytes().to_vec(),
+                rrtype: 1,
+                rrclass: 1,
+                ttl: 244,
+                data: DNSRData::A([192, 0, 78, 25].to_vec()),
+            }
+        )
     }
 
     #[test]
@@ -617,49 +604,42 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, /* .... */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, response)) => {
-                // For now we have some remainder data as there is an
-                // additional record type we don't parse yet.
-                assert!(!rem.is_empty());
+        let (rem, response) = dns_parse_response(pkt).unwrap();
+        // For now we have some remainder data as there is an
+        // additional record type we don't parse yet.
+        assert!(!rem.is_empty());
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x8295,
-                        flags: 0x8183,
-                        questions: 1,
-                        answer_rr: 0,
-                        authority_rr: 1,
-                        additional_rr: 1,
-                    }
-                );
-
-                assert_eq!(response.authorities.len(), 1);
-
-                let authority = &response.authorities[0];
-                assert_eq!(authority.name, "oisf.net".as_bytes().to_vec());
-                assert_eq!(authority.rrtype, 6);
-                assert_eq!(authority.rrclass, 1);
-                assert_eq!(authority.ttl, 899);
-                assert_eq!(
-                    authority.data,
-                    DNSRData::SOA(DNSRDataSOA {
-                        mname: "ns-110.awsdns-13.com".as_bytes().to_vec(),
-                        rname: "awsdns-hostmaster.amazon.com".as_bytes().to_vec(),
-                        serial: 1,
-                        refresh: 7200,
-                        retry: 900,
-                        expire: 1209600,
-                        minimum: 86400,
-                    })
-                );
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x8295,
+                flags: 0x8183,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 1,
+                additional_rr: 1,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(response.authorities.len(), 1);
+
+        let authority = &response.authorities[0];
+        assert_eq!(authority.name, "oisf.net".as_bytes().to_vec());
+        assert_eq!(authority.rrtype, 6);
+        assert_eq!(authority.rrclass, 1);
+        assert_eq!(authority.ttl, 899);
+        assert_eq!(
+            authority.data,
+            DNSRData::SOA(DNSRDataSOA {
+                mname: "ns-110.awsdns-13.com".as_bytes().to_vec(),
+                rname: "awsdns-hostmaster.amazon.com".as_bytes().to_vec(),
+                serial: 1,
+                refresh: 7200,
+                retry: 900,
+                expire: 1209600,
+                minimum: 86400,
+            })
+        );
     }
 
     #[test]
@@ -678,49 +658,42 @@ mod tests {
             0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, response)) => {
-                // The response should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, response) = dns_parse_response(pkt).unwrap();
+        // The response should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x12b0,
-                        flags: 0x8400,
-                        questions: 1,
-                        answer_rr: 1,
-                        authority_rr: 0,
-                        additional_rr: 0,
-                    }
-                );
-
-                assert_eq!(response.queries.len(), 1);
-                let query = &response.queries[0];
-                assert_eq!(query.name, "vaaaakardli.pirate.sea".as_bytes().to_vec());
-                assert_eq!(query.rrtype, DNS_RECORD_TYPE_NULL);
-                assert_eq!(query.rrclass, 1);
-
-                assert_eq!(response.answers.len(), 1);
-
-                let answer = &response.answers[0];
-                assert_eq!(answer.name, "vaaaakardli.pirate.sea".as_bytes().to_vec());
-                assert_eq!(answer.rrtype, DNS_RECORD_TYPE_NULL);
-                assert_eq!(answer.rrclass, 1);
-                assert_eq!(answer.ttl, 0);
-                assert_eq!(
-                    answer.data,
-                    DNSRData::NULL(vec![
-                        0x56, 0x41, 0x43, 0x4b, /* VACK */
-                        0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
-                    ])
-                );
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x12b0,
+                flags: 0x8400,
+                questions: 1,
+                answer_rr: 1,
+                authority_rr: 0,
+                additional_rr: 0,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(response.queries.len(), 1);
+        let query = &response.queries[0];
+        assert_eq!(query.name, "vaaaakardli.pirate.sea".as_bytes().to_vec());
+        assert_eq!(query.rrtype, DNS_RECORD_TYPE_NULL);
+        assert_eq!(query.rrclass, 1);
+
+        assert_eq!(response.answers.len(), 1);
+
+        let answer = &response.answers[0];
+        assert_eq!(answer.name, "vaaaakardli.pirate.sea".as_bytes().to_vec());
+        assert_eq!(answer.rrtype, DNS_RECORD_TYPE_NULL);
+        assert_eq!(answer.rrclass, 1);
+        assert_eq!(answer.ttl, 0);
+        assert_eq!(
+            answer.data,
+            DNSRData::NULL(vec![
+                0x56, 0x41, 0x43, 0x4b, /* VACK */
+                0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
+            ])
+        );
     }
 
     #[test]
@@ -734,26 +707,16 @@ mod tests {
             0x9a, 0xbc, 0xde, 0xf6, 0x78, 0x90,
         ];
 
-        let res = dns_parse_rdata_sshfp(data);
-        match res {
-            Ok((rem, rdata)) => {
-                // The data should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, rdata) = dns_parse_rdata_sshfp(data).unwrap();
+        // The data should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                match rdata {
-                    DNSRData::SSHFP(sshfp) => {
-                        assert_eq!(sshfp.algo, 2);
-                        assert_eq!(sshfp.fp_type, 1);
-                        assert_eq!(sshfp.fingerprint, &data[2..]);
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
-            }
-            _ => {
-                assert!(false);
-            }
+        if let DNSRData::SSHFP(sshfp) = rdata {
+            assert_eq!(sshfp.algo, 2);
+            assert_eq!(sshfp.fp_type, 1);
+            assert_eq!(sshfp.fingerprint, &data[2..]);
+        } else {
+            panic!("Expected DNSRData::SSHFP");
         }
     }
 
@@ -790,48 +753,35 @@ mod tests {
             0x67, 0x6c, 0x65, 0x03, 0x63, 0x6f, 0x6d, 0x00,
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, response)) => {
-                // The data should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, response) = dns_parse_response(pkt).unwrap();
+        // The data should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(response.answers.len(), 2);
+        assert_eq!(response.answers.len(), 2);
 
-                let answer1 = &response.answers[0];
-                match &answer1.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 20);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target,
-                            "sip-anycast-2.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
-                let answer2 = &response.answers[1];
-                match &answer2.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 10);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target,
-                            "sip-anycast-1.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
-            }
-            _ => {
-                assert!(false);
-            }
+        let answer1 = &response.answers[0];
+        if let DNSRData::SRV(srv) = &answer1.data {
+            assert_eq!(srv.priority, 20);
+            assert_eq!(srv.weight, 1);
+            assert_eq!(srv.port, 5060);
+            assert_eq!(
+                srv.target,
+                "sip-anycast-2.voice.google.com".as_bytes().to_vec()
+            );
+        } else {
+            panic!("Expected DNSRData::SRV");
+        }
+        let answer2 = &response.answers[1];
+        if let DNSRData::SRV(srv) = &answer2.data {
+            assert_eq!(srv.priority, 10);
+            assert_eq!(srv.weight, 1);
+            assert_eq!(srv.port, 5060);
+            assert_eq!(
+                srv.target,
+                "sip-anycast-1.voice.google.com".as_bytes().to_vec()
+            );
+        } else {
+            panic!("Expected DNSRData::SRV");
         }
     }
 }

--- a/rust/src/http2/parser.rs
+++ b/rust/src/http2/parser.rs
@@ -879,12 +879,7 @@ mod tests {
         match r {
             Ok((rem, ctx)) => {
                 assert_eq!(ctx.id, HTTP2SettingsId::EnablePush);
-                match ctx.value {
-                    Some(_) => {
-                        panic!("Unexpected value");
-                    }
-                    None => {}
-                }
+                assert!(ctx.value.is_none());
                 assert_eq!(rem.len(), 0);
             }
             Err(e) => {

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn test_parse_publish() {
         let buf = [
-            0x00, 06, /* Topic Length: 6 */
+            0x00, 0x06, /* Topic Length: 6 */
             0x74, 0x6f, 0x70, 0x69, 0x63, 0x58, /* Topic: topicX */
             0x00, 0x01, /* Message Identifier: 1 */
             0x00, /* Properties 6 */
@@ -914,7 +914,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v3() {
         let buf = [
-            0x00, 01, /* Message Identifier: 1 */
+            0x00, 0x01, /* Message Identifier: 1 */
             0x74, 0x6f, 0x70, 0x69, 0x63, 0x58, 0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34,
             0x33, 0x45, 0x38, 0x30,
         ];
@@ -939,7 +939,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v5() {
         let buf = [
-            0x00, 01,   /* Message Identifier: 1 */
+            0x00, 0x01,   /* Message Identifier: 1 */
             0x00, /* Reason Code: 0 */
             0x00, /* Properties */
             0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34, 0x33, 0x45, 0x38, 0x30,

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -113,13 +113,9 @@ mod tests {
             0x00, 0x00, 0xb2, 0x5a, 0x00, 0x00, 0x00, 0x29
         ];
 
-        let result = parse_nfs2_handle(buf).unwrap();
-        match result {
-            (r, res) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(res.value, buf);
-            }
-        }
+        let (r, res) = parse_nfs2_handle(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(res.value, buf);
     }
 
     #[test]
@@ -136,14 +132,10 @@ mod tests {
         let (_, handle) = parse_nfs2_handle(buf).unwrap();
         assert_eq!(handle.value, &buf[..32]);
 
-        let result = parse_nfs2_request_lookup(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, handle);
-                assert_eq!(request.name_vec, b"am".to_vec());
-            }
-        }
+        let (r, request) = parse_nfs2_request_lookup(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, handle);
+        assert_eq!(request.name_vec, b"am".to_vec());
     }
 
     #[test]
@@ -162,14 +154,10 @@ mod tests {
         let (_, handle) = parse_nfs2_handle(buf).unwrap();
         assert_eq!(handle.value, &buf[..32]);
 
-        let result = parse_nfs2_request_read(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 4);
-                assert_eq!(request.handle, handle);
-                assert_eq!(request.offset, 0);
-            }
-        }
+        let (r, request) = parse_nfs2_request_read(buf).unwrap();
+        assert_eq!(r.len(), 4);
+        assert_eq!(request.handle, handle);
+        assert_eq!(request.offset, 0);
     }
 
     #[test]
@@ -192,19 +180,15 @@ mod tests {
             0x00, /*_data_padding*/
         ];
 
-        let result = parse_nfs2_reply_read(buf).unwrap();
-        match result {
-            (r, response) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(response.status, 0);
-                assert_eq!(response.attr_follows, 1);
-                assert_eq!(response.attr_blob.len(), 68);
-                assert_eq!(response.count, response.data_len);
-                assert!(!response.eof);
-                assert_eq!(response.data_len, 11);
-                assert_eq!(response.data, &buf[76..87]);
-            }
-        }
+        let (r, response) = parse_nfs2_reply_read(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(response.status, 0);
+        assert_eq!(response.attr_follows, 1);
+        assert_eq!(response.attr_blob.len(), 68);
+        assert_eq!(response.count, response.data_len);
+        assert!(!response.eof);
+        assert_eq!(response.data_len, 11);
+        assert_eq!(response.data, &buf[76..87]);
     }
 
     #[test]
@@ -223,13 +207,9 @@ mod tests {
             0x00, 0x08, 0x16, 0x50
         ];
 
-        let result = parse_nfs2_attribs(buf).unwrap();
-        match result {
-            (r, res) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(res.atype, 1);
-                assert_eq!(res.asize, 0);
-            }
-        }
+        let (r, res) = parse_nfs2_attribs(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(res.atype, 1);
+        assert_eq!(res.asize, 0);
     }
 }

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -480,17 +480,13 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_create(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_len, 1);
-                assert_eq!(request.create_mode, 0);
-                assert_eq!(request.verifier.len(), 44);
-                assert_eq!(request.name_vec, br#"h"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_create(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_len, 1);
+        assert_eq!(request.create_mode, 0);
+        assert_eq!(request.verifier.len(), 44);
+        assert_eq!(request.name_vec, br#"h"#.to_vec());
     }
 
     #[test]
@@ -511,15 +507,11 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_remove(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_len, 1);
-                assert_eq!(request.name_vec, br#"h"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_remove(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_len, 1);
+        assert_eq!(request.name_vec, br#"h"#.to_vec());
     }
 
     #[test]
@@ -540,14 +532,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_rmdir(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"d"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_rmdir(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"d"#.to_vec());
     }
 
     #[test]
@@ -573,13 +561,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_mkdir(buf).unwrap();
-        match result {
-            (_r, request) => {
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"d"#.to_vec());
-            }
-        }
+        let (_r, request) = parse_nfs3_request_mkdir(buf).unwrap();
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"d"#.to_vec());
     }
 
     #[test]
@@ -611,18 +595,14 @@ mod tests {
         let (_, expected_from_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
         let (_, expected_to_handle) = parse_nfs3_handle(&buf[44..80]).unwrap();
 
-        let result = parse_nfs3_request_rename(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
+        let (r, request) = parse_nfs3_request_rename(buf).unwrap();
+        assert_eq!(r.len(), 0);
 
-                assert_eq!(request.from_handle, expected_from_handle);
-                assert_eq!(request.from_name_vec, br#"a"#.to_vec());
+        assert_eq!(request.from_handle, expected_from_handle);
+        assert_eq!(request.from_name_vec, br#"a"#.to_vec());
 
-                assert_eq!(request.to_handle, expected_to_handle);
-                assert_eq!(request.to_name_vec, br#"am"#.to_vec());
-            }
-        }
+        assert_eq!(request.to_handle, expected_to_handle);
+        assert_eq!(request.to_name_vec, br#"am"#.to_vec());
     }
 
     #[test]
@@ -638,13 +618,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(buf).unwrap();
 
-        let result = parse_nfs3_request_getattr(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-            }
-        }
+        let (r, request) = parse_nfs3_request_getattr(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
     }
 
     #[test]
@@ -662,14 +638,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_access(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.check_access, 12);
-            }
-        }
+        let (r, request) = parse_nfs3_request_access(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.check_access, 12);
     }
 
     #[test]
@@ -689,13 +661,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_commit(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-            }
-        }
+        let (r, request) = parse_nfs3_request_commit(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
     }
 
     #[test]
@@ -714,14 +682,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_read(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.offset, 0);
-            }
-        }
+        let (r, request) = parse_nfs3_request_read(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.offset, 0);
     }
 
     #[test]
@@ -743,14 +707,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_lookup(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"bln"#);
-            }
-        }
+        let (r, request) = parse_nfs3_request_lookup(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"bln"#);
     }
 
     #[test]
@@ -831,14 +791,10 @@ mod tests {
         let (_, entry0) = parse_nfs3_response_readdirplus_entry(entry0_buf).unwrap();
         let (_, entry1) = parse_nfs3_response_readdirplus_entry(entry1_buf).unwrap();
 
-        let response = many0_nfs3_response_readdirplus_entries(data_buf).unwrap();
-        match response {
-            (r, entries) => {
-                assert_eq!(r.len(), 4);
-                assert_eq!(entries[0], Nfs3ResponseReaddirplusEntry { entry: Some(entry0) });
-                assert_eq!(entries[1], Nfs3ResponseReaddirplusEntry { entry: Some(entry1) });
-            }
-        }
+        let (r, entries) = many0_nfs3_response_readdirplus_entries(data_buf).unwrap();
+        assert_eq!(r.len(), 4);
+        assert_eq!(entries[0], Nfs3ResponseReaddirplusEntry { entry: Some(entry0) });
+        assert_eq!(entries[1], Nfs3ResponseReaddirplusEntry { entry: Some(entry1) });
     }
 
     #[test]
@@ -904,18 +860,14 @@ mod tests {
         assert_eq!(expected_handle.len, 36);
         assert_eq!(expected_handle.value, &buf[4..40]);
 
-        let result = parse_nfs3_request_readdirplus(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.cookie, 0);
-                assert_eq!(request.verifier, "\0\0\0\0\0\0\0\0".as_bytes());
-                assert_eq!(request.verifier.len(), 8);
-                assert_eq!(request.dircount, 512);
-                assert_eq!(request.maxcount, 4096);
-            }
-        }
+        let (r, request) = parse_nfs3_request_readdirplus(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.cookie, 0);
+        assert_eq!(request.verifier, "\0\0\0\0\0\0\0\0".as_bytes());
+        assert_eq!(request.verifier.len(), 8);
+        assert_eq!(request.dircount, 512);
+        assert_eq!(request.maxcount, 4096);
     }
 
     #[test]
@@ -942,18 +894,14 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_write(buf, true).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.offset, 0);
-                assert_eq!(request.count, 17);
-                assert_eq!(request.stable, 1);
-                assert_eq!(request.file_len, 17);
-                assert_eq!(request.file_data, "hallo\nthe b file\n".as_bytes());
-            }
-        }
+        let (r, request) = parse_nfs3_request_write(buf, true).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.offset, 0);
+        assert_eq!(request.count, 17);
+        assert_eq!(request.stable, 1);
+        assert_eq!(request.file_len, 17);
+        assert_eq!(request.file_data, "hallo\nthe b file\n".as_bytes());
     }
 
     #[test]
@@ -983,18 +931,14 @@ mod tests {
             0x00, /*_data_padding*/
         ];
 
-        let result = parse_nfs3_reply_read(buf, true).unwrap();
-        match result {
-            (r, reply) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(reply.status, 0);
-                assert_eq!(reply.attr_follows, 1);
-                assert_eq!(reply.attr_blob.len(), 84);
-                assert_eq!(reply.count, 11);
-                assert!(reply.eof);
-                assert_eq!(reply.data_len, 11);
-                assert_eq!(reply.data, "the b file\n".as_bytes());
-            }
-        }
+        let (r, reply) = parse_nfs3_reply_read(buf, true).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(reply.status, 0);
+        assert_eq!(reply.attr_follows, 1);
+        assert_eq!(reply.attr_blob.len(), 84);
+        assert_eq!(reply.count, 11);
+        assert!(reply.eof);
+        assert_eq!(reply.data_len, 11);
+        assert_eq!(reply.data, "the b file\n".as_bytes());
     }
 }

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -1176,8 +1176,7 @@ mod tests {
             name: PgsqlParameters::Database,
             value: br#"mailstore"#.to_vec(),
         };
-        let mut database_param: Vec<PgsqlParameter> = Vec::new();
-        database_param.push(database);
+        let database_param: Vec<PgsqlParameter> = vec![database];
         let params = PgsqlStartupParameters {
             user,
             optional_params: Some(database_param),
@@ -2229,10 +2228,7 @@ mod tests {
             format_code: 0,
         };
 
-        let mut fields_vec = Vec::<RowField>::new();
-        fields_vec.push(field1);
-        fields_vec.push(field2);
-        fields_vec.push(field3);
+        let fields_vec = vec![field1, field2, field3];
 
         let ok_res = PgsqlBEMessage::RowDescription(RowDescriptionMessage {
             identifier: b'T',

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -1197,11 +1197,7 @@ mod tests_core_49350 {
             typ: 0xc002,
             data: BYTES[0x16c..0x16c + 0x8].to_vec(),
         }));
-        let mut channels = Vec::new();
-        channels.push(String::from("rdpdr"));
-        channels.push(String::from("rdpsnd"));
-        channels.push(String::from("drdynvc"));
-        channels.push(String::from("cliprdr"));
+        let channels = vec![String::from("rdpdr"), String::from("rdpsnd"), String::from("drdynvc"), String::from("cliprdr")];
         children.push(McsConnectRequestChild::CsNet(CsNet { channels }));
         let t123_tpkt: T123Tpkt = T123Tpkt {
             child: T123TpktChild::Data(X223Data {

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -275,17 +275,11 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_request(buf) {
-            Ok((_, req)) => {
-                assert_eq!(req.method, "REGISTER");
-                assert_eq!(req.path, "sip:sip.cybercity.dk");
-                assert_eq!(req.version, "SIP/2.0");
-                assert_eq!(req.headers["Content-Length"], "0");
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        let (_, req) = sip_parse_request(buf).unwrap();
+        assert_eq!(req.method, "REGISTER");
+        assert_eq!(req.path, "sip:sip.cybercity.dk");
+        assert_eq!(req.version, "SIP/2.0");
+        assert_eq!(req.headers["Content-Length"], "0");
     }
 
     #[test]
@@ -311,15 +305,9 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_response(buf) {
-            Ok((_, resp)) => {
-                assert_eq!(resp.version, "SIP/2.0");
-                assert_eq!(resp.code, "401");
-                assert_eq!(resp.reason, "Unauthorized");
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        let (_, resp) = sip_parse_response(buf).unwrap();
+        assert_eq!(resp.version, "SIP/2.0");
+        assert_eq!(resp.code, "401");
+        assert_eq!(resp.reason, "Unauthorized");
     }
 }

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -552,11 +552,8 @@ mod tests {
         ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00 ,0x00];
         let mut hassh_string: Vec<u8> = vec!();
         let mut hassh: Vec<u8> = vec!();
-        match ssh_parse_key_exchange(&client_key_exchange){
-            Ok((_, key_exchange)) => { 
-                key_exchange.generate_hassh(&mut hassh_string, &mut hassh, &true); 
-            }
-            Err(_) => { }
+        if let Ok((_, key_exchange)) = ssh_parse_key_exchange(&client_key_exchange){
+            key_exchange.generate_hassh(&mut hassh_string, &mut hassh, &true);
         }
 
         assert_eq!(hassh_string, "curve25519-sha256,curve25519-sha256@libssh.org,\
@@ -643,11 +640,8 @@ mod tests {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
         let mut hassh_server_string: Vec<u8> = vec!();
         let mut hassh_server: Vec<u8> = vec!();
-        match ssh_parse_key_exchange(&server_key_exchange){
-            Ok((_, key_exchange)) => { 
-                key_exchange.generate_hassh(&mut hassh_server_string, &mut hassh_server, &true);
-            }
-            Err(_) => { }
+        if let Ok((_, key_exchange)) = ssh_parse_key_exchange(&server_key_exchange){
+            key_exchange.generate_hassh(&mut hassh_server_string, &mut hassh_server, &true);
         }
         assert_eq!(hassh_server, "b12d2871a1189eff20364cf5333619ee".as_bytes().to_vec());
     }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -225,14 +225,8 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&READ_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true);
-            }
-        }
+        let txp = parse_tftp_request(&READ_REQUEST[..]).unwrap();
+        assert_eq!(tx, txp);
     }
 
     #[test]
@@ -245,14 +239,8 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&WRITE_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true, "fadfasd");
-            }
-        }
+        let txp = parse_tftp_request(&WRITE_REQUEST[..]).unwrap();
+        assert_eq!(tx, txp);
     }
 
     // Invalid request: filename not terminated


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None 

Describe changes:
- rust: fix clippy warnings in tests

#10124 with code review + match_single_binding fixed + CI now listing unit tests

Side question @jasonish `cargo clippy` shows some optimizations because of `SCLogDebug` like
```
error: manual implementation of `Iterator::find`
   --> src/dns/dns.rs:362:9
    |
362 | /         for tx in &mut self.transactions {
363 | |             if tx.id == tx_id + 1 {
364 | |                 SCLogDebug!("Found DNS TX with ID {}", tx_id);
365 | |                 return Some(tx);
...   |
368 | |         SCLogDebug!("Failed to find DNS TX with ID {}", tx_id);
369 | |         return None;
    | |____________________^ help: replace with an iterator: `self.transactions.iter_mut().find(|tx| tx.id == tx_id + 1)`
    |
```

Should we optimize this and remove the debug logs ?