### PR TITLE
Draft/RFC: Engine analysis format

### DIFF
--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -24,6 +24,7 @@
 
 #include "suricata-common.h"
 #include "decode.h"
+#include "detect.h"
 #include "flow.h"
 #include "app-layer-events.h"
 #include "app-layer-parser.h"

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -65,6 +65,7 @@ static DetectBytejumpData *DetectBytejumpParse(
         DetectEngineCtx *de_ctx, const char *optstr, char **nbytes, char **offset);
 static int DetectBytejumpSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr);
 static void DetectBytejumpFree(DetectEngineCtx*, void *ptr);
+static void DetectBytejumpDump (JsonBuilder *, const void *);
 #ifdef UNITTESTS
 static void DetectBytejumpRegisterTests(void);
 #endif
@@ -77,6 +78,7 @@ void DetectBytejumpRegister (void)
     sigmatch_table[DETECT_BYTEJUMP].Match = NULL;
     sigmatch_table[DETECT_BYTEJUMP].Setup = DetectBytejumpSetup;
     sigmatch_table[DETECT_BYTEJUMP].Free  = DetectBytejumpFree;
+    sigmatch_table[DETECT_BYTEJUMP].JsonDump = DetectBytejumpDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_BYTEJUMP].RegisterTests = DetectBytejumpRegisterTests;
 #endif
@@ -615,6 +617,50 @@ static void DetectBytejumpFree(DetectEngineCtx *de_ctx, void *ptr)
     SCFree(data);
 }
 
+static void DetectBytejumpDump (JsonBuilder *js, const void *gcd)
+{
+    DetectBytejumpData *cd = (DetectBytejumpData *) gcd;
+    jb_open_object(js, "byte_jump");
+    jb_set_uint(js, "nbytes", cd->nbytes);
+    jb_set_int(js, "offset", cd->offset);
+    jb_set_uint(js, "multiplier", cd->multiplier);
+    jb_set_int(js, "post_offset", cd->post_offset);
+    switch (cd->base) {
+        case DETECT_BYTEJUMP_BASE_UNSET:
+            jb_set_string(js, "base", "unset");
+            break;
+        case DETECT_BYTEJUMP_BASE_OCT:
+            jb_set_string(js, "base", "oct");
+            break;
+        case DETECT_BYTEJUMP_BASE_DEC:
+            jb_set_string(js, "base", "dec");
+            break;
+        case DETECT_BYTEJUMP_BASE_HEX:
+            jb_set_string(js, "base", "hex");
+            break;
+    }
+    jb_open_array(js, "flags");
+    if (cd->flags & DETECT_BYTEJUMP_BEGIN)
+        jb_append_string(js, "from_beginning");
+    if (cd->flags & DETECT_BYTEJUMP_LITTLE)
+        jb_append_string(js, "little_endian");
+    if (cd->flags & DETECT_BYTEJUMP_BIG)
+        jb_append_string(js, "big_endian");
+    if (cd->flags & DETECT_BYTEJUMP_STRING)
+        jb_append_string(js, "string");
+    if (cd->flags & DETECT_BYTEJUMP_RELATIVE)
+        jb_append_string(js, "relative");
+    if (cd->flags & DETECT_BYTEJUMP_ALIGN)
+        jb_append_string(js, "align");
+    if (cd->flags & DETECT_BYTEJUMP_DCE)
+        jb_append_string(js, "dce");
+    if (cd->flags & DETECT_BYTEJUMP_OFFSET_BE)
+        jb_append_string(js, "offset_be");
+    if (cd->flags & DETECT_BYTEJUMP_END)
+        jb_append_string(js, "from_end");
+    jb_close(js);
+    jb_close(js);
+}
 
 /* UNITTESTS */
 #ifdef UNITTESTS

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -70,6 +70,7 @@ static DetectParseRegex parse_regex;
 
 static int DetectBytetestSetup(DetectEngineCtx *de_ctx, Signature *s, const char *optstr);
 static void DetectBytetestFree(DetectEngineCtx *, void *ptr);
+static void DetectBytetestDump(JsonBuilder *, const void *);
 #ifdef UNITTESTS
 static void DetectBytetestRegisterTests(void);
 #endif
@@ -81,6 +82,7 @@ void DetectBytetestRegister (void)
     sigmatch_table[DETECT_BYTETEST].url = "/rules/payload-keywords.html#byte-test";
     sigmatch_table[DETECT_BYTETEST].Setup = DetectBytetestSetup;
     sigmatch_table[DETECT_BYTETEST].Free  = DetectBytetestFree;
+    sigmatch_table[DETECT_BYTETEST].JsonDump = DetectBytetestDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_BYTETEST].RegisterTests = DetectBytetestRegisterTests;
 #endif
@@ -730,6 +732,42 @@ static void DetectBytetestFree(DetectEngineCtx *de_ctx, void *ptr)
     SCFree(data);
 }
 
+
+static void DetectBytetestDump(JsonBuilder *js, const void *gcd)
+{
+    const DetectBytetestData *cd = (const DetectBytetestData *)gcd;
+
+    jb_open_object(js, "byte_test");
+    jb_set_uint(js, "nbytes", cd->nbytes);
+    jb_set_int(js, "offset", cd->offset);
+    switch (cd->base) {
+        case DETECT_BYTETEST_BASE_UNSET:
+            jb_set_string(js, "base", "unset");
+            break;
+        case DETECT_BYTETEST_BASE_OCT:
+            jb_set_string(js, "base", "oct");
+            break;
+        case DETECT_BYTETEST_BASE_DEC:
+            jb_set_string(js, "base", "dec");
+            break;
+        case DETECT_BYTETEST_BASE_HEX:
+            jb_set_string(js, "base", "hex");
+            break;
+    }
+    jb_open_array(js, "flags");
+    if (cd->flags & DETECT_BYTETEST_LITTLE)
+        jb_append_string(js, "little_endian");
+    if (cd->flags & DETECT_BYTETEST_BIG)
+        jb_append_string(js, "big_endian");
+    if (cd->flags & DETECT_BYTETEST_STRING)
+        jb_append_string(js, "string");
+    if (cd->flags & DETECT_BYTETEST_RELATIVE)
+        jb_append_string(js, "relative");
+    if (cd->flags & DETECT_BYTETEST_DCE)
+        jb_append_string(js, "dce");
+    jb_close(js);
+    jb_close(js);
+}
 
 /* UNITTESTS */
 #ifdef UNITTESTS

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -904,6 +904,21 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 jb_close(js); // object
                 break;
             }
+            case DETECT_FLOW: {
+                const DetectFlowData *cd = (const DetectFlowData *)smd->ctx;
+                jb_open_object(js, "flow");
+                if (cd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
+                    jb_set_bool(js, "established", true);
+                } else {
+                    jb_set_bool(js, "established", false);
+                }
+                if (cd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+                    jb_set_bool(js, "to_server", true);
+                } else {
+                    jb_set_bool(js, "to_server", false);
+                }
+                jb_close(js);
+            }
         }
         jb_close(js);
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -714,6 +714,7 @@ static void DumpContent(JsonBuilder *js, const DetectContentData *cd)
 
 static void DumpPcre(JsonBuilder *js, const DetectPcreData *cd)
 {
+    jb_set_string(js, "pattern", cd->pcre_str);
     jb_set_bool(js, "relative", cd->flags & DETECT_PCRE_RELATIVE);
     jb_set_bool(js, "relative_next", cd->flags & DETECT_PCRE_RELATIVE_NEXT);
     jb_set_bool(js, "nocase", cd->flags & DETECT_PCRE_CASELESS);

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -55,6 +55,7 @@ static int DetectFlowSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectFlowRegisterTests(void);
 #endif
 void DetectFlowFree(DetectEngineCtx *, void *);
+static void DetectFlowDump (JsonBuilder *, const void *);
 
 static int PrefilterSetupFlow(DetectEngineCtx *de_ctx, SigGroupHead *sgh);
 static bool PrefilterFlowIsPrefilterable(const Signature *s);
@@ -70,6 +71,7 @@ void DetectFlowRegister (void)
     sigmatch_table[DETECT_FLOW].Match = DetectFlowMatch;
     sigmatch_table[DETECT_FLOW].Setup = DetectFlowSetup;
     sigmatch_table[DETECT_FLOW].Free  = DetectFlowFree;
+    sigmatch_table[DETECT_FLOW].JsonDump = DetectFlowDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FLOW].RegisterTests = DetectFlowRegisterTests;
 #endif
@@ -441,6 +443,24 @@ void DetectFlowFree(DetectEngineCtx *de_ctx, void *ptr)
     DetectFlowData *fd = (DetectFlowData *)ptr;
     SCFree(fd);
 }
+
+static void DetectFlowDump (JsonBuilder *js, const void *gcd)
+{
+    DetectFlowData *cd = (DetectFlowData *) gcd;
+    jb_open_object(js, "flow");
+    if (cd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
+        jb_set_bool(js, "established", true);
+    } else {
+        jb_set_bool(js, "established", false);
+    }
+    if (cd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+        jb_set_bool(js, "to_server", true);
+    } else {
+        jb_set_bool(js, "to_server", false);
+    }
+    jb_close(js);
+}
+
 
 static void
 PrefilterPacketFlowMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -49,6 +49,7 @@ static int DetectIpOptsSetup (DetectEngineCtx *, Signature *, const char *);
 static void IpOptsRegisterTests(void);
 #endif
 void DetectIpOptsFree(DetectEngineCtx *, void *);
+static void DetectIpOptsDump(JsonBuilder *, const void *);
 
 /**
  * \brief Registration function for ipopts: keyword
@@ -61,6 +62,7 @@ void DetectIpOptsRegister (void)
     sigmatch_table[DETECT_IPOPTS].Match = DetectIpOptsMatch;
     sigmatch_table[DETECT_IPOPTS].Setup = DetectIpOptsSetup;
     sigmatch_table[DETECT_IPOPTS].Free  = DetectIpOptsFree;
+    sigmatch_table[DETECT_IPOPTS].JsonDump = DetectIpOptsDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_IPOPTS].RegisterTests = IpOptsRegisterTests;
 #endif
@@ -272,6 +274,16 @@ void DetectIpOptsFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
     DetectIpOptsData *de = (DetectIpOptsData *)de_ptr;
     if(de) SCFree(de);
+}
+
+
+static void DetectIpOptsDump (JsonBuilder *js, const void *gcd)
+{
+    DetectIpOptsData *cd = (DetectIpOptsData *)gcd;
+    jb_open_object(js, "ipopts");
+    const char *flag = IpOptsFlagToString(cd->ipopt);
+    jb_set_string(js, "option", flag);
+    jb_close(js);
 }
 
 /*

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -56,6 +56,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIPRepSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectIPRepFree (DetectEngineCtx *, void *);
+static void DetectIPRepDump (JsonBuilder *, const void *);
 #ifdef UNITTESTS
 static void IPRepRegisterTests(void);
 #endif
@@ -68,6 +69,7 @@ void DetectIPRepRegister (void)
     sigmatch_table[DETECT_IPREP].Match = DetectIPRepMatch;
     sigmatch_table[DETECT_IPREP].Setup = DetectIPRepSetup;
     sigmatch_table[DETECT_IPREP].Free  = DetectIPRepFree;
+    sigmatch_table[DETECT_IPREP].JsonDump = DetectIPRepDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_IPREP].RegisterTests = IPRepRegisterTests;
 #endif
@@ -246,6 +248,13 @@ void DetectIPRepFree (DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     rs_detect_iprep_free(fd);
+}
+
+static void DetectIPRepDump (JsonBuilder *js, const void *gcd)
+{
+    //DetectIPRepData *cd = (DetectIPRepData *) gcd;
+    jb_open_object(js, "iprep");
+    jb_close(js);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -89,6 +89,7 @@ static inline int DetectPcreExec(DetectEngineThreadCtx *det_ctx, const DetectPcr
 
 static int DetectPcreSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectPcreFree(DetectEngineCtx *, void *);
+static void DetectPcreDump(JsonBuilder *js, const void *gcd);
 #ifdef UNITTESTS
 static void DetectPcreRegisterTests(void);
 #endif
@@ -101,6 +102,7 @@ void DetectPcreRegister (void)
     sigmatch_table[DETECT_PCRE].Match = NULL;
     sigmatch_table[DETECT_PCRE].Setup = DetectPcreSetup;
     sigmatch_table[DETECT_PCRE].Free  = DetectPcreFree;
+    sigmatch_table[DETECT_PCRE].JsonDump = DetectPcreDump;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_PCRE].RegisterTests  = DetectPcreRegisterTests;
 #endif
@@ -979,6 +981,18 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
     SCFree(pd);
 
     return;
+}
+
+static void DetectPcreDump(JsonBuilder *js, const void *gcd)
+{
+    DetectPcreData *cd = (DetectPcreData *) gcd;
+    jb_open_object(js, "pcre");
+    jb_set_string(js, "pattern", cd->pcre_str);
+    jb_set_bool(js, "relative", cd->flags & DETECT_PCRE_RELATIVE);
+    jb_set_bool(js, "relative_next", cd->flags & DETECT_PCRE_RELATIVE_NEXT);
+    jb_set_bool(js, "nocase", cd->flags & DETECT_PCRE_CASELESS);
+    jb_set_bool(js, "negated", cd->flags & DETECT_PCRE_NEGATE);
+    jb_close(js);
 }
 
 #ifdef UNITTESTS /* UNITTESTS */

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -693,6 +693,9 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
     }
 
     pcre2_match_data_free(match);
+    /* store the pcre string */
+    pd->pcre_str = SCStrdup(regexstr);
+
     return pd;
 
 error:
@@ -971,6 +974,8 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
     for (uint8_t i = 0; i < pd->idx; i++) {
         VarNameStoreUnregister(pd->capids[i], pd->captypes[i]);
     }
+    if (pd->pcre_str)
+        SCFree(pd->pcre_str);
     SCFree(pd);
 
     return;

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -42,6 +42,8 @@
 typedef struct DetectPcreData_ {
     DetectParseRegex parse_regex;
     int thread_ctx_id;
+    /* String for logging */
+    char *pcre_str;
 
     uint16_t flags;
     uint8_t idx;

--- a/src/detect.h
+++ b/src/detect.h
@@ -41,6 +41,8 @@
 #include "util-file.h"
 #include "reputation.h"
 
+#include "rust.h"
+
 #define DETECT_MAX_RULE_SIZE 8192
 
 #define DETECT_TRANSFORMS_MAX 16
@@ -1278,6 +1280,8 @@ typedef struct SigTableElmt_ {
     int (*SetupPrefilter)(DetectEngineCtx *de_ctx, struct SigGroupHead_ *sgh);
 
     void (*Free)(DetectEngineCtx *, void *);
+
+    void (*JsonDump)(JsonBuilder *js, const void *detectdata);
 #ifdef UNITTESTS
     void (*RegisterTests)(void);
 #endif

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -19,7 +19,6 @@
 #define __RUST_CONTEXT_H__
 
 #include "flow.h"
-#include "detect.h"
 #include "detect-engine-state.h" //DetectEngineState
 
 #include "app-layer-krb5.h" //KRB5State, KRB5Transaction

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -24,6 +24,7 @@
 #include "app-layer-detect-proto.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
+#include "detect.h"
 #include "util-unittest.h"
 #include "util-debug.h"
 #include "conf-yaml-loader.h"


### PR DESCRIPTION
The `detect-engine-analyzer.c` file is getting really long and I propose to update the signature match structure to include a dump function. This will permit to have the JSON dump function in the detect file of the keyword and with some luck will force people to code it when there is new keyword addition.

I'm opening this PR to sync with @jufajardini and @hadiqaalamdar 

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Add pattern for pcre output
- Add basic flow information
- Add dataset information
- Factorize code