### PR TITLE
pgsql: fix u16 overflow in query data_row (7.0.x backport) - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -237,7 +237,7 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             row_cnt,
             data_size,
         }) => {
-            jb.set_uint("data_rows", (*row_cnt).into())?;
+            jb.set_uint("data_rows", *row_cnt)?;
             jb.set_uint("data_size", *data_size)?;
         }
         PgsqlBEMessage::NotificationResponse(NotificationResponse {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -210,7 +210,7 @@ pub struct BackendKeyDataMessage {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConsolidatedDataRowPacket {
     pub identifier: u8,
-    pub row_cnt: u16,
+    pub row_cnt: u64,
     pub data_size: u64,
 }
 

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -50,7 +50,7 @@ pub struct PgsqlTransaction {
     pub request: Option<PgsqlFEMessage>,
     pub responses: Vec<PgsqlBEMessage>,
 
-    pub data_row_cnt: u16,
+    pub data_row_cnt: u64,
     pub data_size: u64,
 
     tx_data: AppLayerTxData,
@@ -82,10 +82,10 @@ impl PgsqlTransaction {
     }
 
     pub fn incr_row_cnt(&mut self) {
-        self.data_row_cnt += 1;
+        self.data_row_cnt = self.data_row_cnt.saturating_add(1);
     }
 
-    pub fn get_row_cnt(&self) -> u16 {
+    pub fn get_row_cnt(&self) -> u64 {
         self.data_row_cnt
     }
 


### PR DESCRIPTION
Found by oss-fuzz with quadfuzz.

Cf https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63113

According to PostgreSQL documentation the maximum number of rows can be the maximum of tuples that can fit onto max u32 pages - 4,294,967,295 (cf https://www.postgresql.org/docs/current/limits.html). Some rough calculations for that indicate that this could go over max u32, so updating the data_row data type to u64.

Bug #6389

(cherry picked from commit 8d3de85edda97b0c585253803da3faeccc257942)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6521

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/10117 with clean cherry-pick