### PR TITLE
eve/schema: allow authorities in dns.answers in alert

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1156,7 +1156,12 @@
                         "opcode": {
                             "description": "DNS opcode as an integer",
                             "type": "integer"
-                        }
+                        },
+			"authorities": {
+			    "description": "Array of authorities in DNS response",
+			    "$comment": "Probably also need answers and additional records",
+			    "type": "array"
+			}
                     },
                     "additionalProperties": false
                 },


### PR DESCRIPTION
While this might not be ideal, it is how things are currently logged.
