### PR TITLE
eve/schema: allow authorities in dns.answers in alert - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1040,53 +1040,7 @@
                     }
                 },
                 "authorities": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "rdata": {
-                                "type": "string"
-                            },
-                            "rrname": {
-                                "type": "string"
-                            },
-                            "rrtype": {
-                                "type": "string"
-                            },
-                            "ttl": {
-                                "type": "integer"
-                            },
-                            "soa": {
-                                "type": "object",
-                                "properties": {
-                                    "expire": {
-                                        "type": "integer"
-                                    },
-                                    "minimum": {
-                                        "type": "integer"
-                                    },
-                                    "mname": {
-                                        "type": "string"
-                                    },
-                                    "refresh": {
-                                        "type": "integer"
-                                    },
-                                    "retry": {
-                                        "type": "integer"
-                                    },
-                                    "rname": {
-                                        "type": "string"
-                                    },
-                                    "serial": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
-                        },
-                        "additionalProperties": false
-                    }
+                    "$ref": "#/$defs/dns.authorities"
                 },
                 "query": {
                     "type": "array",
@@ -1156,7 +1110,10 @@
                         "opcode": {
                             "description": "DNS opcode as an integer",
                             "type": "integer"
-                        }
+                        },
+                        "authorities": {
+                            "$ref": "#/$defs/dns.authorities"
+			}
                     },
                     "additionalProperties": false
                 },
@@ -5504,6 +5461,55 @@
         }
     },
     "$defs": {
+        "dns.authorities": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rdata": {
+                        "type": "string"
+                    },
+                    "rrname": {
+                        "type": "string"
+                    },
+                    "rrtype": {
+                        "type": "string"
+                    },
+                    "ttl": {
+                        "type": "integer"
+                    },
+                    "soa": {
+                        "type": "object",
+                        "properties": {
+                            "expire": {
+                                "type": "integer"
+                            },
+                            "minimum": {
+                                "type": "integer"
+                            },
+                            "mname": {
+                                "type": "string"
+                            },
+                            "refresh": {
+                                "type": "integer"
+                            },
+                            "retry": {
+                                "type": "integer"
+                            },
+                            "rname": {
+                                "type": "string"
+                            },
+                            "serial": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "stats_applayer_error": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Allows https://github.com/OISF/suricata/pull/10126 to continue.