### PR TITLE
Detect tcp noupdatetotx 6299 v9

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1296,6 +1296,46 @@ static inline void StoreDetectFlags(DetectTransaction *tx, const uint8_t flow_fl
     }
 }
 
+static inline RuleMatchCandidateMergeSorted(DetectEngineThreadCtx *det_ctx, uint32_t j, uint32_t k)
+{
+    for (uint32_t i = det_ctx->match_array_cnt; i > 0;) {
+        const Signature *s = det_ctx->match_array[i - 1];
+        if (s->app_inspect != NULL) {
+            const SigIntId id = s->num;
+            if (j > 0) {
+                const RuleMatchCandidateTx *s0 = &det_ctx->tx_candidates[j - 1];
+                if (s->id > s0->id) {
+                    det_ctx->tx_candidates[k - 1].s = s;
+                    det_ctx->tx_candidates[k - 1].id = id;
+                    det_ctx->tx_candidates[k - 1].flags = NULL;
+                    det_ctx->tx_candidates[k - 1].stream_reset = 0;
+                    i--;
+                } else {
+                    // progress in the sorted list
+                    det_ctx->tx_candidates[k - 1].s = det_ctx->tx_candidates[j - 1].s;
+                    det_ctx->tx_candidates[k - 1].id = det_ctx->tx_candidates[j - 1].id;
+                    det_ctx->tx_candidates[k - 1].flags = det_ctx->tx_candidates[j - 1].flags;
+                    det_ctx->tx_candidates[k - 1].stream_reset =
+                            det_ctx->tx_candidates[j - 1].stream_reset;
+                    j--;
+                }
+            } else {
+                // simply append the end of sorted list
+                det_ctx->tx_candidates[k - 1].s = s;
+                det_ctx->tx_candidates[k - 1].id = id;
+                det_ctx->tx_candidates[k - 1].flags = NULL;
+                det_ctx->tx_candidates[k - 1].stream_reset = 0;
+                i--;
+                SCLogDebug("%p/%" PRIu64 " rule %u (%u) added from 'match' list", tx.tx_ptr,
+                        tx.tx_id, s->id, id);
+            }
+            k--;
+        } else {
+            i--;
+        }
+    }
+}
+
 static void DetectRunTx(ThreadVars *tv,
                     DetectEngineCtx *de_ctx,
                     DetectEngineThreadCtx *det_ctx,
@@ -1373,18 +1413,10 @@ static void DetectRunTx(ThreadVars *tv,
         for (uint32_t i = 0; i < det_ctx->match_array_cnt; i++) {
             const Signature *s = det_ctx->match_array[i];
             if (s->app_inspect != NULL) {
-                const SigIntId id = s->num;
-                det_ctx->tx_candidates[array_idx].s = s;
-                det_ctx->tx_candidates[array_idx].id = id;
-                det_ctx->tx_candidates[array_idx].flags = NULL;
-                det_ctx->tx_candidates[array_idx].stream_reset = 0;
                 array_idx++;
-
-                SCLogDebug("%p/%"PRIu64" rule %u (%u) added from 'match' list",
-                        tx.tx_ptr, tx.tx_id, s->id, id);
             }
         }
-        do_sort = (array_idx > x); // sort if match added anything
+        RuleMatchCandidateMergeSorted(det_ctx, x, array_idx);
         SCLogDebug("%p/%" PRIu64 " rules added from 'match' list: %u", tx.tx_ptr, tx.tx_id,
                 array_idx - x);
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1218,7 +1218,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         } else if ((inspect_flags & DE_STATE_FLAG_FULL_INSPECT) == 0 && mpm_in_progress) {
             TRACE_SID_TXS(s->id, tx, "no need to store no-match sig, "
                     "mpm will revisit it");
-        } else {
+        } else if (inspect_flags != 0) {
             TRACE_SID_TXS(s->id, tx, "storing state: flags %08x", inspect_flags);
             DetectRunStoreStateTx(scratch->sgh, f, tx->tx_ptr, tx->tx_id, s,
                     inspect_flags, flow_flags, file_no_match);

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -316,6 +316,7 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
     }
     SET_PKT_LEN(p, hdr_offset + payload_len);
     p->payload = GET_PKT_DATA(p)+hdr_offset;
+    p->app_update_direction = UPDATE_DIR_BOTH;
 
     return p;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6299

Describe changes:
- Optimization to not run transaction detection when a TCP packet did not update anything (no call to AppLayerParserParse) in the packet direction
- Merge sorted lists should be faster than qsort
- do not store state if there is no flags set
- cleans mqtt code for setting events

#10127 with better commit messages and inline helper function


