### PR TITLE
Backport: endace: Fix source-dag timestamps

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -118,10 +118,10 @@ static inline TmEcode ProcessErfDagRecords(ErfDagThreadVars *ewtn, uint8_t *top,
     uint32_t *pkts_read);
 static inline TmEcode ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec);
 TmEcode ReceiveErfDagLoop(ThreadVars *, void *data, void *slot);
-TmEcode ReceiveErfDagThreadInit(ThreadVars *, void *, void **);
+TmEcode ReceiveErfDagThreadInit(ThreadVars *, const void *, void **);
 void ReceiveErfDagThreadExitStats(ThreadVars *, void *);
 TmEcode ReceiveErfDagThreadDeinit(ThreadVars *, void *);
-TmEcode DecodeErfDagThreadInit(ThreadVars *, void *, void **);
+TmEcode DecodeErfDagThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodeErfDagThreadDeinit(ThreadVars *tv, void *data);
 TmEcode DecodeErfDag(ThreadVars *, Packet *, void *);
 void ReceiveErfDagCloseStream(int dagfd, int stream);
@@ -175,8 +175,7 @@ TmModuleDecodeErfDagRegister(void)
  * \param data      data pointer gets populated with
  *
  */
-TmEcode
-ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
+TmEcode ReceiveErfDagThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
     int stream_count = 0;
@@ -196,14 +195,14 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
      */
     if (dag_parse_name(initdata, ewtn->dagname, DAGNAME_BUFSIZE,
             &ewtn->dagstream) < 0) {
-        SCLogError("Failed to parse DAG interface: %s", (char *)initdata);
+        SCLogError("Failed to parse DAG interface: %s", (const char *)initdata);
         SCFree(ewtn);
         exit(EXIT_FAILURE);
     }
 
     ewtn->livedev = LiveGetDevice(initdata);
     if (ewtn->livedev == NULL) {
-        SCLogError("Unable to get %s live device", (char *)initdata);
+        SCLogError("Unable to get %s live device", (const char *)initdata);
         SCFree(ewtn);
         SCReturnInt(TM_ECODE_FAILED);
     }
@@ -612,8 +611,7 @@ DecodeErfDag(ThreadVars *tv, Packet *p, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
-TmEcode
-DecodeErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
+TmEcode DecodeErfDagThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
     DecodeThreadVars *dtv = NULL;

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -186,12 +186,10 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ErfDagThreadVars *ewtn = SCMalloc(sizeof(ErfDagThreadVars));
+    ErfDagThreadVars *ewtn = SCCalloc(1, sizeof(ErfDagThreadVars));
     if (unlikely(ewtn == NULL)) {
         FatalError("Failed to allocate memory for ERF DAG thread vars.");
     }
-
-    memset(ewtn, 0, sizeof(*ewtn));
 
     /* dag_parse_name will return a DAG device name and stream number
      * to open for this thread.
@@ -508,17 +506,13 @@ ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    /* Convert ERF time to timeval - from libpcap. */
+    /* Convert ERF time to SCTime_t */
     uint64_t ts = dr->ts;
     p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
     uint64_t usecs = ts >> 32;
-    if (usecs >= 1000000) {
-        usecs -= 1000000;
-        p->ts += SCTIME_FROM_SECS(1);
-    }
-    p->ts += SCTIME_FROM_USECS(usecs);
+    p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     StatsIncr(ewtn->tv, ewtn->packets);
     ewtn->bytes += wlen;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -195,17 +195,12 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     GET_PKT_LEN(p) = wlen;
     p->datalink = LINKTYPE_ETHERNET;
 
-    /* Convert ERF time to timeval - from libpcap. */
+    /* Convert ERF time to SCTime_t */
     uint64_t ts = dr.ts;
     p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
     uint64_t usecs = (ts >> 32);
-    if (usecs >= 1000000) {
-        usecs -= 1000000;
-        p->ts = SCTIME_ADD_SECS(p->ts, 1);
-        usecs++;
-    }
     p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     etv->pkts++;


### PR DESCRIPTION
Bug: [#6618](https://redmine.openinfosecfoundation.org/issues/6620)

Fix Endace ERF to SCTime_t timestamp conversion

Fix typo preventing compilation with --enable-dag

(cherry picked from commit https://github.com/OISF/suricata/commit/879db3dbc3e93912c784375c85d88404a9371f31)

Fix compiler const warning with --enable-dag

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6620](https://redmine.openinfosecfoundation.org/issues/6620)

Updates PR https://github.com/OISF/suricata/pull/10092