### PR TITLE
ipfw: close(2) instead shutdown(2) of the divert(4) socket

### DIFF
--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -412,8 +412,7 @@ TmEcode ReceiveIPFWThreadDeinit(ThreadVars *tv, void *data)
 
     SCEnter();
 
-    /* Attempt to shut the socket down...close instead? */
-    if (shutdown(nq->fd, SHUT_RD) < 0) {
+    if (close(nq->fd) < 0) {
         SCLogWarning("Unable to disable ipfw socket: %s", strerror(errno));
         SCReturnInt(TM_ECODE_FAILED);
     }


### PR DESCRIPTION
The shutdown(2) syscall would always return ENOTCONN for FreeBSD 11, FreeBSD 12, FreeBSD 13 and FreeBSD 14.  It could do some action on the socket in the kernel in FreeBSD 10 and before, I did not test. For FreeBSD 15 the plan is just report EOPNOTSUPP.

This was found auditing software that uses divert(4). Suricata was the only software that would use shutdown(2) on divert(4). I can imagine the following use of shutdown(2) on divert(4) socket:

SHUT_RD - will block any incoming packets from ipfw(4) while still allowing to inject packets to the kernel
SHUT_WR - will disallow further injection of packets, but would still allow to read from the kernel

This might be useful if a socket owner wants to restrict socket use and then drop down its privileges to continue packet parsing in a not superuser context. However, reading the code seems suricata wants just to close the socket and that's it.

Let me know if you actually want some meaningful action for shutdown(2) on divert(4) in FreeBSD, I can help with that. Otherwise, please just merge this change it. It will suppress a log warning.

Thanks!