### PR TITLE
output/plugin: Use Suri thread-id for plugins

### DIFF
--- a/examples/plugins/c-json-filetype/Makefile.example
+++ b/examples/plugins/c-json-filetype/Makefile.example
@@ -2,6 +2,7 @@ SRCS :=		filetype.c
 
 LIBSURICATA_CONFIG ?= libsuricata-config
 
+CPPFLAGS += -I../../../src
 CPPFLAGS +=	`$(LIBSURICATA_CONFIG) --cflags`
 CPPFLAGS +=	-DSURICATA_PLUGIN -I.
 CPPFLAGS +=	"-D__SCFILENAME__=\"$(*F)\""

--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -22,7 +22,7 @@
 
 #define FILETYPE_NAME "json-filetype-plugin"
 
-static int FiletypeThreadInit(void *ctx, int thread_id, void **thread_data);
+static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data);
 static int FiletypeThreadDeinit(void *ctx, void *thread_data);
 
 /**
@@ -30,7 +30,7 @@ static int FiletypeThreadDeinit(void *ctx, void *thread_data);
  */
 typedef struct ThreadData_ {
     /** The thread ID, for demonstration purposes only. */
-    int thread_id;
+    ThreadId thread_id;
 
     /** The number of records logged on this thread. */
     uint64_t count;
@@ -143,7 +143,7 @@ static void FiletypeDeinit(void *data)
  * Suricata, but instead this plugin chooses to use this method to create a
  * default (single) thread context.
  */
-static int FiletypeThreadInit(void *ctx, int thread_id, void **thread_data)
+static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data)
 {
     ThreadData *tdata = SCCalloc(1, sizeof(ThreadData));
     if (tdata == NULL) {

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -47,7 +47,7 @@ static int NullLogWrite(const char *buffer, int buffer_len, void *init_data, voi
     return 0;
 }
 
-static int NullLogThreadInit(void *init_data, int thread_id, void **thread_data)
+static int NullLogThreadInit(void *init_data, ThreadId thread_id, void **thread_data)
 {
     *thread_data = NULL;
     return 0;

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -38,7 +38,7 @@ OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
         goto error;
     }
 
-    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx);
+    thread->file_ctx = LogFileEnsureExists(t->id, ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error;
     }
@@ -104,7 +104,7 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx);
+    thread->file_ctx = LogFileEnsureExists(t->id, thread->ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -353,7 +353,7 @@ static TmEcode JsonStatsLogThreadInit(ThreadVars *t, const void *initdata, void 
     /* Use the Output Context (file pointer and mutex) */
     aft->statslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx);
+    aft->file_ctx = LogFileEnsureExists(t->id, aft->statslog_ctx->file_ctx);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -449,8 +449,8 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
     }
 
     SCLogDebug("Preparing file context for stats submodule logger");
-    /* Share output slot with thread 1 */
-    stats_ctx->file_ctx = LogFileEnsureExists(ajt->file_ctx);
+    /* prepared by suricata-main */
+    stats_ctx->file_ctx = LogFileEnsureExists(0, ajt->file_ctx);
     if (!stats_ctx->file_ctx) {
         SCFree(stats_ctx);
         SCFree(output_ctx);

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -40,6 +40,7 @@ typedef struct SCPlugin_ {
 } SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
+typedef uint32_t ThreadId;
 
 /**
  * Structure used to define an Eve output file type plugin.
@@ -54,8 +55,9 @@ typedef struct SCEveFileType_ {
     int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
     /* Close - Called on final close */
     void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object*/
-    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadInit - Called for each thread using file object; non-zero thread_ids correlate
+     * to Suricata's worker threads; 0 correlates to the Suricata main thread */
+    int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
     /* ThreadDeinit - Called for each thread using file object */
     int (*ThreadDeinit)(void *init_data, void *thread_data);
     TAILQ_ENTRY(SCEveFileType_) entries;

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -49,10 +49,13 @@ typedef struct SyslogSetup_ {
 } SyslogSetup;
 
 typedef struct ThreadLogFileHashEntry {
-    uint64_t thread_id;
-    int slot_number; /* slot identifier -- for plugins */
-    bool isopen;
     struct LogFileCtx_ *ctx;
+
+    uint64_t thread_id;          /* OS thread identifier */
+    ThreadId internal_thread_id; /* Suri internal thread id; to assist output plugins correlating
+                                    usage */
+    uint16_t slot_number;        /* Slot identifier - used when forming per-thread output names*/
+    bool isopen;
 } ThreadLogFileHashEntry;
 
 struct LogFileCtx_;
@@ -168,7 +171,7 @@ LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
-LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
+LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 bool SCLogOpenThreadedFile(const char *log_path, const char *append, LogFileCtx *parent_ctx);


### PR DESCRIPTION
Continuation of #9709 

Issue: 6408

Use the Suricata thread id for plugin thread initialization to give the plugin a better correlating factor to the actual Suricata threads.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6408](https://redmine.openinfosecfoundation.org/issues/6408)

Describe changes:
- Pass the actual thread id to the `ThreadInit` function instead of the "slot number"

Update:
- Update example plugin to use `ThreadId` type
- Add `ThreadId` type for plugin interface
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
