### PR TITLE
Detect tcp noupdatetotx 6299 v10

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1218,7 +1218,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         } else if ((inspect_flags & DE_STATE_FLAG_FULL_INSPECT) == 0 && mpm_in_progress) {
             TRACE_SID_TXS(s->id, tx, "no need to store no-match sig, "
                     "mpm will revisit it");
-        } else {
+        } else if (inspect_flags != 0 || file_no_match != 0) {
             TRACE_SID_TXS(s->id, tx, "storing state: flags %08x", inspect_flags);
             DetectRunStoreStateTx(scratch->sgh, f, tx->tx_ptr, tx->tx_id, s,
                     inspect_flags, flow_flags, file_no_match);

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -316,6 +316,7 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
     }
     SET_PKT_LEN(p, hdr_offset + payload_len);
     p->payload = GET_PKT_DATA(p)+hdr_offset;
+    p->app_update_direction = UPDATE_DIR_BOTH;
 
     return p;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6299

Describe changes:
- Optimization to not run transaction detection when a TCP packet did not update anything (no call to AppLayerParserParse) in the packet direction
- Merge sorted lists should be faster than qsort
- do not store state if there is no flags set
- cleans mqtt code for setting events

#10145 with 
- better commit messages
- better comments
- checking file_no_match as well as inspect_flags before calling `DetectRunStoreStateTx` 
- Fixes the sorting by using `id = s->num` and not `s->id`

