### PR TITLE
github-ci: add eBPF to the builds workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1278,7 +1278,10 @@ jobs:
                 pkg-config \
                 sudo \
                 zlib1g \
-                zlib1g-dev
+                zlib1g-dev \
+                clang \
+                libbpf-dev \
+                libelf-dev
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -1295,7 +1298,7 @@ jobs:
           cp prep/cbindgen $HOME/.cargo/bin
           chmod 755 $HOME/.cargo/bin/cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
       - run: make -j2
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/issues/6602) ticket: https://redmine.openinfosecfoundation.org/issues/6602

Describe changes:
- added ebpf dependencies
- added configure flag to enable ebpf build