### PR TITLE
log/pcap: Remove sguil mode

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -457,8 +457,8 @@ look at all packets whenever you want.  In the normal mode a pcap file
 is created in the default-log-dir. It can also be created elsewhere if
 a absolute path is set in the yaml-file.
 
-The file that is saved in example the default -log-dir
-/var/log/suricata, can be be opened with every program which supports
+The file that is saved in example the ``default-log-dir``
+`/var/log/suricata`, can be be opened with every program which supports
 the pcap file format. This can be Wireshark, TCPdump, Suricata, Snort
 and many others.
 
@@ -466,25 +466,13 @@ The pcap-log option can be enabled and disabled.
 
 There is a size limit for the pcap-log file that can be set. The
 default limit is 32 MB. If the log-file reaches this limit, the file
-will be rotated and a new one will be created. The pcap-log option
-has an extra functionality for "Sguil":http://sguil.sourceforge.net/
-that can be enabled in the 'mode' option. In the sguil mode the
-"sguil_base_dir" indicates the base directory. In this base dir the
-pcaps are created in a Sguil-specific directory structure that is
-based on the day:
-
-::
-
-  $sguil_base_dir/YYYY-MM-DD/$filename.<timestamp>
-
-If you would like to use Suricata with Sguil, do not forget to enable
-(and if necessary modify) the base dir in the suricata.yaml file.
+will be rotated and a new one will be created.
 Remember that in the 'normal' mode, the file will be saved in
 default-log-dir or in the absolute path (if set).
 
 The pcap files can be compressed before being written to disk by setting
-the compression option to lz4. This option is incompatible with sguil
-mode. Note: On Windows, this option increases disk I/O instead of
+the compression option to lz4.
+Note: On Windows, this option increases disk I/O instead of
 reducing it. When using lz4 compression, you can enable checksums using
 the lz4-checksum option, and you can set the compression level lz4-level
 to a value between 0 and 16, where higher levels result in higher
@@ -514,8 +502,7 @@ the alert.
       # Limit in MB.
       limit: 32
 
-      mode: sguil # "normal" (default) or sguil.
-      sguil_base_dir: /nsm_data/
+      mode: normal # "normal" or multi
       conditional: alerts
 
 Verbose Alerts Log (alert-debug.log)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -358,8 +358,8 @@ outputs:
       enabled: no
       #certs-log-dir: certs # directory to store the certificates files
 
-  # Packet log... log packets in pcap format. 3 modes of operation: "normal"
-  # "multi" and "sguil".
+  # Packet log... log packets in pcap format. 2 modes of operation: "normal"
+  # and "multi".
   #
   # In normal mode a pcap file "filename" is created in the default-log-dir,
   # or as specified by "dir".
@@ -379,11 +379,6 @@ outputs:
   # So the size limit when using 8 threads with 1000mb files and 2000 files
   # is: 8*1000*2000 ~ 16TiB.
   #
-  # In Sguil mode "dir" indicates the base directory. In this base dir the
-  # pcaps are created in the directory structure Sguil expects:
-  #
-  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>
-  #
   # By default all packets are logged except:
   # - TCP streams beyond stream.reassembly.depth
   # - encrypted streams after the key exchange
@@ -401,8 +396,7 @@ outputs:
       max-files: 2000
 
       # Compression algorithm for pcap files. Possible values: none, lz4.
-      # Enabling compression is incompatible with the sguil mode. Note also
-      # that on Windows, enabling compression will *increase* disk I/O.
+      # Note also that on Windows, enabling compression will *increase* disk I/O.
       compression: none
 
       # Further options for lz4 compression. The compression level can be set
@@ -411,10 +405,10 @@ outputs:
       #lz4-checksum: no
       #lz4-level: 0
 
-      mode: normal # normal, multi or sguil.
+      mode: normal # normal or multi
 
       # Directory to place pcap files. If not provided the default log
-      # directory will be used. Required for "sguil" mode.
+      # directory will be used.
       #dir: /nsm_data/
 
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec


### PR DESCRIPTION
Issue 6347 -- Remove sguil mode from post 7.0.x Suricata releases

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6347](https://redmine.openinfosecfoundation.org/issues/6347)

Describe changes:
- Remove sguil mode support from Suricata configuration and pcap log code
- Remove documentation mentionin sguil mode.


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
