### PR TITLE
htp/swf: Remove flash deprecation notice

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2905,8 +2905,6 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 if (strcasecmp("enabled", pval->name) == 0) {
                     if (ConfValIsTrue(pval->val)) {
                         cfg_prec->swf_decompression_enabled = 1;
-                        SCLogWarning("Flash decompression is deprecated and will be removed in "
-                                     "Suricata 8; see ticket #6179");
                     } else if (ConfValIsFalse(pval->val)) {
                         cfg_prec->swf_decompression_enabled = 0;
                     } else {


### PR DESCRIPTION
Issue: 6605

Flash decompression will remain so the deprecation notice is not needed.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6605](https://redmine.openinfosecfoundation.org/issues/6605)

Describe changes:
- Remove flash decompression deprecation notice

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
