### PR TITLE
detect-engine-iponly: remove insertion sort

### DIFF
--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -351,8 +351,7 @@ error:
 
 /**
  * \brief This function insert a IPOnlyCIDRItem
- *        to a list of IPOnlyCIDRItems sorted by netmask
- *        ascending
+ *        to a list of IPOnlyCIDRItems
  * \param head Pointer to the head of IPOnlyCIDRItems list
  * \param item Pointer to the item to insert in the list
  *
@@ -366,32 +365,9 @@ static IPOnlyCIDRItem *IPOnlyCIDRItemInsertReal(IPOnlyCIDRItem *head,
     if (item == NULL)
         return head;
 
-    /* Compare with the head */
-    if (item->netmask < head->netmask || (item->netmask == head->netmask && IPOnlyCIDRItemCompare(head, item))) {
-        item->next = head;
-        return item;
-    }
-
-    if (item->netmask == head->netmask && !IPOnlyCIDRItemCompare(head, item)) {
-        item->next = head->next;
-        head->next = item;
-        return head;
-    }
-
-    for (prev = it = head;
-         it != NULL && it->netmask < item->netmask;
-         it = it->next)
-        prev = it;
-
-    if (it == NULL) {
-        prev->next = item;
-        item->next = NULL;
-    } else {
-        item->next = it;
-        prev->next = item;
-    }
-
-    return head;
+    /* Always insert item as head */
+    item->next = head;
+    return item;
 }
 
 /**


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- https://redmine.openinfosecfoundation.org/issues/6376

# Describe changes

The runtime complexity of insertion sort is approx. `O(h*n)^2` where `h` is the size of the HOME_NET and `n` is the number of ip only rules that use the HOME_NET.

Removing this sort significantly improves rule load time when a large HOME_NET is used in combination with a moderate amount of ip only rules.

Brief but cursory testing using `vimdiff` and `SCRadixPrintTree` shows no difference in the structure of the radix trees that are created from this temporary linked list.

## Performance testing

### Test Setup

Script to generate `HOME_NET` with `h` random CIDR ranges:
```bash
python -c 'import ipaddress, random; h = 1000; print("[{}]".format(",".join([str(ipaddress.IPv4Address(ip)) + "/" + str(ip%32) for ip in [random.randint(1, 2**32-1) for _ in range(h)]])))'
```

Script to generate ip-only rules with `n` total rules:

```bash
python -c 'n = 10; print("\n".join(["alert ip [203.0.113.0/24] any -> $HOME_NET any (msg:\"test\"; sid:{sid}; rev:1;)".format(sid=sid) for sid in range(100000, 100000+n)]))' > suricata.rules
```

### Test Results
Rule loading time in seconds for inputs `h`, `n` on `master` and PR branch.
h | n | branch: master | branch: 6376-iponly-rule-load-performance
-- | -- | -- | --
500 | 100 | 4 | <1
500 | 200 | 25 | <1
500 | 300 | 54 | <1
500 | 400 | 123 | <1
100 | 500 | 5 | <1
200 | 500 | 24 | <1
300 | 500 | 61 | <1
400 | 500 | 122 | <1
500 | 500 | 206 | <1

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
