### PR TITLE
detect/stream_size: fix prefiltering registration (backport7)

### DIFF
--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -216,7 +216,7 @@ static bool PrefilterPacketStreamSizeCompare(PrefilterPacketHeaderValue v, void 
 
 static int PrefilterSetupStreamSize(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 {
-    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_TCPMSS, PrefilterPacketStreamSizeSet,
+    return PrefilterSetupPacketHeader(de_ctx, sgh, DETECT_STREAM_SIZE, PrefilterPacketStreamSizeSet,
             PrefilterPacketStreamSizeCompare, PrefilterPacketStreamsizeMatch);
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6556

Describe changes:
- Backport of #9830 (clean cherry-pick)
