### PR TITLE
dns: add missing dns keywords to schema.json

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1083,6 +1083,21 @@
                                     }
                                 },
                                 "additionalProperties": false
+                            },
+                            "sshfp": {
+                                "type": "object",
+                                "properties": {
+                                    "fingerprint": {
+                                        "type": "string"
+                                    },
+                                    "algo": {
+                                        "type": "integer"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
                             }
                         },
                         "additionalProperties": false
@@ -1156,6 +1171,15 @@
                         "opcode": {
                             "description": "DNS opcode as an integer",
                             "type": "integer"
+                        },
+                        "aa": {
+                            "type": "boolean"
+                        },
+                        "tc": {
+                            "type": "boolean"
+                        },
+                        "z": {
+                            "type": "boolean"
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
Feature #5642

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5642) ticket: https://redmine.openinfosecfoundation.org/issues/5642

Describe changes:
- Added dns tc, aa and z boolean fields to dns.answer in schema.json file
- Added sshfp field in dns.authorities in schema.json