### PR TITLE
Detect bidir 5665 v1

### DIFF
--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -392,13 +392,15 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
         if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
-            SCLogError("rule %u means to use both directions, cannot specify a flow direction", s->id);
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
             return -1;
         }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
         if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
-            SCLogError("rule %u means to use both directions, cannot specify a flow direction", s->id);
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
             return -1;
         }
         s->flags |= SIG_FLAG_TOCLIENT;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -391,8 +391,16 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError("rule %u means to use both directions, cannot specify a flow direction", s->id);
+            return -1;
+        }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError("rule %u means to use both directions, cannot specify a flow direction", s->id);
+            return -1;
+        }
         s->flags |= SIG_FLAG_TOCLIENT;
     } else {
         s->flags |= SIG_FLAG_TOSERVER;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1394,6 +1394,8 @@ static int SigParseBasics(DetectEngineCtx *de_ctx, Signature *s, const char *sig
 
     if (strcmp(parser->direction, "<>") == 0) {
         s->init_data->init_flags |= SIG_FLAG_INIT_BIDIREC;
+    } else if (strcmp(parser->direction, "--") == 0) {
+        s->init_data->init_flags |= SIG_FLAG_INIT_BOTHDIR;
     } else if (strcmp(parser->direction, "->") != 0) {
         SCLogError("\"%s\" is not a valid direction modifier, "
                    "\"->\" and \"<>\" are supported.",
@@ -2012,7 +2014,7 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         SCLogDebug("%s/%d: %d/%d", DetectEngineBufferTypeGetNameById(de_ctx, x), x, bufdir[x].ts,
                 bufdir[x].tc);
     }
-    if (ts_excl && tc_excl) {
+    if (ts_excl && tc_excl && (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) == 0) {
         SCLogError("rule %u mixes keywords with conflicting directions", s->id);
         SCReturnInt(0);
     } else if (ts_excl) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2032,6 +2032,16 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     } else if (dir_amb) {
         SCLogDebug("%u: rule direction cannot be deduced from keywords", s->id);
     }
+    if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+        if (!ts_excl || !tc_excl) {
+            SCLogError("rule %u should use both directions, but does not", s->id);
+            SCReturnInt(0);
+        }
+        if (dir_amb) {
+            SCLogError("rule %u means to use both directions, cannot have keywords ambiguous about directions", s->id);
+            SCReturnInt(0);
+        }
+    }
 
     if ((s->flags & SIG_FLAG_REQUIRE_PACKET) &&
         (s->flags & SIG_FLAG_REQUIRE_STREAM)) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2038,7 +2038,9 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
             SCReturnInt(0);
         }
         if (dir_amb) {
-            SCLogError("rule %u means to use both directions, cannot have keywords ambiguous about directions", s->id);
+            SCLogError("rule %u means to use both directions, cannot have keywords ambiguous about "
+                       "directions",
+                    s->id);
             SCReturnInt(0);
         }
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -284,6 +284,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
 #define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN                                                           \
     BIT_U32(4) /** < signature has seen the first ip_proto keyword */
+#define SIG_FLAG_INIT_BOTHDIR               BIT_U32(5)  /**< signature needs both directions to match */
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICIT                                                                \

--- a/src/detect.h
+++ b/src/detect.h
@@ -284,7 +284,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
 #define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN                                                           \
     BIT_U32(4) /** < signature has seen the first ip_proto keyword */
-#define SIG_FLAG_INIT_BOTHDIR               BIT_U32(5)  /**< signature needs both directions to match */
+#define SIG_FLAG_INIT_BOTHDIR BIT_U32(5) /**< signature needs both directions to match */
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICIT                                                                \


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5665

Describe changes:
- allows bidirectional signature matching ! POC

```
SV_BRANCH=pr/1589
```
https://github.com/OISF/suricata-verify/pull/1589

Draft: to show POC

TODO : 
- explicitly forbid fast_pattern on to_client
- more tests !!!!!!

Then, think about solution for ambiguous-direction keywords 