### PR TITLE
log/sguil: Issue deprecation notice if sguil mode

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1437,6 +1437,8 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
         if (s_mode != NULL) {
             if (strcasecmp(s_mode, "sguil") == 0) {
                 pl->mode = LOGMODE_SGUIL;
+                SCLogWarning("sguil mode is deprecated and will be removed from Suricata 8; see "
+                             "issue 6688");
             } else if (strcasecmp(s_mode, "multi") == 0) {
                 pl->mode = LOGMODE_MULTI;
             } else if (strcasecmp(s_mode, "normal") != 0) {


### PR DESCRIPTION
Continuation of #10180 

Sguil mode will not be supported with pcap logging in 8. Flag usages of it with a deprecation notice.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6688](https://redmine.openinfosecfoundation.org/issues/6688)

Describe changes:
- Issue deprecation mode if pcap logging is enabled with sguil mode

Updates:
- Removed superfluous commit.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
