### PR TITLE
detect: allow rule which need both directions to match

### DIFF
--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1168,6 +1168,22 @@ void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
              tmp != NULL && priority == tmp->priority;
              tmp = tmp->next)
         {
+            if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+                const DetectEngineAppInspectionEngine *app = de_ctx->app_inspect_engines;
+                bool skip = false;
+                for (; app != NULL; app = app->next) {
+                    if (app->sm_list == tmp->list_id &&
+                            (AppProtoEquals(s->alproto, app->alproto) || s->alproto == 0)) {
+                        if (app->dir == 1) {
+                            skip = true;
+                            break;
+                        }
+                    }
+                }
+                if (skip) {
+                    continue;
+                }
+            }
             SCLogDebug("tmp->list_id %d tmp->priority %d", tmp->list_id, tmp->priority);
             if (tmp->list_id >= nlists)
                 continue;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -391,8 +391,18 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOCLIENT;
     } else {
         s->flags |= SIG_FLAG_TOSERVER;

--- a/src/detect.h
+++ b/src/detect.h
@@ -284,6 +284,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
 #define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN                                                           \
     BIT_U32(4) /** < signature has seen the first ip_proto keyword */
+#define SIG_FLAG_INIT_BOTHDIR BIT_U32(5) /**< signature needs both directions to match */
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICIT                                                                \


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5665

Describe changes:
- allows bidirectional signature matching ! POC

```
SV_BRANCH=pr/1591
```
https://github.com/OISF/suricata-verify/pull/1591

Draft: to show POC and get feedback.
Throw me rules examples ! negative and positive...
Maybe this works so far because of tx progress between request and response for HTTP

TODO : 
- more tests !!!!
- doc !
- Are there protocols/transactions where server speaks first and we want bidirectional rule on it ?
- think about solution for ambiguous-direction keywords  (like new `to_client` and `to_server` keywords that are not in `flow` keyword, but only apply to a previous keyword)

https://github.com/OISF/suricata/pull/10194 with
- scan-build/memory leak fix
- fast pattern handling
- usage of `=>`