### PR TITLE
detect: Inline default pkt inspect engines

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1053,25 +1053,28 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     }
     jb_close(ctx.js);
 
-    const DetectEnginePktInspectionEngine *pkt_mpm = NULL;
+    SigMatchData *pkt_mpm_smd = NULL;
     const DetectEngineAppInspectionEngine *app_mpm = NULL;
 
     jb_open_array(ctx.js, "pkt_engines");
+    if (s->sm_arrays[DETECT_SM_LIST_PMATCH]) {
+        pkt_mpm_smd = s->sm_arrays[DETECT_SM_LIST_PMATCH];
+        jb_start_object(ctx.js);
+        jb_set_string(ctx.js, "name", "payload");
+        jb_set_bool(ctx.js, "is_mpm", s->init_data->mpm_sm_list == DETECT_SM_LIST_PMATCH);
+        jb_close(ctx.js);
+    }
+    if (s->sm_arrays[DETECT_SM_LIST_MATCH]) {
+        jb_start_object(ctx.js);
+        jb_set_string(ctx.js, "name", "packet");
+        jb_set_bool(ctx.js, "is_mpm", s->init_data->mpm_sm_list == DETECT_SM_LIST_MATCH);
+        jb_close(ctx.js);
+    }
     const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
     for ( ; pkt != NULL; pkt = pkt->next) {
         const char *name = DetectEngineBufferTypeGetNameById(de_ctx, pkt->sm_list);
         if (name == NULL) {
-            switch (pkt->sm_list) {
-                case DETECT_SM_LIST_PMATCH:
-                    name = "payload";
-                    break;
-                case DETECT_SM_LIST_MATCH:
-                    name = "packet";
-                    break;
-                default:
-                    name = "unknown";
-                    break;
-            }
+            name = "unknown";
         }
         jb_start_object(ctx.js);
         jb_set_string(ctx.js, "name", name);
@@ -1089,7 +1092,7 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
         DumpMatches(&ctx, ctx.js, pkt->smd);
         jb_close(ctx.js);
         if (pkt->mpm) {
-            pkt_mpm = pkt;
+            pkt_mpm_smd = pkt->smd;
         }
     }
     jb_close(ctx.js);
@@ -1185,10 +1188,10 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     }
     jb_close(ctx.js);
 
-    if (pkt_mpm || app_mpm) {
+    if (pkt_mpm_smd || app_mpm) {
         jb_open_object(ctx.js, "mpm");
 
-        int mpm_list = pkt_mpm ? DETECT_SM_LIST_PMATCH : app_mpm->sm_list;
+        int mpm_list = pkt_mpm_smd ? DETECT_SM_LIST_PMATCH : app_mpm->sm_list;
         const char *name;
         if (mpm_list < DETECT_SM_LIST_DYNAMIC_START)
             name = DetectListToHumanString(mpm_list);
@@ -1196,7 +1199,7 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             name = DetectEngineBufferTypeGetNameById(de_ctx, mpm_list);
         jb_set_string(ctx.js, "buffer", name);
 
-        SigMatchData *smd = pkt_mpm ? pkt_mpm->smd : app_mpm->smd;
+        SigMatchData *smd = pkt_mpm_smd ? pkt_mpm_smd : app_mpm->smd;
         if (smd == NULL && mpm_list == DETECT_SM_LIST_PMATCH) {
             smd = s->sm_arrays[mpm_list];
         }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1898,8 +1898,6 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
             SigMatch *sm = s->init_data->smlists[type];
             s->sm_arrays[type] = SigMatchList2DataArray(sm);
         }
-        /* set up the pkt inspection engines */
-        DetectEnginePktInspectionSetup(s);
 
         if (rule_engine_analysis_set) {
             EngineAnalysisAddAllRulePatterns(de_ctx, s);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -180,7 +180,6 @@ bool DetectEnginePktInspectionRun(ThreadVars *tv,
         DetectEngineThreadCtx *det_ctx, const Signature *s,
         Flow *f, Packet *p,
         uint8_t *alert_flags);
-int DetectEnginePktInspectionSetup(Signature *s);
 
 void DetectEngineSetParseMetadata(void);
 void DetectEngineUnsetParseMetadata(void);


### PR DESCRIPTION
Scenarios with a small number of rules, no MPM-based rules, experienced a 6%-14% performance degradation from the commit 0965afd66 detect: pkt inspect engines
inwhich the default pkt inspect engines were converted to callbacks to simplify adding extra pkt inspect engines.

Avoid adding the default pkt inspect engines to the callback chain and instead call them directly in an inlined function within DetectRulePacketRules().

Bug: #6291

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [✓] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6291

Describe changes:
Updated from Suricata 4.0.6 to Suricata 7, this performance degradation was noticed on a setup with the following:
* 176 signatures
* 3 are inspecting packet payload
* 33 inspect application layer
* 83 are decoder event only
This performance impact was significant when running a small number of lightweight rules, but was not significant on larger (and more heavy-duty) rule sets.

The changes make the default packet inspection engines inline, like they were in Suricata 4 before extra packet inspection engines were supported.

### Provide values to any of the below to override the defaults.

No Suricata-verify test.