### PR TITLE
Backport: endace: Fix source-dag timestamps

### DIFF
--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -118,10 +118,10 @@ static inline TmEcode ProcessErfDagRecords(ErfDagThreadVars *ewtn, uint8_t *top,
     uint32_t *pkts_read);
 static inline TmEcode ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec);
 TmEcode ReceiveErfDagLoop(ThreadVars *, void *data, void *slot);
-TmEcode ReceiveErfDagThreadInit(ThreadVars *, void *, void **);
+TmEcode ReceiveErfDagThreadInit(ThreadVars *, const void *, void **);
 void ReceiveErfDagThreadExitStats(ThreadVars *, void *);
 TmEcode ReceiveErfDagThreadDeinit(ThreadVars *, void *);
-TmEcode DecodeErfDagThreadInit(ThreadVars *, void *, void **);
+TmEcode DecodeErfDagThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodeErfDagThreadDeinit(ThreadVars *tv, void *data);
 TmEcode DecodeErfDag(ThreadVars *, Packet *, void *);
 void ReceiveErfDagCloseStream(int dagfd, int stream);
@@ -175,8 +175,7 @@ TmModuleDecodeErfDagRegister(void)
  * \param data      data pointer gets populated with
  *
  */
-TmEcode
-ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
+TmEcode ReceiveErfDagThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
     int stream_count = 0;
@@ -198,14 +197,14 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
      */
     if (dag_parse_name(initdata, ewtn->dagname, DAGNAME_BUFSIZE,
             &ewtn->dagstream) < 0) {
-        SCLogError("Failed to parse DAG interface: %s", (char *)initdata);
+        SCLogError("Failed to parse DAG interface: %s", (const char *)initdata);
         SCFree(ewtn);
         exit(EXIT_FAILURE);
     }
 
     ewtn->livedev = LiveGetDevice(initdata);
     if (ewtn->livedev == NULL) {
-        SCLogError("Unable to get %s live device", (char *)initdata);
+        SCLogError("Unable to get %s live device", (const char *)initdata);
         SCFree(ewtn);
         SCReturnInt(TM_ECODE_FAILED);
     }
@@ -614,8 +613,7 @@ DecodeErfDag(ThreadVars *tv, Packet *p, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
-TmEcode
-DecodeErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
+TmEcode DecodeErfDagThreadInit(ThreadVars *tv, const void *initdata, void **data)
 {
     SCEnter();
     DecodeThreadVars *dtv = NULL;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -195,17 +195,12 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     GET_PKT_LEN(p) = wlen;
     p->datalink = LINKTYPE_ETHERNET;
 
-    /* Convert ERF time to timeval - from libpcap. */
+    /* Convert ERF time to SCTime_t */
     uint64_t ts = dr.ts;
     p->ts = SCTIME_FROM_SECS(ts >> 32);
     ts = (ts & 0xffffffffULL) * 1000000;
     ts += 0x80000000; /* rounding */
     uint64_t usecs = (ts >> 32);
-    if (usecs >= 1000000) {
-        usecs -= 1000000;
-        p->ts = SCTIME_ADD_SECS(p->ts, 1);
-        usecs++;
-    }
     p->ts = SCTIME_ADD_USECS(p->ts, usecs);
 
     etv->pkts++;


### PR DESCRIPTION
### Fix Endace ERF to SCTime_t timestamp conversion

Fix typo preventing compilation with --enable-dag

Link to redmine ticket Bug: [6618](https://redmine.openinfosecfoundation.org/issues/6618)

(cherry picked from commit 879db3d)

### Fix compiler const warning with --enable-dag

Link to redmine ticket: Bug: [6620](https://redmine.openinfosecfoundation.org/issues/6620)

(cherry picked from commit c28cc93)

Updates PR #10148 

- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
