### PR TITLE
detect: free all tenant detect engines

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -815,7 +815,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
 
   ubuntu-20-04-ndebug:
     name: Ubuntu 20.04 (-DNDEBUG)
@@ -883,7 +883,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
       - run: suricata-update -V
       - run: suricatasc -h
@@ -1011,7 +1011,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
 
   ubuntu-22-04:
     name: Ubuntu 22.04 (Cocci)
@@ -1108,7 +1108,7 @@ jobs:
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
 
   # test build with afl and fuzztargets
   ubuntu-22-04-fuzz:
@@ -1303,7 +1303,7 @@ jobs:
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
       - run: suricata-update -V
       - run: suricatasc -h
@@ -1359,7 +1359,7 @@ jobs:
       - run: rm libhtp/VERSION && make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py
+        run: python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
       - run: suricata-update -V
       - run: suricatasc -h
@@ -1411,7 +1411,7 @@ jobs:
           ./src/suricata --build-info
           ./src/suricata -u -l /tmp/
           # need cwd in path due to npcap dlls (see above)
-          PATH="$PATH:$(pwd)" python3 ./suricata-verify/run.py
+          PATH="$PATH:$(pwd)" python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
       - run: suricata-update -V
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -95,6 +95,7 @@ DetectEngineCtx *DetectEngineGetCurrent(void);
 DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
+void DetectEngineClearMaster(void);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);
 void DetectEngineDeReference(DetectEngineCtx **de_ctx);
 int DetectEngineReload(const SCInstance *suri);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -402,7 +402,7 @@ static void GlobalsDestroy(SCInstance *suri)
         DetectEngineMoveToFreeList(de_ctx);
         DetectEngineDeReference(&de_ctx);
     }
-    DetectEnginePruneFreeList();
+    DetectEngineClearMaster();
 
     AppLayerDeSetup();
     DatasetsSave();


### PR DESCRIPTION
Continuation of #10102 

Free all tenants registered in the master.

(cherry picked from commit a4d80bc7c4910170aba950db0a497124712b330a)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6549](https://redmine.openinfosecfoundation.org/issues/6549)

Describe changes:
- Free all tenant detect engines (and indirect references)

Updates:
- Added --debug-failed to suricata-verify tests.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1562
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
