### PR TITLE
Detect bidir 5665 v4

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -226,10 +226,15 @@ Direction
 
 The directional arrow indicates which way the signature will be evaluated.
 In most signatures an arrow to the right (``->``) is used. This means that only
-packets with the same direction can match. However, it is also possible to
-have a rule match both directions (``<>``)::
+packets with the same direction can match.
+It is also possible to have a double arrow (``=>``) which means that the
+directionality for adresses and ports is used,
+but such a rule can match a bidirectional transaction, using keywords
+matching in each direction.
+However, it is also possible to have a rule match both directions (``<>``)::
 
   source -> destination
+  source => destination
   source <> destination  (both directions)
 
 The following example illustrates direction. In this example there is a client
@@ -249,6 +254,25 @@ as the direction specifies that we do not want to evaluate the response packet.
 .. warning::
 
    There is no 'reverse' style direction, i.e. there is no ``<-``.
+
+Here is an example of a bidirectional rule:
+
+.. container:: example-rule
+
+    alert http any any :example-rule-emphasis:`=>` 5.6.7.8 80 (msg:"matching both uri and status"; sid: 1; http.uri; content: "/download"; http.stat_code; content: "200";)
+
+It will match on flows to 5.6.7.8 and port 80.
+And it will match on a full transaction, using both the uri from the request,
+and the stat_code from the response.
+As such, it will match only when Suricata got both request and response.
+
+Bidirectional rules have some limitations :
+- They are only meant to work on transactions with first a request to the server,
+and then a response to the client, and not the other way around.
+- They cannot have ``fast_pattern`` or ``prefilter`` on a keyword which is on
+the direction to client.
+- They will not work with ambiguous keywords, which work for both directions.
+- They will refuse to load if a single directional rule is enough.
 
 Rule options
 ------------

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1066,6 +1066,19 @@ static SigMatch *GetMpmForList(const Signature *s, SigMatch *list, SigMatch *mpm
 
 int g_skip_prefilter = 0;
 
+bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto)
+{
+    const DetectEngineAppInspectionEngine *app = de_ctx->app_inspect_engines;
+    for (; app != NULL; app = app->next) {
+        if (app->sm_list == buf_id && (AppProtoEquals(alproto, app->alproto) || alproto == 0)) {
+            if (app->dir == 1) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
 {
     if (g_skip_prefilter)
@@ -1168,6 +1181,11 @@ void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
              tmp != NULL && priority == tmp->priority;
              tmp = tmp->next)
         {
+            if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+                if (DetectBufferToClient(de_ctx, tmp->list_id, s->alproto)) {
+                    continue;
+                }
+            }
             SCLogDebug("tmp->list_id %d tmp->priority %d", tmp->list_id, tmp->priority);
             if (tmp->list_id >= nlists)
                 continue;

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1181,7 +1181,7 @@ void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
              tmp != NULL && priority == tmp->priority;
              tmp = tmp->next)
         {
-            if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            if (s->flags & SIG_FLAG_BOTHDIR) {
                 if (DetectBufferToClient(de_ctx, tmp->list_id, s->alproto)) {
                     continue;
                 }

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1066,7 +1066,7 @@ static SigMatch *GetMpmForList(const Signature *s, SigMatch *list, SigMatch *mpm
 
 int g_skip_prefilter = 0;
 
-bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto)
+bool DetectBufferToClient(const DetectEngineCtx *de_ctx, int buf_id, AppProto alproto)
 {
     const DetectEngineAppInspectionEngine *app = de_ctx->app_inspect_engines;
     for (; app != NULL; app = app->next) {

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -135,7 +135,7 @@ struct MpmListIdDataArgs {
 
 void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *s);
 
-bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto);
+bool DetectBufferToClient(const DetectEngineCtx *de_ctx, int buf_id, AppProto alproto);
 
 #endif /* __DETECT_ENGINE_MPM_H__ */
 

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -135,5 +135,7 @@ struct MpmListIdDataArgs {
 
 void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *s);
 
+bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto);
+
 #endif /* __DETECT_ENGINE_MPM_H__ */
 

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -238,6 +238,11 @@ void DetectRunStoreStateTx(
         SCLogDebug("destate created for %"PRIu64, tx_id);
     }
     DeStateSignatureAppend(tx_data->de_state, s, inspect_flags, flow_flags);
+    if (s->flags & SIG_FLAG_BOTHDIR) {
+        // update the other direction as well
+        uint8_t rev_flags = (flow_flags & STREAM_TOSERVER) ? STREAM_TOCLIENT : STREAM_TOSERVER;
+        DeStateSignatureAppend(tx_data->de_state, s, inspect_flags, rev_flags);
+    }
     StoreStateTxHandleFiles(sgh, f, tx_data->de_state, flow_flags, tx, tx_id, file_no_match);
 
     SCLogDebug("Stored for TX %"PRIu64, tx_id);

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -238,7 +238,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         pm = pm2;
     }
 
-    if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR && s->init_data->curbuf != NULL) {
+    if (s->flags & SIG_FLAG_BOTHDIR && s->init_data->curbuf != NULL) {
         if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
             SCLogError("fast_pattern cannot be used on to_client keyword for "
                        "bidirectional rule %u",

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -238,6 +238,15 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         pm = pm2;
     }
 
+    if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR && s->init_data->curbuf != NULL) {
+        if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
+            SCLogError("fast_pattern cannot be used on to_client keyword for "
+                       "bidirectional rule %u",
+                    s->id);
+            goto error;
+        }
+    }
+
     cd = (DetectContentData *)pm->ctx;
     if ((cd->flags & DETECT_CONTENT_NEGATED) &&
         ((cd->flags & DETECT_CONTENT_DISTANCE) ||

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -391,14 +391,14 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
-        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+        if (s->flags & SIG_FLAG_BOTHDIR) {
             SCLogError(
                     "rule %u means to use both directions, cannot specify a flow direction", s->id);
             goto error;
         }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
-        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+        if (s->flags & SIG_FLAG_BOTHDIR) {
             SCLogError(
                     "rule %u means to use both directions, cannot specify a flow direction", s->id);
             goto error;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -391,8 +391,18 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOCLIENT;
     } else {
         s->flags |= SIG_FLAG_TOSERVER;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1395,7 +1395,7 @@ static int SigParseBasics(DetectEngineCtx *de_ctx, Signature *s, const char *sig
     if (strcmp(parser->direction, "<>") == 0) {
         s->init_data->init_flags |= SIG_FLAG_INIT_BIDIREC;
     } else if (strcmp(parser->direction, "=>") == 0) {
-        s->init_data->init_flags |= SIG_FLAG_INIT_BOTHDIR;
+        s->flags |= SIG_FLAG_BOTHDIR;
     } else if (strcmp(parser->direction, "->") != 0) {
         SCLogError("\"%s\" is not a valid direction modifier, "
                    "\"->\" and \"<>\" are supported.",
@@ -2014,7 +2014,7 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         SCLogDebug("%s/%d: %d/%d", DetectEngineBufferTypeGetNameById(de_ctx, x), x, bufdir[x].ts,
                 bufdir[x].tc);
     }
-    if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+    if (s->flags & SIG_FLAG_BOTHDIR) {
         if (!ts_excl || !tc_excl) {
             SCLogError("rule %u should use both directions, but does not", s->id);
             SCReturnInt(0);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1394,6 +1394,8 @@ static int SigParseBasics(DetectEngineCtx *de_ctx, Signature *s, const char *sig
 
     if (strcmp(parser->direction, "<>") == 0) {
         s->init_data->init_flags |= SIG_FLAG_INIT_BIDIREC;
+    } else if (strcmp(parser->direction, "=>") == 0) {
+        s->init_data->init_flags |= SIG_FLAG_INIT_BOTHDIR;
     } else if (strcmp(parser->direction, "->") != 0) {
         SCLogError("\"%s\" is not a valid direction modifier, "
                    "\"->\" and \"<>\" are supported.",
@@ -2012,8 +2014,21 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         SCLogDebug("%s/%d: %d/%d", DetectEngineBufferTypeGetNameById(de_ctx, x), x, bufdir[x].ts,
                 bufdir[x].tc);
     }
-    if (ts_excl && tc_excl) {
-        SCLogError("rule %u mixes keywords with conflicting directions", s->id);
+    if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR) {
+        if (!ts_excl || !tc_excl) {
+            SCLogError("rule %u should use both directions, but does not", s->id);
+            SCReturnInt(0);
+        }
+        if (dir_amb) {
+            SCLogError("rule %u means to use both directions, cannot have keywords ambiguous about "
+                       "directions",
+                    s->id);
+            SCReturnInt(0);
+        }
+    } else if (ts_excl && tc_excl) {
+        SCLogError("rule %u mixes keywords with conflicting directions, a bidirection rule with => "
+                   "should be used",
+                s->id);
         SCReturnInt(0);
     } else if (ts_excl) {
         SCLogDebug("%u: implied rule direction is toserver", s->id);

--- a/src/detect-prefilter.c
+++ b/src/detect-prefilter.c
@@ -76,7 +76,7 @@ static int DetectPrefilterSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     /* if the sig match is content, prefilter should act like
      * 'fast_pattern' w/o options. */
     if (sm->type == DETECT_CONTENT) {
-        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR && s->init_data->curbuf != NULL) {
+        if (s->flags & SIG_FLAG_BOTHDIR && s->init_data->curbuf != NULL) {
             if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
                 SCLogError("prefilter cannot be used on to_client keyword for "
                            "bidirectional rule %u",

--- a/src/detect-prefilter.c
+++ b/src/detect-prefilter.c
@@ -29,6 +29,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-content.h"
+#include "detect-engine-mpm.h"
 #include "detect-prefilter.h"
 #include "util-debug.h"
 
@@ -75,6 +76,15 @@ static int DetectPrefilterSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     /* if the sig match is content, prefilter should act like
      * 'fast_pattern' w/o options. */
     if (sm->type == DETECT_CONTENT) {
+        if (s->init_data->init_flags & SIG_FLAG_INIT_BOTHDIR && s->init_data->curbuf != NULL) {
+            if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
+                SCLogError("prefilter cannot be used on to_client keyword for "
+                           "bidirectional rule %u",
+                        s->id);
+                SCReturnInt(-1);
+            }
+        }
+
         DetectContentData *cd = (DetectContentData *)sm->ctx;
         if ((cd->flags & DETECT_CONTENT_NEGATED) &&
                 ((cd->flags & DETECT_CONTENT_DISTANCE) ||

--- a/src/detect.c
+++ b/src/detect.c
@@ -1168,9 +1168,8 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 inspect_flags |= BIT_U32(engine->id);
             }
             break;
-        } else if(!(inspect_flags & BIT_U32(engine->id)) &&
-                  s->flags & SIG_FLAG_BOTHDIR && direction != engine->dir)
-        {
+        } else if (!(inspect_flags & BIT_U32(engine->id)) && s->flags & SIG_FLAG_BOTHDIR &&
+                   direction != engine->dir) {
             const bool skip_engine = (engine->alproto != 0 && engine->alproto != f->alproto);
             /* special case: 'alert http' will have engines
              * for both HTTP1 and HTTP2. */
@@ -1208,16 +1207,14 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             if (tx_data->de_state == NULL) {
                 goto out;
             }
-            DetectEngineStateDirection *dir_state =
-                    &tx_data->de_state->dir_state[1 - direction];
+            DetectEngineStateDirection *dir_state = &tx_data->de_state->dir_state[1 - direction];
             DeStateStore *tx_store = dir_state->head;
-            //TODO looks like it will be slow
+            // TODO looks like it will be slow
             SigIntId state_cnt = 0;
             for (; tx_store != NULL; tx_store = tx_store->next) {
                 for (SigIntId store_cnt = 0;
-                     store_cnt < DE_STATE_CHUNK_SIZE && state_cnt < dir_state->cnt;
-                     store_cnt++, state_cnt++)
-                {
+                        store_cnt < DE_STATE_CHUNK_SIZE && state_cnt < dir_state->cnt;
+                        store_cnt++, state_cnt++) {
                     DeStateStoreItem *item = &tx_store->store[store_cnt];
                     if (item->sid == s->num) {
                         item->flags = inspect_flags;
@@ -1226,7 +1223,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 }
             }
         }
-out:
+    out:
         TRACE_SID_TXS(s->id, tx, "continue inspect flags %08x", inspect_flags);
     } else {
         // store... or? If tx is done we might not want to come back to this tx

--- a/src/detect.c
+++ b/src/detect.c
@@ -1168,7 +1168,16 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 inspect_flags |= BIT_U32(engine->id);
             }
             break;
+        } else if(!(inspect_flags & BIT_U32(engine->id)) &&
+                  s->flags & SIG_FLAG_BOTHDIR && direction != engine->dir)
+        {
+            // for bidirectional rules, for engines on the opposite direction
+            // as the current packet, check if we have enough progress in the tx.
+            // That means, do not return a full match, if we have only the request
+            // as there are response engines to inspect later.
+            break;
         }
+
         engine = engine->next;
     } while (engine != NULL);
     TRACE_SID_TXS(s->id, tx, "inspect_flags %x, total_matches %u, engine %p",

--- a/src/detect.h
+++ b/src/detect.h
@@ -239,6 +239,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_NOALERT                BIT_U32(4)  /**< no alert flag is set */
 #define SIG_FLAG_DSIZE                  BIT_U32(5)  /**< signature has a dsize setting */
 #define SIG_FLAG_APPLAYER               BIT_U32(6) /**< signature applies to app layer instead of packets */
+#define SIG_FLAG_BOTHDIR BIT_U32(7) /**< signature needs both directions to match */
 
 // vacancy
 
@@ -284,7 +285,6 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
 #define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN                                                           \
     BIT_U32(4) /** < signature has seen the first ip_proto keyword */
-#define SIG_FLAG_INIT_BOTHDIR BIT_U32(5) /**< signature needs both directions to match */
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICIT                                                                \

--- a/src/detect.h
+++ b/src/detect.h
@@ -284,6 +284,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_INIT_BIDIREC               BIT_U32(3)  /**< signature has bidirectional operator */
 #define SIG_FLAG_INIT_FIRST_IPPROTO_SEEN                                                           \
     BIT_U32(4) /** < signature has seen the first ip_proto keyword */
+#define SIG_FLAG_INIT_BOTHDIR BIT_U32(5) /**< signature needs both directions to match */
 #define SIG_FLAG_INIT_STATE_MATCH           BIT_U32(6)  /**< signature has matches that require stateful inspection */
 #define SIG_FLAG_INIT_NEED_FLUSH            BIT_U32(7)
 #define SIG_FLAG_INIT_PRIO_EXPLICIT                                                                \

--- a/src/detect.h
+++ b/src/detect.h
@@ -239,7 +239,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_NOALERT                BIT_U32(4)  /**< no alert flag is set */
 #define SIG_FLAG_DSIZE                  BIT_U32(5)  /**< signature has a dsize setting */
 #define SIG_FLAG_APPLAYER               BIT_U32(6) /**< signature applies to app layer instead of packets */
-#define SIG_FLAG_BOTHDIR BIT_U32(7) /**< signature needs both directions to match */
+#define SIG_FLAG_BOTHDIR                BIT_U32(7) /**< signature needs both directions to match */
 
 // vacancy
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5665

Describe changes:
- allows bidirectional signature matching !

```
SV_BRANCH=pr/1603
```
https://github.com/OISF/suricata-verify/pull/1603

Draft: to show POC and get feedback.
Throw me rules examples ! negative and positive...

TODO : 
- more tests !!!!
- think about solution for ambiguous-direction keywords  (like new `to_client` and `to_server` keywords that are not in `flow` keyword, but only apply to a previous keyword)
- optimize the way to store inspect_flags in `tx_data->de_state` for bidirectional signatures. Now it is storing in both directions, and takes the pain of figuring out where it the other one when it needs an update...
- fixup all commits, shown to see the progression of the reflection

https://github.com/OISF/suricata/pull/10209 with
- doc
- fix FP for matching on first direction, but was not testing second direction