### PR TITLE
flow: Add cfg for optional flow reuse during low memory

### DIFF
--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -687,6 +687,10 @@ static Flow *FlowGetNew(ThreadVars *tv, FlowLookupStruct *fls, Packet *p)
                 FlowWakeupFlowManagerThread();
             }
 
+            if (!flow_config.force_reuse) {
+                StatsIncr(tv, fls->dtv->counter_flow_memcap);
+                return NULL;
+            }
             f = FlowGetUsedFlow(tv, fls->dtv, p->ts);
             if (f == NULL) {
                 NoFlowHandleIPS(p);

--- a/src/flow.c
+++ b/src/flow.c
@@ -622,12 +622,16 @@ void FlowInitConfig(bool quiet)
             flow_config.prealloc = configval;
         }
     }
+    if (ConfGetBool("flow.force-reuse", &flow_config.force_reuse) != 1) {
+        flow_config.force_reuse = 1;
+    }
 
     flow_config.memcap_policy = ExceptionPolicyParse("flow.memcap-policy", false);
 
     SCLogDebug("Flow config from suricata.yaml: memcap: %"PRIu64", hash-size: "
-               "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(flow_config.memcap),
-               flow_config.hash_size, flow_config.prealloc);
+               "%"PRIu32", prealloc: %"PRIu32 ", reuse: %s", SC_ATOMIC_GET(flow_config.memcap),
+               flow_config.hash_size, flow_config.prealloc,
+               flow_config.force_reuse ? "force" : "disabled");
 
     /* alloc hash memory */
     uint64_t hash_size = flow_config.hash_size * sizeof(FlowBucket);

--- a/src/flow.h
+++ b/src/flow.h
@@ -286,6 +286,7 @@ typedef struct FlowCnf_
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
+    int force_reuse;
 
     uint32_t timeout_new;
     uint32_t timeout_est;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1424,6 +1424,7 @@ flow:
   emergency-recovery: 30
   #managers: 1 # default to one flow manager
   #recyclers: 1 # default to one flow recycler thread
+  force-reuse: 1 # Default to forcing flow reuse in low memory conditions
 
 # This option controls the use of VLAN ids in the flow (and defrag)
 # hashing. Normally this should be enabled, but in some (broken)


### PR DESCRIPTION
By default, force flow reuse to reuse an existing flows no matter the state of the flow.

Add a configuration option flow.force-reuse, enabled by default, that can turn off the above behavior.

Ticket: #6293

Make sure these boxes are signed before submitting your Pull Request -- thank you.
- [✓] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [✓] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [✓] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6293

Describe changes:
Add a configuration option flow.force-reuse, enabled by default, that can turn off flow reuse in low memory situations.

### Provide values to any of the below to override the defaults.
```
SV_BRANCH=pr/1607
```
