### PR TITLE
detect/requires: reset sigerror flags for each rule

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -258,3 +258,4 @@ default to 0.
 The ``version`` may only be specified once, if specified more than
 once the rule will log an error and not be loaded.
 
+The ``requires`` keyword was introduced in Suricata 7.0.3 and 8.0.0.

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -122,6 +122,7 @@ static int DetectLoadSigFile(
 
     (*goodsigs) = 0;
     (*badsigs) = 0;
+    (*skippedsigs) = 0;
 
     FILE *fp = fopen(sig_file, "r");
     if (fp == NULL) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2315,7 +2315,9 @@ Signature *SigInit(DetectEngineCtx *de_ctx, const char *sigstr)
     SCEnter();
 
     uint32_t oldsignum = de_ctx->signum;
+    de_ctx->sigerror_ok = false;
     de_ctx->sigerror_silent = false;
+    de_ctx->sigerror_requires = false;
 
     Signature *sig;
 


### PR DESCRIPTION
Fix issue where a bad rule after a skipped rule was recorded as skipped.

Also add a note about which version of Suricata contain this keyword.

Ticket: https://redmine.openinfosecfoundation.org/issues/6710

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1610
