### PR TITLE
Detect integers 6644 v13

### DIFF
--- a/doc/userguide/rules/dhcp-keywords.rst
+++ b/doc/userguide/rules/dhcp-keywords.rst
@@ -6,6 +6,8 @@ dhcp.leasetime
 
 DHCP lease time (integer).
 
+dhcp.leasetime uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
  dhcp.leasetime:[op]<number>
@@ -25,6 +27,8 @@ dhcp.rebinding_time
 
 DHCP rebinding time (integer).
 
+dhcp.rebinding_time uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
  dhcp.rebinding_time:[op]<number>
@@ -43,6 +47,8 @@ dhcp.renewal_time
 -----------------
 
 DHCP renewal time (integer).
+
+dhcp.renewal_time uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
 
 Syntax::
 

--- a/doc/userguide/rules/file-keywords.rst
+++ b/doc/userguide/rules/file-keywords.rst
@@ -244,6 +244,8 @@ filesize
 
 Match on the size of the file as it is being transferred.
 
+filesize uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
   filesize:<value>;

--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -292,6 +292,8 @@ flow.age
 Flow age in seconds (integer)
 This keyword does not wait for the end of the flow, but will be checked at each packet.
 
+flow.age uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
  flow.age: [op]<number>
@@ -314,6 +316,8 @@ flow.pkts_toclient
 Flow number of packets to client (integer)
 This keyword does not wait for the end of the flow, but will be checked at each packet.
 
+flow.pkts_toclient uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
  flow.pkts_toclient: [op]<number>
@@ -333,6 +337,8 @@ flow.pkts_toserver
 
 Flow number of packets to server (integer)
 This keyword does not wait for the end of the flow, but will be checked at each packet.
+
+flow.pkts_toserver uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 Syntax::
 
@@ -354,6 +360,8 @@ flow.bytes_toclient
 Flow number of bytes to client (integer)
 This keyword does not wait for the end of the flow, but will be checked at each packet.
 
+flow.bytes_toclient uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 Syntax::
 
  flow.bytes_toclient: [op]<number>
@@ -373,6 +381,8 @@ flow.bytes_toserver
 
 Flow number of bytes to server (integer)
 This keyword does not wait for the end of the flow, but will be checked at each packet.
+
+flow.bytes_toserver uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
 
 Syntax::
 

--- a/doc/userguide/rules/header-keywords.rst
+++ b/doc/userguide/rules/header-keywords.rst
@@ -15,6 +15,8 @@ For example::
 
   ttl:10;
 
+ttl uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
 At the end of the ttl keyword you can enter the value on which you
 want to match. The Time-to-live value determines the maximal amount
 of time a packet can be in the Internet-system. If this field is set
@@ -431,6 +433,8 @@ tcp.mss
 Match on the TCP MSS option value. Will not match if the option is not
 present.
 
+tcp.mss uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
+
 The format of the keyword::
 
   tcp.mss:<min>-<max>;
@@ -506,6 +510,8 @@ messages. The different messages are distinct by different names, but
 more important by numeric values. For more information see the table
 with message-types and codes.
 
+itype uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
 The format of the itype keyword::
 
   itype:min<>max;
@@ -564,6 +570,8 @@ With the icode keyword you can match on a specific ICMP code. The
 code of a ICMP message clarifies the message. Together with the
 ICMP-type it indicates with what kind of problem you are dealing with.
 A code has a different purpose with every ICMP-type.
+
+icode uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
 The format of the icode keyword::
 
@@ -718,6 +726,8 @@ icmpv6.mtu
 
 Match on the ICMPv6 MTU optional value. Will not match if the MTU is not
 present.
+
+icmpv6.mtu uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 The format of the keyword::
 

--- a/doc/userguide/rules/http-keywords.rst
+++ b/doc/userguide/rules/http-keywords.rst
@@ -237,6 +237,8 @@ The ``urilen`` keyword is used to match on the length of the request
 URI. It is possible to use the ``<`` and ``>`` operators, which
 indicate respectively *smaller than* and *larger than*.
 
+urilen uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 The format of ``urilen`` is::
 
   urilen:3;

--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -31,6 +31,8 @@ http2.priority
 
 Match on the value of the HTTP2 priority field present in a PRIORITY or HEADERS frame.
 
+http2.priority uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)
@@ -48,6 +50,8 @@ http2.window
 ------------
 
 Match on the value of the HTTP2 value field present in a WINDOWUPDATE frame.
+
+http2.window uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
@@ -67,6 +71,8 @@ http2.size_update
 Match on the size of the HTTP2 Dynamic Headers Table.
 More information on the protocol can be found here:
 `<https://tools.ietf.org/html/rfc7541#section-6.3>`_
+
+http2.size_update uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
 
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 

--- a/doc/userguide/rules/ike-keywords.rst
+++ b/doc/userguide/rules/ike-keywords.rst
@@ -61,6 +61,8 @@ ike.exchtype
 
 Match on the value of the Exchange Type.
 
+ike.exchtype uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)
@@ -106,6 +108,8 @@ ike.key_exchange_payload_length
 
 Match against the length of the public key exchange payload (e.g. Diffie-Hellman) of the server or client.
 
+ike.key_exchange_payload_length uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)
@@ -137,6 +141,8 @@ ike.nonce_payload_length
 ------------------------
 
 Match against the length of the nonce of the server or client.
+
+ike.nonce_payload_length uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -7,6 +7,7 @@ Suricata Rules
    meta
    header-keywords
    payload-keywords
+   integer-keywords
    transforms
    prefilter-keywords
    flow-keywords

--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -1,0 +1,77 @@
+.. _rules-integer-keywords:
+
+Integer Keywords
+================
+
+Many keywords will match on an integer value on the network traffic.
+These are unsigned integers that can be 8, 16, 32 or 64 bits.
+
+Simple example::
+
+    bsize:integer value;
+
+The integer value can be written as base-10 like ``100`` or as 
+an hexadecimal value like ``0x64``.
+
+The most direct example is to match for equality, but there are
+different modes.
+
+Comparison modes
+----------------
+
+Integers can be matched for
+* Equality
+* Inequality
+* Greater than
+* Less than
+* Range
+* Negated range
+* Bitmask
+* Negated Bitmask
+
+.. note::
+
+    Comparisons are strict by default. Ranges are thus exclusive.
+    That means a range between 1 and 4 will match 2 and 3, but neither 1 nor 4.
+    Negated range !1-4 will match for 1 or below and for 4 or above.
+
+Examples::
+
+    bsize:19; # equality
+    bsize:=0x13; # equality
+    bsize:!0x14; # inequality
+    bsize:!=20; # inequality
+    bsize:>21; # greater than
+    bsize:>=21; # greater than or equal
+    bsize:<22; # lesser than
+    bsize:<=22; # lesser than or equal
+    bsize:19-22; # range between value1 and value2
+    bsize:!19-22; # negated range between value1 and value2
+    bsize:&0xc0=0x80; # bitmask mask is compared to value for equality
+    bsize:&0xc0!=0; # bitmask mask is compared to value for inequality
+
+Enumerations
+------------
+
+Some integers on the wire represent an enumeration, that is, some values
+have a string/meaning associated to it.
+Rules can be written using one of these strings to check for equality.
+This is meant to make rules more human-readable and equivalent for matching.
+
+Examples::
+
+    websocket.opcode:text;
+    websocket.opcode:1; # behaves the same
+
+Bitmasks
+--------
+
+Some integers on the wire represent multiple bits.
+Some of these bits have a string/meaning associated to it.
+Rules can be written using a list (comma-separated) of these strings,
+where each item can be negated.
+
+Examples::
+
+    websocket.flags:fin,!comp;
+    websocket.flags:&0xc0=0x80; # behaves the same

--- a/doc/userguide/rules/mqtt-keywords.rst
+++ b/doc/userguide/rules/mqtt-keywords.rst
@@ -8,6 +8,8 @@ mqtt.protocol_version
 
 Match on the value of the MQTT protocol version field in the fixed header.
 
+mqtt.protocol_version uses an :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
 The format of the keyword::
 
   mqtt.protocol_version:<min>-<max>;

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -280,6 +280,8 @@ bsize
 With the ``bsize`` keyword, you can match on the length of the buffer. This adds
 precision to the content match, previously this could have been done with ``isdataat``.
 
+bsize uses an :ref:`unsigned 64-bit integer <rules-integer-keywords>`.
+
 An optional operator can be specified; if no operator is present, the operator will
 default to '='. When a relational operator is used, e.g., '<', '>' or '<>' (range),
 the bsize value will be compared using the relational operator. Ranges are inclusive.
@@ -335,6 +337,8 @@ not equal 'dsize:!n' less than 'dsize:<n' or greater than 'dsize:>n'
 This may be convenient in detecting buffer overflows.
 
 dsize cannot be used when using app/streamlayer protocol keywords (i.e. http.uri)
+
+dsize uses an :ref:`unsigned 16-bit integer <rules-integer-keywords>`.
 
 Format::
 

--- a/doc/userguide/rules/rfb-keywords.rst
+++ b/doc/userguide/rules/rfb-keywords.rst
@@ -36,6 +36,8 @@ rfb.sectype
 
 Match on the value of the RFB security type field, e.g. ``2`` for VNC challenge-response authentication, ``0`` for no authentication, and ``30`` for Apple's custom Remote Desktop authentication.
 
+rfb.sectype uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
 This keyword takes a numeric argument after a colon and supports additional qualifiers, such as:
 
 * ``>`` (greater than)

--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -284,6 +284,8 @@ tls.cert_chain_len
 
 Matches on the TLS certificate chain length.
 
+tls.cert_chain_len uses an :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
+
 tls.cert_chain_len supports `<, >, <>, !` and using an exact value.
 
 Example::

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -23,6 +23,7 @@ use proc_macro::TokenStream;
 
 mod applayerevent;
 mod applayerframetype;
+mod stringenum;
 
 /// The `AppLayerEvent` derive macro generates a `AppLayerEvent` trait
 /// implementation for enums that define AppLayerEvents.
@@ -49,4 +50,19 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(AppLayerFrameType)]
 pub fn derive_app_layer_frame_type(input: TokenStream) -> TokenStream {
     applayerframetype::derive_app_layer_frame_type(input)
+}
+
+#[proc_macro_derive(EnumStringU8, attributes(name))]
+pub fn derive_enum_string_u8(input: TokenStream) -> TokenStream {
+    stringenum::derive_enum_string::<u8>(input, "u8")
+}
+
+#[proc_macro_derive(EnumStringU16, attributes(name))]
+pub fn derive_enum_string_u16(input: TokenStream) -> TokenStream {
+    stringenum::derive_enum_string::<u16>(input, "u16")
+}
+
+#[proc_macro_derive(EnumStringU32, attributes(name))]
+pub fn derive_enum_string_u32(input: TokenStream) -> TokenStream {
+    stringenum::derive_enum_string::<u32>(input, "u32")
 }

--- a/rust/derive/src/stringenum.rs
+++ b/rust/derive/src/stringenum.rs
@@ -1,0 +1,96 @@
+/* Copyright (C) 2023 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+extern crate proc_macro;
+use super::applayerevent::transform_name;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{self, parse_macro_input, DeriveInput};
+use std::str::FromStr;
+
+pub fn derive_enum_string<T: std::str::FromStr + quote::ToTokens>(input: TokenStream, ustr: &str) -> TokenStream where <T as FromStr>::Err: std::fmt::Display {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+    let mut values = Vec::new();
+    let mut names = Vec::new();
+    let mut fields = Vec::new();
+
+    if let syn::Data::Enum(ref data) = input.data {
+        for v in (&data.variants).into_iter() {
+            if let Some((_, val)) = &v.discriminant {
+                let fname = transform_name(&v.ident.to_string());
+                names.push(fname);
+                fields.push(v.ident.clone());
+                if let syn::Expr::Lit(l) = val {
+                    if let syn::Lit::Int(li) = &l.lit {
+                        if let Ok(value) = li.base10_parse::<T>() {
+                            values.push(value);
+                        } else {
+                            panic!("EnumString requires explicit {}", ustr);
+                        }
+                    } else {
+                        panic!("EnumString requires explicit literal integer");
+                    }
+                } else {
+                    panic!("EnumString requires explicit literal");
+                }
+            } else {
+                panic!("EnumString requires explicit values");
+            }
+        }
+    } else {
+        panic!("EnumString can only be derived for enums");
+    }
+
+    let is_suricata = std::env::var("CARGO_PKG_NAME").map(|var| var == "suricata").unwrap_or(false);
+    let crate_id = if is_suricata {
+        syn::Ident::new("crate", proc_macro2::Span::call_site())
+    } else {
+        syn::Ident::new("suricata", proc_macro2::Span::call_site())
+    };
+
+    let utype_str = syn::Ident::new(ustr, proc_macro2::Span::call_site());
+
+    let expanded = quote! {
+        impl #crate_id::detect::EnumString<#utype_str> for #name {
+            fn from_u(v: #utype_str) -> Option<Self> {
+                match v {
+                    #( #values => Some(#name::#fields) ,)*
+                    _ => None,
+                }
+            }
+            fn into_u(self) -> #utype_str {
+                match self {
+                    #( #name::#fields => #values ,)*
+                }
+            }
+            fn to_str(&self) -> &'static str {
+                match *self {
+                    #( #name::#fields => #names ,)*
+                }
+            }
+            fn from_str(s: &str) -> Option<Self> {
+                match s {
+                    #( #names => Some(#name::#fields) ,)*
+                    _ => None
+                }
+            }
+        }
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -25,3 +25,46 @@ pub mod stream_size;
 pub mod uint;
 pub mod uri;
 pub mod requires;
+
+/// EnumString trait that will be implemented on enums that
+/// derive StringEnum.
+pub trait EnumString<T> {
+    /// Return the enum variant of the given numeric value.
+    fn from_u(v: T) -> Option<Self> where Self: Sized;
+
+    /// Convert the enum variant to the numeric value.
+    fn into_u(self) -> T;
+
+    /// Return the string for logging the enum value.
+    fn to_str(&self) -> &'static str;
+
+    /// Get an enum variant from parsing a string.
+    fn from_str(s: &str) -> Option<Self> where Self: Sized;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use suricata_derive::EnumStringU8;
+
+    #[derive(Clone, Debug, PartialEq, EnumStringU8)]
+    #[repr(u8)]
+    pub enum TestEnum {
+        Zero = 0,
+        BestValueEver = 42,
+    }
+
+    #[test]
+    fn test_enum_string_u8() {
+        assert_eq!(TestEnum::from_u(0), Some(TestEnum::Zero));
+        assert_eq!(TestEnum::from_u(1), None);
+        assert_eq!(TestEnum::from_u(42), Some(TestEnum::BestValueEver));
+        assert_eq!(TestEnum::Zero.into_u(), 0);
+        assert_eq!(TestEnum::BestValueEver.into_u(), 42);
+        assert_eq!(TestEnum::Zero.to_str(), "zero");
+        assert_eq!(TestEnum::BestValueEver.to_str(), "best_value_ever");
+        assert_eq!(TestEnum::from_str("zero"), Some(TestEnum::Zero));
+        assert_eq!(TestEnum::from_str("nope"), None);
+        assert_eq!(TestEnum::from_str("best_value_ever"), Some(TestEnum::BestValueEver));
+    }
+}

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -38,6 +38,8 @@ pub enum DetectUintMode {
     DetectUintModeRange,
     DetectUintModeNe,
     DetectUintModeNegRg,
+    DetectUintModeBitmask,
+    DetectUintModeNegBitmask,
 }
 
 #[derive(Debug)]
@@ -162,6 +164,37 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
         DetectUintMode::DetectUintModeNegRg
     } else {
         DetectUintMode::DetectUintModeRange
+    };
+    Ok((
+        i,
+        DetectUintData {
+            arg1,
+            arg2,
+            mode,
+        },
+    ))
+}
+
+pub fn detect_parse_uint_bitmask<T: DetectIntType>(
+    i: &str,
+) -> IResult<&str, DetectUintData<T>> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = tag("&")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg1) = detect_parse_uint_value(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, neg) = opt(tag("!"))(i)?;
+    let (i, _) = tag("=")(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg2) = detect_parse_uint_value(i)?;
+    if arg2 & arg1 != arg2 {
+        // could never match
+        return Err(Err::Error(make_error(i, ErrorKind::Verify)));
+    }
+    let mode = if neg.is_none() {
+        DetectUintMode::DetectUintModeBitmask
+    } else {
+        DetectUintMode::DetectUintModeNegBitmask
     };
     Ok((
         i,
@@ -298,6 +331,16 @@ pub fn detect_match_uint<T: DetectIntType>(x: &DetectUintData<T>, val: T) -> boo
                 return true;
             }
         }
+        DetectUintMode::DetectUintModeBitmask => {
+            if val & x.arg1 == x.arg2 {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeNegBitmask => {
+            if val & x.arg1 != x.arg2 {
+                return true;
+            }
+        }
     }
     return false;
 }
@@ -305,6 +348,7 @@ pub fn detect_match_uint<T: DetectIntType>(x: &DetectUintData<T>, val: T) -> boo
 pub fn detect_parse_uint_notending<T: DetectIntType>(i: &str) -> IResult<&str, DetectUintData<T>> {
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, uint) = alt((
+        detect_parse_uint_bitmask,
         detect_parse_uint_start_interval,
         detect_parse_uint_start_equal,
         detect_parse_uint_start_symbol,
@@ -487,6 +531,24 @@ mod tests {
         assert_eq!(ctx.mode, DetectUintMode::DetectUintModeGt);
     }
 
+    #[test]
+    fn test_parse_uint_bitmask() {
+        let (_, val) = detect_parse_uint::<u64>("&0x40!=0").unwrap();
+        assert_eq!(val.arg1, 0x40);
+        assert_eq!(val.arg2, 0);
+        assert_eq!(val.mode, DetectUintMode::DetectUintModeNegBitmask);
+        assert!(!detect_match_uint(&val, 0xBF));
+        assert!(detect_match_uint(&val, 0x40));
+        let (_, val) = detect_parse_uint::<u64>("&0xc0=0x80").unwrap();
+        assert_eq!(val.arg1, 0xc0);
+        assert_eq!(val.arg2, 0x80);
+        assert_eq!(val.mode, DetectUintMode::DetectUintModeBitmask);
+        assert!(detect_match_uint(&val, 0x80));
+        assert!(!detect_match_uint(&val, 0x40));
+        assert!(!detect_match_uint(&val, 0xc0));
+        // could never match
+        assert!(detect_parse_uint::<u64>("&0xc0=12").is_err());
+    }
     #[test]
     fn test_parse_uint_hex() {
         let (_, val) = detect_parse_uint::<u64>("0x100").unwrap();

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -17,7 +17,7 @@
 
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag, tag_no_case, take_while};
-use nom7::character::complete::{digit1, hex_digit1};
+use nom7::character::complete::{char, digit1, hex_digit1};
 use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
 use nom7::error::{make_error, ErrorKind};
 use nom7::Err;
@@ -35,6 +35,7 @@ pub enum DetectUintMode {
     DetectUintModeGte,
     DetectUintModeRange,
     DetectUintModeNe,
+    DetectUintModeNegRg,
 }
 
 #[derive(Debug)]
@@ -124,6 +125,7 @@ pub fn detect_parse_uint_start_equal<T: DetectIntType>(
 pub fn detect_parse_uint_start_interval<T: DetectIntType>(
     i: &str,
 ) -> IResult<&str, DetectUintData<T>> {
+    let (i, neg) = opt(char('!'))(i)?;
     let (i, arg1) = detect_parse_uint_value(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = alt((tag("-"), tag("<>")))(i)?;
@@ -131,12 +133,17 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
     let (i, arg2) = verify(detect_parse_uint_value, |x| {
         x > &arg1 && *x - arg1 > T::one()
     })(i)?;
+    let mode = if neg.is_some() {
+        DetectUintMode::DetectUintModeNegRg
+    } else {
+        DetectUintMode::DetectUintModeRange
+    };
     Ok((
         i,
         DetectUintData {
             arg1,
             arg2,
-            mode: DetectUintMode::DetectUintModeRange,
+            mode,
         },
     ))
 }
@@ -144,6 +151,7 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
 fn detect_parse_uint_start_interval_inclusive<T: DetectIntType>(
     i: &str,
 ) -> IResult<&str, DetectUintData<T>> {
+    let (i, neg) = opt(char('!'))(i)?;
     let (i, arg1) = verify(detect_parse_uint_value::<T>, |x| {
         *x > T::min_value()
     })(i)?;
@@ -153,12 +161,17 @@ fn detect_parse_uint_start_interval_inclusive<T: DetectIntType>(
     let (i, arg2) = verify(detect_parse_uint_value::<T>, |x| {
         *x > arg1 && *x < T::max_value()
     })(i)?;
+    let mode = if neg.is_some() {
+        DetectUintMode::DetectUintModeNegRg
+    } else {
+        DetectUintMode::DetectUintModeRange
+    };
     Ok((
         i,
         DetectUintData {
             arg1: arg1 - T::one(),
             arg2: arg2 + T::one(),
-            mode: DetectUintMode::DetectUintModeRange,
+            mode,
         },
     ))
 }
@@ -252,6 +265,11 @@ pub fn detect_match_uint<T: DetectIntType>(x: &DetectUintData<T>, val: T) -> boo
         }
         DetectUintMode::DetectUintModeRange => {
             if val > x.arg1 && val < x.arg2 {
+                return true;
+            }
+        }
+        DetectUintMode::DetectUintModeNegRg => {
+            if val <= x.arg1 || val >= x.arg2 {
                 return true;
             }
         }
@@ -432,6 +450,18 @@ mod tests {
         assert_eq!(val.arg1, 255);
         let (_, val) = detect_parse_uint::<u8>("0xff").unwrap();
         assert_eq!(val.arg1, 255);
+    }
+
+    #[test]
+    fn test_parse_uint_negated_range() {
+        let (_, val) = detect_parse_uint::<u8>("!1-6").unwrap();
+        assert_eq!(val.arg1, 1);
+        assert_eq!(val.arg2, 6);
+        assert_eq!(val.mode, DetectUintMode::DetectUintModeNegRg);
+        assert!(detect_match_uint(&val, 1));
+        assert!(!detect_match_uint(&val, 2));
+        assert!(!detect_match_uint(&val, 5));
+        assert!(detect_match_uint(&val, 6));
     }
 
     #[test]

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -17,7 +17,7 @@
 
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag, tag_no_case, take_while};
-use nom7::character::complete::digit1;
+use nom7::character::complete::{digit1, hex_digit1};
 use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
 use nom7::error::{make_error, ErrorKind};
 use nom7::Err;
@@ -73,8 +73,25 @@ pub fn detect_parse_uint_unit(i: &str) -> IResult<&str, u64> {
     return Ok((i, unit));
 }
 
+pub fn detect_parse_uint_value_hex<T: DetectIntType>(i: &str) -> IResult<&str, T> {
+    let (i, _) = tag("0x")(i)?;
+    let (i, arg1s) = hex_digit1(i)?;
+    match T::from_str_radix(arg1s, 16) {
+        Ok(arg1) => Ok((i, arg1)),
+        _ => Err(Err::Error(make_error(i, ErrorKind::Verify))),
+    }
+}
+
+pub fn detect_parse_uint_value<T: DetectIntType>(i: &str) -> IResult<&str, T> {
+    let (i, arg1) = alt((
+        detect_parse_uint_value_hex,
+        map_opt(digit1, |s: &str| s.parse::<T>().ok()),
+    ))(i)?;
+    Ok((i, arg1))
+}
+
 pub fn detect_parse_uint_with_unit<T: DetectIntType>(i: &str) -> IResult<&str, T> {
-    let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<T>().ok())(i)?;
+    let (i, arg1) = detect_parse_uint_value::<T>(i)?;
     let (i, unit) = opt(detect_parse_uint_unit)(i)?;
     if arg1 >= T::one() {
         if let Some(u) = unit {
@@ -107,11 +124,11 @@ pub fn detect_parse_uint_start_equal<T: DetectIntType>(
 pub fn detect_parse_uint_start_interval<T: DetectIntType>(
     i: &str,
 ) -> IResult<&str, DetectUintData<T>> {
-    let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<T>().ok())(i)?;
+    let (i, arg1) = detect_parse_uint_value(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = alt((tag("-"), tag("<>")))(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, arg2) = verify(map_opt(digit1, |s: &str| s.parse::<T>().ok()), |x| {
+    let (i, arg2) = verify(detect_parse_uint_value, |x| {
         x > &arg1 && *x - arg1 > T::one()
     })(i)?;
     Ok((
@@ -127,13 +144,13 @@ pub fn detect_parse_uint_start_interval<T: DetectIntType>(
 fn detect_parse_uint_start_interval_inclusive<T: DetectIntType>(
     i: &str,
 ) -> IResult<&str, DetectUintData<T>> {
-    let (i, arg1) = verify(map_opt(digit1, |s: &str| s.parse::<T>().ok()), |x| {
+    let (i, arg1) = verify(detect_parse_uint_value::<T>, |x| {
         *x > T::min_value()
     })(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
     let (i, _) = alt((tag("-"), tag("<>")))(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, arg2) = verify(map_opt(digit1, |s: &str| s.parse::<T>().ok()), |x| {
+    let (i, arg2) = verify(detect_parse_uint_value::<T>, |x| {
         *x > arg1 && *x < T::max_value()
     })(i)?;
     Ok((
@@ -162,7 +179,7 @@ pub fn detect_parse_uint_mode(i: &str) -> IResult<&str, DetectUintMode> {
 fn detect_parse_uint_start_symbol<T: DetectIntType>(i: &str) -> IResult<&str, DetectUintData<T>> {
     let (i, mode) = detect_parse_uint_mode(i)?;
     let (i, _) = opt(is_a(" "))(i)?;
-    let (i, arg1) = map_opt(digit1, |s: &str| s.parse::<T>().ok())(i)?;
+    let (i, arg1) = detect_parse_uint_value(i)?;
 
     match mode {
         DetectUintMode::DetectUintModeNe => {}
@@ -406,6 +423,16 @@ pub unsafe extern "C" fn rs_detect_u16_free(ctx: &mut DetectUintData<u16>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_uint_hex() {
+        let (_, val) = detect_parse_uint::<u64>("0x100").unwrap();
+        assert_eq!(val.arg1, 0x100);
+        let (_, val) = detect_parse_uint::<u8>("0xFF").unwrap();
+        assert_eq!(val.arg1, 255);
+        let (_, val) = detect_parse_uint::<u8>("0xff").unwrap();
+        assert_eq!(val.arg1, 255);
+    }
 
     #[test]
     fn test_parse_uint_unit() {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6644 and all subtickets
https://redmine.openinfosecfoundation.org/issues/6645
https://redmine.openinfosecfoundation.org/issues/6646
https://redmine.openinfosecfoundation.org/issues/6647
https://redmine.openinfosecfoundation.org/issues/6648
https://redmine.openinfosecfoundation.org/issues/6628

Describe changes:
- detect/integers: support hexadecimal notation for parsing
- detect/integers: add mode for negated range
- detect/integers: rust derive for enumerations
- detect/integers: keywords now accept bitmasks
- doc: detect/integers

https://github.com/OISF/suricata/pull/10234 with code review taken into account