### PR TITLE
detect: allow rule which need both directions to match

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -226,10 +226,15 @@ Direction
 
 The directional arrow indicates which way the signature will be evaluated.
 In most signatures an arrow to the right (``->``) is used. This means that only
-packets with the same direction can match. However, it is also possible to
-have a rule match both directions (``<>``)::
+packets with the same direction can match.
+It is also possible to have a double arrow (``=>``) which means that the
+directionality for adresses and ports is used,
+but such a rule can match a bidirectional transaction, using keywords
+matching in each direction.
+However, it is also possible to have a rule match both directions (``<>``)::
 
   source -> destination
+  source => destination
   source <> destination  (both directions)
 
 The following example illustrates direction. In this example there is a client
@@ -249,6 +254,25 @@ as the direction specifies that we do not want to evaluate the response packet.
 .. warning::
 
    There is no 'reverse' style direction, i.e. there is no ``<-``.
+
+Here is an example of a bidirectional rule:
+
+.. container:: example-rule
+
+    alert http any any :example-rule-emphasis:`=>` 5.6.7.8 80 (msg:"matching both uri and status"; sid: 1; http.uri; content: "/download"; http.stat_code; content: "200";)
+
+It will match on flows to 5.6.7.8 and port 80.
+And it will match on a full transaction, using both the uri from the request,
+and the stat_code from the response.
+As such, it will match only when Suricata got both request and response.
+
+Bidirectional rules have some limitations :
+- They are only meant to work on transactions with first a request to the server,
+and then a response to the client, and not the other way around.
+- They cannot have ``fast_pattern`` or ``prefilter`` on a keyword which is on
+the direction to client.
+- They will not work with ambiguous keywords, which work for both directions.
+- They will refuse to load if a single directional rule is enough.
 
 Rule options
 ------------

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1354,6 +1354,8 @@ static void FlagDetectStateNewFile(HtpTxUserData *tx, int dir)
             SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW set");
             tx->tx_data.de_state->dir_state[1].flags |= DETECT_ENGINE_STATE_FLAG_FILE_NEW;
         }
+        tx->tx_data.de_state->dir_state[DETECT_ENGINE_STATE_DIRECTION_BOTHDIR].flags |=
+                DETECT_ENGINE_STATE_FLAG_FILE_NEW;
     }
 }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -454,6 +454,8 @@ static void FlagDetectStateNewFile(SMTPTransaction *tx)
     if (tx && tx->tx_data.de_state) {
         SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW set");
         tx->tx_data.de_state->dir_state[0].flags |= DETECT_ENGINE_STATE_FLAG_FILE_NEW;
+        tx->tx_data.de_state->dir_state[DETECT_ENGINE_STATE_DIRECTION_BOTHDIR].flags |=
+                DETECT_ENGINE_STATE_FLAG_FILE_NEW;
     } else if (tx == NULL) {
         SCLogDebug("DETECT_ENGINE_STATE_FLAG_FILE_NEW NOT set, no TX");
     } else if (tx->tx_data.de_state == NULL) {

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1066,6 +1066,19 @@ static SigMatch *GetMpmForList(const Signature *s, SigMatch *list, SigMatch *mpm
 
 int g_skip_prefilter = 0;
 
+bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto)
+{
+    const DetectEngineAppInspectionEngine *app = de_ctx->app_inspect_engines;
+    for (; app != NULL; app = app->next) {
+        if (app->sm_list == buf_id && (AppProtoEquals(alproto, app->alproto) || alproto == 0)) {
+            if (app->dir == 1) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
 {
     if (g_skip_prefilter)
@@ -1168,6 +1181,11 @@ void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
              tmp != NULL && priority == tmp->priority;
              tmp = tmp->next)
         {
+            if (s->flags & SIG_FLAG_BOTHDIR) {
+                if (DetectBufferToClient(de_ctx, tmp->list_id, s->alproto)) {
+                    continue;
+                }
+            }
             SCLogDebug("tmp->list_id %d tmp->priority %d", tmp->list_id, tmp->priority);
             if (tmp->list_id >= nlists)
                 continue;

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -135,5 +135,7 @@ struct MpmListIdDataArgs {
 
 void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *s);
 
+bool DetectBufferToClient(DetectEngineCtx *de_ctx, int buf_id, AppProto alproto);
+
 #endif /* __DETECT_ENGINE_MPM_H__ */
 

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -33,6 +33,8 @@ typedef struct DetectTransaction_ {
     const uint64_t tx_id;
     struct AppLayerTxData *tx_data_ptr;
     DetectEngineStateDirection *de_state;
+    // state for bidirectional signatures
+    DetectEngineStateDirection *de_state_bidir;
     const uint64_t detect_flags; /* detect flags get/set from/to applayer */
     uint64_t prefilter_flags; /* prefilter flags for direction, to be updated by prefilter code */
     const uint64_t

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -92,9 +92,9 @@ static DeStateStore *DeStateStoreAlloc(void)
 }
 
 #ifdef DEBUG_VALIDATION
-static int DeStateSearchState(DetectEngineState *state, uint8_t direction, SigIntId num)
+static int DeStateSearchState(DetectEngineState *state, uint8_t dsi, SigIntId num)
 {
-    DetectEngineStateDirection *dir_state = &state->dir_state[direction & STREAM_TOSERVER ? 0 : 1];
+    DetectEngineStateDirection *dir_state = &state->dir_state[dsi];
     DeStateStore *tx_store = dir_state->head;
     SigIntId store_cnt;
     SigIntId state_cnt = 0;
@@ -123,11 +123,15 @@ static void DeStateSignatureAppend(DetectEngineState *state,
 {
     SCEnter();
 
-    DetectEngineStateDirection *dir_state =
-            &state->dir_state[(direction & STREAM_TOSERVER) ? 0 : 1];
+    uint8_t dsi = (direction & STREAM_TOSERVER) ? 0 : 1;
+    if (s->flags & SIG_FLAG_BOTHDIR) {
+        dsi = DETECT_ENGINE_STATE_DIRECTION_BOTHDIR;
+    }
+
+    DetectEngineStateDirection *dir_state = &state->dir_state[dsi];
 
 #ifdef DEBUG_VALIDATION
-    BUG_ON(DeStateSearchState(state, direction, s->num));
+    BUG_ON(DeStateSearchState(state, dsi, s->num));
 #endif
     DeStateStore *store = dir_state->tail;
     if (store == NULL) {
@@ -175,7 +179,7 @@ void DetectEngineStateFree(DetectEngineState *state)
     DeStateStore *store_next;
     int i = 0;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < DETECT_ENGINE_STATE_DIRECTIONS; i++) {
         store = state->dir_state[i].head;
         while (store != NULL) {
             store_next = store->next;
@@ -246,17 +250,13 @@ void DetectRunStoreStateTx(
 static inline void ResetTxState(DetectEngineState *s)
 {
     if (s) {
-        s->dir_state[0].cnt = 0;
-        s->dir_state[0].filestore_cnt = 0;
-        s->dir_state[0].flags = 0;
-        /* reset 'cur' back to the list head */
-        s->dir_state[0].cur = s->dir_state[0].head;
-
-        s->dir_state[1].cnt = 0;
-        s->dir_state[1].filestore_cnt = 0;
-        s->dir_state[1].flags = 0;
-        /* reset 'cur' back to the list head */
-        s->dir_state[1].cur = s->dir_state[1].head;
+        for (int i = 0; i < DETECT_ENGINE_STATE_DIRECTIONS; i++) {
+            s->dir_state[i].cnt = 0;
+            s->dir_state[i].filestore_cnt = 0;
+            s->dir_state[i].flags = 0;
+            /* reset 'cur' back to the list head */
+            s->dir_state[i].cur = s->dir_state[0].head;
+        }
     }
 }
 

--- a/src/detect-engine-state.h
+++ b/src/detect-engine-state.h
@@ -90,8 +90,17 @@ typedef struct DetectEngineStateDirection_ {
     /* coccinelle: DetectEngineStateDirection:flags:DETECT_ENGINE_STATE_FLAG_ */
 } DetectEngineStateDirection;
 
+#define DETECT_ENGINE_STATE_DIRECTIONS 3
+
+enum {
+    DETECT_ENGINE_STATE_DIRECTION_TOSERVER = 0,
+    DETECT_ENGINE_STATE_DIRECTION_TOCLIENT = 1,
+    DETECT_ENGINE_STATE_DIRECTION_BOTHDIR = 2,
+};
+
 typedef struct DetectEngineState_ {
-    DetectEngineStateDirection dir_state[2];
+    // to server, to client, and bidirectional
+    DetectEngineStateDirection dir_state[DETECT_ENGINE_STATE_DIRECTIONS];
 } DetectEngineState;
 
 /**

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -238,6 +238,15 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         pm = pm2;
     }
 
+    if (s->flags & SIG_FLAG_BOTHDIR && s->init_data->curbuf != NULL) {
+        if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
+            SCLogError("fast_pattern cannot be used on to_client keyword for "
+                       "bidirectional rule %u",
+                    s->id);
+            goto error;
+        }
+    }
+
     cd = (DetectContentData *)pm->ctx;
     if ((cd->flags & DETECT_CONTENT_NEGATED) &&
         ((cd->flags & DETECT_CONTENT_DISTANCE) ||

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -391,8 +391,18 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, const char *flowstr)
     bool appendsm = true;
     /* set the signature direction flags */
     if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+        if (s->flags & SIG_FLAG_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOSERVER;
     } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+        if (s->flags & SIG_FLAG_BOTHDIR) {
+            SCLogError(
+                    "rule %u means to use both directions, cannot specify a flow direction", s->id);
+            goto error;
+        }
         s->flags |= SIG_FLAG_TOCLIENT;
     } else {
         s->flags |= SIG_FLAG_TOSERVER;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1394,6 +1394,8 @@ static int SigParseBasics(DetectEngineCtx *de_ctx, Signature *s, const char *sig
 
     if (strcmp(parser->direction, "<>") == 0) {
         s->init_data->init_flags |= SIG_FLAG_INIT_BIDIREC;
+    } else if (strcmp(parser->direction, "=>") == 0) {
+        s->flags |= SIG_FLAG_BOTHDIR;
     } else if (strcmp(parser->direction, "->") != 0) {
         SCLogError("\"%s\" is not a valid direction modifier, "
                    "\"->\" and \"<>\" are supported.",
@@ -2012,8 +2014,21 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         SCLogDebug("%s/%d: %d/%d", DetectEngineBufferTypeGetNameById(de_ctx, x), x, bufdir[x].ts,
                 bufdir[x].tc);
     }
-    if (ts_excl && tc_excl) {
-        SCLogError("rule %u mixes keywords with conflicting directions", s->id);
+    if (s->flags & SIG_FLAG_BOTHDIR) {
+        if (!ts_excl || !tc_excl) {
+            SCLogError("rule %u should use both directions, but does not", s->id);
+            SCReturnInt(0);
+        }
+        if (dir_amb) {
+            SCLogError("rule %u means to use both directions, cannot have keywords ambiguous about "
+                       "directions",
+                    s->id);
+            SCReturnInt(0);
+        }
+    } else if (ts_excl && tc_excl) {
+        SCLogError("rule %u mixes keywords with conflicting directions, a bidirection rule with => "
+                   "should be used",
+                s->id);
         SCReturnInt(0);
     } else if (ts_excl) {
         SCLogDebug("%u: implied rule direction is toserver", s->id);

--- a/src/detect-prefilter.c
+++ b/src/detect-prefilter.c
@@ -29,6 +29,7 @@
 #include "detect.h"
 #include "detect-parse.h"
 #include "detect-content.h"
+#include "detect-engine-mpm.h"
 #include "detect-prefilter.h"
 #include "util-debug.h"
 
@@ -75,6 +76,15 @@ static int DetectPrefilterSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
     /* if the sig match is content, prefilter should act like
      * 'fast_pattern' w/o options. */
     if (sm->type == DETECT_CONTENT) {
+        if (s->flags & SIG_FLAG_BOTHDIR && s->init_data->curbuf != NULL) {
+            if (DetectBufferToClient(de_ctx, s->init_data->curbuf->id, s->alproto)) {
+                SCLogError("prefilter cannot be used on to_client keyword for "
+                           "bidirectional rule %u",
+                        s->id);
+                SCReturnInt(-1);
+            }
+        }
+
         DetectContentData *cd = (DetectContentData *)sm->ctx;
         if ((cd->flags & DETECT_CONTENT_NEGATED) &&
                 ((cd->flags & DETECT_CONTENT_DISTANCE) ||

--- a/src/detect.c
+++ b/src/detect.c
@@ -1168,7 +1168,22 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 inspect_flags |= BIT_U32(engine->id);
             }
             break;
+        } else if (!(inspect_flags & BIT_U32(engine->id)) && s->flags & SIG_FLAG_BOTHDIR &&
+                   direction != engine->dir) {
+            const bool skip_engine = (engine->alproto != 0 && engine->alproto != f->alproto);
+            /* special case: 'alert http' will have engines
+             * for both HTTP1 and HTTP2. */
+            if (unlikely(skip_engine)) {
+                engine = engine->next;
+                continue;
+            }
+            // for bidirectional rules, for engines on the opposite direction
+            // as the current packet, check if we have enough progress in the tx.
+            // That means, do not return a full match, if we have only the request
+            // as there are response engines to inspect later.
+            break;
         }
+
         engine = engine->next;
     } while (engine != NULL);
     TRACE_SID_TXS(s->id, tx, "inspect_flags %x, total_matches %u, engine %p",
@@ -1267,16 +1282,18 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
     DEBUG_VALIDATE_BUG_ON(prefilter_flags & APP_LAYER_TX_RESERVED_FLAGS);
 
     DetectTransaction tx = {
-                            .tx_ptr = tx_ptr,
-                            .tx_id = tx_id,
-                            .tx_data_ptr = (struct AppLayerTxData *)txd,
-                            .de_state = tx_dir_state,
-                            .detect_flags = detect_flags,
-                            .prefilter_flags = prefilter_flags,
-                            .prefilter_flags_orig = prefilter_flags,
-                            .tx_progress = tx_progress,
-                            .tx_end_state = tx_end_state,
-                           };
+        .tx_ptr = tx_ptr,
+        .tx_id = tx_id,
+        .tx_data_ptr = (struct AppLayerTxData *)txd,
+        .de_state = tx_dir_state,
+        .de_state_bidir =
+                tx_de_state ? &tx_de_state->dir_state[DETECT_ENGINE_STATE_DIRECTION_BOTHDIR] : NULL,
+        .detect_flags = detect_flags,
+        .prefilter_flags = prefilter_flags,
+        .prefilter_flags_orig = prefilter_flags,
+        .tx_progress = tx_progress,
+        .tx_end_state = tx_end_state,
+    };
     return tx;
 }
 
@@ -1291,6 +1308,52 @@ static inline void StoreDetectFlags(DetectTransaction *tx, const uint8_t flow_fl
             txd->detect_flags_tc = detect_flags;
         }
     }
+}
+
+static bool RuleMatchCandidateMergeStoredState(DetectEngineCtx *de_ctx,
+        DetectEngineThreadCtx *det_ctx, DetectTransaction tx, DetectEngineStateDirection *de_state,
+        uint32_t *array_idx)
+{
+    if (de_state == NULL) {
+        return false;
+    }
+    const uint32_t old = *array_idx;
+
+    /* if de_state->flags has 'new file' set and sig below has
+     * 'file inspected' flag, reset the file part of the state */
+    const bool have_new_file = (de_state->flags & DETECT_ENGINE_STATE_FLAG_FILE_NEW);
+    if (have_new_file) {
+        SCLogDebug("%p/%" PRIu64 " destate: need to consider new file", tx.tx_ptr, tx.tx_id);
+        de_state->flags &= ~DETECT_ENGINE_STATE_FLAG_FILE_NEW;
+    }
+
+    SigIntId state_cnt = 0;
+    DeStateStore *tx_store = de_state->head;
+    for (; tx_store != NULL; tx_store = tx_store->next) {
+        SCLogDebug("tx_store %p", tx_store);
+
+        SigIntId store_cnt = 0;
+        for (store_cnt = 0; store_cnt < DE_STATE_CHUNK_SIZE && state_cnt < de_state->cnt;
+                store_cnt++, state_cnt++) {
+            DeStateStoreItem *item = &tx_store->store[store_cnt];
+            SCLogDebug("rule id %u, inspect_flags %u", item->sid, item->flags);
+            if (have_new_file && (item->flags & DE_STATE_FLAG_FILE_INSPECT)) {
+                /* remove part of the state. File inspect engine will now
+                 * be able to run again */
+                item->flags &= ~(DE_STATE_FLAG_SIG_CANT_MATCH | DE_STATE_FLAG_FULL_INSPECT |
+                                 DE_STATE_FLAG_FILE_INSPECT);
+                SCLogDebug("rule id %u, post file reset inspect_flags %u", item->sid, item->flags);
+            }
+            det_ctx->tx_candidates[*array_idx].s = de_ctx->sig_array[item->sid];
+            det_ctx->tx_candidates[*array_idx].id = item->sid;
+            det_ctx->tx_candidates[*array_idx].flags = &item->flags;
+            det_ctx->tx_candidates[*array_idx].stream_reset = 0;
+            (*array_idx)++;
+        }
+    }
+    SCLogDebug("%p/%" PRIu64 " rules added from 'continue' list: %u", tx.tx_ptr, tx.tx_id,
+            *array_idx - old);
+    return (old && old != *array_idx); // sort if continue list adds sids
 }
 
 static void DetectRunTx(ThreadVars *tv,
@@ -1334,6 +1397,7 @@ static void DetectRunTx(ThreadVars *tv,
         uint32_t array_idx = 0;
         uint32_t total_rules = det_ctx->match_array_cnt;
         total_rules += (tx.de_state ? tx.de_state->cnt : 0);
+        total_rules += (tx.de_state_bidir ? tx.de_state_bidir->cnt : 0);
 
         /* run prefilter engines and merge results into a candidates array */
         if (sgh->tx_engines) {
@@ -1386,47 +1450,9 @@ static void DetectRunTx(ThreadVars *tv,
                 array_idx - x);
 
         /* merge stored state into results */
-        if (tx.de_state != NULL) {
-            const uint32_t old = array_idx;
-
-            /* if tx.de_state->flags has 'new file' set and sig below has
-             * 'file inspected' flag, reset the file part of the state */
-            const bool have_new_file = (tx.de_state->flags & DETECT_ENGINE_STATE_FLAG_FILE_NEW);
-            if (have_new_file) {
-                SCLogDebug("%p/%"PRIu64" destate: need to consider new file",
-                        tx.tx_ptr, tx.tx_id);
-                tx.de_state->flags &= ~DETECT_ENGINE_STATE_FLAG_FILE_NEW;
-            }
-
-            SigIntId state_cnt = 0;
-            DeStateStore *tx_store = tx.de_state->head;
-            for (; tx_store != NULL; tx_store = tx_store->next) {
-                SCLogDebug("tx_store %p", tx_store);
-
-                SigIntId store_cnt = 0;
-                for (store_cnt = 0;
-                        store_cnt < DE_STATE_CHUNK_SIZE && state_cnt < tx.de_state->cnt;
-                        store_cnt++, state_cnt++)
-                {
-                    DeStateStoreItem *item = &tx_store->store[store_cnt];
-                    SCLogDebug("rule id %u, inspect_flags %u", item->sid, item->flags);
-                    if (have_new_file && (item->flags & DE_STATE_FLAG_FILE_INSPECT)) {
-                        /* remove part of the state. File inspect engine will now
-                         * be able to run again */
-                        item->flags &= ~(DE_STATE_FLAG_SIG_CANT_MATCH|DE_STATE_FLAG_FULL_INSPECT|DE_STATE_FLAG_FILE_INSPECT);
-                        SCLogDebug("rule id %u, post file reset inspect_flags %u", item->sid, item->flags);
-                    }
-                    det_ctx->tx_candidates[array_idx].s = de_ctx->sig_array[item->sid];
-                    det_ctx->tx_candidates[array_idx].id = item->sid;
-                    det_ctx->tx_candidates[array_idx].flags = &item->flags;
-                    det_ctx->tx_candidates[array_idx].stream_reset = 0;
-                    array_idx++;
-                }
-            }
-            do_sort |= (old && old != array_idx); // sort if continue list adds sids
-            SCLogDebug("%p/%" PRIu64 " rules added from 'continue' list: %u", tx.tx_ptr, tx.tx_id,
-                    array_idx - old);
-        }
+        do_sort |= RuleMatchCandidateMergeStoredState(de_ctx, det_ctx, tx, tx.de_state, &array_idx);
+        do_sort |= RuleMatchCandidateMergeStoredState(
+                de_ctx, det_ctx, tx, tx.de_state_bidir, &array_idx);
         if (do_sort) {
             qsort(det_ctx->tx_candidates, array_idx, sizeof(RuleMatchCandidateTx),
                     DetectRunTxSortHelper);

--- a/src/detect.h
+++ b/src/detect.h
@@ -239,6 +239,7 @@ typedef struct DetectPort_ {
 #define SIG_FLAG_NOALERT                BIT_U32(4)  /**< no alert flag is set */
 #define SIG_FLAG_DSIZE                  BIT_U32(5)  /**< signature has a dsize setting */
 #define SIG_FLAG_APPLAYER               BIT_U32(6) /**< signature applies to app layer instead of packets */
+#define SIG_FLAG_BOTHDIR                BIT_U32(7) /**< signature needs both directions to match */
 
 // vacancy
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5665

Describe changes:
- allows bidirectional signature matching !

```
SV_BRANCH=pr/1603
```
https://github.com/OISF/suricata-verify/pull/1603

Not so much a draft anymore...
But I still expect to see next iterations...

TODO : 
- more tests !!!! Throw me rules examples ! negative and positive...
- think about solution for ambiguous-direction keywords  (like new `to_client` and `to_server` keywords that are not in `flow` keyword, but only apply to a previous keyword). Here, it is a documented limitation...

https://github.com/OISF/suricata/pull/10231 with
- fixups
- adding one field to `DetectEngineStateDirection dir_state[]` so as to have efficient CPU-time (even if more memory) storage and retrieval of inspect_flags