### PR TITLE
propose: codeql security-extended suite

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        queries: security-extended
 
     - run: |
        sudo apt-get update


### PR DESCRIPTION
Add the CodeQL security-extended suite to the CodeQL workflow configuration.

The `security-extended` query suite consists of all the queries in the default query suite, with addition of queries with slightly lower precision and severity, although, relative to the `default` query suite, the security-extended suite may return a greater number of false positive code scanning results.

It will allow us to catch likely flaws in the codebase that we may have missed during development, and flaws that are not checked for with the `default` suite, hence, allowing for greater hardening of Suricata, and eradicating potential threats.