### PR TITLE
exception/policy: add stats counters - v3.1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5199,6 +5199,23 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1113,7 +1113,7 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
-			}
+                        }
                     },
                     "additionalProperties": false
                 },
@@ -3686,6 +3686,29 @@
                         "error": {
                             "type": "object",
                             "properties": {
+                                "exception_policy": {
+                                    "type": "object",
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/$defs/drop_flow"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/drop_packet"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/pass_flow"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/pass_packet"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/bypass"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/reject"
+                                        }
+                                    ]
+                                },
                                 "bittorrent-dht": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
@@ -3792,7 +3815,7 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": true
                         },
                         "flow": {
                             "type": "object",
@@ -5608,6 +5631,29 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/drop_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/drop_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/bypass"
+                        },
+                        {
+                            "$ref": "#/$defs/reject"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4890,6 +4890,24 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ],
+                            "additionalProperties": "false"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5566,6 +5584,24 @@
                     ]
                 }
             }
+        },
+        "drop_flow": {
+            "type": "object"
+        },
+        "drop_packet": {
+            "type": "object"
+        },
+        "pass_flow": {
+            "type": "object"
+        },
+        "pass_packet": {
+            "type": "object"
+        },
+        "bypass": {
+            "type": "object"
+        },
+        "reject": {
+            "type": "object"
         }
     }
 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5217,6 +5217,32 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5236,9 +5236,6 @@
                                     "$ref": "#/$defs/bypass"
                                 },
                                 {
-                                    "$ref": "#/$defs/ignore"
-                                },
-                                {
                                     "$ref": "#/$defs/reject"
                                 }
                             ]
@@ -5272,6 +5269,32 @@
                         },
                         "ssn_memcap_drop": {
                             "type": "integer"
+                        },
+                        "ssn_memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
                         },
                         "stream_depth_reached": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4777,6 +4777,23 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {
@@ -4928,8 +4945,7 @@
                                 {
                                     "$ref": "#/$defs/reject"
                                 }
-                            ],
-                            "additionalProperties": "false"
+                            ]
                         },
                         "memuse": {
                             "type": "integer"

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -102,6 +102,9 @@ bool stats_decoder_events = true;
 const char *stats_decoder_events_prefix = "decoder.event";
 /**< add stream events as stats? disabled by default */
 bool stats_stream_events = false;
+
+/** add zero valued counters for exception policies stats? disabled by default */
+bool stats_eps_zero_counters = false;
 
 static int StatsOutput(ThreadVars *tv);
 static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext *);
@@ -293,6 +296,11 @@ static void StatsInitCtxPreOutput(void)
             prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;
+
+        ret = ConfGetChildValueBool(stats, "eps-zero-valued-counters", &b);
+        if (ret) {
+            stats_eps_zero_counters = (b == 1);
+        }
     }
     SCReturn;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -569,6 +569,15 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    /* Register stats counters for all exception policy values */
+    dtv->counter_flow_memcap_eps_reject =
+            StatsRegisterCounter("flow.memcap_exception_policy.reject", tv);
+    dtv->counter_flow_memcap_eps_bypass =
+            StatsRegisterCounter("flow.memcap_exception_policy.bypass", tv);
+    dtv->counter_flow_memcap_eps_pass_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_flow_memcap_eps_drop_packet =
+            StatsRegisterCounter("flow.memcap_exception_policy.drop_packet", tv);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -606,6 +606,15 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+    /* Counters for Exception Policy Defrag values */
+    dtv->counter_defrag_memcap_eps_reject =
+            StatsRegisterCounter("defrag.memcap_exception_policy.reject", tv);
+    dtv->counter_defrag_memcap_eps_bypass =
+            StatsRegisterCounter("defrag.memcap_exception_policy.bypass", tv);
+    dtv->counter_defrag_memcap_eps_pass_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.pass_packet", tv);
+    dtv->counter_defrag_memcap_eps_drop_packet =
+            StatsRegisterCounter("defrag.memcap_exception_policy.drop_packet", tv);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.h
+++ b/src/decode.h
@@ -728,6 +728,10 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    uint16_t counter_flow_memcap_eps_reject;
+    uint16_t counter_flow_memcap_eps_bypass;
+    uint16_t counter_flow_memcap_eps_pass_packet;
+    uint16_t counter_flow_memcap_eps_drop_packet;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -726,6 +726,10 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    uint16_t counter_defrag_memcap_eps_reject;
+    uint16_t counter_defrag_memcap_eps_bypass;
+    uint16_t counter_defrag_memcap_eps_pass_packet;
+    uint16_t counter_defrag_memcap_eps_drop_packet;
 
     uint16_t counter_flow_memcap;
     uint16_t counter_flow_memcap_eps_reject;

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -92,7 +92,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -991,7 +991,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1950,6 +1950,37 @@ static int StreamTcpReassembleHandleSegmentUpdateACK (ThreadVars *tv,
     SCReturnInt(0);
 }
 
+static void StreamTcpReassembleExceptionPolicyStatsIncr(
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, enum ExceptionPolicy policy)
+{
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            // We don't log stats counters if we're ignoring the exception
+            // policies
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_reject);
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_bypass);
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_pass_flow);
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_pass_packet);
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_drop_flow);
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            StatsIncr(tv, ra_ctx->counter_tcp_reas_eps_drop_packet);
+            break;
+        case EXCEPTION_POLICY_AUTO:
+            break;
+    }
+}
+
 int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         TcpSession *ssn, TcpStream *stream, Packet *p)
 {
@@ -2016,6 +2047,8 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
                     p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_REASSEMBLY);
+            StreamTcpReassembleExceptionPolicyStatsIncr(
+                    tv, ra_ctx, stream_config.reassembly_memcap_policy);
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -64,6 +64,14 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    uint16_t counter_tcp_reas_eps_ignore;
+    uint16_t counter_tcp_reas_eps_reject;
+    uint16_t counter_tcp_reas_eps_bypass;
+    uint16_t counter_tcp_reas_eps_pass_flow;
+    uint16_t counter_tcp_reas_eps_pass_packet;
+    uint16_t counter_tcp_reas_eps_drop_flow;
+    uint16_t counter_tcp_reas_eps_drop_packet;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -5776,6 +5776,18 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_reject =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.reject", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_bypass =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.bypass", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_pass_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.pass_packet", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_flow =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_flow", tv);
+    stt->ra_ctx->counter_tcp_reas_eps_drop_packet =
+            StatsRegisterCounter("tcp.reassembly_exception_policy.drop_packet", tv);
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -100,6 +100,11 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    uint16_t counter_tcp_midstream_eps_reject;
+    uint16_t counter_tcp_midstream_eps_bypass;
+    uint16_t counter_tcp_midstream_eps_pass_flow;
+    uint16_t counter_tcp_midstream_eps_drop_flow;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseen data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -85,6 +85,13 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    uint16_t counter_tcp_ssn_memcap_eps_reject;
+    uint16_t counter_tcp_ssn_memcap_eps_bypass;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_pass_packet;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_flow;
+    uint16_t counter_tcp_ssn_memcap_eps_drop_packet;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/** add per-proto app-layer error counters for exception policies stats? disabled by default */
+bool g_stats_eps_per_app_proto_errors = false;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2686,6 +2689,12 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     SetMasterExceptionPolicy();
+
+    int b;
+    int ret = ConfGetBool("stats.eps-per-app-proto-errors", &b);
+    if (ret) {
+        g_stats_eps_per_app_proto_errors = (b == 1);
+    }
 
     AppLayerSetup();
 

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -34,6 +34,17 @@ enum ExceptionPolicy {
     EXCEPTION_POLICY_DROP_FLOW,
     EXCEPTION_POLICY_REJECT,
 };
+
+#define EXCEPTION_POLICY_MAX EXCEPTION_POLICY_REJECT + 1
+
+typedef struct ExceptionPolicyCounters_ {
+    uint16_t reject_id;
+    uint16_t bypass_id;
+    uint16_t pass_flow_id;
+    uint16_t pass_packet_id;
+    uint16_t drop_flow_id;
+    uint16_t drop_packet_id;
+} ExceptionPolicyCounters;
 
 void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -76,6 +76,9 @@ stats:
   # Add exception policy counters to stats
   # (Note: if exception policy: ignore, counters are not logged)
   #eps-zero-valued-counters: false       # default: false. True will log counters: 0
+  #eps-per-app-proto-errors: false # default: false. True will log errors for
+                                     # each app-proto. Warning: VERY verbose
+
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -73,6 +73,9 @@ stats:
   #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
+  # Add exception policy counters to stats
+  # (Note: if exception policy: ignore, counters are not logged)
+  #eps-zero-valued-counters: false       # default: false. True will log counters: 0
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5816

Previous PR: https://github.com/OISF/suricata/pull/8735

Describe changes:
- include exception policy stats counters for app-layer errors in summary form, too (see output example)
- allow configuring whether or not exception policy counters are logged if 0
- allow configuring whether or not exception policy error counters are logged for each app-proto
- remove stats counters logging when exception policy == `ignore`
- remove stats counters for exceptions that are never valid, for certain scenarios (based on https://docs.suricata.io/en/latest/configuration/exception-policies.html)

TODO:
- document exception policy stats counters
- check what is the overflow caused when enabling delta counters or thread logs
- confirm if we are not trying to log counters for cases when exception policies are not valid (such as specific situations in IDS or IPS). 
- better align stats.log - as the new counters size character is longer than what we currently have in the stats
- update the json.schema to include delta counters.


Output examples:
`tcp`
```json
  "tcp": {
    "syn": 1,
    "synack": 1,
    "rst": 3,
    "active_sessions": 0,
    "sessions": 1,
    "ssn_memcap_drop": 0,
    "ssn_from_cache": 0,
    "ssn_from_pool": 1,
    "ssn_memcap_exception_policy": {
      "reject": 0,
      "bypass": 0,
      "pass_flow": 0,
      "pass_packet": 0,
      "drop_flow": 0,
      "drop_packet": 0
    },
    "pseudo": 0,
    "pseudo_failed": 0,
    "invalid_checksum": 0,
    "midstream_pickups": 0,
    "midstream_exception_policy": {
      "reject": 0,
      "bypass": 0,
      "pass_flow": 0,
      "drop_flow": 0
    },
```
`app-layer` -> summary, logging zero values, logging per-app-proto:
```json
"app_layer": {
    "error": {
      "exception_policy": {
        "reject": 0,
        "bypass": 0,
        "pass_flow": 0,
        "pass_packet": 1,
        "drop_flow": 0,
        "drop_packet": 0
      },
      "http": {
        "gap": 0,
        "alloc": 0,
        "parser": 0,
        "internal": 0,
        "exception_policy": {
          "reject": 0,
          "bypass": 0,
          "pass_flow": 0,
          "pass_packet": 0,
          "drop_flow": 0,
          "drop_packet": 0
        }
      },
```
`app-layer` -> not logging per app-proto, nor zeroes:
```json
  "app_layer": {
    "error": {
      "exception_policy": {
        "drop_flow": 1
      },
      "tls": {
        "gap": 0,
        "alloc": 0,
        "parser": 1,
        "internal": 0
      },
```
`app-layer`-> logging per app-proto, no zeroes:
```json
  "tls": {
    "gap": 0,
    "alloc": 0,
    "parser": 1,
    "internal": 0,
    "exception_policy": {
      "pass_packet": 1
    }
  },
  "smb": {
    "gap": 0,
    "alloc": 0,
    "parser": 0,
    "internal": 0,
    "exception_policy": {}
  },
```
suricata-verify-pr: https://github.com/OISF/suricata-verify/pull/1617