### PR TITLE
detect/analyzer: add more details for the tcp ack keyword - v5 

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -39,6 +39,7 @@
 #include "detect-bytetest.h"
 #include "detect-flow.h"
 #include "detect-tcp-flags.h"
+#include "detect-tcp-ack.h"
 #include "detect-ipopts.h"
 #include "feature.h"
 #include "util-print.h"
@@ -901,6 +902,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                     jb_set_string(js, "operator", "or");
                 }
                 jb_close(js); // object
+                break;
+            }
+            case DETECT_ACK: {
+                const DetectAckData *cd = (const DetectAckData *)smd->ctx;
+
+                jb_open_object(js, "ack");
+                jb_set_uint(js, "number", cd->ack);
+                jb_close(js);
                 break;
             }
         }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6354

Previous PR: https://github.com/OISF/suricata/pull/9659

Describe changes:
- Included the detect-tcp-ack header.
- Made a mistake submitting this PR before the Suricata-verify PR; had to resubmit so the CI will pick it.

Output:
```
{
  "raw": "alert tcp any any -> any any (msg:\"Testing ack\"; ack:782; sid:1;)",
  "id": 1,
  "gid": 1,
  "rev": 0,
  "msg": "Testing ack",
  "app_proto": "unknown",
  "requirements": [],
  "type": "pkt",
  "flags": [
    "src_any",
    "dst_any",
    "sp_any",
    "dp_any",
    "need_packet",
    "toserver",
    "toclient"
  ],
  "pkt_engines" : [
    {
      "name": "packet",
      "is_mpm": false
    }
  ],
  "frame_engines": [],
  "lists": {
    "packet": {
      "matches": [
        {
          "name": "tcp.ack",
          "ack": {
            "number": 782
          }
        }
      ]
    }
   }
}
```

```
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1618
```
