### PR TITLE
napatech: Close streams on hard errors

### DIFF
--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -908,6 +908,7 @@ TmEcode NapatechPacketLoop(ThreadVars *tv, void *data, void *slot)
             NAPATECH_ERROR(status);
             SCLogInfo("Failed to read from Napatech Stream %d: %s",
                     ntv->stream_id, error_buffer);
+            NapatechStreamThreadDeinit(tv, ntv);
             break;
         }
 


### PR DESCRIPTION
Issue: 5172

This commit forces the current stream to be closed when a hard error occurs.

Without this commit, a hard error will force a 2nd connection the stream that raised the error.

With this commit, the stream with the hard error is closed before opening another connection to the stream.

Verified with the Python snippet in the redmine issue. [5172](https://redmine.openinfosecfoundation.org/issues/5172)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- On hard errors from `NT_RxGet`, the stream is closed before re-opening the stream.
-
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
