### PR TITLE
mqtt: Improve handling of multiple PDU parsing

### DIFF
--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -462,14 +462,15 @@ impl MQTTState {
         }
 
         while !current.is_empty() {
-            SCLogDebug!("request: handling {}", current.len());
+            SCLogDebug!("request: handling {}; rem: {}", current.len(), input.len() - current.len());
             match parse_message(current, self.protocol_version, self.max_msg_len) {
                 Ok((rem, msg)) => {
+                    SCLogDebug!("request: handling {}; rem: {}", current.len(), input.len() - current.len());
                     let _pdu = Frame::new(
                         flow,
                         &stream_slice,
-                        input,
-                        current.len() as i64,
+                        current,
+                        (current.len() - rem.len()) as i64,
                         MQTTFrameType::Pdu as u8,
                     );
                     SCLogDebug!("request msg {:?}", msg);
@@ -550,11 +551,12 @@ impl MQTTState {
             SCLogDebug!("response: handling {}", current.len());
             match parse_message(current, self.protocol_version, self.max_msg_len) {
                 Ok((rem, msg)) => {
+                    SCLogDebug!("response: handling {}; rem: {}", current.len(), input.len() - current.len());
                     let _pdu = Frame::new(
                         flow,
                         &stream_slice,
-                        input,
-                        input.len() as i64,
+                        current,
+                        (current.len() - rem.len()) as i64,
                         MQTTFrameType::Pdu as u8,
                     );
 


### PR DESCRIPTION
Continuation of #10262

Issue: 6592

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6592](https://redmine.openinfosecfoundation.org/issues/6592)

Describe changes:
- Parse PDU instead of entire stream

Updates:
- Ensure frame created with proper size

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1609
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
