### PR TITLE
Revert "detect: do not store state without flags"

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1218,7 +1218,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         } else if ((inspect_flags & DE_STATE_FLAG_FULL_INSPECT) == 0 && mpm_in_progress) {
             TRACE_SID_TXS(s->id, tx, "no need to store no-match sig, "
                     "mpm will revisit it");
-        } else if (inspect_flags != 0 || file_no_match != 0) {
+        } else {
             TRACE_SID_TXS(s->id, tx, "storing state: flags %08x", inspect_flags);
             DetectRunStoreStateTx(scratch->sgh, f, tx->tx_ptr, tx->tx_id, s,
                     inspect_flags, flow_flags, file_no_match);


### PR DESCRIPTION
This reverts commit 2fb50598f23b112f14ec15330e11c40b74caa35f.

Logic is incorrect, a shown by failing tests.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1623