### PR TITLE
config: Remove NSS vestiges

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -235,7 +235,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \
@@ -363,7 +362,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \
@@ -467,7 +465,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \
@@ -539,7 +536,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \
@@ -627,7 +623,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \
@@ -709,7 +704,6 @@ jobs:
                 libpcap-devel \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python36-PyYAML \
@@ -796,7 +790,6 @@ jobs:
                 llvm-devel \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -892,7 +885,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -987,7 +979,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1084,7 +1075,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1173,7 +1163,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1255,7 +1244,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1347,7 +1335,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-softokn-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1398,7 +1398,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 llvm-14-dev \
                 make \
@@ -1516,7 +1515,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 make \
                 parallel \
@@ -1609,7 +1607,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 libpcre2-dev \
                 make \
@@ -1693,7 +1690,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 libpcre2-dev \
                 make \
@@ -1758,7 +1754,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 make \
                 parallel \
@@ -1835,7 +1830,6 @@ jobs:
                 libnfnetlink0 \
                 libhiredis-dev \
                 libjansson-dev \
-                libjansson-dev \
                 libpython2.7 \
                 make \
                 rustc \
@@ -1898,7 +1892,6 @@ jobs:
                   libjansson-dev \
                   libevent-dev \
                   libevent-pthreads-2.1-7 \
-                  libjansson-dev \
                   libpython2.7 \
                   make \
                   parallel \
@@ -1991,7 +1984,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 make \
                 parallel \

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -48,7 +48,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 libpython2.7 \
                 libssl-dev \
                 make \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,6 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
-                nss-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-devel \

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -54,7 +54,6 @@ jobs:
                 libjansson-dev \
                 libevent-dev \
                 libevent-pthreads-2.1-7 \
-                libjansson-dev \
                 liblz4-dev \
                 llvm-16-dev \
                 make \

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -152,7 +152,7 @@ Recommended::
                    jansson-devel jq libcap-ng-devel libevent-devel \
                    libmaxminddb-devel libnet-devel libnetfilter_queue-devel \
                    libnfnetlink-devel libpcap-devel libtool libyaml-devel \
-                   lua-devel lz4-devel make nss-devel pcre2-devel pkgconfig \
+                   lua-devel lz4-devel make pcre2-devel pkgconfig \
                    python3-devel python3-sphinx python3-yaml sudo which \
                    zlib-devel
     cargo install --force cbindgen

--- a/qa/valgrind.suppress
+++ b/qa/valgrind.suppress
@@ -58,8 +58,6 @@
    fun:_dl_catch_error
    fun:dlerror_run
    fun:__libc_dlopen_mode
-   fun:__nss_lookup_function
-   fun:__nss_lookup
    fun:getprotobyname_r@@GLIBC_2.4
    fun:getprotobyname
    fun:DetectIPProtoParse


### PR DESCRIPTION
Remove NSS vestiges from CI and doc.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6712](https://redmine.openinfosecfoundation.org/issues/6712)

Describe changes:
- Remove NSS from doc and CI pipelines
- Remove duplicate libjansson package from CI


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
