### PR TITLE
imap: extend detection patterns - v2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,6 +51,8 @@ noinst_HEADERS = \
 	app-layer-ssh.h \
 	app-layer-ssl.h \
 	app-layer-tftp.h \
+	app-layer-imap.h \
+	autoconf.h \
 	build-info.h \
 	conf.h \
 	conf-yaml-loader.h \
@@ -674,6 +676,7 @@ libsuricata_c_a_SOURCES = \
 	app-layer-ssh.c \
 	app-layer-ssl.c \
 	app-layer-tftp.c \
+	app-layer-imap.c \
 	conf.c \
 	conf-yaml-loader.c \
 	counters.c \

--- a/src/app-layer-imap.c
+++ b/src/app-layer-imap.c
@@ -1,0 +1,88 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Mahmoud Maatuq <mahmoudmatook.mm@gmail.com>
+ *
+ */
+
+#include "app-layer.h"
+#include "app-layer-detect-proto.h"
+#include "rust-bindings.h"
+#include "app-layer-imap.h"
+
+static int IMAPRegisterPatternsForProtocolDetection(void)
+{
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* OK ", 5, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* NO ", 5, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* BAD ", 6, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* LIST ", 7, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* ESEARCH ", 10, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* STATUS ", 9, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "* FLAGS ", 8, 0, STREAM_TOCLIENT) < 0) {
+        return -1;
+    }
+
+    if (AppLayerProtoDetectPMRegisterPatternCI(
+                IPPROTO_TCP, ALPROTO_IMAP, "DONE", 4, 0, STREAM_TOSERVER) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+void RegisterIMAPParsers(void)
+{
+    const char *proto_name = "imap";
+
+    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
+        SCLogDebug("IMAP protocol detection is enabled.");
+        AppLayerProtoDetectRegisterProtocol(ALPROTO_IMAP, proto_name);
+        if (IMAPRegisterPatternsForProtocolDetection() < 0)
+            return;
+    } else {
+        SCLogDebug("Protocol detector and parser disabled for IMAP.");
+        return;
+    }
+}

--- a/src/app-layer-imap.h
+++ b/src/app-layer-imap.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Mahmoud Maatuq <mahmoudmatook.mm@gmail.com>
+ *
+ */
+
+#ifndef __APP_LAYER_IMAP_H__
+#define __APP_LAYER_IMAP_H__
+void RegisterIMAPParsers(void);
+#endif

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -61,6 +61,7 @@
 #include "app-layer-quic.h"
 #include "app-layer-rdp.h"
 #include "app-layer-http2.h"
+#include "app-layer-imap.h"
 
 struct AppLayerParserThreadCtx_ {
     void *alproto_local_storage[FLOW_PROTO_MAX][ALPROTO_MAX];
@@ -1770,21 +1771,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterRdpParsers();
     RegisterHTTP2Parsers();
     rs_telnet_register_parser();
-
-    /** IMAP */
-    AppLayerProtoDetectRegisterProtocol(ALPROTO_IMAP, "imap");
-    if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", "imap")) {
-        if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_IMAP,
-                                  "1|20|capability", 12, 0, STREAM_TOSERVER) < 0)
-        {
-            SCLogInfo("imap proto registration failure");
-            exit(EXIT_FAILURE);
-        }
-    } else {
-        SCLogInfo("Protocol detection and parser disabled for %s protocol.",
-                  "imap");
-    }
-
+    RegisterIMAPParsers();
     ValidateParsers();
     return;
 }


### PR DESCRIPTION
Ticket: #2886

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2886) ticket:2886

Describe changes:
- extend detection patterns for imap protocol as per [rfc9051](https://datatracker.ietf.org/doc/html/rfc9051)
- compared to this previous [PR](https://github.com/OISF/suricata/pull/10275) this one is simpler and way less expensive than the other. 
- this is not comprehensive and might create more false positives, but i think this tradeoff is acceptable, and we can overcome these limitations when we add a complete parser. 


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1620
