### PR TITLE
tcp: flag established even on error

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5430,8 +5430,12 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         }
 
         /* handle the per 'state' logic */
-        if (StreamTcpStateDispatch(tv, p, stt, ssn, ssn->state) < 0)
+        if (StreamTcpStateDispatch(tv, p, stt, ssn, ssn->state) < 0) {
+            if (ssn->state >= TCP_ESTABLISHED) {
+                p->flags |= PKT_STREAM_EST;
+            }
             goto error;
+        }
 
     skip:
         StreamTcpPacketCheckPostRst(ssn, p);


### PR DESCRIPTION
Follows commit 2fb5059, concurrent against #10286

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Should there be one specific for this ?

Describe changes:
- stream/tcp: flag established even on error (error being Suricata `StreamTcpStateDispatch` returning an error value)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1623
