### PR TITLE
detect: do not run tx detection on non established packets

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -144,7 +144,8 @@ static void DetectRun(ThreadVars *th_v,
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_RULES);
 
     /* run tx/state inspection. Don't call for ICMP error msgs. */
-    if (pflow && pflow->alstate && likely(pflow->proto == p->proto)) {
+    if (pflow && pflow->alstate && likely(pflow->proto == p->proto) &&
+            (p->flags & PKT_STREAM_EST)) {
         if (p->proto == IPPROTO_TCP) {
             const TcpSession *ssn = p->flow->protoctx;
             if (ssn && (ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) == 0) {

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -629,8 +629,9 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
             FramesPrune(p->flow, p);
         }
 
-        if ((PKT_IS_PSEUDOPKT(p)) ||
-                (p->flow->flags & (FLOW_TS_APP_UPDATED | FLOW_TC_APP_UPDATED))) {
+        if ((p->flags & PKT_STREAM_EST) &&
+                ((PKT_IS_PSEUDOPKT(p)) ||
+                        (p->flow->flags & (FLOW_TS_APP_UPDATED | FLOW_TC_APP_UPDATED)))) {
             if (PKT_IS_TOSERVER(p)) {
                 if (PKT_IS_PSEUDOPKT(p) || (p->flow->flags & (FLOW_TS_APP_UPDATED))) {
                     AppLayerParserTransactionsCleanup(p->flow, STREAM_TOSERVER);


### PR DESCRIPTION
Follows commit 2fb5059, concurrent against #10286

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Should there be one specific for this ?

Describe changes:
- stream/tcp: flag established even on error (error being Suricata `StreamTcpStateDispatch` returning an error value)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1623

#10299 alternative to run less code when packet is not flagged as established (instead of flagging more packets as established)