### PR TITLE
detect: free all tenant detect engines

### DIFF
--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -77,23 +77,11 @@ char *DetectLoadCompleteSigPath(const DetectEngineCtx *de_ctx, const char *sig_f
 
     /* Path not specified */
     if (PathIsRelative(sig_file)) {
-        if (ConfGet(varname, &defaultpath) == 1) {
-            SCLogDebug("Default path: %s", defaultpath);
-            size_t path_len = sizeof(char) * (strlen(defaultpath) +
-                          strlen(sig_file) + 2);
-            path = SCMalloc(path_len);
+        if (defaultpath) {
+            path = PathMergeAlloc(defaultpath, sig_file);
             if (unlikely(path == NULL))
                 return NULL;
-            strlcpy(path, defaultpath, path_len);
-#if defined OS_WIN32 || defined __CYGWIN__
-            if (path[strlen(path) - 1] != '\\')
-                strlcat(path, "\\\\", path_len);
-#else
-            if (path[strlen(path) - 1] != '/')
-                strlcat(path, "/", path_len);
-#endif
-            strlcat(path, sig_file, path_len);
-       } else {
+        } else {
             path = SCStrdup(sig_file);
             if (unlikely(path == NULL))
                 return NULL;

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -95,6 +95,7 @@ DetectEngineCtx *DetectEngineGetCurrent(void);
 DetectEngineCtx *DetectEngineGetByTenantId(uint32_t tenant_id);
 void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
+void DetectEngineClearMaster(void);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);
 void DetectEngineDeReference(DetectEngineCtx **de_ctx);
 int DetectEngineReload(const SCInstance *suri);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -402,7 +402,7 @@ static void GlobalsDestroy(SCInstance *suri)
         DetectEngineMoveToFreeList(de_ctx);
         DetectEngineDeReference(&de_ctx);
     }
-    DetectEnginePruneFreeList();
+    DetectEngineClearMaster();
 
     AppLayerDeSetup();
     DatasetsSave();

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -59,6 +59,7 @@
 #include "util-memcmp.h"
 #include "util-mpm-ac.h"
 #include "util-memcpy.h"
+#include "util-validate.h"
 
 void SCACInitCtx(MpmCtx *);
 void SCACInitThreadCtx(MpmCtx *, MpmThreadCtx *);
@@ -353,7 +354,7 @@ static inline void SCACDetermineLevel1Gap(MpmCtx *mpm_ctx)
     SCACCtx *ctx = (SCACCtx *)mpm_ctx->ctx;
     uint32_t u = 0;
 
-    int map[256];
+    uint8_t map[256];
     memset(map, 0, sizeof(map));
 
     for (u = 0; u < mpm_ctx->pattern_cnt; u++)
@@ -506,8 +507,10 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
     int32_t state = 0;
     int32_t r_state = 0;
 
-    StateQueue q;
-    memset(&q, 0, sizeof(StateQueue));
+    StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+    if (q == NULL) {
+        FatalError(SC_ERR_FATAL, "Error allocating memory");
+    }
 
     /* allot space for the failure table.  A failure entry in the table for
      * every state(SCACCtx->state_count) */
@@ -523,19 +526,19 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
     for (ascii_code = 0; ascii_code < 256; ascii_code++) {
         int32_t temp_state = ctx->goto_table[0][ascii_code];
         if (temp_state != 0) {
-            SCACEnqueue(&q, temp_state);
+            SCACEnqueue(q, temp_state);
             ctx->failure_table[temp_state] = 0;
         }
     }
 
-    while (!SCACStateQueueIsEmpty(&q)) {
+    while (!SCACStateQueueIsEmpty(q)) {
         /* pick up every state from the queue and add failure transitions */
-        r_state = SCACDequeue(&q);
+        r_state = SCACDequeue(q);
         for (ascii_code = 0; ascii_code < 256; ascii_code++) {
             int32_t temp_state = ctx->goto_table[r_state][ascii_code];
             if (temp_state == SC_AC_FAIL)
                 continue;
-            SCACEnqueue(&q, temp_state);
+            SCACEnqueue(q, temp_state);
             state = ctx->failure_table[r_state];
 
             while(ctx->goto_table[state][ascii_code] == SC_AC_FAIL)
@@ -545,6 +548,7 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
                                  mpm_ctx);
         }
     }
+    SCFree(q);
 
     return;
 }
@@ -569,30 +573,34 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         mpm_ctx->memory_cnt++;
         mpm_ctx->memory_size += (ctx->state_count * sizeof(*ctx->state_table_u16));
 
-        StateQueue q;
-        memset(&q, 0, sizeof(StateQueue));
+        StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+        if (q == NULL) {
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
+        }
 
         for (ascii_code = 0; ascii_code < 256; ascii_code++) {
             SC_AC_STATE_TYPE_U16 temp_state = ctx->goto_table[0][ascii_code];
             ctx->state_table_u16[0][ascii_code] = temp_state;
             if (temp_state != 0)
-                SCACEnqueue(&q, temp_state);
+                SCACEnqueue(q, temp_state);
         }
 
-        while (!SCACStateQueueIsEmpty(&q)) {
-            r_state = SCACDequeue(&q);
+        while (!SCACStateQueueIsEmpty(q)) {
+            r_state = SCACDequeue(q);
 
             for (ascii_code = 0; ascii_code < 256; ascii_code++) {
                 int32_t temp_state = ctx->goto_table[r_state][ascii_code];
                 if (temp_state != SC_AC_FAIL) {
-                    SCACEnqueue(&q, temp_state);
-                    ctx->state_table_u16[r_state][ascii_code] = temp_state;
+                    SCACEnqueue(q, temp_state);
+                    DEBUG_VALIDATE_BUG_ON(temp_state > UINT16_MAX);
+                    ctx->state_table_u16[r_state][ascii_code] = (uint16_t)temp_state;
                 } else {
                     ctx->state_table_u16[r_state][ascii_code] =
                         ctx->state_table_u16[ctx->failure_table[r_state]][ascii_code];
                 }
             }
         }
+        SCFree(q);
     }
 
     if (!(ctx->state_count < 32767) || construct_both_16_and_32_state_tables) {
@@ -606,23 +614,25 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         mpm_ctx->memory_cnt++;
         mpm_ctx->memory_size += (ctx->state_count * sizeof(*ctx->state_table_u32));
 
-        StateQueue q;
-        memset(&q, 0, sizeof(StateQueue));
+        StateQueue *q = SCCalloc(1, sizeof(StateQueue));
+        if (q == NULL) {
+            FatalError(SC_ERR_FATAL, "Error allocating memory");
+        }
 
         for (ascii_code = 0; ascii_code < 256; ascii_code++) {
             SC_AC_STATE_TYPE_U32 temp_state = ctx->goto_table[0][ascii_code];
             ctx->state_table_u32[0][ascii_code] = temp_state;
             if (temp_state != 0)
-                SCACEnqueue(&q, temp_state);
+                SCACEnqueue(q, temp_state);
         }
 
-        while (!SCACStateQueueIsEmpty(&q)) {
-            r_state = SCACDequeue(&q);
+        while (!SCACStateQueueIsEmpty(q)) {
+            r_state = SCACDequeue(q);
 
             for (ascii_code = 0; ascii_code < 256; ascii_code++) {
                 int32_t temp_state = ctx->goto_table[r_state][ascii_code];
                 if (temp_state != SC_AC_FAIL) {
-                    SCACEnqueue(&q, temp_state);
+                    SCACEnqueue(q, temp_state);
                     ctx->state_table_u32[r_state][ascii_code] = temp_state;
                 } else {
                     ctx->state_table_u32[r_state][ascii_code] =
@@ -630,6 +640,7 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
                 }
             }
         }
+        SCFree(q);
     }
 
     return;


### PR DESCRIPTION
Continuation of #10219 

Free all tenants registered in the master.

(cherry picked from commit a4d80bc7c4910170aba950db0a497124712b330a)


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6549](https://redmine.openinfosecfoundation.org/issues/6549)

Describe changes:
- Removed debug-related changes from CI pipelines

Updates:
- Added --debug-failed to suricata-verify tests.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1600
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
