### PR TITLE
stats: Do not expand dots of tm_name

### DIFF
--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -279,7 +279,7 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                     continue;
 
                 // Seems this holds, but assert in debug builds.
-                assert(strcmp(st->tstats[u].tm_name, st->tstats[u].tm_name) == 0);
+                assert(strcmp(st->tstats[offset].tm_name, st->tstats[u].tm_name) == 0);
 
                 json_t *js_type = NULL;
                 const char *stat_name = st->tstats[u].short_name;

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -36,6 +36,7 @@
 #include "util-print.h"
 #include "util-time.h"
 #include "util-unittest.h"
+#include "util-validate.h"
 
 #include "util-debug.h"
 #include "output.h"
@@ -279,7 +280,8 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                     continue;
 
                 // Seems this holds, but assert in debug builds.
-                assert(strcmp(st->tstats[offset].tm_name, st->tstats[u].tm_name) == 0);
+                DEBUG_VALIDATE_BUG_ON(
+                        strcmp(st->tstats[offset].tm_name, st->tstats[u].tm_name) != 0);
 
                 json_t *js_type = NULL;
                 const char *stat_name = st->tstats[u].short_name;


### PR DESCRIPTION



Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine 6732](https://redmine.openinfosecfoundation.org/issues/6732) ticket:

Describe changes:

When an interface with dots is used, per worker stats are nested by the dot-separated-components of the interface due to the usage of OutputStats2Json().

Prevent this by using OutputStats2Json() on a per-thread specific object and setting this object into the threads object using the json_object_set_new() which won't do the dot expansion.

This was tested by creating an interface with dots in the name and checking the stats.

    ip link add name a.b.c type dummy

With Suricata 7.0.2, sniffing on the a.b.c interface results in the following worker stats format:

    "threads": {
      "W#01-a": {
        "b": {
          "c": {
            "capture": {
              "kernel_packets": 0,

After this fix, the output looks as follows:

    "threads": {
      "W#01-a.b.c": {
        "capture": {
          "kernel_packets": 0,


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
