### PR TITLE
tcp: do not assign TCP flags to pseudopackets v1

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -211,7 +211,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
     }
 
     p->tcph->th_offx2 = 0x50;
-    p->tcph->th_flags |= TH_ACK;
+    p->tcph->th_flags = 0;
     p->tcph->th_win = 10;
     p->tcph->th_urp = 0;
 


### PR DESCRIPTION
Previously pseudopackets were assigned with ACK flag which falsely turned "NEW" or "SYN" flows to "SYN/ACK" flows especially when Suricata ran with content-matching rules.
Ticket: #6733
https://redmine.openinfosecfoundation.org/issues/6733

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1630
