### PR TITLE
detect: do not run tx detection on non established packets

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -146,6 +146,9 @@ static void DetectRun(ThreadVars *th_v,
     /* run tx/state inspection. Don't call for ICMP error msgs. */
     if (pflow && pflow->alstate && likely(pflow->proto == p->proto)) {
         if (p->proto == IPPROTO_TCP) {
+            if ((p->flags & PKT_STREAM_EST) == 0) {
+                goto end;
+            }
             const TcpSession *ssn = p->flow->protoctx;
             if (ssn && (ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) == 0) {
                 // PACKET_PROFILING_DETECT_START(p, PROF_DETECT_TX);

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -341,6 +341,9 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCLogDebug("not pseudo, no app update: skip");
         return TM_ECODE_OK;
     }
+    if ((p->flags & PKT_STREAM_EST) == 0 && p->proto == IPPROTO_TCP) {
+        return TM_ECODE_OK;
+    }
     SCLogDebug("pseudo, or app update: run output");
 
     OutputTxLoggerThreadData *op_thread_data = (OutputTxLoggerThreadData *)thread_data;


### PR DESCRIPTION
Follows commit 2fb5059

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Should there be one specific for this ?

Describe changes:
- detect: do not run tx detection on non established packets

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1631

#10307 with `StreamTcpPruneSession` also optimized away, and a needed SV PR