### PR TITLE
use rank balanced trees instead of red black trees

### DIFF
--- a/src/tree.h
+++ b/src/tree.h
@@ -32,15 +32,11 @@
 #ifndef	_SYS_TREE_H_
 #define	_SYS_TREE_H_
 
-#if defined(__clang_analyzer__)
-#define _T_ASSERT(a) assert((a))
-#else
-#define _T_ASSERT(a)
-#endif
+#include <stdint.h>
 
 /*
  * This file defines data structures for different types of trees:
- * splay trees and red-black trees.
+ * splay trees and rank-balanced trees.
  *
  * A splay tree is a self-organizing data structure.  Every operation
  * on the tree causes a splay to happen.  The splay moves the requested
@@ -54,15 +50,24 @@
  * and n inserts on an initially empty tree as O((m + n)lg n).  The
  * amortized cost for a sequence of m accesses to a splay tree is O(lg n);
  *
- * A red-black tree is a binary search tree with the node color as an
- * extra attribute.  It fulfills a set of conditions:
- *	- every search path from the root to a leaf consists of the
- *	  same number of black nodes,
- *	- each red node (except for the root) has a black parent,
- *	- each leaf node is black.
+ * A rank-balanced tree is a binary search tree with an integer
+ * rank-difference as an attribute of each pointer from parent to child.
+ * The sum of the rank-differences on any path from a node down to null is
+ * the same, and defines the rank of that node. The rank of the null node
+ * is -1.
  *
- * Every operation on a red-black tree is bounded as O(lg n).
- * The maximum height of a red-black tree is 2lg (n+1).
+ * Different additional conditions define different sorts of balanced
+ * trees, including "red-black" and "AVL" trees.  The set of conditions
+ * applied here are the "weak-AVL" conditions of Haeupler, Sen and Tarjan:
+ *	- every rank-difference is 1 or 2.
+ *	- the rank of any leaf is 1.
+ *
+ * For historical reasons, rank differences that are even are associated
+ * with the color red (Rank-Even-Difference), and the child that a red edge
+ * points to is called a red child.
+ *
+ * Every operation on a rank-balanced tree is bounded as O(lg n).
+ * The maximum height of a rank-balanced tree is 2lg (n+1).
  */
 
 #define SPLAY_HEAD(name, type)						\
@@ -122,44 +127,41 @@ struct {								\
 
 /* Generates prototypes and inline functions */
 
-#define SPLAY_PROTOTYPE(name, type, field, cmp)				\
-void name##_SPLAY(struct name *, struct type *);			\
-void name##_SPLAY_MINMAX(struct name *, int);				\
-struct type *name##_SPLAY_INSERT(struct name *, struct type *);		\
-struct type *name##_SPLAY_REMOVE(struct name *, struct type *);		\
-									\
-/* Finds the node with the same key as elm */				\
-static __inline struct type *						\
-name##_SPLAY_FIND(struct name *head, struct type *elm)			\
-{									\
-	if (SPLAY_EMPTY(head))						\
-		return(NULL);						\
-	name##_SPLAY(head, elm);					\
-	if ((cmp)(elm, (head)->sph_root) == 0)				\
-		return (head->sph_root);				\
-	return (NULL);							\
-}									\
-									\
-static __inline struct type *						\
-name##_SPLAY_NEXT(struct name *head, struct type *elm)			\
-{									\
-	name##_SPLAY(head, elm);					\
-	if (SPLAY_RIGHT(elm, field) != NULL) {				\
-		elm = SPLAY_RIGHT(elm, field);				\
-		while (SPLAY_LEFT(elm, field) != NULL) {		\
-			elm = SPLAY_LEFT(elm, field);			\
-		}							\
-	} else								\
-		elm = NULL;						\
-	return (elm);							\
-}									\
-									\
-static __inline struct type *						\
-name##_SPLAY_MIN_MAX(struct name *head, int val)			\
-{									\
-	name##_SPLAY_MINMAX(head, val);					\
-        return (SPLAY_ROOT(head));					\
-}
+#define SPLAY_PROTOTYPE(name, type, field, cmp)                                                    \
+    void name##_SPLAY(struct name *, struct type *);                                               \
+    void name##_SPLAY_MINMAX(struct name *, int);                                                  \
+    struct type *name##_SPLAY_INSERT(struct name *, struct type *);                                \
+    struct type *name##_SPLAY_REMOVE(struct name *, struct type *);                                \
+                                                                                                   \
+    /* Finds the node with the same key as elm */                                                  \
+    static __unused __inline struct type *name##_SPLAY_FIND(struct name *head, struct type *elm)   \
+    {                                                                                              \
+        if (SPLAY_EMPTY(head))                                                                     \
+            return (NULL);                                                                         \
+        name##_SPLAY(head, elm);                                                                   \
+        if ((cmp)(elm, (head)->sph_root) == 0)                                                     \
+            return (head->sph_root);                                                               \
+        return (NULL);                                                                             \
+    }                                                                                              \
+                                                                                                   \
+    static __unused __inline struct type *name##_SPLAY_NEXT(struct name *head, struct type *elm)   \
+    {                                                                                              \
+        name##_SPLAY(head, elm);                                                                   \
+        if (SPLAY_RIGHT(elm, field) != NULL) {                                                     \
+            elm = SPLAY_RIGHT(elm, field);                                                         \
+            while (SPLAY_LEFT(elm, field) != NULL) {                                               \
+                elm = SPLAY_LEFT(elm, field);                                                      \
+            }                                                                                      \
+        } else                                                                                     \
+            elm = NULL;                                                                            \
+        return (elm);                                                                              \
+    }                                                                                              \
+                                                                                                   \
+    static __unused __inline struct type *name##_SPLAY_MIN_MAX(struct name *head, int val)         \
+    {                                                                                              \
+        name##_SPLAY_MINMAX(head, val);                                                            \
+        return (SPLAY_ROOT(head));                                                                 \
+    }
 
 /* Main splay operation.
  * Moves node close to the key of elm to top
@@ -298,7 +300,7 @@ void name##_SPLAY_MINMAX(struct name *head, int __comp) \
 	     (x) != NULL;						\
 	     (x) = SPLAY_NEXT(name, head, x))
 
-/* Macros that define a red-black tree */
+/* Macros that define a rank-balanced tree */
 #define RB_HEAD(name, type)						\
 struct name {								\
 	struct type *rbh_root; /* root of the tree */			\
@@ -311,97 +313,118 @@ struct name {								\
 	(root)->rbh_root = NULL;					\
 } while (/*CONSTCOND*/ 0)
 
-#define RB_BLACK	0
-#define RB_RED		1
-#define RB_ENTRY(type)							\
-struct {								\
-	struct type *rbe_left;		/* left element */		\
-	struct type *rbe_right;		/* right element */		\
-	struct type *rbe_parent;	/* parent element */		\
-	int rbe_color;			/* node color */		\
-}
+#define RB_ENTRY(type)                                                                             \
+    struct {                                                                                       \
+        struct type *rbe_left;   /* left element */                                                \
+        struct type *rbe_right;  /* right element */                                               \
+        struct type *rbe_parent; /* parent element */                                              \
+    }
 
 #define RB_LEFT(elm, field)		(elm)->field.rbe_left
 #define RB_RIGHT(elm, field)		(elm)->field.rbe_right
-#define RB_PARENT(elm, field)		(elm)->field.rbe_parent
-#define RB_COLOR(elm, field)		(elm)->field.rbe_color
+
+/*
+ * With the expectation that any object of struct type has an
+ * address that is a multiple of 4, and that therefore the
+ * 2 least significant bits of a pointer to struct type are
+ * always zero, this implementation sets those bits to indicate
+ * that the left or right child of the tree node is "red".
+ */
+#define RB_UP(elm, field)               (elm)->field.rbe_parent
+#define RB_BITS(elm, field)             (*(uintptr_t *)&RB_UP(elm, field))
+#define RB_RED_L                        ((uintptr_t)1)
+#define RB_RED_R                        ((uintptr_t)2)
+#define RB_RED_MASK                     ((uintptr_t)3)
+#define RB_FLIP_LEFT(elm, field)        (RB_BITS(elm, field) ^= RB_RED_L)
+#define RB_FLIP_RIGHT(elm, field)       (RB_BITS(elm, field) ^= RB_RED_R)
+#define RB_RED_LEFT(elm, field)         ((RB_BITS(elm, field) & RB_RED_L) != 0)
+#define RB_RED_RIGHT(elm, field)        ((RB_BITS(elm, field) & RB_RED_R) != 0)
+#define RB_PARENT(elm, field)           ((__typeof(RB_UP(elm, field)))(RB_BITS(elm, field) & ~RB_RED_MASK))
 #define RB_ROOT(head)			(head)->rbh_root
 #define RB_EMPTY(head)			(RB_ROOT(head) == NULL)
 
-#define RB_SET(elm, parent, field) do {					\
-	RB_PARENT(elm, field) = parent;					\
-	RB_LEFT(elm, field) = RB_RIGHT(elm, field) = NULL;		\
-	RB_COLOR(elm, field) = RB_RED;					\
-} while (/*CONSTCOND*/ 0)
+#define RB_SET_PARENT(dst, src, field)                                                             \
+    do {                                                                                           \
+        RB_BITS(dst, field) &= RB_RED_MASK;                                                        \
+        RB_BITS(dst, field) |= (uintptr_t)src;                                                     \
+    } while (/*CONSTCOND*/ 0)
 
-#define RB_SET_BLACKRED(black, red, field) do {				\
-	RB_COLOR(black, field) = RB_BLACK;				\
-	RB_COLOR(red, field) = RB_RED;					\
-} while (/*CONSTCOND*/ 0)
+#define RB_SET(elm, parent, field)                                                                 \
+    do {                                                                                           \
+        RB_UP(elm, field) = parent;                                                                \
+        RB_LEFT(elm, field) = RB_RIGHT(elm, field) = NULL;                                         \
+    } while (/*CONSTCOND*/ 0)
 
+#define RB_COLOR(elm, field)                                                                       \
+    (RB_PARENT(elm, field) == NULL ? 0                                                             \
+            : RB_LEFT(RB_PARENT(elm, field), field) == elm                                         \
+                    ? RB_RED_LEFT(RB_PARENT(elm, field), field)                                    \
+                    : RB_RED_RIGHT(RB_PARENT(elm, field), field))
+
+/*
+ * Something to be invoked in a loop at the root of every modified subtree,
+ * from the bottom up to the root, to update augmented node data.
+ */
 #ifndef RB_AUGMENT
-#define RB_AUGMENT(x)	do {} while (0)
+#define RB_AUGMENT(x) break
 #endif
 
-#define RB_ROTATE_LEFT(head, elm, tmp, field) do {			\
-	(tmp) = RB_RIGHT(elm, field);					\
-	if ((RB_RIGHT(elm, field) = RB_LEFT(tmp, field)) != NULL) {	\
-		RB_PARENT(RB_LEFT(tmp, field), field) = (elm);		\
-	}								\
-	RB_AUGMENT(elm);						\
-	if ((RB_PARENT(tmp, field) = RB_PARENT(elm, field)) != NULL) {	\
-		if ((elm) == RB_LEFT(RB_PARENT(elm, field), field))	\
-			RB_LEFT(RB_PARENT(elm, field), field) = (tmp);	\
-		else							\
-			RB_RIGHT(RB_PARENT(elm, field), field) = (tmp);	\
-	} else								\
-		(head)->rbh_root = (tmp);				\
-	RB_LEFT(tmp, field) = (elm);					\
-	RB_PARENT(elm, field) = (tmp);					\
-	RB_AUGMENT(tmp);						\
-	if ((RB_PARENT(tmp, field)))					\
-		RB_AUGMENT(RB_PARENT(tmp, field));			\
-} while (/*CONSTCOND*/ 0)
+#define RB_SWAP_CHILD(head, out, in, field)                                                        \
+    do {                                                                                           \
+        if (RB_PARENT(out, field) == NULL)                                                         \
+            RB_ROOT(head) = (in);                                                                  \
+        else if ((out) == RB_LEFT(RB_PARENT(out, field), field))                                   \
+            RB_LEFT(RB_PARENT(out, field), field) = (in);                                          \
+        else                                                                                       \
+            RB_RIGHT(RB_PARENT(out, field), field) = (in);                                         \
+    } while (/*CONSTCOND*/ 0)
 
-#define RB_ROTATE_RIGHT(head, elm, tmp, field) do {			\
-	(tmp) = RB_LEFT(elm, field);					\
-	if ((RB_LEFT(elm, field) = RB_RIGHT(tmp, field)) != NULL) {	\
-		RB_PARENT(RB_RIGHT(tmp, field), field) = (elm);		\
-	}								\
-	RB_AUGMENT(elm);						\
-	if ((RB_PARENT(tmp, field) = RB_PARENT(elm, field)) != NULL) {	\
-		if ((elm) == RB_LEFT(RB_PARENT(elm, field), field))	\
-			RB_LEFT(RB_PARENT(elm, field), field) = (tmp);	\
-		else							\
-			RB_RIGHT(RB_PARENT(elm, field), field) = (tmp);	\
-	} else								\
-		(head)->rbh_root = (tmp);				\
-	RB_RIGHT(tmp, field) = (elm);					\
-	RB_PARENT(elm, field) = (tmp);					\
-	RB_AUGMENT(tmp);						\
-	if ((RB_PARENT(tmp, field)))					\
-		RB_AUGMENT(RB_PARENT(tmp, field));			\
-} while (/*CONSTCOND*/ 0)
+#define RB_ROTATE_LEFT(head, elm, tmp, field)                                                      \
+    do {                                                                                           \
+        (tmp) = RB_RIGHT(elm, field);                                                              \
+        if ((RB_RIGHT(elm, field) = RB_LEFT(tmp, field)) != NULL) {                                \
+            RB_SET_PARENT(RB_RIGHT(elm, field), elm, field);                                       \
+        }                                                                                          \
+        RB_SET_PARENT(tmp, RB_PARENT(elm, field), field);                                          \
+        RB_SWAP_CHILD(head, elm, tmp, field);                                                      \
+        RB_LEFT(tmp, field) = (elm);                                                               \
+        RB_SET_PARENT(elm, tmp, field);                                                            \
+        RB_AUGMENT(elm);                                                                           \
+    } while (/*CONSTCOND*/ 0)
+
+#define RB_ROTATE_RIGHT(head, elm, tmp, field)                                                     \
+    do {                                                                                           \
+        (tmp) = RB_LEFT(elm, field);                                                               \
+        if ((RB_LEFT(elm, field) = RB_RIGHT(tmp, field)) != NULL) {                                \
+            RB_SET_PARENT(RB_LEFT(elm, field), elm, field);                                        \
+        }                                                                                          \
+        RB_SET_PARENT(tmp, RB_PARENT(elm, field), field);                                          \
+        RB_SWAP_CHILD(head, elm, tmp, field);                                                      \
+        RB_RIGHT(tmp, field) = (elm);                                                              \
+        RB_SET_PARENT(elm, tmp, field);                                                            \
+        RB_AUGMENT(elm);                                                                           \
+    } while (/*CONSTCOND*/ 0)
 
 /* Generates prototypes and inline functions */
 #define	RB_PROTOTYPE(name, type, field, cmp)				\
 	RB_PROTOTYPE_INTERNAL(name, type, field, cmp,)
 #define	RB_PROTOTYPE_STATIC(name, type, field, cmp)			\
 	RB_PROTOTYPE_INTERNAL(name, type, field, cmp, __unused static)
-#define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)		\
-	RB_PROTOTYPE_INSERT_COLOR(name, type, attr);			\
-	RB_PROTOTYPE_REMOVE_COLOR(name, type, attr);			\
-	RB_PROTOTYPE_INSERT(name, type, attr);				\
-	RB_PROTOTYPE_REMOVE(name, type, attr);				\
-	RB_PROTOTYPE_FIND(name, type, attr);				\
-	RB_PROTOTYPE_NFIND(name, type, attr);				\
-	RB_PROTOTYPE_NEXT(name, type, attr);				\
-	RB_PROTOTYPE_PREV(name, type, attr);				\
-	RB_PROTOTYPE_MINMAX(name, type, attr);
+#define RB_PROTOTYPE_INTERNAL(name, type, field, cmp, attr)                                        \
+    RB_PROTOTYPE_INSERT_COLOR(name, type, attr);                                                   \
+    RB_PROTOTYPE_REMOVE_COLOR(name, type, attr);                                                   \
+    RB_PROTOTYPE_INSERT(name, type, attr);                                                         \
+    RB_PROTOTYPE_REMOVE(name, type, attr);                                                         \
+    RB_PROTOTYPE_FIND(name, type, attr);                                                           \
+    RB_PROTOTYPE_NFIND(name, type, attr);                                                          \
+    RB_PROTOTYPE_NEXT(name, type, attr);                                                           \
+    RB_PROTOTYPE_PREV(name, type, attr);                                                           \
+    RB_PROTOTYPE_MINMAX(name, type, attr);                                                         \
+    RB_PROTOTYPE_REINSERT(name, type, attr);
 #define RB_PROTOTYPE_INSERT_COLOR(name, type, attr)			\
 	attr void name##_RB_INSERT_COLOR(struct name *, struct type *)
-#define RB_PROTOTYPE_REMOVE_COLOR(name, type, attr)			\
-	attr void name##_RB_REMOVE_COLOR(struct name *, struct type *, struct type *)
+#define RB_PROTOTYPE_REMOVE_COLOR(name, type, attr)                                                \
+    attr void name##_RB_REMOVE_COLOR(struct name *, struct type *, struct type *)
 #define RB_PROTOTYPE_REMOVE(name, type, attr)				\
 	attr struct type *name##_RB_REMOVE(struct name *, struct type *)
 #define RB_PROTOTYPE_INSERT(name, type, attr)				\
@@ -416,6 +439,8 @@ struct {								\
 	attr struct type *name##_RB_PREV(struct type *)
 #define RB_PROTOTYPE_MINMAX(name, type, attr)				\
 	attr struct type *name##_RB_MINMAX(struct name *, int)
+#define RB_PROTOTYPE_REINSERT(name, type, attr)                                                    \
+    attr struct type *name##_RB_REINSERT(struct name *, struct type *)
 
 /* Main rb operation.
  * Moves node close to the key of elm to top
@@ -424,246 +449,219 @@ struct {								\
 	RB_GENERATE_INTERNAL(name, type, field, cmp,)
 #define	RB_GENERATE_STATIC(name, type, field, cmp)			\
 	RB_GENERATE_INTERNAL(name, type, field, cmp, __unused static)
-#define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)		\
-	RB_GENERATE_INSERT_COLOR(name, type, field, attr)		\
-	RB_GENERATE_REMOVE_COLOR(name, type, field, attr)		\
-	RB_GENERATE_INSERT(name, type, field, cmp, attr)		\
-	RB_GENERATE_REMOVE(name, type, field, attr)			\
-	RB_GENERATE_FIND(name, type, field, cmp, attr)			\
-	RB_GENERATE_NFIND(name, type, field, cmp, attr)			\
-	RB_GENERATE_NEXT(name, type, field, attr)			\
-	RB_GENERATE_PREV(name, type, field, attr)			\
-	RB_GENERATE_MINMAX(name, type, field, attr)
+#define RB_GENERATE_INTERNAL(name, type, field, cmp, attr)                                         \
+    RB_GENERATE_INSERT_COLOR(name, type, field, attr)                                              \
+    RB_GENERATE_REMOVE_COLOR(name, type, field, attr)                                              \
+    RB_GENERATE_INSERT(name, type, field, cmp, attr)                                               \
+    RB_GENERATE_REMOVE(name, type, field, attr)                                                    \
+    RB_GENERATE_FIND(name, type, field, cmp, attr)                                                 \
+    RB_GENERATE_NFIND(name, type, field, cmp, attr)                                                \
+    RB_GENERATE_NEXT(name, type, field, attr)                                                      \
+    RB_GENERATE_PREV(name, type, field, attr)                                                      \
+    RB_GENERATE_MINMAX(name, type, field, attr)                                                    \
+    RB_GENERATE_REINSERT(name, type, field, cmp, attr)
 
-#define RB_GENERATE_INSERT_COLOR(name, type, field, attr)		\
-attr void								\
-name##_RB_INSERT_COLOR(struct name *head, struct type *elm)		\
-{									\
-	struct type *parent, *gparent, *tmp;				\
-	while ((parent = RB_PARENT(elm, field)) != NULL &&		\
-	    RB_COLOR(parent, field) == RB_RED) {			\
-		gparent = RB_PARENT(parent, field);			\
-		_T_ASSERT(gparent);					\
-		if (parent == RB_LEFT(gparent, field)) {		\
-			tmp = RB_RIGHT(gparent, field);			\
-			if (tmp && RB_COLOR(tmp, field) == RB_RED) {	\
-				RB_COLOR(tmp, field) = RB_BLACK;	\
-				RB_SET_BLACKRED(parent, gparent, field);\
-				elm = gparent;				\
-				continue;				\
-			}						\
-			if (RB_RIGHT(parent, field) == elm) {		\
-				RB_ROTATE_LEFT(head, parent, tmp, field);\
-				tmp = parent;				\
-				parent = elm;				\
-				elm = tmp;				\
-			}						\
-			RB_SET_BLACKRED(parent, gparent, field);	\
-			RB_ROTATE_RIGHT(head, gparent, tmp, field);	\
-		} else {						\
-			tmp = RB_LEFT(gparent, field);			\
-			if (tmp && RB_COLOR(tmp, field) == RB_RED) {	\
-				RB_COLOR(tmp, field) = RB_BLACK;	\
-				RB_SET_BLACKRED(parent, gparent, field);\
-				elm = gparent;				\
-				continue;				\
-			}						\
-			if (RB_LEFT(parent, field) == elm) {		\
-				RB_ROTATE_RIGHT(head, parent, tmp, field);\
-				tmp = parent;				\
-				parent = elm;				\
-				elm = tmp;				\
-			}						\
-			RB_SET_BLACKRED(parent, gparent, field);	\
-			RB_ROTATE_LEFT(head, gparent, tmp, field);	\
-		}							\
-	}								\
-	RB_COLOR(head->rbh_root, field) = RB_BLACK;			\
-}
+#define RB_GENERATE_INSERT_COLOR(name, type, field, attr)                                          \
+    attr void name##_RB_INSERT_COLOR(struct name *head, struct type *elm)                          \
+    {                                                                                              \
+        struct type *child, *parent;                                                               \
+        while ((parent = RB_PARENT(elm, field)) != NULL) {                                         \
+            if (RB_LEFT(parent, field) == elm) {                                                   \
+                if (RB_RED_LEFT(parent, field)) {                                                  \
+                    RB_FLIP_LEFT(parent, field);                                                   \
+                    return;                                                                        \
+                }                                                                                  \
+                RB_FLIP_RIGHT(parent, field);                                                      \
+                if (RB_RED_RIGHT(parent, field)) {                                                 \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                if (!RB_RED_RIGHT(elm, field)) {                                                   \
+                    RB_FLIP_LEFT(elm, field);                                                      \
+                    RB_ROTATE_LEFT(head, elm, child, field);                                       \
+                    if (RB_RED_LEFT(child, field))                                                 \
+                        RB_FLIP_RIGHT(elm, field);                                                 \
+                    else if (RB_RED_RIGHT(child, field))                                           \
+                        RB_FLIP_LEFT(parent, field);                                               \
+                    elm = child;                                                                   \
+                }                                                                                  \
+                RB_ROTATE_RIGHT(head, parent, elm, field);                                         \
+            } else {                                                                               \
+                if (RB_RED_RIGHT(parent, field)) {                                                 \
+                    RB_FLIP_RIGHT(parent, field);                                                  \
+                    return;                                                                        \
+                }                                                                                  \
+                RB_FLIP_LEFT(parent, field);                                                       \
+                if (RB_RED_LEFT(parent, field)) {                                                  \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                if (!RB_RED_LEFT(elm, field)) {                                                    \
+                    RB_FLIP_RIGHT(elm, field);                                                     \
+                    RB_ROTATE_RIGHT(head, elm, child, field);                                      \
+                    if (RB_RED_RIGHT(child, field))                                                \
+                        RB_FLIP_LEFT(elm, field);                                                  \
+                    else if (RB_RED_LEFT(child, field))                                            \
+                        RB_FLIP_RIGHT(parent, field);                                              \
+                    elm = child;                                                                   \
+                }                                                                                  \
+                RB_ROTATE_LEFT(head, parent, elm, field);                                          \
+            }                                                                                      \
+            RB_BITS(elm, field) &= ~RB_RED_MASK;                                                   \
+            break;                                                                                 \
+        }                                                                                          \
+    }
 
-#define RB_GENERATE_REMOVE_COLOR(name, type, field, attr)		\
-attr void								\
-name##_RB_REMOVE_COLOR(struct name *head, struct type *parent, struct type *elm) \
-{									\
-	struct type *tmp;						\
-	while ((elm == NULL || RB_COLOR(elm, field) == RB_BLACK) &&	\
-	    elm != RB_ROOT(head)) {					\
-		if (RB_LEFT(parent, field) == elm) {			\
-			tmp = RB_RIGHT(parent, field);			\
-			if (RB_COLOR(tmp, field) == RB_RED) {		\
-				RB_SET_BLACKRED(tmp, parent, field);	\
-				RB_ROTATE_LEFT(head, parent, tmp, field);\
-				tmp = RB_RIGHT(parent, field);		\
-			}						\
-			_T_ASSERT(tmp);					\
-			if ((RB_LEFT(tmp, field) == NULL ||		\
-			    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) &&\
-			    (RB_RIGHT(tmp, field) == NULL ||		\
-			    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK)) {\
-				RB_COLOR(tmp, field) = RB_RED;		\
-				elm = parent;				\
-				parent = RB_PARENT(elm, field);		\
-			} else {					\
-				if (RB_RIGHT(tmp, field) == NULL ||	\
-				    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK) {\
-					struct type *oleft;		\
-					if ((oleft = RB_LEFT(tmp, field)) \
-					    != NULL)			\
-						RB_COLOR(oleft, field) = RB_BLACK;\
-					RB_COLOR(tmp, field) = RB_RED;	\
-					RB_ROTATE_RIGHT(head, tmp, oleft, field);\
-					tmp = RB_RIGHT(parent, field);	\
-				}					\
-				RB_COLOR(tmp, field) = RB_COLOR(parent, field);\
-				RB_COLOR(parent, field) = RB_BLACK;	\
-				if (RB_RIGHT(tmp, field))		\
-					RB_COLOR(RB_RIGHT(tmp, field), field) = RB_BLACK;\
-				RB_ROTATE_LEFT(head, parent, tmp, field);\
-				elm = RB_ROOT(head);			\
-				break;					\
-			}						\
-		} else {						\
-			tmp = RB_LEFT(parent, field);			\
-			if (RB_COLOR(tmp, field) == RB_RED) {		\
-				RB_SET_BLACKRED(tmp, parent, field);	\
-				RB_ROTATE_RIGHT(head, parent, tmp, field);\
-				tmp = RB_LEFT(parent, field);		\
-			}						\
-			_T_ASSERT(tmp);					\
-			if ((RB_LEFT(tmp, field) == NULL ||		\
-			    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) &&\
-			    (RB_RIGHT(tmp, field) == NULL ||		\
-			    RB_COLOR(RB_RIGHT(tmp, field), field) == RB_BLACK)) {\
-				RB_COLOR(tmp, field) = RB_RED;		\
-				elm = parent;				\
-				parent = RB_PARENT(elm, field);		\
-			} else {					\
-				if (RB_LEFT(tmp, field) == NULL ||	\
-				    RB_COLOR(RB_LEFT(tmp, field), field) == RB_BLACK) {\
-					struct type *oright;		\
-					if ((oright = RB_RIGHT(tmp, field)) \
-					    != NULL)			\
-						RB_COLOR(oright, field) = RB_BLACK;\
-					RB_COLOR(tmp, field) = RB_RED;	\
-					RB_ROTATE_LEFT(head, tmp, oright, field);\
-					tmp = RB_LEFT(parent, field);	\
-				}					\
-				RB_COLOR(tmp, field) = RB_COLOR(parent, field);\
-				RB_COLOR(parent, field) = RB_BLACK;	\
-				if (RB_LEFT(tmp, field))		\
-					RB_COLOR(RB_LEFT(tmp, field), field) = RB_BLACK;\
-				RB_ROTATE_RIGHT(head, parent, tmp, field);\
-				elm = RB_ROOT(head);			\
-				break;					\
-			}						\
-		}							\
-	}								\
-	if (elm)							\
-		RB_COLOR(elm, field) = RB_BLACK;			\
-}
+#define RB_GENERATE_REMOVE_COLOR(name, type, field, attr)                                          \
+    attr void name##_RB_REMOVE_COLOR(struct name *head, struct type *parent, struct type *elm)     \
+    {                                                                                              \
+        struct type *sib;                                                                          \
+        if (RB_LEFT(parent, field) == elm && RB_RIGHT(parent, field) == elm) {                     \
+            RB_BITS(parent, field) &= ~RB_RED_MASK;                                                \
+            elm = parent;                                                                          \
+            parent = RB_PARENT(elm, field);                                                        \
+            if (parent == NULL)                                                                    \
+                return;                                                                            \
+        }                                                                                          \
+        do {                                                                                       \
+            if (RB_LEFT(parent, field) == elm) {                                                   \
+                if (!RB_RED_LEFT(parent, field)) {                                                 \
+                    RB_FLIP_LEFT(parent, field);                                                   \
+                    return;                                                                        \
+                }                                                                                  \
+                if (RB_RED_RIGHT(parent, field)) {                                                 \
+                    RB_FLIP_RIGHT(parent, field);                                                  \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                sib = RB_RIGHT(parent, field);                                                     \
+                if ((~RB_BITS(sib, field) & RB_RED_MASK) == 0) {                                   \
+                    RB_BITS(sib, field) &= ~RB_RED_MASK;                                           \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                RB_FLIP_RIGHT(sib, field);                                                         \
+                if (RB_RED_LEFT(sib, field))                                                       \
+                    RB_FLIP_LEFT(parent, field);                                                   \
+                else if (!RB_RED_RIGHT(sib, field)) {                                              \
+                    RB_FLIP_LEFT(parent, field);                                                   \
+                    RB_ROTATE_RIGHT(head, sib, elm, field);                                        \
+                    if (RB_RED_RIGHT(elm, field))                                                  \
+                        RB_FLIP_LEFT(sib, field);                                                  \
+                    if (RB_RED_LEFT(elm, field))                                                   \
+                        RB_FLIP_RIGHT(parent, field);                                              \
+                    RB_BITS(elm, field) |= RB_RED_MASK;                                            \
+                    sib = elm;                                                                     \
+                }                                                                                  \
+                RB_ROTATE_LEFT(head, parent, sib, field);                                          \
+            } else {                                                                               \
+                if (!RB_RED_RIGHT(parent, field)) {                                                \
+                    RB_FLIP_RIGHT(parent, field);                                                  \
+                    return;                                                                        \
+                }                                                                                  \
+                if (RB_RED_LEFT(parent, field)) {                                                  \
+                    RB_FLIP_LEFT(parent, field);                                                   \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                sib = RB_LEFT(parent, field);                                                      \
+                if ((~RB_BITS(sib, field) & RB_RED_MASK) == 0) {                                   \
+                    RB_BITS(sib, field) &= ~RB_RED_MASK;                                           \
+                    elm = parent;                                                                  \
+                    continue;                                                                      \
+                }                                                                                  \
+                RB_FLIP_LEFT(sib, field);                                                          \
+                if (RB_RED_RIGHT(sib, field))                                                      \
+                    RB_FLIP_RIGHT(parent, field);                                                  \
+                else if (!RB_RED_LEFT(sib, field)) {                                               \
+                    RB_FLIP_RIGHT(parent, field);                                                  \
+                    RB_ROTATE_LEFT(head, sib, elm, field);                                         \
+                    if (RB_RED_LEFT(elm, field))                                                   \
+                        RB_FLIP_RIGHT(sib, field);                                                 \
+                    if (RB_RED_RIGHT(elm, field))                                                  \
+                        RB_FLIP_LEFT(parent, field);                                               \
+                    RB_BITS(elm, field) |= RB_RED_MASK;                                            \
+                    sib = elm;                                                                     \
+                }                                                                                  \
+                RB_ROTATE_RIGHT(head, parent, sib, field);                                         \
+            }                                                                                      \
+            break;                                                                                 \
+        } while ((parent = RB_PARENT(elm, field)) != NULL);                                        \
+    }
 
-#define RB_GENERATE_REMOVE(name, type, field, attr)			\
-attr struct type *							\
-name##_RB_REMOVE(struct name *head, struct type *elm)			\
-{									\
-	struct type *child, *parent, *old = elm;			\
-	int color;							\
-	if (RB_LEFT(elm, field) == NULL)				\
-		child = RB_RIGHT(elm, field);				\
-	else if (RB_RIGHT(elm, field) == NULL)				\
-		child = RB_LEFT(elm, field);				\
-	else {								\
-		struct type *left;					\
-		elm = RB_RIGHT(elm, field);				\
-		while ((left = RB_LEFT(elm, field)) != NULL)		\
-			elm = left;					\
-		child = RB_RIGHT(elm, field);				\
-		parent = RB_PARENT(elm, field);				\
-		color = RB_COLOR(elm, field);				\
-		if (child)						\
-			RB_PARENT(child, field) = parent;		\
-		if (parent) {						\
-			if (RB_LEFT(parent, field) == elm)		\
-				RB_LEFT(parent, field) = child;		\
-			else						\
-				RB_RIGHT(parent, field) = child;	\
-			RB_AUGMENT(parent);				\
-		} else							\
-			RB_ROOT(head) = child;				\
-		if (RB_PARENT(elm, field) == old)			\
-			parent = elm;					\
-		_T_ASSERT((old));					\
-		(elm)->field = (old)->field;				\
-		if (RB_PARENT(old, field)) {				\
-			if (RB_LEFT(RB_PARENT(old, field), field) == old)\
-				RB_LEFT(RB_PARENT(old, field), field) = elm;\
-			else						\
-				RB_RIGHT(RB_PARENT(old, field), field) = elm;\
-			RB_AUGMENT(RB_PARENT(old, field));		\
-		} else							\
-			RB_ROOT(head) = elm;				\
-		_T_ASSERT(old);						\
-		_T_ASSERT(RB_LEFT(old, field));				\
-		RB_PARENT(RB_LEFT(old, field), field) = elm;		\
-		if (RB_RIGHT(old, field))				\
-			RB_PARENT(RB_RIGHT(old, field), field) = elm;	\
-		if (parent) {						\
-			left = parent;					\
-			do {						\
-				RB_AUGMENT(left);			\
-			} while ((left = RB_PARENT(left, field)) != NULL); \
-		}							\
-		goto color;						\
-	}								\
-	parent = RB_PARENT(elm, field);					\
-	color = RB_COLOR(elm, field);					\
-	if (child)							\
-		RB_PARENT(child, field) = parent;			\
-	if (parent) {							\
-		if (RB_LEFT(parent, field) == elm)			\
-			RB_LEFT(parent, field) = child;			\
-		else							\
-			RB_RIGHT(parent, field) = child;		\
-		RB_AUGMENT(parent);					\
-	} else								\
-		RB_ROOT(head) = child;					\
-color:									\
-	if (color == RB_BLACK)						\
-		name##_RB_REMOVE_COLOR(head, parent, child);		\
-	return (old);							\
-}									\
+#define RB_GENERATE_REMOVE(name, type, field, attr)                                                \
+    attr struct type *name##_RB_REMOVE(struct name *head, struct type *elm)                        \
+    {                                                                                              \
+        struct type *child, *old, *parent, *right;                                                 \
+                                                                                                   \
+        old = elm;                                                                                 \
+        parent = RB_PARENT(elm, field);                                                            \
+        right = RB_RIGHT(elm, field);                                                              \
+        if (RB_LEFT(elm, field) == NULL)                                                           \
+            elm = child = right;                                                                   \
+        else if (right == NULL)                                                                    \
+            elm = child = RB_LEFT(elm, field);                                                     \
+        else {                                                                                     \
+            if ((child = RB_LEFT(right, field)) == NULL) {                                         \
+                child = RB_RIGHT(right, field);                                                    \
+                RB_RIGHT(old, field) = child;                                                      \
+                parent = elm = right;                                                              \
+            } else {                                                                               \
+                do                                                                                 \
+                    elm = child;                                                                   \
+                while ((child = RB_LEFT(elm, field)) != NULL);                                     \
+                child = RB_RIGHT(elm, field);                                                      \
+                parent = RB_PARENT(elm, field);                                                    \
+                RB_LEFT(parent, field) = child;                                                    \
+                RB_SET_PARENT(RB_RIGHT(old, field), elm, field);                                   \
+            }                                                                                      \
+            RB_SET_PARENT(RB_LEFT(old, field), elm, field);                                        \
+            elm->field = old->field;                                                               \
+        }                                                                                          \
+        RB_SWAP_CHILD(head, old, elm, field);                                                      \
+        if (child != NULL)                                                                         \
+            RB_SET_PARENT(child, parent, field);                                                   \
+        if (parent != NULL)                                                                        \
+            name##_RB_REMOVE_COLOR(head, parent, child);                                           \
+        while (parent != NULL) {                                                                   \
+            RB_AUGMENT(parent);                                                                    \
+            parent = RB_PARENT(parent, field);                                                     \
+        }                                                                                          \
+        return (old);                                                                              \
+    }
 
-#define RB_GENERATE_INSERT(name, type, field, cmp, attr)		\
-/* Inserts a node into the RB tree */					\
-attr struct type *							\
-name##_RB_INSERT(struct name *head, struct type *elm)			\
-{									\
-	struct type *tmp;						\
-	struct type *parent = NULL;					\
-	int comp = 0;							\
-	tmp = RB_ROOT(head);						\
-	while (tmp) {							\
-		parent = tmp;						\
-		comp = (cmp)(elm, parent);				\
-		if (comp < 0)						\
-			tmp = RB_LEFT(tmp, field);			\
-		else if (comp > 0)					\
-			tmp = RB_RIGHT(tmp, field);			\
-		else							\
-			return (tmp);					\
-	}								\
-	RB_SET(elm, parent, field);					\
-	if (parent != NULL) {						\
-		if (comp < 0)						\
-			RB_LEFT(parent, field) = elm;			\
-		else							\
-			RB_RIGHT(parent, field) = elm;			\
-		RB_AUGMENT(parent);					\
-	} else								\
-		RB_ROOT(head) = elm;					\
-	name##_RB_INSERT_COLOR(head, elm);				\
-	return (NULL);							\
-}
+#define RB_GENERATE_INSERT(name, type, field, cmp, attr)                                           \
+    /* Inserts a node into the RB tree */                                                          \
+    attr struct type *name##_RB_INSERT(struct name *head, struct type *elm)                        \
+    {                                                                                              \
+        struct type *tmp;                                                                          \
+        struct type *parent = NULL;                                                                \
+        int comp = 0;                                                                              \
+        tmp = RB_ROOT(head);                                                                       \
+        while (tmp) {                                                                              \
+            parent = tmp;                                                                          \
+            comp = (cmp)(elm, parent);                                                             \
+            if (comp < 0)                                                                          \
+                tmp = RB_LEFT(tmp, field);                                                         \
+            else if (comp > 0)                                                                     \
+                tmp = RB_RIGHT(tmp, field);                                                        \
+            else                                                                                   \
+                return (tmp);                                                                      \
+        }                                                                                          \
+        RB_SET(elm, parent, field);                                                                \
+        if (parent == NULL)                                                                        \
+            RB_ROOT(head) = elm;                                                                   \
+        else if (comp < 0)                                                                         \
+            RB_LEFT(parent, field) = elm;                                                          \
+        else                                                                                       \
+            RB_RIGHT(parent, field) = elm;                                                         \
+        name##_RB_INSERT_COLOR(head, elm);                                                         \
+        while (elm != NULL) {                                                                      \
+            RB_AUGMENT(elm);                                                                       \
+            elm = RB_PARENT(elm, field);                                                           \
+        }                                                                                          \
+        return (NULL);                                                                             \
+    }
 
 #define RB_GENERATE_FIND(name, type, field, cmp, attr)			\
 /* Finds the node with the same key as elm */				\
@@ -768,6 +766,19 @@ name##_RB_MINMAX(struct name *head, int val)				\
 	return (parent);						\
 }
 
+#define RB_GENERATE_REINSERT(name, type, field, cmp, attr)                                         \
+    attr struct type *name##_RB_REINSERT(struct name *head, struct type *elm)                      \
+    {                                                                                              \
+        struct type *cmpelm;                                                                       \
+        if (((cmpelm = RB_PREV(name, head, elm)) != NULL && cmp(cmpelm, elm) >= 0) ||              \
+                ((cmpelm = RB_NEXT(name, head, elm)) != NULL && cmp(elm, cmpelm) >= 0)) {          \
+            /* XXXLAS: Remove/insert is heavy handed. */                                           \
+            RB_REMOVE(name, head, elm);                                                            \
+            return (RB_INSERT(name, head, elm));                                                   \
+        }                                                                                          \
+        return (NULL);                                                                             \
+    }
+
 #define RB_NEGINF	-1
 #define RB_INF	1
 
@@ -779,6 +790,7 @@ name##_RB_MINMAX(struct name *head, int val)				\
 #define RB_PREV(name, x, y)	name##_RB_PREV(y)
 #define RB_MIN(name, x)		name##_RB_MINMAX(x, RB_NEGINF)
 #define RB_MAX(name, x)		name##_RB_MINMAX(x, RB_INF)
+#define RB_REINSERT(name, x, y) name##_RB_REINSERT(x, y)
 
 #define RB_FOREACH(x, name, head)					\
 	for ((x) = RB_MIN(name, head);					\


### PR DESCRIPTION
This code is currently used by:
```
HttpRangeContainerBuffer
Frag_ (IP Fragments)
TcpSegment
StreamTcpSackRecord
StreamingBufferBlock
```
and, soon to be used by Ports if it makes sense.

Just checking if it passes the QA. Will have QA lab run a test post release to see if there's any perf upgrade/downgrade and make a decision and official PR accordingly.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6702