### PR TITLE
util/mime: fix memory leak

### DIFF
--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -2432,6 +2432,7 @@ MimeDecParseState * MimeDecInitParser(void *data,
     PushStack(state->stack);
     if (state->stack->top == NULL) {
         SCFree(state->stack);
+        SCFree(state->msg);
         SCFree(state);
         return NULL;
     }


### PR DESCRIPTION
Fix memory leak at util-decode-mime:MimeDecInitParser, which root cause is not-freeing allocated memory for mimeMsg

Bug: #6745

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6745](https://redmine.openinfosecfoundation.org/issues/6745)

Describe changes:
- Fix memory leak at util-decode-mime:MimeDecInitParser function

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
