### PR TITLE
ci: authors check using OISF repo

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -8,20 +8,16 @@ jobs:
     name: New Author Check
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - run: sudo apt -y install git
-      - run: git clone https://github.com/${{ github.repository }}
-      - run: git remote add author ${{ github.event.pull_request.head.repo.html_url }}
-        working-directory: suricata
-      - run: git fetch author
-        working-directory: suricata
-      - run: git checkout author/${{ github.event.pull_request.head.ref }}
-        working-directory: suricata
       - name: Export known authors from master branch
-        run: git log --format="%an <%ae>" origin/master | sort | uniq > ../authors.txt
-        working-directory: suricata
+        run: git log --format="%an <%ae>" origin/master | sort | uniq > authors.txt
       - name: Export authors from new commits
-        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > ../commit-authors.txt
-        working-directory: suricata
+        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > commit-authors.txt
       - name: Check new authors
         run: |
           touch new-authors.txt


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None but https://github.com/OISF/suricata/security/code-scanning/238

Describe changes:
- Checks out Suricata OISF repo and not contributor repository to run `git log` on it

cc @jasonish

#10332 as no longer a draft (where you can see the last 2 runs of the new author check)