### PR TITLE
detect/cip: check for sccanf return-value -v1

### DIFF
--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -157,8 +157,9 @@ static DetectCipServiceData *DetectCipServiceParse(const char *rulestrc)
             goto error;
         }
 
-        sscanf(token, "%2" SCNu8, &var);
-        input[i++] = var;
+        if (sscanf(token, "%2" SCNu8, &var) == 1) {
+            input[i++] = var;
+	}
 
         token = strtok_r(NULL, delims, &save);
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6753

Describe changes:
- Added an `if` condition that verifies the return-value of `sscanf` before executing the `input[i++] = var` statement.