### PR TITLE
netmap: Release lock to avoid deadlock

### DIFF
--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -453,6 +453,7 @@ retry:
             }
         }
 
+        SCMutexUnlock(&netmap_devlist_lock);
         NetmapCloseAll();
         FatalError("opening devname %s failed: %s", devname, strerror(errno));
     }


### PR DESCRIPTION
Continuation of #10335 

Issue: 6755

When NetmapOpen encounters an error opening the netmap device, it'll retry a bit. When the retry limit is reached, it'll shutdown Suricata.

This commit ensures that the device list lock is not held when before closing all open devices before terminating Suricata.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6755](https://redmine.openinfosecfoundation.org/issues/6755)

Describe changes:
- Release devlist lock before closing all devices

Updates:
- Rebase
- 
### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
