### PR TITLE
detect/cip: check for sccanf return-value - v2

### DIFF
--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -157,8 +157,9 @@ static DetectCipServiceData *DetectCipServiceParse(const char *rulestrc)
             goto error;
         }
 
-        sscanf(token, "%2" SCNu8, &var);
-        input[i++] = var;
+        if (sscanf(token, "%2" SCNu8, &var) == 1) {
+            input[i++] = var;
+        }
 
         token = strtok_r(NULL, delims, &save);
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6753

Previous PR: #10346

Describe changes:
- Fix `clang-format` error.