### PR TITLE
hugepages: run hugepage check only on DPDK runmode and on Linux v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2974,7 +2974,10 @@ int SuricataMain(int argc, char **argv)
         goto out;
     }
 
-    SystemHugepageSnapshot *prerun_snap = SystemHugepageSnapshotCreate();
+    SystemHugepageSnapshot *prerun_snap = NULL;
+    if (run_mode == RUNMODE_DPDK)
+        prerun_snap = SystemHugepageSnapshotCreate();
+
     SCSetStartTime(&suricata);
     RunModeDispatch(suricata.run_mode, suricata.runmode_custom_mode,
             suricata.capture_plugin_name, suricata.capture_plugin_args);
@@ -3032,13 +3035,12 @@ int SuricataMain(int argc, char **argv)
     OnNotifyRunning();
 
     PostRunStartedDetectSetup(&suricata);
-
-    SystemHugepageSnapshot *postrun_snap = SystemHugepageSnapshotCreate();
-    if (run_mode == RUNMODE_DPDK) // only DPDK uses hpages at the moment
+    if (run_mode == RUNMODE_DPDK) { // only DPDK uses hpages at the moment
+        SystemHugepageSnapshot *postrun_snap = SystemHugepageSnapshotCreate();
         SystemHugepageEvaluateHugepages(prerun_snap, postrun_snap);
-    SystemHugepageSnapshotDestroy(prerun_snap);
-    SystemHugepageSnapshotDestroy(postrun_snap);
-
+        SystemHugepageSnapshotDestroy(prerun_snap);
+        SystemHugepageSnapshotDestroy(postrun_snap);
+    }
     SCPledge();
     SuricataMainLoop(&suricata);
 

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -47,6 +47,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_EINVAL);
         CASE_CODE(SC_ELIMIT);
         CASE_CODE(SC_EEXIST);
+        CASE_CODE(SC_ENOENT);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -30,6 +30,7 @@ typedef enum {
     SC_EINVAL,
     SC_ELIMIT,
     SC_EEXIST,
+    SC_ENOENT,
 
     SC_ERR_MAX
 } SCError;


### PR DESCRIPTION
The previous implementation allowed FreeBSD to enter into the hugepage analysis. It then failed with an error message because hugepage/ NUMA node paths that are used in the codebase to retrieve info about the system are not the same as the structure in Linux.

Additionally, the messages were logged on an error level. It has been demoted to the info level because the whole hugepage analysis checkup is only for informational purposes and does not affect Suricata operation.

The hugepage analysis and the hugepage snapshots are now limited to only run in the DPDK runmode.

Ticket: #6760
https://redmine.openinfosecfoundation.org/issues/6760
Ticket: #6762
https://redmine.openinfosecfoundation.org/issues/6762