### PR TITLE
exception/policy: add stats counters - v4

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -7,7 +7,10 @@ Suricata has a set of configuration variables to indicate what should the engine
 do when certain exception conditions, such as hitting a memcap, are reached.
 
 They are called Exception Policies and are configurable via suricata.yaml. If
-enabled, the engine will call them when it reaches exception states.
+enabled, the engine will call them when it reaches exception states. Stats for
+any applied exception policies can be found in counters related to the specific
+configuration setting (:ref:`read more<eps_stats>`). Some configuration is
+available directly via the :ref:`stats settings<suricata_yaml_outputs>`.
 
 For developers or for researching purposes, there are also simulation options
 exposed in debug mode and passed via command-line. These exist to force or
@@ -206,6 +209,43 @@ Notes:
 
    * Not valid means that Suricata will error out and won't start.
    * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender of the matching packet.
+
+.. _eps_stats:
+
+Available Stats
+---------------
+
+There are stats counters for each supported exception policy scenario:
+
+.. list-table:: **Exception Policy Stats Counters**
+   :widths: 50 50
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Setting
+     - Counter
+   * - stream.memcap
+     - tcp.ssn_memcap_exception_policy
+   * - stream.reassembly.memcap
+     - tcp.reassembly_memcap_exception_policy
+   * - stream.midstream
+     - tcp.midstream_exception_policy
+   * - defrag.memcap
+     - defrag.memcap_exception_policy
+   * - flow.memcap
+     - flow.memcap_exception_policy
+   * - app-layer.error
+     - app_layer.error.exception_policy
+
+If a given exception policy does not apply for a setting, no related counter
+is logged.
+
+Stats for application layer errors are available in summarized form or per
+application layer protocol. As the latter is extremely verbose, by default
+Suricata logs only the summary. If any further investigation is needed, it
+is recommended to enable per-app-proto exception policy error counters
+temporarily (for :ref:`stats configuration<suricata_yaml_outputs>`).
+
 
 Command-line Options for Simulating Exceptions
 ----------------------------------------------

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -62,33 +62,40 @@ Specific settings
 Exception policies are implemented for:
 
 .. list-table:: Exception Policy configuration variables
-   :widths: 20, 18, 62
+   :widths: 18, 18, 18, 44
    :header-rows: 1
 
    * - Config setting
      - Policy variable
+     - Affects
      - Expected behavior
    * - stream.memcap
      - memcap-policy
+     - Flow or packet
      - If a stream memcap limit is reached, apply the memcap policy to the packet and/or
        flow.
    * - stream.midstream
      - midstream-policy
+     - Flow
      - If a session is picked up midstream, apply the midstream policy to the flow.
    * - stream.reassembly.memcap
      - memcap-policy
+     - Flow or packet
      - If stream reassembly reaches memcap limit, apply memcap policy to the
        packet and/or flow.
    * - flow.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for flows is reached and no flow could
        be freed up. **Policy can only be applied to the packet.**
    * - defrag.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for defrag is reached and no tracker
        could be picked up. **Policy can only be applied to the packet.**
    * - app-layer
      - error-policy
+     - Flow or packet
      - Apply policy if a parser reaches an error state. Policy can be applied to packet and/or flow.
 
 To change any of these, go to the specific section in the suricata.yaml file

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -317,6 +317,11 @@ the global config is documented.
       #decoder-events-prefix: "decoder.event"
       # Add stream events as stats.
       #stream-events: false
+      # Exception policy stats counters options
+      # (Note: if exception policy: ignore, counters are not logged)
+      #eps-zero-valued-counters: false  # default: false. True will log counters: 0
+      #eps-per-app-proto-errors: false  # default: false. True will log errors for
+                                        # each app-proto. Warning: VERY verbose
 
 Statistics can be `enabled` or disabled here.
 
@@ -338,6 +343,12 @@ See `issue 2225 <https://redmine.openinfosecfoundation.org/issues/2225>`_.
 Similar to the `decoder-events` option, the `stream-events` option controls
 whether the stream-events are added as counters as well. This is disabled by
 default.
+
+If any exception policy is enabled, stats counters are logged. To control
+verbosity especially for application layer protocol errors, leave
+`eps-per-app-proto-errors` as false. Similarly, leaving
+`eps-zero-valued-counters` disabled, only if an exception policy was applied
+there will be counters logged.
 
 Outputs
 ~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5257,6 +5257,32 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5287,6 +5287,32 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/ignore"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1113,7 +1113,7 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
-			}
+                        }
                     },
                     "additionalProperties": false
                 },
@@ -3686,6 +3686,29 @@
                         "error": {
                             "type": "object",
                             "properties": {
+                                "exception_policy": {
+                                    "type": "object",
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/$defs/drop_flow"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/drop_packet"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/pass_flow"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/pass_packet"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/bypass"
+                                        },
+                                        {
+                                            "$ref": "#/$defs/reject"
+                                        }
+                                    ]
+                                },
                                 "bittorrent-dht": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
@@ -3792,7 +3815,7 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": true
                         },
                         "flow": {
                             "type": "object",
@@ -5559,6 +5582,29 @@
                 },
                 "internal": {
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/drop_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/drop_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_flow"
+                        },
+                        {
+                            "$ref": "#/$defs/pass_packet"
+                        },
+                        {
+                            "$ref": "#/$defs/bypass"
+                        },
+                        {
+                            "$ref": "#/$defs/reject"
+                        }
+                    ]
                 }
             },
             "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4754,6 +4754,23 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4907,6 +4907,24 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_packet"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ],
+                            "additionalProperties": "false"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5583,6 +5601,24 @@
                     ]
                 }
             }
+        },
+        "drop_flow": {
+            "type": "object"
+        },
+        "drop_packet": {
+            "type": "object"
+        },
+        "pass_flow": {
+            "type": "object"
+        },
+        "pass_packet": {
+            "type": "object"
+        },
+        "bypass": {
+            "type": "object"
+        },
+        "reject": {
+            "type": "object"
         }
     }
 }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5239,6 +5239,23 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "type": "object",
+                            "anyOf": [
+                                {
+                                    "$ref": "#/$defs/drop_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/pass_flow"
+                                },
+                                {
+                                    "$ref": "#/$defs/bypass"
+                                },
+                                {
+                                    "$ref": "#/$defs/reject"
+                                }
+                            ]
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,6 +49,7 @@
 #include "app-layer-htp-mem.h"
 #include "util-exception-policy.h"
 
+extern bool g_stats_eps_per_app_proto_errors;
 /**
  * \brief This is for the app layer in general and it contains per thread
  *        context relevant to both the alpd and alp.
@@ -80,6 +81,12 @@ typedef struct AppLayerCounterNames_ {
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
     char alloc_error[MAX_COUNTER_SIZE];
+    char eps_error_pass_packet[MAX_COUNTER_SIZE];
+    char eps_error_pass_flow[MAX_COUNTER_SIZE];
+    char eps_error_bypass[MAX_COUNTER_SIZE];
+    char eps_error_drop_packet[MAX_COUNTER_SIZE];
+    char eps_error_drop_flow[MAX_COUNTER_SIZE];
+    char eps_error_reject[MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
@@ -89,12 +96,39 @@ typedef struct AppLayerCounters_ {
     uint16_t parser_error_id;
     uint16_t internal_error_id;
     uint16_t alloc_error_id;
+    ExceptionPolicyCounters eps_error;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
 AppLayerCounterNames applayer_counter_names[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
 /* counter id's. Used that runtime. */
 AppLayerCounters applayer_counters[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
+/* Exception policy global counters ids */
+ExceptionPolicyCounters eps_error_summary;
+
+ExceptionPolicyStatsSetts app_layer_error_eps_stats = {
+    /* valid_settings_ids */ {
+            /* EXCEPTION_POLICY_NOT_SET */ false,
+            /* EXCEPTION_POLICY_AUTO */ false,
+            /* EXCEPTION_POLICY_PASS_PACKET */ true,
+            /* EXCEPTION_POLICY_PASS_FLOW */ true,
+            /* EXCEPTION_POLICY_BYPASS_FLOW */ true,
+            /* EXCEPTION_POLICY_DROP_PACKET */ false,
+            /* EXCEPTION_POLICY_DROP_FLOW */ false,
+            /* EXCEPTION_POLICY_REJECT */ true,
+    },
+    /* valid_settings_ips */
+    {
+            /* EXCEPTION_POLICY_NOT_SET */ false,
+            /* EXCEPTION_POLICY_AUTO */ false,
+            /* EXCEPTION_POLICY_PASS_PACKET */ true,
+            /* EXCEPTION_POLICY_PASS_FLOW */ true,
+            /* EXCEPTION_POLICY_BYPASS_FLOW */ true,
+            /* EXCEPTION_POLICY_DROP_PACKET */ true,
+            /* EXCEPTION_POLICY_DROP_FLOW */ true,
+            /* EXCEPTION_POLICY_REJECT */ true,
+    },
+};
 
 void AppLayerSetupCounters(void);
 void AppLayerDeSetupCounters(void);
@@ -156,6 +190,51 @@ void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
     const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
+    }
+}
+
+static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum ExceptionPolicy policy)
+{
+    uint16_t id = 0;
+    /* for the summary values */
+    uint16_t g_id = 0;
+    switch (policy) {
+        case EXCEPTION_POLICY_NOT_SET:
+            // We don't log stats when we're ignoring exception policies
+            break;
+        case EXCEPTION_POLICY_REJECT:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_BYPASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_PASS_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_PASS_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_DROP_FLOW:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_DROP_PACKET:
+            id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+            g_id = eps_error_summary.eps_id[policy];
+            break;
+        case EXCEPTION_POLICY_AUTO:
+            break;
+    }
+
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+    if (likely(tv && g_id > 0)) {
+        StatsIncr(tv, g_id);
     }
 }
 
@@ -640,6 +719,7 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
     SCReturnInt(0);
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -707,6 +787,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
         StreamTcpUpdateAppLayerProgress(ssn, direction, data_len);
         if (r < 0) {
             ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+            AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
             SCReturnInt(-1);
         }
         goto end;
@@ -793,6 +874,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
                 if (r < 0) {
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+                    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
                     SCReturnInt(-1);
                 }
             }
@@ -933,6 +1015,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     }
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+        AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
         SCReturnInt(-1);
     }
 
@@ -1062,6 +1145,14 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("app_layer.expectations", ExpectationGetCounter);
 }
 
+static bool IsAppLayerErrorExceptionPolicyStatsValid(int policy)
+{
+    if (EngineModeIsIPS()) {
+        return app_layer_error_eps_stats.valid_settings_ips[policy];
+    }
+    return app_layer_error_eps_stats.valid_settings_ids[policy];
+}
+
 #define IPPROTOS_MAX 2
 void AppLayerSetupCounters(void)
 {
@@ -1108,6 +1199,38 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
+                    if (g_stats_eps_per_app_proto_errors) {
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_reject),
+                                "%s%s%s.exception_policy.reject", estr, alproto_str,
+                                ipproto_suffix);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_bypass),
+                                "%s%s%s.exception_policy.bypass", estr, alproto_str,
+                                ipproto_suffix);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_pass_flow),
+                                "%s%s%s.exception_policy.pass_flow", estr, alproto_str,
+                                ipproto_suffix);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_pass_packet),
+                                "%s%s%s.exception_policy.pass_packet", estr, alproto_str,
+                                ipproto_suffix);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_drop_flow),
+                                "%s%s%s.exception_policy.drop_flow", estr, alproto_str,
+                                ipproto_suffix);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_drop_packet),
+                                "%s%s%s.exception_policy.drop_packet", estr, alproto_str,
+                                ipproto_suffix);
+                    }
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1130,6 +1253,32 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s.internal", estr, alproto_str);
+                    if (g_stats_eps_per_app_proto_errors) {
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_reject,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_reject),
+                                "%s%s.exception_policy.reject", estr, alproto_str);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_bypass,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_bypass),
+                                "%s%s.exception_policy.bypass", estr, alproto_str);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_pass_flow),
+                                "%s%s.exception_policy.pass_flow", estr, alproto_str);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_pass_packet),
+                                "%s%s.exception_policy.pass_packet", estr, alproto_str);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_drop_flow),
+                                "%s%s.exception_policy.drop_flow", estr, alproto_str);
+                        snprintf(applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                                sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                .eps_error_drop_packet),
+                                "%s%s.exception_policy.drop_packet", estr, alproto_str);
+                    }
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1150,6 +1299,19 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
     AppProto alprotos[ALPROTO_MAX];
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
+    /* Register global counters for app layer error exception policy summary */
+    const char *eps_default_str = "app_layer.error.exception_policy.";
+    bool is_eps_valid = false;
+    for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+        is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+        /* "app_layer.error.exception_policy." + longest exception policy size = 45*/
+        char eps_stats[45];
+        if (is_eps_valid) {
+            snprintf(eps_stats, sizeof(eps_stats), "%s%s", eps_default_str,
+                    ExceptionPolicyEnumToString(i));
+            eps_error_summary.eps_id[i] = StatsRegisterCounter(eps_stats, tv);
+        }
+    }
 
     for (uint8_t p = 0; p < IPPROTOS_MAX; p++) {
         const uint8_t ipproto = ipprotos[p];
@@ -1173,6 +1335,46 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
                         applayer_counter_names[ipproto_map][alproto].parser_error, tv);
                 applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
                         applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                if (g_stats_eps_per_app_proto_errors) {
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_REJECT)) {
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error.eps_id[EXCEPTION_POLICY_REJECT] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_reject, tv);
+                    }
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_BYPASS_FLOW)) {
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error
+                                .eps_id[EXCEPTION_POLICY_BYPASS_FLOW] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_bypass, tv);
+                    }
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_PASS_FLOW)) {
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error
+                                .eps_id[EXCEPTION_POLICY_PASS_FLOW] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_flow,
+                                tv);
+                    }
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_PASS_PACKET))
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error
+                                .eps_id[EXCEPTION_POLICY_PASS_PACKET] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_pass_packet,
+                                tv);
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_DROP_FLOW)) {
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error
+                                .eps_id[EXCEPTION_POLICY_DROP_FLOW] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_flow,
+                                tv);
+                    }
+                    if (IsAppLayerErrorExceptionPolicyStatsValid(EXCEPTION_POLICY_DROP_FLOW)) {
+                        applayer_counters[ipproto_map][alproto]
+                                .eps_error
+                                .eps_id[EXCEPTION_POLICY_DROP_FLOW] = StatsRegisterCounter(
+                                applayer_counter_names[ipproto_map][alproto].eps_error_drop_packet,
+                                tv);
+                    }
+                }
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -102,6 +102,9 @@ bool stats_decoder_events = true;
 const char *stats_decoder_events_prefix = "decoder.event";
 /**< add stream events as stats? disabled by default */
 bool stats_stream_events = false;
+
+/** add zero valued counters for exception policies stats? disabled by default */
+bool stats_eps_zero_counters = false;
 
 static int StatsOutput(ThreadVars *tv);
 static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext *);
@@ -293,6 +296,11 @@ static void StatsInitCtxPreOutput(void)
             prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;
+
+        ret = ConfGetChildValueBool(stats, "eps-zero-valued-counters", &b);
+        if (ret) {
+            stats_eps_zero_counters = (b == 1);
+        }
     }
     SCReturn;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -105,6 +105,33 @@ ExceptionPolicyStatsSetts defrag_memcap_eps_stats = {
 };
 // clang-format on
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts flow_memcap_eps_stats = {
+    /* valid_settings_ids */ {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true, /* TODO should bypass flow be
+                                                 valid if defrag.memcap is only valid for packets?*/
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    /* valid_settings_ips */ {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 /**
  * \brief Initialize PacketAlerts with dynamic alerts array size
  *
@@ -559,6 +586,14 @@ static bool IsDefragMemcapExceptionPolicyStatsValid(uint8_t policy)
     return defrag_memcap_eps_stats.valid_settings_ids[policy];
 }
 
+static bool IsFlowMemcapExceptionPolicyStatsValid(uint8_t policy)
+{
+    if (EngineModeIsIPS()) {
+        return flow_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return flow_memcap_eps_stats.valid_settings_ids[policy];
+}
+
 void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 {
     /* register counters */
@@ -606,6 +641,20 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
+    /* Register stats counters for all valid exception policy values */
+    const char *eps_flow_str = "flow.memcap_exception_policy.";
+    bool is_eps_valid = false;
+    for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+        is_eps_valid = IsFlowMemcapExceptionPolicyStatsValid(i);
+        if (is_eps_valid) {
+            /* "flow.memcap_exception_policy." + longest exception policy string size
+             * ("pass_packet") = 41 */
+            char eps_flow_stats[41];
+            snprintf(eps_flow_stats, sizeof(eps_flow_stats), "%s%s", eps_flow_str,
+                    ExceptionPolicyEnumToString(i));
+            dtv->counter_flow_memcap_eps.eps_id[i] = StatsRegisterCounter(eps_flow_stats, tv);
+        }
+    }
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);
     dtv->counter_flow_total = StatsRegisterCounter("flow.total", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,6 +32,7 @@
 #include "threadvars.h"
 #include "util-debug.h"
 #include "decode-events.h"
+#include "util-exception-policy-types.h"
 #ifdef PROFILING
 #include "flow-worker.h"
 #include "app-layer-protos.h"
@@ -726,6 +727,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    ExceptionPolicyCounters counter_defrag_memcap_eps;
 
     uint16_t counter_flow_memcap;
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -730,6 +730,7 @@ typedef struct DecodeThreadVars_
     ExceptionPolicyCounters counter_defrag_memcap_eps;
 
     uint16_t counter_flow_memcap;
+    ExceptionPolicyCounters counter_flow_memcap_eps;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -459,6 +459,15 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
     return CMP_DEFRAGTRACKER(t, p, id);
 }
 
+static void DefragExceptionPolicyStatsIncr(
+        ThreadVars *tv, DecodeThreadVars *dtv, enum ExceptionPolicy policy)
+{
+    uint16_t id = dtv->counter_defrag_memcap_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 /**
  *  \brief Get a new defrag tracker
  *
@@ -467,12 +476,13 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *
  *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
-static DefragTracker *DefragTrackerGetNew(Packet *p)
+static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
 #ifdef DEBUG
     if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
         SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
         ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+        DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
         return NULL;
     }
 #endif
@@ -497,6 +507,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerGetUsedDefragTracker();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -506,6 +517,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerAlloc();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -530,7 +542,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
  *
  * returns a *LOCKED* tracker or NULL
  */
-DefragTracker *DefragGetTrackerFromHash (Packet *p)
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     DefragTracker *dt = NULL;
 
@@ -542,7 +554,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
 
     /* see if the bucket already has a tracker */
     if (hb->head == NULL) {
-        dt = DefragTrackerGetNew(p);
+        dt = DefragTrackerGetNew(tv, dtv, p);
         if (dt == NULL) {
             DRLOCK_UNLOCK(hb);
             return NULL;
@@ -571,7 +583,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
             dt = dt->hnext;
 
             if (dt == NULL) {
-                dt = pdt->hnext = DefragTrackerGetNew(p);
+                dt = pdt->hnext = DefragTrackerGetNew(tv, dtv, p);
                 if (dt == NULL) {
                     DRLOCK_UNLOCK(hb);
                     return NULL;

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -92,7 +92,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -991,7 +991,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -247,8 +247,8 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                 js_type = OutputStats2Json(js_stats, st->stats[u].name);
             }
             if (js_type != NULL) {
-                if (is_exception_policy_counter && st->stats[u].value == 0 &&
-                        !stats_eps_zero_counters) {
+                if (is_exception_policy_counter && !stats_eps_zero_counters &&
+                        st->stats[u].value == 0) {
                     continue;
                 }
                 json_object_set_new(js_type, stat_name, json_integer(st->stats[u].value));
@@ -274,10 +274,10 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
         uint32_t x;
         for (x = 0; x < st->ntstats; x++) {
             uint32_t offset = x * st->nstats;
-            bool is_exception_policy_counter = false;
 
             /* for each counter */
             for (u = offset; u < (offset + st->nstats); u++) {
+                bool is_exception_policy_counter = false;
                 if (st->tstats[u].name == NULL)
                     continue;
 
@@ -297,8 +297,8 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                 }
 
                 if (js_type != NULL) {
-                    if (is_exception_policy_counter && st->stats[u].value == 0 &&
-                            !stats_eps_zero_counters) {
+                    if (is_exception_policy_counter && !stats_eps_zero_counters &&
+                            st->tstats[u].value == 0) {
                         continue;
                     }
                     json_object_set_new(js_type, stat_name, json_integer(st->tstats[u].value));

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,6 +28,7 @@
 #include "suricata.h"
 #include "flow.h"
 #include "stream-tcp-private.h"
+#include "util-exception-policy.h"
 
 /** Supported OS list and default OS policy is BSD */
 enum
@@ -64,6 +65,8 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    ExceptionPolicyCounters counter_tcp_reas_eps;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;
@@ -135,6 +138,7 @@ int StreamTcpCheckStreamContents(uint8_t *, uint16_t , TcpStream *);
 bool StreamReassembleRawHasDataReady(TcpSession *ssn, Packet *p);
 void StreamTcpReassemblySetMinInspectDepth(TcpSession *ssn, int direction, uint32_t depth);
 
+bool IsReassemblyMemcapExceptionPolicyStatsValid(int exception_policy);
 bool IsTcpSessionDumpingEnabled(void);
 void EnableTcpSessionDumping(void);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -90,6 +90,32 @@
 #define STREAMTCP_DEFAULT_MAX_SYN_QUEUED        10
 #define STREAMTCP_DEFAULT_MAX_SYNACK_QUEUED     5
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_memcap_eps_stats = {
+    /* valid_settings_ids */ {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    /* valid_settings_ips */ {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *, TcpSession *, Packet *);
 void StreamTcpReturnStreamSegments (TcpStream *);
 void StreamTcpInitConfig(bool);
@@ -702,6 +728,23 @@ void StreamTcpFreeConfig(bool quiet)
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
 }
 
+static bool IsStreamTcpSessionMemcapExceptionPolicyStatsValid(int policy)
+{
+    if (EngineModeIsIPS()) {
+        return stream_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return stream_memcap_eps_stats.valid_settings_ids[policy];
+}
+
+static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    const uint16_t id = stt->counter_tcp_ssn_memcap_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 /** \internal
  *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
@@ -741,6 +784,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 #endif
@@ -748,6 +792,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 
@@ -5763,6 +5808,21 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    /* set-up tcp stream ssn memcap exception policy counters */
+    const char *eps_default_str = "tcp.ssn_memcap_exception_policy.";
+    bool is_eps_valid = false;
+    for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+        is_eps_valid = IsStreamTcpSessionMemcapExceptionPolicyStatsValid(i);
+        if (is_eps_valid) {
+            /* "tcp.ssn_memcap_exception_policy." + longest exception policy string size
+             * ("pass_packet") = 44 */
+            char eps_stats[44];
+            snprintf(eps_stats, sizeof(eps_stats), "%s%s", eps_default_str,
+                    ExceptionPolicyEnumToString(i));
+            stt->counter_tcp_ssn_memcap_eps.eps_id[i] = StatsRegisterCounter(eps_stats, tv);
+        }
+    }
+
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -5836,6 +5836,22 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+
+    /* set-up tcp stream reassembly memcap exception policy counters */
+    const char *eps_reas_str = "tcp.reassembly_memcap_exception_policy.";
+    is_eps_valid = false;
+    for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+        is_eps_valid = IsReassemblyMemcapExceptionPolicyStatsValid(i);
+        if (is_eps_valid) {
+            /* "tcp.reassembly_memcap_exception_policy." + longest exception policy string size = 51
+             */
+            char eps_stats[51];
+            snprintf(eps_stats, sizeof(eps_stats), "%s%s", eps_reas_str,
+                    ExceptionPolicyEnumToString(i));
+            stt->ra_ctx->counter_tcp_reas_eps.eps_id[i] = StatsRegisterCounter(eps_stats, tv);
+        }
+    }
+
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -96,6 +96,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    ExceptionPolicyCounters counter_tcp_midstream_eps;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseen data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@
 #include "stream.h"
 #include "stream-tcp-reassemble.h"
 #include "suricata.h"
+#include "util-exception-policy-types.h"
 
 #define STREAM_VERBOSE false
 /* Flag to indicate that the checksum validation for the stream engine
@@ -85,6 +86,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    ExceptionPolicyCounters counter_tcp_ssn_memcap_eps;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/** add per-proto app-layer error counters for exception policies stats? disabled by default */
+bool g_stats_eps_per_app_proto_errors = false;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2686,6 +2689,12 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     SetMasterExceptionPolicy();
+
+    int b;
+    int ret = ConfGetBool("stats.eps-per-app-proto-errors", &b);
+    if (ret) {
+        g_stats_eps_per_app_proto_errors = (b == 1);
+    }
 
     AppLayerSetup();
 

--- a/src/util-exception-policy-types.c
+++ b/src/util-exception-policy-types.c
@@ -1,0 +1,20 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */
+
+#ifndef __UTIL_EXCEPTION_POLICY_TYPES_H__
+#define __UTIL_EXCEPTION_POLICY_TYPES_H__
+
+enum ExceptionPolicy {
+    EXCEPTION_POLICY_NOT_SET = 0,
+    EXCEPTION_POLICY_AUTO,
+    // TODO - optimization? - since `AUTO` and `NOT_SET` are not actual values for policies and
+    // stats (only for config), could we leave those out of the `max` count?
+    EXCEPTION_POLICY_PASS_PACKET,
+    EXCEPTION_POLICY_PASS_FLOW,
+    EXCEPTION_POLICY_BYPASS_FLOW,
+    EXCEPTION_POLICY_DROP_PACKET,
+    EXCEPTION_POLICY_DROP_FLOW,
+    EXCEPTION_POLICY_REJECT,
+};
+
+#define EXCEPTION_POLICY_MAX EXCEPTION_POLICY_REJECT + 1
+
+typedef struct ExceptionPolicyCounters_ {
+    /* Follows enum order */
+    uint16_t eps_id[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyCounters;
+
+typedef struct ExceptionPolicyStatsSetts_ {
+    bool valid_settings_ids[EXCEPTION_POLICY_MAX];
+    bool valid_settings_ips[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyStatsSetts;
+
+#endif

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -31,7 +31,7 @@ enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */
 static bool g_eps_have_exception_policy = false;
 
-static const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
 {
     switch (policy) {
         case EXCEPTION_POLICY_NOT_SET:

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,18 +23,9 @@
 #define __UTIL_EXCEPTION_POLICY_H__
 
 #include "decode.h"
+#include "util-exception-policy-types.h"
 
-enum ExceptionPolicy {
-    EXCEPTION_POLICY_NOT_SET = 0,
-    EXCEPTION_POLICY_AUTO,
-    EXCEPTION_POLICY_PASS_PACKET,
-    EXCEPTION_POLICY_PASS_FLOW,
-    EXCEPTION_POLICY_BYPASS_FLOW,
-    EXCEPTION_POLICY_DROP_PACKET,
-    EXCEPTION_POLICY_DROP_FLOW,
-    EXCEPTION_POLICY_REJECT,
-};
-
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy);
 void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -76,6 +76,8 @@ stats:
   # Exception policy stats counters options
   # (Note: if exception policy: ignore, counters are not logged)
   #eps-zero-valued-counters: false  # default: false. True will log counters: 0
+  #eps-per-app-proto-errors: false  # default: false. True will log errors for
+                                    # each app-proto. Warning: VERY verbose
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -73,6 +73,9 @@ stats:
   #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
+  # Exception policy stats counters options
+  # (Note: if exception policy: ignore, counters are not logged)
+  #eps-zero-valued-counters: false  # default: false. True will log counters: 0
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5816

Previous PR: https://github.com/OISF/suricata/pull/10264

**Disclaimer:** 
this code triggers a `stack use after scope` error related, I think, to how I'm trying to "automate" the counter ids registration. I'll point out in the code

Describe changes:
- encode valid exception policy stats 
- extract exception policy types to its own header file
- start documenting exception policy stats counters
- better highlight what exception policies are valid with which exception scenarios
- try to use array and struct for Exception Policy Counters

TODO:
- carefully review if we are not trying to log counters for cases when exception policies are not valid (such as specific situations in IDS or IPS).
- figure out how to apply same logic used for other stats counters for per-app-proto app-layer error exception policy stats
- better align stats.log - as the new counters size character is longer than what we currently have in the stats
- update the json.schema to include delta counters
- fix commit history
