### PR TITLE
http: code simplification

### DIFF
--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -27,10 +27,10 @@
 
 #include "app-layer-htp.h"
 
-int HTPFileOpen(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t,
-        uint64_t, uint8_t);
+int HTPFileOpen(
+        HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint8_t);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
-        uint32_t, uint64_t, bstr *rawvalue, HtpTxUserData *htud);
+        uint32_t, htp_tx_t *, bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(const StreamingBufferConfig *sbcfg, FileContainer *, const uint16_t,
         HttpRangeContainerBlock *, const uint8_t *, uint32_t);
 int HTPFileStoreChunk(HtpState *, HtpTxUserData *, const uint8_t *, uint32_t, uint8_t);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1571,7 +1571,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
 #endif
 
                 result = HTPFileOpen(hstate, htud, filename, filename_len, filedata, filedata_len,
-                        HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
+                        STREAM_TOSERVER);
                 if (result == -1) {
                     goto end;
                 } else if (result == -2) {
@@ -1633,7 +1633,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                         filedata_len = 0;
                     }
                     result = HTPFileOpen(hstate, htud, filename, filename_len, filedata,
-                            filedata_len, HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
+                            filedata_len, STREAM_TOSERVER);
                     if (result == -1) {
                         goto end;
                     } else if (result == -2) {
@@ -1648,7 +1648,7 @@ static int HtpRequestBodyHandleMultipart(HtpState *hstate, HtpTxUserData *htud, 
                     SCLogDebug("filedata_len %u", filedata_len);
 
                     result = HTPFileOpen(hstate, htud, filename, filename_len, filedata,
-                            filedata_len, HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
+                            filedata_len, STREAM_TOSERVER);
                     if (result == -1) {
                         goto end;
                     } else if (result == -2) {
@@ -1725,7 +1725,7 @@ static int HtpRequestBodyHandlePOSTorPUT(HtpState *hstate, HtpTxUserData *htud,
                 HTPSetEvent(hstate, htud, STREAM_TOSERVER, HTTP_DECODER_EVENT_FILE_NAME_TOO_LONG);
             }
             result = HTPFileOpen(hstate, htud, filename, (uint16_t)filename_len, data, data_len,
-                    HtpGetActiveRequestTxID(hstate), STREAM_TOSERVER);
+                    STREAM_TOSERVER);
             if (result == -1) {
                 goto end;
             } else if (result == -2) {
@@ -1802,10 +1802,10 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
             }
             if (h_content_range != NULL) {
                 result = HTPFileOpenWithRange(hstate, htud, filename, (uint16_t)filename_len, data,
-                        data_len, HtpGetActiveResponseTxID(hstate), h_content_range->value, htud);
+                        data_len, tx, h_content_range->value, htud);
             } else {
                 result = HTPFileOpen(hstate, htud, filename, (uint16_t)filename_len, data, data_len,
-                        HtpGetActiveResponseTxID(hstate), STREAM_TOCLIENT);
+                        STREAM_TOCLIENT);
             }
             SCLogDebug("result %d", result);
             if (result == -1) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5921

Describe changes:
- http: code simplification to avoid one direct usage of `htp_list_get`

```
LIBHTP_BRANCH=pr/416
```
https://github.com/OISF/libhtp/pull/416