### PR TITLE
filestore: do not try to store a file set to nostore

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -297,6 +297,13 @@ void FileApplyTxFlags(const AppLayerTxData *txd, const uint8_t direction, File *
     uint16_t update_flags = FileFlowFlagsToFlags(txd->file_flags, direction);
     DEBUG_VALIDATE_BUG_ON(
             (file->flags & (FILE_STORE | FILE_NOSTORE)) == (FILE_STORE | FILE_NOSTORE));
+    // May happen with keyword filestore:both,flow :
+    // There may be one opened unclosed file in one direction without filestore
+    // As such it has file->flags & FILE_NOSTORE
+    // But a new file in the other direction may trigger filestore:both,flow
+    // And thus set txd->file_flags & FILE_STORE
+    if (file->flags & FILE_NOSTORE)
+        update_flags &= ~FILE_STORE;
     if (file->flags & FILE_STORE)
         update_flags &= ~FILE_NOSTORE;
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6390

Describe changes:
- filestore: do not try to store a file set to nostore

use of keyword `filestore:both,flow` may try to store a file that has already been opened (in the other direction) and set to nostore...

```
SV_BRANCH=pr/1524
```
https://github.com/OISF/suricata-verify/pull/1524

#9996 rebased