### PR TITLE
hugepages: run hugepage check only on DPDK runmode and on Linux v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2974,7 +2974,10 @@ int SuricataMain(int argc, char **argv)
         goto out;
     }
 
-    SystemHugepageSnapshot *prerun_snap = SystemHugepageSnapshotCreate();
+    SystemHugepageSnapshot *prerun_snap = NULL;
+    if (run_mode == RUNMODE_DPDK)
+        prerun_snap = SystemHugepageSnapshotCreate();
+
     SCSetStartTime(&suricata);
     RunModeDispatch(suricata.run_mode, suricata.runmode_custom_mode,
             suricata.capture_plugin_name, suricata.capture_plugin_args);
@@ -3032,13 +3035,12 @@ int SuricataMain(int argc, char **argv)
     OnNotifyRunning();
 
     PostRunStartedDetectSetup(&suricata);
-
-    SystemHugepageSnapshot *postrun_snap = SystemHugepageSnapshotCreate();
-    if (run_mode == RUNMODE_DPDK) // only DPDK uses hpages at the moment
+    if (run_mode == RUNMODE_DPDK) { // only DPDK uses hpages at the moment
+        SystemHugepageSnapshot *postrun_snap = SystemHugepageSnapshotCreate();
         SystemHugepageEvaluateHugepages(prerun_snap, postrun_snap);
-    SystemHugepageSnapshotDestroy(prerun_snap);
-    SystemHugepageSnapshotDestroy(postrun_snap);
-
+        SystemHugepageSnapshotDestroy(prerun_snap);
+        SystemHugepageSnapshotDestroy(postrun_snap);
+    }
     SCPledge();
     SuricataMainLoop(&suricata);
 

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -47,6 +47,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE(SC_EINVAL);
         CASE_CODE(SC_ELIMIT);
         CASE_CODE(SC_EEXIST);
+        CASE_CODE(SC_ENOENT);
 
         CASE_CODE (SC_ERR_MAX);
     }

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -30,6 +30,7 @@ typedef enum {
     SC_EINVAL,
     SC_ELIMIT,
     SC_EEXIST,
+    SC_ENOENT,
 
     SC_ERR_MAX
 } SCError;

--- a/src/util-hugepages.c
+++ b/src/util-hugepages.c
@@ -38,15 +38,15 @@ static void SystemHugepageSnapshotDump(SystemHugepageSnapshot *s);
 
 static bool SystemHugepageSupported(void)
 {
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if defined __linux__
     return true;
 #else
     return false;
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
 }
 
-// block of all hugepage-specific internal functions
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+// block of all hugepage-specific internal functions (can be available on Linux, FreeBSD)
+#if defined __linux__
 
 /**
  * \brief Linux-specific function to detect number of NUMA nodes on the system
@@ -57,7 +57,7 @@ static uint16_t SystemNodeCountGetLinux(void)
     char dir_path[] = "/sys/devices/system/node/";
     DIR *dir = opendir(dir_path);
     if (dir == NULL) {
-        SCLogError("unable to open %s", dir_path);
+        SCLogInfo("unable to open %s", dir_path);
         return 0;
     }
 
@@ -83,7 +83,7 @@ static uint16_t SystemHugepageSizesCntPerNodeGetLinux(uint16_t node_index)
     snprintf(dir_path, sizeof(dir_path), "/sys/devices/system/node/node%d/hugepages/", node_index);
     DIR *dir = opendir(dir_path);
     if (dir == NULL) {
-        SCLogError("unable to open %s", dir_path);
+        SCLogInfo("unable to open %s", dir_path);
         return 0;
     }
 
@@ -112,7 +112,7 @@ static void SystemHugepagePerNodeGetHugepageSizesLinux(
     snprintf(dir_path, sizeof(dir_path), "/sys/devices/system/node/node%d/hugepages/", node_index);
     DIR *dir = opendir(dir_path);
     if (dir == NULL) {
-        SCLogError("unable to open %s", dir_path);
+        SCLogInfo("unable to open %s", dir_path);
         return;
     }
     uint16_t index = 0;
@@ -146,11 +146,11 @@ static int16_t SystemHugepagePerNodeGetHugepageInfoLinux(
                 node_index, hp_sizes[i]);
         FILE *f = fopen(path, "r");
         if (!f) {
-            SCLogError("unable to open %s", path);
-            return -SC_EEXIST;
+            SCLogInfo("unable to open %s", path);
+            return -SC_ENOENT;
         }
         if (fscanf(f, "%hu", &hugepages[i].allocated) != 1) {
-            SCLogError("failed to read the total number of allocated hugepages (%ukB) on node %hu",
+            SCLogInfo("failed to read the total number of allocated hugepages (%ukB) on node %hu",
                     hp_sizes[i], node_index);
             fclose(f);
             return -SC_EINVAL;
@@ -162,11 +162,11 @@ static int16_t SystemHugepagePerNodeGetHugepageInfoLinux(
                 node_index, hp_sizes[i]);
         f = fopen(path, "r");
         if (!f) {
-            SCLogError("unable to open %s", path);
-            return -SC_EEXIST;
+            SCLogInfo("unable to open %s", path);
+            return -SC_ENOENT;
         }
         if (fscanf(f, "%hu", &hugepages[i].free) != 1) {
-            SCLogError("failed to read the total number of free hugepages (%ukB) on node %hu",
+            SCLogInfo("failed to read the total number of free hugepages (%ukB) on node %hu",
                     hp_sizes[i], node_index);
             fclose(f);
             return -SC_EINVAL;
@@ -177,7 +177,7 @@ static int16_t SystemHugepagePerNodeGetHugepageInfoLinux(
     return 0;
 }
 
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
 
 /**
  * \brief The function gathers information about hugepages on a given node
@@ -189,8 +189,8 @@ static int16_t SystemHugepagePerNodeGetHugepageInfo(uint16_t node_index, NodeInf
 {
     uint16_t hp_sizes_cnt = SystemHugepageSizesCntPerNodeGet(node_index);
     if (hp_sizes_cnt == 0) {
-        SCLogError("hugepages not found for node %d", node_index);
-        return -SC_EEXIST;
+        SCLogInfo("hugepages not found for node %d", node_index);
+        return -SC_ENOENT;
     }
     uint32_t *hp_sizes = SCCalloc(hp_sizes_cnt, sizeof(*hp_sizes));
     if (hp_sizes == NULL) {
@@ -202,10 +202,10 @@ static int16_t SystemHugepagePerNodeGetHugepageInfo(uint16_t node_index, NodeInf
     node->num_hugepage_sizes = hp_sizes_cnt;
 
     int16_t ret = 0;
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if defined __linux__
     ret = SystemHugepagePerNodeGetHugepageInfoLinux(
             node->hugepages, hp_sizes, node->num_hugepage_sizes, node_index);
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
 
     SCFree(hp_sizes);
     return ret;
@@ -217,9 +217,9 @@ static int16_t SystemHugepagePerNodeGetHugepageInfo(uint16_t node_index, NodeInf
  */
 static uint16_t SystemNodeCountGet(void)
 {
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if defined __linux__
     return SystemNodeCountGetLinux();
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
     return 0;
 }
 
@@ -229,9 +229,9 @@ static uint16_t SystemNodeCountGet(void)
  */
 static uint16_t SystemHugepageSizesCntPerNodeGet(uint16_t node_index)
 {
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if defined __linux__
     return SystemHugepageSizesCntPerNodeGetLinux(node_index);
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
     return 0;
 }
 
@@ -245,9 +245,9 @@ static uint16_t SystemHugepageSizesCntPerNodeGet(uint16_t node_index)
 static void SystemHugepagePerNodeGetHugepageSizes(
         uint16_t node_index, uint16_t hp_sizes_cnt, uint32_t *hp_sizes)
 {
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+#if defined __linux__
     return SystemHugepagePerNodeGetHugepageSizesLinux(node_index, hp_sizes_cnt, hp_sizes);
-#endif /* !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun */
+#endif /* defined __linux__ */
 }
 
 static HugepageInfo *SystemHugepageHugepageInfoCreate(uint16_t hp_size_cnt)
@@ -325,7 +325,7 @@ SystemHugepageSnapshot *SystemHugepageSnapshotCreate(void)
 
     uint16_t node_cnt = SystemNodeCountGet();
     if (node_cnt == 0) {
-        SCLogError("failed to obtain number of NUMA nodes in the system");
+        SCLogInfo("hugepage snapshot failed - cannot obtain number of NUMA nodes in the system");
         return NULL;
     }
     NodeInfo *nodes = SCCalloc(node_cnt, sizeof(*nodes));


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata/pull/10358

The previous implementation allowed FreeBSD to enter into the hugepage analysis. It then failed with an error message because hugepage/ NUMA node paths that are used in the codebase to retrieve info about the system are not the same as the structure in Linux.

Additionally, the messages were logged on an error level. It has been demoted to the info level because the whole hugepage analysis checkup is only for informational purposes and does not affect Suricata operation.

The hugepage analysis and the hugepage snapshots are now limited to only run in the DPDK runmode.

Ticket: https://github.com/OISF/suricata/pull/6760
https://redmine.openinfosecfoundation.org/issues/6760
Ticket: https://github.com/OISF/suricata/pull/6762
https://redmine.openinfosecfoundation.org/issues/6762