### PR TITLE
dpdk: sanitize integer overflow in the configuration v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -475,6 +475,9 @@ static int ConfigSetMempoolSize(DPDKIfaceConfig *iconf, intmax_t entry_int)
     if (entry_int <= 0) {
         SCLogError("%s: positive memory pool size is required", iconf->iface);
         SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT32_MAX) {
+        SCLogError("%s: memory pool size cannot exceed %" PRIu32, iconf->iface, UINT32_MAX);
+        SCReturnInt(-ERANGE);
     }
 
     iconf->mempool_size = entry_int;
@@ -521,6 +524,9 @@ static int ConfigSetRxDescriptors(DPDKIfaceConfig *iconf, intmax_t entry_int)
     if (entry_int <= 0) {
         SCLogError("%s: positive number of RX descriptors is required", iconf->iface);
         SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT16_MAX) {
+        SCLogError("%s: number of RX descriptors cannot exceed %" PRIu16, iconf->iface, UINT16_MAX);
+        SCReturnInt(-ERANGE);
     }
 
     iconf->nb_rx_desc = entry_int;
@@ -532,6 +538,9 @@ static int ConfigSetTxDescriptors(DPDKIfaceConfig *iconf, intmax_t entry_int)
     SCEnter();
     if (entry_int <= 0) {
         SCLogError("%s: positive number of TX descriptors is required", iconf->iface);
+        SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT16_MAX) {
+        SCLogError("%s: number of TX descriptors cannot exceed %" PRIu16, iconf->iface, UINT16_MAX);
         SCReturnInt(-ERANGE);
     }
 


### PR DESCRIPTION
Ticket: #6737
https://redmine.openinfosecfoundation.org/issues/6737

Describe changes:
- check the value of the integer for the max uin16/32_t before assigning it to the variable