### PR TITLE
Fix stats for interface with dots v4

### DIFF
--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -483,3 +483,7 @@ void JsonStatsLogRegister(void) {
         "eve-log.stats", OutputStatsLogInitSub, JsonStatsLogger,
         JsonStatsLogThreadInit, JsonStatsLogThreadDeinit, NULL);
 }
+
+#ifdef UNITTESTS
+#include "tests/output-json-stats.c"
+#endif

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -36,6 +36,7 @@
 #include "util-print.h"
 #include "util-time.h"
 #include "util-unittest.h"
+#include "util-validate.h"
 
 #include "util-debug.h"
 #include "output.h"
@@ -265,10 +266,22 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
         for (x = 0; x < st->ntstats; x++) {
             uint32_t offset = x * st->nstats;
 
+            // Stats for for this thread.
+            json_t *thread = json_object();
+            if (unlikely(thread == NULL)) {
+                json_decref(js_stats);
+                json_decref(threads);
+                return NULL;
+            }
+
             /* for each counter */
             for (u = offset; u < (offset + st->nstats); u++) {
                 if (st->tstats[u].name == NULL)
                     continue;
+
+                // Seems this holds, but assert in debug builds.
+                DEBUG_VALIDATE_BUG_ON(
+                        strcmp(st->tstats[offset].tm_name, st->tstats[u].tm_name) != 0);
 
                 json_t *js_type = NULL;
                 const char *stat_name = st->tstats[u].short_name;
@@ -276,9 +289,7 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                     stat_name = st->tstats[u].name;
                     js_type = threads;
                 } else {
-                    char str[256];
-                    snprintf(str, sizeof(str), "%s.%s", st->tstats[u].tm_name, st->tstats[u].name);
-                    js_type = OutputStats2Json(threads, str);
+                    js_type = OutputStats2Json(thread, st->tstats[u].name);
                 }
 
                 if (js_type != NULL) {
@@ -292,6 +303,7 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
                     }
                 }
             }
+            json_object_set_new(threads, st->tstats[offset].tm_name, thread);
         }
         json_object_set_new(js_stats, "threads", threads);
     }

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -35,4 +35,6 @@ TmEcode OutputEngineStatsReloadTime(json_t **jdata);
 TmEcode OutputEngineStatsRuleset(json_t **jdata);
 void JsonStatsLogRegister(void);
 
+void OutputJsonStatsRegisterTests(void);
+
 #endif /* __OUTPUT_JSON_COUNTERS_H__ */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -114,6 +114,8 @@
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
 
+#include "output-json-stats.h"
+
 #ifdef OS_WIN32
 #include "win32-syscall.h"
 #endif
@@ -215,6 +217,7 @@ static void RegisterUnittests(void)
 #endif
     SCProtoNameRegisterTests();
     UtilCIDRTests();
+    OutputJsonStatsRegisterTests();
 }
 #endif
 

--- a/src/tests/output-json-stats.c
+++ b/src/tests/output-json-stats.c
@@ -1,0 +1,70 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "../suricata-common.h"
+
+#include "../output-json-stats.h"
+
+#include "../util-unittest.h"
+
+static int OutputJsonStatsTest01(void)
+{
+    StatsRecord global_records[] = { { 0 }, { 0 } };
+    StatsRecord thread_records[2];
+    thread_records[0].name = "capture.kernel_packets";
+    thread_records[0].short_name = "kernel_packets";
+    thread_records[0].tm_name = "W#01-bond0.30";
+    thread_records[0].value = 42;
+    thread_records[1].name = "capture.kernel_drops";
+    thread_records[1].short_name = "kernel_drops";
+    thread_records[1].tm_name = "W#01-bond0.30";
+    thread_records[1].value = 4711;
+
+    StatsTable table = {
+        .nstats = 2,
+        .stats = &global_records[0],
+        .ntstats = 1,
+        .tstats = &thread_records[0],
+    };
+
+    json_t *r = StatsToJSON(&table, JSON_STATS_TOTALS | JSON_STATS_THREADS);
+    if (!r)
+        return 0;
+
+    // Remove variable content
+    json_object_del(r, "uptime");
+
+    char *serialized = json_dumps(r, 0);
+
+    // Cheesy comparison
+    const char *expected = "{\"threads\": {\"W#01-bond0.30\": {\"capture\": {\"kernel_packets\": "
+                           "42, \"kernel_drops\": 4711}}}}";
+
+    int cmp_result = strcmp(expected, serialized);
+    if (cmp_result != 0)
+        printf("unexpected result\nexpected=%s\ngot=%s\n", expected, serialized);
+
+    free(serialized);
+    json_decref(r);
+
+    return cmp_result == 0;
+}
+
+void OutputJsonStatsRegisterTests(void)
+{
+    UtRegisterTest("OutputJsonStatsTest01", OutputJsonStatsTest01);
+}


### PR DESCRIPTION
Replaces #10363  

Changes since v3:
* Move unit tests under src/tests/output-json-test.c

Changes since v2:
* Rebase
* More newlines and moving register function in runmode-unittests.c to the end

Changes since v1:
* Squash the fixups for CI runs.
* Add a unit test calling StatsToJSON() verifying the dot of `bond0.30` isn't expanded into a nested object anymore.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to redmine: [6732](https://redmine.openinfosecfoundation.org/issues/6732)

Describe changes:

When an interface with dots is used, per worker stats are nested by the dot-separated-components of the interface due to the usage of OutputStats2Json().

Prevent this by using OutputStats2Json() on a per-thread specific object and setting this object into the threads object using the json_object_set_new() which won't do the dot expansion.

This was tested by creating an interface with dots in the name and checking the stats.

    ip link add name a.b.c type dummy

With Suricata 7.0.2, sniffing on the a.b.c interface results in the following worker stats format:

    "threads": {
      "W#01-a": {
        "b": {
          "c": {
            "capture": {
              "kernel_packets": 0,

After this fix, the output looks as follows:

    "threads": {
      "W#01-a.b.c": {
        "capture": {
          "kernel_packets": 0,


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```