### PR TITLE
dns: add missing dns keywords to schema.json v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -999,6 +999,9 @@
                     "description": "DNS opcode as an integer",
                     "type": "integer"
                 },
+                "tc": {
+                    "type": "boolean"
+                },
                 "answers": {
                     "type": "array",
                     "minItems": 1,
@@ -1030,6 +1033,21 @@
                                         "type": "integer"
                                     },
                                     "weight": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "sshfp": {
+                                "type": "object",
+                                "properties": {
+                                    "fingerprint": {
+                                        "type": "string"
+                                    },
+                                    "algo": {
+                                        "type": "integer"
+                                    },
+                                    "type": {
                                         "type": "integer"
                                     }
                                 },
@@ -1189,6 +1207,25 @@
                             "minItems": 1,
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "SSHFP": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "fingerprint": {
+                                        "type": "string"
+                                    },
+                                    "algo": {
+                                        "type": "integer"
+                                    },
+                                    "type": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": false
                             }
                         }
                     },


### PR DESCRIPTION
Feature #5642

- [x] I have read the contributing guide lines at https://docs.suricata.io/en/latest/devguide/codebase/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata.io/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/5642) ticket: https://redmine.openinfosecfoundation.org/issues/5642

Previous PR: https://github.com/OISF/suricata/pull/10193

Describe changes:
- Added tc boolean field to dns object in schema.json file
- Added sshfp field in dns.answers and dns.grouped in schema.json
- SV tests are passing:
```
===> dns/dns-sshfp: OK

PASSED:  1
FAILED:  0
SKIPPED: 0
```
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1588