### PR TITLE
github-ci: more fixes - v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/rust"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "rust:"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "github-actions:"
+    ignore:
+      - dependency-name: "actions/cache"
+        versions: ["3.x"]
+      - dependency-name: "actions/checkout"
+        versions: ["3.x"]

--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -3,6 +3,8 @@ name: New Authors Check
 on:
   pull_request:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -29,7 +29,7 @@ jobs:
           touch new-authors.txt
           while read -r author; do
              echo "Checking author: ${author}"
-             if ! grep -q "^${author}\$" authors.txt; then
+             if ! grep -qFx "${author}" authors.txt; then
                  echo "ERROR: ${author} NOT FOUND"
                  echo "::warning ::New author found: ${author}"
                  echo "${author}" >> new-authors.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '18 21 * * 1'
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - "doc/**"
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
- github-ci: apply read-only permissions to more workflows
- dependabot: ignore actions/{cache,checkout} v3
- dependabot: disable rust checks
- github-ci: fix authors check with special characters

The ignore for actions/cache and checkout v3 is a bit of an unknown as I
haven't been able to trigger dependabot deep enough to see.
