### PR TITLE
multi-tenant: fix coverity warning

### DIFF
--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -578,8 +578,8 @@ static TmEcode DetectLoaderThreadInit(ThreadVars *t, const void *initdata, void 
 
     DetectLoaderControl *loader = &loaders[ftd->instance];
     SCMutexLock(&loader->m);
-    loader->tv = t;
     SCMutexUnlock(&loader->m);
+    loader->tv = t;
 
     return TM_ECODE_OK;
 }

--- a/src/detect-engine-loader.h
+++ b/src/detect-engine-loader.h
@@ -43,10 +43,14 @@ typedef struct DetectLoaderTask_ {
 
 typedef struct DetectLoaderControl_ {
     int id;
-    int result;     /* 0 for ok, error otherwise */
-    ThreadVars *tv; /* loader threads threadvars - for waking them up */
-    SCMutex m;
-    TAILQ_HEAD(, DetectLoaderTask_) task_list;
+    ThreadVars *tv; /**< loader threads threadvars - for waking them up */
+
+    /** struct to group members and mutex */
+    struct {
+        SCMutex m;  /**< mutex protects result and task_list */
+        int result; /**< 0 for ok, error otherwise */
+        TAILQ_HEAD(, DetectLoaderTask_) task_list;
+    };
 } DetectLoaderControl;
 
 int DetectLoaderQueueTask(int loader_id, LoaderFunc Func, void *func_ctx, LoaderFreeFunc FreeFunc);


### PR DESCRIPTION
Rework locking logic to avoid the following coverity warning.

** CID 1591966:  Concurrent data access violations  (MISSING_LOCK)
/src/detect-engine-loader.c: 475 in DetectLoadersSync()

    474                     SCCtrlMutexLock(loader->tv->ctrl_mutex);
    >>>     CID 1591966:  Concurrent data access violations  (MISSING_LOCK)
    >>>     Accessing "loader->tv" without holding lock "DetectLoaderControl_.m". Elsewhere, "DetectLoaderControl_.tv" is written to with "DetectLoaderControl_.m" held 1 out of 1 times (1 of these accesses strongly imply that it is necessary).
    475                     pthread_cond_broadcast(loader->tv->ctrl_cond);
    476                     SCCtrlMutexUnlock(loader->tv->ctrl_mutex);

The warning itself is harmless.

Rebase and clarify #10395