### PR TITLE
ci: right sha for authors check

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Export known authors from master branch
         run: git log --format="%an <%ae>" origin/master | sort | uniq > authors.txt
       - name: Export authors from new commits
-        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > commit-authors.txt
+        run: git log --format="%an <%ae>" ${{ github.event.pull_request.base.sha }}... | sort | uniq > commit-authors.txt
       - name: Check new authors
         run: |
           touch new-authors.txt


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None

Describe changes:
- ci/authors: use the right commit hashes

Fixes the case, where someone made a PR with an old version of master, and the newly commits merged to master had a new author, because of GitHub process/magic to do a merge...

https://github.com/OISF/suricata/pull/10408 with cleaner PR history after multiple CI tries