### PR TITLE
multi-tenant: remove futile mutex lock

### DIFF
--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -577,8 +577,6 @@ static TmEcode DetectLoaderThreadInit(ThreadVars *t, const void *initdata, void 
     *data = ftd;
 
     DetectLoaderControl *loader = &loaders[ftd->instance];
-    SCMutexLock(&loader->m);
-    SCMutexUnlock(&loader->m);
     loader->tv = t;
 
     return TM_ECODE_OK;


### PR DESCRIPTION
This made sense theoretically. Nothing failed locally. No other occurences of such a pattern was found in the code. Checking how it goes w the CI to check if I'm missing some detail.