### PR TITLE
detect/cip: add check for sscanf return-value - v5

### DIFF
--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -157,7 +157,10 @@ static DetectCipServiceData *DetectCipServiceParse(const char *rulestrc)
             goto error;
         }
 
-        sscanf(token, "%2" SCNu8, &var);
+        if (sscanf(token, "%2" SCNu8, &var) != 1) {
+            SCLogError("incorrect input format; token %s should be uint8", token);
+            goto error;
+        }
         input[i++] = var;
 
         token = strtok_r(NULL, delims, &save);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6753

Previous PR: #10418

Describe changes:
- Format specifier used on message for SCLogError re: sscanf [line 161] was wrong.