### PR TITLE
Decode ppoe pointer arithmetic 6787 v3

### DIFF
--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -80,11 +80,6 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             return TM_ECODE_OK;
     }
 
-    /* parse any tags we have in the packet */
-
-    uint32_t tag_length = 0;
-    const uint8_t* pkt_pppoedt = pkt + PPPOE_DISCOVERY_HEADER_MIN_LEN;
-
     uint32_t pppoe_length = SCNtohs(p->pppoedh->pppoe_length);
     uint32_t packet_length = len - PPPOE_DISCOVERY_HEADER_MIN_LEN ;
 
@@ -97,12 +92,15 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_OK;
     }
 
-    while (pkt_pppoedt < pkt_pppoedt + (len - sizeof(PPPOEDiscoveryTag)) && pppoe_length >=4 && packet_length >=4)
-    {
-        PPPOEDiscoveryTag* pppoedt = (PPPOEDiscoveryTag*)pkt_pppoedt;
 #ifdef DEBUG
+    /* parse any tags we have in the packet */
+
+    uint32_t tag_length = 0;
+    const uint8_t *pkt_pppoedt = pkt + PPPOE_DISCOVERY_HEADER_MIN_LEN;
+    while (pkt_pppoedt < pkt_pppoedt + (len - sizeof(PPPOEDiscoveryTag)) && pppoe_length >= 4 &&
+            packet_length >= 4) {
+        PPPOEDiscoveryTag *pppoedt = (PPPOEDiscoveryTag *)pkt_pppoedt;
         uint16_t tag_type = SCNtohs(pppoedt->pppoe_tag_type);
-#endif
         // upgrade to u32 to avoid u16 overflow
         tag_length = SCNtohs(pppoedt->pppoe_tag_length);
 
@@ -122,6 +120,7 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
         pkt_pppoedt = pkt_pppoedt + (4 + tag_length);
     }
+#endif
 
     return TM_ECODE_OK;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6787

Describe changes:
- decode/pppoe: fix pointer arithmetic, and do in only in debug mode because it is useless otherwise

#10461 with compilation warning fixed by taking more code into the #ifdef DEBUG section