### PR TITLE
backport 7.0.x: tcp: do not assign TCP flags to pseudopackets v1

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -213,7 +213,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
     }
 
     p->tcph->th_offx2 = 0x50;
-    p->tcph->th_flags |= TH_ACK;
+    p->tcph->th_flags = 0;
     p->tcph->th_win = 10;
     p->tcph->th_urp = 0;
 


### PR DESCRIPTION
Backport of: https://github.com/OISF/suricata/pull/10473
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6734

Previously pseudopackets were assigned with ACK flag which falsely turned "SYN" flows to "SYN/ACK" flows when Suricata ran with raw content-matching rules. The problem occured during the flow timeout or Suricata shutdown, essentially, when the flow was being kicked out (with a pseudopacket).

When Suricata ran without raw content-matching rules (the ruleset did not contain content matching keywords or it only contained keywords that are app-layer content-matching) then raw stream reassembly tracking is turned off (SignatureHasStreamContent()).
This in turn disabled a check in StreamNeedsReassembly() and the right edge was not checked with the raw stream progress. In turn, it did not generate a pseudopacket that would go through the detection engine. Suricata with raw content-matching keywords would therefore on a flow with SYN packet only return STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION which would generate the pseudopacket.

In Suricata versions <= 6.0.x, the flow output was correct because only the commit 1bb6f44ff01363fa29488f1ae83b9368e33c2770 started to differentiate the right edge calculation between the raw and application layer streams. The older Suricata versions used only the application layer right edge equation and therefore did not generate a pseudopacket.

Ticket: #6734
(cherry picked from commit ebf465a11bffcd2049e17648e6c46c067692b02a)
