### PR TITLE
examples/lib: fix for non-bundled libhtp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,8 @@ EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
 	     scripts/generate-images.sh \
 	     examples/plugins
 SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib etc python ebpf \
-          $(SURICATA_UPDATE_DIR) examples/lib/simple
+          $(SURICATA_UPDATE_DIR)
+DIST_SUBDIRS = $(SUBDIRS) examples/lib/simple
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -1660,6 +1660,7 @@
         fi
     fi
 
+    AM_CONDITIONAL([HTP_LDADD], [test "x${HTP_LDADD}" != "x"])
 
   # Check for libcap-ng
     case $host in

--- a/examples/lib/simple/Makefile.am
+++ b/examples/lib/simple/Makefile.am
@@ -5,5 +5,8 @@ simple_SOURCES = main.c
 AM_CPPFLAGS = -I$(top_srcdir)/src
 
 simple_LDFLAGS = $(all_libraries) $(SECLDFLAGS)
-simple_LDADD = $(top_builddir)/src/libsuricata_c.a ../../$(RUST_SURICATA_LIB) ../../$(HTP_LDADD) $(RUST_LDADD)
+simple_LDADD = $(top_builddir)/src/libsuricata_c.a ../../$(RUST_SURICATA_LIB) $(RUST_LDADD)
+if HTP_LDADD
+simple_LDADD += ../../$(HTP_LDADD)
+endif
 simple_DEPENDENCIES = $(top_builddir)/src/libsuricata_c.a ../../$(RUST_SURICATA_LIB)


### PR DESCRIPTION
- fixes building of the lib example when libhtp is not bundled
- don't build the example by deafult