### PR TITLE
libsuricata: reorganize SuricataMain code

### DIFF
--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -2,6 +2,17 @@
 
 int main(int argc, char **argv)
 {
-    SuricataMain(argc, argv);
+    SuricataPreInit(argv[0]);
+    SuricataInit(argc, argv);
+    SuricataPostInit();
+
+    /* Suricata is now running, but we enter a loop to keep it running
+     * until it shouldn't be running anymore. */
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
     return 0;
 }

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -191,8 +191,14 @@ int SuriHasSigFile(void);
 
 extern int run_mode;
 
+void SuricataPreInit(const char *progname);
+void SuricataInit(int argc, char **argv);
+void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataMainLoop(void);
+void SuricataShutdown(void);
 int InitGlobal(void);
+void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 


### PR DESCRIPTION
Split SuricataMain code in smaller functions. This is a first step towards running as a library.
Updated "examples/lib/simple/main.c" to reflect the changes.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ x ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ x ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ x ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Previous PR: https://github.com/OISF/suricata/pull/10483
Describe changes:
- Reorganize SuricataMain into modular function calls accessible from suricata.h.
- Reproduce SuricataMain functionalities in `examples/lib/simple/main.c`.
-

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
