### PR TITLE
eve: revert ethernet addresses when needed

### DIFF
--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -281,7 +281,7 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
     /* Close flow. */
     jb_close(jb);
 
-    EveAddCommonOptions(&aft->ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&aft->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW);
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -275,7 +275,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
     NetFlowLogEveToServer(jb, f);
-    EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW_TOSERVER);
     OutputJsonBuilderBuffer(jb, jhl);
     jb_free(jb);
 
@@ -285,7 +285,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
         if (unlikely(jb == NULL))
             return TM_ECODE_OK;
         NetFlowLogEveToClient(jb, f);
-        EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
+        EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW_TOCLIENT);
         OutputJsonBuilderBuffer(jb, jhl);
         jb_free(jb);
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -82,7 +82,8 @@
 
 static void OutputJsonDeInitCtx(OutputCtx *);
 static void CreateEveCommunityFlowId(JsonBuilder *js, const Flow *f, const uint16_t seed);
-static int CreateJSONEther(JsonBuilder *parent, const Packet *p, const Flow *f);
+static int CreateJSONEther(
+        JsonBuilder *parent, const Packet *p, const Flow *f, enum OutputJsonLogDirection dir);
 
 static const char *TRAFFIC_ID_PREFIX = "traffic/id/";
 static const char *TRAFFIC_LABEL_PREFIX = "traffic/label/";
@@ -416,14 +417,14 @@ void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
     }
 }
 
-void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, JsonBuilder *js)
+void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, const Flow *f,
+        JsonBuilder *js, enum OutputJsonLogDirection dir)
 {
     if (cfg->include_metadata) {
         EveAddMetadata(p, f, js);
     }
     if (cfg->include_ethernet) {
-        CreateJSONEther(js, p, f);
+        CreateJSONEther(js, p, f, dir);
     }
     if (cfg->include_community_id && f != NULL) {
         CreateEveCommunityFlowId(js, f, cfg->community_id_seed);
@@ -746,14 +747,49 @@ static int MacSetIterateToJSON(uint8_t *val, MacSetSide side, void *data)
     return 0;
 }
 
-static int CreateJSONEther(JsonBuilder *js, const Packet *p, const Flow *f)
+static int CreateJSONEther(
+        JsonBuilder *js, const Packet *p, const Flow *f, enum OutputJsonLogDirection dir)
 {
     if (p != NULL) {
         /* this is a packet context, so we need to add scalar fields */
         if (p->ethh != NULL) {
             jb_open_object(js, "ether");
-            uint8_t *src = p->ethh->eth_src;
-            uint8_t *dst = p->ethh->eth_dst;
+            uint8_t *src;
+            uint8_t *dst;
+            switch (dir) {
+                case LOG_DIR_FLOW:
+                    if (PKT_IS_TOCLIENT(p)) {
+                        src = p->ethh->eth_dst;
+                        dst = p->ethh->eth_src;
+                    } else {
+                        src = p->ethh->eth_src;
+                        dst = p->ethh->eth_dst;
+                    }
+                    break;
+                case LOG_DIR_FLOW_TOCLIENT:
+                    if (PKT_IS_TOSERVER(p)) {
+                        src = p->ethh->eth_dst;
+                        dst = p->ethh->eth_src;
+                    } else {
+                        src = p->ethh->eth_src;
+                        dst = p->ethh->eth_dst;
+                    }
+                    break;
+                case LOG_DIR_FLOW_TOSERVER:
+                    if (PKT_IS_TOCLIENT(p)) {
+                        src = p->ethh->eth_dst;
+                        dst = p->ethh->eth_src;
+                    } else {
+                        src = p->ethh->eth_src;
+                        dst = p->ethh->eth_dst;
+                    }
+                    break;
+                case LOG_DIR_PACKET:
+                default:
+                    src = p->ethh->eth_src;
+                    dst = p->ethh->eth_dst;
+                    break;
+            }
             JSONFormatAndAddMACAddr(js, "src_mac", src, false);
             JSONFormatAndAddMACAddr(js, "dest_mac", dst, false);
             jb_close(js);
@@ -777,8 +813,14 @@ static int CreateJSONEther(JsonBuilder *js, const Packet *p, const Flow *f)
             }
             jb_close(info.dst);
             jb_close(info.src);
-            jb_set_object(js, "dest_macs", info.dst);
-            jb_set_object(js, "src_macs", info.src);
+            /* case is handling netflow too so may need to revert */
+            if (dir == LOG_DIR_FLOW_TOCLIENT) {
+                jb_set_object(js, "dest_macs", info.src);
+                jb_set_object(js, "src_macs", info.dst);
+            } else {
+                jb_set_object(js, "dest_macs", info.dst);
+                jb_set_object(js, "src_macs", info.src);
+            }
             jb_free(info.dst);
             jb_free(info.src);
             jb_close(js);
@@ -867,7 +909,7 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
     jb_set_string(js, "pkt_src", PktSrcToString(p->pkt_src));
 
     if (eve_ctx != NULL) {
-        EveAddCommonOptions(&eve_ctx->cfg, p, f, js);
+        EveAddCommonOptions(&eve_ctx->cfg, p, f, js, dir);
     }
 
     return js;

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -110,8 +110,8 @@ OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
 TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
 TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 
-void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, JsonBuilder *js);
+void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, const Flow *f,
+        JsonBuilder *js, enum OutputJsonLogDirection dir);
 void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);


### PR DESCRIPTION
Update of #9651 fixing the formatting.

EVE logging has a direction parameter that can cause the logging of an application layer to be done in a direction that is not linked to the packet. As a result the source IP addres could be assigned the MAC address of the destination IP and reverse.

This patch addresses this by propagating the direction to the ethernet logging function and using it there to define the correct mapping.

Issue #6405

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6405

Describe changes:
- Fix formatting
- Rebase on master

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1667
