### PR TITLE
libsuricata: make the Suricata application a user of the Suricata library - v2

### DIFF
--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -2,6 +2,17 @@
 
 int main(int argc, char **argv)
 {
-    SuricataMain(argc, argv);
-    return 0;
+    SuricataPreInit(argv[0]);
+    SuricataInit(argc, argv);
+    SuricataPostInit();
+
+    /* Suricata is now running, but we enter a loop to keep it running
+     * until it shouldn't be running anymore. */
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
+    return EXIT_SUCCESS;
 }

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -14,7 +14,16 @@ int main(int argc, char **argv)
     }
 #endif /* OS_WIN32 */
 
-    SuricataInit(argc, argv);
+    /* Parse command line options. This is optional, you could
+     * directly configuration Suricata through the Conf API. */
+    SCParseCommandLine(argc, argv);
+
+    /* Validate/finalize the runmode. */
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    SuricataInit();
     SuricataPostInit();
 
     /* Suricata is now running, but we enter a loop to keep it running

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -23,6 +23,16 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Handle internal runmodes. Typically you wouldn't do this as a
+     * library however, however this example is showing how to
+     * replicate the Suricata application with the library. */
+    switch (SCStartInternalRunMode(argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
     SuricataInit();
     SuricataPostInit();
 

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -3,6 +3,17 @@
 int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* If on Windows, and you wanted initialize as a service, you
+     * might register that here. Its at this point in the
+     * initialization that the Suricata application initializes as a
+     * Windows service. */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
+
     SuricataInit(argc, argv);
     SuricataPostInit();
 

--- a/src/main.c
+++ b/src/main.c
@@ -19,5 +19,42 @@
 
 int main(int argc, char **argv)
 {
-    return SuricataMain(argc, argv);
+    /* Pre-initialization tasks: initialize global context and variables. */
+    SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* service initialization */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
+
+    if (SCParseCommandLine(argc, argv) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    switch (SCStartInternalRunMode(argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
+    /* Initialization tasks: Loading config, setup logging */
+    SuricataInit();
+
+    /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
+    SuricataPostInit();
+
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
+    exit(EXIT_SUCCESS);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1308,7 +1308,7 @@ static bool IsLogDirectoryWritable(const char* str)
 
 extern int g_skip_prefilter;
 
-static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
+static TmEcode ParseCommandLine(int argc, char **argv)
 {
     int opt;
 
@@ -1461,21 +1461,21 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* HAVE_PFRING */
             }
             else if (strcmp((long_opts[option_index]).name , "capture-plugin") == 0){
-                suri->run_mode = RUNMODE_PLUGIN;
-                suri->capture_plugin_name = optarg;
+                suricata.run_mode = RUNMODE_PLUGIN;
+                suricata.capture_plugin_name = optarg;
             }
             else if (strcmp((long_opts[option_index]).name , "capture-plugin-args") == 0){
-                suri->capture_plugin_args = optarg;
+                suricata.capture_plugin_args = optarg;
             } else if (strcmp((long_opts[option_index]).name, "dpdk") == 0) {
-                if (ParseCommandLineDpdk(suri, optarg) != TM_ECODE_OK) {
+                if (ParseCommandLineDpdk(&suricata, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
             } else if (strcmp((long_opts[option_index]).name, "af-packet") == 0) {
-                if (ParseCommandLineAfpacket(suri, optarg) != TM_ECODE_OK) {
+                if (ParseCommandLineAfpacket(&suricata, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
             } else if (strcmp((long_opts[option_index]).name, "af-xdp") == 0) {
-                if (ParseCommandLineAfxdp(suri, optarg) != TM_ECODE_OK) {
+                if (ParseCommandLineAfxdp(&suricata, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
             } else if (strcmp((long_opts[option_index]).name, "netmap") == 0) {
@@ -1517,7 +1517,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
 #endif /* HAVE_NFLOG */
             } else if (strcmp((long_opts[option_index]).name, "pcap") == 0) {
-                if (ParseCommandLinePcapLive(suri, optarg) != TM_ECODE_OK) {
+                if (ParseCommandLinePcapLive(&suricata, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
             } else if (strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
@@ -1530,8 +1530,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 }
 #ifdef BUILD_UNIX_SOCKET
             } else if (strcmp((long_opts[option_index]).name , "unix-socket") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_UNIX_SOCKET;
+                if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                    suricata.run_mode = RUNMODE_UNIX_SOCKET;
                     if (optarg) {
                         if (ConfSetFinal("unix-command.filename", optarg) != 1) {
                             SCLogError("failed to set unix-command.filename");
@@ -1552,49 +1552,49 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
             else if(strcmp((long_opts[option_index]).name, "list-unittests") == 0) {
 #ifdef UNITTESTS
-                suri->run_mode = RUNMODE_LIST_UNITTEST;
+                suricata.run_mode = RUNMODE_LIST_UNITTEST;
 #else
                 SCLogError("unit tests not enabled. Make sure to pass --enable-unittests to "
                            "configure when building");
                 return TM_ECODE_FAILED;
 #endif /* UNITTESTS */
             } else if (strcmp((long_opts[option_index]).name, "list-runmodes") == 0) {
-                suri->run_mode = RUNMODE_LIST_RUNMODES;
+                suricata.run_mode = RUNMODE_LIST_RUNMODES;
                 return TM_ECODE_OK;
             } else if (strcmp((long_opts[option_index]).name, "list-keywords") == 0) {
                 if (optarg) {
                     if (strcmp("short",optarg)) {
-                        suri->keyword_info = optarg;
+                        suricata.keyword_info = optarg;
                     }
                 }
             } else if (strcmp((long_opts[option_index]).name, "runmode") == 0) {
-                suri->runmode_custom_mode = optarg;
+                suricata.runmode_custom_mode = optarg;
             } else if(strcmp((long_opts[option_index]).name, "engine-analysis") == 0) {
                 // do nothing for now
             }
 #ifdef OS_WIN32
             else if(strcmp((long_opts[option_index]).name, "service-install") == 0) {
-                suri->run_mode = RUNMODE_INSTALL_SERVICE;
+                suricata.run_mode = RUNMODE_INSTALL_SERVICE;
                 return TM_ECODE_OK;
             }
             else if(strcmp((long_opts[option_index]).name, "service-remove") == 0) {
-                suri->run_mode = RUNMODE_REMOVE_SERVICE;
+                suricata.run_mode = RUNMODE_REMOVE_SERVICE;
                 return TM_ECODE_OK;
             }
             else if(strcmp((long_opts[option_index]).name, "service-change-params") == 0) {
-                suri->run_mode = RUNMODE_CHANGE_SERVICE_PARAMS;
+                suricata.run_mode = RUNMODE_CHANGE_SERVICE_PARAMS;
                 return TM_ECODE_OK;
             }
 #endif /* OS_WIN32 */
             else if(strcmp((long_opts[option_index]).name, "pidfile") == 0) {
-                suri->pid_filename = SCStrdup(optarg);
-                if (suri->pid_filename == NULL) {
+                suricata.pid_filename = SCStrdup(optarg);
+                if (suricata.pid_filename == NULL) {
                     SCLogError("strdup failed: %s", strerror(errno));
                     return TM_ECODE_FAILED;
                 }
             }
             else if(strcmp((long_opts[option_index]).name, "disable-detection") == 0) {
-                g_detect_disabled = suri->disabled_detect = 1;
+                g_detect_disabled = suricata.disabled_detect = 1;
             } else if (strcmp((long_opts[option_index]).name, "disable-hashing") == 0) {
                 g_disable_hashing = true;
             } else if (strcmp((long_opts[option_index]).name, "fatal-unittests") == 0) {
@@ -1611,8 +1611,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                            " drop privileges, but it was not compiled into Suricata.");
                 return TM_ECODE_FAILED;
 #else
-                suri->user_name = optarg;
-                suri->do_setuid = true;
+                suricata.user_name = optarg;
+                suricata.do_setuid = true;
 #endif /* HAVE_LIBCAP_NG */
             } else if (strcmp((long_opts[option_index]).name, "group") == 0) {
 #ifndef HAVE_LIBCAP_NG
@@ -1620,21 +1620,20 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                            " drop privileges, but it was not compiled into Suricata.");
                 return TM_ECODE_FAILED;
 #else
-                suri->group_name = optarg;
-                suri->do_setgid = true;
+                suricata.group_name = optarg;
+                suricata.do_setgid = true;
 #endif /* HAVE_LIBCAP_NG */
             } else if (strcmp((long_opts[option_index]).name, "erf-in") == 0) {
-                suri->run_mode = RUNMODE_ERF_FILE;
+                suricata.run_mode = RUNMODE_ERF_FILE;
                 if (ConfSetFinal("erf-file.file", optarg) != 1) {
                     SCLogError("failed to set erf-file.file");
                     return TM_ECODE_FAILED;
                 }
             } else if (strcmp((long_opts[option_index]).name, "dag") == 0) {
 #ifdef HAVE_DAG
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_DAG;
-                }
-                else if (suri->run_mode != RUNMODE_DAG) {
+                if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                    suricata.run_mode = RUNMODE_DAG;
+                } else if (suricata.run_mode != RUNMODE_DAG) {
                     SCLogError("more than one run mode has been specified");
                     PrintUsage(argv[0]);
                     return TM_ECODE_FAILED;
@@ -1647,7 +1646,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* HAVE_DAG */
             } else if (strcmp((long_opts[option_index]).name, "napatech") == 0) {
 #ifdef HAVE_NAPATECH
-                suri->run_mode = RUNMODE_NAPATECH;
+                suricata.run_mode = RUNMODE_NAPATECH;
 #else
                 SCLogError("libntapi and a Napatech adapter are required"
                            " to capture packets using --napatech.");
@@ -1664,16 +1663,16 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                            " doesn't support setting buffer size.");
 #endif /* HAVE_PCAP_SET_BUFF */
             } else if (strcmp((long_opts[option_index]).name, "build-info") == 0) {
-                suri->run_mode = RUNMODE_PRINT_BUILDINFO;
+                suricata.run_mode = RUNMODE_PRINT_BUILDINFO;
                 return TM_ECODE_OK;
             } else if (strcmp((long_opts[option_index]).name, "windivert-forward") == 0) {
 #ifdef WINDIVERT
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_WINDIVERT;
+                if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                    suricata.run_mode = RUNMODE_WINDIVERT;
                     if (WinDivertRegisterQueue(true, optarg) == -1) {
                         exit(EXIT_FAILURE);
                     }
-                } else if (suri->run_mode == RUNMODE_WINDIVERT) {
+                } else if (suricata.run_mode == RUNMODE_WINDIVERT) {
                     if (WinDivertRegisterQueue(true, optarg) == -1) {
                         exit(EXIT_FAILURE);
                     }
@@ -1685,12 +1684,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 }
             }
             else if(strcmp((long_opts[option_index]).name, "windivert") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_WINDIVERT;
+                if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                    suricata.run_mode = RUNMODE_WINDIVERT;
                     if (WinDivertRegisterQueue(false, optarg) == -1) {
                         exit(EXIT_FAILURE);
                     }
-                } else if (suri->run_mode == RUNMODE_WINDIVERT) {
+                } else if (suricata.run_mode == RUNMODE_WINDIVERT) {
                     if (WinDivertRegisterQueue(false, optarg) == -1) {
                         exit(EXIT_FAILURE);
                     }
@@ -1767,39 +1766,39 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                             optarg, optarg);
                     return TM_ECODE_FAILED;
                 }
-                suri->set_datadir = true;
+                suricata.set_datadir = true;
             } else if (strcmp((long_opts[option_index]).name , "strict-rule-keywords") == 0){
                 if (optarg == NULL) {
-                    suri->strict_rule_parsing_string = SCStrdup("all");
+                    suricata.strict_rule_parsing_string = SCStrdup("all");
                 } else {
-                    suri->strict_rule_parsing_string = SCStrdup(optarg);
+                    suricata.strict_rule_parsing_string = SCStrdup(optarg);
                 }
-                if (suri->strict_rule_parsing_string == NULL) {
+                if (suricata.strict_rule_parsing_string == NULL) {
                     FatalError("failed to duplicate 'strict' string");
                 }
             } else if (strcmp((long_opts[option_index]).name, "include") == 0) {
-                if (suri->additional_configs == NULL) {
-                    suri->additional_configs = SCCalloc(2, sizeof(char *));
-                    if (suri->additional_configs == NULL) {
+                if (suricata.additional_configs == NULL) {
+                    suricata.additional_configs = SCCalloc(2, sizeof(char *));
+                    if (suricata.additional_configs == NULL) {
                         FatalError(
                                 "Failed to allocate memory for additional configuration files: %s",
                                 strerror(errno));
                     }
-                    suri->additional_configs[0] = optarg;
+                    suricata.additional_configs[0] = optarg;
                 } else {
                     for (int i = 0;; i++) {
-                        if (suri->additional_configs[i] == NULL) {
-                            const char **additional_configs =
-                                    SCRealloc(suri->additional_configs, (i + 2) * sizeof(char *));
+                        if (suricata.additional_configs[i] == NULL) {
+                            const char **additional_configs = SCRealloc(
+                                    suricata.additional_configs, (i + 2) * sizeof(char *));
                             if (additional_configs == NULL) {
                                 FatalError("Failed to allocate memory for additional configuration "
                                            "files: %s",
                                         strerror(errno));
                             } else {
-                                suri->additional_configs = additional_configs;
+                                suricata.additional_configs = additional_configs;
                             }
-                            suri->additional_configs[i] = optarg;
-                            suri->additional_configs[i + 1] = NULL;
+                            suricata.additional_configs[i] = optarg;
+                            suricata.additional_configs[i + 1] = NULL;
                             break;
                         }
                     }
@@ -1812,7 +1811,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
             break;
         case 'c':
-            suri->conf_filename = optarg;
+            suricata.conf_filename = optarg;
             break;
         case 'T':
             conf_test = 1;
@@ -1823,11 +1822,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
 #ifndef OS_WIN32
         case 'D':
-            suri->daemon = 1;
+            suricata.daemon = 1;
             break;
 #endif /* OS_WIN32 */
         case 'h':
-            suri->run_mode = RUNMODE_PRINT_USAGE;
+            suricata.run_mode = RUNMODE_PRINT_USAGE;
             return TM_ECODE_OK;
         case 'i':
             if (optarg == NULL) {
@@ -1835,7 +1834,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
             }
 #ifdef HAVE_AF_PACKET
-            if (ParseCommandLineAfpacket(suri, optarg) != TM_ECODE_OK) {
+            if (ParseCommandLineAfpacket(&suricata, optarg) != TM_ECODE_OK) {
                 return TM_ECODE_FAILED;
             }
 #else /* not afpacket */
@@ -1898,17 +1897,17 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                         optarg, optarg);
                 return TM_ECODE_FAILED;
             }
-            suri->set_logdir = true;
+            suricata.set_logdir = true;
 
             break;
         case 'q':
 #ifdef NFQ
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_NFQ;
+            if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                suricata.run_mode = RUNMODE_NFQ;
                 EngineModeSetIPS();
                 if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
-            } else if (suri->run_mode == RUNMODE_NFQ) {
+            } else if (suricata.run_mode == RUNMODE_NFQ) {
                 if (NFQParseAndRegisterQueues(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
@@ -1925,12 +1924,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'd':
 #ifdef IPFW
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_IPFW;
+            if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                suricata.run_mode = RUNMODE_IPFW;
                 EngineModeSetIPS();
                 if (IPFWRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
-            } else if (suri->run_mode == RUNMODE_IPFW) {
+            } else if (suricata.run_mode == RUNMODE_IPFW) {
                 if (IPFWRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
@@ -1947,8 +1946,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'r':
             BUG_ON(optarg == NULL); /* for static analysis */
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_PCAP_FILE;
+            if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                suricata.run_mode = RUNMODE_PCAP_FILE;
             } else {
                 SCLogError("more than one run mode "
                            "has been specified");
@@ -1967,24 +1966,24 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 
             break;
         case 's':
-            if (suri->sig_file != NULL) {
+            if (suricata.sig_file != NULL) {
                 SCLogError("can't have multiple -s options or mix -s and -S.");
                 return TM_ECODE_FAILED;
             }
-            suri->sig_file = optarg;
+            suricata.sig_file = optarg;
             break;
         case 'S':
-            if (suri->sig_file != NULL) {
+            if (suricata.sig_file != NULL) {
                 SCLogError("can't have multiple -S options or mix -s and -S.");
                 return TM_ECODE_FAILED;
             }
-            suri->sig_file = optarg;
-            suri->sig_file_exclusive = true;
+            suricata.sig_file = optarg;
+            suricata.sig_file_exclusive = true;
             break;
         case 'u':
 #ifdef UNITTESTS
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_UNITTEST;
+            if (suricata.run_mode == RUNMODE_UNKNOWN) {
+                suricata.run_mode = RUNMODE_UNITTEST;
             } else {
                 SCLogError("more than one run mode has"
                            " been specified");
@@ -1999,14 +1998,14 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'U':
 #ifdef UNITTESTS
-            suri->regex_arg = optarg;
+            suricata.regex_arg = optarg;
 
-            if(strlen(suri->regex_arg) == 0)
-                suri->regex_arg = NULL;
+            if (strlen(suricata.regex_arg) == 0)
+                suricata.regex_arg = NULL;
 #endif
             break;
         case 'V':
-            suri->run_mode = RUNMODE_PRINT_VERSION;
+            suricata.run_mode = RUNMODE_PRINT_VERSION;
             return TM_ECODE_OK;
         case 'F':
             if (optarg == NULL) {
@@ -2017,7 +2016,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             SetBpfStringFromFile(optarg);
             break;
         case 'v':
-            suri->verbose++;
+            suricata.verbose++;
             break;
         case 'k':
             if (optarg == NULL) {
@@ -2025,9 +2024,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
             }
             if (!strcmp("all", optarg))
-                suri->checksum_validation = 1;
+                suricata.checksum_validation = 1;
             else if (!strcmp("none", optarg))
-                suri->checksum_validation = 0;
+                suricata.checksum_validation = 0;
             else {
                 SCLogError("option '%s' invalid for -k", optarg);
                 return TM_ECODE_FAILED;
@@ -2039,31 +2038,31 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         }
     }
 
-    if (suri->disabled_detect && suri->sig_file != NULL) {
+    if (suricata.disabled_detect && suricata.sig_file != NULL) {
         SCLogError("can't use -s/-S when detection is disabled");
         return TM_ECODE_FAILED;
     }
 
     /* save the runmode from the command-line (if any) */
-    suri->aux_run_mode = suri->run_mode;
+    suricata.aux_run_mode = suricata.run_mode;
 
     if (list_app_layer_protocols)
-        suri->run_mode = RUNMODE_LIST_APP_LAYERS;
+        suricata.run_mode = RUNMODE_LIST_APP_LAYERS;
     if (list_keywords)
-        suri->run_mode = RUNMODE_LIST_KEYWORDS;
+        suricata.run_mode = RUNMODE_LIST_KEYWORDS;
     if (list_unittests)
-        suri->run_mode = RUNMODE_LIST_UNITTEST;
+        suricata.run_mode = RUNMODE_LIST_UNITTEST;
     if (dump_config)
-        suri->run_mode = RUNMODE_DUMP_CONFIG;
+        suricata.run_mode = RUNMODE_DUMP_CONFIG;
     if (dump_features)
-        suri->run_mode = RUNMODE_DUMP_FEATURES;
+        suricata.run_mode = RUNMODE_DUMP_FEATURES;
     if (conf_test)
-        suri->run_mode = RUNMODE_CONF_TEST;
+        suricata.run_mode = RUNMODE_CONF_TEST;
     if (engine_analysis)
-        suri->run_mode = RUNMODE_ENGINE_ANALYSIS;
+        suricata.run_mode = RUNMODE_ENGINE_ANALYSIS;
 
-    suri->offline = IsRunModeOffline(suri->run_mode);
-    g_system = suri->system = IsRunModeSystem(suri->run_mode);
+    suricata.offline = IsRunModeOffline(suricata.run_mode);
+    g_system = suricata.system = IsRunModeSystem(suricata.run_mode);
 
     ret = SetBpfString(optind, argv);
     if (ret != TM_ECODE_OK)
@@ -2889,7 +2888,7 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-    if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
+    if (ParseCommandLine(argc, argv) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2362,11 +2362,11 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
     return TM_ECODE_OK;
 }
 
-static int FinalizeRunMode(SCInstance *suri, char **argv)
+static int FinalizeRunMode(SCInstance *suri)
 {
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
-            PrintUsage(argv[0]);
+            PrintUsage(suri->progname);
             return TM_ECODE_FAILED;
         default:
             break;
@@ -2892,7 +2892,7 @@ void SuricataInit(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (FinalizeRunMode(&suricata, argv) != TM_ECODE_OK) {
+    if (FinalizeRunMode(&suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/* snapshot of the system's hugepages before system intitialization. */
+SystemHugepageSnapshot *prerun_snap = NULL;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2875,14 +2878,17 @@ int InitGlobal(void)
     return 0;
 }
 
-int SuricataMain(int argc, char **argv)
+void SuricataPreInit(const char *progname)
 {
-    SCInstanceInit(&suricata, argv[0]);
+    SCInstanceInit(&suricata, progname);
 
     if (InitGlobal() != 0) {
         exit(EXIT_FAILURE);
     }
+}
 
+void SuricataInit(int argc, char **argv)
+{
 #ifdef OS_WIN32
     /* service initialization */
     if (WindowsInitService(argc, argv) != 0) {
@@ -2974,7 +2980,6 @@ int SuricataMain(int argc, char **argv)
         goto out;
     }
 
-    SystemHugepageSnapshot *prerun_snap = NULL;
     if (run_mode == RUNMODE_DPDK)
         prerun_snap = SystemHugepageSnapshotCreate();
 
@@ -2985,8 +2990,29 @@ int SuricataMain(int argc, char **argv)
         UnixManagerThreadSpawnNonRunmode(suricata.unix_socket_enabled);
     }
 
+    return;
+
+out:
+    GlobalsDestroy(&suricata);
+    exit(EXIT_SUCCESS);
+}
+
+void SuricataShutdown(void)
+{
+    /* Update the engine stage/status flag */
+    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
+
+    UnixSocketKillSocketThread();
+    PostRunDeinit(suricata.run_mode, &suricata.start_time);
+    /* kill remaining threads */
+    TmThreadKillThreads();
+}
+
+void SuricataPostInit(void)
+{
     /* Wait till all the threads have been initialized */
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         FatalError("Engine initialization failed, "
                    "aborting...");
     }
@@ -3028,6 +3054,7 @@ int SuricataMain(int argc, char **argv)
 
     /* Must ensure all threads are fully operational before continuing with init process */
     if (TmThreadWaitOnThreadRunning() != TM_ECODE_OK) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         exit(EXIT_FAILURE);
     }
 
@@ -3042,17 +3069,23 @@ int SuricataMain(int argc, char **argv)
         SystemHugepageSnapshotDestroy(postrun_snap);
     }
     SCPledge();
+}
+
+int SuricataMain(int argc, char **argv)
+{
+    /* Pre-initialization tasks: initialize global context and variables. */
+    SuricataPreInit(argv[0]);
+
+    /* Initialization tasks: parse command line options, load yaml, start runmode... */
+    SuricataInit(argc, argv);
+
+    /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
+    SuricataPostInit();
+
     SuricataMainLoop(&suricata);
 
-    /* Update the engine stage/status flag */
-    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
-
-    UnixSocketKillSocketThread();
-    PostRunDeinit(suricata.run_mode, &suricata.start_time);
-    /* kill remaining threads */
-    TmThreadKillThreads();
-
-out:
+    /* Shutdown engine. */
+    SuricataShutdown();
     GlobalsDestroy(&suricata);
 
     exit(EXIT_SUCCESS);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2343,7 +2343,7 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
             SCLogInfo("Suricata service has been successfully installed.");
             return TM_ECODE_DONE;
         case RUNMODE_REMOVE_SERVICE:
-            if (SCServiceRemove(argc, argv)) {
+            if (SCServiceRemove()) {
                 return TM_ECODE_FAILED;
             }
             SCLogInfo("Suricata service has been successfully removed.");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2889,13 +2889,6 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-#ifdef OS_WIN32
-    /* service initialization */
-    if (WindowsInitService(argc, argv) != 0) {
-        exit(EXIT_FAILURE);
-    }
-#endif /* OS_WIN32 */
-
     if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
@@ -3075,6 +3068,13 @@ int SuricataMain(int argc, char **argv)
 {
     /* Pre-initialization tasks: initialize global context and variables. */
     SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* service initialization */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
 
     /* Initialization tasks: parse command line options, load yaml, start runmode... */
     SuricataInit(argc, argv);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -363,7 +363,7 @@ void GlobalsInitPreConfig(void)
     FrameConfigInit();
 }
 
-static void GlobalsDestroy(SCInstance *suri)
+void GlobalsDestroy(void)
 {
     HostShutdown();
     HTPFreeConfig();
@@ -415,9 +415,9 @@ static void GlobalsDestroy(SCInstance *suri)
 #endif
     DetectParseFreeRegexes();
 
-    SCPidfileRemove(suri->pid_filename);
-    SCFree(suri->pid_filename);
-    suri->pid_filename = NULL;
+    SCPidfileRemove(suricata.pid_filename);
+    SCFree(suricata.pid_filename);
+    suricata.pid_filename = NULL;
 
     VarNameStoreDestroy();
     SCLogDeInitLogModule();
@@ -2803,7 +2803,7 @@ int PostConfLoadedSetup(SCInstance *suri)
     SCReturnInt(TM_ECODE_OK);
 }
 
-static void SuricataMainLoop(SCInstance *suri)
+void SuricataMainLoop(void)
 {
     while(1) {
         if (sigterm_count || sigint_count) {
@@ -2825,13 +2825,13 @@ static void SuricataMainLoop(SCInstance *suri)
         if (sigusr2_count > 0) {
             if (!(DetectEngineReloadIsStart())) {
                 DetectEngineReloadStart();
-                DetectEngineReload(suri);
+                DetectEngineReload(&suricata);
                 DetectEngineReloadSetIdle();
                 sigusr2_count--;
             }
 
         } else if (DetectEngineReloadIsStart()) {
-            DetectEngineReload(suri);
+            DetectEngineReload(&suricata);
             DetectEngineReloadSetIdle();
         }
 
@@ -2993,7 +2993,7 @@ void SuricataInit(int argc, char **argv)
     return;
 
 out:
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
     exit(EXIT_SUCCESS);
 }
 
@@ -3082,11 +3082,11 @@ int SuricataMain(int argc, char **argv)
     /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
     SuricataPostInit();
 
-    SuricataMainLoop(&suricata);
+    SuricataMainLoop();
 
     /* Shutdown engine. */
     SuricataShutdown();
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
 
     exit(EXIT_SUCCESS);
 }

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -192,7 +192,7 @@ int SuriHasSigFile(void);
 extern int run_mode;
 
 void SuricataPreInit(const char *progname);
-void SuricataInit(int argc, char **argv);
+void SuricataInit(void);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
@@ -201,6 +201,8 @@ int InitGlobal(void);
 void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
+int SCFinalizeRunMode(void);
+TmEcode SCParseCommandLine(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -195,8 +195,10 @@ void SuricataPreInit(const char *progname);
 void SuricataInit(int argc, char **argv);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
+void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -191,7 +191,11 @@ int SuriHasSigFile(void);
 
 extern int run_mode;
 
+void SuricataPreInit(const char *progname);
+void SuricataInit(int argc, char **argv);
+void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataShutdown(void);
 int InitGlobal(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -194,7 +194,6 @@ extern int run_mode;
 void SuricataPreInit(const char *progname);
 void SuricataInit(void);
 void SuricataPostInit(void);
-int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
@@ -203,11 +202,16 @@ int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 int SCFinalizeRunMode(void);
 TmEcode SCParseCommandLine(int argc, char **argv);
+int SCStartInternalRunMode(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);
 void PostRunDeinit(const int runmode, struct timeval *start_time);
 void RegisterAllModules(void);
+
+#ifdef OS_WIN32
+int WindowsInitService(int argc, char **argv);
+#endif
 
 const char *GetProgramVersion(void);
 

--- a/src/win32-service.c
+++ b/src/win32-service.c
@@ -279,7 +279,7 @@ int SCServiceInstall(int argc, char **argv)
  * \param argc num of arguments
  * \param argv passed arguments
  */
-int SCServiceRemove(int argc, char **argv)
+int SCServiceRemove(void)
 {
     SERVICE_STATUS status;
     SC_HANDLE service = NULL;

--- a/src/win32-service.h
+++ b/src/win32-service.h
@@ -28,7 +28,7 @@
 int SCRunningAsService(void);
 int SCServiceInit(int argc, char **argv);
 int SCServiceInstall(int argc, char **argv);
-int SCServiceRemove(int argc, char **argv);
+int SCServiceRemove(void);
 int SCServiceChangeParams(int argc, char **argv);
 #endif /* OS_WIN32 */
 


### PR DESCRIPTION
Some refactoring of `suricata.c`, in particular moving the contents of SuricataMain back to `main()` in `main.c`, which forces it to use only functions that are exposed via the library.

This does *undo* some of the work of passing around a `SCInstance`, however as that wasn't complete, and it was still being accessed as a global, it was easier to move more accesses to the global instead of figuring out how to deal with this from library context at this time as its not an immediate concern.

Other changes:
- SCParseCommandLine is opt-in by library users so has been moved out of `SuricataInit`.

Other observations:
- `SuricataInit` and `SuricataPostInit` now take no arguments and are back to back. They could be merged or further broken out. For example, signal handling, process limiting and some other options should become opt-in as well for library users.  They're more part of the Suricata the application, not the library.
- Broken out like this `PreInit`, `Init`, `PostInit` might need some rethinking in their names.  For example as a library it would be nicer to do:
  - `SuricataInit`: initializes the very basics, like config etc..
  - user code that registers modules, programmatic configuration, calls our wrappers around loading configuration files and command line options..
  - `SuricataPostConfiguration`: The stuff that is done after the configuration file
  - `SuricataMainLoop` 