### PR TITLE
libsuricata: make the Suricata application a user of the Suricata library - v3

### DIFF
--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -2,6 +2,17 @@
 
 int main(int argc, char **argv)
 {
-    SuricataMain(argc, argv);
-    return 0;
+    SuricataPreInit(argv[0]);
+    SuricataInit(argc, argv);
+    SuricataPostInit();
+
+    /* Suricata is now running, but we enter a loop to keep it running
+     * until it shouldn't be running anymore. */
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
+    return EXIT_SUCCESS;
 }

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -13,6 +13,16 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Handle internal runmodes. Typically you wouldn't do this as a
+     * library however, however this example is showing how to
+     * replicate the Suricata application with the library. */
+    switch (SCStartInternalRunMode(argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
     SuricataInit();
     SuricataPostInit();
 

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -3,6 +3,7 @@
 int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
+
     SuricataInit(argc, argv);
     SuricataPostInit();
 

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -4,7 +4,16 @@ int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
 
-    SuricataInit(argc, argv);
+    /* Parse command line options. This is optional, you could
+     * directly configuration Suricata through the Conf API. */
+    SCParseCommandLine(argc, argv);
+
+    /* Validate/finalize the runmode. */
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    SuricataInit();
     SuricataPostInit();
 
     /* Suricata is now running, but we enter a loop to keep it running

--- a/src/main.c
+++ b/src/main.c
@@ -19,5 +19,42 @@
 
 int main(int argc, char **argv)
 {
-    return SuricataMain(argc, argv);
+    /* Pre-initialization tasks: initialize global context and variables. */
+    SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* service initialization */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
+
+    if (SCParseCommandLine(argc, argv) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    switch (SCStartInternalRunMode(argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
+    /* Initialization tasks: Loading config, setup logging */
+    SuricataInit();
+
+    /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
+    SuricataPostInit();
+
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
+    exit(EXIT_SUCCESS);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2891,13 +2891,6 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-#ifdef OS_WIN32
-    /* service initialization */
-    if (WindowsInitService(argc, argv) != 0) {
-        exit(EXIT_FAILURE);
-    }
-#endif /* OS_WIN32 */
-
     if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
@@ -3077,6 +3070,13 @@ int SuricataMain(int argc, char **argv)
 {
     /* Pre-initialization tasks: initialize global context and variables. */
     SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* service initialization */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
 
     /* Initialization tasks: parse command line options, load yaml, start runmode... */
     SuricataInit(argc, argv);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2346,7 +2346,7 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
             SCLogInfo("Suricata service has been successfully installed.");
             return TM_ECODE_DONE;
         case RUNMODE_REMOVE_SERVICE:
-            if (SCServiceRemove(argc, argv)) {
+            if (SCServiceRemove()) {
                 return TM_ECODE_FAILED;
             }
             SCLogInfo("Suricata service has been successfully removed.");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2365,11 +2365,11 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
     return TM_ECODE_OK;
 }
 
-static int FinalizeRunMode(SCInstance *suri, char **argv)
+static int FinalizeRunMode(SCInstance *suri)
 {
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
-            PrintUsage(argv[0]);
+            PrintUsage(suri->progname);
             return TM_ECODE_FAILED;
         default:
             break;
@@ -2896,7 +2896,7 @@ void SuricataInit(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (FinalizeRunMode(&suricata, argv) != TM_ECODE_OK) {
+    if (FinalizeRunMode(&suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1309,8 +1309,9 @@ static bool IsLogDirectoryWritable(const char* str)
 
 extern int g_skip_prefilter;
 
-static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
+static TmEcode ParseCommandLine(int argc, char **argv)
 {
+    SCInstance *suri = &suricata;
     int opt;
 
     int dump_config = 0;
@@ -2891,7 +2892,7 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-    if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
+    if (ParseCommandLine(argc, argv) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -363,8 +363,9 @@ void GlobalsInitPreConfig(void)
     FrameConfigInit();
 }
 
-static void GlobalsDestroy(SCInstance *suri)
+void GlobalsDestroy(void)
 {
+    SCInstance *suri = &suricata;
     HostShutdown();
     HTPFreeConfig();
     HTPAtExitPrintStats();
@@ -2803,8 +2804,9 @@ int PostConfLoadedSetup(SCInstance *suri)
     SCReturnInt(TM_ECODE_OK);
 }
 
-static void SuricataMainLoop(SCInstance *suri)
+void SuricataMainLoop(void)
 {
+    SCInstance *suri = &suricata;
     while(1) {
         if (sigterm_count || sigint_count) {
             suricata_ctl_flags |= SURICATA_STOP;
@@ -2993,7 +2995,7 @@ void SuricataInit(int argc, char **argv)
     return;
 
 out:
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
     exit(EXIT_SUCCESS);
 }
 
@@ -3082,11 +3084,11 @@ int SuricataMain(int argc, char **argv)
     /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
     SuricataPostInit();
 
-    SuricataMainLoop(&suricata);
+    SuricataMainLoop();
 
     /* Shutdown engine. */
     SuricataShutdown();
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
 
     exit(EXIT_SUCCESS);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2075,7 +2075,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 }
 
 #ifdef OS_WIN32
-static int WindowsInitService(int argc, char **argv)
+int WindowsInitService(int argc, char **argv)
 {
     if (SCRunningAsService()) {
         char path[MAX_PATH];
@@ -2309,11 +2309,11 @@ void PostRunDeinit(const int runmode, struct timeval *start_time)
 #endif
 }
 
-
-static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
+int SCStartInternalRunMode(int argc, char **argv)
 {
+    SCInstance *suri = &suricata;
     /* Treat internal running mode */
-    switch(suri->run_mode) {
+    switch (suri->run_mode) {
         case RUNMODE_LIST_KEYWORDS:
             return ListKeywords(suri->keyword_info);
         case RUNMODE_LIST_APP_LAYERS:
@@ -3051,46 +3051,4 @@ void SuricataPostInit(void)
         SystemHugepageSnapshotDestroy(postrun_snap);
     }
     SCPledge();
-}
-
-int SuricataMain(int argc, char **argv)
-{
-    /* Pre-initialization tasks: initialize global context and variables. */
-    SuricataPreInit(argv[0]);
-
-#ifdef OS_WIN32
-    /* service initialization */
-    if (WindowsInitService(argc, argv) != 0) {
-        exit(EXIT_FAILURE);
-    }
-#endif /* OS_WIN32 */
-
-    if (SCParseCommandLine(argc, argv) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
-    if (SCFinalizeRunMode() != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
-    switch (StartInternalRunMode(&suricata, argc, argv)) {
-        case TM_ECODE_DONE:
-            exit(EXIT_SUCCESS);
-        case TM_ECODE_FAILED:
-            exit(EXIT_FAILURE);
-    }
-
-    /* Initialization tasks: Loading config, setup logging */
-    SuricataInit();
-
-    /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
-    SuricataPostInit();
-
-    SuricataMainLoop();
-
-    /* Shutdown engine. */
-    SuricataShutdown();
-    GlobalsDestroy();
-
-    exit(EXIT_SUCCESS);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/* snapshot of the system's hugepages before system intitialization. */
+SystemHugepageSnapshot *prerun_snap = NULL;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2875,14 +2878,17 @@ int InitGlobal(void)
     return 0;
 }
 
-int SuricataMain(int argc, char **argv)
+void SuricataPreInit(const char *progname)
 {
-    SCInstanceInit(&suricata, argv[0]);
+    SCInstanceInit(&suricata, progname);
 
     if (InitGlobal() != 0) {
         exit(EXIT_FAILURE);
     }
+}
 
+void SuricataInit(int argc, char **argv)
+{
 #ifdef OS_WIN32
     /* service initialization */
     if (WindowsInitService(argc, argv) != 0) {
@@ -2974,7 +2980,6 @@ int SuricataMain(int argc, char **argv)
         goto out;
     }
 
-    SystemHugepageSnapshot *prerun_snap = NULL;
     if (run_mode == RUNMODE_DPDK)
         prerun_snap = SystemHugepageSnapshotCreate();
 
@@ -2985,8 +2990,29 @@ int SuricataMain(int argc, char **argv)
         UnixManagerThreadSpawnNonRunmode(suricata.unix_socket_enabled);
     }
 
+    return;
+
+out:
+    GlobalsDestroy(&suricata);
+    exit(EXIT_SUCCESS);
+}
+
+void SuricataShutdown(void)
+{
+    /* Update the engine stage/status flag */
+    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
+
+    UnixSocketKillSocketThread();
+    PostRunDeinit(suricata.run_mode, &suricata.start_time);
+    /* kill remaining threads */
+    TmThreadKillThreads();
+}
+
+void SuricataPostInit(void)
+{
     /* Wait till all the threads have been initialized */
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         FatalError("Engine initialization failed, "
                    "aborting...");
     }
@@ -3028,6 +3054,7 @@ int SuricataMain(int argc, char **argv)
 
     /* Must ensure all threads are fully operational before continuing with init process */
     if (TmThreadWaitOnThreadRunning() != TM_ECODE_OK) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         exit(EXIT_FAILURE);
     }
 
@@ -3042,17 +3069,23 @@ int SuricataMain(int argc, char **argv)
         SystemHugepageSnapshotDestroy(postrun_snap);
     }
     SCPledge();
+}
+
+int SuricataMain(int argc, char **argv)
+{
+    /* Pre-initialization tasks: initialize global context and variables. */
+    SuricataPreInit(argv[0]);
+
+    /* Initialization tasks: parse command line options, load yaml, start runmode... */
+    SuricataInit(argc, argv);
+
+    /* Post-initialization tasks: wait on thread start/running and get ready fpr the main loop. */
+    SuricataPostInit();
+
     SuricataMainLoop(&suricata);
 
-    /* Update the engine stage/status flag */
-    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
-
-    UnixSocketKillSocketThread();
-    PostRunDeinit(suricata.run_mode, &suricata.start_time);
-    /* kill remaining threads */
-    TmThreadKillThreads();
-
-out:
+    /* Shutdown engine. */
+    SuricataShutdown();
     GlobalsDestroy(&suricata);
 
     exit(EXIT_SUCCESS);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -192,7 +192,7 @@ int SuriHasSigFile(void);
 extern int run_mode;
 
 void SuricataPreInit(const char *progname);
-void SuricataInit(int argc, char **argv);
+void SuricataInit(void);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
@@ -201,6 +201,8 @@ int InitGlobal(void);
 void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
+int SCFinalizeRunMode(void);
+TmEcode SCParseCommandLine(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -195,8 +195,10 @@ void SuricataPreInit(const char *progname);
 void SuricataInit(int argc, char **argv);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
+void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -191,7 +191,11 @@ int SuriHasSigFile(void);
 
 extern int run_mode;
 
+void SuricataPreInit(const char *progname);
+void SuricataInit(int argc, char **argv);
+void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataShutdown(void);
 int InitGlobal(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -194,7 +194,6 @@ extern int run_mode;
 void SuricataPreInit(const char *progname);
 void SuricataInit(void);
 void SuricataPostInit(void);
-int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
@@ -203,11 +202,16 @@ int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 int SCFinalizeRunMode(void);
 TmEcode SCParseCommandLine(int argc, char **argv);
+int SCStartInternalRunMode(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);
 void PostRunDeinit(const int runmode, struct timeval *start_time);
 void RegisterAllModules(void);
+
+#ifdef OS_WIN32
+int WindowsInitService(int argc, char **argv);
+#endif
 
 const char *GetProgramVersion(void);
 

--- a/src/win32-service.c
+++ b/src/win32-service.c
@@ -279,7 +279,7 @@ int SCServiceInstall(int argc, char **argv)
  * \param argc num of arguments
  * \param argv passed arguments
  */
-int SCServiceRemove(int argc, char **argv)
+int SCServiceRemove(void)
 {
     SERVICE_STATUS status;
     SC_HANDLE service = NULL;

--- a/src/win32-service.h
+++ b/src/win32-service.h
@@ -28,7 +28,7 @@
 int SCRunningAsService(void);
 int SCServiceInit(int argc, char **argv);
 int SCServiceInstall(int argc, char **argv);
-int SCServiceRemove(int argc, char **argv);
+int SCServiceRemove(void);
 int SCServiceChangeParams(int argc, char **argv);
 #endif /* OS_WIN32 */
 


### PR DESCRIPTION
Very similar to https://github.com/OISF/suricata/pull/10507 but lessens patch size.

Some refactoring of `suricata.c`, in particular moving the contents of SuricataMain back to `main()` in `main.c`, which forces it to use only functions that are exposed via the library.

This does *undo* some of the work of passing around a `SCInstance`, however as that wasn't complete, and it was still being accessed as a global, it was easier to move more accesses to the global instead of figuring out how to deal with this from library context at this time as its not an immediate concern.

Other changes:
- SCParseCommandLine is opt-in by library users so has been moved out of `SuricataInit`.

Other observations:
- `SuricataInit` and `SuricataPostInit` now take no arguments and are back to back. They could be merged or further broken out. For example, signal handling, process limiting and some other options should become opt-in as well for library users.  They're more part of the Suricata the application, not the library.
- Broken out like this `PreInit`, `Init`, `PostInit` might need some rethinking in their names.  For example as a library it would be nicer to do:
  - `SuricataInit`: initializes the very basics, like config etc..
  - user code that registers modules, programmatic configuration, calls our wrappers around loading configuration files and command line options..
  - `SuricataPostConfiguration`: The stuff that is done after the configuration file
  - `SuricataMainLoop` 