### PR TITLE
exception/policy: add stats counters - v5

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -7,7 +7,10 @@ Suricata has a set of configuration variables to indicate what should the engine
 do when certain exception conditions, such as hitting a memcap, are reached.
 
 They are called Exception Policies and are configurable via suricata.yaml. If
-enabled, the engine will call them when it reaches exception states.
+enabled, the engine will call them when it reaches exception states. Stats for
+any applied exception policies can be found in counters related to the specific
+configuration setting (:ref:`read more<eps_stats>`). Some configuration is
+available directly via the :ref:`stats settings<suricata_yaml_outputs>`.
 
 For developers or for researching purposes, there are also simulation options
 exposed in debug mode and passed via command-line. These exist to force or
@@ -206,6 +209,43 @@ Notes:
 
    * Not valid means that Suricata will error out and won't start.
    * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender of the matching packet.
+
+.. _eps_stats:
+
+Available Stats
+---------------
+
+There are stats counters for each supported exception policy scenario:
+
+.. list-table:: **Exception Policy Stats Counters**
+   :widths: 50 50
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Setting
+     - Counter
+   * - stream.memcap
+     - tcp.ssn_memcap_exception_policy
+   * - stream.reassembly.memcap
+     - tcp.reassembly_memcap_exception_policy
+   * - stream.midstream
+     - tcp.midstream_exception_policy
+   * - defrag.memcap
+     - defrag.memcap_exception_policy
+   * - flow.memcap
+     - flow.memcap_exception_policy
+   * - app-layer.error
+     - app_layer.error.exception_policy
+
+If a given exception policy does not apply for a setting, no related counter
+is logged.
+
+Stats for application layer errors are available in summarized form or per
+application layer protocol. As the latter is extremely verbose, by default
+Suricata logs only the summary. If any further investigation is needed, it
+is recommended to enable per-app-proto exception policy error counters
+temporarily (for :ref:`stats configuration<suricata_yaml_outputs>`).
+
 
 Command-line Options for Simulating Exceptions
 ----------------------------------------------

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -62,33 +62,40 @@ Specific settings
 Exception policies are implemented for:
 
 .. list-table:: Exception Policy configuration variables
-   :widths: 20, 18, 62
+   :widths: 18, 18, 18, 44
    :header-rows: 1
 
    * - Config setting
      - Policy variable
+     - Affects
      - Expected behavior
    * - stream.memcap
      - memcap-policy
+     - Flow or packet
      - If a stream memcap limit is reached, apply the memcap policy to the packet and/or
        flow.
    * - stream.midstream
      - midstream-policy
+     - Flow
      - If a session is picked up midstream, apply the midstream policy to the flow.
    * - stream.reassembly.memcap
      - memcap-policy
+     - Flow or packet
      - If stream reassembly reaches memcap limit, apply memcap policy to the
        packet and/or flow.
    * - flow.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for flows is reached and no flow could
        be freed up. **Policy can only be applied to the packet.**
    * - defrag.memcap
      - memcap-policy
+     - Packet
      - Apply policy when the memcap limit for defrag is reached and no tracker
        could be picked up. **Policy can only be applied to the packet.**
    * - app-layer
      - error-policy
+     - Flow or packet
      - Apply policy if a parser reaches an error state. Policy can be applied to packet and/or flow.
 
 To change any of these, go to the specific section in the suricata.yaml file

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -317,6 +317,11 @@ the global config is documented.
       #decoder-events-prefix: "decoder.event"
       # Add stream events as stats.
       #stream-events: false
+      # Exception policy stats counters options
+      # (Note: if exception policy: ignore, counters are not logged)
+      #eps-zero-valued-counters: false  # default: false. True will log counters: 0
+      #eps-per-app-proto-errors: false  # default: false. True will log errors for
+                                        # each app-proto. Warning: VERY verbose
 
 Statistics can be `enabled` or disabled here.
 
@@ -338,6 +343,12 @@ See `issue 2225 <https://redmine.openinfosecfoundation.org/issues/2225>`_.
 Similar to the `decoder-events` option, the `stream-events` option controls
 whether the stream-events are added as counters as well. This is disabled by
 default.
+
+If any exception policy is enabled, stats counters are logged. To control
+verbosity especially for application layer protocol errors, leave
+`eps-per-app-proto-errors` as false. Similarly, leaving
+`eps-zero-valued-counters` disabled, only if an exception policy was applied
+there will be counters logged.
 
 Outputs
 ~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5347,6 +5347,11 @@
                         "pseudo_failed": {
                             "type": "integer"
                         },
+                        "reassembly_exception_policy": {
+                            "description":
+                                    "How many times reassembly memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "reassembly_gap": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3733,6 +3733,11 @@
                         "error": {
                             "type": "object",
                             "properties": {
+                                "exception_policy": {
+                                    "description":
+                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                    "$ref": "#/$defs/exceptionPolicy"
+                                },
                                 "bittorrent-dht": {
                                     "description":
                                             "Errors encountered parsing BitTorrent DHT protocol",
@@ -5671,6 +5676,11 @@
                 "internal": {
                     "description": "Number of internal parser errors",
                     "type": "integer"
+                },
+                "exception_policy": {
+                    "description":
+                            "How many times app-layer error exception policy was applied, and which one",
+                    "$ref": "#/$defs/exceptionPolicy"
                 }
             },
             "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1040,7 +1040,8 @@
                                 "additionalProperties": false
                             },
                             "sshfp": {
-                                "description": "A Secure Shell fingerprint, used to verify the system’s authenticity",
+                                "description":
+                                        "A Secure Shell fingerprint, used to verify the system’s authenticity",
                                 "type": "object",
                                 "properties": {
                                     "fingerprint": {
@@ -1133,7 +1134,7 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
-			}
+                        }
                     },
                     "additionalProperties": false
                 },
@@ -1212,7 +1213,8 @@
                             }
                         },
                         "SSHFP": {
-                            "description": "A Secure Shell fingerprint is used to verify the system’s authenticity",
+                            "description":
+                                    "A Secure Shell fingerprint is used to verify the system’s authenticity",
                             "type": "array",
                             "minItems": 1,
                             "items": {
@@ -3713,7 +3715,8 @@
                     "type": "integer"
                 },
                 "memcap_pressure": {
-                    "description": "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
+                    "description":
+                            "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
                     "type": "integer"
                 },
                 "memcap_pressure_max": {
@@ -3731,7 +3734,8 @@
                             "type": "object",
                             "properties": {
                                 "bittorrent-dht": {
-                                    "description": "Errors encountered parsing BitTorrent DHT protocol",
+                                    "description":
+                                            "Errors encountered parsing BitTorrent DHT protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "dcerpc_tcp": {
@@ -3795,11 +3799,13 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_tcp": {
-                                    "description": "Errors encountered parsing Kerberos v5/TCP protocol",
+                                    "description":
+                                            "Errors encountered parsing Kerberos v5/TCP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_udp": {
-                                    "description": "Errors encountered parsing Kerberos v5/UDP protocol",
+                                    "description":
+                                            "Errors encountered parsing Kerberos v5/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "modbus": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5377,6 +5377,11 @@
                         "ssn_memcap_drop": {
                             "type": "integer"
                         },
+                        "ssn_memcap_exception_policy": {
+                            "description":
+                                    "How many times session memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "stream_depth_reached": {
                             "type": "integer"
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4887,6 +4887,11 @@
                         "max_frag_hits": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "description":
+                                    "How many times defrag memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5023,6 +5023,11 @@
                         "memcap": {
                             "type": "integer"
                         },
+                        "memcap_exception_policy": {
+                            "description":
+                                    "How many times flow memcap exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "memuse": {
                             "type": "integer"
                         },
@@ -5701,6 +5706,35 @@
                             ]
                         }
                     ]
+                }
+            }
+        },
+        "exceptionPolicy": {
+            "type": "object",
+            "properties": {
+                "drop_flow": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "drop_packet": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "pass_flow": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "pass_packet": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "bypass": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "reject": {
+                    "type": "integer",
+                    "minimum": 0
                 }
             }
         }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5329,6 +5329,11 @@
                         "midstream_pickups": {
                             "type": "integer"
                         },
+                        "midstream_exception_policy": {
+                            "description":
+                                    "How many times midstream exception policy was applied, and which one",
+                            "$ref": "#/$defs/exceptionPolicy"
+                        },
                         "no_flow": {
                             "type": "integer"
                         },

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -544,6 +544,7 @@ noinst_HEADERS = \
 	util-enum.h \
 	util-error.h \
 	util-exception-policy.h \
+	util-exception-policy-types.h \
 	util-file-decompression.h \
 	util-file.h \
 	util-file-swf-decompression.h \

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -49,6 +49,7 @@
 #include "app-layer-htp-mem.h"
 #include "util-exception-policy.h"
 
+extern bool g_stats_eps_per_app_proto_errors;
 /**
  * \brief This is for the app layer in general and it contains per thread
  *        context relevant to both the alpd and alp.
@@ -80,6 +81,7 @@ typedef struct AppLayerCounterNames_ {
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
     char alloc_error[MAX_COUNTER_SIZE];
+    char eps_name[EXCEPTION_POLICY_MAX][MAX_COUNTER_SIZE];
 } AppLayerCounterNames;
 
 typedef struct AppLayerCounters_ {
@@ -89,12 +91,41 @@ typedef struct AppLayerCounters_ {
     uint16_t parser_error_id;
     uint16_t internal_error_id;
     uint16_t alloc_error_id;
+    ExceptionPolicyCounters eps_error;
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
 AppLayerCounterNames applayer_counter_names[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
 /* counter id's. Used that runtime. */
 AppLayerCounters applayer_counters[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
+/* Exception policy global counters ids */
+ExceptionPolicyCounters eps_error_summary;
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts app_layer_error_eps_stats = {
+    .valid_settings_ids = {
+       /* EXCEPTION_POLICY_NOT_SET */      false,
+       /* EXCEPTION_POLICY_AUTO */         false,
+       /* EXCEPTION_POLICY_PASS_PACKET */  true,
+       /* EXCEPTION_POLICY_PASS_FLOW */    true,
+       /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+       /* EXCEPTION_POLICY_DROP_PACKET */  false,
+       /* EXCEPTION_POLICY_DROP_FLOW */    false,
+       /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+       /* EXCEPTION_POLICY_NOT_SET */      false,
+       /* EXCEPTION_POLICY_AUTO */         false,
+       /* EXCEPTION_POLICY_PASS_PACKET */  true,
+       /* EXCEPTION_POLICY_PASS_FLOW */    true,
+       /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+       /* EXCEPTION_POLICY_DROP_PACKET */  true,
+       /* EXCEPTION_POLICY_DROP_FLOW */    true,
+       /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
 
 void AppLayerSetupCounters(void);
 void AppLayerDeSetupCounters(void);
@@ -156,6 +187,22 @@ void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
     const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
+    }
+}
+
+static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum ExceptionPolicy policy)
+{
+    uint16_t id = 0;
+    /* for the summary values */
+    uint16_t g_id = 0;
+    id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+    g_id = eps_error_summary.eps_id[policy];
+
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+    if (likely(tv && g_id > 0)) {
+        StatsIncr(tv, g_id);
     }
 }
 
@@ -640,6 +687,7 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
     SCReturnInt(0);
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -707,6 +755,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
         StreamTcpUpdateAppLayerProgress(ssn, direction, data_len);
         if (r < 0) {
             ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+            AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
             SCReturnInt(-1);
         }
         goto end;
@@ -793,6 +842,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
                 if (r < 0) {
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+                    AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
                     SCReturnInt(-1);
                 }
             }
@@ -933,6 +983,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     }
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
+        AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
         SCReturnInt(-1);
     }
 
@@ -1062,6 +1113,14 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("app_layer.expectations", ExpectationGetCounter);
 }
 
+static bool IsAppLayerErrorExceptionPolicyStatsValid(int policy)
+{
+    if (EngineModeIsIPS()) {
+        return app_layer_error_eps_stats.valid_settings_ips[policy];
+    }
+    return app_layer_error_eps_stats.valid_settings_ids[policy];
+}
+
 #define IPPROTOS_MAX 2
 void AppLayerSetupCounters(void)
 {
@@ -1069,6 +1128,21 @@ void AppLayerSetupCounters(void)
     AppProto alprotos[ALPROTO_MAX];
     const char *str = "app_layer.flow.";
     const char *estr = "app_layer.error.";
+
+    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+    if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+        /* Register global counters for app layer error exception policy summary */
+        const char *eps_default_str = "app_layer.error.exception_policy.";
+        bool is_eps_valid = false;
+        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+            is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+            if (is_eps_valid) {
+                snprintf(app_layer_error_eps_stats.eps_name[i],
+                        sizeof(app_layer_error_eps_stats.eps_name[i]), "%s%s", eps_default_str,
+                        ExceptionPolicyEnumToString(i, true));
+            }
+        }
+    }
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
@@ -1108,6 +1182,22 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
+
+                    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+                    if (g_stats_eps_per_app_proto_errors &&
+                            g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+                        bool is_eps_valid = false;
+                        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+                            is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+                            if (is_eps_valid) {
+                                snprintf(applayer_counter_names[ipproto_map][alproto].eps_name[i],
+                                        sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                        .eps_name[i]),
+                                        "%s%s%s.exception_policy.%s", estr, alproto_str,
+                                        ipproto_suffix, ExceptionPolicyEnumToString(i, true));
+                            }
+                        }
+                    }
                 } else {
                     snprintf(applayer_counter_names[ipproto_map][alproto].name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].name),
@@ -1130,6 +1220,21 @@ void AppLayerSetupCounters(void)
                     snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
                             sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
                             "%s%s.internal", estr, alproto_str);
+                    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+                    if (g_stats_eps_per_app_proto_errors &&
+                            g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+                        bool is_eps_valid = false;
+                        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+                            is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+                            if (is_eps_valid) {
+                                snprintf(applayer_counter_names[ipproto_map][alproto].eps_name[i],
+                                        sizeof(applayer_counter_names[ipproto_map][alproto]
+                                                        .eps_name[i]),
+                                        "%s%s.exception_policy.%s", estr, alproto_str,
+                                        ExceptionPolicyEnumToString(i, true));
+                            }
+                        }
+                    }
                 }
             } else if (alproto == ALPROTO_FAILED) {
                 snprintf(applayer_counter_names[ipproto_map][alproto].name,
@@ -1150,6 +1255,19 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
     AppProto alprotos[ALPROTO_MAX];
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
+
+    /* We don't log stats counters if exception policy is `ignore`/`not set` */
+    if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+        /* Register global counters for app layer error exception policy summary */
+        bool is_eps_valid = false;
+        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+            is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+            if (is_eps_valid) {
+                eps_error_summary.eps_id[i] =
+                        StatsRegisterCounter(app_layer_error_eps_stats.eps_name[i], tv);
+            }
+        }
+    }
 
     for (uint8_t p = 0; p < IPPROTOS_MAX; p++) {
         const uint8_t ipproto = ipprotos[p];
@@ -1173,6 +1291,19 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
                         applayer_counter_names[ipproto_map][alproto].parser_error, tv);
                 applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
                         applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                /* We don't log stats counters if exception policy is `ignore`/`not set` */
+                if (g_stats_eps_per_app_proto_errors &&
+                        g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
+                    bool is_eps_valid = false;
+                    for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+                        is_eps_valid = IsAppLayerErrorExceptionPolicyStatsValid(i);
+                        if (is_eps_valid) {
+                            applayer_counters[ipproto_map][alproto]
+                                    .eps_error.eps_id[i] = StatsRegisterCounter(
+                                    applayer_counter_names[ipproto_map][alproto].eps_name[i], tv);
+                        }
+                    }
+                }
             } else if (alproto == ALPROTO_FAILED) {
                 applayer_counters[ipproto_map][alproto].counter_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/counters.c
+++ b/src/counters.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -102,6 +102,9 @@ bool stats_decoder_events = true;
 const char *stats_decoder_events_prefix = "decoder.event";
 /**< add stream events as stats? disabled by default */
 bool stats_stream_events = false;
+
+/** add zero valued counters for exception policies stats? disabled by default */
+bool stats_eps_zero_counters = false;
 
 static int StatsOutput(ThreadVars *tv);
 static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext *);
@@ -293,6 +296,11 @@ static void StatsInitCtxPreOutput(void)
             prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;
+
+        ret = ConfGetChildValueBool(stats, "eps-zero-valued-counters", &b);
+        if (ret) {
+            stats_eps_zero_counters = (b == 1);
+        }
     }
     SCReturn;
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -62,11 +62,15 @@
 #include "decode-erspan.h"
 #include "decode-teredo.h"
 
+#include "defrag-hash.h"
+
 #include "util-hash.h"
 #include "util-hash-string.h"
 #include "util-print.h"
 #include "util-profiling.h"
 #include "util-validate.h"
+#include "util-debug.h"
+#include "util-exception-policy.h"
 #include "action-globals.h"
 
 uint32_t default_packet_size = 0;
@@ -75,6 +79,32 @@ extern const char *stats_decoder_events_prefix;
 extern bool stats_stream_events;
 uint8_t decoder_max_layers = PKT_DEFAULT_MAX_DECODED_LAYERS;
 uint16_t packet_alert_max = PACKET_ALERT_MAX;
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts defrag_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    false,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
 
 /* Settings order as in the enum */
 // clang-format off
@@ -548,6 +578,14 @@ void DecodeUnregisterCounters(void)
     SCMutexUnlock(&g_counter_table_mutex);
 }
 
+static bool IsDefragMemcapExceptionPolicyStatsValid(uint8_t policy)
+{
+    if (EngineModeIsIPS()) {
+        return defrag_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return defrag_memcap_eps_stats.valid_settings_ids[policy];
+}
+
 static bool IsFlowMemcapExceptionPolicyStatsValid(uint8_t policy)
 {
     if (EngineModeIsIPS()) {
@@ -647,6 +685,22 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_ipv6_reassembled = StatsRegisterCounter("defrag.ipv6.reassembled", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
+
+    if (DefragGetMemcapExceptionPolicy() != EXCEPTION_POLICY_NOT_SET) {
+        /* set-up counters for Exception Policy Defrag values */
+        const char *eps_defrag_str = "defrag.memcap_exception_policy.";
+        bool is_eps_valid = false;
+        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+            is_eps_valid = IsDefragMemcapExceptionPolicyStatsValid(i);
+            if (is_eps_valid) {
+                snprintf(defrag_memcap_eps_stats.eps_name[i],
+                        sizeof(defrag_memcap_eps_stats.eps_name[i]), "%s%s", eps_defrag_str,
+                        ExceptionPolicyEnumToString(i, true));
+                dtv->counter_defrag_memcap_eps.eps_id[i] =
+                        StatsRegisterCounter(defrag_memcap_eps_stats.eps_name[i], tv);
+            }
+        }
+    }
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {
         BUG_ON(i != (int)DEvents[i].code);

--- a/src/decode.h
+++ b/src/decode.h
@@ -32,6 +32,7 @@
 #include "threadvars.h"
 #include "util-debug.h"
 #include "decode-events.h"
+#include "util-exception-policy-types.h"
 #ifdef PROFILING
 #include "flow-worker.h"
 #include "app-layer-protos.h"
@@ -728,6 +729,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_max_hit;
 
     uint16_t counter_flow_memcap;
+    ExceptionPolicyCounters counter_flow_memcap_eps;
 
     uint16_t counter_tcp_active_sessions;
     uint16_t counter_flow_total;

--- a/src/decode.h
+++ b/src/decode.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -727,6 +727,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_fragments;
     uint16_t counter_defrag_ipv6_reassembled;
     uint16_t counter_defrag_max_hit;
+    ExceptionPolicyCounters counter_defrag_memcap_eps;
 
     uint16_t counter_flow_memcap;
     ExceptionPolicyCounters counter_flow_memcap_eps;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -72,6 +72,11 @@ uint64_t DefragTrackerGetMemuse(void)
 {
     uint64_t memusecopy = (uint64_t)SC_ATOMIC_GET(defrag_memuse);
     return memusecopy;
+}
+
+enum ExceptionPolicy DefragGetMemcapExceptionPolicy(void)
+{
+    return defrag_config.memcap_policy;
 }
 
 uint32_t DefragTrackerSpareQueueGetSize(void)
@@ -459,6 +464,15 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
     return CMP_DEFRAGTRACKER(t, p, id);
 }
 
+static void DefragExceptionPolicyStatsIncr(
+        ThreadVars *tv, DecodeThreadVars *dtv, enum ExceptionPolicy policy)
+{
+    uint16_t id = dtv->counter_defrag_memcap_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 /**
  *  \brief Get a new defrag tracker
  *
@@ -467,12 +481,13 @@ static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
  *
  *  \retval dt *LOCKED* tracker on success, NULL on error.
  */
-static DefragTracker *DefragTrackerGetNew(Packet *p)
+static DefragTracker *DefragTrackerGetNew(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
 #ifdef DEBUG
     if (g_eps_defrag_memcap != UINT64_MAX && g_eps_defrag_memcap == p->pcap_cnt) {
         SCLogNotice("simulating memcap hit for packet %" PRIu64, p->pcap_cnt);
         ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+        DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
         return NULL;
     }
 #endif
@@ -497,6 +512,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerGetUsedDefragTracker();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -506,6 +522,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
             dt = DefragTrackerAlloc();
             if (dt == NULL) {
                 ExceptionPolicyApply(p, defrag_config.memcap_policy, PKT_DROP_REASON_DEFRAG_MEMCAP);
+                DefragExceptionPolicyStatsIncr(tv, dtv, defrag_config.memcap_policy);
                 return NULL;
             }
 
@@ -530,7 +547,7 @@ static DefragTracker *DefragTrackerGetNew(Packet *p)
  *
  * returns a *LOCKED* tracker or NULL
  */
-DefragTracker *DefragGetTrackerFromHash (Packet *p)
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
     DefragTracker *dt = NULL;
 
@@ -542,7 +559,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
 
     /* see if the bucket already has a tracker */
     if (hb->head == NULL) {
-        dt = DefragTrackerGetNew(p);
+        dt = DefragTrackerGetNew(tv, dtv, p);
         if (dt == NULL) {
             DRLOCK_UNLOCK(hb);
             return NULL;
@@ -571,7 +588,7 @@ DefragTracker *DefragGetTrackerFromHash (Packet *p)
             dt = dt->hnext;
 
             if (dt == NULL) {
-                dt = pdt->hnext = DefragTrackerGetNew(p);
+                dt = pdt->hnext = DefragTrackerGetNew(tv, dtv, p);
                 if (dt == NULL) {
                     DRLOCK_UNLOCK(hb);
                     return NULL;

--- a/src/defrag-hash.h
+++ b/src/defrag-hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -27,6 +27,7 @@
 #include "decode.h"
 #include "defrag.h"
 #include "util-exception-policy.h"
+#include "util-exception-policy-types.h"
 
 /** Spinlocks or Mutex for the flow buckets. */
 //#define DRLOCK_SPIN
@@ -92,7 +93,7 @@ void DefragInitConfig(bool quiet);
 void DefragHashShutdown(void);
 
 DefragTracker *DefragLookupTrackerFromHash (Packet *);
-DefragTracker *DefragGetTrackerFromHash (Packet *);
+DefragTracker *DefragGetTrackerFromHash(ThreadVars *tv, DecodeThreadVars *dtv, Packet *);
 void DefragTrackerRelease(DefragTracker *);
 void DefragTrackerClearMemory(DefragTracker *);
 void DefragTrackerMoveToSpare(DefragTracker *);
@@ -101,6 +102,7 @@ uint32_t DefragTrackerSpareQueueGetSize(void);
 int DefragTrackerSetMemcap(uint64_t);
 uint64_t DefragTrackerGetMemcap(void);
 uint64_t DefragTrackerGetMemuse(void);
+enum ExceptionPolicy DefragGetMemcapExceptionPolicy(void);
 
 #endif /* __DEFRAG_HASH_H__ */
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -991,7 +991,7 @@ DefragGetOsPolicy(Packet *p)
 static DefragTracker *
 DefragGetTracker(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
 {
-    return DefragGetTrackerFromHash(p);
+    return DefragGetTrackerFromHash(tv, dtv, p);
 }
 
 /**

--- a/src/flow.c
+++ b/src/flow.c
@@ -143,6 +143,11 @@ uint64_t FlowGetMemuse(void)
     return memusecopy;
 }
 
+enum ExceptionPolicy FlowGetMemcapExceptionPolicy(void)
+{
+    return flow_config.memcap_policy;
+}
+
 void FlowCleanupAppLayer(Flow *f)
 {
     if (f == NULL || f->proto == 0)

--- a/src/flow.h
+++ b/src/flow.h
@@ -30,6 +30,7 @@ typedef struct FlowStorageId FlowStorageId;
 #include "decode.h"
 #include "util-time.h"
 #include "util-exception-policy.h"
+#include "util-exception-policy-types.h"
 #include "util-var.h"
 #include "util-optimize.h"
 #include "app-layer-protos.h"
@@ -576,6 +577,7 @@ void FlowUpdateState(Flow *f, enum FlowState s);
 int FlowSetMemcap(uint64_t size);
 uint64_t FlowGetMemcap(void);
 uint64_t FlowGetMemuse(void);
+enum ExceptionPolicy FlowGetMemcapExceptionPolicy(void);
 
 FlowStorageId GetFlowBypassInfoID(void);
 void RegisterFlowBypassInfo(void);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1950,6 +1950,15 @@ static int StreamTcpReassembleHandleSegmentUpdateACK (ThreadVars *tv,
     SCReturnInt(0);
 }
 
+static void StreamTcpReassembleExceptionPolicyStatsIncr(
+        ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, enum ExceptionPolicy policy)
+{
+    uint16_t id = ra_ctx->counter_tcp_reas_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         TcpSession *ssn, TcpStream *stream, Packet *p)
 {
@@ -2016,6 +2025,8 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
             /* failure can only be because of memcap hit, so see if this should lead to a drop */
             ExceptionPolicyApply(
                     p, stream_config.reassembly_memcap_policy, PKT_DROP_REASON_STREAM_REASSEMBLY);
+            StreamTcpReassembleExceptionPolicyStatsIncr(
+                    tv, ra_ctx, stream_config.reassembly_memcap_policy);
             SCReturnInt(-1);
         }
 

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,6 +28,7 @@
 #include "suricata.h"
 #include "flow.h"
 #include "stream-tcp-private.h"
+#include "util-exception-policy.h"
 
 /** Supported OS list and default OS policy is BSD */
 enum
@@ -64,6 +65,8 @@ typedef struct TcpReassemblyThreadCtx_ {
 
     /** TCP segments which are not being reassembled due to memcap was reached */
     uint16_t counter_tcp_segment_memcap;
+    /** times exception policy for stream reassembly memcap was applied **/
+    ExceptionPolicyCounters counter_tcp_reas_eps;
 
     uint16_t counter_tcp_segment_from_cache;
     uint16_t counter_tcp_segment_from_pool;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -93,6 +93,32 @@
 /* Settings order as in the enum */
 // clang-format off
 ExceptionPolicyStatsSetts stream_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_reassembly_memcap_eps_stats = {
     .valid_settings_ids = {
     /* EXCEPTION_POLICY_NOT_SET */      false,
     /* EXCEPTION_POLICY_AUTO */         false,
@@ -726,6 +752,14 @@ void StreamTcpFreeConfig(bool quiet)
     SCMutexDestroy(&ssn_pool_mutex);
 
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
+}
+
+static bool IsReassemblyMemcapExceptionPolicyStatsValid(int exception_policy)
+{
+    if (EngineModeIsIPS()) {
+        return stream_reassembly_memcap_eps_stats.valid_settings_ips[exception_policy];
+    }
+    return stream_reassembly_memcap_eps_stats.valid_settings_ids[exception_policy];
 }
 
 static bool IsStreamTcpSessionMemcapExceptionPolicyStatsValid(int policy)
@@ -5837,6 +5871,22 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
 
     stt->ra_ctx->counter_tcp_segment_memcap = StatsRegisterCounter("tcp.segment_memcap_drop", tv);
+
+    if (stream_config.reassembly_memcap_policy != EXCEPTION_POLICY_NOT_SET) {
+        /* set-up tcp stream reassembly memcap exception policy counters */
+        const char *eps_reas_str = "tcp.reassembly_exception_policy.";
+        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+            bool is_eps_valid = IsReassemblyMemcapExceptionPolicyStatsValid(i);
+            if (is_eps_valid) {
+                snprintf(stream_reassembly_memcap_eps_stats.eps_name[i],
+                        sizeof(stream_reassembly_memcap_eps_stats.eps_name[i]), "%s%s",
+                        eps_reas_str, ExceptionPolicyEnumToString(i, true));
+                stt->ra_ctx->counter_tcp_reas_eps.eps_id[i] =
+                        StatsRegisterCounter(stream_reassembly_memcap_eps_stats.eps_name[i], tv);
+            }
+        }
+    }
+
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);
     stt->ra_ctx->counter_tcp_segment_from_pool = StatsRegisterCounter("tcp.segment_from_pool", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -90,6 +90,32 @@
 #define STREAMTCP_DEFAULT_MAX_SYN_QUEUED        10
 #define STREAMTCP_DEFAULT_MAX_SYNACK_QUEUED     5
 
+/* Settings order as in the enum */
+// clang-format off
+ExceptionPolicyStatsSetts stream_memcap_eps_stats = {
+    .valid_settings_ids = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  false,
+    /* EXCEPTION_POLICY_DROP_FLOW */    false,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+    .valid_settings_ips = {
+    /* EXCEPTION_POLICY_NOT_SET */      false,
+    /* EXCEPTION_POLICY_AUTO */         false,
+    /* EXCEPTION_POLICY_PASS_PACKET */  true,
+    /* EXCEPTION_POLICY_PASS_FLOW */    true,
+    /* EXCEPTION_POLICY_BYPASS_FLOW */  true,
+    /* EXCEPTION_POLICY_DROP_PACKET */  true,
+    /* EXCEPTION_POLICY_DROP_FLOW */    true,
+    /* EXCEPTION_POLICY_REJECT */       true,
+    },
+};
+// clang-format on
+
 static int StreamTcpHandleFin(ThreadVars *tv, StreamTcpThread *, TcpSession *, Packet *);
 void StreamTcpReturnStreamSegments (TcpStream *);
 void StreamTcpInitConfig(bool);
@@ -702,6 +728,23 @@ void StreamTcpFreeConfig(bool quiet)
     SCLogDebug("ssn_pool_cnt %"PRIu64"", ssn_pool_cnt);
 }
 
+static bool IsStreamTcpSessionMemcapExceptionPolicyStatsValid(int policy)
+{
+    if (EngineModeIsIPS()) {
+        return stream_memcap_eps_stats.valid_settings_ips[policy];
+    }
+    return stream_memcap_eps_stats.valid_settings_ids[policy];
+}
+
+static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
+        ThreadVars *tv, StreamTcpThread *stt, enum ExceptionPolicy policy)
+{
+    const uint16_t id = stt->counter_tcp_ssn_memcap_eps.eps_id[policy];
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
+    }
+}
+
 /** \internal
  *  \brief The function is used to fetch a TCP session from the
  *         ssn_pool, when a TCP SYN is received.
@@ -741,6 +784,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
                       g_eps_stream_ssn_memcap == t_pcapcnt))) {
             SCLogNotice("simulating memcap reached condition for packet %" PRIu64, t_pcapcnt);
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 #endif
@@ -748,6 +792,7 @@ static TcpSession *StreamTcpNewSession(ThreadVars *tv, StreamTcpThread *stt, Pac
         if (ssn == NULL) {
             SCLogDebug("ssn_pool is empty");
             ExceptionPolicyApply(p, stream_config.ssn_memcap_policy, PKT_DROP_REASON_STREAM_MEMCAP);
+            StreamTcpSsnMemcapExceptionPolicyStatsIncr(tv, stt, stream_config.ssn_memcap_policy);
             return NULL;
         }
 
@@ -5763,6 +5808,22 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_memcap = StatsRegisterCounter("tcp.ssn_memcap_drop", tv);
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
+    if (stream_config.ssn_memcap_policy != EXCEPTION_POLICY_NOT_SET) {
+        /* set-up tcp stream ssn memcap exception policy counters */
+        const char *eps_default_str = "tcp.ssn_memcap_exception_policy.";
+        bool is_eps_valid = false;
+        for (uint8_t i = 0; i < EXCEPTION_POLICY_MAX; i++) {
+            is_eps_valid = IsStreamTcpSessionMemcapExceptionPolicyStatsValid(i);
+            if (is_eps_valid) {
+                snprintf(stream_memcap_eps_stats.eps_name[i],
+                        sizeof(stream_memcap_eps_stats.eps_name[i]), "%s%s", eps_default_str,
+                        ExceptionPolicyEnumToString(i, true));
+                stt->counter_tcp_ssn_memcap_eps.eps_id[i] =
+                        StatsRegisterCounter(stream_memcap_eps_stats.eps_name[i], tv);
+            }
+        }
+    }
+
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
     stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -96,6 +96,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */
     uint16_t counter_tcp_midstream_pickups;
+    /** exception policy stats */
+    ExceptionPolicyCounters counter_tcp_midstream_eps;
     /** wrong thread */
     uint16_t counter_tcp_wrong_thread;
     /** ack for unseen data */

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -30,6 +30,7 @@
 #include "stream.h"
 #include "stream-tcp-reassemble.h"
 #include "suricata.h"
+#include "util-exception-policy-types.h"
 
 #define STREAM_VERBOSE false
 /* Flag to indicate that the checksum validation for the stream engine
@@ -85,6 +86,8 @@ typedef struct StreamTcpThread_ {
     uint16_t counter_tcp_ssn_memcap;
     uint16_t counter_tcp_ssn_from_cache;
     uint16_t counter_tcp_ssn_from_pool;
+    /** exception policy */
+    ExceptionPolicyCounters counter_tcp_ssn_memcap_eps;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
     /** pseudo packets failed to setup */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/** add per-proto app-layer error counters for exception policies stats? disabled by default */
+bool g_stats_eps_per_app_proto_errors = false;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2686,6 +2689,12 @@ int PostConfLoadedSetup(SCInstance *suri)
     }
 
     SetMasterExceptionPolicy();
+
+    int b;
+    int ret = ConfGetBool("stats.eps-per-app-proto-errors", &b);
+    if (ret) {
+        g_stats_eps_per_app_proto_errors = (b == 1);
+    }
 
     AppLayerSetup();
 

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -1,0 +1,49 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ */
+
+#ifndef __UTIL_EXCEPTION_POLICY_TYPES_H__
+#define __UTIL_EXCEPTION_POLICY_TYPES_H__
+
+enum ExceptionPolicy {
+    EXCEPTION_POLICY_NOT_SET = 0,
+    EXCEPTION_POLICY_AUTO,
+    EXCEPTION_POLICY_PASS_PACKET,
+    EXCEPTION_POLICY_PASS_FLOW,
+    EXCEPTION_POLICY_BYPASS_FLOW,
+    EXCEPTION_POLICY_DROP_PACKET,
+    EXCEPTION_POLICY_DROP_FLOW,
+    EXCEPTION_POLICY_REJECT,
+};
+
+#define EXCEPTION_POLICY_MAX EXCEPTION_POLICY_REJECT + 1
+
+typedef struct ExceptionPolicyCounters_ {
+    /* Follows enum order */
+    uint16_t eps_id[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyCounters;
+
+typedef struct ExceptionPolicyStatsSetts_ {
+    char eps_name[EXCEPTION_POLICY_MAX][51];
+    bool valid_settings_ids[EXCEPTION_POLICY_MAX];
+    bool valid_settings_ips[EXCEPTION_POLICY_MAX];
+} ExceptionPolicyStatsSetts;
+
+#endif

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -31,7 +31,7 @@ enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */
 static bool g_eps_have_exception_policy = false;
 
-static const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy, bool isJson)
 {
     switch (policy) {
         case EXCEPTION_POLICY_NOT_SET:
@@ -43,13 +43,13 @@ static const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy)
         case EXCEPTION_POLICY_BYPASS_FLOW:
             return "bypass";
         case EXCEPTION_POLICY_DROP_FLOW:
-            return "drop-flow";
+            return isJson ? "drop_flow" : "drop-flow";
         case EXCEPTION_POLICY_DROP_PACKET:
-            return "drop-packet";
+            return isJson ? "drop_packet" : "drop-packet";
         case EXCEPTION_POLICY_PASS_PACKET:
-            return "pass-packet";
+            return isJson ? "pass_packet" : "pass-packet";
         case EXCEPTION_POLICY_PASS_FLOW:
-            return "pass-flow";
+            return isJson ? "pass_flow" : "pass-flow";
     }
     // TODO we shouldn't reach this, but if we do, better not to leave this as simply null...
     return "not set";
@@ -197,7 +197,7 @@ static enum ExceptionPolicy ExceptionPolicyMasterParse(const char *value)
     }
     g_eps_have_exception_policy = true;
 
-    SCLogInfo("master exception-policy set to: %s", ExceptionPolicyEnumToString(policy));
+    SCLogInfo("master exception-policy set to: %s", ExceptionPolicyEnumToString(policy, false));
 
     return policy;
 }
@@ -217,13 +217,13 @@ static enum ExceptionPolicy ExceptionPolicyGetDefault(
             p = PickPacketAction(option, p);
         }
         SCLogConfig("%s: %s (defined via 'exception-policy' master switch)", option,
-                ExceptionPolicyEnumToString(p));
+                ExceptionPolicyEnumToString(p, false));
         return p;
     } else if (EngineModeIsIPS() && !midstream) {
         p = EXCEPTION_POLICY_DROP_FLOW;
     }
     SCLogConfig("%s: %s (defined via 'built-in default' for %s-mode)", option,
-            ExceptionPolicyEnumToString(p), EngineModeIsIPS() ? "IPS" : "IDS");
+            ExceptionPolicyEnumToString(p, false), EngineModeIsIPS() ? "IPS" : "IDS");
 
     return p;
 }
@@ -244,7 +244,7 @@ enum ExceptionPolicy ExceptionPolicyParse(const char *option, bool support_flow)
             if (!support_flow) {
                 policy = PickPacketAction(option, policy);
             }
-            SCLogConfig("%s: %s", option, ExceptionPolicyEnumToString(policy));
+            SCLogConfig("%s: %s", option, ExceptionPolicyEnumToString(policy, false));
         }
     } else {
         policy = ExceptionPolicyGetDefault(option, support_flow, false);

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,18 +23,9 @@
 #define __UTIL_EXCEPTION_POLICY_H__
 
 #include "decode.h"
+#include "util-exception-policy-types.h"
 
-enum ExceptionPolicy {
-    EXCEPTION_POLICY_NOT_SET = 0,
-    EXCEPTION_POLICY_AUTO,
-    EXCEPTION_POLICY_PASS_PACKET,
-    EXCEPTION_POLICY_PASS_FLOW,
-    EXCEPTION_POLICY_BYPASS_FLOW,
-    EXCEPTION_POLICY_DROP_PACKET,
-    EXCEPTION_POLICY_DROP_FLOW,
-    EXCEPTION_POLICY_REJECT,
-};
-
+const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy, bool isJson);
 void SetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -74,6 +74,9 @@ stats:
   #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
+  # Exception policy stats counters options
+  # (Note: if exception policy: ignore, counters are not logged)
+  #eps-zero-valued-counters: false  # default: false. True will log counters: 0
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -77,6 +77,8 @@ stats:
   # Exception policy stats counters options
   # (Note: if exception policy: ignore, counters are not logged)
   #eps-zero-valued-counters: false  # default: false. True will log counters: 0
+  #eps-per-app-proto-errors: false  # default: false. True will log errors for
+                                    # each app-proto. Warning: VERY verbose
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5816

Previous PR: https://github.com/OISF/suricata/pull/10364

Changes from last PR:
- rebase
- if exception policies stats counters are zero and config is set to not log those, nothing is logged for exception policies
- fix `stack use after scope error`
- documentation updates - list stats, describe counters, better highlight which policies affect what exception scenarios
- ExceptionPolicyToStr accepts a parameter to log in JSON-compliant format
- add descriptions to json schema fields
- json schema accepts all exception policies for each of the possible scenarios (no checking if a certain policy is valid or not via the schema)
- if exception policy is set to `ignore`, skip the stats counters registering logic.

TODO?:
- better align stats.log - as the new counters size character is longer than what we currently have in the stats

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1674

How exception policy docs look like: https://suri-rtd-test.readthedocs.io/en/5816-excep-policy-stats-v5/configuration/exception-policies.html

Output samples:

app_layer (zero counters disabled, per-app-proto exception policies disabled:
```json
 "app_layer": {
    "error": {
      "exception_policy": {
        "drop_flow": 1
      },
  }
}
```

app_layer (zero counters enabled, per-app-proto exception policies enabled:
```json
  "app_layer": {
    "error": {
      "exception_policy": {
        "pass_packet": 1,
        "pass_flow": 0,
        "bypass": 0,
        "drop_packet": 0,
        "drop_flow": 0,
        "reject": 0
      },
...
    "tls": {
      "gap": 0,
      "alloc": 0,
      "parser": 1,
      "internal": 0,
      "exception_policy": {
        "pass_packet": 1,
        "pass_flow": 0,
        "bypass": 0,
        "drop_packet": 0,
        "drop_flow": 0,
        "reject": 0
      }
    },
```