### PR TITLE
capture plugins: load before device validation - v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2672,6 +2672,10 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
+#ifdef HAVE_PLUGINS
+    SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
+#endif
+
     LiveDeviceFinalize(); // must be after EBPF extension registration
 
     RunModeEngineIsIPS(
@@ -2743,9 +2747,6 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
-#ifdef HAVE_PLUGINS
-    SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
-#endif
     AppLayerHtpNeedFileInspection();
 
     StorageFinalize();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -879,9 +879,6 @@ int g_ut_covered;
 
 void RegisterAllModules(void)
 {
-    // zero all module storage
-    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
-
     /* commanders */
     TmModuleUnixManagerRegister();
     /* managers */
@@ -2872,6 +2869,10 @@ int InitGlobal(void)
     ConfInit();
 
     VarNameStoreInit();
+
+    // zero all module storage
+    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
+
     return 0;
 }
 


### PR DESCRIPTION
Capture plugins were not being loaded soon enough, and Suricata would error out before they had a chance to register. This happened sometime during the 7.0 development cycle.

Submitting now for a feedback, but also working on a light capture plugin that can be used in CI to avoid having this happen again.

Ticket: https://redmine.openinfosecfoundation.org/issues/6811