### PR TITLE
schema: add flow.wrong_thread

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1549,6 +1549,9 @@
                 },
                 "state": {
                     "type": "string"
+                },
+                "wrong_thread": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
Fixes the issue I'm seeing when I run https://github.com/OISF/suricata-verify/pull/1673 locally.