### PR TITLE
backport-7.0.x: dpdk: sanitize integer overflow in the configuration v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -464,6 +464,9 @@ static int ConfigSetMempoolSize(DPDKIfaceConfig *iconf, intmax_t entry_int)
     if (entry_int <= 0) {
         SCLogError("%s: positive memory pool size is required", iconf->iface);
         SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT32_MAX) {
+        SCLogError("%s: memory pool size cannot exceed %" PRIu32, iconf->iface, UINT32_MAX);
+        SCReturnInt(-ERANGE);
     }
 
     iconf->mempool_size = entry_int;
@@ -510,6 +513,9 @@ static int ConfigSetRxDescriptors(DPDKIfaceConfig *iconf, intmax_t entry_int)
     if (entry_int <= 0) {
         SCLogError("%s: positive number of RX descriptors is required", iconf->iface);
         SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT16_MAX) {
+        SCLogError("%s: number of RX descriptors cannot exceed %" PRIu16, iconf->iface, UINT16_MAX);
+        SCReturnInt(-ERANGE);
     }
 
     iconf->nb_rx_desc = entry_int;
@@ -521,6 +527,9 @@ static int ConfigSetTxDescriptors(DPDKIfaceConfig *iconf, intmax_t entry_int)
     SCEnter();
     if (entry_int <= 0) {
         SCLogError("%s: positive number of TX descriptors is required", iconf->iface);
+        SCReturnInt(-ERANGE);
+    } else if (entry_int > UINT16_MAX) {
+        SCLogError("%s: number of TX descriptors cannot exceed %" PRIu16, iconf->iface, UINT16_MAX);
         SCReturnInt(-ERANGE);
     }
 


### PR DESCRIPTION
Redmine ticket: [#6738](https://redmine.openinfosecfoundation.org/issues/6738) 
https://redmine.openinfosecfoundation.org/issues/6738

Backport of https://github.com/OISF/suricata/pull/10386

(cherry picked from commit cc2eb2d8b77e96586a607f661c7eed9ab41076fc)