### PR TITLE
backport-7.0.x: dpdk: fix auto cache-size calculation v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -484,7 +484,7 @@ static int ConfigSetMempoolCacheSize(DPDKIfaceConfig *iconf, const char *entry_s
             SCReturnInt(-EINVAL);
         }
 
-        uint32_t max_cache_size = MAX(RTE_MEMPOOL_CACHE_MAX_SIZE, iconf->mempool_size / 1.5);
+        uint32_t max_cache_size = MIN(RTE_MEMPOOL_CACHE_MAX_SIZE, iconf->mempool_size / 1.5);
         iconf->mempool_cache_size = GreatestDivisorUpTo(iconf->mempool_size, max_cache_size);
         SCReturnInt(0);
     }


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6742
Backport of https://github.com/OISF/suricata/pull/10388
(cherry picked from commit c65ff35819845a3f42c75f79d54f9ab91c5c2ec9)
