### PR TITLE
output-json: Enrich eve-log with geoip information from libmaxminddb

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -27,6 +27,10 @@ Output types::
 
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable GeoIP on source ip and destination ip
+      # Enter full path of GeoLite City database to enrich eve-log with geoip
+      # Disable geoip enrichment by commenting geoip-city-database
+      #geoip-city-database: /usr/share/GeoIP/GeoLite2-City.mmdb
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -92,6 +92,10 @@ outputs:
       enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable GeoIP on source ip and destination ip
+      # Enter full path of GeoLite City database to enrich eve-log with geoip
+      # Disable geoip enrichment by commenting geoip-city-database
+      #geoip-city-database: /usr/share/GeoIP/GeoLite2-City.mmdb
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false


### PR DESCRIPTION
I faced a very large log to be enriched using geoip. At the moment I utilize logstash to enrich the log file from Suricata but at the cost of additional resources in RAM, CPU, and storage. I would like to optimize this by adding optional geoip enrichment into Suricata.


- [ X ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ X ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ X ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: none

Describe changes:
- I adds optional geoip enrichment into Eve log by setting geoip-city-database option under eve-log configuration in suricata.yaml
- The JSON structure of geoip is based on [Elastic ECS geo specification](https://www.elastic.co/guide/en/ecs/current/ecs-geo.html) 

Eve output example with enrichment
```
{
    "timestamp": "2021-05-27T03:37:44.575843+0700",
    "flow_id": 2130735805455113,
    "pcap_cnt": 15756,
    "event_type": "fileinfo",
    "geoip_src": {
        "ip": "192.236.155.230",
        "geo": {
            "continent_code": "NA",
            "country_iso_code": "US",
            "city_name": "Seattle",
            "country_name": "United States",
            "continent_name": "North America",
            "timezone": "America/Los_Angeles",
            "location": {
                "lat": 47.4902,
                "lon": -122.3004
            }
        }
    },
    "geoip_dst": {},
    "src_ip": "192.236.155.230",
    "src_port": 80,
    "dest_ip": "10.5.26.4",
    "dest_port": 56042,
    "proto": "TCP",
    "pkt_src": "wire/pcap",
    "http": {
        "hostname": "192.236.155.230",
        "url": "/images/redbutton.png",
        "http_user_agent": "WinHTTP loader/1.0",
        "http_content_type": "Content-type: application/octet-stream",
        "http_method": "GET",
        "protocol": "HTTP/1.1",
        "status": 200,
        "length": 105556
    },
    "app_proto": "http",
    "fileinfo": {
        "filename": "/images/redbutton.png",
        "gaps": false,
        "state": "TRUNCATED",
        "stored": false,
        "size": 102400,
        "tx_id": 0
    },
}
```