### PR TITLE
devguide: add chapter and short intro to libsuricata - v1

### DIFF
--- a/doc/userguide/devguide/index.rst
+++ b/doc/userguide/devguide/index.rst
@@ -8,3 +8,4 @@ Suricata Developer Guide
    contributing/index.rst
    internals/index.rst
    extending/index.rst
+   libsuricata/index.rst

--- a/doc/userguide/devguide/libsuricata/index.rst
+++ b/doc/userguide/devguide/libsuricata/index.rst
@@ -1,0 +1,14 @@
+.. _libsuricata:
+
+LibSuricata
+===========
+
+Using Suricata as a Library
+---------------------------
+
+The ability to turn Suricata into a library that can be utilized in other tools
+is currently a work in progress, tracked by Redmine Ticket #2693:
+https://redmine.openinfosecfoundation.org/issues/2693.
+
+A related work are Suricata plugins, also in progress and tracked by Redmine
+Ticket #4101: https://redmine.openinfosecfoundation.org/issues/4101.


### PR DESCRIPTION
With this, we intend to make more users aware of this use case, and that we are working towards this.

Related to
Task #2693

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: none yet

Describe changes:
- add a directory `libsuricata` as `devguide` child
- add short index with references to redmine tickets that track libsuricata and suricata plugins work

We don't want to have more for now, as it's still a work in progress and don't want to be on the way of Jason's work, but also want to leave the door partially open, so we know where docs should go.
