### PR TITLE
Fix stats missing for non workers v6

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -51,6 +51,9 @@
         "icmp_type": {
             "type": "integer"
         },
+        "in_iface": {
+            "type": "string"
+        },
         "log_level": {
             "type": "string"
         },
@@ -3714,6 +3717,20 @@
                 "uptime": {
                     "description": "Suricata engine's uptime",
                     "type": "integer"
+                },
+                "capture": {
+                    "type": "object",
+                    "properties": {
+                        "kernel_packets": {
+                            "type": "integer"
+                        },
+                        "kernel_drops": {
+                            "type": "integer"
+                        },
+                        "kernel_ifdrops": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "memcap_pressure": {
                     "description": "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",

--- a/src/tests/output-json-stats.c
+++ b/src/tests/output-json-stats.c
@@ -23,7 +23,7 @@
 
 static int OutputJsonStatsTest01(void)
 {
-    StatsRecord global_records[] = { { 0 }, { 0 } };
+    StatsRecord total_records[] = { { 0 }, { 0 } };
     StatsRecord thread_records[2];
     thread_records[0].name = "capture.kernel_packets";
     thread_records[0].short_name = "kernel_packets";
@@ -36,7 +36,7 @@ static int OutputJsonStatsTest01(void)
 
     StatsTable table = {
         .nstats = 2,
-        .stats = &global_records[0],
+        .stats = &total_records[0],
         .ntstats = 1,
         .tstats = &thread_records[0],
     };
@@ -64,7 +64,72 @@ static int OutputJsonStatsTest01(void)
     return cmp_result == 0;
 }
 
+static int OutputJsonStatsTest02(void)
+{
+    StatsRecord total_records[4] = { 0 };
+    StatsRecord thread_records[8] = { 0 };
+
+    // Totals
+    total_records[0].name = "tcp.syn";
+    total_records[0].short_name = "syn";
+    total_records[0].tm_name = NULL;
+    total_records[0].value = 1234;
+
+    // Worker
+    // thread_records[0] is a global counter
+    thread_records[1].name = "capture.kernel_packets";
+    thread_records[1].short_name = "kernel_packets";
+    thread_records[1].tm_name = "W#01-bond0.30";
+    thread_records[1].value = 42;
+    thread_records[2].name = "capture.kernel_drops";
+    thread_records[2].short_name = "kernel_drops";
+    thread_records[2].tm_name = "W#01-bond0.30";
+    thread_records[2].value = 4711;
+    // thread_records[3] is a FM specific counter
+
+    // Flow manager
+    // thread_records[4] is a global counter
+    // thread_records[5] is a worker specific counter
+    // thread_records[6] is a worker specific counter
+    thread_records[7].name = "flow.mgr.full_hash_passes";
+    thread_records[7].short_name = "full_hash_passes";
+    thread_records[7].tm_name = "FM#01";
+    thread_records[7].value = 10;
+
+    StatsTable table = {
+        .nstats = 4,
+        .stats = &total_records[0],
+        .ntstats = 2,
+        .tstats = &thread_records[0],
+    };
+
+    json_t *r = StatsToJSON(&table, JSON_STATS_TOTALS | JSON_STATS_THREADS);
+    if (!r)
+        return 0;
+
+    // Remove variable content
+    json_object_del(r, "uptime");
+
+    char *serialized = json_dumps(r, 0);
+
+    // Cheesy comparison
+    const char *expected = "{\"tcp\": {\"syn\": 1234}, \"threads\": {\"W#01-bond0.30\": "
+                           "{\"capture\": {\"kernel_packets\": "
+                           "42, \"kernel_drops\": 4711}}, \"FM#01\": {\"flow\": {\"mgr\": "
+                           "{\"full_hash_passes\": 10}}}}}";
+
+    int cmp_result = strcmp(expected, serialized);
+    if (cmp_result != 0)
+        printf("unexpected result\nexpected=%s\ngot=%s\n", expected, serialized);
+
+    free(serialized);
+    json_decref(r);
+
+    return cmp_result == 0;
+}
+
 void OutputJsonStatsRegisterTests(void)
 {
     UtRegisterTest("OutputJsonStatsTest01", OutputJsonStatsTest01);
+    UtRegisterTest("OutputJsonStatsTest02", OutputJsonStatsTest02);
 }


### PR DESCRIPTION
Replaces: https://github.com/OISF/suricata/pull/10574

Changes since v5:
* Update just SV_BRANCH to not use `ps` and invoke suricatasc with python3.

Changes since v4:
* Replace warning with DEBUG_VALIDATE_BUG_ON when tm_name is NULL.

Changes since v3:

* Update just SV_BRANCH

Changes since v2:
* Don't use `ip` in new suricata-verify test, instead, grep for `lo` in `/proc/net/dev`

Changes since v1:
* Add SV test, update schmea.json for SV test.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Follow up for: https://redmine.openinfosecfoundation.org/issues/6732

Describe changes:

Commit b8b8aa69b49ac0dd222446c28d00a50f9fd7d716 used tm_name of the first StatsRecord of a thread block as key for the "threads" object. However, depending on the type of thread, tm_name can be NULL and would result in no entry being included for that thread at all. This caused non-worker metrics to vanish from the "threads" object in the dump-counters output.

This patch fixes this by remembering the first occurrence of a valid tm_name within the per-thread block and adds another unittest to cover this scenario.


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1683