### PR TITLE
7.0.x: capture plugins: load before device validation - v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2669,6 +2669,10 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     MacSetRegisterFlowStorage();
 
+#ifdef HAVE_PLUGINS
+    SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
+#endif
+
     LiveDeviceFinalize(); // must be after EBPF extension registration
 
     RunModeEngineIsIPS(
@@ -2740,9 +2744,6 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     FeatureTrackingRegister(); /* must occur prior to output mod registration */
     RegisterAllModules();
-#ifdef HAVE_PLUGINS
-    SCPluginsLoad(suri->capture_plugin_name, suri->capture_plugin_args);
-#endif
     AppLayerHtpNeedFileInspection();
 
     StorageFinalize();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -881,9 +881,6 @@ int g_ut_covered;
 
 void RegisterAllModules(void)
 {
-    // zero all module storage
-    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
-
     /* commanders */
     TmModuleUnixManagerRegister();
     /* managers */
@@ -2869,6 +2866,10 @@ int InitGlobal(void)
     ConfInit();
 
     VarNameStoreInit();
+
+    // zero all module storage
+    memset(tmm_modules, 0, TMM_SIZE * sizeof(TmModule));
+
     return 0;
 }
 


### PR DESCRIPTION
Backport of https://github.com/OISF/suricata/pull/10535.
Ticket: https://redmine.openinfosecfoundation.org/issues/6811

Tested with 7.0.x example PF_RING plugin (https://github.com/jasonish/suricata-example-plugins/tree/7.0/pf-ring)

I did not backport the example plugin with CI update, but could add that.
