### PR TITLE
libsuricata: make the Suricata application a user of the Suricata library - v4

### DIFF
--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -20,7 +20,17 @@
 int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
-    SuricataInit(argc, argv);
+
+    /* Parse command line options. This is optional, you could
+     * directly configure Suricata through the Conf API. */
+    SCParseCommandLine(argc, argv);
+
+    /* Validate/finalize the runmode. */
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    SuricataInit();
     SuricataPostInit();
 
     /* Suricata is now running, but we enter a loop to keep it running

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -30,6 +30,16 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Handle internal runmodes. Typically you wouldn't do this as a
+     * library user, however this example is showing how to replicate
+     * the Suricata application with the library. */
+    switch (SCStartInternalRunMode(argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
     SuricataInit();
     SuricataPostInit();
 

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -1,7 +1,35 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
 #include "suricata.h"
 
 int main(int argc, char **argv)
 {
-    SuricataMain(argc, argv);
-    return 0;
+    SuricataPreInit(argv[0]);
+    SuricataInit(argc, argv);
+    SuricataPostInit();
+
+    /* Suricata is now running, but we enter a loop to keep it running
+     * until it shouldn't be running anymore. */
+    SuricataMainLoop();
+
+    /* Shutdown engine. */
+    SuricataShutdown();
+    GlobalsDestroy();
+
+    return EXIT_SUCCESS;
 }

--- a/examples/lib/simple/main.c
+++ b/examples/lib/simple/main.c
@@ -40,6 +40,13 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
     }
 
+    /* Load configuration file, could be done earlier but must be done
+     * before SuricataInit, but even then its still optional as you
+     * may be programmatically configuration Suricata. */
+    if (SCLoadYamlConfig() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
     SuricataInit();
     SuricataPostInit();
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -353,6 +353,10 @@ static void SMTPConfigure(void) {
             if (unlikely(seq_node->name == NULL)) {
                 FatalError("SCStrdup failure.");
             }
+            scheme->name = SCStrdup("0");
+            if (unlikely(scheme->name == NULL)) {
+                FatalError("SCStrdup failure.");
+            }
             scheme->val = SCStrdup("http://");
             if (unlikely(scheme->val == NULL)) {
                 FatalError("SCStrdup failure.");

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,13 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
     }
 
-    /* Initialization tasks: Loading config, setup logging */
+    /* Load yaml configuration file if provided. */
+    if (SCLoadYamlConfig() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    /* Initialization tasks: apply configuration, drop privileges,
+     * etc. */
     SuricataInit();
 
     /* Post-initialization tasks: wait on thread start/running and get ready for the main loop. */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -955,9 +955,11 @@ void RegisterAllModules(void)
     TmModuleDecodeDPDKRegister();
 }
 
-static TmEcode LoadYamlConfig(SCInstance *suri)
+TmEcode SCLoadYamlConfig(void)
 {
     SCEnter();
+
+    SCInstance *suri = &suricata;
 
     if (suri->conf_filename == NULL)
         suri->conf_filename = DEFAULT_CONF_FILE;
@@ -2903,11 +2905,6 @@ void SuricataInit(void)
 {
     /* Initializations for global vars, queues, etc (memsets, mutex init..) */
     GlobalsInitPreConfig();
-
-    /* Load yaml configuration file if provided. */
-    if (LoadYamlConfig(&suricata) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
 
     if (suricata.run_mode == RUNMODE_DUMP_CONFIG) {
         ConfDump();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2899,13 +2899,6 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-#ifdef OS_WIN32
-    /* service initialization */
-    if (WindowsInitService(argc, argv) != 0) {
-        exit(EXIT_FAILURE);
-    }
-#endif /* OS_WIN32 */
-
     if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
@@ -3085,6 +3078,13 @@ int SuricataMain(int argc, char **argv)
 {
     /* Pre-initialization tasks: initialize global context and variables. */
     SuricataPreInit(argv[0]);
+
+#ifdef OS_WIN32
+    /* service initialization */
+    if (WindowsInitService(argc, argv) != 0) {
+        exit(EXIT_FAILURE);
+    }
+#endif /* OS_WIN32 */
 
     /* Initialization tasks: parse command line options, load yaml, start runmode... */
     SuricataInit(argc, argv);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2349,7 +2349,7 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
             SCLogInfo("Suricata service has been successfully installed.");
             return TM_ECODE_DONE;
         case RUNMODE_REMOVE_SERVICE:
-            if (SCServiceRemove(argc, argv)) {
+            if (SCServiceRemove()) {
                 return TM_ECODE_FAILED;
             }
             SCLogInfo("Suricata service has been successfully removed.");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1312,8 +1312,9 @@ static bool IsLogDirectoryWritable(const char* str)
 
 extern int g_skip_prefilter;
 
-static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
+static TmEcode ParseCommandLine(int argc, char **argv)
 {
+    SCInstance *suri = &suricata;
     int opt;
 
     int dump_config = 0;
@@ -2899,7 +2900,7 @@ void SuricataPreInit(const char *progname)
 
 void SuricataInit(int argc, char **argv)
 {
-    if (ParseCommandLine(argc, argv, &suricata) != TM_ECODE_OK) {
+    if (ParseCommandLine(argc, argv) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1312,7 +1312,7 @@ static bool IsLogDirectoryWritable(const char* str)
 
 extern int g_skip_prefilter;
 
-static TmEcode ParseCommandLine(int argc, char **argv)
+TmEcode SCParseCommandLine(int argc, char **argv)
 {
     SCInstance *suri = &suricata;
     int opt;
@@ -2368,8 +2368,9 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
     return TM_ECODE_OK;
 }
 
-static int FinalizeRunMode(SCInstance *suri)
+int SCFinalizeRunMode(void)
 {
+    SCInstance *suri = &suricata;
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
             PrintUsage(suri->progname);
@@ -2898,23 +2899,8 @@ void SuricataPreInit(const char *progname)
     }
 }
 
-void SuricataInit(int argc, char **argv)
+void SuricataInit(void)
 {
-    if (ParseCommandLine(argc, argv) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
-    if (FinalizeRunMode(&suricata) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
-    switch (StartInternalRunMode(&suricata, argc, argv)) {
-        case TM_ECODE_DONE:
-            exit(EXIT_SUCCESS);
-        case TM_ECODE_FAILED:
-            exit(EXIT_FAILURE);
-    }
-
     /* Initializations for global vars, queues, etc (memsets, mutex init..) */
     GlobalsInitPreConfig();
 
@@ -3087,8 +3073,23 @@ int SuricataMain(int argc, char **argv)
     }
 #endif /* OS_WIN32 */
 
-    /* Initialization tasks: parse command line options, load yaml, start runmode... */
-    SuricataInit(argc, argv);
+    if (SCParseCommandLine(argc, argv) != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    if (SCFinalizeRunMode() != TM_ECODE_OK) {
+        exit(EXIT_FAILURE);
+    }
+
+    switch (StartInternalRunMode(&suricata, argc, argv)) {
+        case TM_ECODE_DONE:
+            exit(EXIT_SUCCESS);
+        case TM_ECODE_FAILED:
+            exit(EXIT_FAILURE);
+    }
+
+    /* Initialization tasks: Loading config, setup logging */
+    SuricataInit();
 
     /* Post-initialization tasks: wait on thread start/running and get ready for the main loop. */
     SuricataPostInit();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -213,6 +213,9 @@ uint16_t g_livedev_mask = 0xffff;
  * support */
 bool g_disable_hashing = false;
 
+/* snapshot of the system's hugepages before system intitialization. */
+SystemHugepageSnapshot *prerun_snap = NULL;
+
 /** Suricata instance */
 SCInstance suricata;
 
@@ -2883,14 +2886,17 @@ int InitGlobal(void)
     return 0;
 }
 
-int SuricataMain(int argc, char **argv)
+void SuricataPreInit(const char *progname)
 {
-    SCInstanceInit(&suricata, argv[0]);
+    SCInstanceInit(&suricata, progname);
 
     if (InitGlobal() != 0) {
         exit(EXIT_FAILURE);
     }
+}
 
+void SuricataInit(int argc, char **argv)
+{
 #ifdef OS_WIN32
     /* service initialization */
     if (WindowsInitService(argc, argv) != 0) {
@@ -2982,7 +2988,6 @@ int SuricataMain(int argc, char **argv)
         goto out;
     }
 
-    SystemHugepageSnapshot *prerun_snap = NULL;
     if (run_mode == RUNMODE_DPDK)
         prerun_snap = SystemHugepageSnapshotCreate();
 
@@ -2993,8 +2998,29 @@ int SuricataMain(int argc, char **argv)
         UnixManagerThreadSpawnNonRunmode(suricata.unix_socket_enabled);
     }
 
+    return;
+
+out:
+    GlobalsDestroy(&suricata);
+    exit(EXIT_SUCCESS);
+}
+
+void SuricataShutdown(void)
+{
+    /* Update the engine stage/status flag */
+    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
+
+    UnixSocketKillSocketThread();
+    PostRunDeinit(suricata.run_mode, &suricata.start_time);
+    /* kill remaining threads */
+    TmThreadKillThreads();
+}
+
+void SuricataPostInit(void)
+{
     /* Wait till all the threads have been initialized */
     if (TmThreadWaitOnThreadInit() == TM_ECODE_FAILED) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         FatalError("Engine initialization failed, "
                    "aborting...");
     }
@@ -3036,6 +3062,7 @@ int SuricataMain(int argc, char **argv)
 
     /* Must ensure all threads are fully operational before continuing with init process */
     if (TmThreadWaitOnThreadRunning() != TM_ECODE_OK) {
+        SystemHugepageSnapshotDestroy(prerun_snap);
         exit(EXIT_FAILURE);
     }
 
@@ -3050,17 +3077,23 @@ int SuricataMain(int argc, char **argv)
         SystemHugepageSnapshotDestroy(postrun_snap);
     }
     SCPledge();
+}
+
+int SuricataMain(int argc, char **argv)
+{
+    /* Pre-initialization tasks: initialize global context and variables. */
+    SuricataPreInit(argv[0]);
+
+    /* Initialization tasks: parse command line options, load yaml, start runmode... */
+    SuricataInit(argc, argv);
+
+    /* Post-initialization tasks: wait on thread start/running and get ready for the main loop. */
+    SuricataPostInit();
+
     SuricataMainLoop(&suricata);
 
-    /* Update the engine stage/status flag */
-    SC_ATOMIC_SET(engine_stage, SURICATA_DEINIT);
-
-    UnixSocketKillSocketThread();
-    PostRunDeinit(suricata.run_mode, &suricata.start_time);
-    /* kill remaining threads */
-    TmThreadKillThreads();
-
-out:
+    /* Shutdown engine. */
+    SuricataShutdown();
     GlobalsDestroy(&suricata);
 
     exit(EXIT_SUCCESS);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -363,8 +363,9 @@ void GlobalsInitPreConfig(void)
     FrameConfigInit();
 }
 
-static void GlobalsDestroy(SCInstance *suri)
+void GlobalsDestroy(void)
 {
+    SCInstance *suri = &suricata;
     HostShutdown();
     HTPFreeConfig();
     HTPAtExitPrintStats();
@@ -2807,8 +2808,9 @@ int PostConfLoadedSetup(SCInstance *suri)
     SCReturnInt(TM_ECODE_OK);
 }
 
-static void SuricataMainLoop(SCInstance *suri)
+void SuricataMainLoop(void)
 {
+    SCInstance *suri = &suricata;
     while(1) {
         if (sigterm_count || sigint_count) {
             suricata_ctl_flags |= SURICATA_STOP;
@@ -3001,7 +3003,7 @@ void SuricataInit(int argc, char **argv)
     return;
 
 out:
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
     exit(EXIT_SUCCESS);
 }
 
@@ -3090,11 +3092,11 @@ int SuricataMain(int argc, char **argv)
     /* Post-initialization tasks: wait on thread start/running and get ready for the main loop. */
     SuricataPostInit();
 
-    SuricataMainLoop(&suricata);
+    SuricataMainLoop();
 
     /* Shutdown engine. */
     SuricataShutdown();
-    GlobalsDestroy(&suricata);
+    GlobalsDestroy();
 
     exit(EXIT_SUCCESS);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2368,11 +2368,11 @@ static int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
     return TM_ECODE_OK;
 }
 
-static int FinalizeRunMode(SCInstance *suri, char **argv)
+static int FinalizeRunMode(SCInstance *suri)
 {
     switch (suri->run_mode) {
         case RUNMODE_UNKNOWN:
-            PrintUsage(argv[0]);
+            PrintUsage(suri->progname);
             return TM_ECODE_FAILED;
         default:
             break;
@@ -2904,7 +2904,7 @@ void SuricataInit(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (FinalizeRunMode(&suricata, argv) != TM_ECODE_OK) {
+    if (FinalizeRunMode(&suricata) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -192,7 +192,7 @@ int SuriHasSigFile(void);
 extern int run_mode;
 
 void SuricataPreInit(const char *progname);
-void SuricataInit(int argc, char **argv);
+void SuricataInit(void);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
@@ -201,6 +201,8 @@ int InitGlobal(void);
 void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
+int SCFinalizeRunMode(void);
+TmEcode SCParseCommandLine(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -195,8 +195,10 @@ void SuricataPreInit(const char *progname);
 void SuricataInit(int argc, char **argv);
 void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
+void GlobalsDestroy(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -191,7 +191,11 @@ int SuriHasSigFile(void);
 
 extern int run_mode;
 
+void SuricataPreInit(const char *progname);
+void SuricataInit(int argc, char **argv);
+void SuricataPostInit(void);
 int SuricataMain(int argc, char **argv);
+void SuricataShutdown(void);
 int InitGlobal(void);
 int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -203,6 +203,7 @@ void PostConfLoadedDetectSetup(SCInstance *suri);
 int SCFinalizeRunMode(void);
 TmEcode SCParseCommandLine(int argc, char **argv);
 int SCStartInternalRunMode(int argc, char **argv);
+TmEcode SCLoadYamlConfig(void);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -194,7 +194,6 @@ extern int run_mode;
 void SuricataPreInit(const char *progname);
 void SuricataInit(void);
 void SuricataPostInit(void);
-int SuricataMain(int argc, char **argv);
 void SuricataMainLoop(void);
 void SuricataShutdown(void);
 int InitGlobal(void);
@@ -203,11 +202,16 @@ int PostConfLoadedSetup(SCInstance *suri);
 void PostConfLoadedDetectSetup(SCInstance *suri);
 int SCFinalizeRunMode(void);
 TmEcode SCParseCommandLine(int argc, char **argv);
+int SCStartInternalRunMode(int argc, char **argv);
 
 void PreRunInit(const int runmode);
 void PreRunPostPrivsDropInit(const int runmode);
 void PostRunDeinit(const int runmode, struct timeval *start_time);
 void RegisterAllModules(void);
+
+#ifdef OS_WIN32
+int WindowsInitService(int argc, char **argv);
+#endif
 
 const char *GetProgramVersion(void);
 

--- a/src/win32-service.c
+++ b/src/win32-service.c
@@ -279,7 +279,7 @@ int SCServiceInstall(int argc, char **argv)
  * \param argc num of arguments
  * \param argv passed arguments
  */
-int SCServiceRemove(int argc, char **argv)
+int SCServiceRemove(void)
 {
     SERVICE_STATUS status;
     SC_HANDLE service = NULL;

--- a/src/win32-service.h
+++ b/src/win32-service.h
@@ -28,7 +28,7 @@
 int SCRunningAsService(void);
 int SCServiceInit(int argc, char **argv);
 int SCServiceInstall(int argc, char **argv);
-int SCServiceRemove(int argc, char **argv);
+int SCServiceRemove(void);
 int SCServiceChangeParams(int argc, char **argv);
 #endif /* OS_WIN32 */
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/10521
Changes from previous PR:
- break out configuration file loading

Very similar to https://github.com/OISF/suricata/pull/10507 but lessens patch size.

Some refactoring of `suricata.c`, in particular moving the contents of SuricataMain back to `main()` in `main.c`, which forces it to use only functions that are exposed via the library.

This does *undo* some of the work of passing around a `SCInstance`, however as that wasn't complete, and it was still being accessed as a global, it was easier to move more accesses to the global instead of figuring out how to deal with this from library context at this time as its not an immediate concern.

Other changes:
- SCParseCommandLine is opt-in by library users so has been moved out of `SuricataInit`.
- Configuration loading has been factored out of `SuricataInit`, the user now has to call it sometime before `SuricataInit`, or programmatically configure Suricata before `SuricataInit`.

Other observations:
- `SuricataInit` and `SuricataPostInit` now take no arguments and are back to back. They could be merged or further broken out. For example, signal handling, process limiting and some other options should become opt-in as well for library users.  They're more part of the Suricata the application, not the library.
- Broken out like this `PreInit`, `Init`, `PostInit` might need some rethinking in their names.  For example as a library it would be nicer to do:
  - `SuricataInit`: initializes the very basics, like config etc..
  - user code that registers modules, programmatic configuration, calls our wrappers around loading configuration files and command line options..
  - `SuricataPostConfiguration`: The stuff that is done after the configuration file
  - `SuricataMainLoop` 