### PR TITLE
doc: Describe noalert keyword

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -280,6 +280,14 @@ keywords.
 
 Some generic details about keywords follow.
 
+Disabling Alerts
+~~~~~~~~~~~~~~~~
+There is a way to disable alert generation for a rule using the keyword ``noalert``.
+When this keyword is part of a rule, no alert is generated if the other
+portions of the rule match. Using ``noalert`` can be helpful when a rule is
+collecting or setting state using `flowbits`, `datasets` or other
+state maintenance constructs of the rule language.
+
 .. _rules-modifiers:
 
 Modifier Keywords


### PR DESCRIPTION
Issue: 6685

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6685](https://redmine.openinfosecfoundation.org/issues/6685)

Describe changes:
- Document `noalert` keyword.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
