### PR TITLE
netmap: Avoid HW errors when using pipes

### DIFF
--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -344,7 +344,9 @@ static void *ParseNetmapConfig(const char *iface_name)
         }
     }
 
-    int ring_count = NetmapGetRSSCount(aconf->iface_name);
+    int ring_count = 0;
+    if (aconf->in.real)
+		ring_count = NetmapGetRSSCount(aconf->iface_name);
     if (strlen(aconf->iface_name) > 0 &&
             (aconf->iface_name[strlen(aconf->iface_name) - 1] == '^' ||
                     aconf->iface_name[strlen(aconf->iface_name) - 1] == '*')) {


### PR DESCRIPTION
Issue: 6837

When using netmap pipes (with lb, for example), avoid direct hardware related IOCTLs that will fail (not supported with pipes).

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6837](https://redmine.openinfosecfoundation.org/issues/6837)

Describe changes:
- Skip ioctl to obtain the HW ring count when not using a "real" device

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
