### PR TITLE
eve-filetypes: separate from plugins, as eve filetypes are not plugins: plugins can register eve filetypes - v1

### DIFF
--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -17,6 +17,7 @@
 
 #include "suricata-common.h"
 #include "suricata-plugin.h"
+#include "output-eve.h"
 #include "util-mem.h"
 #include "util-debug.h"
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -392,6 +392,7 @@ noinst_HEADERS = \
 	log-tcp-data.h \
 	log-tlslog.h \
 	log-tlsstore.h \
+	output-eve.h \
 	output-eve-stream.h \
 	output-eve-null.h \
 	output-filedata.h \
@@ -1056,6 +1057,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-template.c \
 	output-json-tftp.c \
 	output-json-tls.c \
+	output-eve.c \
 	output-eve-syslog.c \
 	output-eve-null.c \
 	output-lua.c \

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -39,6 +39,7 @@
 #include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "conf.h"
 
 /**
  * \brief Functions to decode ERSPAN Type I and II packets

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -26,6 +26,7 @@
 #include "defrag-config.h"
 #include "util-misc.h"
 #include "util-radix-tree.h"
+#include "conf.h"
 
 static SCRadixTree *defrag_tree = NULL;
 

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -27,6 +27,7 @@
 
 #include "output.h" /* DEFAULT_LOG_* */
 #include "output-eve-null.h"
+#include "output-eve.h"
 
 #ifdef OS_WIN32
 void NullLogInitialize(void)

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "output.h"          /* DEFAULT_LOG_* */
+#include "output-eve.h"
 #include "output-eve-syslog.h"
 #include "util-syslog.h"
 

--- a/src/output-eve.c
+++ b/src/output-eve.c
@@ -1,0 +1,82 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "output-eve.h"
+#include "util-debug.h"
+
+static TAILQ_HEAD(, SCEveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
+
+static bool IsBuiltinTypeName(const char *name)
+{
+    const char *builtin[] = {
+        "regular",
+        "unix_dgram",
+        "unix_stream",
+        "redis",
+        NULL,
+    };
+    for (int i = 0;; i++) {
+        if (builtin[i] == NULL) {
+            break;
+        }
+        if (strcmp(builtin[i], name) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+SCEveFileType *SCEveFindFileType(const char *name)
+{
+    SCEveFileType *plugin = NULL;
+    TAILQ_FOREACH (plugin, &output_types, entries) {
+        if (strcmp(name, plugin->name) == 0) {
+            return plugin;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * \brief Register an Eve file type.
+ *
+ * \retval true if registered successfully, false if the file type name
+ *      conflicts with a built-in or previously registered
+ *      file type.
+ */
+bool SCRegisterEveFileType(SCEveFileType *plugin)
+{
+    /* First check that the name doesn't conflict with a built-in filetype. */
+    if (IsBuiltinTypeName(plugin->name)) {
+        SCLogError("Eve file type name conflicts with built-in type: %s", plugin->name);
+        return false;
+    }
+
+    /* Now check against previously registered file types. */
+    SCEveFileType *existing = NULL;
+    TAILQ_FOREACH (existing, &output_types, entries) {
+        if (strcmp(existing->name, plugin->name) == 0) {
+            SCLogError("Eve file type name conflicts with previously registered type: %s",
+                    plugin->name);
+            return false;
+        }
+    }
+
+    SCLogDebug("Registering EVE file type plugin %s", plugin->name);
+    TAILQ_INSERT_TAIL(&output_types, plugin, entries);
+    return true;
+}

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -1,0 +1,60 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \brief EVE logging subsystem
+ *
+ * This file will attempt to the main module for EVE logging
+ * sub-system. Currently most of the API resides in output-json.[ch],
+ * but due to some circular dependencies between EVE, and LogFileCtx,
+ * it made it hard to add EVE filetype modules there until some
+ * include issues are figured out.
+ */
+
+#ifndef __SURICATA_OUTPUT_EVE_H__
+#define __SURICATA_OUTPUT_EVE_H__
+
+#include "suricata-common.h"
+#include "conf.h"
+
+/**
+ * Structure used to define an Eve output file type plugin.
+ */
+typedef struct SCEveFileType_ {
+    /* The name of the output, used to specify the output in the filetype section
+     * of the eve-log configuration. */
+    const char *name;
+    /* Init Called on first access */
+    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    /* Write - Called on each write to the object */
+    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    /* Close - Called on final close */
+    void (*Deinit)(void *init_data);
+    /* ThreadInit - Called for each thread using file object*/
+    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadDeinit - Called for each thread using file object */
+    int (*ThreadDeinit)(void *init_data, void *thread_data);
+    TAILQ_ENTRY(SCEveFileType_) entries;
+} SCEveFileType;
+
+bool SCRegisterEveFileType(SCEveFileType *);
+
+SCEveFileType *SCEveFindFileType(const char *name);
+
+#endif

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -65,15 +65,12 @@
 #include "util-log-redis.h"
 #include "util-device.h"
 #include "util-validate.h"
-#include "util-plugin.h"
 
 #include "flow-var.h"
 #include "flow-bit.h"
 #include "flow-storage.h"
 
 #include "source-pcap-file-helper.h"
-
-#include "suricata-plugin.h"
 
 #define DEFAULT_LOG_FILENAME "eve.json"
 #define MODULE_NAME "OutputJSON"
@@ -1088,13 +1085,11 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
-#ifdef HAVE_PLUGINS
-            SCEveFileType *plugin = SCPluginFindFileType(output_s);
+            SCEveFileType *plugin = SCEveFindFileType(output_s);
             if (plugin != NULL) {
                 log_filetype = LOGFILE_TYPE_PLUGIN;
                 json_ctx->plugin = plugin;
             } else
-#endif
                 FatalError("Invalid JSON output option: %s", output_s);
         }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1008,7 +1008,7 @@ static int LogFileTypePrepare(
         }
     }
 #endif
-    else if (log_filetype == LOGFILE_TYPE_PLUGIN) {
+    else if (log_filetype == LOGFILE_TYPE_FILETYPE) {
         if (json_ctx->file_ctx->threaded) {
             /* Prepare for threaded log output. */
             if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx)) {
@@ -1016,11 +1016,11 @@ static int LogFileTypePrepare(
             }
         }
         void *init_data = NULL;
-        if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
+        if (json_ctx->filetype->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
             return -1;
         }
-        json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
-        json_ctx->file_ctx->plugin.init_data = init_data;
+        json_ctx->file_ctx->filetype.filetype = json_ctx->filetype;
+        json_ctx->file_ctx->filetype.init_data = init_data;
     }
 
     return 0;
@@ -1085,10 +1085,10 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
-            SCEveFileType *plugin = SCEveFindFileType(output_s);
-            if (plugin != NULL) {
-                log_filetype = LOGFILE_TYPE_PLUGIN;
-                json_ctx->plugin = plugin;
+            SCEveFileType *filetype = SCEveFindFileType(output_s);
+            if (filetype != NULL) {
+                log_filetype = LOGFILE_TYPE_FILETYPE;
+                json_ctx->filetype = filetype;
             } else
                 FatalError("Invalid JSON output option: %s", output_s);
         }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -28,10 +28,8 @@
 #include "util-buffer.h"
 #include "util-logopenfile.h"
 #include "output.h"
-#include "rust.h"
 
 #include "app-layer-htp-xff.h"
-#include "suricata-plugin.h"
 
 void OutputJsonRegister(void);
 
@@ -83,7 +81,7 @@ typedef struct OutputJsonCtx_ {
     enum LogFileType json_out;
     OutputJsonCommonSettings cfg;
     HttpXFFCfg *xff_cfg;
-    SCEveFileType *plugin;
+    SCEveFileType *filetype;
 } OutputJsonCtx;
 
 typedef struct OutputJsonThreadCtx_ {

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -31,6 +31,7 @@
 #include "util-checksum.h"
 #include "runmode-unix-socket.h"
 #include "suricata.h"
+#include "conf.h"
 
 extern uint16_t max_pending_packets;
 PcapFileGlobalVars pcap_g;

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -22,8 +22,6 @@
 #include <stdbool.h>
 #include <queue.h>
 
-#include "conf.h"
-
 /**
  * The size of the data chunk inside each packet structure a plugin
  * has for private data (Packet->plugin_v).

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <queue.h>
 
 #include "conf.h"
 
@@ -40,28 +41,6 @@ typedef struct SCPlugin_ {
 } SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
-
-/**
- * Structure used to define an Eve output file type plugin.
- */
-typedef struct SCEveFileType_ {
-    /* The name of the output, used to specify the output in the filetype section
-     * of the eve-log configuration. */
-    const char *name;
-    /* Init Called on first access */
-    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
-    /* Write - Called on each write to the object */
-    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
-    /* Close - Called on final close */
-    void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object*/
-    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
-    /* ThreadDeinit - Called for each thread using file object */
-    int (*ThreadDeinit)(void *init_data, void *thread_data);
-    TAILQ_ENTRY(SCEveFileType_) entries;
-} SCEveFileType;
-
-bool SCRegisterEveFileType(SCEveFileType *);
 
 typedef struct SCCapturePlugin_ {
     char *name;

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -25,6 +25,7 @@
 #define __UTIL_EBPF_H__
 
 #include "flow-bypass.h"
+#include "conf.h"
 
 #ifdef HAVE_PACKET_EBPF
 

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -26,6 +26,7 @@
 #include "util-misc.h"
 #include "stream-tcp-reassemble.h"
 #include "action-globals.h"
+#include "conf.h"
 
 enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -828,10 +828,10 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
         thread->Write = SCLogFileWriteNoLock;
         thread->Close = SCLogFileCloseNoLock;
         OutputRegisterFileRotationFlag(&thread->rotation_flag);
-    } else if (parent_ctx->type == LOGFILE_TYPE_PLUGIN) {
+    } else if (parent_ctx->type == LOGFILE_TYPE_FILETYPE) {
         entry->slot_number = SC_ATOMIC_ADD(eve_file_id, 1);
-        thread->plugin.plugin->ThreadInit(
-                thread->plugin.init_data, entry->slot_number, &thread->plugin.thread_data);
+        thread->filetype.filetype->ThreadInit(
+                thread->filetype.init_data, entry->slot_number, &thread->filetype.thread_data);
     }
     thread->threaded = false;
     thread->parent = parent_ctx;
@@ -864,8 +864,9 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCReturnInt(0);
     }
 
-    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN && lf_ctx->parent != NULL) {
-        lf_ctx->plugin.plugin->ThreadDeinit(lf_ctx->plugin.init_data, lf_ctx->plugin.thread_data);
+    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE && lf_ctx->parent != NULL) {
+        lf_ctx->filetype.filetype->ThreadDeinit(
+                lf_ctx->filetype.init_data, lf_ctx->filetype.thread_data);
     }
 
     if (lf_ctx->threaded) {
@@ -878,7 +879,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         }
         SCFree(lf_ctx->threads);
     } else {
-        if (lf_ctx->type != LOGFILE_TYPE_PLUGIN) {
+        if (lf_ctx->type != LOGFILE_TYPE_FILETYPE) {
             if (lf_ctx->fp != NULL) {
                 lf_ctx->Close(lf_ctx);
             }
@@ -901,11 +902,11 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);
     }
 
-    /* Deinitialize output plugins. We only want to call this for the
-     * parent of threaded output, or always for non-threaded
+    /* Deinitialize output filetypes. We only want to call this for
+     * the parent of threaded output, or always for non-threaded
      * output. */
-    if (lf_ctx->type == LOGFILE_TYPE_PLUGIN && lf_ctx->parent == NULL) {
-        lf_ctx->plugin.plugin->Deinit(lf_ctx->plugin.init_data);
+    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE && lf_ctx->parent == NULL) {
+        lf_ctx->filetype.filetype->Deinit(lf_ctx->filetype.init_data);
     }
 
     memset(lf_ctx, 0, sizeof(*lf_ctx));
@@ -922,9 +923,10 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
         MemBufferWriteString(buffer, "\n");
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
                         MEMBUFFER_OFFSET(buffer), file_ctx);
-    } else if (file_ctx->type == LOGFILE_TYPE_PLUGIN) {
-        file_ctx->plugin.plugin->Write((const char *)MEMBUFFER_BUFFER(buffer),
-                MEMBUFFER_OFFSET(buffer), file_ctx->plugin.init_data, file_ctx->plugin.thread_data);
+    } else if (file_ctx->type == LOGFILE_TYPE_FILETYPE) {
+        file_ctx->filetype.filetype->Write((const char *)MEMBUFFER_BUFFER(buffer),
+                MEMBUFFER_OFFSET(buffer), file_ctx->filetype.init_data,
+                file_ctx->filetype.thread_data);
     }
 #ifdef HAVE_LIBHIREDIS
     else if (file_ctx->type == LOGFILE_TYPE_REDIS) {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -33,7 +33,6 @@
 #include "util-log-redis.h"
 #endif /* HAVE_LIBHIREDIS */
 
-#include "suricata-plugin.h"
 #include "output-eve.h"
 
 enum LogFileType {
@@ -41,7 +40,8 @@ enum LogFileType {
     LOGFILE_TYPE_UNIX_DGRAM,
     LOGFILE_TYPE_UNIX_STREAM,
     LOGFILE_TYPE_REDIS,
-    LOGFILE_TYPE_PLUGIN,
+    /** New style or modular filetypes. */
+    LOGFILE_TYPE_FILETYPE,
     LOGFILE_TYPE_NOTSET
 };
 
@@ -51,7 +51,7 @@ typedef struct SyslogSetup_ {
 
 typedef struct ThreadLogFileHashEntry {
     uint64_t thread_id;
-    int slot_number; /* slot identifier -- for plugins */
+    int slot_number; /* slot identifier -- for modular filetypes */
     bool isopen;
     struct LogFileCtx_ *ctx;
 } ThreadLogFileHashEntry;
@@ -63,11 +63,11 @@ typedef struct LogThreadedFileCtx_ {
     char *append;
 } LogThreadedFileCtx;
 
-typedef struct LogFilePluginCtx_ {
-    SCEveFileType *plugin;
+typedef struct LogFileTypeCtx_ {
+    SCEveFileType *filetype;
     void *init_data;
     void *thread_data;
-} LogFilePluginCtx;
+} LogFileTypeCtx;
 
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
@@ -88,7 +88,7 @@ typedef struct LogFileCtx_ {
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
 
-    LogFilePluginCtx plugin;
+    LogFileTypeCtx filetype;
 
     /** It will be locked if the log/alert
      * record cannot be written to the file in one call */

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -34,6 +34,7 @@
 #endif /* HAVE_LIBHIREDIS */
 
 #include "suricata-plugin.h"
+#include "output-eve.h"
 
 enum LogFileType {
     LOGFILE_TYPE_FILE,

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -33,6 +33,7 @@
 #include "util-macset.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "conf.h"
 
 typedef uint8_t MacAddr[6];
 typedef enum {

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -19,7 +19,6 @@
 #include "suricata-plugin.h"
 #include "suricata.h"
 #include "runmodes.h"
-#include "output-eve-syslog.h"
 #include "util-plugin.h"
 #include "util-debug.h"
 
@@ -40,8 +39,6 @@ typedef struct PluginListNode_ {
  * dlopen, but could have other uses, such as a plugin unload destructor.
  */
 static TAILQ_HEAD(, PluginListNode_) plugins = TAILQ_HEAD_INITIALIZER(plugins);
-
-static TAILQ_HEAD(, SCEveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
 
 static TAILQ_HEAD(, SCCapturePlugin_) capture_plugins = TAILQ_HEAD_INITIALIZER(capture_plugins);
 
@@ -131,67 +128,6 @@ void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_a
         capture->Init(capture_plugin_args, RUNMODE_PLUGIN, TMM_RECEIVEPLUGIN,
                 TMM_DECODEPLUGIN);
     }
-}
-
-static bool IsBuiltinTypeName(const char *name)
-{
-    const char *builtin[] = {
-        "regular",
-        "unix_dgram",
-        "unix_stream",
-        "redis",
-        NULL,
-    };
-    for (int i = 0;; i++) {
-        if (builtin[i] == NULL) {
-            break;
-        }
-        if (strcmp(builtin[i], name) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * \brief Register an Eve file type.
- *
- * \retval true if registered successfully, false if the file type name
- *      conflicts with a built-in or previously registered
- *      file type.
- */
-bool SCRegisterEveFileType(SCEveFileType *plugin)
-{
-    /* First check that the name doesn't conflict with a built-in filetype. */
-    if (IsBuiltinTypeName(plugin->name)) {
-        SCLogError("Eve file type name conflicts with built-in type: %s", plugin->name);
-        return false;
-    }
-
-    /* Now check against previously registered file types. */
-    SCEveFileType *existing = NULL;
-    TAILQ_FOREACH (existing, &output_types, entries) {
-        if (strcmp(existing->name, plugin->name) == 0) {
-            SCLogError("Eve file type name conflicts with previously registered type: %s",
-                    plugin->name);
-            return false;
-        }
-    }
-
-    SCLogDebug("Registering EVE file type plugin %s", plugin->name);
-    TAILQ_INSERT_TAIL(&output_types, plugin, entries);
-    return true;
-}
-
-SCEveFileType *SCPluginFindFileType(const char *name)
-{
-    SCEveFileType *plugin = NULL;
-    TAILQ_FOREACH(plugin, &output_types, entries) {
-        if (strcmp(name, plugin->name) == 0) {
-            return plugin;
-        }
-    }
-    return NULL;
 }
 
 int SCPluginRegisterCapture(SCCapturePlugin *plugin)

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -21,6 +21,7 @@
 #include "runmodes.h"
 #include "util-plugin.h"
 #include "util-debug.h"
+#include "conf.h"
 
 #ifdef HAVE_PLUGINS
 

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -21,7 +21,6 @@
 #include "suricata-plugin.h"
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
-SCEveFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
 bool RegisterPlugin(SCPlugin *, void *);


### PR DESCRIPTION
EVE filetypes and plugins were conflated in naming and discussion when they are really different things which is clear by examples in code such as the nullsink and syslog eve filetypes, which are very much not plugins.

To make this more clear, rename and refactor such that these registered EVE filetypes are referred to as filetypes, not plugins.

Plugins can register these filetypes, but so can internal code as well as library users.

Includes some header cleanup due to removing "suricata-plugin.h" from places that shouldn't need any knowledge of plugins, but somehow become the way some files were getting the "conf.h" header.

Pushing for review, but as I'm reviewing myself right now, I want to fill out more of the in-code documentation.

Ticket: https://redmine.openinfosecfoundation.org/issues/6838