### PR TITLE
flow: Use proper thread id for injection

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -340,7 +340,7 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
  */
 void FlowForceReassemblyForFlow(Flow *f)
 {
-    const int thread_id = (int)f->thread_id[0];
+    const int thread_id = (int)(f->thread_id[0] ? f->thread_id[0] : f->thread_id[1]);
     TmThreadsInjectFlowById(f, thread_id);
 }
 

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -355,7 +355,7 @@ void FlowForceReassemblyForFlow(Flow *f)
  * - silence complaining profilers
  * - allow us to aggressively check using debug validation assertions
  * - be robust in case of future changes
- * - locking overhead if neglectable when no other thread fights us
+ * - locking overhead is negligible when no other thread fights us
  *
  * \param q The queue to process flows from.
  */

--- a/src/flow.c
+++ b/src/flow.c
@@ -291,6 +291,8 @@ void FlowSwap(Flow *f)
     FlowSwapFlags(f);
     FlowSwapFileFlags(f);
 
+    SWAP_VARS(int, f->thread_id[0], f->thread_id[1]);
+
     if (f->proto == IPPROTO_TCP) {
         TcpStreamFlowSwap(f);
     }


### PR DESCRIPTION
Continuation of #10617 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6835](https://redmine.openinfosecfoundation.org/issues/6835)

Describe changes:
- Also swap thread_ids when reversing a flow's direction
- Never choose an uninitialized thread_id during injectiona
- Typo fix
Updates:
- Udpate commit author

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
