### PR TITLE
eve/filetypes: eve filetypes are not always plugins; API docs; simpler - v3

### DIFF
--- a/doc/userguide/devguide/index.rst
+++ b/doc/userguide/devguide/index.rst
@@ -9,3 +9,4 @@ Suricata Developer Guide
    internals/index.rst
    extending/index.rst
    libsuricata/index.rst
+   upgrading/index.rst

--- a/doc/userguide/devguide/upgrading/index.rst
+++ b/doc/userguide/devguide/upgrading/index.rst
@@ -1,0 +1,21 @@
+Upgrading
+=========
+
+Upgrading 7.0 to 8.0
+--------------------
+
+EVE File Types
+~~~~~~~~~~~~~~
+
+- The ``ThreadInit`` function will now be called when in *threaded*
+  and *non-threaded* modes. This simplifies the initialization for EVE
+  filetypes as they can use the same flow of execution for both
+  modes. To upgrade, either remove the call to ``ThreadInit`` from
+  ``Init``, or move per-thread setup code from ``Init`` to
+  ``ThreadInit``.
+- Many of the function arguments to the callbacks have been made
+  ``const`` where it made sense.
+
+Please see the latest example EVE filetype plugin for an up to date
+example.
+

--- a/doxygen.cfg
+++ b/doxygen.cfg
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src/ libhtp/htp/
+INPUT                  = src/ libhtp/htp/ examples/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -17,6 +17,7 @@
 
 #include "suricata-common.h"
 #include "suricata-plugin.h"
+#include "output-eve.h"
 #include "util-mem.h"
 #include "util-debug.h"
 

--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -64,7 +64,7 @@ typedef struct Context_ {
  * configuration for the eve instance, not just a node named after the plugin.
  * This allows the plugin to get more context about what it is logging.
  */
-static int FiletypeInit(ConfNode *conf, bool threaded, void **data)
+static int FiletypeInit(const ConfNode *conf, const bool threaded, void **data)
 {
     SCLogNotice("Initializing template eve output plugin: threaded=%d", threaded);
     Context *context = SCCalloc(1, sizeof(Context));
@@ -125,7 +125,7 @@ static void FiletypeDeinit(void *data)
  * In the case of non-threaded EVE logging this function is called
  * once with a thread_id of 0.
  */
-static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data)
+static int FiletypeThreadInit(const void *ctx, const ThreadId thread_id, void **thread_data)
 {
     SCLogNotice("thread_id=%d", thread_id);
     ThreadData *tdata = SCCalloc(1, sizeof(ThreadData));
@@ -146,7 +146,7 @@ static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data)
  * This is where any cleanup per thread should be done including free'ing of the
  * thread_data if needed.
  */
-static void FiletypeThreadDeinit(void *ctx, void *thread_data)
+static void FiletypeThreadDeinit(const void *ctx, void *thread_data)
 {
     SCLogNotice("thread_data=%p", thread_data);
     if (thread_data == NULL) {
@@ -171,9 +171,10 @@ static void FiletypeThreadDeinit(void *ctx, void *thread_data)
  * to any resource that may block it might be best to enqueue the buffers for
  * further processing which will require copying of the provided buffer.
  */
-static int FiletypeWrite(const char *buffer, int buffer_len, void *data, void *thread_data)
+static int FiletypeWrite(
+        const char *buffer, const int buffer_len, const void *data, void *thread_data)
 {
-    Context *ctx = data;
+    const Context *ctx = data;
     ThreadData *thread = thread_data;
 
     SCLogNotice("thread_id=%d, data=%p, thread_data=%p", thread->thread_id, data, thread_data);

--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -22,7 +22,7 @@
 
 #define FILETYPE_NAME "json-filetype-plugin"
 
-static int FiletypeThreadInit(void *ctx, int thread_id, void **thread_data);
+static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data);
 static int FiletypeThreadDeinit(void *ctx, void *thread_data);
 
 /**
@@ -30,7 +30,7 @@ static int FiletypeThreadDeinit(void *ctx, void *thread_data);
  */
 typedef struct ThreadData_ {
     /** The thread ID, for demonstration purposes only. */
-    int thread_id;
+    ThreadId thread_id;
 
     /** The number of records logged on this thread. */
     uint64_t count;
@@ -143,7 +143,7 @@ static void FiletypeDeinit(void *data)
  * Suricata, but instead this plugin chooses to use this method to create a
  * default (single) thread context.
  */
-static int FiletypeThreadInit(void *ctx, int thread_id, void **thread_data)
+static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data)
 {
     ThreadData *tdata = SCCalloc(1, sizeof(ThreadData));
     if (tdata == NULL) {

--- a/examples/plugins/c-json-filetype/filetype.c
+++ b/examples/plugins/c-json-filetype/filetype.c
@@ -23,9 +23,6 @@
 
 #define FILETYPE_NAME "json-filetype-plugin"
 
-static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data);
-static int FiletypeThreadDeinit(void *ctx, void *thread_data);
-
 /**
  * Per thread context data for each logging thread.
  */
@@ -149,19 +146,18 @@ static int FiletypeThreadInit(void *ctx, ThreadId thread_id, void **thread_data)
  * This is where any cleanup per thread should be done including free'ing of the
  * thread_data if needed.
  */
-static int FiletypeThreadDeinit(void *ctx, void *thread_data)
+static void FiletypeThreadDeinit(void *ctx, void *thread_data)
 {
     SCLogNotice("thread_data=%p", thread_data);
     if (thread_data == NULL) {
         // Nothing to do.
-        return 0;
+        return;
     }
 
     ThreadData *tdata = thread_data;
     SCLogNotice(
             "Deinitializing thread %d: records written: %" PRIu64, tdata->thread_id, tdata->count);
     SCFree(tdata);
-    return 0;
 }
 
 /**

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -393,6 +393,7 @@ noinst_HEADERS = \
 	log-tcp-data.h \
 	log-tlslog.h \
 	log-tlsstore.h \
+	output-eve.h \
 	output-eve-stream.h \
 	output-eve-null.h \
 	output-filedata.h \
@@ -1058,6 +1059,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-template.c \
 	output-json-tftp.c \
 	output-json-tls.c \
+	output-eve.c \
 	output-eve-syslog.c \
 	output-eve-null.c \
 	output-lua.c \

--- a/src/decode-erspan.c
+++ b/src/decode-erspan.c
@@ -39,6 +39,7 @@
 #include "util-validate.h"
 #include "util-unittest.h"
 #include "util-debug.h"
+#include "conf.h"
 
 /**
  * \brief Functions to decode ERSPAN Type I and II packets

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -26,6 +26,7 @@
 #include "defrag-config.h"
 #include "util-misc.h"
 #include "util-radix-tree.h"
+#include "conf.h"
 
 static SCRadixTree *defrag_tree = NULL;
 

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -54,9 +54,8 @@ static int NullLogThreadInit(void *init_data, ThreadId thread_id, void **thread_
     return 0;
 }
 
-static int NullLogThreadDeInit(void *init_data, void *thread_data)
+static void NullLogThreadDeInit(void *init_data, void *thread_data)
 {
-    return 0;
 }
 
 static void NullLogDeInit(void *init_data)

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -27,6 +27,7 @@
 
 #include "output.h" /* DEFAULT_LOG_* */
 #include "output-eve-null.h"
+#include "output-eve.h"
 
 #ifdef OS_WIN32
 void NullLogInitialize(void)

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -47,7 +47,7 @@ static int NullLogWrite(const char *buffer, int buffer_len, void *init_data, voi
     return 0;
 }
 
-static int NullLogThreadInit(void *init_data, int thread_id, void **thread_data)
+static int NullLogThreadInit(void *init_data, ThreadId thread_id, void **thread_data)
 {
     *thread_data = NULL;
     return 0;

--- a/src/output-eve-null.c
+++ b/src/output-eve-null.c
@@ -37,24 +37,25 @@ void NullLogInitialize(void)
 
 #define OUTPUT_NAME "nullsink"
 
-static int NullLogInit(ConfNode *conf, bool threaded, void **init_data)
+static int NullLogInit(const ConfNode *conf, const bool threaded, void **init_data)
 {
     *init_data = NULL;
     return 0;
 }
 
-static int NullLogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+static int NullLogWrite(
+        const char *buffer, const int buffer_len, const void *init_data, void *thread_data)
 {
     return 0;
 }
 
-static int NullLogThreadInit(void *init_data, ThreadId thread_id, void **thread_data)
+static int NullLogThreadInit(const void *init_data, const ThreadId thread_id, void **thread_data)
 {
     *thread_data = NULL;
     return 0;
 }
 
-static void NullLogThreadDeInit(void *init_data, void *thread_data)
+static void NullLogThreadDeInit(const void *init_data, void *thread_data)
 {
 }
 

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -41,7 +41,7 @@ typedef struct Context_ {
     int alert_syslog_level;
 } Context;
 
-static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
+static int SyslogInit(const ConfNode *conf, const bool threaded, void **init_data)
 {
     Context *context = SCCalloc(1, sizeof(Context));
     if (context == NULL) {
@@ -79,9 +79,10 @@ static int SyslogInit(ConfNode *conf, bool threaded, void **init_data)
     return 0;
 }
 
-static int SyslogWrite(const char *buffer, int buffer_len, void *init_data, void *thread_data)
+static int SyslogWrite(
+        const char *buffer, const int buffer_len, const void *init_data, void *thread_data)
 {
-    Context *context = init_data;
+    const Context *context = init_data;
     syslog(context->alert_syslog_level, "%s", (const char *)buffer);
 
     return 0;

--- a/src/output-eve-syslog.c
+++ b/src/output-eve-syslog.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "output.h"          /* DEFAULT_LOG_* */
+#include "output-eve.h"
 #include "output-eve-syslog.h"
 #include "util-syslog.h"
 

--- a/src/output-eve.c
+++ b/src/output-eve.c
@@ -1,0 +1,82 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "output-eve.h"
+#include "util-debug.h"
+
+static TAILQ_HEAD(, SCEveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
+
+static bool IsBuiltinTypeName(const char *name)
+{
+    const char *builtin[] = {
+        "regular",
+        "unix_dgram",
+        "unix_stream",
+        "redis",
+        NULL,
+    };
+    for (int i = 0;; i++) {
+        if (builtin[i] == NULL) {
+            break;
+        }
+        if (strcmp(builtin[i], name) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+SCEveFileType *SCEveFindFileType(const char *name)
+{
+    SCEveFileType *plugin = NULL;
+    TAILQ_FOREACH (plugin, &output_types, entries) {
+        if (strcmp(name, plugin->name) == 0) {
+            return plugin;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * \brief Register an Eve file type.
+ *
+ * \retval true if registered successfully, false if the file type name
+ *      conflicts with a built-in or previously registered
+ *      file type.
+ */
+bool SCRegisterEveFileType(SCEveFileType *plugin)
+{
+    /* First check that the name doesn't conflict with a built-in filetype. */
+    if (IsBuiltinTypeName(plugin->name)) {
+        SCLogError("Eve file type name conflicts with built-in type: %s", plugin->name);
+        return false;
+    }
+
+    /* Now check against previously registered file types. */
+    SCEveFileType *existing = NULL;
+    TAILQ_FOREACH (existing, &output_types, entries) {
+        if (strcmp(existing->name, plugin->name) == 0) {
+            SCLogError("Eve file type name conflicts with previously registered type: %s",
+                    plugin->name);
+            return false;
+        }
+    }
+
+    SCLogDebug("Registering EVE file type plugin %s", plugin->name);
+    TAILQ_INSERT_TAIL(&output_types, plugin, entries);
+    return true;
+}

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -1,0 +1,63 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \brief EVE logging subsystem
+ *
+ * This file will attempt to the main module for EVE logging
+ * sub-system. Currently most of the API resides in output-json.[ch],
+ * but due to some circular dependencies between EVE, and LogFileCtx,
+ * it made it hard to add EVE filetype modules there until some
+ * include issues are figured out.
+ */
+
+#ifndef SURICATA_OUTPUT_EVE_H
+#define SURICATA_OUTPUT_EVE_H
+
+#include "suricata-common.h"
+#include "conf.h"
+
+typedef uint32_t ThreadId;
+
+/**
+ * Structure used to define an Eve output file type plugin.
+ */
+typedef struct SCEveFileType_ {
+    /* The name of the output, used to specify the output in the filetype section
+     * of the eve-log configuration. */
+    const char *name;
+    /* Init Called on first access */
+    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    /* Write - Called on each write to the object */
+    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    /* Close - Called on final close */
+    void (*Deinit)(void *init_data);
+    /* ThreadInit - Called for each thread using file object; non-zero thread_ids correlate
+     * to Suricata's worker threads; 0 correlates to the Suricata main thread */
+    int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
+    /* ThreadDeinit - Called for each thread using file object */
+    int (*ThreadDeinit)(void *init_data, void *thread_data);
+    TAILQ_ENTRY(SCEveFileType_) entries;
+} SCEveFileType;
+
+bool SCRegisterEveFileType(SCEveFileType *);
+
+SCEveFileType *SCEveFindFileType(const char *name);
+
+#endif

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -36,23 +36,137 @@
 typedef uint32_t ThreadId;
 
 /**
- * Structure used to define an Eve output file type plugin.
+ * \brief Structure used to define an EVE output file type plugin.
+ *
+ * EVE filetypes implement an object with a file-like interface and
+ * are used to output EVE log records to files, syslog, or
+ * database. They can be built-in such as the syslog (see
+ * SyslogInitialize()) and nullsink (see NullLogInitialize()) outputs,
+ * registered by a library user or dynamically loaded as a plugin.
+ *
+ * The life cycle of an EVE filetype is:
+ *   - Init: called once for each EVE instance using this filetype
+ *   - ThreadInit: called once for each output thread
+ *   - Write: called for each log record
+ *   - ThreadInit: called once for each output thread on exit
+ *   - Deinit: called once for each EVE instance using this filetype on exit
+ *
+ * Examples:
+ * - built-in syslog: \ref src/output-eve-syslog.c
+ * - built-in nullsink: \ref src/output-eve-null.c
+ * - example plugin: \ref examples/plugins/c-json-filetype/filetype.c
+ *
+ * ### Multi-Threaded Note:
+ *
+ * The EVE logging system can be configured by the Suricata user to
+ * run in threaded or non-threaded modes. In the default non-threaded
+ * mode, ThreadInit will only be called once and the filetype does not
+ * need to be concerned with threads.
+ *
+ * However, in **threaded** mode, ThreadInit will be called multiple
+ * times and the filetype needs to be thread aware and thread-safe. If
+ * utilizing a unique resource such as afile for each thread then you
+ * may be naturally thread safe. However, if sharing a single file
+ * handle across all threads then your filetype will have to take care
+ * of locking, etc.
  */
 typedef struct SCEveFileType_ {
-    /* The name of the output, used to specify the output in the filetype section
-     * of the eve-log configuration. */
+    /**
+     * \brief The name of the output, used in the configuration.
+     *
+     * This name is used by the configuration file to specify the EVE
+     * filetype used.
+     *
+     * For example:
+     *
+     * \code{.yaml}
+     * outputs:
+     *   - eve-log:
+     *       filetype: my-output-name
+     * \endcode
+     */
     const char *name;
-    /* Init Called on first access */
+
+    /**
+     * \brief Function to initialize this filetype.
+     *
+     * \param conf The ConfNode of the `eve-log` configuration
+     *     section this filetype is being initialized for
+     *
+     * \param threaded Flag to specify if the EVE sub-systems is in
+     *     threaded mode or not
+     *
+     * \param init_data An output pointer for filetype specific data
+     *
+     * \retval 0 on success, -1 on failure
+     */
     int (*Init)(ConfNode *conf, bool threaded, void **init_data);
-    /* Write - Called on each write to the object */
+
+    /**
+     * \brief Called for each EVE log record.
+     *
+     * The Write function is called for each log EVE log record. The
+     * provided buffer contains a fully formatted EVE record in JSON
+     * format.
+     *
+     * \param buffer The fully formatted JSON EVE log record
+     *
+     * \param buffer_len The length of the buffer
+     *
+     * \param init_data The data setup in the call to Init
+     *
+     * \param thread_data The data setup in the call to ThreadInit
+     *
+     * \retval 0 on success, -1 on failure
+     */
     int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
-    /* Close - Called on final close */
+
+    /**
+     * \brief Final call to deinitialize this filetype.
+     *
+     * Called, usually on exit to deinitialize and free any resources
+     * allocated during Init.
+     *
+     * \param init_data Data setup in the call to Init.
+     */
     void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object; non-zero thread_ids correlate
-     * to Suricata's worker threads; 0 correlates to the Suricata main thread */
+
+    /**
+     * \brief Initiaize thread specific data.
+     *
+     * Initialize any thread specific data. For example, if
+     * implementing a file output you might open the files here, so
+     * you have one output file per thread.
+     *
+     * \param init_data Data setup during Init
+     *
+     * \param thread_id A unique ID to differentiate this thread from
+     *     others. If EVE is not in threaded mode this will be called
+     *     one with a ThreadId of 0. In threaded mode the ThreadId of
+     *     0 correlates to the main Suricata thread.
+     *
+     * \param thread_data Output pointer for any data required by this
+     *     thread.
+     *
+     * \retval 0 on success, -1 on failure
+     */
     int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
-    /* ThreadDeinit - Called for each thread using file object */
+
+    /**
+     * \brief Called to deinitialize each thread.
+     *
+     * This function will be called for each thread. It is where any
+     * resources allocated in ThreadInit should be released.
+     *
+     * \param init_data The data setup in Init
+     *
+     * \param thread_data The data setup in ThreadInit
+     *
+     * \retval 0 on success, -1 on failure
+     */
     int (*ThreadDeinit)(void *init_data, void *thread_data);
+
+    /* Internal list management. */
     TAILQ_ENTRY(SCEveFileType_) entries;
 } SCEveFileType;
 

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -100,7 +100,7 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
+    int (*Init)(const ConfNode *conf, const bool threaded, void **init_data);
 
     /**
      * \brief Called for each EVE log record.
@@ -119,7 +119,8 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
+    int (*Write)(
+            const char *buffer, const int buffer_len, const void *init_data, void *thread_data);
 
     /**
      * \brief Final call to deinitialize this filetype.
@@ -150,7 +151,7 @@ typedef struct SCEveFileType_ {
      *
      * \retval 0 on success, -1 on failure
      */
-    int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
+    int (*ThreadInit)(const void *init_data, const ThreadId thread_id, void **thread_data);
 
     /**
      * \brief Called to deinitialize each thread.
@@ -162,7 +163,7 @@ typedef struct SCEveFileType_ {
      *
      * \param thread_data The data setup in ThreadInit
      */
-    void (*ThreadDeinit)(void *init_data, void *thread_data);
+    void (*ThreadDeinit)(const void *init_data, void *thread_data);
 
     /* Internal list management. */
     TAILQ_ENTRY(SCEveFileType_) entries;

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -161,10 +161,8 @@ typedef struct SCEveFileType_ {
      * \param init_data The data setup in Init
      *
      * \param thread_data The data setup in ThreadInit
-     *
-     * \retval 0 on success, -1 on failure
      */
-    int (*ThreadDeinit)(void *init_data, void *thread_data);
+    void (*ThreadDeinit)(void *init_data, void *thread_data);
 
     /* Internal list management. */
     TAILQ_ENTRY(SCEveFileType_) entries;

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -103,36 +103,6 @@ typedef struct SCEveFileType_ {
     int (*Init)(const ConfNode *conf, const bool threaded, void **init_data);
 
     /**
-     * \brief Called for each EVE log record.
-     *
-     * The Write function is called for each log EVE log record. The
-     * provided buffer contains a fully formatted EVE record in JSON
-     * format.
-     *
-     * \param buffer The fully formatted JSON EVE log record
-     *
-     * \param buffer_len The length of the buffer
-     *
-     * \param init_data The data setup in the call to Init
-     *
-     * \param thread_data The data setup in the call to ThreadInit
-     *
-     * \retval 0 on success, -1 on failure
-     */
-    int (*Write)(
-            const char *buffer, const int buffer_len, const void *init_data, void *thread_data);
-
-    /**
-     * \brief Final call to deinitialize this filetype.
-     *
-     * Called, usually on exit to deinitialize and free any resources
-     * allocated during Init.
-     *
-     * \param init_data Data setup in the call to Init.
-     */
-    void (*Deinit)(void *init_data);
-
-    /**
      * \brief Initiaize thread specific data.
      *
      * Initialize any thread specific data. For example, if
@@ -154,6 +124,26 @@ typedef struct SCEveFileType_ {
     int (*ThreadInit)(const void *init_data, const ThreadId thread_id, void **thread_data);
 
     /**
+     * \brief Called for each EVE log record.
+     *
+     * The Write function is called for each log EVE log record. The
+     * provided buffer contains a fully formatted EVE record in JSON
+     * format.
+     *
+     * \param buffer The fully formatted JSON EVE log record
+     *
+     * \param buffer_len The length of the buffer
+     *
+     * \param init_data The data setup in the call to Init
+     *
+     * \param thread_data The data setup in the call to ThreadInit
+     *
+     * \retval 0 on success, -1 on failure
+     */
+    int (*Write)(
+            const char *buffer, const int buffer_len, const void *init_data, void *thread_data);
+
+    /**
      * \brief Called to deinitialize each thread.
      *
      * This function will be called for each thread. It is where any
@@ -164,6 +154,16 @@ typedef struct SCEveFileType_ {
      * \param thread_data The data setup in ThreadInit
      */
     void (*ThreadDeinit)(const void *init_data, void *thread_data);
+
+    /**
+     * \brief Final call to deinitialize this filetype.
+     *
+     * Called, usually on exit to deinitialize and free any resources
+     * allocated during Init.
+     *
+     * \param init_data Data setup in the call to Init.
+     */
+    void (*Deinit)(void *init_data);
 
     /* Internal list management. */
     TAILQ_ENTRY(SCEveFileType_) entries;

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -38,7 +38,7 @@ OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx)
         goto error;
     }
 
-    thread->file_ctx = LogFileEnsureExists(ctx->file_ctx);
+    thread->file_ctx = LogFileEnsureExists(t->id, ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error;
     }
@@ -104,7 +104,7 @@ TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data)
     }
 
     thread->ctx = ((OutputCtx *)initdata)->data;
-    thread->file_ctx = LogFileEnsureExists(thread->ctx->file_ctx);
+    thread->file_ctx = LogFileEnsureExists(t->id, thread->ctx->file_ctx);
     if (!thread->file_ctx) {
         goto error_exit;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -375,7 +375,7 @@ static TmEcode JsonStatsLogThreadInit(ThreadVars *t, const void *initdata, void 
     /* Use the Output Context (file pointer and mutex) */
     aft->statslog_ctx = ((OutputCtx *)initdata)->data;
 
-    aft->file_ctx = LogFileEnsureExists(aft->statslog_ctx->file_ctx);
+    aft->file_ctx = LogFileEnsureExists(t->id, aft->statslog_ctx->file_ctx);
     if (!aft->file_ctx) {
         goto error_exit;
     }
@@ -471,8 +471,8 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
     }
 
     SCLogDebug("Preparing file context for stats submodule logger");
-    /* Share output slot with thread 1 */
-    stats_ctx->file_ctx = LogFileEnsureExists(ajt->file_ctx);
+    /* prepared by suricata-main */
+    stats_ctx->file_ctx = LogFileEnsureExists(0, ajt->file_ctx);
     if (!stats_ctx->file_ctx) {
         SCFree(stats_ctx);
         SCFree(output_ctx);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -65,15 +65,12 @@
 #include "util-log-redis.h"
 #include "util-device.h"
 #include "util-validate.h"
-#include "util-plugin.h"
 
 #include "flow-var.h"
 #include "flow-bit.h"
 #include "flow-storage.h"
 
 #include "source-pcap-file-helper.h"
-
-#include "suricata-plugin.h"
 
 #define DEFAULT_LOG_FILENAME "eve.json"
 #define MODULE_NAME "OutputJSON"
@@ -1088,13 +1085,11 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
-#ifdef HAVE_PLUGINS
-            SCEveFileType *plugin = SCPluginFindFileType(output_s);
+            SCEveFileType *plugin = SCEveFindFileType(output_s);
             if (plugin != NULL) {
                 log_filetype = LOGFILE_TYPE_PLUGIN;
                 json_ctx->plugin = plugin;
             } else
-#endif
                 FatalError("Invalid JSON output option: %s", output_s);
         }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1015,12 +1015,15 @@ static int LogFileTypePrepare(
                 return -1;
             }
         }
-        void *init_data = NULL;
-        if (json_ctx->filetype->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
+        if (json_ctx->filetype->Init(conf, json_ctx->file_ctx->threaded,
+                    &json_ctx->file_ctx->filetype.init_data) < 0) {
+            return -1;
+        }
+        if (json_ctx->filetype->ThreadInit(json_ctx->file_ctx->filetype.init_data, 0,
+                    &json_ctx->file_ctx->filetype.thread_data) < 0) {
             return -1;
         }
         json_ctx->file_ctx->filetype.filetype = json_ctx->filetype;
-        json_ctx->file_ctx->filetype.init_data = init_data;
     }
 
     return 0;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1008,7 +1008,7 @@ static int LogFileTypePrepare(
         }
     }
 #endif
-    else if (log_filetype == LOGFILE_TYPE_PLUGIN) {
+    else if (log_filetype == LOGFILE_TYPE_FILETYPE) {
         if (json_ctx->file_ctx->threaded) {
             /* Prepare for threaded log output. */
             if (!SCLogOpenThreadedFile(NULL, NULL, json_ctx->file_ctx)) {
@@ -1016,11 +1016,11 @@ static int LogFileTypePrepare(
             }
         }
         void *init_data = NULL;
-        if (json_ctx->plugin->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
+        if (json_ctx->filetype->Init(conf, json_ctx->file_ctx->threaded, &init_data) < 0) {
             return -1;
         }
-        json_ctx->file_ctx->plugin.plugin = json_ctx->plugin;
-        json_ctx->file_ctx->plugin.init_data = init_data;
+        json_ctx->file_ctx->filetype.filetype = json_ctx->filetype;
+        json_ctx->file_ctx->filetype.init_data = init_data;
     }
 
     return 0;
@@ -1085,10 +1085,10 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
 
         enum LogFileType log_filetype = FileTypeFromConf(output_s);
         if (log_filetype == LOGFILE_TYPE_NOTSET) {
-            SCEveFileType *plugin = SCEveFindFileType(output_s);
-            if (plugin != NULL) {
-                log_filetype = LOGFILE_TYPE_PLUGIN;
-                json_ctx->plugin = plugin;
+            SCEveFileType *filetype = SCEveFindFileType(output_s);
+            if (filetype != NULL) {
+                log_filetype = LOGFILE_TYPE_FILETYPE;
+                json_ctx->filetype = filetype;
             } else
                 FatalError("Invalid JSON output option: %s", output_s);
         }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -28,10 +28,8 @@
 #include "util-buffer.h"
 #include "util-logopenfile.h"
 #include "output.h"
-#include "rust.h"
 
 #include "app-layer-htp-xff.h"
-#include "suricata-plugin.h"
 
 void OutputJsonRegister(void);
 
@@ -83,7 +81,7 @@ typedef struct OutputJsonCtx_ {
     enum LogFileType json_out;
     OutputJsonCommonSettings cfg;
     HttpXFFCfg *xff_cfg;
-    SCEveFileType *plugin;
+    SCEveFileType *filetype;
 } OutputJsonCtx;
 
 typedef struct OutputJsonThreadCtx_ {

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -31,6 +31,7 @@
 #include "util-checksum.h"
 #include "runmode-unix-socket.h"
 #include "suricata.h"
+#include "conf.h"
 
 extern uint16_t max_pending_packets;
 PcapFileGlobalVars pcap_g;

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -23,8 +23,6 @@
 
 #include "queue.h"
 
-#include "conf.h"
-
 /**
  * The size of the data chunk inside each packet structure a plugin
  * has for private data (Packet->plugin_v).

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "queue.h"
+
 #include "conf.h"
 
 /**
@@ -40,30 +42,6 @@ typedef struct SCPlugin_ {
 } SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
-typedef uint32_t ThreadId;
-
-/**
- * Structure used to define an Eve output file type plugin.
- */
-typedef struct SCEveFileType_ {
-    /* The name of the output, used to specify the output in the filetype section
-     * of the eve-log configuration. */
-    const char *name;
-    /* Init Called on first access */
-    int (*Init)(ConfNode *conf, bool threaded, void **init_data);
-    /* Write - Called on each write to the object */
-    int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
-    /* Close - Called on final close */
-    void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object; non-zero thread_ids correlate
-     * to Suricata's worker threads; 0 correlates to the Suricata main thread */
-    int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
-    /* ThreadDeinit - Called for each thread using file object */
-    int (*ThreadDeinit)(void *init_data, void *thread_data);
-    TAILQ_ENTRY(SCEveFileType_) entries;
-} SCEveFileType;
-
-bool SCRegisterEveFileType(SCEveFileType *);
 
 typedef struct SCCapturePlugin_ {
     char *name;

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -40,6 +40,7 @@ typedef struct SCPlugin_ {
 } SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
+typedef uint32_t ThreadId;
 
 /**
  * Structure used to define an Eve output file type plugin.
@@ -54,8 +55,9 @@ typedef struct SCEveFileType_ {
     int (*Write)(const char *buffer, int buffer_len, void *init_data, void *thread_data);
     /* Close - Called on final close */
     void (*Deinit)(void *init_data);
-    /* ThreadInit - Called for each thread using file object*/
-    int (*ThreadInit)(void *init_data, int thread_id, void **thread_data);
+    /* ThreadInit - Called for each thread using file object; non-zero thread_ids correlate
+     * to Suricata's worker threads; 0 correlates to the Suricata main thread */
+    int (*ThreadInit)(void *init_data, ThreadId thread_id, void **thread_data);
     /* ThreadDeinit - Called for each thread using file object */
     int (*ThreadDeinit)(void *init_data, void *thread_data);
     TAILQ_ENTRY(SCEveFileType_) entries;

--- a/src/util-ebpf.h
+++ b/src/util-ebpf.h
@@ -25,6 +25,7 @@
 #define SURICATA_UTIL_EBPF_H
 
 #include "flow-bypass.h"
+#include "conf.h"
 
 #ifdef HAVE_PACKET_EBPF
 

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -26,6 +26,7 @@
 #include "util-misc.h"
 #include "stream-tcp-reassemble.h"
 #include "action-globals.h"
+#include "conf.h"
 
 enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -871,7 +871,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCReturnInt(0);
     }
 
-    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE && lf_ctx->parent != NULL) {
+    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE) {
         lf_ctx->filetype.filetype->ThreadDeinit(
                 lf_ctx->filetype.init_data, lf_ctx->filetype.thread_data);
     }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -33,7 +33,6 @@
 #include "util-log-redis.h"
 #endif /* HAVE_LIBHIREDIS */
 
-#include "suricata-plugin.h"
 #include "output-eve.h"
 
 enum LogFileType {
@@ -41,7 +40,8 @@ enum LogFileType {
     LOGFILE_TYPE_UNIX_DGRAM,
     LOGFILE_TYPE_UNIX_STREAM,
     LOGFILE_TYPE_REDIS,
-    LOGFILE_TYPE_PLUGIN,
+    /** New style or modular filetypes. */
+    LOGFILE_TYPE_FILETYPE,
     LOGFILE_TYPE_NOTSET
 };
 
@@ -66,11 +66,11 @@ typedef struct LogThreadedFileCtx_ {
     char *append;
 } LogThreadedFileCtx;
 
-typedef struct LogFilePluginCtx_ {
-    SCEveFileType *plugin;
+typedef struct LogFileTypeCtx_ {
+    SCEveFileType *filetype;
     void *init_data;
     void *thread_data;
-} LogFilePluginCtx;
+} LogFileTypeCtx;
 
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
@@ -91,7 +91,7 @@ typedef struct LogFileCtx_ {
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
 
-    LogFilePluginCtx plugin;
+    LogFileTypeCtx filetype;
 
     /** It will be locked if the log/alert
      * record cannot be written to the file in one call */

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -34,6 +34,7 @@
 #endif /* HAVE_LIBHIREDIS */
 
 #include "suricata-plugin.h"
+#include "output-eve.h"
 
 enum LogFileType {
     LOGFILE_TYPE_FILE,

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -49,10 +49,13 @@ typedef struct SyslogSetup_ {
 } SyslogSetup;
 
 typedef struct ThreadLogFileHashEntry {
-    uint64_t thread_id;
-    int slot_number; /* slot identifier -- for plugins */
-    bool isopen;
     struct LogFileCtx_ *ctx;
+
+    uint64_t thread_id;          /* OS thread identifier */
+    ThreadId internal_thread_id; /* Suri internal thread id; to assist output plugins correlating
+                                    usage */
+    uint16_t slot_number;        /* Slot identifier - used when forming per-thread output names*/
+    bool isopen;
 } ThreadLogFileHashEntry;
 
 struct LogFileCtx_;
@@ -168,7 +171,7 @@ LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
-LogFileCtx *LogFileEnsureExists(LogFileCtx *lf_ctx);
+LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 bool SCLogOpenThreadedFile(const char *log_path, const char *append, LogFileCtx *parent_ctx);

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -33,6 +33,7 @@
 #include "util-macset.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "conf.h"
 
 typedef uint8_t MacAddr[6];
 typedef enum {

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -19,7 +19,6 @@
 #include "suricata-plugin.h"
 #include "suricata.h"
 #include "runmodes.h"
-#include "output-eve-syslog.h"
 #include "util-plugin.h"
 #include "util-debug.h"
 
@@ -40,8 +39,6 @@ typedef struct PluginListNode_ {
  * dlopen, but could have other uses, such as a plugin unload destructor.
  */
 static TAILQ_HEAD(, PluginListNode_) plugins = TAILQ_HEAD_INITIALIZER(plugins);
-
-static TAILQ_HEAD(, SCEveFileType_) output_types = TAILQ_HEAD_INITIALIZER(output_types);
 
 static TAILQ_HEAD(, SCCapturePlugin_) capture_plugins = TAILQ_HEAD_INITIALIZER(capture_plugins);
 
@@ -131,67 +128,6 @@ void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_a
         capture->Init(capture_plugin_args, RUNMODE_PLUGIN, TMM_RECEIVEPLUGIN,
                 TMM_DECODEPLUGIN);
     }
-}
-
-static bool IsBuiltinTypeName(const char *name)
-{
-    const char *builtin[] = {
-        "regular",
-        "unix_dgram",
-        "unix_stream",
-        "redis",
-        NULL,
-    };
-    for (int i = 0;; i++) {
-        if (builtin[i] == NULL) {
-            break;
-        }
-        if (strcmp(builtin[i], name) == 0) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * \brief Register an Eve file type.
- *
- * \retval true if registered successfully, false if the file type name
- *      conflicts with a built-in or previously registered
- *      file type.
- */
-bool SCRegisterEveFileType(SCEveFileType *plugin)
-{
-    /* First check that the name doesn't conflict with a built-in filetype. */
-    if (IsBuiltinTypeName(plugin->name)) {
-        SCLogError("Eve file type name conflicts with built-in type: %s", plugin->name);
-        return false;
-    }
-
-    /* Now check against previously registered file types. */
-    SCEveFileType *existing = NULL;
-    TAILQ_FOREACH (existing, &output_types, entries) {
-        if (strcmp(existing->name, plugin->name) == 0) {
-            SCLogError("Eve file type name conflicts with previously registered type: %s",
-                    plugin->name);
-            return false;
-        }
-    }
-
-    SCLogDebug("Registering EVE file type plugin %s", plugin->name);
-    TAILQ_INSERT_TAIL(&output_types, plugin, entries);
-    return true;
-}
-
-SCEveFileType *SCPluginFindFileType(const char *name)
-{
-    SCEveFileType *plugin = NULL;
-    TAILQ_FOREACH(plugin, &output_types, entries) {
-        if (strcmp(name, plugin->name) == 0) {
-            return plugin;
-        }
-    }
-    return NULL;
 }
 
 int SCPluginRegisterCapture(SCCapturePlugin *plugin)

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -21,6 +21,7 @@
 #include "runmodes.h"
 #include "util-plugin.h"
 #include "util-debug.h"
+#include "conf.h"
 
 #ifdef HAVE_PLUGINS
 

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -21,7 +21,6 @@
 #include "suricata-plugin.h"
 
 void SCPluginsLoad(const char *capture_plugin_name, const char *capture_plugin_args);
-SCEveFileType *SCPluginFindFileType(const char *name);
 SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
 bool RegisterPlugin(SCPlugin *, void *);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/10591

Includes: https://github.com/OISF/suricata/pull/10159

Other changes:
- Also adds a change to simplify the setup between threaded and non-threaded mode; as this is a breaking change I added an upgrade section to the docs.  But I'm happy with the API now, this bit always bugged me.
- Constify some arguments per https://github.com/OISF/suricata/pull/10591#discussion_r1517399811
- Document, in code for Doxygen the SCEveFileType.

Tickets:
- https://redmine.openinfosecfoundation.org/issues/6838
- https://redmine.openinfosecfoundation.org/issues/6408