### PR TITLE
Output notx 6846 v4

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -272,7 +272,7 @@ static inline PacketAlert PacketAlertSet(
     pa.s = (Signature *)s;
     pa.flags = alert_flags;
     /* Set tx_id if the frame has it */
-    pa.tx_id = (tx_id == UINT64_MAX) ? 0 : tx_id;
+    pa.tx_id = tx_id;
     pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
     return pa;
 }
@@ -317,8 +317,9 @@ static int AlertQueueSortHelper(const void *a, const void *b)
 {
     const PacketAlert *pa0 = a;
     const PacketAlert *pa1 = b;
+    // use tx_id + 1 because notx = UINT64_MAX
     if (pa1->num == pa0->num)
-        return pa0->tx_id < pa1->tx_id ? 1 : -1;
+        return ((pa0->tx_id + 1) < (pa1->tx_id + 1)) ? 1 : -1;
     return pa0->num > pa1->num ? 1 : -1;
 }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -317,9 +317,14 @@ static int AlertQueueSortHelper(const void *a, const void *b)
 {
     const PacketAlert *pa0 = a;
     const PacketAlert *pa1 = b;
-    // use tx_id + 1 because notx = UINT64_MAX
-    if (pa1->num == pa0->num)
-        return ((pa0->tx_id + 1) < (pa1->tx_id + 1)) ? 1 : -1;
+    if (pa1->num == pa0->num) {
+        if (pa1->tx_id == PACKET_ALERT_NOTX) {
+            return -1;
+        } else if (pa0->tx_id == PACKET_ALERT_NOTX) {
+            return 1;
+        }
+        return pa0->tx_id < pa1->tx_id ? 1 : -1;
+    }
     return pa0->num > pa1->num ? 1 : -1;
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -808,8 +808,7 @@ static inline void DetectRulePacketRules(
 #endif
         DetectRunPostMatch(tv, det_ctx, p, s);
 
-        // UINT64_MAX means notx
-        AlertQueueAppend(det_ctx, s, p, UINT64_MAX, alert_flags);
+        AlertQueueAppend(det_ctx, s, p, PACKET_ALERT_NOTX, alert_flags);
 next:
         DetectVarProcessList(det_ctx, pflow, p);
         DetectReplaceFree(det_ctx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -808,7 +808,8 @@ static inline void DetectRulePacketRules(
 #endif
         DetectRunPostMatch(tv, det_ctx, p, s);
 
-        AlertQueueAppend(det_ctx, s, p, 0, alert_flags);
+        // UINT64_MAX means notx
+        AlertQueueAppend(det_ctx, s, p, UINT64_MAX, alert_flags);
 next:
         DetectVarProcessList(det_ctx, pflow, p);
         DetectReplaceFree(det_ctx);

--- a/src/detect.h
+++ b/src/detect.h
@@ -49,6 +49,9 @@
  *  classtype. */
 #define DETECT_DEFAULT_PRIO 3
 
+// tx_id value to use when there is no transaction
+#define PACKET_ALERT_NOTX UINT64_MAX
+
 /* forward declarations for the structures from detect-engine-sigorder.h */
 struct SCSigOrderFunc_;
 struct SCSigSignatureWrapper_;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -567,12 +567,14 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         }
 
         if (p->flow != NULL) {
-            if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
-                AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
-            }
-            /* including fileinfo data is configured by the metadata setting */
-            if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
-                AlertAddFiles(p, jb, pa->tx_id);
+            if (pa->flags & PACKET_ALERT_FLAG_TX) {
+                if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
+                    AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
+                }
+                /* including fileinfo data is configured by the metadata setting */
+                if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
+                    AlertAddFiles(p, jb, pa->tx_id);
+                }
             }
 
             EveAddAppProto(p->flow, jb);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6846

Describe changes:
- output/alert: do not use tx_id 0 when there is no transaction

### Provide values to any of the below to override the defaults.

```
SV_BRANCH=pr/1700
```
Requires https://github.com/OISF/suricata-verify/pull/1700