### PR TITLE
[draft] pcap-file: use larger buffer for reading pcap files

### DIFF
--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -208,6 +208,11 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    errno = 0;
+    if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, sizeof(pfv->buffer)) < 0) {
+        SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+    }
+
     if (pfv->shared != NULL && pfv->shared->bpf_string != NULL) {
         SCLogInfo("using bpf-filter \"%s\"", pfv->shared->bpf_string);
 

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -80,6 +80,8 @@ typedef struct PcapFileFileVars_
     const u_char *first_pkt_data;
     struct pcap_pkthdr *first_pkt_hdr;
     struct timeval first_pkt_ts;
+
+    char buffer[131072];
 } PcapFileFileVars;
 
 /**


### PR DESCRIPTION
Inspired by a recent Zeek blog post, this could speed up PCAP processing by a few percent.

https://zeek.org/2024/03/12/recent-zeek-performance-improvements/

On a 30GB pcap:
```
Benchmark 1: ./suricata.old -c ./suricata.yaml -l . -S /dev/null -r ~/scratch/synthetic-15.pcap --runmode single
  Time (mean ± σ):     39.962 s ±  0.284 s    [User: 40.840 s, System: 4.707 s]
  Range (min … max):   39.598 s … 40.270 s    5 runs
 
Benchmark 2: ./suricata.new -c ./suricata.yaml -l . -S /dev/null -r ~/scratch/synthetic-15.pcap --runmode single
  Time (mean ± σ):     36.391 s ±  0.203 s    [User: 38.439 s, System: 3.437 s]
  Range (min … max):   36.206 s … 36.713 s    5 runs
 
Summary
  ./suricata.new -c ./suricata.yaml -l . -S /dev/null -r ~/scratch/synthetic-15.pcap --runmode single ran
    1.10 ± 0.01 times faster than ./suricata.old -c ./suricata.yaml -l . -S /dev/null -r ~/scratch/synthetic-15.pcap --runmode single
```