### PR TITLE
base64_data: reject fast_pattern use

### DIFF
--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -272,6 +272,10 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, const c
                 }
             }
         }
+        if (SigMatchListSMBelongsTo(s, pm) == DETECT_SM_LIST_BASE64_DATA) {
+            SCLogError("fast_pattern cannot be used with base64_data");
+            goto error;
+        }
         cd->flags |= DETECT_CONTENT_FAST_PATTERN;
         return 0;
     }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/5220

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1703

Previous PR: https://github.com/OISF/suricata/pull/10637

Changes since v3:
- use much simpler fix suggested b Victor