### PR TITLE
flow: Use proper thread id for injection 

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -334,14 +334,21 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
  *
  *        The function requires flow to be locked beforehand.
  *
+ * Normally, the first thread_id value should be used. This is when the flow is
+ * created on seeing the first packet to the server; sometimes, if the first
+ * packet is determined to be to the client, the second thread_id value should
+ * be used.
+ *
  * \param f Pointer to the flow.
  *
  * \retval 0 This flow doesn't need any reassembly processing; 1 otherwise.
  */
 void FlowForceReassemblyForFlow(Flow *f)
 {
-    const int thread_id = (int)f->thread_id[0];
-    TmThreadsInjectFlowById(f, thread_id);
+    // Have packets traveled to the server? If not,
+    // use the reverse direction
+    int idx = f->todstpktcnt > 0 ? 0 : 1;
+    TmThreadsInjectFlowById(f, (const int)f->thread_id[idx]);
 }
 
 /**

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -362,7 +362,7 @@ void FlowForceReassemblyForFlow(Flow *f)
  * - silence complaining profilers
  * - allow us to aggressively check using debug validation assertions
  * - be robust in case of future changes
- * - locking overhead if neglectable when no other thread fights us
+ * - locking overhead is negligible when no other thread fights us
  *
  * \param q The queue to process flows from.
  */

--- a/src/flow.c
+++ b/src/flow.c
@@ -291,6 +291,8 @@ void FlowSwap(Flow *f)
     FlowSwapFlags(f);
     FlowSwapFileFlags(f);
 
+    SWAP_VARS(FlowThreadId, f->thread_id[0], f->thread_id[1]);
+
     if (f->proto == IPPROTO_TCP) {
         TcpStreamFlowSwap(f);
     }


### PR DESCRIPTION
Continuation of #10643 

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6835](https://redmine.openinfosecfoundation.org/issues/6835)

Describe changes:
- Also swap thread_ids when reversing a flow's direction
- Never choose an uninitialized thread_id during injection
- Typo fix

Updates:
- Updated commit comment to mention issue 2725 may be addressed.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
