### PR TITLE
profiling/rules: Clear profiling flag at end

### DIFF
--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -423,6 +423,7 @@ void SCProfilingRuleThreatAggregate(DetectEngineThreadCtx *det_ctx);
                 ctx, r->profiling_id, profile_rule_end_ - profile_rule_start_, m);                 \
         profiling_rules_entered--;                                                                 \
         BUG_ON(profiling_rules_entered < 0);                                                       \
+        (p)->flags &= ~PKT_PROFILE;                                                                \
     }
 
 #else /* PROFILE_RULES */


### PR DESCRIPTION
Issue: 6861

When profiling ends, clear the per-packet profiling flag to prevent future profiling processing on the packet *unless it was enabled* again for that packet.

With lightweight rule profiling, it's possible to perform profiling end-time processing if profiling was active in the past but since has been disabled.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6861](https://redmine.openinfosecfoundation.org/issues/6861)

Describe changes:
- Clear per-packet profiling flag when profiling ends. It'll be reset if the packet is selected for profiling in the future.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
