### PR TITLE
SDP protocol: implement parser and logger

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -50,6 +50,9 @@ Major changes
 - ``SIP_PORTS`` variable has been introduced in suricata.yaml
 - Application layer's ``sip`` counter has been split into ``sip_tcp`` and ``sip_udp``
   for the ``stats`` event.
+- SDP parser and logger has been introduced.
+  Due to SDP being encapsulated within other protocols, such as SIP, they cannot be directly enabled or disabled.
+  Instead, both the SDP parser and logger depend on being invoked by another parser (or logger).
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3307,6 +3307,135 @@
                 },
                 "version": {
                     "type": "string"
+                },
+                "sdp": {
+                    "type": "object",
+                    "description": "SDP message body",
+                    "optional": true,
+                    "properties": {
+                        "v": {
+                            "type": "integer",
+                            "description": "SDP protocol version"
+                        },
+                        "o": {
+                            "type": "string",
+                            "description": "Owner of the session"
+                        },
+                        "s": {
+                            "type": "string",
+                            "description": "Session name"
+                        },
+                        "i": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Textual information about the session"
+                        },
+                        "u": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "A pointer to additional information about the session"
+                        },
+                        "e": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Email address for the person responsible for the conference"
+                        },
+                        "p": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Phone number for the person responsible for the conference"
+                        },
+                        "c": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Connection data"
+                        },
+                        "b": {
+                            "type": "array",
+                            "optional": true,
+                            "description": "Proposed bandwidths to be used by the session or media",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "t": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Start and stop times for a session"
+                        },
+                        "r": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Specify repeat times for a session"
+                        },
+                        "z": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Timezone to specify adjustments for times and offsets from the base time"
+                        },
+                        "k": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Field used to convey encryption keys if SDP is used over a secure channel"
+                        },
+                        "a": {
+                            "type": "array",
+                            "optional": true,
+                            "description": "A list of attributes to extend SDP",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string",
+                                "description": "Attribute's name and value"
+                            }
+                        },
+                        "m": {
+                            "type": "array",
+                            "description": "A list of media descriptions for a session",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "optional": true,
+                                "properties": {
+                                    "m": {
+                                        "type": "string",
+                                        "description": "Media description"
+                                    },
+                                    "i": {
+                                        "type": "string",
+                                        "optional": true,
+                                        "description": "Media information primarily intended for labelling media streams"
+                                    },
+                                    "b": {
+                                        "type": "array",
+                                        "optional": true,
+                                        "description": "A list of bandwidth proposed for a media",
+                                        "minItems": 1,
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "c": {
+                                        "type": "string",
+                                        "optional": true,
+                                        "description": "Connection data per media description"
+                                    },
+                                    "a": {
+                                        "type": "array",
+                                        "description": "A list of attributes specified for a media description",
+                                        "optional": true,
+                                        "minItems": 1,
+                                        "items": {
+                                            "type": "string",
+                                            "description": "Attribute's name and value"
+                                        }
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -120,3 +120,4 @@ pub mod lzma;
 pub mod util;
 pub mod ffi;
 pub mod feature;
+pub mod sdp;

--- a/rust/src/sdp/logger.rs
+++ b/rust/src/sdp/logger.rs
@@ -1,0 +1,153 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+
+use super::parser::{ConnectionData, MediaDescription, SdpMessage};
+
+pub fn sdp_log(msg: &SdpMessage, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.set_uint("v", msg.version as u64)?;
+
+    let origin = format!(
+        "{} {} {} {} {} {}",
+        &msg.origin.username,
+        &msg.origin.sess_id,
+        &msg.origin.sess_version,
+        &msg.origin.nettype,
+        &msg.origin.addrtype,
+        &msg.origin.unicast_address
+    );
+
+    js.set_string("o", &origin)?;
+    js.set_string("s", &msg.session_name)?;
+
+    if let Some(session_info) = &msg.session_info {
+        js.set_string("i", session_info)?;
+    }
+    if let Some(uri) = &msg.uri {
+        js.set_string("u", uri)?;
+    }
+    if let Some(email) = &msg.email {
+        js.set_string("e", email)?;
+    }
+    if let Some(phone_number) = &msg.phone_number {
+        js.set_string("p", phone_number)?;
+    }
+    if let Some(conn_data) = &msg.connection_data {
+        log_connection_data(conn_data, js)?;
+    }
+    if let Some(bws) = &msg.bandwidths {
+        log_bandwidth(bws, js)?;
+    }
+    js.set_string("t", &msg.time)?;
+    if let Some(repeat_time) = &msg.time_zone {
+        js.set_string("r", repeat_time)?;
+    }
+    if let Some(tz) = &msg.time_zone {
+        js.set_string("z", tz)?;
+    }
+    if let Some(enc_key) = &msg.encryption_key {
+        js.set_string("k", enc_key)?;
+    }
+    if let Some(attrs) = &msg.attributes {
+        log_attributes(attrs, js)?;
+    }
+    if let Some(media) = &msg.media_description {
+        log_media_description(media, js)?;
+    }
+    Ok(())
+}
+
+fn log_media_description(
+    media: &Vec<MediaDescription>, js: &mut JsonBuilder,
+) -> Result<(), JsonError> {
+    if !media.is_empty() {
+        js.open_array("m")?;
+        for m in media {
+            js.start_object()?;
+            let port = if let Some(num_ports) = m.number_of_ports {
+                format!("{}/{}", m.port, num_ports)
+            } else {
+                format!("{}", m.port)
+            };
+            let mut media = format!("{} {} {}", &m.media, &port, &m.proto);
+            for f in &m.fmt {
+                media = format!("{} {}", media, f);
+            }
+            js.set_string("m", &media)?;
+
+            if let Some(session_info) = &m.session_info {
+                js.set_string("i", session_info)?;
+            };
+            if let Some(bws) = &m.bandwidths {
+                log_bandwidth(bws, js)?;
+            }
+            if let Some(conn_data) = &m.connection_data {
+                log_connection_data(conn_data, js)?;
+            }
+            if let Some(attrs) = &m.attributes {
+                log_attributes(attrs, js)?;
+            }
+            js.close()?;
+        }
+    }
+    js.close()?;
+
+    Ok(())
+}
+
+fn log_bandwidth(bws: &Vec<String>, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    if !bws.is_empty() {
+        js.open_array("b")?;
+        for bw in bws {
+            js.append_string(bw)?;
+        }
+        js.close()?;
+    }
+    Ok(())
+}
+
+fn log_connection_data(conn_data: &ConnectionData, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    let mut conn = format!(
+        "{} {} {}",
+        &conn_data.nettype,
+        &conn_data.addrtype,
+        &conn_data.connection_address.to_string()
+    );
+    if let Some(ttl) = conn_data.ttl {
+        conn = format!("{}/{}", conn, ttl);
+        js.set_uint("ttl", ttl as u64)?;
+    }
+    if let Some(num_addrs) = conn_data.number_of_addresses {
+        conn = format!("{}/{}", conn, num_addrs);
+    }
+    js.set_string("c", &conn)?;
+    Ok(())
+}
+
+fn log_attributes(attrs: &Vec<String>, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    if !attrs.is_empty() {
+        js.open_array("a")?;
+        for attr in attrs {
+            js.append_string(attr)?;
+        }
+        js.close()?;
+    }
+    Ok(())
+}

--- a/rust/src/sdp/mod.rs
+++ b/rust/src/sdp/mod.rs
@@ -1,0 +1,1 @@
+pub mod parser;

--- a/rust/src/sdp/mod.rs
+++ b/rust/src/sdp/mod.rs
@@ -1,1 +1,2 @@
+pub mod logger;
 pub mod parser;

--- a/rust/src/sdp/parser.rs
+++ b/rust/src/sdp/parser.rs
@@ -1,0 +1,675 @@
+use nom7::{
+    branch::alt,
+    bytes::complete::{tag, take_till, take_while, take_while_m_n},
+    character::{
+        complete::{char as char_parser, digit1, line_ending, space1, u8 as take_u8},
+        is_alphabetic,
+    },
+    character::{is_alphanumeric, is_digit, is_space},
+    combinator::map_res,
+    combinator::{opt, peek},
+    error::{make_error, ErrorKind},
+    multi::{many0, many1},
+    number::complete::be_u8,
+    sequence::{preceded, tuple},
+    {Err, IResult},
+};
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct SdpMessage {
+    pub version: u32,
+    pub origin: OriginField,
+    pub session_name: String,
+    pub session_info: Option<String>,
+    pub uri: Option<String>,
+    pub email: Option<String>,
+    pub phone_number: Option<String>,
+    pub connection_data: Option<ConnectionData>,
+    pub bandwidths: Option<Vec<String>>,
+    pub time: String,
+    pub repeat_time: Option<String>,
+    pub time_zone: Option<String>,
+    pub encryption_key: Option<String>,
+    pub attributes: Option<Vec<String>>,
+    pub media_description: Option<Vec<MediaDescription>>,
+}
+
+#[derive(Debug)]
+pub struct OriginField {
+    pub username: String,
+    pub sess_id: String,
+    pub sess_version: String,
+    pub nettype: String,
+    pub addrtype: String,
+    pub unicast_address: String,
+}
+
+#[derive(Debug)]
+pub struct ConnectionData {
+    pub nettype: String,
+    pub addrtype: String,
+    pub connection_address: IpAddr,
+    pub ttl: Option<u8>,
+    pub number_of_addresses: Option<u8>,
+}
+
+#[derive(Debug)]
+pub struct MediaDescription {
+    pub media: String,
+    pub port: u16,
+    pub number_of_ports: Option<u16>,
+    pub proto: String,
+    pub fmt: Vec<String>,
+    pub session_info: Option<String>,
+    pub connection_data: Option<ConnectionData>,
+    pub bandwidths: Option<Vec<String>>,
+    pub encryption_key: Option<String>,
+    pub attributes: Option<Vec<String>>,
+}
+
+// token-char = %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39 / %x41-5A / %x5E-7E
+#[inline]
+fn is_token_char(b: u8) -> bool {
+    matches!(b, 0x21 | 0x2A | 0x2B | 0x2D | 0x2E)
+        || (0x23..=0x27).contains(&b)
+        || (0x30..=0x39).contains(&b)
+        || (0x41..=0x5a).contains(&b)
+        || (0x5e..=0x7e).contains(&b)
+}
+
+#[inline]
+fn is_request_uri_char(b: u8) -> bool {
+    is_alphanumeric(b) || is_token_char(b) || b"~#@:;=?+&$,/".contains(&b)
+}
+
+#[inline]
+fn is_line_ending(b: u8) -> bool {
+    b == b'\r' || b == b'\n'
+}
+
+#[inline]
+fn is_ipaddr(b: u8) -> bool {
+    b.is_ascii_hexdigit() || b".:".contains(&b)
+}
+
+#[inline]
+fn is_session_name_char(b: u8) -> bool {
+    is_alphanumeric(b) || is_space(b)
+}
+
+#[inline]
+fn is_time_char(b: u8) -> bool {
+    is_digit(b) || b"dhms-".contains(&b)
+}
+
+fn parse_num(i: &[u8]) -> IResult<&[u8], u8> {
+    let (i, first_digit) = peek(be_u8)(i)?;
+    if first_digit == 0 {
+        return Err(Err::Error(make_error(i, ErrorKind::HexDigit)));
+    }
+    let (i, num) = take_u8(i)?;
+    Ok((i, num))
+}
+
+// SDP Message format (fields marked with * are optional):
+// https://www.rfc-editor.org/rfc/rfc4566#page-9
+//
+//       Session description
+//         v=  (protocol version)
+//         o=  (originator and session identifier)
+//         s=  (session name)
+//         i=* (session information)
+//         u=* (URI of description)
+//         e=* (email address)
+//         p=* (phone number)
+//         c=* (connection information -- not required if included in
+//              all media)
+//         b=* (zero or more bandwidth information lines)
+//         One or more time descriptions ("t=" and "r=" lines; see below)
+//         z=* (time zone adjustments)
+//         k=* (encryption key)
+//         a=* (zero or more session attribute lines)
+//         Zero or more media descriptions
+//
+//      Time description
+//         t=  (time the session is active)
+//         r=* (zero or more repeat times)
+//
+//      Media description, if present
+//         m=  (media name and transport address)
+//         i=* (media title)
+//         c=* (connection information -- optional if included at
+//              session level)
+//         b=* (zero or more bandwidth information lines)
+//         k=* (encryption key)
+//         a=* (zero or more media attribute lines)
+
+pub fn sdp_parse_message(i: &[u8]) -> IResult<&[u8], SdpMessage> {
+    let (i, version) = parse_version_line(i)?;
+    let (i, origin) = parse_origin_line(i)?;
+    let (i, session_name) = parse_session_name(i)?;
+    let (i, session_info) = opt(parse_session_info)(i)?;
+    let (i, uri) = opt(parse_uri)(i)?;
+    let (i, email) = opt(parse_email)(i)?;
+    let (i, phone_number) = opt(parse_phone_number)(i)?;
+    let (i, connection_data) = opt(parse_connection_data)(i)?;
+    let (i, bandwidths) = opt(parse_bandwidth)(i)?;
+    let (i, time) = parse_time(i)?;
+    let (i, repeat_time) = opt(parse_repeat_times)(i)?;
+    let (i, time_zone) = opt(parse_time_zone)(i)?;
+    let (i, encryption_key) = opt(parse_encryption_key)(i)?;
+    let (i, attributes) = opt(parse_attributes)(i)?;
+    let (i, media_description) = opt(many0(parse_media_description))(i)?;
+    Ok((
+        i,
+        SdpMessage {
+            version,
+            origin,
+            session_name,
+            session_info,
+            uri,
+            email,
+            phone_number,
+            connection_data,
+            bandwidths,
+            time,
+            repeat_time,
+            time_zone,
+            encryption_key,
+            attributes,
+            media_description,
+        },
+    ))
+}
+
+fn parse_version_line(i: &[u8]) -> IResult<&[u8], u32> {
+    let (i, _) = tag("v=")(i)?;
+    let (i, _v) = tag("0")(i)?;
+    let (i, _) = line_ending(i)?;
+
+    Ok((i, 0))
+}
+
+fn parse_origin_line(i: &[u8]) -> IResult<&[u8], OriginField> {
+    let (i, _) = tag("o=")(i)?;
+    let (i, username) = map_res(take_while(is_token_char), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, sess_id) = map_res(take_while(is_digit), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, sess_version) = map_res(take_while(is_digit), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, nettype) = map_res(take_while(is_alphabetic), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, addrtype) = map_res(take_while(is_alphanumeric), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, unicast_address) = map_res(take_till(is_line_ending), std::str::from_utf8)(i)?;
+    let (i, _) = line_ending(i)?;
+
+    Ok((
+        i,
+        OriginField {
+            username: username.to_string(),
+            sess_id: sess_id.to_string(),
+            sess_version: sess_version.to_string(),
+            nettype: nettype.to_string(),
+            addrtype: addrtype.to_string(),
+            unicast_address: unicast_address.to_string(),
+        },
+    ))
+}
+
+fn parse_session_name(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, _) = tag("s=")(i)?;
+    let (i, name) = map_res(take_while(is_session_name_char), std::str::from_utf8)(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, name.to_string()))
+}
+
+fn parse_session_info(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, _) = tag("i=")(i)?;
+    let (i, info) = map_res(take_while(is_session_name_char), std::str::from_utf8)(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, info.to_string()))
+}
+
+fn parse_uri(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, _) = tag("u=")(i)?;
+    let (i, uri) = map_res(take_while(is_request_uri_char), std::str::from_utf8)(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, uri.to_string()))
+}
+
+fn parse_connection_data(i: &[u8]) -> IResult<&[u8], ConnectionData> {
+    let (i, _) = tag("c=")(i)?;
+    let (i, nettype) = map_res(take_while(is_alphabetic), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, addrtype) = map_res(take_while(is_alphanumeric), std::str::from_utf8)(i)?;
+    let (i, _) = space1(i)?;
+    let (i, connection_address) = map_res(
+        map_res(take_while(is_ipaddr), std::str::from_utf8),
+        IpAddr::from_str,
+    )(i)?;
+    let (i, first_num) = opt(preceded(char_parser('/'), parse_num))(i)?;
+    let (i, second_num) = opt(preceded(char_parser('/'), parse_num))(i)?;
+    let (i, _) = line_ending(i)?;
+
+    let (ttl, number_of_addresses) = match connection_address {
+        _ if connection_address.is_ipv6() => (None, first_num),
+        _ if connection_address.is_ipv4() && connection_address.is_multicast() => {
+            match (first_num, second_num) {
+                (None, _) => return Err(Err::Error(make_error(i, ErrorKind::HexDigit))),
+                _ => (first_num, second_num),
+            }
+        }
+        _ if connection_address.is_ipv4() => match (first_num, second_num) {
+            (Some(_), None) => (None, first_num),
+            _ => (first_num, second_num),
+        },
+        _ => (None, None),
+    };
+
+    Ok((
+        i,
+        ConnectionData {
+            nettype: nettype.to_string(),
+            addrtype: addrtype.to_string(),
+            connection_address,
+            ttl,
+            number_of_addresses,
+        },
+    ))
+}
+
+fn parse_email(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, email) = preceded(
+        tag("e="),
+        map_res(take_till(is_line_ending), std::str::from_utf8),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, email.to_string()))
+}
+
+fn parse_phone_number(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, phone_number) = preceded(
+        tag("p="),
+        map_res(take_till(is_line_ending), std::str::from_utf8),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, phone_number.to_string()))
+}
+
+fn parse_bandwidth(i: &[u8]) -> IResult<&[u8], Vec<String>> {
+    let (i, bws) = many0(preceded(
+        tag("b="),
+        tuple((
+            map_res(
+                alt((tag("CT"), tag("AS"), tag("TIAS"))),
+                std::str::from_utf8,
+            ),
+            char_parser(':'),
+            map_res(digit1, std::str::from_utf8),
+            line_ending,
+        )),
+    ))(i)?;
+    let vec = bws.iter().map(|bw| format!("{}:{}", bw.0, bw.2)).collect();
+    Ok((i, vec))
+}
+
+fn parse_time(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, (start_time, _, stop_time)) = preceded(
+        tag("t="),
+        tuple((
+            map_res(digit1, std::str::from_utf8),
+            space1,
+            map_res(digit1, std::str::from_utf8),
+        )),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    let time = format!("{} {}", start_time, stop_time);
+    Ok((i, time))
+}
+
+fn parse_repeat_times(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, (d, _, h, _, m, _, s)) = preceded(
+        tag("r="),
+        tuple((
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+        )),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    let val = format!("{} {} {} {}", d, h, m, s);
+    Ok((i, val.to_string()))
+}
+
+fn parse_time_zone(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, (z1, _, z2, _, z3, _, z4)) = preceded(
+        tag("z="),
+        tuple((
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+            space1,
+            map_res(take_while(is_time_char), std::str::from_utf8),
+        )),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    let tz = format!("{} {} {} {}", z1, z2, z3, z4);
+    Ok((i, tz.to_string()))
+}
+
+fn parse_encryption_key(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, key) = preceded(
+        tag("k="),
+        map_res(take_till(is_line_ending), std::str::from_utf8),
+    )(i)?;
+    let (i, _) = line_ending(i)?;
+    Ok((i, key.to_string()))
+}
+
+fn parse_attributes(i: &[u8]) -> IResult<&[u8], Vec<String>> {
+    let (i, attrs) = many0(preceded(
+        tag("a="),
+        tuple((
+            map_res(take_while(is_alphabetic), std::str::from_utf8),
+            opt(preceded(
+                char_parser(':'),
+                map_res(take_till(is_line_ending), std::str::from_utf8),
+            )),
+            line_ending,
+        )),
+    ))(i)?;
+    let vec = attrs
+        .iter()
+        .map(|a| {
+            if let Some(val) = a.1 {
+                format!("{}:{}", a.0, val)
+            } else {
+                a.0.to_string()
+            }
+        })
+        .collect();
+    Ok((i, vec))
+}
+
+fn parse_media_description(i: &[u8]) -> IResult<&[u8], MediaDescription> {
+    let (i, _) = tag("m=")(i)?;
+    let (i, media) = map_res(
+        alt((
+            tag("audio"),
+            tag("video"),
+            tag("text"),
+            tag("application"),
+            tag("message"),
+        )),
+        |bytes: &[u8]| String::from_utf8(bytes.to_vec()),
+    )(i)?;
+    let (i, _) = space1(i)?;
+
+    let (i, port) = map_res(
+        take_while_m_n(1, 5, |b: u8| b.is_ascii_digit()),
+        std::str::from_utf8,
+    )(i)?;
+    let (i, number_of_ports) = opt(preceded(
+        char_parser('/'),
+        map_res(
+            take_while_m_n(1, 5, |b: u8| b.is_ascii_digit()),
+            std::str::from_utf8,
+        ),
+    ))(i)?;
+    let (i, _) = space1(i)?;
+
+    let (i, proto) = map_res(
+        alt((tag("udp"), tag("RTP/AVP"), tag("RTP/SAVP"))),
+        |bytes: &[u8]| String::from_utf8(bytes.to_vec()),
+    )(i)?;
+
+    // Parse fmt list
+    let (i, fmt) = many1(preceded(
+        space1,
+        map_res(
+            take_while_m_n(1, 255, |b: u8| b.is_ascii_alphanumeric()),
+            std::str::from_utf8,
+        ),
+    ))(i)?;
+    let (i, _) = line_ending(i)?;
+
+    let (i, session_info) = opt(parse_session_info)(i)?;
+    let (i, connection_data) = opt(parse_connection_data)(i)?;
+    let (i, bandwidths) = opt(parse_bandwidth)(i)?;
+    let (i, encryption_key) = opt(parse_encryption_key)(i)?;
+    let (i, attributes) = opt(parse_attributes)(i)?;
+
+    let port = port.parse::<u16>().unwrap();
+    let number_of_ports = match number_of_ports {
+        Some(num_str) => num_str.parse().ok(),
+        None => None,
+    };
+
+    Ok((
+        i,
+        MediaDescription {
+            media,
+            port,
+            number_of_ports,
+            proto,
+            fmt: fmt.into_iter().map(String::from).collect(),
+            session_info,
+            connection_data,
+            bandwidths,
+            encryption_key,
+            attributes,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sdp::parser::*;
+
+    #[test]
+    fn test_version_line() {
+        let buf: &[u8] = "v=0\n\r".as_bytes();
+        let (_, v) = parse_version_line(buf).expect("parsing failed");
+        assert_eq!(v, 0);
+    }
+
+    #[test]
+    fn test_origin_line() {
+        let buf: &[u8] = "o=Clarent 120386 120387 IN IP4 200.57.7.196\r\n".as_bytes();
+
+        let (_, o) = parse_origin_line(buf).expect("parsing failed");
+        assert_eq!(o.username, "Clarent");
+        assert_eq!(o.sess_id, "120386");
+        assert_eq!(o.sess_version, "120387");
+        assert_eq!(o.nettype, "IN");
+        assert_eq!(o.addrtype, "IP4");
+        assert_eq!(o.unicast_address, "200.57.7.196");
+    }
+
+    #[test]
+    fn test_session_name_line() {
+        let buf: &[u8] = "s=Clarent C5CM\r\n".as_bytes();
+
+        let (_, s) = parse_session_name(buf).expect("parsing failed");
+        assert_eq!(s, "Clarent C5CM");
+    }
+
+    #[test]
+    fn test_session_info_line() {
+        let buf: &[u8] = "i=Session Description Protocol\r\n".as_bytes();
+
+        let (_, s) = parse_session_info(buf).expect("parsing failed");
+        assert_eq!(s, "Session Description Protocol");
+    }
+
+    #[test]
+    fn test_uri_line() {
+        let buf: &[u8] = "u=https://www.sdp.proto\r\n".as_bytes();
+
+        let (_, u) = parse_uri(buf).expect("parsing failed");
+        assert_eq!(u, "https://www.sdp.proto");
+    }
+
+    #[test]
+    fn test_connection_line_1() {
+        let buf: &[u8] = "c=IN IP4 224.2.36.42/127\r\n".as_bytes();
+
+        let (_, c) = parse_connection_data(buf).expect("parsing failed");
+        assert_eq!(c.nettype, "IN");
+        assert_eq!(c.addrtype, "IP4");
+        assert_eq!(
+            c.connection_address,
+            IpAddr::from_str("224.2.36.42").unwrap()
+        );
+        assert_eq!(c.ttl, Some(127));
+        assert_eq!(c.number_of_addresses, None);
+    }
+
+    #[test]
+    fn test_connection_line_2() {
+        let buf: &[u8] = "c=IN IP6 FF15::101/3\r\n".as_bytes();
+
+        let (_, c) = parse_connection_data(buf).expect("parsing failed");
+        assert_eq!(c.nettype, "IN");
+        assert_eq!(c.addrtype, "IP6");
+        assert_eq!(c.connection_address, IpAddr::from_str("FF15::101").unwrap());
+        assert_eq!(c.ttl, None);
+        assert_eq!(c.number_of_addresses, Some(3));
+    }
+
+    #[test]
+    fn test_connection_line_3() {
+        let buf: &[u8] = "c=IN IP4 224.2.36.42/127/2\r\n".as_bytes();
+
+        let (_, c) = parse_connection_data(buf).expect("parsing failed");
+        assert_eq!(c.nettype, "IN");
+        assert_eq!(c.addrtype, "IP4");
+        assert_eq!(
+            c.connection_address,
+            IpAddr::from_str("224.2.36.42").unwrap()
+        );
+        assert_eq!(c.ttl, Some(127));
+        assert_eq!(c.number_of_addresses, Some(2));
+    }
+
+    #[test]
+    fn test_connection_line_4() {
+        let buf: &[u8] = "c=IN IP4 224.2.36.42\r\n".as_bytes();
+
+        let result = parse_connection_data(buf);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_connection_line_5() {
+        let buf: &[u8] = "c=IN IP4 8.8.8.8\r\n".as_bytes();
+
+        let (_, c) = parse_connection_data(buf).expect("parsing failed");
+        assert_eq!(c.nettype, "IN");
+        assert_eq!(c.addrtype, "IP4");
+        assert_eq!(c.connection_address, IpAddr::from_str("8.8.8.8").unwrap());
+        assert_eq!(c.ttl, None);
+        assert_eq!(c.number_of_addresses, None);
+    }
+
+    #[test]
+    fn test_connection_line_6() {
+        let buf: &[u8] = "c=IN IP6 FF15::101\r\n".as_bytes();
+
+        let (_, c) = parse_connection_data(buf).expect("parsing failed");
+        assert_eq!(c.nettype, "IN");
+        assert_eq!(c.addrtype, "IP6");
+        assert_eq!(c.connection_address, IpAddr::from_str("FF15::101").unwrap());
+        assert_eq!(c.ttl, None);
+        assert_eq!(c.number_of_addresses, None);
+    }
+
+    #[test]
+    fn test_email_line() {
+        let buf: &[u8] = "e=j.doe@example.com (Jane Doe)\r\n".as_bytes();
+
+        let (_, e) = parse_email(buf).expect("parsing failed");
+        assert_eq!(e, "j.doe@example.com (Jane Doe)");
+    }
+
+    #[test]
+    fn test_phone_line() {
+        let buf: &[u8] = "p=+1 617 555-6011 (Jane Doe)\r\n".as_bytes();
+
+        let (_, p) = parse_phone_number(buf).expect("parsing failed");
+        assert_eq!(p, "+1 617 555-6011 (Jane Doe)");
+    }
+
+    #[test]
+    fn test_bandwidth_line() {
+        let buf: &[u8] = "b=AS:64\r\n".as_bytes();
+        let (_, b) = parse_bandwidth(buf).expect("parsing failed");
+        assert_eq!(b.first().unwrap(), "AS:64");
+    }
+
+    #[test]
+    fn test_time_line() {
+        let buf: &[u8] = "t=3034423619 3042462419\r\n".as_bytes();
+        let (_, t) = parse_time(buf).expect("parsing failed");
+        assert_eq!(t, "3034423619 3042462419");
+    }
+
+    #[test]
+    fn test_repeat_time_line_1() {
+        let buf: &[u8] = "r=604800 3600 0 90000\r\n".as_bytes();
+        let (_, t) = parse_repeat_times(buf).expect("parsing failed");
+        assert_eq!(t, "604800 3600 0 90000");
+    }
+
+    #[test]
+    fn test_repeat_time_line_2() {
+        let buf: &[u8] = "r=7d 1h 0 25h\r\n".as_bytes();
+        let (_, t) = parse_repeat_times(buf).expect("parsing failed");
+        assert_eq!(t, "7d 1h 0 25h");
+    }
+
+    #[test]
+    fn test_time_zone_line() {
+        let buf: &[u8] = "z=2882844526 -1h 2898848070 0\r\n".as_bytes();
+        let (_, t) = parse_time_zone(buf).expect("parsing failed");
+        assert_eq!(t, "2882844526 -1h 2898848070 0");
+    }
+
+    #[test]
+    fn test_encryption_key_line() {
+        let buf: &[u8] = "k=prompt\r\n".as_bytes();
+        let (_, k) = parse_encryption_key(buf).expect("parsing failed");
+        assert_eq!(k, "prompt");
+    }
+
+    #[test]
+    fn test_attribute_line() {
+        let buf: &[u8] = "a=sendrecv\r\na=rtpmap:8 PCMA/8000/1\r\n".as_bytes();
+        let (_, a) = parse_attributes(buf).expect("parsing failed");
+        assert_eq!(a.first().unwrap(), "sendrecv");
+        assert_eq!(a.get(1).unwrap(), "rtpmap:8 PCMA/8000/1");
+    }
+
+    #[test]
+    fn test_media_line() {
+        let buf: &[u8] = "m=audio 40392 RTP/AVP 8 0\r\n".as_bytes();
+        let (_, m) = parse_media_description(buf).expect("parsing failed");
+        assert_eq!(m.media, "audio");
+        assert_eq!(m.port, 40392);
+        assert_eq!(m.number_of_ports, None);
+        assert_eq!(m.proto, "RTP/AVP");
+        assert_eq!(m.fmt.first().unwrap(), "8");
+        assert_eq!(m.fmt.get(1).unwrap(), "0");
+    }
+}

--- a/rust/src/sip/log.rs
+++ b/rust/src/sip/log.rs
@@ -18,6 +18,7 @@
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use crate::sdp::logger::sdp_log;
 use crate::sip::sip::SIPTransaction;
 
 fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
@@ -27,6 +28,12 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.set_string("method", &req.method)?
             .set_string("uri", &req.path)?
             .set_string("version", &req.version)?;
+
+        if let Some(sdp_body) = &req.body {
+            js.open_object("sdp")?;
+            let _ = sdp_log(sdp_body, js);
+            js.close()?;
+        }
     }
 
     if let Some(req_line) = &tx.request_line {
@@ -37,6 +44,11 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         js.set_string("version", &resp.version)?
             .set_string("code", &resp.code)?
             .set_string("reason", &resp.reason)?;
+        if let Some(sdp_body) = &resp.body {
+            js.open_object("sdp")?;
+            let _ = sdp_log(sdp_body, js);
+            js.close()?;
+        }
     }
 
     if let Some(resp_line) = &tx.response_line {


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6627

Describe changes:
- Parser and logger implementation for the SDP protocol.
- SIP parser and logger extension to parse and log SDP messages.
- Documentation updated.

Open to discussion:

The JSON schema for SDP messages adheres to the structure defined in RFC4566, which describes the protocol.
Below is an example

```
"sdp": {
      "v": 0,
      "o": "cp10 112047106116 112047106116 IN IP4 212.242.33.75",
      "s": "SIP Call",
      "c": "IN IP4 212.242.33.36",
      "t": "0 0",
      "m": [
        {
          "m": "audio 40392 RTP/AVP 8 0",
          "b": [
            "AS:64"
          ],
          "a": [
            "rtpmap:8 PCMA/8000/1",
            "rtpmap:0 PCMU/8000/1",
            "ptime:20"
          ]
        }
      ]
    }
```

I have concerns regarding the clarity of the field keys (such as 'v', 'o', etc.), below is a more verbose alternative for the JSON schema:
```
"sdp": {
      "version": 0,
      "origin": {
        "username": "SIPPS",
        "session_id": "11888330",
        "session_version": "11888327",
        "nettype": "IN",
        "addrtype": "IP4",
        "unicast_address": "192.168.1.2"
      },
      "session_name": "SIP call",
      "connection_data": {
        "nettype": "IN",
        "addrtype": "IP4",
        "address": "192.168.1.2"
      },
      "time": "0 0",
      "media_descriptions": [
        {
          "media": "audio",
          "port": "30000",
          "protocol": "RTP/AVP",
          "fmt": [
            "0",
            "8",
            "97",
            "2",
            "3"
          ],
          "attributes": [
            "rtpmap:0 pcmu/8000",
            "rtpmap:8 pcma/8000",
            "rtpmap:97 iLBC/8000",
            "rtpmap:2 G726-32/8000",
            "rtpmap:3 GSM/8000",
            "fmtp:97 mode=20",
            "sendrecv"
          ]
        }
      ]
    },

```


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1709

