### PR TITLE
backports/6.0.x/v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1114,7 +1114,9 @@ jobs:
   ubuntu-22-04-fuzz:
     name: Ubuntu 22.04 (Fuzz)
     runs-on: ubuntu-22.04
-    container: ubuntu:22.04
+    container:
+      image: ubuntu:22.04
+      options: --privileged
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -1157,6 +1159,7 @@ jobs:
                 make \
                 rustc \
                 software-properties-common \
+                sudo \
                 zlib1g \
                 zlib1g-dev
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
@@ -1171,7 +1174,13 @@ jobs:
           mkdir -p $HOME/.cargo/bin
           cp prep/cbindgen $HOME/.cargo/bin
           chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH      - run: tar xf prep/libhtp.tar.gz
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - run: tar xf prep/libhtp.tar.gz
+      - name: Fix kernel mmap rnd bits
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://github.com/actions/runner-images/issues/9491
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - run: ./autogen.sh
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ ./configure --enable-fuzztargets --disable-shared
       - run: AFL_HARDEN=1 make -j2

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1352,7 +1352,6 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* set the packets to no inspection and reassembly if required */
     if (pstate->flags & APP_LAYER_PARSER_NO_INSPECTION) {
         AppLayerParserSetEOF(pstate);
-        FlowSetNoPayloadInspectionFlag(f);
 
         if (f->proto == IPPROTO_TCP) {
             StreamTcpDisableAppLayer(f);
@@ -1374,6 +1373,9 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
                     StreamTcpSetSessionBypassFlag(ssn);
                 }
             }
+        } else {
+            // for TCP, this is set after flushing
+            FlowSetNoPayloadInspectionFlag(f);
         }
     }
 

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -192,8 +192,8 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int rlevel)
     while (!done) {
         if (!yaml_parser_parse(parser, &event)) {
             SCLogError(SC_ERR_CONF_YAML_ERROR,
-                "Failed to parse configuration file at line %" PRIuMAX ": %s\n",
-                (uintmax_t)parser->problem_mark.line, parser->problem);
+                    "Failed to parse configuration file at line %" PRIuMAX ": %s",
+                    (uintmax_t)parser->problem_mark.line, parser->problem);
             retval = -1;
             break;
         }

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -372,8 +372,16 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
     StreamTcp(tv, p, fw->stream_thread, &fw->pq);
     FLOWWORKER_PROFILING_END(p, PROFILE_FLOWWORKER_STREAM);
 
-    if (FlowChangeProto(p->flow)) {
+    // this is the first packet that sets no payload inspection
+    bool setting_nopayload =
+            p->flow->alparser &&
+            AppLayerParserStateIssetFlag(p->flow->alparser, APP_LAYER_PARSER_NO_INSPECTION) &&
+            !(p->flags & PKT_NOPAYLOAD_INSPECTION);
+    if (FlowChangeProto(p->flow) || setting_nopayload) {
         StreamTcpDetectLogFlush(tv, fw->stream_thread, p->flow, p, &fw->pq);
+        if (setting_nopayload) {
+            FlowSetNoPayloadInspectionFlag(p->flow);
+        }
         AppLayerParserStateSetFlag(p->flow->alparser, APP_LAYER_PARSER_EOF_TS);
         AppLayerParserStateSetFlag(p->flow->alparser, APP_LAYER_PARSER_EOF_TC);
     }

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -404,6 +404,10 @@ static inline void FlowWorkerStreamTCPUpdate(ThreadVars *tv, FlowWorkerThreadDat
             TmqhOutputPacketpool(tv, x);
         }
     }
+    if (FlowChangeProto(p->flow) && p->flow->flags & FLOW_ACTION_DROP) {
+        // in case f->flags & FLOW_ACTION_DROP was set by one of the dequeued packets
+        PacketDrop(p, ACTION_DROP, PKT_DROP_REASON_FLOW_DROP);
+    }
 }
 
 static void FlowWorkerFlowTimeout(ThreadVars *tv, Packet *p, FlowWorkerThreadData *fw,


### PR DESCRIPTION
Backports for 6, equivalant to https://github.com/OISF/suricata/pull/10660.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1714
