### PR TITLE
detect/port: fix grouping of ports w gaps

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1425,7 +1425,13 @@ static inline int CreatePortList(DetectEngineCtx *de_ctx, const uint8_t *unique_
                 port = port2 + 1;
             } else if (p1 && p1->single) {
                 SCPortIntervalFindOverlappingRanges(de_ctx, port, port, &it->tree, list);
-                port = port + 1;
+                if ((port2 > port + 1)) {
+                    SCPortIntervalFindOverlappingRanges(
+                            de_ctx, port + 1, port2 - 1, &it->tree, list);
+                    port = port2;
+                } else {
+                    port = port + 1;
+                }
             } else if (p2->single) {
                 /* If port2 is boundary and less or equal to port + 1, create a range
                  * keeping the boundary away as it is single port */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6881
`master`
```
real	0m29.752s
user	0m29.283s
sys	0m0.441s
```
vs this PR
```
real	0m29.670s
user	0m29.213s
sys	0m0.430s
```

Previous PR: https://github.com/OISF/suricata/pull/10686

Changes since v1:
- Don't look for a port that has been looked up already

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1724