### PR TITLE
rust: fix clippy 1.77 warning

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -33,7 +33,7 @@ pub struct Asn1<'a>(Vec<BerObject<'a>>);
 enum Asn1DecodeError {
     InvalidKeywordParameter,
     MaxFrames,
-    BerError(Err<der_parser::error::BerError>),
+    BerError,
 }
 
 /// Enumeration of Asn1 checks
@@ -282,8 +282,8 @@ impl From<std::num::TryFromIntError> for Asn1DecodeError {
 }
 
 impl From<Err<der_parser::error::BerError>> for Asn1DecodeError {
-    fn from(e: Err<der_parser::error::BerError>) -> Asn1DecodeError {
-        Asn1DecodeError::BerError(e)
+    fn from(_e: Err<der_parser::error::BerError>) -> Asn1DecodeError {
+        Asn1DecodeError::BerError
     }
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6883

Describe changes:
- rust: fix clippy 1.77 warning

And get CI green again