### PR TITLE
Clippy 177 v2

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -33,7 +33,7 @@ pub struct Asn1<'a>(Vec<BerObject<'a>>);
 enum Asn1DecodeError {
     InvalidKeywordParameter,
     MaxFrames,
-    BerError(Err<der_parser::error::BerError>),
+    BerError,
 }
 
 /// Enumeration of Asn1 checks
@@ -282,8 +282,8 @@ impl From<std::num::TryFromIntError> for Asn1DecodeError {
 }
 
 impl From<Err<der_parser::error::BerError>> for Asn1DecodeError {
-    fn from(e: Err<der_parser::error::BerError>) -> Asn1DecodeError {
-        Asn1DecodeError::BerError(e)
+    fn from(_e: Err<der_parser::error::BerError>) -> Asn1DecodeError {
+        Asn1DecodeError::BerError
     }
 }
 

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -89,7 +89,7 @@ impl DHCPLogger {
         
         js.set_uint("id", header.txid as u64)?;
         js.set_string("client_mac",
-                      &format_addr_hex(&header.clienthw.to_vec()))?;
+                      &format_addr_hex(&header.clienthw))?;
         js.set_string("assigned_ip", &dns_print_addr(&header.yourip))?;
 
         if self.extended {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1045,7 +1045,7 @@ impl SMBState {
 
     pub fn get_service_for_guid(&self, guid: &[u8]) -> (&'static str, bool)
     {
-        let (name, is_dcerpc) = match self.guid2name_map.get(&guid.to_vec()) {
+        let (name, is_dcerpc) = match self.guid2name_map.get(guid) {
             Some(n) => {
                 let mut s = n.as_slice();
                 // skip leading \ if we have it

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -482,7 +482,7 @@ fn smb1_request_record_one(state: &mut SMBState, r: &SmbRecord, command: u8, and
                     state.ssn2vec_map.insert(name_key, name_val);
 
                     let tx_hdr = SMBCommonHdr::from1(r, SMBHDR_TYPE_GENERICTX);
-                    let tx = state.new_create_tx(&cr.file_name.to_vec(),
+                    let tx = state.new_create_tx(&cr.file_name,
                             cr.disposition, del, dir, tx_hdr);
                     tx.vercmd.set_smb1_cmd(command);
                     SCLogDebug!("TS CREATE TX {} created", tx.id);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6883

Describe changes:
- rust: fix clippy 1.77 warning
- rust: fix some clippy nightly 1.79 warning and other unnecessary to_vec

And get CI green again

https://github.com/OISF/suricata/pull/10690 + second commit