### PR TITLE
ARP: implement decoder and logger v4

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -3002,3 +3002,47 @@ Example of DHCP log entry (extended logging enabled):
     "client_id":"54:ee:75:51:e0:66",
     "dns_servers":["192.168.1.50","192.168.1.49"]
   }
+
+Event type: ARP
+-----------------
+
+Fields
+~~~~~~
+
+* "hw_type": network link protocol type
+* "proto_type": internetwork protocol for which the request is intended
+* "opcode": operation that the sender is performing (e.g. request, response)  
+* "src_mac": source MAC address
+* "src_ip": source IP address
+* "dest_mac": destination MAC address
+* "dest_ip": destination IP address
+
+Examples
+~~~~~~~~
+
+Example of ARP logging: request and response
+
+::
+
+  "arp": {
+    "hw_type": "ethernet",
+    "proto_type": "ipv4",
+    "opcode": "request",
+    "src_mac": "00:1a:6b:6c:0c:cc",
+    "src_ip": "10.10.10.2",
+    "dest_mac": "00:00:00:00:00:00",
+    "dest_ip": "10.10.10.1"
+  }
+
+::
+
+  "arp": {
+    "hw_type": "ethernet",
+    "proto_type": "ipv4",
+    "opcode": "reply",
+    "src_mac": "00:1a:6b:6c:0c:cc",
+    "src_ip": "10.10.10.2",
+    "dest_mac": "00:1d:09:f0:92:ab",
+    "dest_ip": "10.10.10.1"
+  }
+

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -266,6 +266,20 @@ enabled, then the log gets more verbose.
 
 By using ``custom`` it is possible to select which TLS fields to log.
 
+ARP
+~~~
+
+ARP records are logged as one entry for the request, and one entry for
+the response.
+
+YAML::
+
+        - arp:
+            enabled: no
+
+The logger is disabled by default since ARP can generate a large
+number of events.
+
 Drops
 ~~~~~
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -165,6 +165,8 @@ outputs:
         # BitTorrent DHT logging.
         - bittorrent-dht
         - ssh
+        - arp:
+            enabled: no
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -50,6 +50,8 @@ Major changes
 - ``SIP_PORTS`` variable has been introduced in suricata.yaml
 - Application layer's ``sip`` counter has been split into ``sip_tcp`` and ``sip_udp``
   for the ``stats`` event.
+- Decoder and logger for ARP protocol has been introduced.
+  Given that ARP can be quite verbose and produce many events, it is disabled by default.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4364,6 +4364,15 @@
                         "event": {
                             "type": "object",
                             "properties": {
+                                "arp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
                                 "chdlc": {
                                     "type": "object",
                                     "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -334,6 +334,41 @@
             },
             "additionalProperties": false
         },
+        "arp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "hw_type": {
+                    "type": "string",
+                    "description": "Network link protocol type"
+                },
+                "proto_type": {
+                    "type": "string",
+                    "description": "Internetwork protocol for which the ARP request is intended"
+                },
+                "opcode": {
+                    "type": "string",
+                    "description": "Specifies the operation that the sender is performing"
+                },
+                "src_mac": {
+                    "type": "string",
+                    "description": "Physical address of the sender"
+                },
+                "src_ip": {
+                    "type": "string",
+                    "description": "Logical address of the sender"
+                },
+                "dest_mac": {
+                    "type": "string",
+                    "description": "Physical address of the intended receiver"
+                },
+                "dest_ip": {
+                    "type": "string",
+                    "description": "Logical address of the intended receiver"
+                }
+            },
+            "additionalProperties": false
+        },
         "bittorrent_dht": {
             "type": "object",
             "properties": {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -404,6 +404,7 @@ noinst_HEADERS = \
 	output.h \
 	output-json-alert.h \
 	output-json-anomaly.h \
+	output-json-arp.h \
 	output-json-bittorrent-dht.h \
 	output-json-dcerpc.h \
 	output-json-dhcp.h \
@@ -1025,6 +1026,7 @@ libsuricata_c_a_SOURCES = \
 	output-flow.c \
 	output-json-alert.c \
 	output-json-anomaly.c \
+	output-json-arp.c \
 	output-json-bittorrent-dht.c \
 	output-json.c \
 	output-json-common.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ noinst_HEADERS = \
 	datasets-reputation.h \
 	datasets-sha256.h \
 	datasets-string.h \
+	decode-arp.h \
 	decode-chdlc.h \
 	decode-erspan.h \
 	decode-esp.h \
@@ -686,6 +687,7 @@ libsuricata_c_a_SOURCES = \
 	datasets-sha256.c \
 	datasets-string.c \
 	decode.c \
+	decode-arp.c \
 	decode-chdlc.c \
 	decode-erspan.c \
 	decode-esp.c \

--- a/src/decode-arp.c
+++ b/src/decode-arp.c
@@ -1,0 +1,50 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ */
+
+#include "suricata-common.h"
+#include "decode.h"
+#include "decode-arp.h"
+#include "decode-events.h"
+
+#include "util-unittest.h"
+#include "util-debug.h"
+
+int DecodeARP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    StatsIncr(tv, dtv->counter_arp);
+
+    if (unlikely(len < ARP_HEADER_LEN)) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_PKT_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    if (!PacketIncreaseCheckLayers(p)) {
+        return TM_ECODE_FAILED;
+    }
+
+    p->arph = (ArpHdr *)pkt;
+    if (unlikely(p->arph == NULL))
+        return TM_ECODE_FAILED;
+
+    return TM_ECODE_OK;
+}

--- a/src/decode-arp.h
+++ b/src/decode-arp.h
@@ -1,0 +1,42 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ */
+
+#ifndef __DECODE_ARP_H__
+#define __DECODE_ARP_H__
+
+#include "util-enum.h"
+
+#define ARP_HEADER_LEN 28
+
+typedef struct ArpHdr_ {
+    uint16_t hw_type;
+    uint16_t proto_type;
+    uint8_t hw_size;
+    uint8_t proto_size;
+    uint16_t opcode;
+    uint8_t source_mac[6];
+    uint8_t source_ip[4];
+    uint8_t dest_mac[6];
+    uint8_t dest_ip[6];
+} __attribute__((__packed__)) ArpHdr;
+
+#endif /* __DECODE_ARP_H__ */

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -873,5 +873,11 @@ const struct DecodeEvents_ DEvents[] = {
             STREAM_REASSEMBLY_INSERT_INVALID,
     },
 
+    /* ARP EVENTS */
+    {
+            "decoder.arp.pkt_too_small",
+            ARP_PKT_TOO_SMALL,
+    },
+
     { NULL, 0 },
 };

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -297,6 +297,9 @@ enum {
     STREAM_REASSEMBLY_INSERT_LIMIT,
     STREAM_REASSEMBLY_INSERT_INVALID,
 
+    /* ARP EVENTS */
+    ARP_PKT_TOO_SMALL, /**< arp packet smaller than minimum size */
+
     /* should always be last! */
     DECODE_EVENT_MAX,
 };

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -280,6 +280,16 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
             break;
         }
 
+        case ETHERNET_TYPE_ARP: {
+            Packet *tp = PacketTunnelPktSetup(
+                    tv, dtv, p, pkt + header_len, len - header_len, DECODE_TUNNEL_ARP);
+            if (tp != NULL) {
+                PKT_SET_SRC(tp, PKT_SRC_DECODER_GRE);
+                PacketEnqueueNoLock(&tv->decode_pq, tp);
+            }
+            break;
+        }
+
         default:
             return TM_ECODE_OK;
     }

--- a/src/decode.c
+++ b/src/decode.c
@@ -61,6 +61,7 @@
 #include "decode-geneve.h"
 #include "decode-erspan.h"
 #include "decode-teredo.h"
+#include "decode-arp.h"
 
 #include "util-hash.h"
 #include "util-hash-string.h"
@@ -121,6 +122,8 @@ static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const 
             return DecodeERSPANTypeI(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_NSH:
             return DecodeNSH(tv, dtv, p, pkt, len);
+        case DECODE_TUNNEL_ARP:
+            return DecodeARP(tv, dtv, p, pkt, len);
         default:
             SCLogDebug("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
             break;

--- a/src/decode.h
+++ b/src/decode.h
@@ -97,7 +97,7 @@ enum PktSrcEnum {
 #include "decode-esp.h"
 #include "decode-vlan.h"
 #include "decode-mpls.h"
-
+#include "decode-arp.h"
 
 /* forward declarations */
 struct DetectionEngineThreadCtx_;
@@ -250,6 +250,7 @@ typedef uint16_t Port;
 #define PKT_IS_ICMPV6(p)    (((p)->icmpv6h != NULL))
 #define PKT_IS_TOSERVER(p)  (((p)->flowflags & FLOW_PKT_TOSERVER))
 #define PKT_IS_TOCLIENT(p)  (((p)->flowflags & FLOW_PKT_TOCLIENT))
+#define PKT_IS_ARP(p)       (((p)->arph != NULL))
 
 #define IPH_IS_VALID(p) (PKT_IS_IPV4((p)) || PKT_IS_IPV6((p)))
 
@@ -581,6 +582,8 @@ typedef struct Packet_
 
     GREHdr *greh;
 
+    ArpHdr *arph;
+
     /* ptr to the payload of the packet
      * with it's length. */
     uint8_t *payload;
@@ -884,6 +887,7 @@ int DecodeERSPANTypeI(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t 
 int DecodeCHDLC(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeTEMPLATE(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeNSH(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
+int DecodeARP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 
 #ifdef UNITTESTS
 void DecodeIPV6FragHeader(Packet *p, const uint8_t *pkt,
@@ -1231,7 +1235,7 @@ static inline bool DecodeNetworkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             DecodeIEEE8021ah(tv, dtv, p, data, len);
             break;
         case ETHERNET_TYPE_ARP:
-            StatsIncr(tv, dtv->counter_arp);
+            DecodeARP(tv, dtv, p, data, len);
             break;
         case ETHERNET_TYPE_MPLS_UNICAST:
         case ETHERNET_TYPE_MPLS_MULTICAST:

--- a/src/decode.h
+++ b/src/decode.h
@@ -830,6 +830,7 @@ enum DecodeTunnelProto {
     DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
     DECODE_TUNNEL_PPP,
     DECODE_TUNNEL_NSH,
+    DECODE_TUNNEL_ARP,
     DECODE_TUNNEL_UNSET
 };
 

--- a/src/output-json-arp.c
+++ b/src/output-json-arp.c
@@ -1,0 +1,256 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ * Implement JSON/eve logging for ARP Protocol.
+ */
+
+#include "suricata-common.h"
+#include "detect.h"
+#include "flow.h"
+#include "conf.h"
+
+#include "threads.h"
+#include "tm-threads.h"
+#include "threadvars.h"
+#include "util-debug.h"
+
+#include "decode-ipv4.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-reference.h"
+
+#include "output.h"
+#include "output-json.h"
+#include "output-json-arp.h"
+
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "util-classification-config.h"
+#include "util-privs.h"
+#include "util-print.h"
+#include "util-proto-name.h"
+#include "util-logopenfile.h"
+#include "util-time.h"
+#include "util-buffer.h"
+
+static const char *HwtypeToString(uint16_t hwtype)
+{
+    switch (hwtype) {
+        case 0:
+            return "reserved";
+        case 1:
+            return "ethernet";
+        case 2:
+            return "experimental_ethernet";
+        case 3:
+            return "amateur_radio_ax25";
+        case 4:
+            return "proteon_token_ring";
+        case 5:
+            return "chaos";
+        case 6:
+            return "ieee802";
+        case 7:
+            return "arcnet";
+        case 8:
+            return "hyperchannel";
+        case 9:
+            return "lanstar";
+        case 10:
+            return "autonet_short_address";
+        case 11:
+            return "localtalk";
+        case 12:
+            return "localnet";
+        case 13:
+            return "ultralink";
+        case 14:
+            return "smds";
+        case 15:
+            return "framerelay";
+        case 16:
+        case 19:
+        case 21:
+            return "atm";
+        case 17:
+            return "hdlc";
+        case 18:
+            return "fibre_channel";
+        case 20:
+            return "serial_line";
+        case 22:
+            return "mil_std_188_220";
+        case 23:
+            return "metricom";
+        case 24:
+            return "ieee1394.1995";
+        case 25:
+            return "mapos";
+        case 26:
+            return "twinaxial";
+        case 27:
+            return "eui64";
+        case 28:
+            return "hiparp";
+        case 29:
+            return "ip_over_arp";
+        case 30:
+            return "arpsec";
+        case 31:
+            return "ipsec";
+        case 32:
+            return "infiniband";
+        case 33:
+            return "cai";
+        case 34:
+            return "wiegand_interface";
+        case 35:
+            return "pure_ip";
+        case 36:
+            return "hw_exp1";
+        case 37:
+            return "hw_exp2";
+        case 38:
+            return "unified_bus";
+        case 256:
+            return "hw_exp2";
+        case 257:
+            return "aethernet";
+        default:
+            return "unknown";
+    }
+}
+
+static const char *PrototypeToString(uint16_t proto)
+{
+    switch (proto) {
+        case 0x0800:
+            return "ipv4";
+        default:
+            return "unknown";
+    }
+}
+
+static const char *OpcodeToString(uint16_t opcode)
+{
+    switch (opcode) {
+        case 0:
+        case 65535:
+            return "reserved";
+        case 1:
+            return "request";
+        case 2:
+            return "reply";
+        case 3:
+            return "request_reverse";
+        case 4:
+            return "reply_reverse";
+        case 5:
+            return "drarp_request";
+        case 6:
+            return "drarp_reply";
+        case 7:
+            return "drarp_error";
+        case 8:
+            return "inarp_request";
+        case 9:
+            return "inarp_reply";
+        case 10:
+            return "arp_nak";
+        case 11:
+            return "mars_request";
+        case 12:
+            return "mars_multi";
+        case 13:
+            return "mars_mserv";
+        case 14:
+            return "mars_join";
+        case 15:
+            return "mars_leave";
+        case 16:
+            return "mars_nak";
+        case 17:
+            return "mars_unserv";
+        case 18:
+            return "mars_sjoin";
+        case 19:
+            return "mars_sleave";
+        case 20:
+            return "mars_grouplist_request";
+        case 21:
+            return "mars_grouplist_reply";
+        case 22:
+            return "mars_redirect_map";
+        case 23:
+            return "mapos_unarp";
+        case 24:
+            return "op_exp1";
+        case 25:
+            return "op_exp2";
+        default:
+            return "unknown";
+    }
+}
+
+static int JsonArpLogger(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    OutputJsonThreadCtx *thread = thread_data;
+    char srcip[46] = "";
+    char dstip[46] = "";
+
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "arp", NULL, thread->ctx);
+    if (unlikely(jb == NULL)) {
+        return TM_ECODE_OK;
+    }
+
+    PrintInet(AF_INET, p->arph->source_ip, srcip, sizeof(srcip));
+    PrintInet(AF_INET, p->arph->dest_ip, dstip, sizeof(dstip));
+
+    jb_open_object(jb, "arp");
+    jb_set_string(jb, "hw_type", HwtypeToString(ntohs(p->arph->hw_type)));
+    jb_set_string(jb, "proto_type", PrototypeToString(ntohs(p->arph->proto_type)));
+    jb_set_string(jb, "opcode", OpcodeToString(ntohs(p->arph->opcode)));
+    JSONFormatAndAddMACAddr(jb, "src_mac", p->arph->source_mac, false);
+    jb_set_string(jb, "src_ip", srcip);
+    JSONFormatAndAddMACAddr(jb, "dest_mac", p->arph->dest_mac, false);
+    jb_set_string(jb, "dest_ip", dstip);
+    jb_close(jb); /* arp */
+    OutputJsonBuilderBuffer(jb, thread);
+    jb_free(jb);
+
+    return TM_ECODE_OK;
+}
+
+static bool JsonArpLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    return PKT_IS_ARP(p);
+}
+
+void JsonArpLogRegister(void)
+{
+    OutputRegisterPacketSubModule(LOGGER_JSON_ARP, "eve-log", "JsonArpLog", "eve-log.arp",
+            OutputJsonLogInitSub, JsonArpLogger, JsonArpLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
+
+    SCLogDebug("ARP JSON logger registered.");
+}

--- a/src/output-json-arp.h
+++ b/src/output-json-arp.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ */
+#ifndef __OUTPUT_JSON_ARP_H__
+#define __OUTPUT_JSON_ARP_H__
+
+void JsonArpLogRegister(void);
+
+#endif /* __OUTPUT_JSON_ARP_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -714,8 +714,7 @@ void CreateEveFlowId(JsonBuilder *js, const Flow *f)
     }
 }
 
-static inline void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key,
-                                   uint8_t *val, bool is_array)
+void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key, uint8_t *val, bool is_array)
 {
     char eth_addr[19];
     (void) snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -575,8 +575,10 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
         case IPPROTO_SCTP:
             addr->sp = sp;
             addr->dp = dp;
+            addr->log_port = true;
             break;
         default:
+            addr->log_port = false;
             break;
     }
 
@@ -838,11 +840,21 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         JsonAddrInfoInit(p, dir, &addr_info);
         addr = &addr_info;
     }
-    jb_set_string(js, "src_ip", addr->src_ip);
-    jb_set_uint(js, "src_port", addr->sp);
-    jb_set_string(js, "dest_ip", addr->dst_ip);
-    jb_set_uint(js, "dest_port", addr->dp);
-    jb_set_string(js, "proto", addr->proto);
+    if (strlen(addr->src_ip) > 0) {
+        jb_set_string(js, "src_ip", addr->src_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "src_port", addr->sp);
+    }
+    if (strlen(addr->src_ip) > 0) {
+        jb_set_string(js, "dest_ip", addr->dst_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "dest_port", addr->dp);
+    }
+    if (strlen(addr->proto) > 0) {
+        jb_set_string(js, "proto", addr->proto);
+    }
 
     /* icmp */
     switch (p->proto) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -116,5 +116,6 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
 void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
+void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key, uint8_t *val, bool is_array);
 
 #endif /* SURICATA_OUTPUT_JSON_H */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -50,6 +50,7 @@ typedef struct JsonAddrInfo_ {
     Port sp;
     Port dp;
     char proto[JSON_PROTO_LEN];
+    bool log_port;
 } JsonAddrInfo;
 
 extern const JsonAddrInfo json_addr_info_zero;

--- a/src/output.c
+++ b/src/output.c
@@ -90,6 +90,7 @@
 #include "output-json-frame.h"
 #include "output-json-bittorrent-dht.h"
 #include "output-filestore.h"
+#include "output-json-arp.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -1127,6 +1128,8 @@ void OutputRegisterLoggers(void)
     JsonFrameLogRegister();
     /* BitTorrent DHT JSON logger */
     JsonBitTorrentDHTLogRegister();
+    /* ARP JSON logger */
+    JsonArpLogRegister();
 }
 
 static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {

--- a/src/packet.c
+++ b/src/packet.c
@@ -142,6 +142,7 @@ void PacketReinit(Packet *p)
     p->pppoesh = NULL;
     p->pppoedh = NULL;
     p->greh = NULL;
+    p->arph = NULL;
     p->payload = NULL;
     p->payload_len = 0;
     p->BypassPacketsFlow = NULL;

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -491,6 +491,7 @@ typedef enum {
     LOGGER_JSON_FRAME,
     LOGGER_JSON_STREAM,
     LOGGER_SIZE,
+    LOGGER_JSON_ARP,
 } LoggerId;
 
 #ifndef HAVE_LUA

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1287,6 +1287,7 @@ const char *PacketProfileLoggerIdToString(LoggerId id)
         CASE_CODE(LOGGER_JSON_METADATA);
         CASE_CODE(LOGGER_JSON_FRAME);
         CASE_CODE(LOGGER_JSON_STREAM);
+        CASE_CODE(LOGGER_JSON_ARP);
 
         case LOGGER_SIZE:
             return "UNKNOWN";

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -294,6 +294,8 @@ outputs:
         - rfb
         - sip
         - quic
+        - arp:
+            enabled: no
         - dhcp:
             enabled: yes
             # When extended mode is on, all DHCP messages are logged


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6827

Describe changes:

- Don't log IPs, ports, or protocols if their lengths are zero.

The entry now appears as follows:

```
{
  "timestamp": "2012-11-11T02:00:25.652633+0100",
  "pcap_cnt": 5,
  "event_type": "arp",
  "pkt_src": "wire/pcap",
  "arp": {
    "hw_type": "ethernet",
    "proto_type": "ipv4",
    "opcode": "request",
    "src_mac": "00:1d:09:f0:92:ab",
    "src_ip": "10.10.10.1",
    "dest_mac": "00:00:00:00:00:00",
    "dest_ip": "10.10.10.2"
  }
}
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1711
