### PR TITLE
napatech: fix to allow correct hardware bypass when more than one physical adapters are connected to the sensor

### DIFF
--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -216,6 +216,8 @@ static int NapatechInit(int runmode)
         exit(EXIT_FAILURE);
     }
 
+    NapatechGetAdapter(0); /* initialize port to adapter mapping */
+
     status = NapatechRegisterDeviceStreams();
     if (status < 0 || num_configured_streams <= 0) {
         FatalError("Unable to find existing Napatech Streams");

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1580,14 +1580,21 @@ uint32_t NapatechSetupTraffic(uint32_t first_stream, uint32_t last_stream)
     if (bypass_supported) {
         if (is_inline) {
             char inline_setup_cmd[512];
+            /*
+             * https://supportportal.napatech.com/index.php?/selfhelp/view-article/how-to-configure-txport-in-inline-mode/340
+             * If the descriptor is Dyn3, TxPortPos=28 should be used, which is the color_lo field
+             * in Dyn3. The TX port configuration will be done in the field from bit 28 of Dyn3.
+             */
             if (first_stream == last_stream) {
-                snprintf(inline_setup_cmd, sizeof (ntpl_cmd),
-                    "Setup[TxDescriptor=Dyn;TxPorts=%s;RxCRC=False;TxPortPos=112;UseWL=True] = StreamId == %d",
-                    ports_spec.str, first_stream);
+                snprintf(inline_setup_cmd, sizeof(ntpl_cmd),
+                        "Setup[TxDescriptor=Dyn;TxPorts=%s;RxCRC=False;TxPortPos=28;UseWL=True] = "
+                        "StreamId == %d",
+                        ports_spec.str, first_stream);
             } else {
-                snprintf(inline_setup_cmd, sizeof (ntpl_cmd),
-                    "Setup[TxDescriptor=Dyn;TxPorts=%s;RxCRC=False;TxPortPos=112;UseWL=True] = StreamId == (%d..%d)",
-                    ports_spec.str, first_stream, last_stream);
+                snprintf(inline_setup_cmd, sizeof(ntpl_cmd),
+                        "Setup[TxDescriptor=Dyn;TxPorts=%s;RxCRC=False;TxPortPos=28;UseWL=True] = "
+                        "StreamId == (%d..%d)",
+                        ports_spec.str, first_stream, last_stream);
             }
             NapatechSetFilter(hconfig, inline_setup_cmd);
         }


### PR DESCRIPTION
napatech: fix to allow correct hardware bypass when more than one physical adapters are connected to the sensor

Two different issues result in incorrect (always zero) napatech interface number.

1. Static array port_adapter_map defined in the scope of NapatechGetAdapter function is initialized as { -1 }. As a result, only the first item is initialized to -1. The rest of the items are zeroed. Thus the NT_InfoRead is never called for ports > 0. The NapatechGetAdapter function always returns zero.
2. According to Napatech API documentation, rxPort in NtDyn3Descr_t is relative, i.e. it's port number inside a specific adapter. However, NT_InfoRead expects an absolute port number in the whole system.

To fix (1.) i propose to avoid the initialization of each port_adapter_map item on-demand separately. All available items are initialized during the first call that is done from the main thread while workers are not started (from runmode-napatech.c).
To fix (2.) portOffset is added to the rxPort when NapatechGetAdapter is called.
Other fixes in the scope of this task:
- According to Napatech API documentation txPort is sent through the field at offset 28 instead of 112 since Dyn3 header is used

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
Two different issues result in incorrect (always zero) napatech interface number.

1. Static array port_adapter_map defined in the scope of NapatechGetAdapter function is initialized as { -1 }. As a result, only the first item is initialized to -1. The rest of the items are zeroed. Thus the NT_InfoRead is never called for ports > 0. The NapatechGetAdapter function always returns zero.
2. According to Napatech API documentation, rxPort in NtDyn3Descr_t is relative, i.e. it's port number inside a specific adapter. However, NT_InfoRead expects an absolute port number in the whole system.

To fix (1.) i propose to avoid the initialization of each port_adapter_map item on-demand separately. All available items are initialized during the first call that is done from the main thread while workers are not started (from runmode-napatech.c).
To fix (2.) portOffset is added to the rxPort when NapatechGetAdapter is called.
Other fixes in the scope of this task:
- According to Napatech API documentation txPort is sent through the field at offset 28 instead of 112 since Dyn3 header is used

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
