### PR TITLE
output-json: Enrich eve-log with geoip information from libmaxminddb (target master)

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -27,6 +27,9 @@ Output types::
 
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable GeoIP on source ip and destination ip, default is disabled
+      # Make sure that you have set geoip-database path
+      #geoip-enrichment: yes
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -4,6 +4,9 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable GeoIP on source ip and destination ip
+      # Disable geoip enrichment by commenting geoip-enrichment
+      #geoip-enrichment: yes
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json
       #threaded: false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -179,6 +179,90 @@
                 "type": "number"
             }
         },
+        "geoip_src": {
+            "type": "object",
+            "properties": {
+                "ip":{
+                    "type": "string"
+                },
+                "geo": {
+                    "type": "object",
+                    "properties": {
+                        "continent_code": {
+                            "type": "string"
+                        },
+                        "country_iso_code": {
+                            "type": "string"
+                        },
+                        "city_name": {
+                            "type": "string"
+                        },
+                        "country_name": {
+                            "type": "string"
+                        },
+                        "continent_name": {
+                            "type": "string"
+                        },
+                        "timezone": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "object",
+                            "properties": {
+                                "latitude": {
+                                    "type": "number"
+                                },
+                                "longitude": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "geoip_dst": {
+            "type": "object",
+            "properties": {
+                "ip":{
+                    "type": "string"
+                },
+                "geo": {
+                    "type": "object",
+                    "properties": {
+                        "continent_code": {
+                            "type": "string"
+                        },
+                        "country_iso_code": {
+                            "type": "string"
+                        },
+                        "city_name": {
+                            "type": "string"
+                        },
+                        "country_name": {
+                            "type": "string"
+                        },
+                        "continent_name": {
+                            "type": "string"
+                        },
+                        "timezone": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "object",
+                            "properties": {
+                                "latitude": {
+                                    "type": "number"
+                                },
+                                "longitude": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "alert": {
             "type": "object",
             "properties": {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -77,6 +77,82 @@
 
 #define MAX_JSON_SIZE 2048
 
+#ifdef HAVE_GEOIP
+#include <maxminddb.h>
+
+static MMDB_s mmdb;
+static int mmdb_status = MMDB_FILE_OPEN_ERROR;
+
+void GeoIPGet(JsonBuilder *js, const MMDB_s *const mmdb, const char *ip_address, const char *key);
+
+#define GeoIPSetString(js, entry_data, key)                                                        \
+    {                                                                                              \
+        if (entry_data.has_data && entry_data.utf8_string != NULL) {                               \
+            jb_set_string_from_bytes(                                                              \
+                    js, key, (const uint8_t *)entry_data.utf8_string, entry_data.data_size);       \
+        }                                                                                          \
+    }
+
+void GeoIPGet(JsonBuilder *js, const MMDB_s *const mmdb, const char *ip_address, const char *key)
+{
+    int gai_error, mmdb_error;
+    MMDB_entry_data_s entry_data;
+
+    if (mmdb_status != MMDB_SUCCESS) {
+        return;
+    }
+    MMDB_lookup_result_s result = MMDB_lookup_string(mmdb, ip_address, &gai_error, &mmdb_error);
+    if (MMDB_SUCCESS != gai_error) {
+        return;
+    }
+
+    if (!result.found_entry) {
+        return;
+    }
+
+    jb_open_object(js, key);
+    jb_set_string(js, "ip", ip_address);
+
+    /* Create geo object */
+    jb_open_object(js, "geo");
+
+    if (MMDB_get_value(&result.entry, &entry_data, "continent", "code", NULL) == MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "continent_code");
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL) == MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "country_iso_code");
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "city", "names", "en", NULL) == MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "city_name");
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "country", "names", "en", NULL) ==
+            MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "country_name");
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "continent", "names", "en", NULL) ==
+            MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "continent_name");
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "location", "time_zone", NULL) == MMDB_SUCCESS) {
+        GeoIPSetString(js, entry_data, "timezone");
+    }
+
+    /* Create location object */
+    jb_open_object(js, "location");
+    if (MMDB_get_value(&result.entry, &entry_data, "location", "latitude", NULL) == MMDB_SUCCESS) {
+        if (entry_data.has_data)
+            jb_set_float(js, "lat", entry_data.double_value);
+    }
+    if (MMDB_get_value(&result.entry, &entry_data, "location", "longitude", NULL) == MMDB_SUCCESS) {
+        if (entry_data.has_data)
+            jb_set_float(js, "lon", entry_data.double_value);
+    }
+    jb_close(js); /* close location */
+    jb_close(js); /* close geo */
+    jb_close(js); /* close key */
+}
+#endif /* HAVE_GEOIP */
+
 static void OutputJsonDeInitCtx(OutputCtx *);
 static void CreateEveCommunityFlowId(JsonBuilder *js, const Flow *f, const uint16_t seed);
 static int CreateJSONEther(JsonBuilder *parent, const Packet *p, const Flow *f);
@@ -839,6 +915,14 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         JsonAddrInfoInit(p, dir, &addr_info);
         addr = &addr_info;
     }
+
+#ifdef HAVE_GEOIP
+    if (mmdb_status == MMDB_SUCCESS) {
+        GeoIPGet(js, &mmdb, addr->src_ip, "geoip_src");
+        GeoIPGet(js, &mmdb, addr->dst_ip, "geoip_dst");
+    }
+#endif /* HAVE_GEOIP */
+
     jb_set_string(js, "src_ip", addr->src_ip);
     jb_set_uint(js, "src_port", addr->sp);
     jb_set_string(js, "dest_ip", addr->dst_ip);
@@ -1096,6 +1180,31 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
                 FatalError("Invalid JSON output option: %s", output_s);
         }
 
+#ifdef HAVE_GEOIP
+        const ConfNode *geoip_enrichment = ConfNodeLookupChild(conf, "geoip-enrichment");
+        if (geoip_enrichment && geoip_enrichment->val && ConfValIsFalse(geoip_enrichment->val)) {
+            SCLogConfig("GeoIP enrichment is disabled.");
+        } else {
+            const char *geoip_db_s = NULL;
+
+            SCLogConfig("GeoIP enrichment is enabled.");
+            (void)ConfGet("geoip-database", &geoip_db_s);
+            if (geoip_db_s == NULL) {
+                mmdb_status = MMDB_FILE_OPEN_ERROR;
+                SCLogWarning("Set geoip-database path if you wish to enable geoip-enrichment");
+            } else {
+                /* Attempt to open MaxMind DB and save file handle if successful */
+                int status = MMDB_open(geoip_db_s, MMDB_MODE_MMAP, &mmdb);
+                mmdb_status = status;
+                if (mmdb_status == MMDB_SUCCESS) {
+                    SCLogNotice("Open GeoLite2 database successfully, path %s", geoip_db_s);
+                } else {
+                    SCLogWarning("Failed to open GeoLite2 database, path %s, error message %s",
+                            geoip_db_s, MMDB_strerror(mmdb_status));
+                }
+            }
+        }
+#endif /* HAVE_GEOIP */
         const char *prefix = ConfNodeLookupChildValue(conf, "prefix");
         if (prefix != NULL)
         {
@@ -1214,6 +1323,12 @@ static void OutputJsonDeInitCtx(OutputCtx *output_ctx)
                      "disconnected socket",
                 logfile_ctx->dropped);
     }
+#ifdef HAVE_GEOIP
+    if (mmdb_status == MMDB_SUCCESS) {
+        MMDB_close(&mmdb);
+        SCLogDebug("GeoLite2 database is closed");
+    }
+#endif /* HAVE_GEOIP */
     if (json_ctx->xff_cfg != NULL) {
         SCFree(json_ctx->xff_cfg);
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -93,6 +93,9 @@ outputs:
       enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
+      # Enable GeoIP on source ip and destination ip, default is disabled
+      # Make sure that you have set geoip-database path
+      #geoip-enrichment: yes
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
@@ -1297,6 +1300,8 @@ unix-command:
 
 # GeoIP2 database file. Specify path and filename of GeoIP2 database
 # if using rules with "geoip" rule option.
+# This database is also used by geoip-enrichment in EVE output.
+# If you wish to enrich in city level please use GeoLite2 City database.
 #geoip-database: /usr/local/share/GeoLite2/GeoLite2-Country.mmdb
 
 legacy:


### PR DESCRIPTION
I faced a very large log to be enriched using geoip. At the moment I utilize logstash to enrich the log file from Suricata but at the cost of additional resources in RAM, CPU, and storage. I would like to optimize this by adding optional geoip enrichment into Suricata.

This PR is replacement of https://github.com/OISF/suricata/pull/10565 to target master branch.

- [ X ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ X ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ X ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6999](https://redmine.openinfosecfoundation.org/issues/6999)

Describe changes:
- I adds optional geoip enrichment into Eve log by setting geoip-enrichment option under eve-log configuration in suricata.yaml
- The JSON structure of geoip is based on [Elastic ECS geo specification](https://www.elastic.co/guide/en/ecs/current/ecs-geo.html) 

Eve output example with enrichment
```
{
    "timestamp": "2021-05-27T03:37:44.575843+0700",
    "flow_id": 2130735805455113,
    "pcap_cnt": 15756,
    "event_type": "fileinfo",
    "geoip_src": {
        "ip": "192.236.155.230",
        "geo": {
            "continent_code": "NA",
            "country_iso_code": "US",
            "city_name": "Seattle",
            "country_name": "United States",
            "continent_name": "North America",
            "timezone": "America/Los_Angeles",
            "location": {
                "lat": 47.4902,
                "lon": -122.3004
            }
        }
    },
    "geoip_dst": {},
    "src_ip": "192.236.155.230",
    "src_port": 80,
    "dest_ip": "10.5.26.4",
    "dest_port": 56042,
    "proto": "TCP",
    "pkt_src": "wire/pcap",
    "http": {
        "hostname": "192.236.155.230",
        "url": "/images/redbutton.png",
        "http_user_agent": "WinHTTP loader/1.0",
        "http_content_type": "Content-type: application/octet-stream",
        "http_method": "GET",
        "protocol": "HTTP/1.1",
        "status": 200,
        "length": 105556
    },
    "app_proto": "http",
    "fileinfo": {
        "filename": "/images/redbutton.png",
        "gaps": false,
        "state": "TRUNCATED",
        "stored": false,
        "size": 102400,
        "tx_id": 0
    },
}
```