### PR TITLE
stats: Memcap pressure max relocation

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1043,7 +1043,8 @@
                                 "additionalProperties": false
                             },
                             "sshfp": {
-                                "description": "A Secure Shell fingerprint, used to verify the system’s authenticity",
+                                "description":
+                                        "A Secure Shell fingerprint, used to verify the system’s authenticity",
                                 "type": "object",
                                 "properties": {
                                     "fingerprint": {
@@ -1136,7 +1137,7 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
-			}
+                        }
                     },
                     "additionalProperties": false
                 },
@@ -1215,7 +1216,8 @@
                             }
                         },
                         "SSHFP": {
-                            "description": "A Secure Shell fingerprint is used to verify the system’s authenticity",
+                            "description":
+                                    "A Secure Shell fingerprint is used to verify the system’s authenticity",
                             "type": "array",
                             "minItems": 1,
                             "items": {
@@ -3732,14 +3734,6 @@
                         }
                     }
                 },
-                "memcap_pressure": {
-                    "description": "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
-                    "type": "integer"
-                },
-                "memcap_pressure_max": {
-                    "description": "Maximum memcap_pressure seen by the engine",
-                    "type": "integer"
-                },
                 "app_layer": {
                     "type": "object",
                     "properties": {
@@ -3751,7 +3745,8 @@
                             "type": "object",
                             "properties": {
                                 "bittorrent-dht": {
-                                    "description": "Errors encountered parsing BitTorrent DHT protocol",
+                                    "description":
+                                            "Errors encountered parsing BitTorrent DHT protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "dcerpc_tcp": {
@@ -3815,11 +3810,13 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_tcp": {
-                                    "description": "Errors encountered parsing Kerberos v5/TCP protocol",
+                                    "description":
+                                            "Errors encountered parsing Kerberos v5/TCP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_udp": {
-                                    "description": "Errors encountered parsing Kerberos v5/UDP protocol",
+                                    "description":
+                                            "Errors encountered parsing Kerberos v5/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "modbus": {
@@ -5272,6 +5269,21 @@
                             "type": "integer"
                         },
                         "rows_skipped": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "memcap": {
+                    "type": "object",
+                    "properties": {
+                        "pressure": {
+                            "description":
+                                    "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
+                            "type": "integer"
+                        },
+                        "pressure_max": {
+                            "description": "Maximum pressure seen by the engine",
                             "type": "integer"
                         }
                     },

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -654,8 +654,8 @@ static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
     fc->flow_bypassed_pkts = StatsRegisterCounter("flow_bypassed.pkts", t);
     fc->flow_bypassed_bytes = StatsRegisterCounter("flow_bypassed.bytes", t);
 
-    fc->memcap_pressure = StatsRegisterCounter("memcap_pressure", t);
-    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap_pressure_max", t);
+    fc->memcap_pressure = StatsRegisterCounter("memcap.pressure", t);
+    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap.pressure_max", t);
 }
 
 static void FlowCountersUpdate(


### PR DESCRIPTION
This commit moves the memcap pressure/pressure_max stats from the global stats namespace into the memcap namespace.

With per-thread stats, they will be within the flow-manager's values.

Issue: 6398

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6398](https://redmine.openinfosecfoundation.org/issues/6398)

Describe changes:
- Move memcap values into their own section
- Update schema
- Formatting: `clang-format` updated several unrelated parts of the json schema

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1727
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
