### PR TITLE
Fuzz base64/v4

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ if BUILD_FUZZTARGETS
     bin_PROGRAMS += fuzz_applayerprotodetectgetproto \
     fuzz_applayerparserparse fuzz_siginit \
     fuzz_confyamlloadstring fuzz_decodepcapfile \
-    fuzz_sigpcap fuzz_mimedecparseline
+    fuzz_sigpcap fuzz_mimedecparseline fuzz_decodebase64
 if HAS_FUZZPCAP
     bin_PROGRAMS += fuzz_sigpcap_aware fuzz_predefpcap_aware
 endif
@@ -1446,6 +1446,17 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_predefpcap_aware_SOURCES = force-cxx-linking.cxx
 endif
+
+fuzz_decodebase64_SOURCES = tests/fuzz/fuzz_decodebase64.c
+fuzz_decodebase64_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_decodebase64_LDADD = $(LDADD_FUZZ)
+if HAS_FUZZLDFLAGS
+    fuzz_decodebase64_LDFLAGS += $(LIB_FUZZING_ENGINE)
+else
+    fuzz_decodebase64_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+nodist_EXTRA_fuzz_decodebase64_SOURCES = force-cxx-linking.cxx
 
 fuzz_mimedecparseline_SOURCES = tests/fuzz/fuzz_mimedecparseline.c
 fuzz_mimedecparseline_LDFLAGS = $(LDFLAGS_FUZZ)

--- a/src/tests/fuzz/fuzz_decodebase64.c
+++ b/src/tests/fuzz/fuzz_decodebase64.c
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * @author Shivani Bhardwaj <shivani@oisf.net>
+ * fuzz target for DecodeBase64
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "util-base64.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size, size_t dest_size);
+
+static int initialized = 0;
+
+static void Base64FuzzTest(const uint8_t *src, size_t len, size_t dest_size)
+{
+    for (uint8_t mode = BASE64_MODE_RELAX; mode <= BASE64_MODE_RFC4648; mode++) {
+        uint8_t *dest = malloc(dest_size);
+        uint32_t consumed_bytes = 0;
+        uint32_t decoded_bytes = 0;
+
+        DecodeBase64(dest, dest_size, src, len, &consumed_bytes, &decoded_bytes, mode);
+    }
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size, size_t dest_size)
+{
+    if (initialized == 0) {
+        // Redirects logs to /dev/null
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+        // global init
+        InitGlobal();
+        run_mode = RUNMODE_UNITTEST;
+        initialized = 1;
+    }
+
+    Base64FuzzTest(data, size, dest_size);
+
+    return 0;
+}

--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -24,6 +24,7 @@
 
 #include "util-base64.h"
 #include "util-debug.h"
+#include "util-validate.h"
 #include "util-unittest.h"
 /* Constants */
 #define BASE64_TABLE_MAX  122
@@ -156,7 +157,7 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
                 ecode = BASE64_ECODE_BUF;
                 break;
             }
-
+            DEBUG_VALIDATE_BUG_ON(ecode == BASE64_ECODE_BUF);
             /* Decode base-64 block into ascii block and move pointer */
             DecodeBase64Block(dptr, b64);
             dptr += numDecoded_blk;
@@ -165,6 +166,7 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
             bbidx = 0;
             padding = 0;
             *consumed_bytes += B64_BLOCK + sp;
+            DEBUG_VALIDATE_BUG_ON(*consumed_bytes > len);
             sp = 0;
             leading_sp = 0;
             memset(&b64, 0, sizeof(b64));
@@ -188,20 +190,24 @@ Base64Ecode DecodeBase64(uint8_t *dest, uint32_t dest_size, const uint8_t *src, 
         *decoded_bytes += numDecoded_blk;
         DecodeBase64Block(dptr, b64);
         *consumed_bytes += bbidx;
+        DEBUG_VALIDATE_BUG_ON(*consumed_bytes > len);
     }
 
     /* Finish remaining b64 bytes by padding */
     if (valid && bbidx > 0 && (mode != BASE64_MODE_RFC2045)) {
         /* Decode remaining */
+        DEBUG_VALIDATE_BUG_ON(ecode == BASE64_ECODE_BUF);
         *decoded_bytes += ASCII_BLOCK - (B64_BLOCK - bbidx);
         DecodeBase64Block(dptr, b64);
     }
 
     if (*decoded_bytes == 0) {
+        DEBUG_VALIDATE_BUG_ON(consumed_bytes == 0 && ecode != BASE64_ECODE_ERR);
         SCLogDebug("base64 decoding failed");
     }
 
     *consumed_bytes += leading_sp;
+    DEBUG_VALIDATE_BUG_ON(*consumed_bytes > len);
     return ecode;
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6050

Previous PR: https://github.com/OISF/suricata/pull/10715

Changes since v3:
- use just one fuzzing fn
- make dest_size a variable
.. as per Philippe's suggestion