### PR TITLE
suricata: suppress coverity warnings in command line parsing

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1594,6 +1594,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
             }
 #endif /* OS_WIN32 */
             else if(strcmp((long_opts[option_index]).name, "pidfile") == 0) {
+                // coverity[forward_null : FALSE]
                 suri->pid_filename = SCStrdup(optarg);
                 if (suri->pid_filename == NULL) {
                     SCLogError("strdup failed: %s", strerror(errno));
@@ -1632,6 +1633,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 #endif /* HAVE_LIBCAP_NG */
             } else if (strcmp((long_opts[option_index]).name, "erf-in") == 0) {
                 suri->run_mode = RUNMODE_ERF_FILE;
+                // coverity[forward_null : FALSE]
                 if (ConfSetFinal("erf-file.file", optarg) != 1) {
                     SCLogError("failed to set erf-file.file");
                     return TM_ECODE_FAILED;
@@ -1662,6 +1664,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
 #endif /* HAVE_NAPATECH */
             } else if (strcmp((long_opts[option_index]).name, "pcap-buffer-size") == 0) {
 #ifdef HAVE_PCAP_SET_BUFF
+                // coverity[forward_null : FALSE]
                 if (ConfSetFinal("pcap.buffer-size", optarg) != 1) {
                     SCLogError("failed to set pcap-buffer-size");
                     return TM_ECODE_FAILED;


### PR DESCRIPTION
The other option is to actually check that `optarg` is not NULL and `FatalError` if it is, which is fine, but `getopt_long` has already done this for us.

But from the commit message:

Suppress the Coverity warnings for FORWARD_NULL in command line parsing. The call to getopt_long ensures that an argument is always provided for these command line options.
```
*** CID 1595704:    (FORWARD_NULL)
/src/suricata.c: 1635 in SCParseCommandLine()
1629     #else
1630                     suri->group_name = optarg;
1631                     suri->do_setgid = true;
1632     #endif /* HAVE_LIBCAP_NG */
1633                 } else if (strcmp((long_opts[option_index]).name,
"erf-in") == 0) {
1634                     suri->run_mode = RUNMODE_ERF_FILE;
>>>     CID 1595704:    (FORWARD_NULL)
>>>     Passing null pointer "optarg" to "ConfSetFinal", which dereferences it.
1635                     if (ConfSetFinal("erf-file.file", optarg) != 1) {
1636                         SCLogError("failed to set erf-file.file");
1637                         return TM_ECODE_FAILED;
1638                     }
1639                 } else if (strcmp((long_opts[option_index]).name,
"dag") == 0) {
1640     #ifdef HAVE_DAG
/src/suricata.c: 1597 in SCParseCommandLine()
1591                 else if(strcmp((long_opts[option_index]).name,
"service-change-params") == 0) {
1592                     suri->run_mode = RUNMODE_CHANGE_SERVICE_PARAMS;
1593                     return TM_ECODE_OK;
1594                 }
1595     #endif /* OS_WIN32 */
1596                 else if(strcmp((long_opts[option_index]).name,
"pidfile") == 0) {
>>>     CID 1595704:    (FORWARD_NULL)
>>>     Passing null pointer "optarg" to "SCStrdupFunc", which dereferences it.
1597                     suri->pid_filename = SCStrdup(optarg);
1598                     if (suri->pid_filename == NULL) {
1599                         SCLogError("strdup failed: %s",
strerror(errno));
1600                         return TM_ECODE_FAILED;
1601                     }
1602                 }
/src/suricata.c: 1665 in SCParseCommandLine()
1659                     SCLogError("libntapi and a Napatech adapter are
required"
1660                                " to capture packets using
--napatech.");
1661                     return TM_ECODE_FAILED;
1662     #endif /* HAVE_NAPATECH */
1663                 } else if (strcmp((long_opts[option_index]).name,
"pcap-buffer-size") == 0) {
1664     #ifdef HAVE_PCAP_SET_BUFF
>>>     CID 1595704:    (FORWARD_NULL)
>>>     Passing null pointer "optarg" to "ConfSetFinal", which dereferences it.
1665                     if (ConfSetFinal("pcap.buffer-size", optarg) !=
1) {
1666                         SCLogError("failed to set pcap-buffer-size");
1667                         return TM_ECODE_FAILED;
1668                     }
1669     #else
1670                     SCLogError("The version of libpcap you have"
```