### PR TITLE
smtp: exit data mode if data command was rejected

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -997,6 +997,10 @@ static int SMTPProcessReply(SMTPState *state, Flow *f, AppLayerParserState *psta
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else {
             /* decoder event */
+            if (state->parser_state & SMTP_PARSER_STATE_PIPELINING_SERVER) {
+                // reset data mode if we had entered it prematurely
+                state->parser_state &= ~SMTP_PARSER_STATE_COMMAND_DATA_MODE;
+            }
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6906

Describe changes:
- smtp: exit data mode if data command was rejected

Will need a QA rebase line as #10734 

```
SV_BRANCH=pr/1737
```
https://github.com/OISF/suricata-verify/pull/1737
