### PR TITLE
detect/ipopts: Multiple option support

### DIFF
--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -154,20 +154,18 @@ typedef struct IPV4Hdr_
     memset(&p->ip4vars, 0x00, sizeof(p->ip4vars)); \
 } while (0)
 
-enum IPV4OptionFlags {
-    IPV4_OPT_FLAG_EOL = 0,
-    IPV4_OPT_FLAG_NOP,
-    IPV4_OPT_FLAG_RR,
-    IPV4_OPT_FLAG_TS,
-    IPV4_OPT_FLAG_QS,
-    IPV4_OPT_FLAG_LSRR,
-    IPV4_OPT_FLAG_SSRR,
-    IPV4_OPT_FLAG_SID,
-    IPV4_OPT_FLAG_SEC,
-    IPV4_OPT_FLAG_CIPSO,
-    IPV4_OPT_FLAG_RTRALT,
-    IPV4_OPT_FLAG_ESEC,
-};
+#define IPV4_OPT_FLAG_EOL    BIT_U16(1)
+#define IPV4_OPT_FLAG_NOP    BIT_U16(2)
+#define IPV4_OPT_FLAG_RR     BIT_U16(3)
+#define IPV4_OPT_FLAG_TS     BIT_U16(4)
+#define IPV4_OPT_FLAG_QS     BIT_U16(5)
+#define IPV4_OPT_FLAG_LSRR   BIT_U16(6)
+#define IPV4_OPT_FLAG_SSRR   BIT_U16(7)
+#define IPV4_OPT_FLAG_SID    BIT_U16(8)
+#define IPV4_OPT_FLAG_SEC    BIT_U16(9)
+#define IPV4_OPT_FLAG_CIPSO  BIT_U16(10)
+#define IPV4_OPT_FLAG_RTRALT BIT_U16(11)
+#define IPV4_OPT_FLAG_ESEC   BIT_U16(12)
 
 /* helper structure with parsed ipv4 info */
 typedef struct IPV4Vars_

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -32,10 +32,6 @@
 #include "detect-ipopts.h"
 #include "util-unittest.h"
 
-#define PARSE_REGEX "\\S[A-z]"
-
-static DetectParseRegex parse_regex;
-
 static int DetectIpOptsMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
 static int DetectIpOptsSetup (DetectEngineCtx *, Signature *, const char *);
@@ -58,7 +54,6 @@ void DetectIpOptsRegister (void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_IPOPTS].RegisterTests = IpOptsRegisterTests;
 #endif
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
 /**
@@ -167,11 +162,7 @@ static int DetectIpOptsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     if (!de || !PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
-    if (p->ip4vars.opts_set & de->ipopt) {
-        return 1;
-    }
-
-    return 0;
+    return (p->ip4vars.opts_set & de->ipopt) == de->ipopt;
 }
 
 /**
@@ -185,17 +176,11 @@ static int DetectIpOptsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
  */
 static DetectIpOptsData *DetectIpOptsParse (const char *rawstr)
 {
+    if (rawstr == NULL || strlen(rawstr) == 0)
+        return NULL;
+
     int i;
-    DetectIpOptsData *de = NULL;
     bool found = false;
-
-    pcre2_match_data *match = NULL;
-    int ret = DetectParsePcreExec(&parse_regex, &match, rawstr, 0, 0);
-    if (ret < 1) {
-        SCLogError("pcre_exec parse error, ret %" PRId32 ", string %s", ret, rawstr);
-        goto error;
-    }
-
     for(i = 0; ipopts[i].ipopt_name != NULL; i++)  {
         if((strcasecmp(ipopts[i].ipopt_name,rawstr)) == 0) {
             found = true;
@@ -205,24 +190,16 @@ static DetectIpOptsData *DetectIpOptsParse (const char *rawstr)
 
     if (!found) {
         SCLogError("unknown IP option specified \"%s\"", rawstr);
-        goto error;
+        return NULL;
     }
 
-    de = SCMalloc(sizeof(DetectIpOptsData));
+    DetectIpOptsData *de = SCMalloc(sizeof(DetectIpOptsData));
     if (unlikely(de == NULL))
-        goto error;
+        return NULL;
 
     de->ipopt = ipopts[i].code;
 
-    pcre2_match_data_free(match);
     return de;
-
-error:
-    if (match) {
-        pcre2_match_data_free(match);
-    }
-    if (de) SCFree(de);
-    return NULL;
 }
 
 /**
@@ -371,6 +348,20 @@ static int IpOptsTestParse04 (void)
 }
 
 /**
+ * \test IpOptsTestParse05 tests the NULL and empty string
+ */
+static int IpOptsTestParse05(void)
+{
+    DetectIpOptsData *de = DetectIpOptsParse("");
+    FAIL_IF_NOT_NULL(de);
+
+    de = DetectIpOptsParse(NULL);
+    FAIL_IF_NOT_NULL(de);
+
+    PASS;
+}
+
+/**
  * \brief this function registers unit tests for IpOpts
  */
 void IpOptsRegisterTests(void)
@@ -379,5 +370,6 @@ void IpOptsRegisterTests(void)
     UtRegisterTest("IpOptsTestParse02", IpOptsTestParse02);
     UtRegisterTest("IpOptsTestParse03", IpOptsTestParse03);
     UtRegisterTest("IpOptsTestParse04", IpOptsTestParse04);
+    UtRegisterTest("IpOptsTestParse05", IpOptsTestParse05);
 }
 #endif /* UNITTESTS */

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -25,15 +25,9 @@
 
 #include "suricata-common.h"
 #include "suricata.h"
-#include "decode.h"
 
 #include "detect.h"
 #include "detect-parse.h"
-
-#include "flow-var.h"
-#include "decode-events.h"
-
-#include "util-debug.h"
 
 #include "detect-ipopts.h"
 #include "util-unittest.h"
@@ -193,7 +187,7 @@ static DetectIpOptsData *DetectIpOptsParse (const char *rawstr)
 {
     int i;
     DetectIpOptsData *de = NULL;
-    int found = 0;
+    bool found = false;
 
     pcre2_match_data *match = NULL;
     int ret = DetectParsePcreExec(&parse_regex, &match, rawstr, 0, 0);
@@ -204,13 +198,15 @@ static DetectIpOptsData *DetectIpOptsParse (const char *rawstr)
 
     for(i = 0; ipopts[i].ipopt_name != NULL; i++)  {
         if((strcasecmp(ipopts[i].ipopt_name,rawstr)) == 0) {
-            found = 1;
+            found = true;
             break;
         }
     }
 
-    if(found == 0)
+    if (!found) {
+        SCLogError("unknown IP option specified \"%s\"", rawstr);
         goto error;
+    }
 
     de = SCMalloc(sizeof(DetectIpOptsData));
     if (unlikely(de == NULL))
@@ -242,9 +238,7 @@ error:
  */
 static int DetectIpOptsSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawstr)
 {
-    DetectIpOptsData *de = NULL;
-
-    de = DetectIpOptsParse(rawstr);
+    DetectIpOptsData *de = DetectIpOptsParse(rawstr);
     if (de == NULL)
         goto error;
 
@@ -270,8 +264,9 @@ error:
  */
 void DetectIpOptsFree(DetectEngineCtx *de_ctx, void *de_ptr)
 {
-    DetectIpOptsData *de = (DetectIpOptsData *)de_ptr;
-    if(de) SCFree(de);
+    if (de_ptr) {
+        SCFree(de_ptr);
+    }
 }
 
 /*


### PR DESCRIPTION
Continuation of #10700  

Support multiple options.

This PR changes the IP option definitions from an enum into bit values so the values added during packet parsing are compared properly when evaluation with an IP option specified with `ipopts` occurs.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6864](https://redmine.openinfosecfoundation.org/issues/6864)

Describe changes:
- Misc. cleanups
- Move IPv4 option values to a bit mask
- suricata-verify test to validate each option lacking coverage.

Updates:
- Update `Match` function to return 0 or 1 instead of 0 or a positive integer.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1722
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
