### PR TITLE
reproducible builds: use consistent date in man pages - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2526,6 +2526,13 @@ return 0;
         fi
     fi
 
+# Get the release date. As the date of the last commit doesn't mean
+# much in terms of release date, pull the date from Changelog.
+    AC_MSG_CHECKING([for release date])
+    RELEASE_DATE=`awk '/^[[0-9\.]]+ -- [[0-9]]{4}-[[0-9]]{2}-[[0-9]]{2}/ { print $3; exit }' $srcdir/ChangeLog`
+    AC_MSG_RESULT([${RELEASE_DATE}])
+    AC_SUBST(RELEASE_DATE)
+
 # get MAJOR_MINOR version for embedding in configuration file.
     MAJOR_MINOR=`expr "${PACKAGE_VERSION}" : "\([[0-9]]\+\.[[0-9]]\+\).*"`
 

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -74,6 +74,7 @@ userguide.pdf: _build/latex/Suricata.pdf
 pdf: userguide.pdf
 
 _build/man: manpages/suricata.rst manpages/suricatasc.rst manpages/suricatactl.rst manpages/suricatactl-filestore.rst
+	RELEASE_DATE=$(RELEASE_DATE) \
 	sysconfdir=$(sysconfdir) \
 	localstatedir=$(localstatedir) \
 	version=$(PACKAGE_VERSION) \

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -19,6 +19,10 @@ import re
 import subprocess
 import datetime
 
+# Set 'today'. This will be used as the man page date. If an empty
+# string todays date will be used.
+today = os.environ.get('RELEASE_DATE', '')
+
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -67,7 +67,7 @@ try:
     version = os.environ.get('version', None)
     if not version:
         version = re.search(
-            "AC_INIT\(\[suricata\],\s*\[(.*)?\]\)",
+            r"AC_INIT\(\[suricata\],\s*\[(.*)?\]\)",
             open("../../configure.ac").read()).groups()[0]
     if not version:
         version = "unknown"


### PR DESCRIPTION
From the commits:

> Attempt to automate the extraction and setting of the release
date. The best source we have for this is the Changelog, however that
also has its own issues.
>
>For example, in git master, the latest ChangeLog revision is 7.0.2
which has a 2023 date. However, for release package this should always
be up to date.
>
>The git revision date isn't ideal either.  It could be days before the
release, and the most recent commit date may not be the most recently
dated commit in the history.

Any other thoughts on what do use for the release date? Perhaps if in git and git branch is master, use the date of the last commit?