### PR TITLE
eve/stats: allow hiding counters whose valued is 0 - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -317,6 +317,9 @@ the global config is documented.
       #decoder-events-prefix: "decoder.event"
       # Add stream events as stats.
       #stream-events: false
+      # Don't log stats counters that are zero. Default: true
+      #zero-valued-counters: false    # False will NOT log stats counters: 0
+      # Exception policy stats counters options
 
 Statistics can be `enabled` or disabled here.
 
@@ -338,6 +341,10 @@ See `issue 2225 <https://redmine.openinfosecfoundation.org/issues/2225>`_.
 Similar to the `decoder-events` option, the `stream-events` option controls
 whether the stream-events are added as counters as well. This is disabled by
 default.
+
+To reduce log file size, one may set `zero-valued-counters` to false. This may
+impact on the visibility of information for which a stats counter as zero is
+relevant.
 
 Outputs
 ~~~~~~~

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -50,6 +50,9 @@ Major changes
 - ``SIP_PORTS`` variable has been introduced in suricata.yaml
 - Application layer's ``sip`` counter has been split into ``sip_tcp`` and ``sip_udp``
   for the ``stats`` event.
+- Stats counters that are 0 can now be hidden from eve log. Default behavior
+  still logs those (see :ref:`stats settings<suricata_yaml_outputs>` for
+  configuration setting).
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/src/counters.c
+++ b/src/counters.c
@@ -103,6 +103,10 @@ const char *stats_decoder_events_prefix = "decoder.event";
 /**< add stream events as stats? disabled by default */
 bool stats_stream_events = false;
 
+/** Log stats counters that are zero. Enabled by default, as that's the existing
+ * behavior */
+bool stats_zero_counters = true;
+
 static int StatsOutput(ThreadVars *tv);
 static int StatsThreadRegister(const char *thread_name, StatsPublicThreadContext *);
 void StatsReleaseCounters(StatsCounter *head);
@@ -293,6 +297,11 @@ static void StatsInitCtxPreOutput(void)
             prefix = "decoder.event";
         }
         stats_decoder_events_prefix = prefix;
+
+        ret = ConfGetChildValueBool(stats, "zero-valued-counters", &b);
+        if (ret) {
+            stats_zero_counters = (b != 0);
+        }
     }
     SCReturn;
 }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -52,6 +52,7 @@
 
 extern bool stats_decoder_events;
 extern const char *stats_decoder_events_prefix;
+extern bool stats_zero_counters;
 
 /**
  * specify which engine info will be printed in stats log.
@@ -229,6 +230,10 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
         for (u = 0; u < st->nstats; u++) {
             if (st->stats[u].name == NULL)
                 continue;
+            if (st->stats[u].value == 0 && !stats_zero_counters) {
+                continue;
+            }
+
             json_t *js_type = NULL;
             const char *stat_name = st->stats[u].short_name;
             /*
@@ -272,6 +277,9 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
             for (u = offset; u < (offset + st->nstats); u++) {
                 if (st->tstats[u].name == NULL)
                     continue;
+                if (!stats_zero_counters && st->tstats[u].value == 0) {
+                    continue;
+                }
 
                 DEBUG_VALIDATE_BUG_ON(st->tstats[u].tm_name == NULL);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -74,6 +74,9 @@ stats:
   #decoder-events-prefix: "decoder.event"
   # Add stream events as stats.
   #stream-events: false
+  # Don't log stats counters that are zero. Default: true
+  #zero-valued-counters: false    # False will NOT log stats counters: 0
+  # Exception policy stats counters options
 
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:


### PR DESCRIPTION
Some stats can be quite verbose if logging all zero-valued counters. This allows users to disable logging such counters. Default is still true, as that's the expected behavior for the engine.

Task #5976

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5976

Describe changes:
- Add a flag for eve stats that allows for optionally hiding of stats counters that are zero in the Stats EVE logs
- update related documentation

This doesn't allow any customization in terms of leaving certain fields out, as that would require extra checks that might bring in a lot of overheard.

Output sample:
`jq .stats -c eve.json` (from the corresponding sv test)
```json
{"uptime":0,"ips":{"accepted":3,"blocked":29,"drop_reason":{"flow_drop":28,"applayer_error":1}},"decoder":{"pkts":32,"bytes":9598,"ipv6":32,"ethernet":32,"tcp":32,"avg_pkt_size":299,"max_pkt_size":2974},"tcp":{"syn":1,"synack":1,"rst":3,"sessions":1,"ssn_from_pool":1,"segment_from_pool":1,"memuse":7667712,"reassembly_memuse":1376256},"flow":{"total":1,"tcp":1,"wrk":{"spare_sync_avg":100,"spare_sync":1,"flows_injected":1},"end":{"state":{"established":1},"tcp_state":{"established":1}},"mgr":{"rows_per_sec":13762},"spare":9900,"memuse":7154304},"app_layer":{"error":{"tls":{"parser":1}}},"memcap_pressure":21,"memcap_pressure_max":21}
```

### Provide values to any of the below to override the defaults.

SV_BRANCH=pr/1745
https://github.com/OISF/suricata-verify/pull/1745

