### PR TITLE
configure: .git can be a file as well

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2513,7 +2513,7 @@ return 0;
 # get git revision and last commit date
     AC_PATH_PROG(HAVE_GIT_CMD, git, "no")
     if test "$HAVE_GIT_CMD" != "no"; then
-        if [ test -d .git ]; then
+        if [ test -e .git ]; then
             REVISION=`git rev-parse --short HEAD`
             LAST_COMMIT_DATE=`git log -1 --date=short --pretty=format:%cd`
             REVISION="$REVISION $LAST_COMMIT_DATE"


### PR DESCRIPTION
In worktree scenarios, .git is a file. Assuming its a directory causes the release date to check the ChangeLog instead of the last commit, while not a big issue, can be confusing.
