### PR TITLE
7.0.x: reproducible builds: use consistent date in man pages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2480,19 +2480,14 @@ return 0;
 
     AM_CONDITIONAL([HAS_FUZZLDFLAGS], [test "x$has_sanitizefuzzer" = "xyes"])
 
-# get revision
-    if test -f ./revision; then
-        REVISION=`cat ./revision`
-        AC_DEFINE_UNQUOTED([REVISION],[${REVISION}],[Git revision])
-    else
-        AC_PATH_PROG(HAVE_GIT_CMD, git, "no")
-        if test "$HAVE_GIT_CMD" != "no"; then
-            if [ test -d .git ]; then
-                REVISION=`git rev-parse --short HEAD`
-                DATE=`git log -1 --date=short --pretty=format:%cd`
-                REVISION="$REVISION $DATE"
-                AC_DEFINE_UNQUOTED([REVISION],[${REVISION}],[Git revision])
-            fi
+# get git revision and last commit date
+    AC_PATH_PROG(HAVE_GIT_CMD, git, "no")
+    if test "$HAVE_GIT_CMD" != "no"; then
+        if [ test -d .git ]; then
+            REVISION=`git rev-parse --short HEAD`
+            DATE=`git log -1 --date=short --pretty=format:%cd`
+            REVISION="$REVISION $DATE"
+            AC_DEFINE_UNQUOTED([REVISION],[${REVISION}],[Git revision])
         fi
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -2483,7 +2483,7 @@ return 0;
 # get git revision and last commit date
     AC_PATH_PROG(HAVE_GIT_CMD, git, "no")
     if test "$HAVE_GIT_CMD" != "no"; then
-        if [ test -d .git ]; then
+        if [ test -e .git ]; then
             REVISION=`git rev-parse --short HEAD`
             LAST_COMMIT_DATE=`git log -1 --date=short --pretty=format:%cd`
             REVISION="$REVISION $LAST_COMMIT_DATE"

--- a/configure.ac
+++ b/configure.ac
@@ -2485,11 +2485,25 @@ return 0;
     if test "$HAVE_GIT_CMD" != "no"; then
         if [ test -d .git ]; then
             REVISION=`git rev-parse --short HEAD`
-            DATE=`git log -1 --date=short --pretty=format:%cd`
-            REVISION="$REVISION $DATE"
+            LAST_COMMIT_DATE=`git log -1 --date=short --pretty=format:%cd`
+            REVISION="$REVISION $LAST_COMMIT_DATE"
             AC_DEFINE_UNQUOTED([REVISION],[${REVISION}],[Git revision])
         fi
     fi
+
+# Get the release date. If LAST_COMMIT_DATE was set in the previous
+# step, use it, otherwise parse it from the ChangeLog.
+    AC_MSG_CHECKING([for release date])
+    if test "x$LAST_COMMIT_DATE" != "x"; then
+	RELEASE_DATE=$LAST_COMMIT_DATE
+    else
+        RELEASE_DATE=`awk '/^[[0-9\.]]+ -- [[0-9]][[0-9]][[0-9]][[0-9]]-[[0-9]][[0-9]]-[[0-9]][[0-9]]/ { print $3; exit }' $srcdir/ChangeLog`
+        if test "x$RELEASE_DATE" = "x"; then
+            AC_MSG_ERROR([Failed to determine release date])
+        fi
+    fi
+    AC_MSG_RESULT([${RELEASE_DATE}])
+    AC_SUBST(RELEASE_DATE)
 
 # get MAJOR_MINOR version for embedding in configuration file.
     MAJOR_MINOR=`expr "${PACKAGE_VERSION}" : "\([[0-9]]\+\.[[0-9]]\+\).*"`

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -74,6 +74,7 @@ userguide.pdf: _build/latex/Suricata.pdf
 pdf: userguide.pdf
 
 _build/man: manpages/suricata.rst manpages/suricatasc.rst manpages/suricatactl.rst manpages/suricatactl-filestore.rst
+	RELEASE_DATE=$(RELEASE_DATE) \
 	sysconfdir=$(sysconfdir) \
 	localstatedir=$(localstatedir) \
 	version=$(PACKAGE_VERSION) \

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -19,6 +19,10 @@ import re
 import subprocess
 import datetime
 
+# Set 'today'. This will be used as the man page date. If an empty
+# string todays date will be used.
+today = os.environ.get('RELEASE_DATE', '')
+
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -67,7 +67,7 @@ try:
     version = os.environ.get('version', None)
     if not version:
         version = re.search(
-            "AC_INIT\(\[suricata\],\s*\[(.*)?\]\)",
+            r"AC_INIT\(\[suricata\],\s*\[(.*)?\]\)",
             open("../../configure.ac").read()).groups()[0]
     if not version:
         version = "unknown"


### PR DESCRIPTION
Backport of https://github.com/OISF/suricata/pull/10755.

Skips the CI updates as they were not needed in 7.0, and it's not a clean backport.

Includes https://github.com/OISF/suricata/pull/10777.
