### PR TITLE
dpdk: fix DPDK crash on startup v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2009,7 +2009,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.3, 21.11.5, 20.11.9, 19.11.14 ]
+        dpdk_version: [ 22.11.4, 21.11.6, 20.11.10, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2106,6 +2106,20 @@ jobs:
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-dpdk
       - run: make -j ${{ env.CPUS }}
       - run: make check
+      # IDS config
+      - run: rm -f ./eve.json
+      - run: |
+          timeout --kill-after=30 --preserve-status 3 \
+            ./src/suricata -c .github/workflows/dpdk/suricata-null-ids.yaml -S /dev/null -l ./ --dpdk -vvvv
+      - run: |
+          test $(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.capture.packets > 0')  = true
+      # IPS config
+      - run: rm -f ./eve.json
+      - run: |
+          timeout --kill-after=30 --preserve-status 3 \
+            ./src/suricata -c .github/workflows/dpdk/suricata-null-ips.yaml -S /dev/null -l ./ --dpdk -vvvv
+      - run: |
+          test $(jq -c 'select(.event_type == "stats")' ./eve.json | tail -n1 | jq '.stats.capture.packets > 0')  = true
 
   debian-12:
     name: Debian 12

--- a/.github/workflows/dpdk/suricata-null-ids.yaml
+++ b/.github/workflows/dpdk/suricata-null-ids.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      append: false
+      filename: eve.json
+      level: Info
+      types:
+        - stats:
+            totals: yes
+dpdk:
+  eal-params:
+    proc-type: primary
+    vdev: net_null0
+    no-huge:
+    m: 256
+
+  interfaces:
+    - interface: net_null0 # PCIe address of the NIC port
+      threads: auto
+      mempool-size: 511
+      mempool-cache-size: auto
+      rx-descriptors: 16
+      tx-descriptors: 16
+      copy-mode: none
+      copy-iface: none # or PCIe address of the second interface
+
+threading:
+  set-cpu-affinity: yes
+  cpu-affinity:
+    - management-cpu-set:
+        cpu: [ 0 ]
+    - worker-cpu-set:
+        cpu: [ "all" ]
+        mode: "exclusive"

--- a/.github/workflows/dpdk/suricata-null-ips.yaml
+++ b/.github/workflows/dpdk/suricata-null-ips.yaml
@@ -1,0 +1,47 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      append: false
+      filename: eve.json
+      level: Info
+      types:
+        - stats:
+            totals: yes
+
+dpdk:
+  eal-params:
+    proc-type: primary
+    vdev: ["net_null0", "net_null1"]
+    no-huge:
+    m: 256
+
+  interfaces:
+    - interface: net_null0
+      threads: 1
+      mempool-size: 511
+      mempool-cache-size: auto
+      rx-descriptors: 16
+      tx-descriptors: 16
+      copy-mode: ips
+      copy-iface: net_null1
+    - interface: net_null1
+      threads: 1
+      mempool-size: 511
+      mempool-cache-size: auto
+      rx-descriptors: 16
+      tx-descriptors: 16
+      copy-mode: ips
+      copy-iface: net_null0
+
+threading:
+  set-cpu-affinity: yes
+  cpu-affinity:
+    - management-cpu-set:
+        cpu: [ 0 ]
+    - worker-cpu-set:
+        cpu: [ "1-2" ]
+        mode: "exclusive"

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -568,7 +568,7 @@ static TmEcode ReceiveDPDKLoop(ThreadVars *tv, void *data, void *slot)
 {
     SCEnter();
     DPDKThreadVars *ptv = (DPDKThreadVars *)data;
-    ptv->slot = (TmSlot *)slot;
+    ptv->slot = ((TmSlot *)slot)->slot_next;
     TmEcode ret = ReceiveDPDKLoopInit(tv, ptv);
     if (ret != TM_ECODE_OK) {
         SCReturnInt(ret);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -414,7 +414,7 @@ static TmEcode ReceiveDPDKLoopInit(ThreadVars *tv, DPDKThreadVars *ptv)
 
 static inline void LoopHandleTimeoutOnIdle(ThreadVars *tv)
 {
-    static uint64_t last_timeout_msec = 0;
+    static thread_local uint64_t last_timeout_msec = 0;
     SCTime_t t = DPDKSetTimevalReal(&machine_start_time);
     uint64_t msecs = SCTIME_MSECS(t);
     if (msecs > last_timeout_msec + 100) {
@@ -429,7 +429,7 @@ static inline void LoopHandleTimeoutOnIdle(ThreadVars *tv)
  */
 static inline bool RXPacketCountHeuristic(ThreadVars *tv, DPDKThreadVars *ptv, uint16_t nb_rx)
 {
-    static uint32_t zero_pkt_polls_cnt = 0;
+    static thread_local uint32_t zero_pkt_polls_cnt = 0;
 
     if (nb_rx > 0) {
         zero_pkt_polls_cnt = 0;
@@ -508,7 +508,7 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
 
 static inline void DPDKSegmentedMbufWarning(struct rte_mbuf *mbuf)
 {
-    static bool segmented_mbufs_warned = false;
+    static thread_local bool segmented_mbufs_warned = false;
     if (!segmented_mbufs_warned && !rte_pktmbuf_is_contiguous(mbuf)) {
         char warn_s[] = "Segmented mbufs detected! Redmine Ticket #6012 "
                         "Check your configuration or report the issue";
@@ -552,7 +552,7 @@ static void HandleShutdown(DPDKThreadVars *ptv)
 
 static void PeriodicDPDKDumpCounters(DPDKThreadVars *ptv)
 {
-    static time_t last_dump = 0;
+    static thread_local time_t last_dump = 0;
     time_t current_time = DPDKGetSeconds();
     /* Trigger one dump of stats every second */
     if (current_time != last_dump) {


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6877
Follow-up of: #10723 

Describe changes:
v4
- dropped pthread_barrier worker synchronization

v2
- increased verbosity of commit messages
- reduced the content of the YAML configs 

v1
-  updated the DPDK versions,
- replaced "custom" Suricata worker sync to a pthread_barrier,
- static variables changed to also thread_local, 
- fixed the redmine ticket - a linked list of thread slots assigned the current slot instead of the next one,
- added new SW tests to GitHub CI, runs Suricata with predefined configs to make sure Suricata can run.