### PR TITLE
detect/http: fix compile warning in body tests

### DIFF
--- a/src/tests/detect-http-client-body.c
+++ b/src/tests/detect-http-client-body.c
@@ -157,6 +157,7 @@ static int RunTest (struct TestSteps *steps, const char *sig, const char *yaml)
     int i = 0;
     while (b->input != NULL) {
         SCLogDebug("chunk %p %d", b, i);
+        (void)i;
         Packet *p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
         FAIL_IF_NULL(p);
         p->flow = &f;

--- a/src/tests/detect-http-server-body.c
+++ b/src/tests/detect-http-server-body.c
@@ -119,6 +119,7 @@ static int RunTest(struct TestSteps *steps, const char *sig, const char *yaml)
     int i = 0;
     while (b->input != NULL) {
         SCLogDebug("chunk %p %d", b, i);
+        (void)i;
         Packet *p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
         FAIL_IF_NULL(p);
         p->flow = &f;


### PR DESCRIPTION
When --enable-unittests w/o --enable-debug is used.

(cherry picked from commit e651cf922a02f5882593a23bd2ed9327a5e8d2cc)
