### PR TITLE
app-layer-* miscellaneous clean-ups - v1

### DIFF
--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Open Information Security Foundation
+/* Copyright (C) 2015-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -562,9 +562,7 @@ void RegisterENIPUDPParsers(void)
                 IPPROTO_UDP, ALPROTO_ENIP, STREAM_TOSERVER | STREAM_TOCLIENT);
     } else
     {
-        SCLogInfo(
-                "Parsed disabled for %s protocol. Protocol detection" "still on.",
-                proto_name);
+        SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 
 #ifdef UNITTESTS

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1355,8 +1355,7 @@ void RegisterFTPParsers(void)
 
         FTPParseMemcap();
     } else {
-        SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
-                  "still on.", proto_name);
+        SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 
     FTPSetMpmState();

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -4024,7 +4024,6 @@ libhtp:\n\
         goto end;
     HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
     if (tx_ud != NULL && tx_ud->request_uri_normalized != NULL) {
-        //printf("uri %s\n", bstr_util_strdup_to_c(tx->request_uri_normalized));
         PrintRawDataFp(stdout, bstr_ptr(tx_ud->request_uri_normalized),
                        bstr_len(tx_ud->request_uri_normalized));
     }
@@ -4104,7 +4103,6 @@ libhtp:\n\
         goto end;
     HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
     if (tx_ud != NULL && tx_ud->request_uri_normalized != NULL) {
-        //printf("uri %s\n", bstr_util_strdup_to_c(tx->request_uri_normalized));
         PrintRawDataFp(stdout, bstr_ptr(tx_ud->request_uri_normalized),
                        bstr_len(tx_ud->request_uri_normalized));
     }
@@ -4867,80 +4865,6 @@ end:
     UTHFreeFlow(f);
     return result;
 }
-
-/* disabled when we upgraded to libhtp 0.5.x */
-#if 0
-static int HTPParserConfigTest04(void)
-{
-    int result = 0;
-
-    char input[] = "\
-%YAML 1.1\n\
----\n\
-libhtp:\n\
-\n\
-  default-config:\n\
-    personality: IDS\n\
-    path-control-char-handling: status_400\n\
-    path-convert-utf8: yes\n\
-    path-invalid-encoding-handling: remove_percent\n\
-\n\
-  server-config:\n\
-\n\
-    - apache-tomcat:\n\
-        personality: Tomcat_6_0\n\
-        path-invalid-utf8-handling: none\n\
-        path-nul-encoded-handling: status_404\n\
-        path-nul-raw-handling: status_400\n\
-\n\
-    - iis7:\n\
-        personality: IIS_7_0\n\
-        path-replacement-char: o\n\
-        path-unicode-mapping: status_400\n\
-";
-
-    ConfCreateContextBackup();
-    ConfInit();
-    HtpConfigCreateBackup();
-
-    ConfYamlLoadString(input, strlen(input));
-
-    HTPConfigure();
-
-    HTPCfgRec *cfg_rec = &cfglist;
-    if (cfg_rec->cfg->path_control_char_handling != STATUS_400 ||
-        cfg_rec->cfg->path_convert_utf8 != 1 ||
-        cfg_rec->cfg->path_invalid_encoding_handling != URL_DECODER_REMOVE_PERCENT) {
-        printf("failed 1\n");
-        goto end;
-    }
-
-    cfg_rec = cfg_rec->next;
-    if (cfg_rec->cfg->bestfit_replacement_char != 'o' ||
-        cfg_rec->cfg->path_unicode_mapping != STATUS_400) {
-        printf("failed 2\n");
-        goto end;
-    }
-
-    cfg_rec = cfg_rec->next;
-    if (cfg_rec->cfg->path_invalid_utf8_handling != NONE ||
-        cfg_rec->cfg->path_nul_encoded_handling != STATUS_404 ||
-        cfg_rec->cfg->path_nul_raw_handling != STATUS_400) {
-        printf("failed 3\n");
-        goto end;
-    }
-
-    result = 1;
-
-end:
-    HTPFreeConfig();
-    ConfDeInit();
-    ConfRestoreContextBackup();
-    HtpConfigRestoreBackup();
-
-    return result;
-}
-#endif
 
 /** \test Test %2f decoding in profile Apache_2_2
  *
@@ -7080,9 +7004,6 @@ static void HTPParserRegisterTests(void)
     UtRegisterTest("HTPParserConfigTest01", HTPParserConfigTest01);
     UtRegisterTest("HTPParserConfigTest02", HTPParserConfigTest02);
     UtRegisterTest("HTPParserConfigTest03", HTPParserConfigTest03);
-#if 0 /* disabled when we upgraded to libhtp 0.5.x */
-    UtRegisterTest("HTPParserConfigTest04", HTPParserConfigTest04, 1);
-#endif
 
     UtRegisterTest("HTPParserDecodingTest01", HTPParserDecodingTest01);
     UtRegisterTest("HTPParserDecodingTest01a", HTPParserDecodingTest01a);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -3281,8 +3281,7 @@ void RegisterHTPParsers(void)
         /* app-layer-frame-documentation tag end: registering relevant callbacks */
         HTPConfigure();
     } else {
-        SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
-                  "still on.", proto_name);
+        SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_HTTP1, HTPParserRegisterTests);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1902,8 +1902,7 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterStateDataFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPGetStateData);
         AppLayerParserRegisterStateProgressCompletionStatus(ALPROTO_SMTP, 1, 1);
     } else {
-        SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
-                  "still on.", proto_name);
+        SCLogInfo("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 
     SMTPSetMpmState();

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1018,7 +1018,7 @@ static inline int TLSDecodeHSHelloExtensionSupportedVersions(SSLState *ssl_state
         if (!(HAS_SPACE(supported_ver_len)))
             goto invalid_length;
 
-        /* Use the first (and prefered) valid version as client version,
+        /* Use the first (and preferred) valid version as client version,
          * skip over GREASE and other possible noise. */
         uint16_t i = 0;
         while (i + 1 < (uint16_t)supported_ver_len) {
@@ -3074,8 +3074,7 @@ void RegisterSSLParsers(void)
             }
         }
     } else {
-        SCLogConfig("Parsed disabled for %s protocol. Protocol detection"
-                  "still on.", proto_name);
+        SCLogConfig("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 
     return;


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
none

Noticed these while working on https://redmine.openinfosecfoundation.org/issues/6929, thought I could spare a bit of time to fix them

Describe changes:
- remove unused code in app-layer-htp.c - has been commented out since 2013
- fix typo and formatting in SCLogInfo message when parser disabled but detection enabled

