### PR TITLE
defrag: fix wrong datalink being logged

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -468,7 +468,6 @@ Packet *PacketDefragPktSetup(Packet *parent, const uint8_t *pkt, uint32_t len, u
     }
     p->recursion_level = parent->recursion_level; /* NOT incremented */
     p->ts = parent->ts;
-    p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
     memcpy(&p->vlan_id[0], &parent->vlan_id[0], sizeof(p->vlan_id));
     p->vlan_idx = parent->vlan_idx;

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -430,6 +430,7 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
     }
     PKT_SET_SRC(rp, PKT_SRC_DEFRAG);
     rp->flags |= PKT_REBUILT_FRAGMENT;
+    rp->datalink = tracker->datalink;
 
     uint16_t unfragmentable_len = 0;
     int fragmentable_offset = 0;
@@ -861,6 +862,9 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
 #ifdef DEBUG
     new->pcap_cnt = pcap_cnt;
 #endif
+    if (new->offset == 0) {
+        tracker->datalink = p->datalink;
+    }
 
     IP_FRAGMENTS_RB_INSERT(&tracker->fragment_tree, new);
 

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -106,6 +106,7 @@ typedef struct DefragTracker_ {
     Address src_addr; /**< Source address for this tracker. */
     Address dst_addr; /**< Destination address for this tracker. */
 
+    int datalink;           /**< datalink for reassembled packet, set by first fragment */
     SCTime_t timeout;       /**< When this tracker will timeout. */
     uint32_t host_timeout;  /**< Host timeout, statically assigned from the yaml */
 


### PR DESCRIPTION
Bug: #6887.

https://redmine.openinfosecfoundation.org/issues/6887