### PR TITLE
eve/stats: allow hiding counters whose valued is 0 - v3

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -281,6 +281,27 @@ Config::
         # (will show more information in case of a drop caused by 'reject')
         verdict: yes
 
+.. _eve-json-output-stats:
+
+Stats
+~~~~~
+
+Zero-valued Counters
+""""""""""""""""""""
+
+While the human-friendly `stats.log` output will only log out non-zeroed
+counters, by default EVE Stats logs output all enabled counters, which may lead
+to fairly verbose logs.
+
+To reduce log file size, one may set `zero-valued-counters` to false. Do note
+that this may impact on the visibility of information for which a stats counter
+as zero is relevant.
+
+Config::
+
+    - stats:
+        # Don't log stats counters that are zero. Default: true
+        #zero-valued-counters: false    # False will NOT log stats counters: 0
 
 Date modifiers in filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -169,6 +169,8 @@ outputs:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats
             deltas: no        # include delta values
+            # Don't log stats counters that are zero. Default: true
+            #zero-valued-counters: false    # False will NOT log stats counters: 0
         - dhcp:
             # DHCP logging.
             enabled: yes

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -50,6 +50,8 @@ Major changes
 - ``SIP_PORTS`` variable has been introduced in suricata.yaml
 - Application layer's ``sip`` counter has been split into ``sip_tcp`` and ``sip_udp``
   for the ``stats`` event.
+- Stats counters that are 0 can now be hidden from EVE logs. Default behavior
+  still logs those (see :ref:`EVE Output - Stats <eve-json-output-stats>` for configuration setting).
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -229,6 +229,10 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
         for (u = 0; u < st->nstats; u++) {
             if (st->stats[u].name == NULL)
                 continue;
+            if (flags & JSON_STATS_NO_ZEROES && st->stats[u].value == 0) {
+                continue;
+            }
+
             json_t *js_type = NULL;
             const char *stat_name = st->stats[u].short_name;
             /*
@@ -272,6 +276,9 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
             for (u = offset; u < (offset + st->nstats); u++) {
                 if (st->tstats[u].name == NULL)
                     continue;
+                if (flags & JSON_STATS_NO_ZEROES && st->tstats[u].value == 0) {
+                    continue;
+                }
 
                 DEBUG_VALIDATE_BUG_ON(st->tstats[u].tm_name == NULL);
 
@@ -443,6 +450,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         const char *totals = ConfNodeLookupChildValue(conf, "totals");
         const char *threads = ConfNodeLookupChildValue(conf, "threads");
         const char *deltas = ConfNodeLookupChildValue(conf, "deltas");
+        const char *zero_counters = ConfNodeLookupChildValue(conf, "zero-valued-counters");
         SCLogDebug("totals %s threads %s deltas %s", totals, threads, deltas);
 
         if ((totals != NULL && ConfValIsFalse(totals)) &&
@@ -460,6 +468,9 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         }
         if (deltas != NULL && ConfValIsTrue(deltas)) {
             stats_ctx->flags |= JSON_STATS_DELTAS;
+        }
+        if (zero_counters != NULL && ConfValIsFalse(zero_counters)) {
+            stats_ctx->flags |= JSON_STATS_NO_ZEROES;
         }
         SCLogDebug("stats_ctx->flags %08x", stats_ctx->flags);
     }

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,9 +26,10 @@
 
 #include "output-stats.h"
 
-#define JSON_STATS_TOTALS  (1<<0)
-#define JSON_STATS_THREADS (1<<1)
-#define JSON_STATS_DELTAS  (1<<2)
+#define JSON_STATS_TOTALS    (1 << 0)
+#define JSON_STATS_THREADS   (1 << 1)
+#define JSON_STATS_DELTAS    (1 << 2)
+#define JSON_STATS_NO_ZEROES (1 << 3)
 
 json_t *StatsToJSON(const StatsTable *st, uint8_t flags);
 TmEcode OutputEngineStatsReloadTime(json_t **jdata);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -315,6 +315,9 @@ outputs:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats
             deltas: no        # include delta values
+            # Don't log stats counters that are zero. Default: true
+            #zero-valued-counters: false    # False will NOT log stats counters: 0
+            # Exception policy stats counters options
         # bi-directional flows
         - flow
         # uni-directional flows


### PR DESCRIPTION
Some stats can be quite verbose if logging all zero valued-counters. This allows users to disable logging such counters. Default is still true, as that's the expected behavior for the engine.

Task https://github.com/OISF/suricata/pull/5976

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/5976

Previous PR: https://github.com/OISF/suricata/pull/10766

Describe changes:
- rebased

Provide values to any of the below to override the defaults.
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1753

Json Stats Output Sample
jq .stats -c eve.json (from the `feature-5976-zero-stats-01` sv test)
```json
{"uptime":0,"ips":{"accepted":32},"decoder":{"pkts":32,"bytes":9598,"ipv6":32,"ethernet":32,"tcp":32,"avg_pkt_size":299,"max_pkt_size":2974},"tcp":{"syn":1,"synack":1,"rst":3,"sessions":1,"ssn_from_pool":1,"segment_from_cache":9,"segment_from_pool":7,"memuse":7667712,"reassembly_memuse":1376256},"flow":{"total":1,"tcp":1,"wrk":{"spare_sync_avg":100,"spare_sync":1},"end":{"state":{"closed":1},"tcp_state":{"closed":1}},"mgr":{"rows_per_sec":13762},"spare":9900,"recycler":{"recycled":1,"queue_max":1},"memuse":7154304},"app_layer":{"flow":{"tls":1}},"memcap_pressure":21,"memcap_pressure_max":21}
```