### PR TITLE
rust: make dist redo - v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -1,6 +1,8 @@
 [package]
 name = "suricata"
 version = "@PACKAGE_VERSION@"
+license = "GPL-2.0-only"
+description = "Suricata Rust components"
 edition = "2021"
 rust-version = "1.63.0"
 
@@ -63,7 +65,7 @@ asn1-rs = { version = "~0.6.1" }
 # last version to work with MSRV 1.63
 time = "=0.3.20"
 
-suricata-derive = { path = "./derive" }
+suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -9,7 +9,6 @@ members = [".", "./derive"]
 
 [lib]
 crate-type = ["staticlib", "rlib"]
-path = "@e_rustdir@/src/lib.rs"
 name = "suricata"
 
 [profile.release]

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -2,7 +2,9 @@ EXTRA_DIST =	src derive \
 		.cargo/config.in \
 		cbindgen.toml \
 		dist/rust-bindings.h \
-		vendor
+		vendor \
+		Cargo.toml Cargo.lock \
+		derive/Cargo.toml
 
 if !DEBUG
 RELEASE = --release
@@ -30,14 +32,14 @@ endif
 
 all-local: Cargo.toml
 if HAVE_CYGPATH
-	@rustup_home@ \
-		CARGO_HOME="$(CARGO_HOME)" \
+	cd $(abs_top_srcdir)/rust && \
+		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(e_rustdir)/target" \
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
-	@rustup_home@ \
-		CARGO_HOME="$(CARGO_HOME)" \
+	cd $(abs_top_srcdir)/rust && \
+		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
@@ -72,7 +74,8 @@ maintainer-clean-local:
 	rm -rf vendor gen
 
 check:
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ \
+	cd $(abs_top_srcdir)/rust && \
+		CARGO_HOME="$(CARGO_HOME)" @rustup_home@ \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
 		$(CARGO) test --all $(RELEASE) --features "$(RUST_FEATURES)"
 

--- a/rust/derive/Cargo.toml.in
+++ b/rust/derive/Cargo.toml.in
@@ -5,7 +5,6 @@ edition = "2021"
 
 [lib]
 proc-macro = true
-path = "@e_rustdir@/derive/src/lib.rs"
 
 [dependencies]
 proc-macro-crate = "= 1.1.0"

--- a/rust/derive/Cargo.toml.in
+++ b/rust/derive/Cargo.toml.in
@@ -1,7 +1,10 @@
 [package]
 name = "suricata-derive"
 version = "@PACKAGE_VERSION@"
+license = "GPL-2.0-only"
+description = "Derive macros for Suricata"
 edition = "2021"
+
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- Instead of substituting in the library path into the Cargo.toml (which makes the Cargo.toml non-portable, for example to crates.io), "cd" into the src directory. We already set the rust target directory, so this just works.
- Add the missing bits to Cargo.toml for publishing to crates.io. The version still needs to be fixed up, but the license and description should be there anyways.
