### PR TITLE
ci: clean some disk space to run CIFuzz again

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -18,6 +18,12 @@ jobs:
      matrix:
        sanitizer: [address, undefined]
    steps:
+   - name: Clear unnecessary files
+     run: |
+        df
+        sudo apt clean
+        sudo rm -rf /usr/share/dotnet/ /usr/share/swift /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules
+        df
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, related to https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- ci: clean some disk space to run CIFuzz again

As advised from openssl which had the same issue cf https://github.com/google/oss-fuzz/issues/11575#issuecomment-2051250795