### PR TITLE
stats: Memcap pressure max relocation

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3734,15 +3734,6 @@
                         }
                     }
                 },
-                "memcap_pressure": {
-                    "description":
-                            "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
-                    "type": "integer"
-                },
-                "memcap_pressure_max": {
-                    "description": "Maximum memcap_pressure seen by the engine",
-                    "type": "integer"
-                },
                 "app_layer": {
                     "type": "object",
                     "properties": {
@@ -5293,6 +5284,21 @@
                             "type": "integer"
                         },
                         "rows_skipped": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "memcap": {
+                    "type": "object",
+                    "properties": {
+                        "pressure": {
+                            "description":
+                                    "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
+                            "type": "integer"
+                        },
+                        "pressure_max": {
+                            "description": "Maximum pressure seen by the engine",
                             "type": "integer"
                         }
                     },

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -654,8 +654,8 @@ static void FlowCountersInit(ThreadVars *t, FlowCounters *fc)
     fc->flow_bypassed_pkts = StatsRegisterCounter("flow_bypassed.pkts", t);
     fc->flow_bypassed_bytes = StatsRegisterCounter("flow_bypassed.bytes", t);
 
-    fc->memcap_pressure = StatsRegisterCounter("memcap_pressure", t);
-    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap_pressure_max", t);
+    fc->memcap_pressure = StatsRegisterCounter("memcap.pressure", t);
+    fc->memcap_pressure_max = StatsRegisterMaxCounter("memcap.pressure_max", t);
 }
 
 static void FlowCountersUpdate(


### PR DESCRIPTION
Continuation of #10711 

This commit moves the memcap pressure/pressure_max stats from the global stats namespace into the memcap namespace.

With per-thread stats, they will be within the flow-manager's values.

Issue: 6398

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Created `memcap` section and relocated `pressure` and `pressure_max`

Updates:
- Rebase to remove unintended format changes in schema.json

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=pr/1727
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
