### PR TITLE
detect/analyzer: add more details for tcp_mss

### DIFF
--- a/rust/src/detect/dump/mod.rs
+++ b/rust/src/detect/dump/mod.rs
@@ -1,0 +1,79 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use crate::detect::uint::{DetectIntType, DetectUintData, DetectUintMode};
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+
+pub fn detect_dump_uint<T: DetectIntType>(
+    js: &mut JsonBuilder, du: &DetectUintData<T>,
+) -> Result<(), JsonError>
+where
+    u64: From<T>,
+{
+    match du.mode {
+        DetectUintMode::DetectUintModeEqual => {
+            js.set_uint("equal", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeNe => {
+            js.set_uint("diff", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeLt => {
+            js.set_uint("lt", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeLte => {
+            js.set_uint("lte", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeGt => {
+            js.set_uint("gt", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeGte => {
+            js.set_uint("gte", du.arg1.into())?;
+        }
+        DetectUintMode::DetectUintModeRange => {
+            js.open_object("range")?;
+            js.set_uint("min", du.arg1.into())?;
+            js.set_uint("max", du.arg2.into())?;
+            js.close()?;
+        }
+        DetectUintMode::DetectUintModeNegRg => {
+            js.open_object("negated_range")?;
+            js.set_uint("min", du.arg1.into())?;
+            js.set_uint("max", du.arg2.into())?;
+            js.close()?;
+        }
+        DetectUintMode::DetectUintModeBitmask => {
+            js.open_object("bitmask")?;
+            js.set_uint("mask", du.arg1.into())?;
+            js.set_uint("value", du.arg2.into())?;
+            js.close()?;
+        }
+        DetectUintMode::DetectUintModeNegBitmask => {
+            js.open_object("negated_bitmask")?;
+            js.set_uint("mask", du.arg1.into())?;
+            js.set_uint("value", du.arg2.into())?;
+            js.close()?;
+        }
+    }
+    Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_u16_dump(
+    js: &mut JsonBuilder, du: &DetectUintData<u16>,
+) -> bool {
+    return detect_dump_uint(js, du).is_ok();
+}

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -25,6 +25,7 @@ pub mod stream_size;
 pub mod uint;
 pub mod uri;
 pub mod requires;
+pub mod dump;
 
 /// EnumString trait that will be implemented on enums that
 /// derive StringEnum.

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -32,6 +32,7 @@
 #include "detect-engine.h"
 #include "detect-engine-analyzer.h"
 #include "detect-engine-mpm.h"
+#include "detect-engine-uint.h"
 #include "conf.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
@@ -915,9 +916,15 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
             }
             case DETECT_SEQ: {
                 const DetectSeqData *cd = (const DetectSeqData *)smd->ctx;
-
                 jb_open_object(js, "seq");
                 jb_set_uint(js, "number", cd->seq);
+                jb_close(js);
+                break;
+            }
+            case DETECT_TCPMSS: {
+                const DetectU16Data *cd = (const DetectU16Data *)smd->ctx;
+                jb_open_object(js, "tcp_mss");
+                rs_detect_u16_dump(js, cd);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6355

Describe changes:
- detect/analyzer: add more details for tcp_mss

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1759

https://github.com/OISF/suricata/pull/9778 with output changed as asked by Jason, and moving to generic rust for uint stringing, also handling the new cases since (rust checks for switch completeness)