### PR TITLE
flow/inject: Select thread_id by flow flag

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -335,9 +335,8 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
  *        The function requires flow to be locked beforehand.
  *
  * Normally, the first thread_id value should be used. This is when the flow is
- * created on seeing the first packet to the server; sometimes, if the first
- * packet is determined to be to the client, the second thread_id value should
- * be used.
+ * created on seeing the first packet to the server; when the flow's reversed
+ * flag is set, choose the second thread_id (to client/source).
  *
  * \param f Pointer to the flow.
  *
@@ -345,9 +344,9 @@ int FlowForceReassemblyNeedReassembly(Flow *f)
  */
 void FlowForceReassemblyForFlow(Flow *f)
 {
-    // Have packets traveled to the server? If not,
-    // use the reverse direction
-    int idx = f->todstpktcnt > 0 ? 0 : 1;
+    // Choose the thread_id based on whether the flow has been
+    // reversed.
+    int idx = f->flags & FLOW_DIR_REVERSED ? 1 : 0;
     TmThreadsInjectFlowById(f, (const int)f->thread_id[idx]);
 }
 


### PR DESCRIPTION
Issue: 6957

Rather than selecting the thread_id index by packets traveling to the server, use the flow flags. If the flow has been reversed, the second slot is represents the thread id to be used.


Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6957](https://redmine.openinfosecfoundation.org/issues/6957)

Describe changes:
- Choose the `thread_id` slot based on whether the flow's been reversed.

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
