### PR TITLE
pgsql: low hanging fruits - v2

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -661,7 +661,13 @@ pub unsafe extern "C" fn rs_pgsql_parse_response(
     flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
-    let _eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0;
+    if stream_slice.is_empty() {
+        if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0 {
+            return AppLayerResult::ok();
+        } else {
+            return AppLayerResult::err();
+        }
+    }
 
     let state_safe: &mut PgsqlState = cast_pointer!(state, PgsqlState);
 

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -47,6 +47,7 @@
 #include "rust.h"
 
 #define PGSQL_LOG_PASSWORDS BIT_U32(0)
+#define PGSQL_DEFAULTS      (PGSQL_LOG_PASSWORDS)
 
 typedef struct OutputPgsqlCtx_ {
     uint32_t flags;
@@ -57,6 +58,11 @@ typedef struct LogPgsqlLogThread_ {
     OutputPgsqlCtx *pgsqllog_ctx;
     OutputJsonThreadCtx *ctx;
 } LogPgsqlLogThread;
+
+bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb)
+{
+    return rs_pgsql_logger(vtx, PGSQL_DEFAULTS, jb);
+}
 
 static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state,
         void *txptr, uint64_t tx_id)

--- a/src/output-json-pgsql.h
+++ b/src/output-json-pgsql.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,5 +25,6 @@
 #define SURICATA_OUTPUT_JSON_PGSQL_H
 
 void JsonPgsqlLogRegister(void);
+bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb);
 
 #endif /* SURICATA_OUTPUT_JSON_PGSQL_H */

--- a/src/output.c
+++ b/src/output.c
@@ -1133,7 +1133,7 @@ static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json },
     { ALPROTO_RFB, rs_rfb_logger_log },
     { ALPROTO_MQTT, JsonMQTTAddMetadata },
-    { ALPROTO_PGSQL, NULL },  // TODO missing
+    { ALPROTO_PGSQL, JsonPgsqlAddMetadata },
     { ALPROTO_TELNET, NULL }, // no logging
     { ALPROTO_TEMPLATE, rs_template_logger_log },
     { ALPROTO_RDP, (EveJsonSimpleTxLogFunc)rs_rdp_to_json },


### PR DESCRIPTION
While starting review for the LDAP protocol parser, noticed that we had a TODO for adding a simpler logger function for PGSQL, following up https://github.com/OISF/suricata/pull/9851.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6092

Previous PR: https://github.com/OISF/suricata/pull/10830

Describe changes:
- rebased, new PR to trigger CI checks with SV PR

These commits don't change the output behavior, just ensure that we pass pgsql config flags as metadata, therefore, these tests should pass with master, too.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1770
