### PR TITLE
decode/ppp: fix iplen check int handling

### DIFF
--- a/src/decode-ppp.c
+++ b/src/decode-ppp.c
@@ -52,7 +52,7 @@ static int DecodePPPCompressedProto(ThreadVars *tv, DecodeThreadVars *dtv, Packe
                 return TM_ECODE_FAILED;
             }
             DEBUG_VALIDATE_BUG_ON(len < data_offset);
-            uint16_t iplen = MIN(USHRT_MAX, (uint16_t)(len - data_offset));
+            uint16_t iplen = (uint16_t)MIN((uint32_t)USHRT_MAX, len - data_offset);
             return DecodeIPV4(tv, dtv, p, pkt + data_offset, iplen);
         }
         case 0x57: { /* PPP_IPV6 */
@@ -61,7 +61,7 @@ static int DecodePPPCompressedProto(ThreadVars *tv, DecodeThreadVars *dtv, Packe
                 return TM_ECODE_FAILED;
             }
             DEBUG_VALIDATE_BUG_ON(len < data_offset);
-            uint16_t iplen = MIN(USHRT_MAX, (uint16_t)(len - data_offset));
+            uint16_t iplen = (uint16_t)MIN((uint32_t)USHRT_MAX, len - data_offset);
             return DecodeIPV6(tv, dtv, p, pkt + data_offset, iplen);
         }
         case 0x2f: /* PPP_VJ_UCOMP */


### PR DESCRIPTION
```
** CID 1596376:    (CONSTANT_EXPRESSION_RESULT)
/src/decode-ppp.c: 64 in DecodePPPCompressedProto()
/src/decode-ppp.c: 55 in DecodePPPCompressedProto()

________________________________________________________________________________________________________
*** CID 1596376:    (CONSTANT_EXPRESSION_RESULT)
/src/decode-ppp.c: 64 in DecodePPPCompressedProto()
58             case 0x57: { /* PPP_IPV6 */
59                 if (unlikely(len < (data_offset + IPV6_HEADER_LEN))) {
60                     ENGINE_SET_INVALID_EVENT(p, PPPIPV6_PKT_TOO_SMALL);
61                     return TM_ECODE_FAILED;
62                 }
63                 DEBUG_VALIDATE_BUG_ON(len < data_offset);
>>>     CID 1596376:    (CONSTANT_EXPRESSION_RESULT)
>>>     "65535 /* 32767 * 2 + 1 */ < (uint16_t)(len - data_offset)" is always false regardless of the values of its operands. This occurs as the logical first operand of "?:".
64                 uint16_t iplen = MIN(USHRT_MAX, (uint16_t)(len - data_offset));
65                 return DecodeIPV6(tv, dtv, p, pkt + data_offset, iplen);
66             }
67             case 0x2f: /* PPP_VJ_UCOMP */
68                 if (unlikely(len < (data_offset + IPV4_HEADER_LEN))) {
69                     ENGINE_SET_INVALID_EVENT(p, PPPVJU_PKT_TOO_SMALL);
/src/decode-ppp.c: 55 in DecodePPPCompressedProto()
49             case 0x21: { /* PPP_IP */
50                 if (unlikely(len < (data_offset + IPV4_HEADER_LEN))) {
51                     ENGINE_SET_INVALID_EVENT(p, PPPVJU_PKT_TOO_SMALL);
52                     return TM_ECODE_FAILED;
53                 }
54                 DEBUG_VALIDATE_BUG_ON(len < data_offset);
>>>     CID 1596376:    (CONSTANT_EXPRESSION_RESULT)
>>>     "65535 /* 32767 * 2 + 1 */ < (uint16_t)(len - data_offset)" is always false regardless of the values of its operands. This occurs as the logical first operand of "?:".
55                 uint16_t iplen = MIN(USHRT_MAX, (uint16_t)(len - data_offset));
56                 return DecodeIPV4(tv, dtv, p, pkt + data_offset, iplen);
57             }
58             case 0x57: { /* PPP_IPV6 */
59                 if (unlikely(len < (data_offset + IPV6_HEADER_LEN))) {
60                     ENGINE_SET_INVALID_EVENT(p, PPPIPV6_PKT_TOO_SMALL);
```