### PR TITLE
dataset: cleanup datasets that hit the memcap while loading

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -746,6 +746,11 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
     }
 
+    if (set->hash && SC_ATOMIC_GET(set->hash->memcap_reached)) {
+        SCLogError("dataset too large for set memcap");
+        return -1;
+    }
+
     SCLogDebug("set %p/%s type %u save %s load %s",
             set, set->name, set->type, set->save, set->load);
 

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -406,10 +406,6 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         SCLogError("failed to set up dataset '%s'.", name);
         return -1;
     }
-    if (set->hash && SC_ATOMIC_GET(set->hash->memcap_reached)) {
-        SCLogError("dataset too large for set memcap");
-        return -1;
-    }
 
     cd = SCCalloc(1, sizeof(DetectDatasetData));
     if (unlikely(cd == NULL))


### PR DESCRIPTION
Datasets that hit the memcap limit need to be discarded if the memcap is hit or otherwise the datasets are still loaded with partial data while the signature is not loaded due to the memcap error. This moves the check prior to the final cleanup. This also adds the check for datarep sets a well due to the move to the generic dataset code section.

Ticket: #6678

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/6678

Describe changes:
- move the memcap check within the `DatasetGet` function to ensure a proper cleanup
- adds memcap check for datarep sets as well due to the move

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
