### PR TITLE
Bug 6726 livedev ips/v5

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -90,7 +90,6 @@ static int AFPRunModeIsIPS(void)
             SCLogError("Problem with config file");
             return 0;
         }
-        const char *copymodestr = NULL;
         if_root = ConfFindDeviceConfig(af_packet_node, live_dev);
 
         if (if_root == NULL) {
@@ -101,7 +100,10 @@ static int AFPRunModeIsIPS(void)
             if_root = if_default;
         }
 
-        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1) {
+        const char *copymodestr = NULL;
+        const char *copyifacestr = NULL;
+        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1 &&
+                ConfGetChildValue(if_root, "copy-iface", &copyifacestr) == 1) {
             if (strcmp(copymodestr, "ips") == 0) {
                 has_ips = 1;
             } else {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1663,7 +1663,9 @@ static int DPDKRunModeIsIPS(void)
         }
 
         const char *copymodestr = NULL;
-        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1) {
+        const char *copyifacestr = NULL;
+        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1 &&
+                ConfGetChildValue(if_root, "copy-iface", &copyifacestr) == 1) {
             if (strcmp(copymodestr, "ips") == 0) {
                 has_ips = true;
             } else {

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -1685,12 +1685,14 @@ static int DPDKRunModeIsIPS(void)
     return has_ips;
 }
 
-static void DPDKRunModeEnableIPS(void)
+static int DPDKRunModeEnableIPS(void)
 {
-    if (DPDKRunModeIsIPS()) {
+    int r = DPDKRunModeIsIPS();
+    if (r == 1) {
         SCLogInfo("Setting IPS mode");
         EngineModeSetIPS();
     }
+    return r;
 }
 
 const char *RunModeDpdkGetDefaultMode(void)

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -81,7 +81,6 @@ static int NetmapRunModeIsIPS(void)
             SCLogError("Problem with config file");
             return 0;
         }
-        const char *copymodestr = NULL;
         if_root = ConfNodeLookupKeyValue(netmap_node, "interface", live_dev);
 
         if (if_root == NULL) {
@@ -92,7 +91,10 @@ static int NetmapRunModeIsIPS(void)
             if_root = if_default;
         }
 
-        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1) {
+        const char *copymodestr = NULL;
+        const char *copyifacestr = NULL;
+        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1 &&
+                ConfGetChildValue(if_root, "copy-iface", &copyifacestr) == 1) {
             if (strcmp(copymodestr, "ips") == 0) {
                 has_ips = 1;
             } else {

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -98,7 +98,7 @@ typedef struct RunMode_ {
     const char *description;
     /* runmode function */
     int (*RunModeFunc)(void);
-    void (*RunModeIsIPSEnabled)(void);
+    int (*RunModeIsIPSEnabled)(void);
 } RunMode;
 
 typedef struct RunModes_ {
@@ -393,22 +393,23 @@ static const char *RunModeGetConfOrDefault(int capture_mode, const char *capture
     return custom_mode;
 }
 
-void RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *capture_plugin_name)
+int RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *capture_plugin_name)
 {
     if (runmode == NULL) {
         runmode = RunModeGetConfOrDefault(capture_mode, capture_plugin_name);
         if (runmode == NULL) // non-standard runmode
-            return;
+            return 0;
     }
 
     RunMode *mode = RunModeGetCustomMode(capture_mode, runmode);
     if (mode == NULL) {
-        return;
+        return 0;
     }
 
     if (mode->RunModeIsIPSEnabled != NULL) {
-        mode->RunModeIsIPSEnabled();
+        return mode->RunModeIsIPSEnabled();
     }
+    return 0;
 }
 
 /**
@@ -489,7 +490,7 @@ int RunModeNeedsBypassManager(void)
  * \param RunModeFunc The function to be run for this runmode.
  */
 void RunModeRegisterNewRunMode(enum RunModes runmode, const char *name, const char *description,
-        int (*RunModeFunc)(void), void (*RunModeIsIPSEnabled)(void))
+        int (*RunModeFunc)(void), int (*RunModeIsIPSEnabled)(void))
 {
     if (RunModeGetCustomMode(runmode, name) != NULL) {
         FatalError("runmode '%s' has already "

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -393,6 +393,7 @@ static const char *RunModeGetConfOrDefault(int capture_mode, const char *capture
     return custom_mode;
 }
 
+#include "util-device.h"
 int RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *capture_plugin_name)
 {
     if (runmode == NULL) {
@@ -406,10 +407,19 @@ int RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *captur
         return 0;
     }
 
+    int ips_enabled = 0;
     if (mode->RunModeIsIPSEnabled != NULL) {
-        return mode->RunModeIsIPSEnabled();
+        ips_enabled = mode->RunModeIsIPSEnabled();
+        if (ips_enabled == 1) {
+            extern uint16_t g_livedev_mask;
+            if (g_livedev_mask != 0 && LiveGetDeviceCount() > 0) {
+                SCLogWarning("disabling livedev.use-for-tracking with IPS mode. See ticket #6726.");
+                g_livedev_mask = 0;
+            }
+        }
     }
-    return 0;
+
+    return ips_enabled;
 }
 
 /**

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -80,11 +80,11 @@ char *RunmodeGetActive(void);
 const char *RunModeGetMainMode(void);
 
 void RunModeListRunmodes(void);
-void RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *capture_plugin_name);
+int RunModeEngineIsIPS(int capture_mode, const char *runmode, const char *capture_plugin_name);
 void RunModeDispatch(int, const char *, const char *capture_plugin_name, const char *capture_plugin_args);
 void RunModeRegisterRunModes(void);
 void RunModeRegisterNewRunMode(enum RunModes, const char *, const char *, int (*RunModeFunc)(void),
-        void (*RunModeIsIPSEnabled)(void));
+        int (*RunModeIsIPSEnabled)(void));
 void RunModeInitializeThreadSettings(void);
 void RunModeInitializeOutputs(void);
 void RunModeShutDown(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2697,8 +2697,10 @@ int PostConfLoadedSetup(SCInstance *suri)
 
     LiveDeviceFinalize(); // must be after EBPF extension registration
 
-    RunModeEngineIsIPS(
-            suricata.run_mode, suricata.runmode_custom_mode, suricata.capture_plugin_name);
+    if (RunModeEngineIsIPS(suricata.run_mode, suricata.runmode_custom_mode,
+                suricata.capture_plugin_name) < 0) {
+        FatalError("IPS mode setup failed");
+    }
 
     if (EngineModeIsUnknown()) { // if still uninitialized, set the default
         SCLogInfo("Setting engine mode to IDS mode by default");


### PR DESCRIPTION
Alternative approach to #10863: instead of erroring out, we just disable the offending setting with a warning.
![image](https://github.com/OISF/suricata/assets/32410611/a58c3701-1e55-4de6-bf78-22e1e8fcec43)

I think I like this better, as the `livedev.use-for-tracking` is enabled by default and will confuse everyone enabling the relevant IPS modes. So this is a more user friendly approach.

https://redmine.openinfosecfoundation.org/issues/5588
https://redmine.openinfosecfoundation.org/issues/6726