### PR TITLE
yaml/eve/stats: remove mention exception policy - v1

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -317,7 +317,6 @@ outputs:
             deltas: no        # include delta values
             # Don't log stats counters that are zero. Default: true
             #zero-valued-counters: false    # False will NOT log stats counters: 0
-            # Exception policy stats counters options
         # bi-directional flows
         - flow
         # uni-directional flows


### PR DESCRIPTION
The stats config for EVE logs have a comment about exception policy stats counters. This went in with 72146b969c06fb953, but shouldn't have, as there are no options there. >__<'
