### PR TITLE
yaml: unify 0 stats counter config option terms - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -293,7 +293,7 @@ While the human-friendly `stats.log` output will only log out non-zeroed
 counters, by default EVE Stats logs output all enabled counters, which may lead
 to fairly verbose logs.
 
-To reduce log file size, one may set `zero-valued-counters` to false. Do note
+To reduce log file size, one may set `null-values` to false. Do note
 that this may impact on the visibility of information for which a stats counter
 as zero is relevant.
 
@@ -301,7 +301,7 @@ Config::
 
     - stats:
         # Don't log stats counters that are zero. Default: true
-        #zero-valued-counters: false    # False will NOT log stats counters: 0
+        #null-values: false    # False will NOT log stats counters: 0
 
 Date modifiers in filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -170,7 +170,7 @@ outputs:
             threads: no       # per thread stats
             deltas: no        # include delta values
             # Don't log stats counters that are zero. Default: true
-            #zero-valued-counters: false    # False will NOT log stats counters: 0
+            #null-values: false    # False will NOT log stats counters: 0
         - dhcp:
             # DHCP logging.
             enabled: yes

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -450,7 +450,7 @@ static OutputInitResult OutputStatsLogInitSub(ConfNode *conf, OutputCtx *parent_
         const char *totals = ConfNodeLookupChildValue(conf, "totals");
         const char *threads = ConfNodeLookupChildValue(conf, "threads");
         const char *deltas = ConfNodeLookupChildValue(conf, "deltas");
-        const char *zero_counters = ConfNodeLookupChildValue(conf, "zero-valued-counters");
+        const char *zero_counters = ConfNodeLookupChildValue(conf, "null-values");
         SCLogDebug("totals %s threads %s deltas %s", totals, threads, deltas);
 
         if ((totals != NULL && ConfValIsFalse(totals)) &&

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -317,7 +317,6 @@ outputs:
             deltas: no        # include delta values
             # Don't log stats counters that are zero. Default: true
             #zero-valued-counters: false    # False will NOT log stats counters: 0
-            # Exception policy stats counters options
         # bi-directional flows
         - flow
         # uni-directional flows

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -316,7 +316,7 @@ outputs:
             threads: no       # per thread stats
             deltas: no        # include delta values
             # Don't log stats counters that are zero. Default: true
-            #zero-valued-counters: false    # False will NOT log stats counters: 0
+            #null-values: false    # False will NOT log stats counters: 0
         # bi-directional flows
         - flow
         # uni-directional flows


### PR DESCRIPTION
When doing the research for [#5976](https://redmine.openinfosecfoundation.org/issues/5976) I failed to see that we also have a config stats option for the human-readable logs to output 0 counters.
Due to not seeing this before, we now have two different setting names for basically the same thing, but in different logs:
zero-valued-counters for EVE https://github.com/OISF/suricata/blob/master/suricata.yaml.in#L319 and
null-values for stats.log https://github.com/OISF/suricata/blob/master/suricata.yaml.in#L444C9-L444C20.

This PR replaces the newly introduced `zero-valued-counters` with `null-values`, as this one has been around for longer.

I've brought the fix from https://github.com/OISF/suricata/pull/10867, to avoid having possible merging conflicts.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6962

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1774
