### PR TITLE
ci: clean some disk space to run CIFuzz again (backport7)

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -14,6 +14,12 @@ jobs:
      matrix:
        sanitizer: [address, undefined]
    steps:
+   - name: Clear unnecessary files
+     run: |
+        df
+        sudo apt clean
+        sudo rm -rf /usr/share/dotnet/ /usr/share/swift /usr/local/.ghcup/ /usr/local/share/powershell /usr/local/share/chromium /usr/local/lib/android /usr/local/lib/node_modules
+        df
    - name: Build Fuzzers (${{ matrix.sanitizer }})
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
None, related to https://redmine.openinfosecfoundation.org/issues/4125

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/10816 clean cherry-pick
