### PR TITLE
detect/http-server-body: avoid FP on toserver direction

### DIFF
--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -124,6 +124,9 @@ static int DetectHttpServerBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s
         return -1;
     if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
+    // file data is on both directions, but we only take the one to client here
+    s->flags |= SIG_FLAG_TOCLIENT;
+    s->flags &= ~SIG_FLAG_TOSERVER;
     return 0;
 }
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6948

Describe changes:
- detect/http-server-body: avoid false positive on toserver direction

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1784
