### PR TITLE
Clippy 177 (backport6)

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -30,7 +30,7 @@ pub struct Asn1<'a>(Vec<BerObject<'a>>);
 enum Asn1DecodeError {
     InvalidKeywordParameter,
     MaxFrames,
-    BerError(nom::Err<der_parser::error::BerError>),
+    BerError,
 }
 
 /// Enumeration of Asn1 checks
@@ -276,8 +276,8 @@ impl From<std::num::TryFromIntError> for Asn1DecodeError {
 }
 
 impl From<nom::Err<der_parser::error::BerError>> for Asn1DecodeError {
-    fn from(e: nom::Err<der_parser::error::BerError>) -> Asn1DecodeError {
-        Asn1DecodeError::BerError(e)
+    fn from(_e: nom::Err<der_parser::error::BerError>) -> Asn1DecodeError {
+        Asn1DecodeError::BerError
     }
 }
 

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -838,8 +838,7 @@ export_tx_data_get!(rs_mqtt_get_tx_data, MQTTTransaction);
 #[no_mangle]
 pub unsafe extern "C" fn rs_mqtt_register_parser(cfg_max_msg_len: u32) {
     let default_port = CString::new("[1883]").unwrap();
-    let max_msg_len = &mut MAX_MSG_LEN;
-    *max_msg_len = cfg_max_msg_len;
+    MAX_MSG_LEN = cfg_max_msg_len;
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6883 but it was not set for back porting at first...

Describe changes:
- Backport of 02f2fb88333af767ab3b171643357d607f4e86f6, with conflict fixed
- Backport of 80d2c6e0a1a10b7378534a265e11127280f19af1 which is in main-7.0.x as master did not have the issue cf https://github.com/OISF/suricata/pull/10721

No backports of the other commit in https://github.com/OISF/suricata/pull/10691
