### PR TITLE
dataset: cleanup datasets that hit the memcap while loading

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -746,6 +746,11 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
     }
 
+    if (set->hash && SC_ATOMIC_GET(set->hash->memcap_reached)) {
+        SCLogError("dataset too large for set memcap");
+        goto out_err;
+    }
+
     SCLogDebug("set %p/%s type %u save %s load %s",
             set, set->name, set->type, set->save, set->load);
 

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -407,10 +407,6 @@ int DetectDatasetSetup (DetectEngineCtx *de_ctx, Signature *s, const char *rawst
         SCLogError("failed to set up dataset '%s'.", name);
         return -1;
     }
-    if (set->hash && SC_ATOMIC_GET(set->hash->memcap_reached)) {
-        SCLogError("dataset too large for set memcap");
-        return -1;
-    }
 
     cd = SCCalloc(1, sizeof(DetectDatasetData));
     if (unlikely(cd == NULL))


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6679

Describe changes:
- Backport of #10860 clean cherry-pick

cc @norg 