### PR TITLE
Pkt ptrs/v41

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -186,11 +186,11 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
                          "DST IP:            %s\n"
                          "PROTO:             %" PRIu32 "\n",
                          srcip, dstip, p->proto);
-    if (PKT_IS_TCP(p) || PKT_IS_UDP(p)) {
+    if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
         MemBufferWriteString(aft->buffer, "SRC PORT:          %" PRIu32 "\n"
                              "DST PORT:          %" PRIu32 "\n",
                              p->sp, p->dp);
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             MemBufferWriteString(aft->buffer, "TCP SEQ:           %"PRIu32"\n"
                                  "TCP ACK:           %"PRIu32"\n",
                                  TCP_GET_SEQ(p), TCP_GET_ACK(p));
@@ -286,8 +286,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
             /* This is an app layer or stream alert */
             int ret;
             uint8_t flag;
-            if (!(PKT_IS_TCP(p)) || p->flow == NULL ||
-                    p->flow->protoctx == NULL) {
+            if (!(PacketIsTCP(p)) || p->flow == NULL || p->flow->protoctx == NULL) {
                 return TM_ECODE_OK;
             }
             /* IDS mode reverse the data */

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -173,11 +173,11 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     MemBufferWriteString(aft->buffer, "PKT SRC:           %s\n", pkt_src_str);
 
     char srcip[46], dstip[46];
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
     } else {
-        DEBUG_VALIDATE_BUG_ON(!(PKT_IS_IPV6(p)));
+        DEBUG_VALIDATE_BUG_ON(!(PacketIsIPv6(p)));
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
     }
@@ -473,7 +473,7 @@ static bool AlertDebugLogCondition(ThreadVars *tv, void *thread_data, const Pack
 
 static int AlertDebugLogLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
-    if (PKT_IS_IPV4(p) || PKT_IS_IPV6(p)) {
+    if (PacketIsIPv4(p) || PacketIsIPv6(p)) {
         return AlertDebugLogger(tv, p, thread_data);
     } else if (p->events.cnt > 0) {
         return AlertDebugLogDecoderEvent(tv, p, thread_data);

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -191,9 +191,11 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
                              "DST PORT:          %" PRIu32 "\n",
                              p->sp, p->dp);
         if (PacketIsTCP(p)) {
-            MemBufferWriteString(aft->buffer, "TCP SEQ:           %"PRIu32"\n"
-                                 "TCP ACK:           %"PRIu32"\n",
-                                 TCP_GET_SEQ(p), TCP_GET_ACK(p));
+            const TCPHdr *tcph = PacketGetTCP(p);
+            MemBufferWriteString(aft->buffer,
+                    "TCP SEQ:           %" PRIu32 "\n"
+                    "TCP ACK:           %" PRIu32 "\n",
+                    TCP_GET_RAW_SEQ(tcph), TCP_GET_RAW_ACK(tcph));
         }
     }
 

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -186,7 +186,7 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
                          "DST IP:            %s\n"
                          "PROTO:             %" PRIu32 "\n",
                          srcip, dstip, p->proto);
-    if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
+    if (PacketIsTCP(p) || PacketIsUDP(p)) {
         MemBufferWriteString(aft->buffer, "SRC PORT:          %" PRIu32 "\n"
                              "DST PORT:          %" PRIu32 "\n",
                              p->sp, p->dp);

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -129,15 +129,15 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
 
     char proto[16] = "";
     const char *protoptr;
-    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
-        protoptr = known_proto[IP_GET_IPPROTO(p)];
+    if (SCProtoNameValid(PacketGetIPProto(p))) {
+        protoptr = known_proto[PacketGetIPProto(p)];
     } else {
-        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, IP_GET_IPPROTO(p));
+        snprintf(proto, sizeof(proto), "PROTO:%03" PRIu32, PacketGetIPProto(p));
         protoptr = proto;
     }
     uint16_t src_port_or_icmp = p->sp;
     uint16_t dst_port_or_icmp = p->dp;
-    if (IP_GET_IPPROTO(p) == IPPROTO_ICMP || IP_GET_IPPROTO(p) == IPPROTO_ICMPV6) {
+    if (PacketGetIPProto(p) == IPPROTO_ICMP || PacketGetIPProto(p) == IPPROTO_ICMPV6) {
         src_port_or_icmp = p->icmp_s.type;
         dst_port_or_icmp = p->icmp_s.code;
     }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -109,10 +109,10 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
     CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
     char srcip[46], dstip[46];
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
     } else {

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -204,7 +204,8 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
 
     char proto[16] = "";
     const char *protoptr;
-    const uint8_t ipproto = IPV4_GET_IPPROTO(p);
+    const IPV4Hdr *ipv4h = PacketGetIPv4(p);
+    const uint8_t ipproto = IPV4_GET_RAW_IPPROTO(ipv4h);
     if (SCProtoNameValid(ipproto)) {
         protoptr = known_proto[ipproto];
     } else {

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -364,9 +364,9 @@ static bool AlertSyslogCondition(ThreadVars *tv, void *thread_data, const Packet
 
 static int AlertSyslogLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         return AlertSyslogIPv4(tv, p, thread_data);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         return AlertSyslogIPv6(tv, p, thread_data);
     } else if (p->events.cnt > 0) {
         return AlertSyslogDecoderEvent(tv, p, thread_data);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1336,7 +1336,7 @@ void AppLayerDeSetupCounters(void)
     f.flags = FLOW_IPV4;                                                                           \
     f.proto = IPPROTO_TCP;                                                                         \
     p->flow = &f;                                                                                  \
-    p->tcph = &tcph;                                                                               \
+    PacketSetTCP(p, (uint8_t *)&tcph);                                                             \
                                                                                                    \
     StreamTcpInitConfig(true);                                                                     \
     IPPairInitConfig(true);                                                                        \
@@ -1364,8 +1364,8 @@ void AppLayerDeSetupCounters(void)
     FAIL_IF(ssn->data_first_seen_dir != 0);                                                        \
                                                                                                    \
     /* handshake */                                                                                \
-    p->tcph->th_ack = htonl(1);                                                                    \
-    p->tcph->th_flags = TH_SYN | TH_ACK;                                                           \
+    tcph.th_ack = htonl(1);                                                                        \
+    tcph.th_flags = TH_SYN | TH_ACK;                                                               \
     p->flowflags = FLOW_PKT_TOCLIENT;                                                              \
     p->payload_len = 0;                                                                            \
     p->payload = NULL;                                                                             \
@@ -1383,9 +1383,9 @@ void AppLayerDeSetupCounters(void)
     FAIL_IF(ssn->data_first_seen_dir != 0);                                                        \
                                                                                                    \
     /* handshake */                                                                                \
-    p->tcph->th_ack = htonl(1);                                                                    \
-    p->tcph->th_seq = htonl(1);                                                                    \
-    p->tcph->th_flags = TH_ACK;                                                                    \
+    tcph.th_ack = htonl(1);                                                                        \
+    tcph.th_seq = htonl(1);                                                                        \
+    tcph.th_flags = TH_ACK;                                                                        \
     p->flowflags = FLOW_PKT_TOSERVER;                                                              \
     p->payload_len = 0;                                                                            \
     p->payload = NULL;                                                                             \
@@ -1429,9 +1429,9 @@ static int AppLayerTest01(void)
         0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -1491,9 +1491,9 @@ static int AppLayerTest01(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -1511,9 +1511,9 @@ static int AppLayerTest01(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -1543,9 +1543,9 @@ static int AppLayerTest02(void)
 
     /* partial request */
     uint8_t request1[] = { 0x47, 0x45, };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request1);
     p->payload = request1;
@@ -1563,9 +1563,9 @@ static int AppLayerTest02(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack against partial request */
-    p->tcph->th_ack = htonl(3);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(3);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = 0;
     p->payload = NULL;
@@ -1595,9 +1595,9 @@ static int AppLayerTest02(void)
         0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(3);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(3);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request2);
     p->payload = request2;
@@ -1657,9 +1657,9 @@ static int AppLayerTest02(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -1677,9 +1677,9 @@ static int AppLayerTest02(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -1720,9 +1720,9 @@ static int AppLayerTest03(void)
         0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -1782,9 +1782,9 @@ static int AppLayerTest03(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -1802,9 +1802,9 @@ static int AppLayerTest03(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -1846,9 +1846,9 @@ static int AppLayerTest04(void)
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
     PrintRawDataFp(stdout, request, sizeof(request));
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -1868,9 +1868,9 @@ static int AppLayerTest04(void)
     /* partial response */
     uint8_t response1[] = { 0x58, 0x54, 0x54, 0x50, };
     PrintRawDataFp(stdout, response1, sizeof(response1));
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response1);
     p->payload = response1;
@@ -1888,9 +1888,9 @@ static int AppLayerTest04(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);  // first data sent to applayer
 
     /* partial response ack */
-    p->tcph->th_ack = htonl(5);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(5);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -1951,9 +1951,9 @@ static int AppLayerTest04(void)
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
     PrintRawDataFp(stdout, response2, sizeof(response2));
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(5);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(5);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response2);
     p->payload = response2;
@@ -1971,9 +1971,9 @@ static int AppLayerTest04(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);  // first data sent to applayer
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2015,9 +2015,9 @@ static int AppLayerTest05(void)
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
     PrintRawDataFp(stdout, request, sizeof(request));
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -2078,9 +2078,9 @@ static int AppLayerTest05(void)
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
     PrintRawDataFp(stdout, response, sizeof(response));
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2098,9 +2098,9 @@ static int AppLayerTest05(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2171,9 +2171,9 @@ static int AppLayerTest06(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2203,9 +2203,9 @@ static int AppLayerTest06(void)
         0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -2222,9 +2222,9 @@ static int AppLayerTest06(void)
     FAIL_IF(FLOW_IS_PP_DONE(&f, STREAM_TOCLIENT));
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
-    p->tcph->th_ack = htonl(1 + sizeof(request));
-    p->tcph->th_seq = htonl(328);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1 + sizeof(request));
+    tcph.th_seq = htonl(328);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2265,9 +2265,9 @@ static int AppLayerTest07(void)
         0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20,
         0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -2307,9 +2307,9 @@ static int AppLayerTest07(void)
         0x0a, 0x3c, 0x68, 0x74, 0x6d, 0x6c, 0x3e, 0x3c, 0x62, 0x6f, 0x64, 0x79, 0x3e, 0x3c, 0x68,
         0x31, 0x3e, 0x49, 0x74, 0x20, 0x77, 0x6f, 0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e, 0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2327,9 +2327,9 @@ static int AppLayerTest07(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2364,9 +2364,9 @@ static int AppLayerTest08(void)
         0x0a, 0x55, 0x73, 0x65, 0x72, 0x2d, 0x41, 0x67, 0x65, 0x6e, 0x74, 0x3a, 0x20, 0x41, 0x70,
         0x61, 0x63, 0x68, 0x65, 0x42, 0x65, 0x6e, 0x63, 0x68, 0x2f, 0x32, 0x2e, 0x33, 0x0d, 0x0a,
         0x41, 0x63, 0x63, 0x65, 0x70, 0x74, 0x3a, 0x20, 0x2a, 0x2f, 0x2a, 0x0d, 0x0a, 0x0d, 0x0a };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request);
     p->payload = request;
@@ -2426,9 +2426,9 @@ static int AppLayerTest08(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(88);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(88);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2446,9 +2446,9 @@ static int AppLayerTest08(void)
     FAIL_IF(ssn->data_first_seen_dir != APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(88);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(88);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2481,9 +2481,9 @@ static int AppLayerTest09(void)
     /* full request */
     uint8_t request1[] = {
         0x47, 0x47, 0x49, 0x20, 0x2f, 0x69, 0x6e, 0x64 };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request1);
     p->payload = request1;
@@ -2501,9 +2501,9 @@ static int AppLayerTest09(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response - request ack */
-    p->tcph->th_ack = htonl(9);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(9);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2523,9 +2523,9 @@ static int AppLayerTest09(void)
     /* full request */
     uint8_t request2[] = {
         0x44, 0x44, 0x45, 0x20, 0x2f, 0x69, 0x6e, 0x64, 0xff };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(9);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(9);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request2);
     p->payload = request2;
@@ -2585,9 +2585,9 @@ static int AppLayerTest09(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2605,9 +2605,9 @@ static int AppLayerTest09(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(18);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(18);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2640,9 +2640,9 @@ static int AppLayerTest10(void)
     uint8_t request1[] = {
         0x47, 0x47, 0x49, 0x20, 0x2f, 0x69, 0x6e, 0x64,
         0x47, 0x47, 0x49, 0x20, 0x2f, 0x69, 0x6e, 0x64, 0xff };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request1);
     p->payload = request1;
@@ -2660,9 +2660,9 @@ static int AppLayerTest10(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response - request ack */
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2722,9 +2722,9 @@ static int AppLayerTest10(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response);
     p->payload = response;
@@ -2742,9 +2742,9 @@ static int AppLayerTest10(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(18);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(18);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2778,9 +2778,9 @@ static int AppLayerTest11(void)
     uint8_t request1[] = {
         0x47, 0x47, 0x49, 0x20, 0x2f, 0x69, 0x6e, 0x64,
         0x47, 0x47, 0x49, 0x20, 0x2f, 0x69, 0x6e, 0x64, 0xff };
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = sizeof(request1);
     p->payload = request1;
@@ -2798,9 +2798,9 @@ static int AppLayerTest11(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response - request ack */
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2820,9 +2820,9 @@ static int AppLayerTest11(void)
     /* full response - request ack */
     uint8_t response1[] = {
         0x55, 0x74, 0x54, 0x50, };
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response1);
     p->payload = response1;
@@ -2840,9 +2840,9 @@ static int AppLayerTest11(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack from request */
-    p->tcph->th_ack = htonl(5);
-    p->tcph->th_seq = htonl(18);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(5);
+    tcph.th_seq = htonl(18);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;
@@ -2901,9 +2901,9 @@ static int AppLayerTest11(void)
         0x72, 0x6b, 0x73, 0x21, 0x3c, 0x2f, 0x68, 0x31,
         0x3e, 0x3c, 0x2f, 0x62, 0x6f, 0x64, 0x79, 0x3e,
         0x3c, 0x2f, 0x68, 0x74, 0x6d, 0x6c, 0x3e };
-    p->tcph->th_ack = htonl(18);
-    p->tcph->th_seq = htonl(5);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(18);
+    tcph.th_seq = htonl(5);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->payload_len = sizeof(response2);
     p->payload = response2;
@@ -2921,9 +2921,9 @@ static int AppLayerTest11(void)
     FAIL_IF(ssn->data_first_seen_dir != STREAM_TOSERVER);
 
     /* response ack from request */
-    p->tcph->th_ack = htonl(328);
-    p->tcph->th_seq = htonl(18);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(328);
+    tcph.th_seq = htonl(18);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload_len = 0;
     p->payload = NULL;

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -89,7 +89,7 @@ static int DecodeCHDLCTest01 (void)
     DecodeCHDLC(&tv, &dtv, p, raw, sizeof(raw));
 
     FAIL_IF_NOT(PacketIsIPv4(p));
-    FAIL_IF_NOT(PKT_IS_TCP(p));
+    FAIL_IF_NOT(PacketIsTCP(p));
     FAIL_IF_NOT(p->dp == 80);
 
     SCFree(p);

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -88,7 +88,7 @@ static int DecodeCHDLCTest01 (void)
 
     DecodeCHDLC(&tv, &dtv, p, raw, sizeof(raw));
 
-    FAIL_IF_NOT(PKT_IS_IPV4(p));
+    FAIL_IF_NOT(PacketIsIPv4(p));
     FAIL_IF_NOT(PKT_IS_TCP(p));
     FAIL_IF_NOT(p->dp == 80);
 

--- a/src/decode-esp.c
+++ b/src/decode-esp.c
@@ -42,7 +42,7 @@ static int DecodeESPPacket(ThreadVars *tv, Packet *p, const uint8_t *pkt, uint16
         return -1;
     }
 
-    p->esph = (ESPHdr *)pkt;
+    (void)PacketSetESP(p, pkt);
 
     p->payload = (uint8_t *)pkt + sizeof(ESPHdr);
     p->payload_len = len - sizeof(ESPHdr);
@@ -71,11 +71,12 @@ int DecodeESP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
         return TM_ECODE_FAILED;
     }
     if (unlikely(DecodeESPPacket(tv, p, pkt, len) < 0)) {
-        CLEAR_ESP_PACKET(p);
+        PacketClearL4(p);
         return TM_ECODE_FAILED;
     }
 
-    SCLogDebug("ESP spi: %" PRIu32 " sequence: %" PRIu32, ESP_GET_SPI(p), ESP_GET_SEQUENCE(p));
+    SCLogDebug("ESP spi: %" PRIu32 " sequence: %" PRIu32, ESP_GET_SPI(PacketGetESP(p)),
+            ESP_GET_SEQUENCE(PacketGetESP(p)));
 
     FlowSetupPacket(p);
 
@@ -105,8 +106,8 @@ static int DecodeESPTest01(void)
 
     FAIL_IF(p->proto != IPPROTO_ESP);
     FAIL_IF(p->payload_len != sizeof(raw_esp) - ESP_HEADER_LEN);
-    FAIL_IF(ESP_GET_SPI(p) != 0x7b);
-    FAIL_IF(ESP_GET_SEQUENCE(p) != 0x08);
+    FAIL_IF(ESP_GET_SPI(PacketGetESP(p)) != 0x7b);
+    FAIL_IF(ESP_GET_SEQUENCE(PacketGetESP(p)) != 0x08);
 
     SCFree(p);
 
@@ -133,8 +134,8 @@ static int DecodeESPTest02(void)
     FAIL_IF(p->proto != IPPROTO_ESP);
     FAIL_IF(p->payload_len != sizeof(raw_esp) - ESP_HEADER_LEN);
     FAIL_IF(memcmp(p->payload, raw_esp + ESP_HEADER_LEN, p->payload_len) != 0);
-    FAIL_IF(ESP_GET_SPI(p) != 0x7b);
-    FAIL_IF(ESP_GET_SEQUENCE(p) != 0x08);
+    FAIL_IF(ESP_GET_SPI(PacketGetESP(p)) != 0x7b);
+    FAIL_IF(ESP_GET_SEQUENCE(PacketGetESP(p)) != 0x08);
 
     SCFree(p);
 

--- a/src/decode-esp.h
+++ b/src/decode-esp.h
@@ -25,26 +25,16 @@
 /** \brief size of the ESP header */
 #define ESP_HEADER_LEN 8
 
-#define ESP_GET_RAW_SPI(esph)      SCNtohl((esph)->spi)
-#define ESP_GET_RAW_SEQUENCE(esph) SCNtohl((esph)->sequence)
-
 /** \brief Get the spi field off a packet */
-#define ESP_GET_SPI(p) ESP_GET_RAW_SPI(p->esph)
-
+#define ESP_GET_SPI(esph) SCNtohl((esph)->spi)
 /** \brief Get the sequence field off a packet */
-#define ESP_GET_SEQUENCE(p) ESP_GET_RAW_SEQUENCE(p->esph)
+#define ESP_GET_SEQUENCE(esph) SCNtohl((esph)->sequence)
 
 /** \brief ESP Header */
 typedef struct ESPHdr_ {
     uint32_t spi;      /** < ESP Security Parameters Index */
     uint32_t sequence; /** < ESP sequence number */
 } __attribute__((__packed__)) ESPHdr;
-
-#define CLEAR_ESP_PACKET(p)                                                                        \
-    {                                                                                              \
-        (p)->esph = NULL;                                                                          \
-    }                                                                                              \
-    while (0)
 
 void DecodeESPRegisterTests(void);
 

--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -54,12 +54,12 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (!PacketIncreaseCheckLayers(p)) {
         return TM_ECODE_FAILED;
     }
-    p->ethh = (EthernetHdr *)pkt;
+    EthernetHdr *ethh = PacketSetEthernet(p, pkt);
 
-    SCLogDebug("p %p pkt %p ether type %04x", p, pkt, SCNtohs(p->ethh->eth_type));
+    SCLogDebug("p %p pkt %p ether type %04x", p, pkt, SCNtohs(ethh->eth_type));
 
-    DecodeNetworkLayer(tv, dtv, SCNtohs(p->ethh->eth_type), p,
-            pkt + ETHERNET_HEADER_LEN, len - ETHERNET_HEADER_LEN);
+    DecodeNetworkLayer(tv, dtv, SCNtohs(ethh->eth_type), p, pkt + ETHERNET_HEADER_LEN,
+            len - ETHERNET_HEADER_LEN);
 
     return TM_ECODE_OK;
 }

--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -305,11 +305,11 @@ static int DecodeGeneveTest01(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF(tp->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(tp));
     FAIL_IF_NOT(tp->sp == 546);
 
     FlowShutdown();
@@ -347,11 +347,11 @@ static int DecodeGeneveTest02(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF(tp->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -394,11 +394,11 @@ static int DecodeGeneveTest03(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF(tp->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -438,7 +438,7 @@ static int DecodeGeneveTest04(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top != NULL); /* Geneve packet should not have been processed */
 
     DecodeGeneveConfigPorts(GENEVE_DEFAULT_PORT_S); /* Reset Geneve port list for future calls */
@@ -478,7 +478,7 @@ static int DecodeGeneveTest05(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top != NULL); /* Geneve packet should not have been processed */
 
     FlowShutdown();

--- a/src/decode-geneve.c
+++ b/src/decode-geneve.c
@@ -305,11 +305,11 @@ static int DecodeGeneveTest01(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF_NOT(PKT_IS_UDP(tp));
+    FAIL_IF_NOT(PacketIsUDP(tp));
     FAIL_IF_NOT(tp->sp == 546);
 
     FlowShutdown();
@@ -347,11 +347,11 @@ static int DecodeGeneveTest02(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF_NOT(PKT_IS_UDP(tp));
+    FAIL_IF_NOT(PacketIsUDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -394,11 +394,11 @@ static int DecodeGeneveTest03(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF_NOT(PKT_IS_UDP(tp));
+    FAIL_IF_NOT(PacketIsUDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -438,7 +438,7 @@ static int DecodeGeneveTest04(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top != NULL); /* Geneve packet should not have been processed */
 
     DecodeGeneveConfigPorts(GENEVE_DEFAULT_PORT_S); /* Reset Geneve port list for future calls */
@@ -478,7 +478,7 @@ static int DecodeGeneveTest05(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeUDP(&tv, &dtv, p, raw_geneve, sizeof(raw_geneve));
 
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top != NULL); /* Geneve packet should not have been processed */
 
     FlowShutdown();

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -74,9 +74,10 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
     switch (IPV4_GET_RAW_IPPROTO(icmp4_ip4h)) {
         case IPPROTO_TCP:
             if (len >= IPV4_HEADER_LEN + TCP_HEADER_LEN ) {
-                p->icmpv4vars.emb_tcph = (TCPHdr*)(partial_packet + IPV4_HEADER_LEN);
-                p->icmpv4vars.emb_sport = SCNtohs(p->icmpv4vars.emb_tcph->th_sport);
-                p->icmpv4vars.emb_dport = SCNtohs(p->icmpv4vars.emb_tcph->th_dport);
+                TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV4_HEADER_LEN);
+                p->icmpv4vars.emb_sport = SCNtohs(emb_tcph->th_sport);
+                p->icmpv4vars.emb_dport = SCNtohs(emb_tcph->th_dport);
+                p->icmpv4vars.emb_ports_set = true;
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP header sport: "
@@ -84,11 +85,10 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
                             p->icmpv4vars.emb_dport);
             } else if (len >= IPV4_HEADER_LEN + 4) {
                 /* only access th_sport and th_dport */
-                TCPHdr *emb_tcph = (TCPHdr*)(partial_packet + IPV4_HEADER_LEN);
-
-                p->icmpv4vars.emb_tcph = NULL;
+                TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV4_HEADER_LEN);
                 p->icmpv4vars.emb_sport = SCNtohs(emb_tcph->th_sport);
                 p->icmpv4vars.emb_dport = SCNtohs(emb_tcph->th_dport);
+                p->icmpv4vars.emb_ports_set = true;
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP partial header sport: "
                            "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
@@ -103,9 +103,10 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
             break;
         case IPPROTO_UDP:
             if (len >= IPV4_HEADER_LEN + UDP_HEADER_LEN ) {
-                p->icmpv4vars.emb_udph = (UDPHdr*)(partial_packet + IPV4_HEADER_LEN);
-                p->icmpv4vars.emb_sport = SCNtohs(p->icmpv4vars.emb_udph->uh_sport);
-                p->icmpv4vars.emb_dport = SCNtohs(p->icmpv4vars.emb_udph->uh_dport);
+                UDPHdr *emb_udph = (UDPHdr *)(partial_packet + IPV4_HEADER_LEN);
+                p->icmpv4vars.emb_sport = SCNtohs(emb_udph->uh_sport);
+                p->icmpv4vars.emb_dport = SCNtohs(emb_udph->uh_dport);
+                p->icmpv4vars.emb_ports_set = true;
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_UDP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->UDP header sport: "
@@ -120,8 +121,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
 
             break;
         case IPPROTO_ICMP:
-            if (len >= IPV4_HEADER_LEN + ICMPV4_HEADER_LEN ) {
-                p->icmpv4vars.emb_icmpv4h = (ICMPV4Hdr*)(partial_packet + IPV4_HEADER_LEN);
+            if (len >= IPV4_HEADER_LEN + ICMPV4_HEADER_LEN) {
                 p->icmpv4vars.emb_sport = 0;
                 p->icmpv4vars.emb_dport = 0;
                 p->icmpv4vars.emb_ip4_proto = IPPROTO_ICMP;

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -69,62 +69,62 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
     }
 
     /** We need to fill icmpv4vars */
-    p->icmpv4vars.emb_ipv4h = icmp4_ip4h;
+    p->l4.vars.icmpv4.emb_ipv4h = icmp4_ip4h;
 
     switch (IPV4_GET_RAW_IPPROTO(icmp4_ip4h)) {
         case IPPROTO_TCP:
             if (len >= IPV4_HEADER_LEN + TCP_HEADER_LEN ) {
                 TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV4_HEADER_LEN);
-                p->icmpv4vars.emb_sport = SCNtohs(emb_tcph->th_sport);
-                p->icmpv4vars.emb_dport = SCNtohs(emb_tcph->th_dport);
-                p->icmpv4vars.emb_ports_set = true;
-                p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
+                p->l4.vars.icmpv4.emb_sport = SCNtohs(emb_tcph->th_sport);
+                p->l4.vars.icmpv4.emb_dport = SCNtohs(emb_tcph->th_dport);
+                p->l4.vars.icmpv4.emb_ports_set = true;
+                p->l4.vars.icmpv4.emb_ip4_proto = IPPROTO_TCP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP header sport: "
-                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
-                            p->icmpv4vars.emb_dport);
+                           "%" PRIu16 " dport %" PRIu16 "",
+                        p->l4.vars.icmpv4.emb_sport, p->l4.vars.icmpv4.emb_dport);
             } else if (len >= IPV4_HEADER_LEN + 4) {
                 /* only access th_sport and th_dport */
                 TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV4_HEADER_LEN);
-                p->icmpv4vars.emb_sport = SCNtohs(emb_tcph->th_sport);
-                p->icmpv4vars.emb_dport = SCNtohs(emb_tcph->th_dport);
-                p->icmpv4vars.emb_ports_set = true;
-                p->icmpv4vars.emb_ip4_proto = IPPROTO_TCP;
+                p->l4.vars.icmpv4.emb_sport = SCNtohs(emb_tcph->th_sport);
+                p->l4.vars.icmpv4.emb_dport = SCNtohs(emb_tcph->th_dport);
+                p->l4.vars.icmpv4.emb_ports_set = true;
+                p->l4.vars.icmpv4.emb_ip4_proto = IPPROTO_TCP;
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->TCP partial header sport: "
-                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
-                            p->icmpv4vars.emb_dport);
+                           "%" PRIu16 " dport %" PRIu16 "",
+                        p->l4.vars.icmpv4.emb_sport, p->l4.vars.icmpv4.emb_dport);
             } else {
                 SCLogDebug("DecodePartialIPV4: Warning, ICMPV4->IPV4->TCP "
                            "header Didn't fit in the packet!");
-                p->icmpv4vars.emb_sport = 0;
-                p->icmpv4vars.emb_dport = 0;
+                p->l4.vars.icmpv4.emb_sport = 0;
+                p->l4.vars.icmpv4.emb_dport = 0;
             }
 
             break;
         case IPPROTO_UDP:
             if (len >= IPV4_HEADER_LEN + UDP_HEADER_LEN ) {
                 UDPHdr *emb_udph = (UDPHdr *)(partial_packet + IPV4_HEADER_LEN);
-                p->icmpv4vars.emb_sport = SCNtohs(emb_udph->uh_sport);
-                p->icmpv4vars.emb_dport = SCNtohs(emb_udph->uh_dport);
-                p->icmpv4vars.emb_ports_set = true;
-                p->icmpv4vars.emb_ip4_proto = IPPROTO_UDP;
+                p->l4.vars.icmpv4.emb_sport = SCNtohs(emb_udph->uh_sport);
+                p->l4.vars.icmpv4.emb_dport = SCNtohs(emb_udph->uh_dport);
+                p->l4.vars.icmpv4.emb_ports_set = true;
+                p->l4.vars.icmpv4.emb_ip4_proto = IPPROTO_UDP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->UDP header sport: "
-                           "%"PRIu16" dport %"PRIu16"", p->icmpv4vars.emb_sport,
-                            p->icmpv4vars.emb_dport);
+                           "%" PRIu16 " dport %" PRIu16 "",
+                        p->l4.vars.icmpv4.emb_sport, p->l4.vars.icmpv4.emb_dport);
             } else {
                 SCLogDebug("DecodePartialIPV4: Warning, ICMPV4->IPV4->UDP "
                            "header Didn't fit in the packet!");
-                p->icmpv4vars.emb_sport = 0;
-                p->icmpv4vars.emb_dport = 0;
+                p->l4.vars.icmpv4.emb_sport = 0;
+                p->l4.vars.icmpv4.emb_dport = 0;
             }
 
             break;
         case IPPROTO_ICMP:
             if (len >= IPV4_HEADER_LEN + ICMPV4_HEADER_LEN) {
-                p->icmpv4vars.emb_sport = 0;
-                p->icmpv4vars.emb_dport = 0;
-                p->icmpv4vars.emb_ip4_proto = IPPROTO_ICMP;
+                p->l4.vars.icmpv4.emb_sport = 0;
+                p->l4.vars.icmpv4.emb_dport = 0;
+                p->l4.vars.icmpv4.emb_ip4_proto = IPPROTO_ICMP;
 
                 SCLogDebug("DecodePartialIPV4: ICMPV4->IPV4->ICMP header");
             }
@@ -147,34 +147,33 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
         return TM_ECODE_FAILED;
     }
 
-    p->icmpv4h = (ICMPV4Hdr *)pkt;
+    ICMPV4Hdr *icmpv4h = PacketSetICMPv4(p, pkt);
 
-    SCLogDebug("ICMPV4 TYPE %" PRIu32 " CODE %" PRIu32 "", p->icmpv4h->type, p->icmpv4h->code);
+    SCLogDebug("ICMPV4 TYPE %" PRIu32 " CODE %" PRIu32 "", icmpv4h->type, icmpv4h->code);
 
     p->proto = IPPROTO_ICMP;
-    p->icmp_s.type = p->icmpv4h->type;
-    p->icmp_s.code = p->icmpv4h->code;
+    const uint8_t type = p->icmp_s.type = icmpv4h->type;
+    const uint8_t code = p->icmp_s.code = icmpv4h->code;
 
-    int ctype = ICMPv4GetCounterpart(p->icmp_s.type);
+    int ctype = ICMPv4GetCounterpart(type);
     if (ctype != -1) {
         p->icmp_d.type = (uint8_t)ctype;
     }
 
-    ICMPV4ExtHdr* icmp4eh = (ICMPV4ExtHdr*) p->icmpv4h;
-    p->icmpv4vars.hlen = ICMPV4_HEADER_LEN;
+    ICMPV4ExtHdr *icmp4eh = (ICMPV4ExtHdr *)icmpv4h;
+    p->l4.vars.icmpv4.hlen = ICMPV4_HEADER_LEN;
 
-    switch (p->icmpv4h->type)
-    {
+    switch (type) {
         case ICMP_ECHOREPLY:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
 
         case ICMP_DEST_UNREACH:
-            if (p->icmpv4h->code > NR_ICMP_UNREACH) {
+            if (code > NR_ICMP_UNREACH) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             } else {
                 /* parse IP header plus 64 bytes */
@@ -189,7 +188,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             break;
 
         case ICMP_SOURCE_QUENCH:
-            if (p->icmpv4h->code!=0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             } else {
                 // parse IP header plus 64 bytes
@@ -204,7 +203,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             break;
 
         case ICMP_REDIRECT:
-            if (p->icmpv4h->code>ICMP_REDIR_HOSTTOS) {
+            if (code > ICMP_REDIR_HOSTTOS) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             } else {
                 // parse IP header plus 64 bytes
@@ -219,15 +218,15 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             break;
 
         case ICMP_ECHO:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
 
         case ICMP_TIME_EXCEEDED:
-            if (p->icmpv4h->code>ICMP_EXC_FRAGTIME) {
+            if (code > ICMP_EXC_FRAGTIME) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             } else {
                 // parse IP header plus 64 bytes
@@ -242,7 +241,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             break;
 
         case ICMP_PARAMETERPROB:
-            if (p->icmpv4h->code!=0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             } else {
                 // parse IP header plus 64 bytes
@@ -257,45 +256,45 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             break;
 
         case ICMP_TIMESTAMP:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
 
             if (len < (sizeof(ICMPV4Timestamp) + ICMPV4_HEADER_LEN)) {
                 ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
             } else {
-                p->icmpv4vars.hlen += sizeof(ICMPV4Timestamp);
+                p->l4.vars.icmpv4.hlen += sizeof(ICMPV4Timestamp);
             }
             break;
 
         case ICMP_TIMESTAMPREPLY:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
 
             if (len < (sizeof(ICMPV4Timestamp) + ICMPV4_HEADER_LEN)) {
                 ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
             } else {
-                p->icmpv4vars.hlen += sizeof(ICMPV4Timestamp);
+                p->l4.vars.icmpv4.hlen += sizeof(ICMPV4Timestamp);
             }
             break;
 
         case ICMP_INFO_REQUEST:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
 
         case ICMP_INFO_REPLY:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
@@ -308,34 +307,33 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t
             if (len < (advert_len + ICMPV4_HEADER_LEN)) {
                 ENGINE_SET_EVENT(p, ICMPV4_IPV4_TRUNC_PKT);
             } else {
-                p->icmpv4vars.hlen += advert_len;
+                p->l4.vars.icmpv4.hlen += advert_len;
             }
         } break;
 
         case ICMP_ADDRESS:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
 
         case ICMP_ADDRESSREPLY:
-            p->icmpv4vars.id=icmp4eh->id;
-            p->icmpv4vars.seq=icmp4eh->seq;
-            if (p->icmpv4h->code!=0) {
+            p->l4.vars.icmpv4.id = icmp4eh->id;
+            p->l4.vars.icmpv4.seq = icmp4eh->seq;
+            if (code != 0) {
                 ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_CODE);
             }
             break;
 
         default:
-            ENGINE_SET_EVENT(p,ICMPV4_UNKNOWN_TYPE);
-
+            ENGINE_SET_EVENT(p, ICMPV4_UNKNOWN_TYPE);
     }
 
-    p->payload = (uint8_t *)pkt + p->icmpv4vars.hlen;
-    DEBUG_VALIDATE_BUG_ON(len - p->icmpv4vars.hlen > UINT16_MAX);
-    p->payload_len = (uint16_t)(len - p->icmpv4vars.hlen);
+    p->payload = (uint8_t *)pkt + p->l4.vars.icmpv4.hlen;
+    DEBUG_VALIDATE_BUG_ON(len - p->l4.vars.icmpv4.hlen > UINT16_MAX);
+    p->payload_len = (uint16_t)(len - p->l4.vars.icmpv4.hlen);
 
     FlowSetupPacket(p);
     return TM_ECODE_OK;
@@ -374,11 +372,9 @@ static int DecodeICMPV4test01(void)
         0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
         0xab };
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int ret = 0;
     IPV4Hdr ip4h;
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -398,16 +394,17 @@ static int DecodeICMPV4test01(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL!=p->icmpv4h) {
-        if (p->icmpv4h->type==8 && p->icmpv4h->code==0) {
-            ret = 1;
-        }
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
+
+    FAIL_IF_NOT(icmpv4h->type == 8);
+    FAIL_IF_NOT(icmpv4h->code == 0);
 
     FlowShutdown();
     SCFree(p);
-    return ret;
+    PASS;
 }
 
 /** DecodeICMPV4test02
@@ -425,11 +422,9 @@ static int DecodeICMPV4test02(void)
         0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
         0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f };
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int ret = 0;
     IPV4Hdr ip4h;
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -448,16 +443,17 @@ static int DecodeICMPV4test02(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL!=p->icmpv4h) {
-        if (p->icmpv4h->type==0 && p->icmpv4h->code==0) {
-            ret = 1;
-        }
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
+
+    FAIL_IF_NOT(icmpv4h->type == 0);
+    FAIL_IF_NOT(icmpv4h->code == 0);
 
     FlowShutdown();
     SCFree(p);
-    return ret;
+    PASS;
 }
 
 /** DecodeICMPV4test03
@@ -473,11 +469,9 @@ static int DecodeICMPV4test03(void)
         0xd1, 0x55, 0xe3, 0x93, 0x8b, 0x12, 0x82, 0xaa,
         0x00, 0x28, 0x7c, 0xdd };
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int ret = 0;
     IPV4Hdr ip4h;
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -496,26 +490,18 @@ static int DecodeICMPV4test03(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL == p->icmpv4h) {
-	    printf("NULL == p->icmpv4h: ");
-        goto end;
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
 
     /* check it's type 11 code 0 */
-    if (p->icmpv4h->type != 11 || p->icmpv4h->code != 0) {
-	    printf("p->icmpv4h->type %u, p->icmpv4h->code %u: ",
-			    p->icmpv4h->type, p->icmpv4h->code);
-        goto end;
-    }
+    FAIL_IF_NOT(icmpv4h->type == 11);
+    FAIL_IF_NOT(icmpv4h->code == 0);
 
     /* check it's source port 35602 to port 33450 */
-    if (p->icmpv4vars.emb_sport != 35602 ||
-            p->icmpv4vars.emb_dport != 33450) {
-	    printf("p->icmpv4vars.emb_sport %u, p->icmpv4vars.emb_dport %u: ",
-			    p->icmpv4vars.emb_sport, p->icmpv4vars.emb_dport);
-        goto end;
-    }
+    FAIL_IF(p->l4.vars.icmpv4.emb_sport != 35602);
+    FAIL_IF(p->l4.vars.icmpv4.emb_dport != 33450);
 
     /* check the src,dst IPs contained inside */
     uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
@@ -525,17 +511,12 @@ static int DecodeICMPV4test03(void)
     PrintInet(AF_INET, &dst_ip, d, sizeof(d));
 
     /* ICMPv4 embedding IPV4 192.168.1.13->209.85.227.147 pass */
-    if (strcmp(s, "192.168.1.13") == 0 && strcmp(d, "209.85.227.147") == 0) {
-        ret = 1;
-    }
-    else {
-	    printf("s %s, d %s: ", s, d);
-    }
+    FAIL_IF_NOT(strcmp(s, "192.168.1.13") == 0);
+    FAIL_IF_NOT(strcmp(d, "209.85.227.147") == 0);
 
-end:
     FlowShutdown();
     SCFree(p);
-    return ret;
+    PASS;
 }
 
 /** DecodeICMPV4test04
@@ -576,19 +557,17 @@ static int DecodeICMPV4test04(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL == p->icmpv4h) {
-        goto end;
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
 
     /* check the type,code pair is correct - type 3, code 10 */
-    if (p->icmpv4h->type != 3 || p->icmpv4h->code != 10) {
-        goto end;
-    }
+    FAIL_IF_NOT(icmpv4h->type == 3);
+    FAIL_IF_NOT(icmpv4h->code == 10);
 
     /* check it's src port 45322 to dst port 50 */
-    if (p->icmpv4vars.emb_sport != 45322 ||
-            p->icmpv4vars.emb_dport != 50) {
+    if (p->l4.vars.icmpv4.emb_sport != 45322 || p->l4.vars.icmpv4.emb_dport != 50) {
         goto end;
     }
 
@@ -646,19 +625,17 @@ static int DecodeICMPV4test05(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL == p->icmpv4h) {
-        goto end;
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
 
     /* check the type,code pair is correct - type 11, code 0 */
-    if (p->icmpv4h->type != 11 || p->icmpv4h->code != 0) {
-        goto end;
-    }
+    FAIL_IF_NOT(icmpv4h->type == 11);
+    FAIL_IF_NOT(icmpv4h->code == 0);
 
     /* check it's src port 1048 to dst port 80 */
-    if (p->icmpv4vars.emb_sport != 1048 ||
-            p->icmpv4vars.emb_dport != 80) {
+    if (p->l4.vars.icmpv4.emb_sport != 1048 || p->l4.vars.icmpv4.emb_dport != 80) {
         goto end;
     }
 
@@ -773,11 +750,9 @@ static int DecodeICMPV4test08(void)
         0x08, 0x00, 0x78, 0x47, 0xfc, 0x55, 0x00, 0x00
     };
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int ret = 0;
     IPV4Hdr ip4h;
 
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -796,16 +771,17 @@ static int DecodeICMPV4test08(void)
     UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    if (NULL!=p->icmpv4h) {
-        if (p->icmpv4h->type==8 && p->icmpv4h->code==0) {
-            ret = 1;
-        }
-    }
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
+    FAIL_IF_NULL(icmpv4h);
+
+    FAIL_IF_NOT(icmpv4h->type == 8);
+    FAIL_IF_NOT(icmpv4h->code == 0);
 
     FlowShutdown();
     SCFree(p);
-    return ret;
+    PASS;
 }
 #endif /* UNITTESTS */
 

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -143,7 +143,7 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
     char s[16], d[16];
     PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_src), s, sizeof(s));
     PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_dst), d, sizeof(d));
-    SCLogDebug("ICMPv4 embedding IPV4 %s->%s - PROTO: %" PRIu32 " ID: %" PRIu32 "", s,d,
+    SCLogDebug("ICMPv4 embedding IPV4 %s->%s - PROTO: %" PRIu32 " ID: %" PRIu32 "", s, d,
             IPV4_GET_RAW_IPPROTO(icmp4_ip4h), IPV4_GET_RAW_IPID(icmp4_ip4h));
 #endif
 
@@ -410,7 +410,7 @@ static int DecodeICMPV4test01(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -460,7 +460,7 @@ static int DecodeICMPV4test02(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -508,7 +508,7 @@ static int DecodeICMPV4test03(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -587,7 +587,7 @@ static int DecodeICMPV4test04(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -656,7 +656,7 @@ static int DecodeICMPV4test05(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -762,7 +762,7 @@ static int ICMPV4InvalidType07(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 
@@ -805,7 +805,7 @@ static int DecodeICMPV4test08(void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&tv, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -69,7 +69,8 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
     }
 
     /** We need to fill icmpv4vars */
-    p->l4.vars.icmpv4.emb_ipv4h = icmp4_ip4h;
+    const uint8_t *icmpv4_ptr = (const uint8_t *)p->l4.hdrs.icmpv4h;
+    p->l4.vars.icmpv4.emb_ip4h_offset = partial_packet - icmpv4_ptr;
 
     switch (IPV4_GET_RAW_IPPROTO(icmp4_ip4h)) {
         case IPPROTO_TCP:

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -505,8 +505,8 @@ static int DecodeICMPV4test03(void)
     FAIL_IF(p->l4.vars.icmpv4.emb_dport != 33450);
 
     /* check the src,dst IPs contained inside */
-    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
-    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
     char s[16], d[16];
     PrintInet(AF_INET, &src_ip, s, sizeof(s));
     PrintInet(AF_INET, &dst_ip, d, sizeof(d));
@@ -573,8 +573,8 @@ static int DecodeICMPV4test04(void)
     }
 
     // check the src,dst IPs contained inside
-    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
-    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
     char s[16], d[16];
     PrintInet(AF_INET, &src_ip, s, sizeof(s));
     PrintInet(AF_INET, &dst_ip, d, sizeof(d));
@@ -641,8 +641,8 @@ static int DecodeICMPV4test05(void)
     }
 
     // check the src,dst IPs contained inside
-    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
-    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
     char s[16], d[16];
     PrintInet(AF_INET, &src_ip, s, sizeof(s));
     PrintInet(AF_INET, &dst_ip, d, sizeof(d));

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -71,12 +71,6 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
     /** We need to fill icmpv4vars */
     p->icmpv4vars.emb_ipv4h = icmp4_ip4h;
 
-    /** Get the IP address from the contained packet */
-    p->icmpv4vars.emb_ip4_src = IPV4_GET_RAW_IPSRC(icmp4_ip4h);
-    p->icmpv4vars.emb_ip4_dst = IPV4_GET_RAW_IPDST(icmp4_ip4h);
-
-    p->icmpv4vars.emb_ip4_hlen = (uint8_t)(IPV4_GET_RAW_HLEN(icmp4_ip4h) << 2);
-
     switch (IPV4_GET_RAW_IPPROTO(icmp4_ip4h)) {
         case IPPROTO_TCP:
             if (len >= IPV4_HEADER_LEN + TCP_HEADER_LEN ) {
@@ -137,15 +131,6 @@ static int DecodePartialIPV4(Packet* p, uint8_t* partial_packet, uint16_t len)
 
             break;
     }
-
-    /* debug print */
-#ifdef DEBUG
-    char s[16], d[16];
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_src), s, sizeof(s));
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_dst), d, sizeof(d));
-    SCLogDebug("ICMPv4 embedding IPV4 %s->%s - PROTO: %" PRIu32 " ID: %" PRIu32 "", s, d,
-            IPV4_GET_RAW_IPPROTO(icmp4_ip4h), IPV4_GET_RAW_IPID(icmp4_ip4h));
-#endif
 
     return 0;
 }
@@ -533,10 +518,11 @@ static int DecodeICMPV4test03(void)
     }
 
     /* check the src,dst IPs contained inside */
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
     char s[16], d[16];
-
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_src), s, sizeof(s));
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_dst), d, sizeof(d));
+    PrintInet(AF_INET, &src_ip, s, sizeof(s));
+    PrintInet(AF_INET, &dst_ip, d, sizeof(d));
 
     /* ICMPv4 embedding IPV4 192.168.1.13->209.85.227.147 pass */
     if (strcmp(s, "192.168.1.13") == 0 && strcmp(d, "209.85.227.147") == 0) {
@@ -607,10 +593,11 @@ static int DecodeICMPV4test04(void)
     }
 
     // check the src,dst IPs contained inside
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
     char s[16], d[16];
-
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_src), s, sizeof(s));
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_dst), d, sizeof(d));
+    PrintInet(AF_INET, &src_ip, s, sizeof(s));
+    PrintInet(AF_INET, &dst_ip, d, sizeof(d));
 
     // ICMPv4 embedding IPV4 192.168.1.13->88.96.22.41
     if (strcmp(s, "192.168.1.13") == 0 && strcmp(d, "88.96.22.41") == 0) {
@@ -676,10 +663,11 @@ static int DecodeICMPV4test05(void)
     }
 
     // check the src,dst IPs contained inside
+    uint32_t src_ip = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
+    uint32_t dst_ip = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
     char s[16], d[16];
-
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_src), s, sizeof(s));
-    PrintInet(AF_INET, &(p->icmpv4vars.emb_ip4_dst), d, sizeof(d));
+    PrintInet(AF_INET, &src_ip, s, sizeof(s));
+    PrintInet(AF_INET, &dst_ip, d, sizeof(d));
 
     // ICMPv4 embedding IPV4 192.168.2.5->61.35.161.35
     if (strcmp(s, "192.168.2.5") == 0 && strcmp(d, "61.35.161.35") == 0) {

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -252,7 +252,7 @@ typedef struct ICMPV4Timestamp_ {
  */
 #define ICMPV4_DEST_UNREACH_IS_VALID(p)                                                            \
     ((!((p)->flags & PKT_IS_INVALID)) && PacketIsICMPv4((p)) &&                                    \
-            ((p)->icmp_s.type == ICMP_DEST_UNREACH) && (ICMPV4_GET_EMB_IPV4((p)) != NULL) &&       \
+            ((p)->icmp_s.type == ICMP_DEST_UNREACH) && (PacketGetICMPv4EmbIPv4((p)) != NULL) &&    \
             (p)->l4.vars.icmpv4.emb_ports_set)
 
 /**

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -234,18 +234,18 @@ typedef struct ICMPV4Timestamp_ {
 /* If message is informational */
 
 /** macro for icmpv4 "id" access */
-#define ICMPV4_GET_ID(p)        ((p)->icmpv4vars.id)
+#define ICMPV4_GET_ID(p) ((p)->l4.vars.icmpv4.id)
 /** macro for icmpv4 "seq" access */
-#define ICMPV4_GET_SEQ(p)       ((p)->icmpv4vars.seq)
+#define ICMPV4_GET_SEQ(p) ((p)->l4.vars.icmpv4.seq)
 
 /* If message is Error */
 
 /** macro for icmpv4 embedded "protocol" access */
-#define ICMPV4_GET_EMB_PROTO(p)    (p)->icmpv4vars.emb_ip4_proto
+#define ICMPV4_GET_EMB_PROTO(p) (p)->l4.vars.icmpv4.emb_ip4_proto
 /** macro for icmpv4 embedded "ipv4h" header access */
-#define ICMPV4_GET_EMB_IPV4(p) (p)->icmpv4vars.emb_ipv4h
+#define ICMPV4_GET_EMB_IPV4(p) (p)->l4.vars.icmpv4.emb_ipv4h
 /** macro for icmpv4 header length */
-#define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->icmpv4vars.hlen
+#define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->l4.vars.icmpv4.hlen
 
 /** macro for checking if a ICMP DEST UNREACH packet is valid for use
  *  in other parts of the engine, such as the flow engine. 
@@ -253,9 +253,9 @@ typedef struct ICMPV4Timestamp_ {
  *  \warning use only _after_ the decoder has processed the packet
  */
 #define ICMPV4_DEST_UNREACH_IS_VALID(p)                                                            \
-    ((!((p)->flags & PKT_IS_INVALID)) && ((p)->icmpv4h != NULL) &&                                 \
-            (ICMPV4_GET_TYPE((p)) == ICMP_DEST_UNREACH) && (ICMPV4_GET_EMB_IPV4((p)) != NULL) &&   \
-            (p)->icmpv4vars.emb_ports_set)
+    ((!((p)->flags & PKT_IS_INVALID)) && PacketIsICMPv4((p)) &&                                    \
+            ((p)->icmp_s.type == ICMP_DEST_UNREACH) && (ICMPV4_GET_EMB_IPV4((p)) != NULL) &&       \
+            (p)->l4.vars.icmpv4.emb_ports_set)
 
 /**
  *  marco for checking if a ICMP packet is an error message or an
@@ -266,11 +266,9 @@ typedef struct ICMPV4Timestamp_ {
  *        stage so we can to a bit check instead of the more expensive
  *        check below.
  */
-#define ICMPV4_IS_ERROR_MSG(p) (ICMPV4_GET_TYPE((p)) == ICMP_DEST_UNREACH || \
-        ICMPV4_GET_TYPE((p)) == ICMP_SOURCE_QUENCH || \
-        ICMPV4_GET_TYPE((p)) == ICMP_REDIRECT || \
-        ICMPV4_GET_TYPE((p)) == ICMP_TIME_EXCEEDED || \
-        ICMPV4_GET_TYPE((p)) == ICMP_PARAMETERPROB)
+#define ICMPV4_IS_ERROR_MSG(type)                                                                  \
+    ((type) == ICMP_DEST_UNREACH || (type) == ICMP_SOURCE_QUENCH || (type) == ICMP_REDIRECT ||     \
+            (type) == ICMP_TIME_EXCEEDED || (type) == ICMP_PARAMETERPROB)
 
 void DecodeICMPV4RegisterTests(void);
 

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -189,12 +189,10 @@ typedef struct ICMPV4Vars_
 
     /** Pointers to the embedded packet headers */
     IPV4Hdr *emb_ipv4h;
-    TCPHdr *emb_tcph;
-    UDPHdr *emb_udph;
-    ICMPV4Hdr *emb_icmpv4h;
 
     uint8_t emb_ip4_proto;
 
+    bool emb_ports_set;
     /** TCP/UDP ports */
     uint16_t emb_sport;
     uint16_t emb_dport;
@@ -245,13 +243,7 @@ typedef struct ICMPV4Timestamp_ {
 /** macro for icmpv4 embedded "protocol" access */
 #define ICMPV4_GET_EMB_PROTO(p)    (p)->icmpv4vars.emb_ip4_proto
 /** macro for icmpv4 embedded "ipv4h" header access */
-#define ICMPV4_GET_EMB_IPV4(p)     (p)->icmpv4vars.emb_ipv4h
-/** macro for icmpv4 embedded "tcph" header access */
-#define ICMPV4_GET_EMB_TCP(p)      (p)->icmpv4vars.emb_tcph
-/** macro for icmpv4 embedded "udph" header access */
-#define ICMPV4_GET_EMB_UDP(p)      (p)->icmpv4vars.emb_udph
-/** macro for icmpv4 embedded "icmpv4h" header access */
-#define ICMPV4_GET_EMB_ICMPV4H(p)  (p)->icmpv4vars.emb_icmpv4h
+#define ICMPV4_GET_EMB_IPV4(p) (p)->icmpv4vars.emb_ipv4h
 /** macro for icmpv4 header length */
 #define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->icmpv4vars.hlen
 
@@ -260,13 +252,10 @@ typedef struct ICMPV4Timestamp_ {
  *
  *  \warning use only _after_ the decoder has processed the packet
  */
-#define ICMPV4_DEST_UNREACH_IS_VALID(p) ( \
-    (!((p)->flags & PKT_IS_INVALID)) && \
-    ((p)->icmpv4h != NULL) && \
-    (ICMPV4_GET_TYPE((p)) == ICMP_DEST_UNREACH) && \
-    (ICMPV4_GET_EMB_IPV4((p)) != NULL) && \
-    ((ICMPV4_GET_EMB_TCP((p)) != NULL) || \
-     (ICMPV4_GET_EMB_UDP((p)) != NULL)))
+#define ICMPV4_DEST_UNREACH_IS_VALID(p)                                                            \
+    ((!((p)->flags & PKT_IS_INVALID)) && ((p)->icmpv4h != NULL) &&                                 \
+            (ICMPV4_GET_TYPE((p)) == ICMP_DEST_UNREACH) && (ICMPV4_GET_EMB_IPV4((p)) != NULL) &&   \
+            (p)->icmpv4vars.emb_ports_set)
 
 /**
  *  marco for checking if a ICMP packet is an error message or an

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -193,10 +193,6 @@ typedef struct ICMPV4Vars_
     UDPHdr *emb_udph;
     ICMPV4Hdr *emb_icmpv4h;
 
-    /** IPv4 src and dst address */
-    struct in_addr emb_ip4_src;
-    struct in_addr emb_ip4_dst;
-    uint8_t emb_ip4_hlen;
     uint8_t emb_ip4_proto;
 
     /** TCP/UDP ports */

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -181,11 +181,10 @@ typedef struct ICMPV4ExtHdr_
 /* ICMPv4 vars */
 typedef struct ICMPV4Vars_
 {
-    /** Pointers to the embedded packet headers */
-    IPV4Hdr *emb_ipv4h;
+    uint16_t emb_ip4h_offset;
 
-    uint16_t  id;
-    uint16_t  seq;
+    uint16_t id;
+    uint16_t seq;
 
     /** Actual header length **/
     uint16_t hlen;
@@ -242,8 +241,7 @@ typedef struct ICMPV4Timestamp_ {
 
 /** macro for icmpv4 embedded "protocol" access */
 #define ICMPV4_GET_EMB_PROTO(p) (p)->l4.vars.icmpv4.emb_ip4_proto
-/** macro for icmpv4 embedded "ipv4h" header access */
-#define ICMPV4_GET_EMB_IPV4(p) (p)->l4.vars.icmpv4.emb_ipv4h
+
 /** macro for icmpv4 header length */
 #define ICMPV4_GET_HLEN_ICMPV4H(p) (p)->l4.vars.icmpv4.hlen
 

--- a/src/decode-icmpv4.h
+++ b/src/decode-icmpv4.h
@@ -181,14 +181,14 @@ typedef struct ICMPV4ExtHdr_
 /* ICMPv4 vars */
 typedef struct ICMPV4Vars_
 {
+    /** Pointers to the embedded packet headers */
+    IPV4Hdr *emb_ipv4h;
+
     uint16_t  id;
     uint16_t  seq;
 
     /** Actual header length **/
     uint16_t hlen;
-
-    /** Pointers to the embedded packet headers */
-    IPV4Hdr *emb_ipv4h;
 
     uint8_t emb_ip4_proto;
 

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -37,6 +37,14 @@
 #include "util-print.h"
 #include "util-validate.h"
 
+#if defined(DEBUG) || defined(UNITTESTS)
+static inline const IPV6Hdr *PacketGetICMPv6EmbIPv6(const Packet *p)
+{
+    BUG_ON(p->l4.type != PACKET_L4_ICMPV6);
+    return p->l4.vars.icmpv6.emb_ipv6h;
+}
+#endif
+
 /**
  * \brief Get variables and do some checks of the embedded IPV6 packet
  *
@@ -66,51 +74,51 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
         return;
     }
 
-    /** We need to fill icmpv6vars */
-    p->icmpv6vars.emb_ipv6h = icmp6_ip6h;
+    /** We need to fill l4.vars.icmpv6 */
+    p->l4.vars.icmpv6.emb_ipv6h = icmp6_ip6h;
     /** Get protocol and ports inside the embedded ipv6 packet and set the pointers */
-    p->icmpv6vars.emb_ip6_proto_next = icmp6_ip6h->s_ip6_nxt;
+    p->l4.vars.icmpv6.emb_ip6_proto_next = icmp6_ip6h->s_ip6_nxt;
 
     switch (icmp6_ip6h->s_ip6_nxt) {
         case IPPROTO_TCP:
             if (len >= IPV6_HEADER_LEN + TCP_HEADER_LEN ) {
                 TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV6_HEADER_LEN);
-                p->icmpv6vars.emb_sport = emb_tcph->th_sport;
-                p->icmpv6vars.emb_dport = emb_tcph->th_dport;
-                p->icmpv6vars.emb_ports_set = true;
+                p->l4.vars.icmpv6.emb_sport = emb_tcph->th_sport;
+                p->l4.vars.icmpv6.emb_dport = emb_tcph->th_dport;
+                p->l4.vars.icmpv6.emb_ports_set = true;
 
                 SCLogDebug("ICMPV6->IPV6->TCP header sport: "
-                           "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
-                            p->icmpv6vars.emb_dport);
+                           "%" PRIu16 " dport %" PRIu16 "",
+                        p->l4.vars.icmpv6.emb_sport, p->l4.vars.icmpv6.emb_dport);
             } else {
                 SCLogDebug("Warning, ICMPV6->IPV6->TCP "
                            "header Didn't fit in the packet!");
-                p->icmpv6vars.emb_sport = 0;
-                p->icmpv6vars.emb_dport = 0;
+                p->l4.vars.icmpv6.emb_sport = 0;
+                p->l4.vars.icmpv6.emb_dport = 0;
             }
 
             break;
         case IPPROTO_UDP:
             if (len >= IPV6_HEADER_LEN + UDP_HEADER_LEN ) {
                 UDPHdr *emb_udph = (UDPHdr *)(partial_packet + IPV6_HEADER_LEN);
-                p->icmpv6vars.emb_sport = emb_udph->uh_sport;
-                p->icmpv6vars.emb_dport = emb_udph->uh_dport;
-                p->icmpv6vars.emb_ports_set = true;
+                p->l4.vars.icmpv6.emb_sport = emb_udph->uh_sport;
+                p->l4.vars.icmpv6.emb_dport = emb_udph->uh_dport;
+                p->l4.vars.icmpv6.emb_ports_set = true;
 
                 SCLogDebug("ICMPV6->IPV6->UDP header sport: "
-                           "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
-                            p->icmpv6vars.emb_dport);
+                           "%" PRIu16 " dport %" PRIu16 "",
+                        p->l4.vars.icmpv6.emb_sport, p->l4.vars.icmpv6.emb_dport);
             } else {
                 SCLogDebug("Warning, ICMPV6->IPV6->UDP "
                            "header Didn't fit in the packet!");
-                p->icmpv6vars.emb_sport = 0;
-                p->icmpv6vars.emb_dport = 0;
+                p->l4.vars.icmpv6.emb_sport = 0;
+                p->l4.vars.icmpv6.emb_dport = 0;
             }
 
             break;
         case IPPROTO_ICMPV6:
-            p->icmpv6vars.emb_sport = 0;
-            p->icmpv6vars.emb_dport = 0;
+            p->l4.vars.icmpv6.emb_sport = 0;
+            p->l4.vars.icmpv6.emb_dport = 0;
 
             SCLogDebug("ICMPV6->IPV6->ICMP header");
 
@@ -120,8 +128,8 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
     /* debug print */
 #ifdef DEBUG
     char s[46], d[46];
-    PrintInet(AF_INET6, (const void *)ICMPV6_GET_EMB_IPV6(p)->s_ip6_src, s, sizeof(s));
-    PrintInet(AF_INET6, (const void *)ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst, d, sizeof(d));
+    PrintInet(AF_INET6, (const void *)PacketGetICMPv6EmbIPv6(p)->s_ip6_src, s, sizeof(s));
+    PrintInet(AF_INET6, (const void *)PacketGetICMPv6EmbIPv6(p)->s_ip6_dst, d, sizeof(d));
     SCLogDebug("ICMPv6 embedding IPV6 %s->%s - CLASS: %" PRIu32 " FLOW: "
                "%" PRIu32 " NH: %" PRIu32 " PLEN: %" PRIu32 " HLIM: %" PRIu32,
                s, d, IPV6_GET_RAW_CLASS(icmp6_ip6h), IPV6_GET_RAW_FLOW(icmp6_ip6h),
@@ -177,10 +185,10 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
 
-    p->icmpv6h = (ICMPV6Hdr *)pkt;
+    ICMPV6Hdr *icmpv6h = PacketSetICMPv6(p, pkt);
     p->proto = IPPROTO_ICMPV6;
-    p->icmp_s.type = p->icmpv6h->type;
-    p->icmp_s.code = p->icmpv6h->code;
+    const uint8_t type = p->icmp_s.type = icmpv6h->type;
+    const uint8_t code = p->icmp_s.code = icmpv6h->code;
     DEBUG_VALIDATE_BUG_ON(len - ICMPV6_HEADER_LEN > UINT16_MAX);
     p->payload_len = (uint16_t)(len - ICMPV6_HEADER_LEN);
     p->payload = (uint8_t *)pkt + ICMPV6_HEADER_LEN;
@@ -190,14 +198,13 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         p->icmp_d.type = (uint8_t)ctype;
     }
 
-    SCLogDebug("ICMPV6 TYPE %" PRIu32 " CODE %" PRIu32 "", p->icmpv6h->type,
-               p->icmpv6h->code);
+    SCLogDebug("ICMPV6 TYPE %u CODE %u", type, code);
 
-    switch (ICMPV6_GET_TYPE(p)) {
+    switch (type) {
         case ICMP6_DST_UNREACH:
             SCLogDebug("ICMP6_DST_UNREACH");
 
-            if (ICMPV6_GET_CODE(p) > ICMP6_DST_UNREACH_REJECTROUTE) {
+            if (code > ICMP6_DST_UNREACH_REJECTROUTE) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
@@ -212,13 +219,13 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case ICMP6_PACKET_TOO_BIG:
             SCLogDebug("ICMP6_PACKET_TOO_BIG");
 
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
                     return TM_ECODE_FAILED;
                 }
-                p->icmpv6vars.mtu = ICMPV6_GET_MTU(p);
+                p->l4.vars.icmpv6.mtu = ICMPV6_GET_MTU(icmpv6h);
                 DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
                         (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;
@@ -228,7 +235,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case ICMP6_TIME_EXCEEDED:
             SCLogDebug("ICMP6_TIME_EXCEEDED");
 
-            if (ICMPV6_GET_CODE(p) > ICMP6_TIME_EXCEED_REASSEMBLY) {
+            if (code > ICMP6_TIME_EXCEED_REASSEMBLY) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
@@ -243,7 +250,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case ICMP6_PARAM_PROB:
             SCLogDebug("ICMP6_PARAM_PROB");
 
-            if (ICMPV6_GET_CODE(p) > ICMP6_PARAMPROB_OPTION) {
+            if (code > ICMP6_PARAMPROB_OPTION) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
@@ -256,64 +263,64 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
             break;
         case ICMP6_ECHO_REQUEST:
-            SCLogDebug("ICMP6_ECHO_REQUEST id: %u seq: %u",
-                       p->icmpv6h->icmpv6b.icmpv6i.id, p->icmpv6h->icmpv6b.icmpv6i.seq);
+            SCLogDebug("ICMP6_ECHO_REQUEST id: %u seq: %u", icmpv6h->icmpv6b.icmpv6i.id,
+                    icmpv6h->icmpv6b.icmpv6i.seq);
 
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
-                p->icmpv6vars.id = p->icmpv6h->icmpv6b.icmpv6i.id;
-                p->icmpv6vars.seq = p->icmpv6h->icmpv6b.icmpv6i.seq;
+                p->l4.vars.icmpv6.id = icmpv6h->icmpv6b.icmpv6i.id;
+                p->l4.vars.icmpv6.seq = icmpv6h->icmpv6b.icmpv6i.seq;
                 full_hdr = 1;
             }
 
             break;
         case ICMP6_ECHO_REPLY:
-            SCLogDebug("ICMP6_ECHO_REPLY id: %u seq: %u",
-                       p->icmpv6h->icmpv6b.icmpv6i.id, p->icmpv6h->icmpv6b.icmpv6i.seq);
+            SCLogDebug("ICMP6_ECHO_REPLY id: %u seq: %u", icmpv6h->icmpv6b.icmpv6i.id,
+                    icmpv6h->icmpv6b.icmpv6i.seq);
 
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             } else {
-                p->icmpv6vars.id = p->icmpv6h->icmpv6b.icmpv6i.id;
-                p->icmpv6vars.seq = p->icmpv6h->icmpv6b.icmpv6i.seq;
+                p->l4.vars.icmpv6.id = icmpv6h->icmpv6b.icmpv6i.id;
+                p->l4.vars.icmpv6.seq = icmpv6h->icmpv6b.icmpv6i.seq;
                 full_hdr = 1;
             }
 
             break;
         case ND_ROUTER_SOLICIT:
             SCLogDebug("ND_ROUTER_SOLICIT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_ROUTER_ADVERT:
             SCLogDebug("ND_ROUTER_ADVERT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_NEIGHBOR_SOLICIT:
             SCLogDebug("ND_NEIGHBOR_SOLICIT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_NEIGHBOR_ADVERT:
             SCLogDebug("ND_NEIGHBOR_ADVERT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_REDIRECT:
             SCLogDebug("ND_REDIRECT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case MLD_LISTENER_QUERY:
             SCLogDebug("MLD_LISTENER_QUERY");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             if (IPV6_GET_RAW_HLIM(ip6h) != 1) {
@@ -322,7 +329,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             break;
         case MLD_LISTENER_REPORT:
             SCLogDebug("MLD_LISTENER_REPORT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             if (IPV6_GET_RAW_HLIM(ip6h) != 1) {
@@ -331,7 +338,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             break;
         case MLD_LISTENER_REDUCTION:
             SCLogDebug("MLD_LISTENER_REDUCTION");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             if (IPV6_GET_RAW_HLIM(ip6h) != 1) {
@@ -340,73 +347,73 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             break;
         case ICMP6_RR:
             SCLogDebug("ICMP6_RR");
-            if (ICMPV6_GET_CODE(p) > 2 && ICMPV6_GET_CODE(p) != 255) {
+            if (code > 2 && code != 255) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ICMP6_NI_QUERY:
             SCLogDebug("ICMP6_NI_QUERY");
-            if (ICMPV6_GET_CODE(p) > 2) {
+            if (code > 2) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ICMP6_NI_REPLY:
             SCLogDebug("ICMP6_NI_REPLY");
-            if (ICMPV6_GET_CODE(p) > 2) {
+            if (code > 2) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_INVERSE_SOLICIT:
             SCLogDebug("ND_INVERSE_SOLICIT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case ND_INVERSE_ADVERT:
             SCLogDebug("ND_INVERSE_ADVERT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case MLD_V2_LIST_REPORT:
             SCLogDebug("MLD_V2_LIST_REPORT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case HOME_AGENT_AD_REQUEST:
             SCLogDebug("HOME_AGENT_AD_REQUEST");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case HOME_AGENT_AD_REPLY:
             SCLogDebug("HOME_AGENT_AD_REPLY");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case MOBILE_PREFIX_SOLICIT:
             SCLogDebug("MOBILE_PREFIX_SOLICIT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case MOBILE_PREFIX_ADVERT:
             SCLogDebug("MOBILE_PREFIX_ADVERT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case CERT_PATH_SOLICIT:
             SCLogDebug("CERT_PATH_SOLICIT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case CERT_PATH_ADVERT:
             SCLogDebug("CERT_PATH_ADVERT");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
@@ -424,40 +431,40 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             break;
         case FMIPV6_MSG:
             SCLogDebug("FMIPV6_MSG");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case RPL_CONTROL_MSG:
             SCLogDebug("RPL_CONTROL_MSG");
-            if (ICMPV6_GET_CODE(p) > 3 && ICMPV6_GET_CODE(p) < 128) {
+            if (code > 3 && code < 128) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
-            if (ICMPV6_GET_CODE(p) > 132) {
+            if (code > 132) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case LOCATOR_UDATE_MSG:
             SCLogDebug("LOCATOR_UDATE_MSG");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case DUPL_ADDR_REQUEST:
             SCLogDebug("DUPL_ADDR_REQUEST");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case DUPL_ADDR_CONFIRM:
             SCLogDebug("DUPL_ADDR_CONFIRM");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
         case MPL_CONTROL_MSG:
             SCLogDebug("MPL_CONTROL_MSG");
-            if (ICMPV6_GET_CODE(p) != 0) {
+            if (code != 0) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_CODE);
             }
             break;
@@ -465,21 +472,22 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             /* Various range taken from:
              *   http://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-2
              */
-            if ((ICMPV6_GET_TYPE(p) > 4) &&  (ICMPV6_GET_TYPE(p) < 100)) {
+            if (type > 4 && type < 100) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNASSIGNED_TYPE);
-            } else if ((ICMPV6_GET_TYPE(p) >= 100) &&  (ICMPV6_GET_TYPE(p) < 102)) {
+            } else if (type >= 100 && type < 102) {
                 ENGINE_SET_EVENT(p, ICMPV6_EXPERIMENTATION_TYPE);
-            } else  if ((ICMPV6_GET_TYPE(p) >= 102) &&  (ICMPV6_GET_TYPE(p) < 127)) {
+            } else if (type >= 102 && type < 127) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNASSIGNED_TYPE);
-            } else if ((ICMPV6_GET_TYPE(p) >= 160) &&  (ICMPV6_GET_TYPE(p) < 200)) {
+            } else if (type >= 160 && type < 200) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNASSIGNED_TYPE);
-            } else if ((ICMPV6_GET_TYPE(p) >= 200) &&  (ICMPV6_GET_TYPE(p) < 202)) {
+            } else if (type >= 200 && type < 202) {
                 ENGINE_SET_EVENT(p, ICMPV6_EXPERIMENTATION_TYPE);
-            } else if (ICMPV6_GET_TYPE(p) >= 202) {
+            } else if (type >= 202) {
                 ENGINE_SET_EVENT(p, ICMPV6_UNASSIGNED_TYPE);
             } else {
-                SCLogDebug("ICMPV6 Message type %" PRIu8 " not "
-                        "implemented yet", ICMPV6_GET_TYPE(p));
+                SCLogDebug("ICMPV6 Message type %u not "
+                           "implemented yet",
+                        type);
                 ENGINE_SET_EVENT(p, ICMPV6_UNKNOWN_TYPE);
             }
     }
@@ -609,13 +617,14 @@ static int ICMPV6ParamProbTest01(void)
     FAIL_IF(!PacketIsICMPv6(p));
 
     /* ICMPv6 not processed at all? */
-    FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0 ||
-        ICMPV6_GET_EMB_PROTO(p) != IPPROTO_ICMPV6);
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 4);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
+    FAIL_IF(ICMPV6_GET_EMB_PROTO(p) != IPPROTO_ICMPV6);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
     for (int i = 0; i < 4; i++) {
-        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
-                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
+        FAIL_IF(PacketGetICMPv6EmbIPv6(p)->s_ip6_src[i] != ipv6src[i] ||
+                PacketGetICMPv6EmbIPv6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     PacketRecycle(p);
@@ -664,12 +673,13 @@ static int ICMPV6PktTooBigTest01(void)
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6
      * (IPPROTO_NONE) */
     /* Check if ICMPv6 header was processed at all. */
-    FAIL_IF(ICMPV6_GET_TYPE(p) != 2 || ICMPV6_GET_CODE(p) != 0 );
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 2);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
     for (int i = 0; i < 4; i++) {
-        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
-                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
+        FAIL_IF(PacketGetICMPv6EmbIPv6(p)->s_ip6_src[i] != ipv6src[i] ||
+                PacketGetICMPv6EmbIPv6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     SCLogDebug("ICMPV6 IPV6 src and dst properly set");
@@ -718,14 +728,15 @@ static int ICMPV6TimeExceedTest01(void)
     FAIL_IF(!PacketIsICMPv6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
-    FAIL_IF(ICMPV6_GET_TYPE(p) != 3 || ICMPV6_GET_CODE(p) != 0 ||
-        ICMPV6_GET_EMB_IPV6(p) == NULL ||
-        ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 3);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
+    FAIL_IF_NULL(PacketGetICMPv6EmbIPv6(p));
+    FAIL_IF(ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
     for (int i = 0; i < 4; i++) {
-        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
-                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
+        FAIL_IF(PacketGetICMPv6EmbIPv6(p)->s_ip6_src[i] != ipv6src[i] ||
+                PacketGetICMPv6EmbIPv6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     SCLogDebug("ICMPV6 IPV6 src and dst properly set");
@@ -774,14 +785,15 @@ static int ICMPV6DestUnreachTest01(void)
     FAIL_IF(!PacketIsICMPv6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
-    FAIL_IF(ICMPV6_GET_TYPE(p) != 1 || ICMPV6_GET_CODE(p) != 0 ||
-        ICMPV6_GET_EMB_IPV6(p) == NULL ||
-        ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 1);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
+    FAIL_IF_NULL(PacketGetICMPv6EmbIPv6(p));
+    FAIL_IF(ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
     for (int i = 0; i < 4; i++) {
-        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
-                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
+        FAIL_IF(PacketGetICMPv6EmbIPv6(p)->s_ip6_src[i] != ipv6src[i] ||
+                PacketGetICMPv6EmbIPv6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     PacketRecycle(p);
@@ -819,13 +831,10 @@ static int ICMPV6EchoReqTest01(void)
 
     SCLogDebug("ID: %u seq: %u", ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
 
-    if (ICMPV6_GET_TYPE(p) != 128 || ICMPV6_GET_CODE(p) != 0 ||
-        SCNtohs(ICMPV6_GET_ID(p)) != 9712 || SCNtohs(ICMPV6_GET_SEQ(p)) != 29987) {
-        printf("ICMPv6 Echo reply decode failed TYPE %u CODE %u ID %04x(%u) SEQ %04x(%u): ",
-                ICMPV6_GET_TYPE(p), ICMPV6_GET_CODE(p), ICMPV6_GET_ID(p), SCNtohs(ICMPV6_GET_ID(p)),
-                ICMPV6_GET_SEQ(p), SCNtohs(ICMPV6_GET_SEQ(p)));
-        FAIL;
-    }
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 128);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
+    FAIL_IF(SCNtohs(ICMPV6_GET_ID(p)) != 9712);
+    FAIL_IF(SCNtohs(ICMPV6_GET_SEQ(p)) != 29987);
 
     PacketRecycle(p);
     FlowShutdown();
@@ -861,16 +870,10 @@ static int ICMPV6EchoRepTest01(void)
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
     FAIL_IF(!PacketIsICMPv6(p));
 
-    SCLogDebug("type: %u code %u ID: %u seq: %u", ICMPV6_GET_TYPE(p),
-               ICMPV6_GET_CODE(p),ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
-
-    if (ICMPV6_GET_TYPE(p) != 129 || ICMPV6_GET_CODE(p) != 0 ||
-        SCNtohs(ICMPV6_GET_ID(p)) != 9712 || SCNtohs(ICMPV6_GET_SEQ(p)) != 29987) {
-        printf("ICMPv6 Echo reply decode failed TYPE %u CODE %u ID %04x(%u) SEQ %04x(%u): ",
-                ICMPV6_GET_TYPE(p), ICMPV6_GET_CODE(p), ICMPV6_GET_ID(p), SCNtohs(ICMPV6_GET_ID(p)),
-                ICMPV6_GET_SEQ(p), SCNtohs(ICMPV6_GET_SEQ(p)));
-        FAIL;
-    }
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 129);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
+    FAIL_IF(SCNtohs(ICMPV6_GET_ID(p)) != 9712);
+    FAIL_IF(SCNtohs(ICMPV6_GET_SEQ(p)) != 29987);
 
     PacketRecycle(p);
     FlowShutdown();
@@ -911,7 +914,8 @@ static int ICMPV6ParamProbTest02(void)
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
     FAIL_IF(!PacketIsICMPv6(p));
-    FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0);
+    FAIL_IF(ICMPV6_GET_TYPE(PacketGetICMPv6(p)) != 4);
+    FAIL_IF(ICMPV6_GET_CODE(PacketGetICMPv6(p)) != 0);
     FAIL_IF(!ENGINE_ISSET_EVENT(p, ICMPV6_IPV6_UNKNOWN_VER));
 
     PacketRecycle(p);
@@ -1501,19 +1505,19 @@ static int ICMPV6CalculateValidChecksumWithFCS(void)
     FAIL_IF_NULL(p);
     ThreadVars tv;
     DecodeThreadVars dtv;
-
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
     FlowInitConfig(FLOW_QUIET);
-    DecodeIPV6(&tv, &dtv, p, raw_ipv6 + 14, sizeof(raw_ipv6) - 14);
+    DecodeEthernet(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
     FAIL_IF(!PacketIsICMPv6(p));
 
+    const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
     const IPV6Hdr *ip6h = PacketGetIPv6(p);
     uint16_t icmpv6_len = IPV6_GET_RAW_PLEN(ip6h) -
-                          ((const uint8_t *)p->icmpv6h - (const uint8_t *)ip6h - IPV6_HEADER_LEN);
+                          ((const uint8_t *)icmpv6h - (const uint8_t *)ip6h - IPV6_HEADER_LEN);
     FAIL_IF(icmpv6_len != 28);
-    FAIL_IF(ICMPV6CalculateChecksum(ip6h->s_ip6_addrs, (uint16_t *)p->icmpv6h, icmpv6_len) != csum);
+    FAIL_IF(ICMPV6CalculateChecksum(ip6h->s_ip6_addrs, (uint16_t *)icmpv6h, icmpv6_len) != csum);
 
     PacketRecycle(p);
     FlowShutdown();

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -606,8 +606,7 @@ static int ICMPV6ParamProbTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF(p->icmpv6h == NULL);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     /* ICMPv6 not processed at all? */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0 ||
@@ -660,8 +659,7 @@ static int ICMPV6PktTooBigTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF(p->icmpv6h == NULL);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6
      * (IPPROTO_NONE) */
@@ -717,8 +715,7 @@ static int ICMPV6TimeExceedTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 3 || ICMPV6_GET_CODE(p) != 0 ||
@@ -774,8 +771,7 @@ static int ICMPV6DestUnreachTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 1 || ICMPV6_GET_CODE(p) != 0 ||
@@ -819,8 +815,7 @@ static int ICMPV6EchoReqTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     SCLogDebug("ID: %u seq: %u", ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
 
@@ -864,8 +859,7 @@ static int ICMPV6EchoRepTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     SCLogDebug("type: %u code %u ID: %u seq: %u", ICMPV6_GET_TYPE(p),
                ICMPV6_GET_CODE(p),ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
@@ -916,8 +910,7 @@ static int ICMPV6ParamProbTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
     FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0);
     FAIL_IF(!ENGINE_ISSET_EVENT(p, ICMPV6_IPV6_UNKNOWN_VER));
 
@@ -958,8 +951,7 @@ static int ICMPV6PktTooBigTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
     FAIL_IF(!ENGINE_ISSET_EVENT(p, ICMPV6_UNKNOWN_CODE));
 
     PacketRecycle(p);
@@ -1515,7 +1507,7 @@ static int ICMPV6CalculateValidChecksumWithFCS(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6 + 14, sizeof(raw_ipv6) - 14);
-    FAIL_IF_NULL(p->icmpv6h);
+    FAIL_IF(!PKT_IS_ICMPV6(p));
 
     const IPV6Hdr *ip6h = PacketGetIPv6(p);
     uint16_t icmpv6_len = IPV6_GET_RAW_PLEN(ip6h) -

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -68,18 +68,6 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
 
     /** We need to fill icmpv6vars */
     p->icmpv6vars.emb_ipv6h = icmp6_ip6h;
-
-    /** Get the IP6 address */
-    p->icmpv6vars.emb_ip6_src[0] = icmp6_ip6h->s_ip6_src[0];
-    p->icmpv6vars.emb_ip6_src[1] = icmp6_ip6h->s_ip6_src[1];
-    p->icmpv6vars.emb_ip6_src[2] = icmp6_ip6h->s_ip6_src[2];
-    p->icmpv6vars.emb_ip6_src[3] = icmp6_ip6h->s_ip6_src[3];
-
-    p->icmpv6vars.emb_ip6_dst[0] = icmp6_ip6h->s_ip6_dst[0];
-    p->icmpv6vars.emb_ip6_dst[1] = icmp6_ip6h->s_ip6_dst[1];
-    p->icmpv6vars.emb_ip6_dst[2] = icmp6_ip6h->s_ip6_dst[2];
-    p->icmpv6vars.emb_ip6_dst[3] = icmp6_ip6h->s_ip6_dst[3];
-
     /** Get protocol and ports inside the embedded ipv6 packet and set the pointers */
     p->icmpv6vars.emb_ip6_proto_next = icmp6_ip6h->s_ip6_nxt;
 
@@ -132,8 +120,8 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
     /* debug print */
 #ifdef DEBUG
     char s[46], d[46];
-    PrintInet(AF_INET6, (const void *)p->icmpv6vars.emb_ip6_src, s, sizeof(s));
-    PrintInet(AF_INET6, (const void *)p->icmpv6vars.emb_ip6_dst, d, sizeof(d));
+    PrintInet(AF_INET6, (const void *)ICMPV6_GET_EMB_IPV6(p)->s_ip6_src, s, sizeof(s));
+    PrintInet(AF_INET6, (const void *)ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst, d, sizeof(d));
     SCLogDebug("ICMPv6 embedding IPV6 %s->%s - CLASS: %" PRIu32 " FLOW: "
                "%" PRIu32 " NH: %" PRIu32 " PLEN: %" PRIu32 " HLIM: %" PRIu32,
                s, d, IPV6_GET_RAW_CLASS(icmp6_ip6h), IPV6_GET_RAW_FLOW(icmp6_ip6h),
@@ -627,10 +615,9 @@ static int ICMPV6ParamProbTest01(void)
         ICMPV6_GET_EMB_PROTO(p) != IPPROTO_ICMPV6);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
-    uint32_t i=0;
-    for (i = 0; i < 4; i++) {
-        FAIL_IF(p->icmpv6vars.emb_ip6_src[i] != ipv6src[i] ||
-            p->icmpv6vars.emb_ip6_dst[i] != ipv6dst[i]);
+    for (int i = 0; i < 4; i++) {
+        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
+                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     PacketRecycle(p);
@@ -683,10 +670,9 @@ static int ICMPV6PktTooBigTest01(void)
     FAIL_IF(ICMPV6_GET_TYPE(p) != 2 || ICMPV6_GET_CODE(p) != 0 );
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
-    uint32_t i=0;
-    for (i = 0; i < 4; i++) {
-        FAIL_IF(p->icmpv6vars.emb_ip6_src[i] != ipv6src[i] ||
-            p->icmpv6vars.emb_ip6_dst[i] != ipv6dst[i]);
+    for (int i = 0; i < 4; i++) {
+        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
+                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     SCLogDebug("ICMPV6 IPV6 src and dst properly set");
@@ -741,10 +727,9 @@ static int ICMPV6TimeExceedTest01(void)
         ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
-    uint32_t i=0;
-    for (i = 0; i < 4; i++) {
-        FAIL_IF(p->icmpv6vars.emb_ip6_src[i] != ipv6src[i] ||
-            p->icmpv6vars.emb_ip6_dst[i] != ipv6dst[i]);
+    for (int i = 0; i < 4; i++) {
+        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
+                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     SCLogDebug("ICMPV6 IPV6 src and dst properly set");
@@ -799,10 +784,9 @@ static int ICMPV6DestUnreachTest01(void)
         ICMPV6_GET_EMB_PROTO(p) != IPPROTO_NONE);
 
     /* Let's check if we retrieved the embedded ipv6 addresses correctly */
-    uint32_t i=0;
-    for (i = 0; i < 4; i++) {
-        FAIL_IF(p->icmpv6vars.emb_ip6_src[i] != ipv6src[i] ||
-            p->icmpv6vars.emb_ip6_dst[i] != ipv6dst[i]);
+    for (int i = 0; i < 4; i++) {
+        FAIL_IF(ICMPV6_GET_EMB_IPV6(p)->s_ip6_src[i] != ipv6src[i] ||
+                ICMPV6_GET_EMB_IPV6(p)->s_ip6_dst[i] != ipv6dst[i]);
     }
 
     PacketRecycle(p);

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -41,7 +41,9 @@
 static inline const IPV6Hdr *PacketGetICMPv6EmbIPv6(const Packet *p)
 {
     BUG_ON(p->l4.type != PACKET_L4_ICMPV6);
-    return p->l4.vars.icmpv6.emb_ipv6h;
+    const uint8_t *start = (const uint8_t *)PacketGetICMPv6(p);
+    const uint8_t *ip = start + p->l4.vars.icmpv6.emb_ip6h_offset;
+    return (const IPV6Hdr *)ip;
 }
 #endif
 
@@ -75,7 +77,8 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
     }
 
     /** We need to fill l4.vars.icmpv6 */
-    p->l4.vars.icmpv6.emb_ipv6h = icmp6_ip6h;
+    const uint8_t *icmpv6_ptr = (const uint8_t *)p->l4.hdrs.icmpv6h;
+    p->l4.vars.icmpv6.emb_ip6h_offset = partial_packet - icmpv6_ptr;
     /** Get protocol and ports inside the embedded ipv6 packet and set the pointers */
     p->l4.vars.icmpv6.emb_ip6_proto_next = icmp6_ip6h->s_ip6_nxt;
 

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -249,7 +249,6 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
                 if (unlikely(len > ICMPV6_HEADER_LEN + USHRT_MAX)) {
                     return TM_ECODE_FAILED;
                 }
-                p->icmpv6vars.error_ptr= ICMPV6_GET_ERROR_PTR(p);
                 DecodePartialIPV6(p, (uint8_t *)(pkt + ICMPV6_HEADER_LEN),
                         (uint16_t)(len - ICMPV6_HEADER_LEN));
                 full_hdr = 1;

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -86,9 +86,10 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
     switch (icmp6_ip6h->s_ip6_nxt) {
         case IPPROTO_TCP:
             if (len >= IPV6_HEADER_LEN + TCP_HEADER_LEN ) {
-                p->icmpv6vars.emb_tcph = (TCPHdr*)(partial_packet + IPV6_HEADER_LEN);
-                p->icmpv6vars.emb_sport = p->icmpv6vars.emb_tcph->th_sport;
-                p->icmpv6vars.emb_dport = p->icmpv6vars.emb_tcph->th_dport;
+                TCPHdr *emb_tcph = (TCPHdr *)(partial_packet + IPV6_HEADER_LEN);
+                p->icmpv6vars.emb_sport = emb_tcph->th_sport;
+                p->icmpv6vars.emb_dport = emb_tcph->th_dport;
+                p->icmpv6vars.emb_ports_set = true;
 
                 SCLogDebug("ICMPV6->IPV6->TCP header sport: "
                            "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
@@ -103,9 +104,10 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
             break;
         case IPPROTO_UDP:
             if (len >= IPV6_HEADER_LEN + UDP_HEADER_LEN ) {
-                p->icmpv6vars.emb_udph = (UDPHdr*)(partial_packet + IPV6_HEADER_LEN);
-                p->icmpv6vars.emb_sport = p->icmpv6vars.emb_udph->uh_sport;
-                p->icmpv6vars.emb_dport = p->icmpv6vars.emb_udph->uh_dport;
+                UDPHdr *emb_udph = (UDPHdr *)(partial_packet + IPV6_HEADER_LEN);
+                p->icmpv6vars.emb_sport = emb_udph->uh_sport;
+                p->icmpv6vars.emb_dport = emb_udph->uh_dport;
+                p->icmpv6vars.emb_ports_set = true;
 
                 SCLogDebug("ICMPV6->IPV6->UDP header sport: "
                            "%"PRIu16" dport %"PRIu16"", p->icmpv6vars.emb_sport,
@@ -119,7 +121,6 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
 
             break;
         case IPPROTO_ICMPV6:
-            p->icmpv6vars.emb_icmpv6h = (ICMPV6Hdr*)(partial_packet + IPV6_HEADER_LEN);
             p->icmpv6vars.emb_sport = 0;
             p->icmpv6vars.emb_dport = 0;
 

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -606,7 +606,7 @@ static int ICMPV6ParamProbTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     /* ICMPv6 not processed at all? */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0 ||
@@ -659,7 +659,7 @@ static int ICMPV6PktTooBigTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6
      * (IPPROTO_NONE) */
@@ -715,7 +715,7 @@ static int ICMPV6TimeExceedTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 3 || ICMPV6_GET_CODE(p) != 0 ||
@@ -771,7 +771,7 @@ static int ICMPV6DestUnreachTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     /* Note: it has an embedded ipv6 packet but no protocol after ipv6 (IPPROTO_NONE) */
     FAIL_IF(ICMPV6_GET_TYPE(p) != 1 || ICMPV6_GET_CODE(p) != 0 ||
@@ -815,7 +815,7 @@ static int ICMPV6EchoReqTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     SCLogDebug("ID: %u seq: %u", ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
 
@@ -859,7 +859,7 @@ static int ICMPV6EchoRepTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     SCLogDebug("type: %u code %u ID: %u seq: %u", ICMPV6_GET_TYPE(p),
                ICMPV6_GET_CODE(p),ICMPV6_GET_ID(p), ICMPV6_GET_SEQ(p));
@@ -910,7 +910,7 @@ static int ICMPV6ParamProbTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
     FAIL_IF(ICMPV6_GET_TYPE(p) != 4 || ICMPV6_GET_CODE(p) != 0);
     FAIL_IF(!ENGINE_ISSET_EVENT(p, ICMPV6_IPV6_UNKNOWN_VER));
 
@@ -951,7 +951,7 @@ static int ICMPV6PktTooBigTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6, sizeof(raw_ipv6));
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
     FAIL_IF(!ENGINE_ISSET_EVENT(p, ICMPV6_UNKNOWN_CODE));
 
     PacketRecycle(p);
@@ -1507,7 +1507,7 @@ static int ICMPV6CalculateValidChecksumWithFCS(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeIPV6(&tv, &dtv, p, raw_ipv6 + 14, sizeof(raw_ipv6) - 14);
-    FAIL_IF(!PKT_IS_ICMPV6(p));
+    FAIL_IF(!PacketIsICMPv6(p));
 
     const IPV6Hdr *ip6h = PacketGetIPv6(p);
     uint16_t icmpv6_len = IPV6_GET_RAW_PLEN(ip6h) -

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -156,8 +156,8 @@ typedef struct ICMPV6Vars_ {
     uint16_t emb_sport;
     uint16_t emb_dport;
 
-    /** Pointers to the embedded packet headers */
-    IPV6Hdr *emb_ipv6h;
+    /** offset of the embedded packet header */
+    uint16_t emb_ip6h_offset;
 } ICMPV6Vars;
 
 void DecodeICMPV6RegisterTests(void);

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -162,9 +162,6 @@ typedef struct ICMPV6Vars_ {
     /** Pointers to the embedded packet headers */
     IPV6Hdr *emb_ipv6h;
 
-    /** IPv6 src and dst address */
-    uint32_t emb_ip6_src[4];
-    uint32_t emb_ip6_dst[4];
     uint8_t emb_ip6_proto_next;
 
     bool emb_ports_set;

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -156,9 +156,6 @@ typedef struct ICMPV6Vars_ {
     uint16_t  seq;
     uint32_t mtu;
 
-    /** Pointers to the embedded packet headers */
-    IPV6Hdr *emb_ipv6h;
-
     uint8_t emb_ip6_proto_next;
 
     bool emb_ports_set;
@@ -166,6 +163,8 @@ typedef struct ICMPV6Vars_ {
     uint16_t emb_sport;
     uint16_t emb_dport;
 
+    /** Pointers to the embedded packet headers */
+    IPV6Hdr *emb_ipv6h;
 } ICMPV6Vars;
 
 #define CLEAR_ICMPV6_PACKET(p)                                                                     \

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -98,32 +98,25 @@
 
 
 /** macro for icmpv6 "type" access */
-#define ICMPV6_GET_TYPE(p)      (p)->icmpv6h->type
+#define ICMPV6_GET_TYPE(icmp6h) (icmp6h)->type
 /** macro for icmpv6 "code" access */
-#define ICMPV6_GET_CODE(p)      (p)->icmpv6h->code
-/** macro for icmpv6 "csum" access */
-#define ICMPV6_GET_RAW_CSUM(p)      SCNtohs((p)->icmpv6h->csum)
-#define ICMPV6_GET_CSUM(p)      (p)->icmpv6h->csum
+#define ICMPV6_GET_CODE(icmp6h) (icmp6h)->code
 
 /** If message is informational */
 /** macro for icmpv6 "id" access */
-#define ICMPV6_GET_ID(p)        (p)->icmpv6vars.id
+#define ICMPV6_GET_ID(p) (p)->l4.vars.icmpv6.id
 /** macro for icmpv6 "seq" access */
-#define ICMPV6_GET_SEQ(p)       (p)->icmpv6vars.seq
+#define ICMPV6_GET_SEQ(p) (p)->l4.vars.icmpv6.seq
 
 /** If message is Error */
-/** macro for icmpv6 "unused" access */
-#define ICMPV6_GET_UNUSED(p) (p)->icmpv6h->icmpv6b.icmpv6e.unused
 /** macro for icmpv6 "mtu" accessibility */
 // ICMPv6 has MTU only for type too big
-#define ICMPV6_HAS_MTU(p)          ((p)->icmpv6h->type == ICMP6_PACKET_TOO_BIG)
+#define ICMPV6_HAS_MTU(icmp6h) ((icmp6h)->type == ICMP6_PACKET_TOO_BIG)
 /** macro for icmpv6 "mtu" access */
-#define ICMPV6_GET_MTU(p)          SCNtohl((p)->icmpv6h->icmpv6b.icmpv6e.mtu)
+#define ICMPV6_GET_MTU(icmp6h) SCNtohl((icmp6h)->icmpv6b.icmpv6e.mtu)
 
 /** macro for icmpv6 embedded "protocol" access */
-#define ICMPV6_GET_EMB_PROTO(p)    (p)->icmpv6vars.emb_ip6_proto_next
-/** macro for icmpv6 embedded "ipv6h" header access */
-#define ICMPV6_GET_EMB_IPV6(p) (p)->icmpv6vars.emb_ipv6h
+#define ICMPV6_GET_EMB_PROTO(p) (p)->l4.vars.icmpv6.emb_ip6_proto_next
 
 typedef struct ICMPV6Info_
 {
@@ -166,12 +159,6 @@ typedef struct ICMPV6Vars_ {
     /** Pointers to the embedded packet headers */
     IPV6Hdr *emb_ipv6h;
 } ICMPV6Vars;
-
-#define CLEAR_ICMPV6_PACKET(p)                                                                     \
-    do {                                                                                           \
-        PACKET_CLEAR_L4VARS((p));                                                                  \
-        (p)->icmpv6h = NULL;                                                                       \
-    } while (0)
 
 void DecodeICMPV6RegisterTests(void);
 

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -113,9 +113,7 @@
 
 /** If message is Error */
 /** macro for icmpv6 "unused" access */
-#define ICMPV6_GET_UNUSED(p)       (p)->icmpv6h->icmpv6b.icmpv6e.unused
-/** macro for icmpv6 "error_ptr" access */
-#define ICMPV6_GET_ERROR_PTR(p)    (p)->icmpv6h->icmpv6b.icmpv6e.error_ptr
+#define ICMPV6_GET_UNUSED(p) (p)->icmpv6h->icmpv6b.icmpv6e.unused
 /** macro for icmpv6 "mtu" accessibility */
 // ICMPv6 has MTU only for type too big
 #define ICMPV6_HAS_MTU(p)          ((p)->icmpv6h->type == ICMP6_PACKET_TOO_BIG)
@@ -156,8 +154,7 @@ typedef struct ICMPV6Vars_ {
     /* checksum of the icmpv6 packet */
     uint16_t  id;
     uint16_t  seq;
-    uint32_t  mtu;
-    uint32_t  error_ptr;
+    uint32_t mtu;
 
     /** Pointers to the embedded packet headers */
     IPV6Hdr *emb_ipv6h;

--- a/src/decode-icmpv6.h
+++ b/src/decode-icmpv6.h
@@ -125,13 +125,7 @@
 /** macro for icmpv6 embedded "protocol" access */
 #define ICMPV6_GET_EMB_PROTO(p)    (p)->icmpv6vars.emb_ip6_proto_next
 /** macro for icmpv6 embedded "ipv6h" header access */
-#define ICMPV6_GET_EMB_IPV6(p)     (p)->icmpv6vars.emb_ipv6h
-/** macro for icmpv6 embedded "tcph" header access */
-#define ICMPV6_GET_EMB_TCP(p)      (p)->icmpv6vars.emb_tcph
-/** macro for icmpv6 embedded "udph" header access */
-#define ICMPV6_GET_EMB_UDP(p)      (p)->icmpv6vars.emb_udph
-/** macro for icmpv6 embedded "icmpv6h" header access */
-#define ICMPV6_GET_EMB_icmpv6h(p)  (p)->icmpv6vars.emb_icmpv6h
+#define ICMPV6_GET_EMB_IPV6(p) (p)->icmpv6vars.emb_ipv6h
 
 typedef struct ICMPV6Info_
 {
@@ -167,15 +161,13 @@ typedef struct ICMPV6Vars_ {
 
     /** Pointers to the embedded packet headers */
     IPV6Hdr *emb_ipv6h;
-    TCPHdr *emb_tcph;
-    UDPHdr *emb_udph;
-    ICMPV6Hdr *emb_icmpv6h;
 
     /** IPv6 src and dst address */
     uint32_t emb_ip6_src[4];
     uint32_t emb_ip6_dst[4];
     uint8_t emb_ip6_proto_next;
 
+    bool emb_ports_set;
     /** TCP/UDP ports */
     uint16_t emb_sport;
     uint16_t emb_dport;

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -559,39 +559,33 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     }
 #endif /* DEBUG */
 
+    const uint8_t *data = pkt + IPV4_GET_HLEN(p);
+    const uint16_t data_len = IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p);
+
     /* check what next decoder to invoke */
     switch (IPV4_GET_IPPROTO(p)) {
         case IPPROTO_TCP:
-            DecodeTCP(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                      IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeTCP(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_UDP:
-            DecodeUDP(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                      IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeUDP(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_ICMP:
-            DecodeICMPV4(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                         IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeICMPV4(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_GRE:
-            DecodeGRE(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                      IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeGRE(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_SCTP:
-            DecodeSCTP(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                      IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeSCTP(tv, dtv, p, data, data_len);
             break;
-
         case IPPROTO_ESP:
-            DecodeESP(tv, dtv, p, pkt + IPV4_GET_HLEN(p), IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p));
+            DecodeESP(tv, dtv, p, data, data_len);
             break;
-
         case IPPROTO_IPV6:
             {
                 /* spawn off tunnel packet */
-                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                        IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p),
-                        DECODE_TUNNEL_IPV6);
+                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, data, data_len, DECODE_TUNNEL_IPV6);
                 if (tp != NULL) {
                     PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
                     PacketEnqueueNoLock(&tv->decode_pq,tp);
@@ -602,8 +596,7 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case IPPROTO_IP:
             /* check PPP VJ uncompressed packets and decode tcp dummy */
             if (p->flags & PKT_PPP_VJ_UCOMP) {
-                DecodeTCP(tv, dtv, p, pkt + IPV4_GET_HLEN(p),
-                          IPV4_GET_IPLEN(p) -  IPV4_GET_HLEN(p));
+                DecodeTCP(tv, dtv, p, data, data_len);
             }
             break;
         case IPPROTO_ICMPV6:

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -318,14 +318,14 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
 
     while (plen)
     {
-        p->ip4vars.opt_cnt++;
+        p->l3.vars.ip4.opt_cnt++;
 
         /* single byte options */
         if (*pkt == IPV4_OPT_EOL) {
             /** \todo What if more data exist after EOL (possible covert channel or data leakage)? */
             SCLogDebug("IPV4OPT %" PRIu8 " len 1 @ %d/%d",
                    *pkt, (len - plen), (len - 1));
-            p->ip4vars.opts_set |= IPV4_OPT_FLAG_EOL;
+            p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_EOL;
             break;
         } else if (*pkt == IPV4_OPT_NOP) {
             SCLogDebug("IPV4OPT %" PRIu8 " len 1 @ %d/%d",
@@ -333,9 +333,9 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
             pkt++;
             plen--;
 
-            p->ip4vars.opts_set |= IPV4_OPT_FLAG_NOP;
+            p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_NOP;
 
-        /* multibyte options */
+            /* multibyte options */
         } else {
             if (unlikely(plen < 2)) {
                 /** \todo What if padding is non-zero (possible covert channel or data leakage)? */
@@ -370,7 +370,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateTimestamp(p, &opt) == 0) {
                         opts->o_ts = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_TS;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_TS;
                     }
                     break;
                 case IPV4_OPT_RR:
@@ -379,7 +379,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateRoute(p, &opt) == 0) {
                         opts->o_rr = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_RR;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_RR;
                     }
                     break;
                 case IPV4_OPT_QS:
@@ -388,7 +388,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateGeneric(p, &opt) == 0) {
                         opts->o_qs = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_QS;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_QS;
                     }
                     break;
                 case IPV4_OPT_SEC:
@@ -397,7 +397,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateGeneric(p, &opt) == 0) {
                         opts->o_sec = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_SEC;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_SEC;
                     }
                     break;
                 case IPV4_OPT_LSRR:
@@ -406,7 +406,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateRoute(p, &opt) == 0) {
                         opts->o_lsrr = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_LSRR;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_LSRR;
                     }
                     break;
                 case IPV4_OPT_ESEC:
@@ -415,7 +415,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateGeneric(p, &opt) == 0) {
                         opts->o_esec = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_ESEC;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_ESEC;
                     }
                     break;
                 case IPV4_OPT_CIPSO:
@@ -424,7 +424,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateCIPSO(p, &opt) == 0) {
                         opts->o_cipso = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_CIPSO;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_CIPSO;
                     }
                     break;
                 case IPV4_OPT_SID:
@@ -433,7 +433,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateGeneric(p, &opt) == 0) {
                         opts->o_sid = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_SID;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_SID;
                     }
                     break;
                 case IPV4_OPT_SSRR:
@@ -442,7 +442,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateRoute(p, &opt) == 0) {
                         opts->o_ssrr = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_SSRR;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_SSRR;
                     }
                     break;
                 case IPV4_OPT_RTRALT:
@@ -451,7 +451,7 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
                         /* Warn - we can keep going */
                     } else if (IPV4OptValidateGeneric(p, &opt) == 0) {
                         opts->o_rtralt = opt;
-                        p->ip4vars.opts_set |= IPV4_OPT_FLAG_RTRALT;
+                        p->l3.vars.ip4.opts_set |= IPV4_OPT_FLAG_RTRALT;
                     }
                     break;
                 default:
@@ -470,51 +470,51 @@ static int DecodeIPV4Options(Packet *p, const uint8_t *pkt, uint16_t len, IPV4Op
     return 0;
 }
 
-static int DecodeIPV4Packet(Packet *p, const uint8_t *pkt, uint16_t len)
+static const IPV4Hdr *DecodeIPV4Packet(Packet *p, const uint8_t *pkt, uint16_t len)
 {
     if (unlikely(len < IPV4_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, IPV4_PKT_TOO_SMALL);
-        return -1;
+        return NULL;
     }
 
     if (unlikely(IP_GET_RAW_VER(pkt) != 4)) {
         SCLogDebug("wrong ip version %d",IP_GET_RAW_VER(pkt));
         ENGINE_SET_INVALID_EVENT(p, IPV4_WRONG_IP_VER);
-        return -1;
+        return NULL;
     }
 
-    p->ip4h = (IPV4Hdr *)pkt;
+    const IPV4Hdr *ip4h = PacketSetIPV4(p, pkt);
 
-    if (unlikely(IPV4_GET_HLEN(p) < IPV4_HEADER_LEN)) {
+    if (unlikely(IPV4_GET_RAW_HLEN(ip4h) < IPV4_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, IPV4_HLEN_TOO_SMALL);
-        return -1;
+        return NULL;
     }
 
-    if (unlikely(IPV4_GET_IPLEN(p) < IPV4_GET_HLEN(p))) {
+    if (unlikely(IPV4_GET_RAW_IPLEN(ip4h) < IPV4_GET_RAW_HLEN(ip4h))) {
         ENGINE_SET_INVALID_EVENT(p, IPV4_IPLEN_SMALLER_THAN_HLEN);
-        return -1;
+        return NULL;
     }
 
-    if (unlikely(len < IPV4_GET_IPLEN(p))) {
+    if (unlikely(len < IPV4_GET_RAW_IPLEN(ip4h))) {
         ENGINE_SET_INVALID_EVENT(p, IPV4_TRUNC_PKT);
-        return -1;
+        return NULL;
     }
 
     /* set the address struct */
-    SET_IPV4_SRC_ADDR(p,&p->src);
-    SET_IPV4_DST_ADDR(p,&p->dst);
+    SET_IPV4_SRC_ADDR(ip4h, &p->src);
+    SET_IPV4_DST_ADDR(ip4h, &p->dst);
 
     /* save the options len */
-    uint8_t ip_opt_len = IPV4_GET_HLEN(p) - IPV4_HEADER_LEN;
+    uint8_t ip_opt_len = IPV4_GET_RAW_HLEN(ip4h) - IPV4_HEADER_LEN;
     if (ip_opt_len > 0) {
         IPV4Options opts;
         memset(&opts, 0x00, sizeof(opts));
         if (DecodeIPV4Options(p, pkt + IPV4_HEADER_LEN, ip_opt_len, &opts) < 0) {
-            return -1;
+            return NULL;
         }
     }
 
-    return 0;
+    return ip4h;
 }
 
 int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
@@ -528,15 +528,16 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
     /* do the actual decoding */
-    if (unlikely(DecodeIPV4Packet (p, pkt, len) < 0)) {
+    const IPV4Hdr *ip4h = DecodeIPV4Packet(p, pkt, len);
+    if (unlikely(ip4h == NULL)) {
         SCLogDebug("decoding IPv4 packet failed");
-        CLEAR_IPV4_PACKET((p));
+        PacketClearL3(p);
         return TM_ECODE_FAILED;
     }
-    p->proto = IPV4_GET_IPPROTO(p);
+    p->proto = IPV4_GET_RAW_IPPROTO(ip4h);
 
     /* If a fragment, pass off for re-assembly. */
-    if (unlikely(IPV4_GET_IPOFFSET(p) > 0 || IPV4_GET_MF(p) == 1)) {
+    if (unlikely(IPV4_GET_RAW_FRAGOFFSET(ip4h) > 0 || IPV4_GET_RAW_FLAG_MF(ip4h))) {
         Packet *rp = Defrag(tv, dtv, p);
         if (rp != NULL) {
             PacketEnqueueNoLock(&tv->decode_pq, rp);
@@ -553,17 +554,19 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         char s[16], d[16];
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), s, sizeof(s));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), d, sizeof(d));
-        SCLogDebug("IPV4 %s->%s PROTO: %" PRIu32 " OFFSET: %" PRIu32 " RF: %" PRIu32 " DF: %" PRIu32 " MF: %" PRIu32 " ID: %" PRIu32 "", s,d,
-                IPV4_GET_IPPROTO(p), IPV4_GET_IPOFFSET(p), IPV4_GET_RF(p),
-                IPV4_GET_DF(p), IPV4_GET_MF(p), IPV4_GET_IPID(p));
+        SCLogDebug("IPV4 %s->%s PROTO: %" PRIu32 " OFFSET: %" PRIu32 " RF: %" PRIu8 " DF: %" PRIu8
+                   " MF: %" PRIu8 " ID: %" PRIu32 "",
+                s, d, IPV4_GET_RAW_IPPROTO(ip4h), IPV4_GET_RAW_IPOFFSET(ip4h),
+                IPV4_GET_RAW_FLAG_RF(ip4h), IPV4_GET_RAW_FLAG_DF(ip4h), IPV4_GET_RAW_FLAG_MF(ip4h),
+                IPV4_GET_RAW_IPID(ip4h));
     }
 #endif /* DEBUG */
 
-    const uint8_t *data = pkt + IPV4_GET_HLEN(p);
-    const uint16_t data_len = IPV4_GET_IPLEN(p) - IPV4_GET_HLEN(p);
+    const uint8_t *data = pkt + IPV4_GET_RAW_HLEN(ip4h);
+    const uint16_t data_len = IPV4_GET_RAW_IPLEN(ip4h) - IPV4_GET_RAW_HLEN(ip4h);
 
     /* check what next decoder to invoke */
-    switch (IPV4_GET_IPPROTO(p)) {
+    switch (p->proto) {
         case IPPROTO_TCP:
             DecodeTCP(tv, dtv, p, data, data_len);
             break;
@@ -1331,7 +1334,7 @@ static int DecodeIPV4DefragTest01(void)
         result = 0;
         goto end;
     }
-    if (tp->ip4h == NULL || tp->tcph == NULL) {
+    if (tp->l3.hdrs.ip4h == NULL || tp->tcph == NULL) {
         printf("pseudo packet's ip header and tcp header shouldn't be NULL, "
                "but it is\n");
         result = 0;
@@ -1462,7 +1465,7 @@ static int DecodeIPV4DefragTest02(void)
                tp->recursion_level, p->recursion_level);
         goto end;
     }
-    if (tp->ip4h == NULL || tp->tcph == NULL) {
+    if (tp->l3.hdrs.ip4h == NULL || tp->tcph == NULL) {
         printf("pseudo packet's ip header and tcp header shouldn't be NULL, "
                "but it is\n");
         goto end;
@@ -1615,7 +1618,7 @@ static int DecodeIPV4DefragTest03(void)
         result = 0;
         goto end;
     }
-    if (tp->ip4h == NULL || tp->tcph == NULL) {
+    if (tp->l3.hdrs.ip4h == NULL || tp->tcph == NULL) {
         printf("pseudo packet's ip header and tcp header shouldn't be NULL, "
                "but it is\n");
         result = 0;

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1294,24 +1294,24 @@ static int DecodeIPV4DefragTest01(void)
     PacketCopyData(p, pkt1, sizeof(pkt1));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt2, sizeof(pkt2));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt3, sizeof(pkt3));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
     FAIL_IF_NULL(tp);
     FAIL_IF(tp->recursion_level != p->recursion_level);
     FAIL_IF_NOT(PacketIsIPv4(tp));
-    FAIL_IF_NOT(PKT_IS_TCP(tp));
+    FAIL_IF_NOT(PacketIsTCP(tp));
     FAIL_IF(GET_PKT_LEN(tp) != sizeof(tunnel_pkt));
     FAIL_IF(memcmp(GET_PKT_DATA(tp), tunnel_pkt, sizeof(tunnel_pkt)) != 0);
     PacketRecycle(tp);
@@ -1390,25 +1390,25 @@ static int DecodeIPV4DefragTest02(void)
     PacketCopyData(p, pkt1, sizeof(pkt1));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt2, sizeof(pkt2));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     p->recursion_level = 3;
     PacketCopyData(p, pkt3, sizeof(pkt3));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
     FAIL_IF_NULL(tp);
     FAIL_IF(tp->recursion_level != p->recursion_level);
     FAIL_IF_NOT(PacketIsIPv4(tp));
-    FAIL_IF_NOT(PKT_IS_TCP(tp));
+    FAIL_IF_NOT(PacketIsTCP(tp));
     FAIL_IF(GET_PKT_LEN(tp) != sizeof(tunnel_pkt));
     FAIL_IF(memcmp(GET_PKT_DATA(tp), tunnel_pkt, sizeof(tunnel_pkt)) != 0);
     PacketRecycle(tp);
@@ -1481,26 +1481,26 @@ static int DecodeIPV4DefragTest03(void)
     PacketCopyData(p, pkt, sizeof(pkt));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF_NOT(PKT_IS_TCP(p));
+    FAIL_IF_NOT(PacketIsTCP(p));
     FAIL_IF(!(p->flags & PKT_WANTS_FLOW));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt1, sizeof(pkt1));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt2, sizeof(pkt2));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
     PacketRecycle(p);
 
     PacketCopyData(p, pkt3, sizeof(pkt3));
     DecodeIPV4(&tv, &dtv, p, GET_PKT_DATA(p) + ETHERNET_HEADER_LEN,
                GET_PKT_LEN(p) - ETHERNET_HEADER_LEN);
-    FAIL_IF(PKT_IS_TCP(p));
+    FAIL_IF(PacketIsTCP(p));
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
     FAIL_IF_NULL(tp);
@@ -1508,7 +1508,7 @@ static int DecodeIPV4DefragTest03(void)
     FAIL_IF(tp->flow_hash != p->flow_hash);
     FAIL_IF(tp->recursion_level != p->recursion_level);
     FAIL_IF_NOT(PacketIsIPv4(tp));
-    FAIL_IF_NOT(PKT_IS_TCP(tp));
+    FAIL_IF_NOT(PacketIsTCP(tp));
     FAIL_IF(GET_PKT_LEN(tp) != sizeof(tunnel_pkt));
     FAIL_IF(memcmp(GET_PKT_DATA(tp), tunnel_pkt, sizeof(tunnel_pkt)) != 0);
     PacketRecycle(tp);

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -93,11 +93,12 @@ typedef struct IPV4Hdr_
 #define s_ip_addrs                        ip4_hdrun1.ip_addrs
 
 #define IPV4_GET_RAW_VER(ip4h)            (((ip4h)->ip_verhl & 0xf0) >> 4)
-#define IPV4_GET_RAW_HLEN(ip4h)           ((ip4h)->ip_verhl & 0x0f)
+#define IPV4_GET_RAW_HLEN(ip4h)           (uint8_t)(((ip4h)->ip_verhl & (uint8_t)0x0f) << (uint8_t)2)
 #define IPV4_GET_RAW_IPTOS(ip4h)          ((ip4h)->ip_tos)
-#define IPV4_GET_RAW_IPLEN(ip4h)          ((ip4h)->ip_len)
-#define IPV4_GET_RAW_IPID(ip4h)           ((ip4h)->ip_id)
-#define IPV4_GET_RAW_IPOFFSET(ip4h)       ((ip4h)->ip_off)
+#define IPV4_GET_RAW_IPLEN(ip4h)          (SCNtohs((ip4h)->ip_len))
+#define IPV4_GET_RAW_IPID(ip4h)           (SCNtohs((ip4h)->ip_id))
+#define IPV4_GET_RAW_IPOFFSET(ip4h)       SCNtohs((ip4h)->ip_off)
+#define IPV4_GET_RAW_FRAGOFFSET(ip4h)     (IPV4_GET_RAW_IPOFFSET((ip4h)) & 0x1fff)
 #define IPV4_GET_RAW_IPTTL(ip4h)          ((ip4h)->ip_ttl)
 #define IPV4_GET_RAW_IPPROTO(ip4h)        ((ip4h)->ip_proto)
 #define IPV4_GET_RAW_IPSRC(ip4h)          ((ip4h)->s_ip_src)
@@ -108,51 +109,9 @@ typedef struct IPV4Hdr_
 /** return the raw (directly from the header) dst ip as uint32_t */
 #define IPV4_GET_RAW_IPDST_U32(ip4h)      (uint32_t)((ip4h)->s_ip_dst.s_addr)
 
-/* we need to change them as well as get them */
-#define IPV4_SET_RAW_VER(ip4h, value)     ((ip4h)->ip_verhl = (((ip4h)->ip_verhl & 0x0f) | (value << 4)))
-#define IPV4_SET_RAW_HLEN(ip4h, value)    ((ip4h)->ip_verhl = (((ip4h)->ip_verhl & 0xf0) | (value & 0x0f)))
-#define IPV4_SET_RAW_IPTOS(ip4h, value)   ((ip4h)->ip_tos = value)
-#define IPV4_SET_RAW_IPLEN(ip4h, value)   ((ip4h)->ip_len = value)
-#define IPV4_SET_RAW_IPPROTO(ip4h, value) ((ip4h)->ip_proto = value)
-
-/* ONLY call these functions after making sure that:
- * 1. p->ip4h is set
- * 2. p->ip4h is valid (len is correct)
- */
-#define IPV4_GET_VER(p) \
-    IPV4_GET_RAW_VER((p)->ip4h)
-#define IPV4_GET_HLEN(p) ((uint8_t)(IPV4_GET_RAW_HLEN((p)->ip4h) << 2))
-#define IPV4_GET_IPTOS(p) \
-    IPV4_GET_RAW_IPTOS((p)->ip4h)
-#define IPV4_GET_IPLEN(p) \
-    (SCNtohs(IPV4_GET_RAW_IPLEN((p)->ip4h)))
-#define IPV4_GET_IPID(p) \
-    (SCNtohs(IPV4_GET_RAW_IPID((p)->ip4h)))
-/* _IPV4_GET_IPOFFSET: get the content of the offset header field in host order */
-#define _IPV4_GET_IPOFFSET(p) \
-    (SCNtohs(IPV4_GET_RAW_IPOFFSET((p)->ip4h)))
-/* IPV4_GET_IPOFFSET: get the final offset */
-#define IPV4_GET_IPOFFSET(p) \
-    (_IPV4_GET_IPOFFSET(p) & 0x1fff)
-/* IPV4_GET_RF: get the RF flag. Use _IPV4_GET_IPOFFSET to save a SCNtohs call. */
-#define IPV4_GET_RF(p) \
-    (uint8_t)((_IPV4_GET_IPOFFSET((p)) & 0x8000) >> 15)
-/* IPV4_GET_DF: get the DF flag. Use _IPV4_GET_IPOFFSET to save a SCNtohs call. */
-#define IPV4_GET_DF(p) \
-    (uint8_t)((_IPV4_GET_IPOFFSET((p)) & 0x4000) >> 14)
-/* IPV4_GET_MF: get the MF flag. Use _IPV4_GET_IPOFFSET to save a SCNtohs call. */
-#define IPV4_GET_MF(p) \
-    (uint8_t)((_IPV4_GET_IPOFFSET((p)) & 0x2000) >> 13)
-#define IPV4_GET_IPTTL(p) \
-     IPV4_GET_RAW_IPTTL(p->ip4h)
-#define IPV4_GET_IPPROTO(p) \
-    IPV4_GET_RAW_IPPROTO((p)->ip4h)
-
-#define CLEAR_IPV4_PACKET(p)                                                                       \
-    do {                                                                                           \
-        (p)->ip4h = NULL;                                                                          \
-        memset(&p->ip4vars, 0x00, sizeof(p->ip4vars));                                             \
-    } while (0)
+#define IPV4_GET_RAW_FLAG_MF(ip4h) ((IPV4_GET_RAW_IPOFFSET((ip4h)) & 0x2000) != 0)
+#define IPV4_GET_RAW_FLAG_DF(ip4h) ((IPV4_GET_RAW_IPOFFSET((ip4h)) & 0x4000) != 0)
+#define IPV4_GET_RAW_FLAG_RF(ip4h) ((IPV4_GET_RAW_IPOFFSET((ip4h)) & 0x8000) != 0)
 
 #define IPV4_OPT_FLAG_EOL    BIT_U16(1)
 #define IPV4_OPT_FLAG_NOP    BIT_U16(2)

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -588,34 +588,37 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
     }
 #endif /* DEBUG */
 
+    const uint8_t *data = pkt + IPV6_HEADER_LEN;
+    const uint16_t data_len = IPV6_GET_PLEN(p);
+
     /* now process the Ext headers and/or the L4 Layer */
     switch(IPV6_GET_NH(p)) {
         case IPPROTO_TCP:
             IPV6_SET_L4PROTO (p, IPPROTO_TCP);
-            DecodeTCP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeTCP(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_UDP:
             IPV6_SET_L4PROTO (p, IPPROTO_UDP);
-            DecodeUDP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeUDP(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_ICMPV6:
             IPV6_SET_L4PROTO (p, IPPROTO_ICMPV6);
-            DecodeICMPV6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeICMPV6(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_SCTP:
             IPV6_SET_L4PROTO (p, IPPROTO_SCTP);
-            DecodeSCTP(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeSCTP(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_IPIP:
             IPV6_SET_L4PROTO(p, IPPROTO_IPIP);
-            DecodeIPv4inIPv6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeIPv4inIPv6(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_IPV6:
-            DecodeIP6inIP6(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeIP6inIP6(tv, dtv, p, data, data_len);
             return TM_ECODE_OK;
         case IPPROTO_GRE:
             IPV6_SET_L4PROTO(p, IPPROTO_GRE);
-            DecodeGRE(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeGRE(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_FRAGMENT:
         case IPPROTO_HOPOPTS:
@@ -627,7 +630,7 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *
         case IPPROTO_MH:
         case IPPROTO_HIP:
         case IPPROTO_SHIM6:
-            DecodeIPV6ExtHdrs(tv, dtv, p, pkt + IPV6_HEADER_LEN, IPV6_GET_PLEN(p));
+            DecodeIPV6ExtHdrs(tv, dtv, p, data, data_len);
             break;
         case IPPROTO_ICMP:
             ENGINE_SET_EVENT(p,IPV6_WITH_ICMPV4);

--- a/src/decode-ipv6.h
+++ b/src/decode-ipv6.h
@@ -69,31 +69,11 @@ typedef struct IPV6Hdr_
 #define IPV6_SET_RAW_VER(ip6h, value)   ((ip6h)->s_ip6_vfc = (((ip6h)->s_ip6_vfc & 0x0f) | (value << 4)))
 #define IPV6_SET_RAW_NH(ip6h, value)    ((ip6h)->s_ip6_nxt = (value))
 
-#define IPV6_SET_L4PROTO(p,proto)       (p)->ip6vars.l4proto = (proto)
-#define IPV6_SET_EXTHDRS_LEN(p,len)     (p)->ip6vars.exthdrs_len = (len)
+#define IPV6_SET_L4PROTO(p, proto)   (p)->l3.vars.ip6.v.l4proto = (proto)
+#define IPV6_SET_EXTHDRS_LEN(p, len) (p)->l3.vars.ip6.v.exthdrs_len = (len)
 
-
-/* ONLY call these functions after making sure that:
- * 1. p->ip6h is set
- * 2. p->ip6h is valid (len is correct)
- */
-#define IPV6_GET_VER(p) \
-    IPV6_GET_RAW_VER((p)->ip6h)
-#define IPV6_GET_CLASS(p) \
-    IPV6_GET_RAW_CLASS((p)->ip6h)
-#define IPV6_GET_FLOW(p) \
-    IPV6_GET_RAW_FLOW((p)->ip6h)
-#define IPV6_GET_NH(p) \
-    (IPV6_GET_RAW_NH((p)->ip6h))
-#define IPV6_GET_PLEN(p) \
-    IPV6_GET_RAW_PLEN((p)->ip6h)
-#define IPV6_GET_HLIM(p) \
-    (IPV6_GET_RAW_HLIM((p)->ip6h))
-
-#define IPV6_GET_L4PROTO(p) \
-    ((p)->ip6vars.l4proto)
-#define IPV6_GET_EXTHDRS_LEN(p) \
-    ((p)->ip6vars.exthdrs_len)
+#define IPV6_GET_L4PROTO(p)     ((p)->l3.vars.ip6.v.l4proto)
+#define IPV6_GET_EXTHDRS_LEN(p) ((p)->l3.vars.ip6.v.exthdrs_len)
 
 /** \brief get the highest proto/next header field we know */
 //#define IPV6_GET_UPPER_PROTO(p)         (p)->ip6eh.ip6_exthdrs_cnt ?
@@ -108,13 +88,6 @@ typedef struct IPV6Vars_
     uint16_t exthdrs_len;  /**< length of the exthdrs */
 } IPV6Vars;
 
-#define CLEAR_IPV6_PACKET(p) do { \
-    (p)->ip6h = NULL; \
-    (p)->ip6vars.l4proto = 0; \
-    (p)->ip6vars.exthdrs_len = 0; \
-    memset(&(p)->ip6eh, 0x00, sizeof((p)->ip6eh)); \
-} while (0)
-
 /* Fragment header */
 typedef struct IPV6FragHdr_
 {
@@ -124,10 +97,10 @@ typedef struct IPV6FragHdr_
     uint32_t ip6fh_ident;           /* identification */
 } __attribute__((__packed__)) IPV6FragHdr;
 
-#define IPV6_EXTHDR_GET_FH_NH(p)            (p)->ip6eh.fh_nh
-#define IPV6_EXTHDR_GET_FH_OFFSET(p)        (p)->ip6eh.fh_offset
-#define IPV6_EXTHDR_GET_FH_FLAG(p)          (p)->ip6eh.fh_more_frags_set
-#define IPV6_EXTHDR_GET_FH_ID(p)            (p)->ip6eh.fh_id
+#define IPV6_EXTHDR_GET_FH_NH(p)     (p)->l3.vars.ip6.eh.fh_nh
+#define IPV6_EXTHDR_GET_FH_OFFSET(p) (p)->l3.vars.ip6.eh.fh_offset
+#define IPV6_EXTHDR_GET_FH_FLAG(p)   (p)->l3.vars.ip6.eh.fh_more_frags_set
+#define IPV6_EXTHDR_GET_FH_ID(p)     (p)->l3.vars.ip6.eh.fh_id
 
 /* rfc 1826 */
 typedef struct IPV6AuthHdr_
@@ -235,10 +208,10 @@ typedef struct IPV6ExtHdrs_
 
 } IPV6ExtHdrs;
 
-#define IPV6_EXTHDR_SET_FH(p)       (p)->ip6eh.fh_set = true
-#define IPV6_EXTHDR_ISSET_FH(p)     (p)->ip6eh.fh_set
-#define IPV6_EXTHDR_SET_RH(p)       (p)->ip6eh.rh_set = true
-#define IPV6_EXTHDR_ISSET_RH(p)     (p)->ip6eh.rh_set
+#define IPV6_EXTHDR_SET_FH(p)   (p)->l3.vars.ip6.eh.fh_set = true
+#define IPV6_EXTHDR_ISSET_FH(p) (p)->l3.vars.ip6.eh.fh_set
+#define IPV6_EXTHDR_SET_RH(p)   (p)->l3.vars.ip6.eh.rh_set = true
+#define IPV6_EXTHDR_ISSET_RH(p) (p)->l3.vars.ip6.eh.rh_set
 
 void DecodeIPV6RegisterTests(void);
 

--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -134,17 +134,19 @@ int DecodePPPOESession(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
 
-    p->pppoesh = (PPPOESessionHdr *)pkt;
+    PPPOESessionHdr *pppoesh = (PPPOESessionHdr *)pkt;
 
-    SCLogDebug("PPPOE VERSION %" PRIu32 " TYPE %" PRIu32 " CODE %" PRIu32 " SESSIONID %" PRIu32 " LENGTH %" PRIu32 "",
-           PPPOE_SESSION_GET_VERSION(p->pppoesh),  PPPOE_SESSION_GET_TYPE(p->pppoesh),  p->pppoesh->pppoe_code,  SCNtohs(p->pppoesh->session_id),  SCNtohs(p->pppoesh->pppoe_length));
+    SCLogDebug("PPPOE VERSION %" PRIu32 " TYPE %" PRIu32 " CODE %" PRIu32 " SESSIONID %" PRIu32
+               " LENGTH %" PRIu32 "",
+            PPPOE_SESSION_GET_VERSION(pppoesh), PPPOE_SESSION_GET_TYPE(pppoesh),
+            pppoesh->pppoe_code, SCNtohs(pppoesh->session_id), SCNtohs(pppoesh->pppoe_length));
 
     /* can't use DecodePPP() here because we only get a single 2-byte word to indicate protocol instead of the full PPP header */
-    if (SCNtohs(p->pppoesh->pppoe_length) > 0) {
+    if (SCNtohs(pppoesh->pppoe_length) > 0) {
         /* decode contained PPP packet */
 
         uint8_t pppoesh_len;
-        uint16_t ppp_protocol = SCNtohs(p->pppoesh->protocol);
+        uint16_t ppp_protocol = SCNtohs(pppoesh->protocol);
 
         /* According to RFC1661-2, if the least significant bit of the most significant octet is
          * set, we're dealing with a single-octet protocol field */

--- a/src/decode-pppoe.c
+++ b/src/decode-pppoe.c
@@ -59,28 +59,27 @@ int DecodePPPOEDiscovery(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         return TM_ECODE_FAILED;
     }
 
-    p->pppoedh = (PPPOEDiscoveryHdr *)pkt;
+    PPPOEDiscoveryHdr *pppoedh = (PPPOEDiscoveryHdr *)pkt;
 
     /* parse the PPPOE code */
-    switch (p->pppoedh->pppoe_code)
-    {
-        case  PPPOE_CODE_PADI:
+    switch (pppoedh->pppoe_code) {
+        case PPPOE_CODE_PADI:
             break;
-        case  PPPOE_CODE_PADO:
+        case PPPOE_CODE_PADO:
             break;
-        case  PPPOE_CODE_PADR:
+        case PPPOE_CODE_PADR:
             break;
         case PPPOE_CODE_PADS:
             break;
         case PPPOE_CODE_PADT:
             break;
         default:
-            SCLogDebug("unknown PPPOE code: 0x%0"PRIX8"", p->pppoedh->pppoe_code);
+            SCLogDebug("unknown PPPOE code: 0x%0" PRIX8 "", pppoedh->pppoe_code);
             ENGINE_SET_INVALID_EVENT(p, PPPOE_WRONG_CODE);
             return TM_ECODE_OK;
     }
 
-    uint32_t pppoe_length = SCNtohs(p->pppoedh->pppoe_length);
+    uint32_t pppoe_length = SCNtohs(pppoedh->pppoe_length);
     uint32_t packet_length = len - PPPOE_DISCOVERY_HEADER_MIN_LEN ;
 
     SCLogDebug("pppoe_length %"PRIu32", packet_length %"PRIu32"",
@@ -318,7 +317,6 @@ static int DecodePPPOEtest02 (void)
  */
 static int DecodePPPOEtest03 (void)
 {
-
     /* example PADO packet taken from RFC2516 */
     uint8_t raw_pppoe[] = {
         0x11, 0x07, 0x00, 0x00, 0x00, 0x20, 0x01, 0x01,
@@ -336,8 +334,8 @@ static int DecodePPPOEtest03 (void)
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
 
-    DecodePPPOEDiscovery(&tv, &dtv, p, raw_pppoe, sizeof(raw_pppoe));
-    FAIL_IF_NULL(p->pppoedh);
+    int r = DecodePPPOEDiscovery(&tv, &dtv, p, raw_pppoe, sizeof(raw_pppoe));
+    FAIL_IF_NOT(r == TM_ECODE_OK);
 
     SCFree(p);
     PASS;

--- a/src/decode-raw.c
+++ b/src/decode-raw.c
@@ -113,12 +113,7 @@ static int DecodeRawTest01 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeRaw(&tv, &dtv, p, raw_ip, GET_PKT_LEN(p));
-    if (p->ip6h == NULL) {
-        printf("expected a valid ipv6 header but it was NULL: ");
-        FlowShutdown();
-        SCFree(p);
-        return 0;
-    }
+    FAIL_IF_NOT(PacketIsIPv6(p));
 
     PacketRecycle(p);
     FlowShutdown();
@@ -159,13 +154,7 @@ static int DecodeRawTest02 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeRaw(&tv, &dtv, p, raw_ip, GET_PKT_LEN(p));
-    if (p->ip4h == NULL) {
-        printf("expected a valid ipv4 header but it was NULL: ");
-        PacketRecycle(p);
-        FlowShutdown();
-        SCFree(p);
-        return 0;
-    }
+    FAIL_IF_NOT(PacketIsIPv4(p));
 
     PacketRecycle(p);
     FlowShutdown();

--- a/src/decode-sctp.h
+++ b/src/decode-sctp.h
@@ -27,13 +27,6 @@
 /** size of the packet header without any chunk headers */
 #define SCTP_HEADER_LEN                       12
 
-/* XXX RAW* needs to be really 'raw', so no SCNtohs there */
-#define SCTP_GET_RAW_SRC_PORT(sctph)          SCNtohs((sctph)->sh_sport)
-#define SCTP_GET_RAW_DST_PORT(sctph)          SCNtohs((sctph)->sh_dport)
-
-#define SCTP_GET_SRC_PORT(p)                  SCTP_GET_RAW_SRC_PORT(p->sctph)
-#define SCTP_GET_DST_PORT(p)                  SCTP_GET_RAW_DST_PORT(p->sctph)
-
 typedef struct SCTPHdr_
 {
     uint16_t sh_sport;     /* source port */
@@ -41,10 +34,6 @@ typedef struct SCTPHdr_
     uint32_t sh_vtag;      /* verification tag, defined per flow */
     uint32_t sh_sum;       /* checksum, computed via crc32 */
 } __attribute__((__packed__)) SCTPHdr;
-
-#define CLEAR_SCTP_PACKET(p) { \
-    (p)->sctph = NULL; \
-} while (0)
 
 void DecodeSCTPRegisterTests(void);
 

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -401,7 +401,7 @@ static int TCPGetWscaleTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-    FAIL_IF_NOT(PKT_IS_TCP(p));
+    FAIL_IF_NOT(PacketIsTCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
     FAIL_IF(wscale != 2);
@@ -436,7 +436,7 @@ static int TCPGetWscaleTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-    FAIL_IF_NOT(PKT_IS_TCP(p));
+    FAIL_IF_NOT(PacketIsTCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
     FAIL_IF(wscale != 0);
@@ -469,7 +469,7 @@ static int TCPGetWscaleTest03(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-    FAIL_IF_NOT(PKT_IS_TCP(p));
+    FAIL_IF_NOT(PacketIsTCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
     FAIL_IF(wscale != 0);

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -111,10 +111,10 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     if (olen != TCP_OPT_SACKOK_LEN) {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {
-                        if (p->tcpvars.sackok.type != 0) {
+                        if (TCP_GET_SACKOK(p)) {
                             ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                         } else {
-                            SET_OPTS(p->tcpvars.sackok, tcp_opts[tcp_opt_cnt]);
+                            p->tcpvars.sack_ok = true;
                         }
                     }
                     break;
@@ -266,11 +266,12 @@ int DecodeTCP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         StatsIncr(tv, dtv->counter_tcp_rst);
     }
 #ifdef DEBUG
-    SCLogDebug("TCP sp: %" PRIu32 " -> dp: %" PRIu32 " - HLEN: %" PRIu32 " LEN: %" PRIu32 " %s%s%s%s%s%s",
-        GET_TCP_SRC_PORT(p), GET_TCP_DST_PORT(p), TCP_GET_HLEN(p), len,
-        TCP_HAS_SACKOK(p) ? "SACKOK " : "", TCP_HAS_SACK(p) ? "SACK " : "",
-        TCP_HAS_WSCALE(p) ? "WS " : "", TCP_HAS_TS(p) ? "TS " : "",
-        TCP_HAS_MSS(p) ? "MSS " : "", TCP_HAS_TFO(p) ? "TFO " : "");
+    SCLogDebug("TCP sp: %" PRIu32 " -> dp: %" PRIu32 " - HLEN: %" PRIu32 " LEN: %" PRIu32
+               " %s%s%s%s%s%s",
+            GET_TCP_SRC_PORT(p), GET_TCP_DST_PORT(p), TCP_GET_HLEN(p), len,
+            TCP_GET_SACKOK(p) ? "SACKOK " : "", TCP_HAS_SACK(p) ? "SACK " : "",
+            TCP_HAS_WSCALE(p) ? "WS " : "", TCP_HAS_TS(p) ? "TS " : "",
+            TCP_HAS_MSS(p) ? "MSS " : "", TCP_HAS_TFO(p) ? "TFO " : "");
 #endif
 
     FlowSetupPacket(p);

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -394,8 +394,7 @@ static int TCPGetWscaleTest01(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->ip4h = &ip4h;
-
+    UTHSetIPV4Hdr(p, &ip4h);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
@@ -441,7 +440,7 @@ static int TCPGetWscaleTest02(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
@@ -486,7 +485,7 @@ static int TCPGetWscaleTest03(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
@@ -535,7 +534,7 @@ static int TCPGetSackTest01(void)
 
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -156,10 +156,10 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                                                !(((olen - 2) & 0x1) == 0))) {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {
-                        if (p->tcpvars.tfo.type != 0) {
+                        if (p->tcpvars.tfo_set) {
                             ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                         } else {
-                            SET_OPTS(p->tcpvars.tfo, tcp_opts[tcp_opt_cnt]);
+                            p->tcpvars.tfo_set = true;
                         }
                     }
                     break;
@@ -170,11 +170,10 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     if (olen == 4 || olen == 12) {
                         uint16_t magic = SCNtohs(*(uint16_t *)tcp_opts[tcp_opt_cnt].data);
                         if (magic == 0xf989) {
-                            if (p->tcpvars.tfo.type != 0) {
+                            if (p->tcpvars.tfo_set) {
                                 ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                             } else {
-                                SET_OPTS(p->tcpvars.tfo, tcp_opts[tcp_opt_cnt]);
-                                p->tcpvars.tfo.type = TCP_OPT_TFO; // treat as regular TFO
+                                p->tcpvars.tfo_set = true;
                             }
                         }
                     } else {

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -89,10 +89,16 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     if (olen != TCP_OPT_WS_LEN) {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {
-                        if (p->tcpvars.ws.type != 0) {
+                        if (p->tcpvars.wscale_set != 0) {
                             ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                         } else {
-                            SET_OPTS(p->tcpvars.ws, tcp_opts[tcp_opt_cnt]);
+                            p->tcpvars.wscale_set = 1;
+                            const uint8_t wscale = *(tcp_opts[tcp_opt_cnt].data);
+                            if (wscale <= TCP_WSCALE_MAX) {
+                                p->tcpvars.wscale = wscale;
+                            } else {
+                                p->tcpvars.wscale = 0;
+                            }
                         }
                     }
                     break;

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -381,19 +381,16 @@ static int TCPV6CalculateInvalidChecksumtest04(void)
 /** \test Get the wscale of 2 */
 static int TCPGetWscaleTest01(void)
 {
-    int retval = 0;
     static uint8_t raw_tcp[] = {0xda, 0xc1, 0x00, 0x50, 0xb6, 0x21, 0x7f, 0x58,
                                 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, 0x16, 0xd0,
                                 0x8a, 0xaf, 0x00, 0x00, 0x02, 0x04, 0x05, 0xb4,
                                 0x04, 0x02, 0x08, 0x0a, 0x00, 0x62, 0x88, 0x28,
                                 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x03, 0x02};
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     IPV4Hdr ip4h;
     ThreadVars tv;
     DecodeThreadVars dtv;
-
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -404,38 +401,27 @@ static int TCPGetWscaleTest01(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-
-    if (p->tcph == NULL) {
-        printf("tcp packet decode failed: ");
-        goto end;
-    }
+    FAIL_IF_NOT(PKT_IS_TCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
-    if (wscale != 2) {
-        printf("wscale %"PRIu8", expected 2: ", wscale);
-        goto end;
-    }
+    FAIL_IF(wscale != 2);
 
-    retval = 1;
-end:
     PacketRecycle(p);
     FlowShutdown();
     SCFree(p);
-    return retval;
+    PASS;
 }
 
 /** \test Get the wscale of 15, so see if return 0 properly */
 static int TCPGetWscaleTest02(void)
 {
-    int retval = 0;
     static uint8_t raw_tcp[] = {0xda, 0xc1, 0x00, 0x50, 0xb6, 0x21, 0x7f, 0x58,
                                 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, 0x16, 0xd0,
                                 0x8a, 0xaf, 0x00, 0x00, 0x02, 0x04, 0x05, 0xb4,
                                 0x04, 0x02, 0x08, 0x0a, 0x00, 0x62, 0x88, 0x28,
                                 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x03, 0x0f};
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     IPV4Hdr ip4h;
     ThreadVars tv;
     DecodeThreadVars dtv;
@@ -450,41 +436,29 @@ static int TCPGetWscaleTest02(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-
-    if (p->tcph == NULL) {
-        printf("tcp packet decode failed: ");
-        goto end;
-    }
+    FAIL_IF_NOT(PKT_IS_TCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
-    if (wscale != 0) {
-        printf("wscale %"PRIu8", expected 0: ", wscale);
-        goto end;
-    }
+    FAIL_IF(wscale != 0);
 
-    retval = 1;
-end:
     PacketRecycle(p);
     FlowShutdown();
     SCFree(p);
-    return retval;
+    PASS;
 }
 
 /** \test Get the wscale, but it's missing, so see if return 0 properly */
 static int TCPGetWscaleTest03(void)
 {
-    int retval = 0;
     static uint8_t raw_tcp[] = {0xda, 0xc1, 0x00, 0x50, 0xb6, 0x21, 0x7f, 0x59,
                                 0xdd, 0xa3, 0x6f, 0xf8, 0x80, 0x10, 0x05, 0xb4,
                                 0x7c, 0x70, 0x00, 0x00, 0x01, 0x01, 0x08, 0x0a,
                                 0x00, 0x62, 0x88, 0x9e, 0x00, 0x00, 0x00, 0x00};
     Packet *p = PacketGetFromAlloc();
-    if (unlikely(p == NULL))
-        return 0;
+    FAIL_IF_NULL(p);
     IPV4Hdr ip4h;
     ThreadVars tv;
     DecodeThreadVars dtv;
-
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&dtv, 0, sizeof(DecodeThreadVars));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
@@ -495,24 +469,15 @@ static int TCPGetWscaleTest03(void)
 
     FlowInitConfig(FLOW_QUIET);
     DecodeTCP(&tv, &dtv, p, raw_tcp, sizeof(raw_tcp));
-
-    if (p->tcph == NULL) {
-        printf("tcp packet decode failed: ");
-        goto end;
-    }
+    FAIL_IF_NOT(PKT_IS_TCP(p));
 
     uint8_t wscale = TCP_GET_WSCALE(p);
-    if (wscale != 0) {
-        printf("wscale %"PRIu8", expected 0: ", wscale);
-        goto end;
-    }
+    FAIL_IF(wscale != 0);
 
-    retval = 1;
-end:
     PacketRecycle(p);
     FlowShutdown();
     SCFree(p);
-    return retval;
+    PASS;
 }
 
 static int TCPGetSackTest01(void)

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -38,11 +38,6 @@
 #include "util-debug.h"
 #include "util-optimize.h"
 #include "flow.h"
-
-#define SET_OPTS(dst, src) \
-    (dst).type = (src).type; \
-    (dst).len  = (src).len; \
-    (dst).data = (src).data
 
 static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
 {

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -100,10 +100,11 @@ static void DecodeTCPOptions(Packet *p, const uint8_t *pkt, uint16_t pktlen)
                     if (olen != TCP_OPT_MSS_LEN) {
                         ENGINE_SET_EVENT(p,TCP_OPT_INVALID_LEN);
                     } else {
-                        if (p->tcpvars.mss.type != 0) {
+                        if (p->tcpvars.mss_set) {
                             ENGINE_SET_EVENT(p,TCP_OPT_DUPLICATE);
                         } else {
-                            SET_OPTS(p->tcpvars.mss, tcp_opts[tcp_opt_cnt]);
+                            p->tcpvars.mss_set = true;
+                            p->tcpvars.mss = SCNtohs(*(uint16_t *)(tcp_opts[tcp_opt_cnt].data));
                         }
                     }
                     break;

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -160,10 +160,10 @@ typedef struct TCPVars_
     bool tfo_set;
     uint8_t wscale_set : 1;
     uint8_t wscale : 4;
-    uint16_t mss;       /**< MSS value in host byte order */
+    uint16_t mss; /**< MSS value in host byte order */
+    uint16_t stream_pkt_flags;
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
-    uint16_t stream_pkt_flags;
     TCPOpt sack;
 } TCPVars;
 

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -70,6 +70,7 @@
 #define TCP_WSCALE_MAX                       14
 
 #define TCP_GET_RAW_OFFSET(tcph)             (((tcph)->th_offx2 & 0xf0) >> 4)
+#define TCP_GET_RAW_HLEN(tcph)               ((uint8_t)(TCP_GET_RAW_OFFSET((tcph)) << 2))
 #define TCP_GET_RAW_X2(tcph)                 (unsigned char)((tcph)->th_offx2 & 0x0f)
 #define TCP_GET_RAW_SRC_PORT(tcph)           SCNtohs((tcph)->th_sport)
 #define TCP_GET_RAW_DST_PORT(tcph)           SCNtohs((tcph)->th_dport)
@@ -85,24 +86,24 @@
 #define TCP_GET_RAW_SUM(tcph)                SCNtohs((tcph)->th_sum)
 
 /** macro for getting the first timestamp from the packet in host order */
-#define TCP_GET_TSVAL(p)                    ((p)->tcpvars.ts_val)
+#define TCP_GET_TSVAL(p) ((p)->l4.vars.tcp.ts_val)
 
 /** macro for getting the second timestamp from the packet in host order. */
-#define TCP_GET_TSECR(p)                    ((p)->tcpvars.ts_ecr)
+#define TCP_GET_TSECR(p) ((p)->l4.vars.tcp.ts_ecr)
 
-#define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.wscale_set)
-#define TCP_HAS_SACK(p)                     (p)->tcpvars.sack_set
-#define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
-#define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss_set)
-#define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo_set)
+#define TCP_HAS_WSCALE(p) ((p)->l4.vars.tcp.wscale_set)
+#define TCP_HAS_SACK(p)   (p)->l4.vars.tcp.sack_set
+#define TCP_HAS_TS(p)     ((p)->l4.vars.tcp.ts_set)
+#define TCP_HAS_MSS(p)    ((p)->l4.vars.tcp.mss_set)
+#define TCP_HAS_TFO(p)    ((p)->l4.vars.tcp.tfo_set)
 
 /** macro for getting the wscale from the packet. */
-#define TCP_GET_WSCALE(p) (p)->tcpvars.wscale
+#define TCP_GET_WSCALE(p) (p)->l4.vars.tcp.wscale
 
-#define TCP_GET_SACKOK(p)                    (p)->tcpvars.sack_ok
-#define TCP_GET_SACK_PTR(p)                  ((uint8_t *)(p)->tcph) + (p)->tcpvars.sack_offset
-#define TCP_GET_SACK_CNT(p)                  (p)->tcpvars.sack_cnt
-#define TCP_GET_MSS(p)                       (p)->tcpvars.mss
+#define TCP_GET_SACKOK(p)         (p)->l4.vars.tcp.sack_ok
+#define TCP_GET_SACK_PTR(p, tcph) ((uint8_t *)(tcph)) + (p)->l4.vars.tcp.sack_offset
+#define TCP_GET_SACK_CNT(p)       (p)->l4.vars.tcp.sack_cnt
+#define TCP_GET_MSS(p)            (p)->l4.vars.tcp.mss
 
 #define TCP_GET_OFFSET(p)                    TCP_GET_RAW_OFFSET((p)->tcph)
 #define TCP_GET_X2(p)                        TCP_GET_RAW_X2((p)->tcph)
@@ -115,6 +116,15 @@
 #define TCP_GET_URG_POINTER(p)               TCP_GET_RAW_URG_POINTER((p)->tcph)
 #define TCP_GET_SUM(p)                       TCP_GET_RAW_SUM((p)->tcph)
 #define TCP_GET_FLAGS(p)                     (p)->tcph->th_flags
+
+#define TCP_ISSET_FLAG_RAW_FIN(p)  ((tcph)->th_flags & TH_FIN)
+#define TCP_ISSET_FLAG_RAW_SYN(p)  ((tcph)->th_flags & TH_SYN)
+#define TCP_ISSET_FLAG_RAW_RST(p)  ((tcph)->th_flags & TH_RST)
+#define TCP_ISSET_FLAG_RAW_PUSH(p) ((tcph)->th_flags & TH_PUSH)
+#define TCP_ISSET_FLAG_RAW_ACK(p)  ((tcph)->th_flags & TH_ACK)
+#define TCP_ISSET_FLAG_RAW_URG(p)  ((tcph)->th_flags & TH_URG)
+#define TCP_ISSET_FLAG_RAW_RES2(p) ((tcph)->th_flags & TH_RES2)
+#define TCP_ISSET_FLAG_RAW_RES1(p) ((tcph)->th_flags & TH_RES1)
 
 #define TCP_ISSET_FLAG_FIN(p)                ((p)->tcph->th_flags & TH_FIN)
 #define TCP_ISSET_FLAG_SYN(p)                ((p)->tcph->th_flags & TH_SYN)
@@ -168,12 +178,6 @@ typedef struct TCPVars_
     uint8_t sack_cnt;     /**< number of sack records */
     uint16_t sack_offset; /**< offset relative to tcp header start */
 } TCPVars;
-
-#define CLEAR_TCP_PACKET(p)                                                                        \
-    {                                                                                              \
-        PACKET_CLEAR_L4VARS((p));                                                                  \
-        (p)->tcph = NULL;                                                                          \
-    }
 
 void DecodeTCPRegisterTests(void);
 

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -94,7 +94,7 @@
 #define TCP_HAS_SACK(p)                     ((p)->tcpvars.sack.type == TCP_OPT_SACK)
 #define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
 #define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss_set)
-#define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo.type == TCP_OPT_TFO)
+#define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo_set)
 
 /** macro for getting the wscale from the packet. */
 #define TCP_GET_WSCALE(p)                    (TCP_HAS_WSCALE((p)) ? \
@@ -159,13 +159,13 @@ typedef struct TCPVars_
     bool ts_set;
     bool sack_ok;
     bool mss_set;
+    bool tfo_set;
     uint16_t mss;       /**< MSS value in host byte order */
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
     uint16_t stream_pkt_flags;
     TCPOpt sack;
     TCPOpt ws;
-    TCPOpt tfo;         /* tcp fast open */
 } TCPVars;
 
 #define CLEAR_TCP_PACKET(p)                                                                        \

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -92,7 +92,6 @@
 
 #define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.ws.type == TCP_OPT_WS)
 #define TCP_HAS_SACK(p)                     ((p)->tcpvars.sack.type == TCP_OPT_SACK)
-#define TCP_HAS_SACKOK(p)                   ((p)->tcpvars.sackok.type == TCP_OPT_SACKOK)
 #define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
 #define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss.type == TCP_OPT_MSS)
 #define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo.type == TCP_OPT_TFO)
@@ -102,7 +101,7 @@
                                                 (((*(uint8_t *)(p)->tcpvars.ws.data) <= TCP_WSCALE_MAX) ? \
                                                   (*(uint8_t *)((p)->tcpvars.ws.data)) : 0) : 0)
 
-#define TCP_GET_SACKOK(p)                    (TCP_HAS_SACKOK((p)) ? 1 : 0)
+#define TCP_GET_SACKOK(p)                    (p)->tcpvars.sack_ok
 #define TCP_GET_SACK_PTR(p)                  TCP_HAS_SACK((p)) ? (p)->tcpvars.sack.data : NULL
 #define TCP_GET_SACK_CNT(p)                  (TCP_HAS_SACK((p)) ? (((p)->tcpvars.sack.len - 2) / 8) : 0)
 #define TCP_GET_MSS(p)                       SCNtohs(*(uint16_t *)((p)->tcpvars.mss.data))
@@ -158,11 +157,11 @@ typedef struct TCPVars_
     bool md5_option_present;
     bool ao_option_present;
     bool ts_set;
+    bool sack_ok;
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
     uint16_t stream_pkt_flags;
     TCPOpt sack;
-    TCPOpt sackok;
     TCPOpt ws;
     TCPOpt mss;
     TCPOpt tfo;         /* tcp fast open */

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -91,7 +91,7 @@
 #define TCP_GET_TSECR(p)                    ((p)->tcpvars.ts_ecr)
 
 #define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.wscale_set)
-#define TCP_HAS_SACK(p)                     ((p)->tcpvars.sack.type == TCP_OPT_SACK)
+#define TCP_HAS_SACK(p)                     (p)->tcpvars.sack_set
 #define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
 #define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss_set)
 #define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo_set)
@@ -100,8 +100,8 @@
 #define TCP_GET_WSCALE(p) (p)->tcpvars.wscale
 
 #define TCP_GET_SACKOK(p)                    (p)->tcpvars.sack_ok
-#define TCP_GET_SACK_PTR(p)                  TCP_HAS_SACK((p)) ? (p)->tcpvars.sack.data : NULL
-#define TCP_GET_SACK_CNT(p)                  (TCP_HAS_SACK((p)) ? (((p)->tcpvars.sack.len - 2) / 8) : 0)
+#define TCP_GET_SACK_PTR(p)                  ((uint8_t *)(p)->tcph) + (p)->tcpvars.sack_offset
+#define TCP_GET_SACK_CNT(p)                  (p)->tcpvars.sack_cnt
 #define TCP_GET_MSS(p)                       (p)->tcpvars.mss
 
 #define TCP_GET_OFFSET(p)                    TCP_GET_RAW_OFFSET((p)->tcph)
@@ -164,7 +164,9 @@ typedef struct TCPVars_
     uint16_t stream_pkt_flags;
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
-    TCPOpt sack;
+    bool sack_set;
+    uint8_t sack_cnt;     /**< number of sack records */
+    uint16_t sack_offset; /**< offset relative to tcp header start */
 } TCPVars;
 
 #define CLEAR_TCP_PACKET(p)                                                                        \

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -93,7 +93,7 @@
 #define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.ws.type == TCP_OPT_WS)
 #define TCP_HAS_SACK(p)                     ((p)->tcpvars.sack.type == TCP_OPT_SACK)
 #define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
-#define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss.type == TCP_OPT_MSS)
+#define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss_set)
 #define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo.type == TCP_OPT_TFO)
 
 /** macro for getting the wscale from the packet. */
@@ -104,7 +104,7 @@
 #define TCP_GET_SACKOK(p)                    (p)->tcpvars.sack_ok
 #define TCP_GET_SACK_PTR(p)                  TCP_HAS_SACK((p)) ? (p)->tcpvars.sack.data : NULL
 #define TCP_GET_SACK_CNT(p)                  (TCP_HAS_SACK((p)) ? (((p)->tcpvars.sack.len - 2) / 8) : 0)
-#define TCP_GET_MSS(p)                       SCNtohs(*(uint16_t *)((p)->tcpvars.mss.data))
+#define TCP_GET_MSS(p)                       (p)->tcpvars.mss
 
 #define TCP_GET_OFFSET(p)                    TCP_GET_RAW_OFFSET((p)->tcph)
 #define TCP_GET_X2(p)                        TCP_GET_RAW_X2((p)->tcph)
@@ -158,12 +158,13 @@ typedef struct TCPVars_
     bool ao_option_present;
     bool ts_set;
     bool sack_ok;
+    bool mss_set;
+    uint16_t mss;       /**< MSS value in host byte order */
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
     uint16_t stream_pkt_flags;
     TCPOpt sack;
     TCPOpt ws;
-    TCPOpt mss;
     TCPOpt tfo;         /* tcp fast open */
 } TCPVars;
 

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -162,20 +162,20 @@ typedef struct TCPHdr_
 typedef struct TCPVars_
 {
     /* commonly used and needed opts */
-    bool md5_option_present;
-    bool ao_option_present;
-    bool ts_set;
-    bool sack_ok;
-    bool mss_set;
-    bool tfo_set;
+    uint8_t md5_option_present : 1;
+    uint8_t ao_option_present : 1;
+    uint8_t ts_set : 1;
+    uint8_t sack_ok : 1;
+    uint8_t mss_set : 1;
+    uint8_t tfo_set : 1;
     uint8_t wscale_set : 1;
-    uint8_t wscale : 4;
+    uint8_t sack_set : 1;
+    uint8_t wscale;
+    uint8_t sack_cnt; /**< number of sack records */
     uint16_t mss; /**< MSS value in host byte order */
     uint16_t stream_pkt_flags;
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
-    bool sack_set;
-    uint8_t sack_cnt;     /**< number of sack records */
     uint16_t sack_offset; /**< offset relative to tcp header start */
 } TCPVars;
 

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -90,16 +90,14 @@
 /** macro for getting the second timestamp from the packet in host order. */
 #define TCP_GET_TSECR(p)                    ((p)->tcpvars.ts_ecr)
 
-#define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.ws.type == TCP_OPT_WS)
+#define TCP_HAS_WSCALE(p)                   ((p)->tcpvars.wscale_set)
 #define TCP_HAS_SACK(p)                     ((p)->tcpvars.sack.type == TCP_OPT_SACK)
 #define TCP_HAS_TS(p)                       ((p)->tcpvars.ts_set)
 #define TCP_HAS_MSS(p)                      ((p)->tcpvars.mss_set)
 #define TCP_HAS_TFO(p)                      ((p)->tcpvars.tfo_set)
 
 /** macro for getting the wscale from the packet. */
-#define TCP_GET_WSCALE(p)                    (TCP_HAS_WSCALE((p)) ? \
-                                                (((*(uint8_t *)(p)->tcpvars.ws.data) <= TCP_WSCALE_MAX) ? \
-                                                  (*(uint8_t *)((p)->tcpvars.ws.data)) : 0) : 0)
+#define TCP_GET_WSCALE(p) (p)->tcpvars.wscale
 
 #define TCP_GET_SACKOK(p)                    (p)->tcpvars.sack_ok
 #define TCP_GET_SACK_PTR(p)                  TCP_HAS_SACK((p)) ? (p)->tcpvars.sack.data : NULL
@@ -160,12 +158,13 @@ typedef struct TCPVars_
     bool sack_ok;
     bool mss_set;
     bool tfo_set;
+    uint8_t wscale_set : 1;
+    uint8_t wscale : 4;
     uint16_t mss;       /**< MSS value in host byte order */
     uint32_t ts_val;    /* host-order */
     uint32_t ts_ecr;    /* host-order */
     uint16_t stream_pkt_flags;
     TCPOpt sack;
-    TCPOpt ws;
 } TCPVars;
 
 #define CLEAR_TCP_PACKET(p)                                                                        \

--- a/src/decode-udp.h
+++ b/src/decode-udp.h
@@ -46,11 +46,6 @@ typedef struct UDPHdr_
 	uint16_t uh_sum;    /* checksum */
 } UDPHdr;
 
-#define CLEAR_UDP_PACKET(p)                                                                        \
-    do {                                                                                           \
-        (p)->udph = NULL;                                                                          \
-    } while (0)
-
 void DecodeUDPV4RegisterTests(void);
 
 /** ------ Inline function ------ */

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -218,11 +218,11 @@ static int DecodeVXLANtest01 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeUDP(&tv, &dtv, p, raw_vxlan, sizeof(raw_vxlan));
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF_NOT(PKT_IS_UDP(tp));
+    FAIL_IF_NOT(PacketIsUDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -257,7 +257,7 @@ static int DecodeVXLANtest02 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeUDP(&tv, &dtv, p, raw_vxlan, sizeof(raw_vxlan));
-    FAIL_IF_NOT(PKT_IS_UDP(p));
+    FAIL_IF_NOT(PacketIsUDP(p));
     FAIL_IF(tv.decode_pq.top != NULL);
 
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S); /* reset */

--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -218,11 +218,11 @@ static int DecodeVXLANtest01 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeUDP(&tv, &dtv, p, raw_vxlan, sizeof(raw_vxlan));
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top == NULL);
 
     Packet *tp = PacketDequeueNoLock(&tv.decode_pq);
-    FAIL_IF(tp->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(tp));
     FAIL_IF_NOT(tp->sp == 53);
 
     FlowShutdown();
@@ -257,7 +257,7 @@ static int DecodeVXLANtest02 (void)
     FlowInitConfig(FLOW_QUIET);
 
     DecodeUDP(&tv, &dtv, p, raw_vxlan, sizeof(raw_vxlan));
-    FAIL_IF(p->udph == NULL);
+    FAIL_IF_NOT(PKT_IS_UDP(p));
     FAIL_IF(tv.decode_pq.top != NULL);
 
     DecodeVXLANConfigPorts(VXLAN_DEFAULT_PORT_S); /* reset */

--- a/src/decode.h
+++ b/src/decode.h
@@ -759,6 +759,11 @@ static inline void PacketClearL4(Packet *p)
     memset(&p->l4, 0, sizeof(p->l4));
 }
 
+static inline bool PacketIsTCP(const Packet *p)
+{
+    return PKT_IS_TCP(p);
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -439,6 +439,7 @@ struct PacketL3 {
 
 enum PacketL4Types {
     PACKET_L4_UNKNOWN = 0,
+    PACKET_L4_TCP,
     PACKET_L4_UDP,
     PACKET_L4_ICMPV4,
     PACKET_L4_ICMPV6,
@@ -452,6 +453,7 @@ struct PacketL4 {
     bool csum_set;
     uint16_t csum;
     union L4Hdrs {
+        TCPHdr *tcph;
         UDPHdr *udph;
         ICMPV4Hdr *icmpv4h;
         ICMPV6Hdr *icmpv6h;
@@ -460,6 +462,7 @@ struct PacketL4 {
         ESPHdr *esph;
     } hdrs;
     union L4Vars {
+        TCPVars tcp;
         ICMPV4Vars icmpv4;
         ICMPV6Vars icmpv6;
     } vars;
@@ -585,14 +588,6 @@ typedef struct Packet_
     struct PacketL2 l2;
     struct PacketL3 l3;
     struct PacketL4 l4;
-
-    /* Can only be one of TCP, UDP, ICMP at any given time */
-    union {
-        TCPVars tcpvars;
-    } l4vars;
-#define tcpvars l4vars.tcpvars
-
-    TCPHdr *tcph;
 
     /* ptr to the payload of the packet
      * with it's length. */
@@ -739,11 +734,6 @@ static inline uint8_t PacketGetIPv4IPProto(const Packet *p)
     return 0;
 }
 
-static inline bool PacketIsIPv6(const Packet *p)
-{
-    return p->l3.type == PACKET_L3_IPV6;
-}
-
 static inline const IPV6Hdr *PacketGetIPv6(const Packet *p)
 {
     DEBUG_VALIDATE_BUG_ON(!PacketIsIPv6(p));
@@ -756,6 +746,11 @@ static inline IPV6Hdr *PacketSetIPV6(Packet *p, const uint8_t *buf)
     p->l3.type = PACKET_L3_IPV6;
     p->l3.hdrs.ip6h = (IPV6Hdr *)buf;
     return p->l3.hdrs.ip6h;
+}
+
+static inline bool PacketIsIPv6(const Packet *p)
+{
+    return p->l3.type == PACKET_L3_IPV6;
 }
 
 static inline void PacketClearL2(Packet *p)
@@ -793,9 +788,23 @@ static inline void PacketClearL4(Packet *p)
     memset(&p->l4, 0, sizeof(p->l4));
 }
 
+static inline TCPHdr *PacketSetTCP(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_TCP;
+    p->l4.hdrs.tcph = (TCPHdr *)buf;
+    return p->l4.hdrs.tcph;
+}
+
+static inline const TCPHdr *PacketGetTCP(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_TCP);
+    return p->l4.hdrs.tcph;
+}
+
 static inline bool PacketIsTCP(const Packet *p)
 {
-    return PKT_IS_TCP(p);
+    return p->l4.type == PACKET_L4_TCP;
 }
 
 static inline UDPHdr *PacketSetUDP(Packet *p, const uint8_t *buf)

--- a/src/decode.h
+++ b/src/decode.h
@@ -429,6 +429,7 @@ struct PacketL3 {
 enum PacketL4Types {
     PACKET_L4_UNKNOWN = 0,
     PACKET_L4_SCTP,
+    PACKET_L4_GRE,
 };
 
 struct PacketL4 {
@@ -437,6 +438,7 @@ struct PacketL4 {
     uint16_t csum;
     union L4Hdrs {
         SCTPHdr *sctph;
+        GREHdr *greh;
     } hdrs;
 };
 
@@ -580,7 +582,6 @@ typedef struct Packet_
     ICMPV6Hdr *icmpv6h;
     PPPOESessionHdr *pppoesh;
     PPPOEDiscoveryHdr *pppoedh;
-    GREHdr *greh;
 
     /* ptr to the payload of the packet
      * with it's length. */
@@ -793,6 +794,25 @@ static inline const SCTPHdr *PacketGetSCTP(const Packet *p)
 static inline bool PacketIsSCTP(const Packet *p)
 {
     return p->l4.type == PACKET_L4_SCTP;
+}
+
+static inline GREHdr *PacketSetGRE(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_GRE;
+    p->l4.hdrs.greh = (GREHdr *)buf;
+    return p->l4.hdrs.greh;
+}
+
+static inline const GREHdr *PacketGetGRE(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_GRE);
+    return p->l4.hdrs.greh;
+}
+
+static inline bool PacketIsGRE(const Packet *p)
+{
+    return p->l4.type == PACKET_L4_GRE;
 }
 
 /** \brief Structure to hold thread specific data for all decode modules */

--- a/src/decode.h
+++ b/src/decode.h
@@ -254,11 +254,6 @@ typedef uint16_t Port;
 
 #define IPH_IS_VALID(p) (PKT_IS_IPV4((p)) || PKT_IS_IPV6((p)))
 
-/* Retrieve proto regardless of IP version */
-#define IP_GET_IPPROTO(p) \
-    (p->proto ? p->proto : \
-    (PKT_IS_IPV4((p))? IPV4_GET_IPPROTO((p)) : (PKT_IS_IPV6((p))? IPV6_GET_L4PROTO((p)) : 0)))
-
 /* structure to store the sids/gids/etc the detection engine
  * found in this packet */
 typedef struct PacketAlert_ {
@@ -679,6 +674,21 @@ typedef struct Packet_
 #define MAX_PAYLOAD_SIZE (IPV6_HEADER_LEN + 65536 + 28)
 extern uint32_t default_packet_size;
 #define SIZE_OF_PACKET (default_packet_size + sizeof(Packet))
+
+/* Retrieve proto regardless of IP version */
+static inline uint8_t IP_GET_IPPROTO(const Packet *p)
+{
+    if (p->proto != 0) {
+        return p->proto;
+    }
+    if (PKT_IS_IPV4(p)) {
+        return IPV4_GET_IPPROTO(p);
+    } else if (PKT_IS_IPV6(p)) {
+        return IPV6_GET_L4PROTO(p);
+    } else {
+        return 0;
+    }
+}
 
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_

--- a/src/decode.h
+++ b/src/decode.h
@@ -769,6 +769,11 @@ static inline bool PacketIsUDP(const Packet *p)
     return PKT_IS_UDP(p);
 }
 
+static inline bool PacketIsICMPv4(const Packet *p)
+{
+    return PKT_IS_ICMPV4(p);
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -690,6 +690,16 @@ static inline uint8_t PacketGetIPProto(const Packet *p)
     }
 }
 
+static inline bool PacketIsIPv4(const Packet *p)
+{
+    return PKT_IS_IPV4(p);
+}
+
+static inline bool PacketIsIPv6(const Packet *p)
+{
+    return PKT_IS_IPV6(p);
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -676,7 +676,7 @@ extern uint32_t default_packet_size;
 #define SIZE_OF_PACKET (default_packet_size + sizeof(Packet))
 
 /* Retrieve proto regardless of IP version */
-static inline uint8_t IP_GET_IPPROTO(const Packet *p)
+static inline uint8_t PacketGetIPProto(const Packet *p)
 {
     if (p->proto != 0) {
         return p->proto;

--- a/src/decode.h
+++ b/src/decode.h
@@ -774,6 +774,11 @@ static inline bool PacketIsICMPv4(const Packet *p)
     return PKT_IS_ICMPV4(p);
 }
 
+static inline bool PacketIsICMPv6(const Packet *p)
+{
+    return PKT_IS_ICMPV6(p);
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -99,6 +99,7 @@ enum PktSrcEnum {
 #include "decode-vlan.h"
 #include "decode-mpls.h"
 
+#include "util-validate.h"
 
 /* forward declarations */
 struct DetectionEngineThreadCtx_;
@@ -141,20 +142,22 @@ typedef struct Address_ {
  *
  * We set the rest of the struct to 0 so we can
  * prevent using memset. */
-#define SET_IPV4_SRC_ADDR(p, a) do {                              \
-        (a)->family = AF_INET;                                    \
-        (a)->addr_data32[0] = (uint32_t)(p)->ip4h->s_ip_src.s_addr; \
-        (a)->addr_data32[1] = 0;                                  \
-        (a)->addr_data32[2] = 0;                                  \
-        (a)->addr_data32[3] = 0;                                  \
+#define SET_IPV4_SRC_ADDR(ip4h, a)                                                                 \
+    do {                                                                                           \
+        (a)->family = AF_INET;                                                                     \
+        (a)->addr_data32[0] = (uint32_t)(ip4h)->s_ip_src.s_addr;                                   \
+        (a)->addr_data32[1] = 0;                                                                   \
+        (a)->addr_data32[2] = 0;                                                                   \
+        (a)->addr_data32[3] = 0;                                                                   \
     } while (0)
 
-#define SET_IPV4_DST_ADDR(p, a) do {                              \
-        (a)->family = AF_INET;                                    \
-        (a)->addr_data32[0] = (uint32_t)(p)->ip4h->s_ip_dst.s_addr; \
-        (a)->addr_data32[1] = 0;                                  \
-        (a)->addr_data32[2] = 0;                                  \
-        (a)->addr_data32[3] = 0;                                  \
+#define SET_IPV4_DST_ADDR(ip4h, a)                                                                 \
+    do {                                                                                           \
+        (a)->family = AF_INET;                                                                     \
+        (a)->addr_data32[0] = (uint32_t)(ip4h)->s_ip_dst.s_addr;                                   \
+        (a)->addr_data32[1] = 0;                                                                   \
+        (a)->addr_data32[2] = 0;                                                                   \
+        (a)->addr_data32[3] = 0;                                                                   \
     } while (0)
 
 /* Set the IPv6 addresses into the Addrs of the Packet.
@@ -243,7 +246,6 @@ typedef uint16_t Port;
  *We determine the ip version. */
 #define IP_GET_RAW_VER(pkt) ((((pkt)[0] & 0xf0) >> 4))
 
-#define PKT_IS_IPV4(p)      (((p)->ip4h != NULL))
 #define PKT_IS_IPV6(p)      (((p)->ip6h != NULL))
 #define PKT_IS_TCP(p)       (((p)->tcph != NULL))
 #define PKT_IS_UDP(p)       (((p)->udph != NULL))
@@ -251,8 +253,6 @@ typedef uint16_t Port;
 #define PKT_IS_ICMPV6(p)    (((p)->icmpv6h != NULL))
 #define PKT_IS_TOSERVER(p)  (((p)->flowflags & FLOW_PKT_TOSERVER))
 #define PKT_IS_TOCLIENT(p)  (((p)->flowflags & FLOW_PKT_TOCLIENT))
-
-#define IPH_IS_VALID(p) (PKT_IS_IPV4((p)) || PKT_IS_IPV6((p)))
 
 /* structure to store the sids/gids/etc the detection engine
  * found in this packet */
@@ -412,6 +412,24 @@ enum PacketTunnelType {
 /* forward declaration since Packet struct definition requires this */
 struct PacketQueue_;
 
+enum PacketL3Types {
+    PACKET_L3_UNKNOWN = 0,
+    PACKET_L3_IPV4,
+};
+
+struct PacketL3 {
+    enum PacketL3Types type;
+    /* Checksum for IP packets. */
+    int32_t comp_csum;
+    union Hdrs {
+        IPV4Hdr *ip4h;
+    } hdrs;
+    /* IPv4 and IPv6 are mutually exclusive */
+    union {
+        IPV4Vars ip4;
+    } vars;
+};
+
 /* sizes of the members:
  * src: 17 bytes
  * dst: 17 bytes
@@ -532,23 +550,16 @@ typedef struct Packet_
     /* header pointers */
     EthernetHdr *ethh;
 
-    /* Checksum for IP packets. */
-    int32_t level3_comp_csum;
     /* Check sum for TCP, UDP or ICMP packets */
     int32_t level4_comp_csum;
 
-    IPV4Hdr *ip4h;
-
+    struct PacketL3 l3;
     IPV6Hdr *ip6h;
-
-    /* IPv4 and IPv6 are mutually exclusive */
-    union {
-        IPV4Vars ip4vars;
-        struct {
-            IPV6Vars ip6vars;
-            IPV6ExtHdrs ip6eh;
-        };
+    struct {
+        IPV6Vars ip6vars;
+        IPV6ExtHdrs ip6eh;
     };
+
     /* Can only be one of TCP, UDP, ICMP at any given time */
     union {
         TCPVars tcpvars;
@@ -658,6 +669,8 @@ typedef struct Packet_
     uint8_t pkt_data[];
 } Packet;
 
+static inline bool PacketIsIPv4(const Packet *p);
+
 /** highest mtu of the interfaces we monitor */
 #define DEFAULT_MTU 1500
 #define MINIMUM_MTU 68      /**< ipv4 minimum: rfc791 */
@@ -668,24 +681,52 @@ typedef struct Packet_
 extern uint32_t default_packet_size;
 #define SIZE_OF_PACKET (default_packet_size + sizeof(Packet))
 
+static inline bool PacketIsIPv4(const Packet *p)
+{
+    return p->l3.type == PACKET_L3_IPV4;
+}
+
+static inline const IPV4Hdr *PacketGetIPv4(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(!PacketIsIPv4(p));
+    return p->l3.hdrs.ip4h;
+}
+
+static inline IPV4Hdr *PacketSetIPV4(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l3.type != PACKET_L3_UNKNOWN);
+    p->l3.type = PACKET_L3_IPV4;
+    p->l3.hdrs.ip4h = (IPV4Hdr *)buf;
+    return p->l3.hdrs.ip4h;
+}
+
 /* Retrieve proto regardless of IP version */
 static inline uint8_t PacketGetIPProto(const Packet *p)
 {
     if (p->proto != 0) {
         return p->proto;
     }
-    if (PKT_IS_IPV4(p)) {
-        return IPV4_GET_IPPROTO(p);
+    if (PacketIsIPv4(p)) {
+        const IPV4Hdr *hdr = PacketGetIPv4(p);
+        return IPV4_GET_RAW_IPPROTO(hdr);
     } else if (PKT_IS_IPV6(p)) {
         return IPV6_GET_L4PROTO(p);
-    } else {
-        return 0;
     }
+    return 0;
 }
 
-static inline bool PacketIsIPv4(const Packet *p)
+static inline uint8_t PacketGetIPv4IPProto(const Packet *p)
 {
-    return PKT_IS_IPV4(p);
+    if (PacketGetIPv4(p)) {
+        const IPV4Hdr *hdr = PacketGetIPv4(p);
+        return IPV4_GET_RAW_IPPROTO(hdr);
+    }
+    return 0;
+}
+
+static inline void PacketClearL3(Packet *p)
+{
+    memset(&p->l3, 0, sizeof(p->l3));
 }
 
 static inline bool PacketIsIPv6(const Packet *p)
@@ -793,9 +834,9 @@ void CaptureStatsSetup(ThreadVars *tv);
 /**
  *  \brief reset these to -1(indicates that the packet is fresh from the queue)
  */
-#define PACKET_RESET_CHECKSUMS(p) do { \
-        (p)->level3_comp_csum = -1;   \
-        (p)->level4_comp_csum = -1;   \
+#define PACKET_RESET_CHECKSUMS(p)                                                                  \
+    do {                                                                                           \
+        (p)->level4_comp_csum = -1;                                                                \
     } while (0)
 
 /* if p uses extended data, free them */

--- a/src/decode.h
+++ b/src/decode.h
@@ -421,7 +421,8 @@ enum PacketL3Types {
 struct PacketL3 {
     enum PacketL3Types type;
     /* Checksum for IP packets. */
-    int32_t comp_csum;
+    bool csum_set;
+    uint16_t csum;
     union Hdrs {
         IPV4Hdr *ip4h;
         IPV6Hdr *ip6h;

--- a/src/decode.h
+++ b/src/decode.h
@@ -87,7 +87,6 @@ enum PktSrcEnum {
 #include "decode-ethernet.h"
 #include "decode-gre.h"
 #include "decode-ppp.h"
-#include "decode-pppoe.h"
 #include "decode-ipv4.h"
 #include "decode-ipv6.h"
 #include "decode-icmpv4.h"
@@ -583,7 +582,6 @@ typedef struct Packet_
 
     TCPHdr *tcph;
     UDPHdr *udph;
-    PPPOEDiscoveryHdr *pppoedh;
 
     /* ptr to the payload of the packet
      * with it's length. */

--- a/src/decode.h
+++ b/src/decode.h
@@ -430,6 +430,7 @@ enum PacketL4Types {
     PACKET_L4_UNKNOWN = 0,
     PACKET_L4_SCTP,
     PACKET_L4_GRE,
+    PACKET_L4_ESP,
 };
 
 struct PacketL4 {
@@ -439,6 +440,7 @@ struct PacketL4 {
     union L4Hdrs {
         SCTPHdr *sctph;
         GREHdr *greh;
+        ESPHdr *esph;
     } hdrs;
 };
 
@@ -577,7 +579,6 @@ typedef struct Packet_
 
     TCPHdr *tcph;
     UDPHdr *udph;
-    ESPHdr *esph;
     ICMPV4Hdr *icmpv4h;
     ICMPV6Hdr *icmpv6h;
     PPPOESessionHdr *pppoesh;
@@ -813,6 +814,25 @@ static inline const GREHdr *PacketGetGRE(const Packet *p)
 static inline bool PacketIsGRE(const Packet *p)
 {
     return p->l4.type == PACKET_L4_GRE;
+}
+
+static inline ESPHdr *PacketSetESP(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_ESP;
+    p->l4.hdrs.esph = (ESPHdr *)buf;
+    return p->l4.hdrs.esph;
+}
+
+static inline const ESPHdr *PacketGetESP(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_ESP);
+    return p->l4.hdrs.esph;
+}
+
+static inline bool PacketIsESP(const Packet *p)
+{
+    return p->l4.type == PACKET_L4_ESP;
 }
 
 /** \brief Structure to hold thread specific data for all decode modules */

--- a/src/decode.h
+++ b/src/decode.h
@@ -428,6 +428,7 @@ struct PacketL3 {
 
 enum PacketL4Types {
     PACKET_L4_UNKNOWN = 0,
+    PACKET_L4_ICMPV4,
     PACKET_L4_ICMPV6,
     PACKET_L4_SCTP,
     PACKET_L4_GRE,
@@ -439,12 +440,14 @@ struct PacketL4 {
     bool csum_set;
     uint16_t csum;
     union L4Hdrs {
+        ICMPV4Hdr *icmpv4h;
         ICMPV6Hdr *icmpv6h;
         SCTPHdr *sctph;
         GREHdr *greh;
         ESPHdr *esph;
     } hdrs;
     union L4Vars {
+        ICMPV4Vars icmpv4;
         ICMPV6Vars icmpv6;
     } vars;
 };
@@ -575,14 +578,11 @@ typedef struct Packet_
     /* Can only be one of TCP, UDP, ICMP at any given time */
     union {
         TCPVars tcpvars;
-        ICMPV4Vars icmpv4vars;
     } l4vars;
-#define tcpvars     l4vars.tcpvars
-#define icmpv4vars  l4vars.icmpv4vars
+#define tcpvars l4vars.tcpvars
 
     TCPHdr *tcph;
     UDPHdr *udph;
-    ICMPV4Hdr *icmpv4h;
     PPPOESessionHdr *pppoesh;
     PPPOEDiscoveryHdr *pppoedh;
 
@@ -770,9 +770,23 @@ static inline bool PacketIsUDP(const Packet *p)
     return PKT_IS_UDP(p);
 }
 
+static inline ICMPV4Hdr *PacketSetICMPv4(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_ICMPV4;
+    p->l4.hdrs.icmpv4h = (ICMPV4Hdr *)buf;
+    return p->l4.hdrs.icmpv4h;
+}
+
+static inline const ICMPV4Hdr *PacketGetICMPv4(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_ICMPV4);
+    return p->l4.hdrs.icmpv4h;
+}
+
 static inline bool PacketIsICMPv4(const Packet *p)
 {
-    return PKT_IS_ICMPV4(p);
+    return p->l4.type == PACKET_L4_ICMPV4;
 }
 
 static inline ICMPV6Hdr *PacketSetICMPv6(Packet *p, const uint8_t *buf)

--- a/src/decode.h
+++ b/src/decode.h
@@ -845,7 +845,7 @@ static inline bool PacketIsICMPv4(const Packet *p)
     return p->l4.type == PACKET_L4_ICMPV4;
 }
 
-static inline const IPV4Hdr *ICMPV4_GET_EMB_IPV4(const Packet *p)
+static inline const IPV4Hdr *PacketGetICMPv4EmbIPv4(const Packet *p)
 {
     const uint8_t *start = (const uint8_t *)PacketGetICMPv4(p);
     const uint8_t *ip = start + p->l4.vars.icmpv4.emb_ip4h_offset;

--- a/src/decode.h
+++ b/src/decode.h
@@ -160,22 +160,23 @@ typedef struct Address_ {
         (a)->addr_data32[3] = 0;                                                                   \
     } while (0)
 
-/* Set the IPv6 addresses into the Addrs of the Packet.
- * Make sure p->ip6h is initialized and validated. */
-#define SET_IPV6_SRC_ADDR(p, a) do {                    \
-        (a)->family = AF_INET6;                         \
-        (a)->addr_data32[0] = (p)->ip6h->s_ip6_src[0];  \
-        (a)->addr_data32[1] = (p)->ip6h->s_ip6_src[1];  \
-        (a)->addr_data32[2] = (p)->ip6h->s_ip6_src[2];  \
-        (a)->addr_data32[3] = (p)->ip6h->s_ip6_src[3];  \
+/* Set the IPv6 addresses into the Addrs of the Packet. */
+#define SET_IPV6_SRC_ADDR(ip6h, a)                                                                 \
+    do {                                                                                           \
+        (a)->family = AF_INET6;                                                                    \
+        (a)->addr_data32[0] = (ip6h)->s_ip6_src[0];                                                \
+        (a)->addr_data32[1] = (ip6h)->s_ip6_src[1];                                                \
+        (a)->addr_data32[2] = (ip6h)->s_ip6_src[2];                                                \
+        (a)->addr_data32[3] = (ip6h)->s_ip6_src[3];                                                \
     } while (0)
 
-#define SET_IPV6_DST_ADDR(p, a) do {                    \
-        (a)->family = AF_INET6;                         \
-        (a)->addr_data32[0] = (p)->ip6h->s_ip6_dst[0];  \
-        (a)->addr_data32[1] = (p)->ip6h->s_ip6_dst[1];  \
-        (a)->addr_data32[2] = (p)->ip6h->s_ip6_dst[2];  \
-        (a)->addr_data32[3] = (p)->ip6h->s_ip6_dst[3];  \
+#define SET_IPV6_DST_ADDR(ip6h, a)                                                                 \
+    do {                                                                                           \
+        (a)->family = AF_INET6;                                                                    \
+        (a)->addr_data32[0] = (ip6h)->s_ip6_dst[0];                                                \
+        (a)->addr_data32[1] = (ip6h)->s_ip6_dst[1];                                                \
+        (a)->addr_data32[2] = (ip6h)->s_ip6_dst[2];                                                \
+        (a)->addr_data32[3] = (ip6h)->s_ip6_dst[3];                                                \
     } while (0)
 
 /* Set the TCP ports into the Ports of the Packet.
@@ -246,7 +247,6 @@ typedef uint16_t Port;
  *We determine the ip version. */
 #define IP_GET_RAW_VER(pkt) ((((pkt)[0] & 0xf0) >> 4))
 
-#define PKT_IS_IPV6(p)      (((p)->ip6h != NULL))
 #define PKT_IS_TCP(p)       (((p)->tcph != NULL))
 #define PKT_IS_UDP(p)       (((p)->udph != NULL))
 #define PKT_IS_ICMPV4(p)    (((p)->icmpv4h != NULL))
@@ -415,6 +415,7 @@ struct PacketQueue_;
 enum PacketL3Types {
     PACKET_L3_UNKNOWN = 0,
     PACKET_L3_IPV4,
+    PACKET_L3_IPV6,
 };
 
 struct PacketL3 {
@@ -423,10 +424,15 @@ struct PacketL3 {
     int32_t comp_csum;
     union Hdrs {
         IPV4Hdr *ip4h;
+        IPV6Hdr *ip6h;
     } hdrs;
     /* IPv4 and IPv6 are mutually exclusive */
     union {
         IPV4Vars ip4;
+        struct {
+            IPV6Vars v;
+            IPV6ExtHdrs eh;
+        } ip6;
     } vars;
 };
 
@@ -554,11 +560,6 @@ typedef struct Packet_
     int32_t level4_comp_csum;
 
     struct PacketL3 l3;
-    IPV6Hdr *ip6h;
-    struct {
-        IPV6Vars ip6vars;
-        IPV6ExtHdrs ip6eh;
-    };
 
     /* Can only be one of TCP, UDP, ICMP at any given time */
     union {
@@ -670,6 +671,7 @@ typedef struct Packet_
 } Packet;
 
 static inline bool PacketIsIPv4(const Packet *p);
+static inline bool PacketIsIPv6(const Packet *p);
 
 /** highest mtu of the interfaces we monitor */
 #define DEFAULT_MTU 1500
@@ -709,7 +711,7 @@ static inline uint8_t PacketGetIPProto(const Packet *p)
     if (PacketIsIPv4(p)) {
         const IPV4Hdr *hdr = PacketGetIPv4(p);
         return IPV4_GET_RAW_IPPROTO(hdr);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         return IPV6_GET_L4PROTO(p);
     }
     return 0;
@@ -724,14 +726,28 @@ static inline uint8_t PacketGetIPv4IPProto(const Packet *p)
     return 0;
 }
 
-static inline void PacketClearL3(Packet *p)
+static inline const IPV6Hdr *PacketGetIPv6(const Packet *p)
 {
-    memset(&p->l3, 0, sizeof(p->l3));
+    DEBUG_VALIDATE_BUG_ON(!PacketIsIPv6(p));
+    return p->l3.hdrs.ip6h;
+}
+
+static inline IPV6Hdr *PacketSetIPV6(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l3.type != PACKET_L3_UNKNOWN);
+    p->l3.type = PACKET_L3_IPV6;
+    p->l3.hdrs.ip6h = (IPV6Hdr *)buf;
+    return p->l3.hdrs.ip6h;
 }
 
 static inline bool PacketIsIPv6(const Packet *p)
 {
-    return PKT_IS_IPV6(p);
+    return p->l3.type == PACKET_L3_IPV6;
+}
+
+static inline void PacketClearL3(Packet *p)
+{
+    memset(&p->l3, 0, sizeof(p->l3));
 }
 
 /** \brief Structure to hold thread specific data for all decode modules */

--- a/src/decode.h
+++ b/src/decode.h
@@ -560,20 +560,13 @@ typedef struct Packet_
 #define icmpv6vars  l4vars.icmpv6vars
 
     TCPHdr *tcph;
-
     UDPHdr *udph;
-
     SCTPHdr *sctph;
-
     ESPHdr *esph;
-
     ICMPV4Hdr *icmpv4h;
-
     ICMPV6Hdr *icmpv6h;
-
     PPPOESessionHdr *pppoesh;
     PPPOEDiscoveryHdr *pppoedh;
-
     GREHdr *greh;
 
     /* ptr to the payload of the packet

--- a/src/decode.h
+++ b/src/decode.h
@@ -437,6 +437,11 @@ struct PacketL3 {
     } vars;
 };
 
+struct PacketL4 {
+    bool csum_set;
+    uint16_t csum;
+};
+
 /* sizes of the members:
  * src: 17 bytes
  * dst: 17 bytes
@@ -557,10 +562,8 @@ typedef struct Packet_
     /* header pointers */
     EthernetHdr *ethh;
 
-    /* Check sum for TCP, UDP or ICMP packets */
-    int32_t level4_comp_csum;
-
     struct PacketL3 l3;
+    struct PacketL4 l4;
 
     /* Can only be one of TCP, UDP, ICMP at any given time */
     union {
@@ -751,6 +754,11 @@ static inline void PacketClearL3(Packet *p)
     memset(&p->l3, 0, sizeof(p->l3));
 }
 
+static inline void PacketClearL4(Packet *p)
+{
+    memset(&p->l4, 0, sizeof(p->l4));
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {
@@ -846,14 +854,6 @@ void CaptureStatsSetup(ThreadVars *tv);
 
 #define PACKET_CLEAR_L4VARS(p) do {                         \
         memset(&(p)->l4vars, 0x00, sizeof((p)->l4vars));    \
-    } while (0)
-
-/**
- *  \brief reset these to -1(indicates that the packet is fresh from the queue)
- */
-#define PACKET_RESET_CHECKSUMS(p)                                                                  \
-    do {                                                                                           \
-        (p)->level4_comp_csum = -1;                                                                \
     } while (0)
 
 /* if p uses extended data, free them */

--- a/src/decode.h
+++ b/src/decode.h
@@ -764,6 +764,11 @@ static inline bool PacketIsTCP(const Packet *p)
     return PKT_IS_TCP(p);
 }
 
+static inline bool PacketIsUDP(const Packet *p)
+{
+    return PKT_IS_UDP(p);
+}
+
 /** \brief Structure to hold thread specific data for all decode modules */
 typedef struct DecodeThreadVars_
 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -583,7 +583,6 @@ typedef struct Packet_
 
     TCPHdr *tcph;
     UDPHdr *udph;
-    PPPOESessionHdr *pppoesh;
     PPPOEDiscoveryHdr *pppoedh;
 
     /* ptr to the payload of the packet

--- a/src/decode.h
+++ b/src/decode.h
@@ -845,6 +845,13 @@ static inline bool PacketIsICMPv4(const Packet *p)
     return p->l4.type == PACKET_L4_ICMPV4;
 }
 
+static inline const IPV4Hdr *ICMPV4_GET_EMB_IPV4(const Packet *p)
+{
+    const uint8_t *start = (const uint8_t *)PacketGetICMPv4(p);
+    const uint8_t *ip = start + p->l4.vars.icmpv4.emb_ip4h_offset;
+    return (const IPV4Hdr *)ip;
+}
+
 static inline ICMPV6Hdr *PacketSetICMPv6(Packet *p, const uint8_t *buf)
 {
     DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);

--- a/src/decode.h
+++ b/src/decode.h
@@ -439,6 +439,7 @@ struct PacketL3 {
 
 enum PacketL4Types {
     PACKET_L4_UNKNOWN = 0,
+    PACKET_L4_UDP,
     PACKET_L4_ICMPV4,
     PACKET_L4_ICMPV6,
     PACKET_L4_SCTP,
@@ -451,6 +452,7 @@ struct PacketL4 {
     bool csum_set;
     uint16_t csum;
     union L4Hdrs {
+        UDPHdr *udph;
         ICMPV4Hdr *icmpv4h;
         ICMPV6Hdr *icmpv6h;
         SCTPHdr *sctph;
@@ -591,7 +593,6 @@ typedef struct Packet_
 #define tcpvars l4vars.tcpvars
 
     TCPHdr *tcph;
-    UDPHdr *udph;
 
     /* ptr to the payload of the packet
      * with it's length. */
@@ -797,9 +798,23 @@ static inline bool PacketIsTCP(const Packet *p)
     return PKT_IS_TCP(p);
 }
 
+static inline UDPHdr *PacketSetUDP(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_UDP;
+    p->l4.hdrs.udph = (UDPHdr *)buf;
+    return p->l4.hdrs.udph;
+}
+
+static inline const UDPHdr *PacketGetUDP(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UDP);
+    return p->l4.hdrs.udph;
+}
+
 static inline bool PacketIsUDP(const Packet *p)
 {
-    return PKT_IS_UDP(p);
+    return p->l4.type == PACKET_L4_UDP;
 }
 
 static inline ICMPV4Hdr *PacketSetICMPv4(Packet *p, const uint8_t *buf)

--- a/src/decode.h
+++ b/src/decode.h
@@ -198,17 +198,6 @@ typedef struct Address_ {
         SET_PORT(UDP_GET_DST_PORT((pkt)), *(prt)); \
     } while (0)
 
-/* Set the SCTP ports into the Ports of the Packet.
- * Make sure p->sctph is initialized and validated. */
-#define SET_SCTP_SRC_PORT(pkt, prt) do {            \
-        SET_PORT(SCTP_GET_SRC_PORT((pkt)), *(prt)); \
-    } while (0)
-
-#define SET_SCTP_DST_PORT(pkt, prt) do {            \
-        SET_PORT(SCTP_GET_DST_PORT((pkt)), *(prt)); \
-    } while (0)
-
-
 #define GET_IPV4_SRC_ADDR_U32(p) ((p)->src.addr_data32[0])
 #define GET_IPV4_DST_ADDR_U32(p) ((p)->dst.addr_data32[0])
 #define GET_IPV4_SRC_ADDR_PTR(p) ((p)->src.addr_data32)
@@ -437,9 +426,18 @@ struct PacketL3 {
     } vars;
 };
 
+enum PacketL4Types {
+    PACKET_L4_UNKNOWN = 0,
+    PACKET_L4_SCTP,
+};
+
 struct PacketL4 {
+    enum PacketL4Types type;
     bool csum_set;
     uint16_t csum;
+    union L4Hdrs {
+        SCTPHdr *sctph;
+    } hdrs;
 };
 
 /* sizes of the members:
@@ -577,7 +575,6 @@ typedef struct Packet_
 
     TCPHdr *tcph;
     UDPHdr *udph;
-    SCTPHdr *sctph;
     ESPHdr *esph;
     ICMPV4Hdr *icmpv4h;
     ICMPV6Hdr *icmpv6h;
@@ -777,6 +774,25 @@ static inline bool PacketIsICMPv4(const Packet *p)
 static inline bool PacketIsICMPv6(const Packet *p)
 {
     return PKT_IS_ICMPV6(p);
+}
+
+static inline SCTPHdr *PacketSetSCTP(Packet *p, const uint8_t *buf)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_UNKNOWN);
+    p->l4.type = PACKET_L4_SCTP;
+    p->l4.hdrs.sctph = (SCTPHdr *)buf;
+    return p->l4.hdrs.sctph;
+}
+
+static inline const SCTPHdr *PacketGetSCTP(const Packet *p)
+{
+    DEBUG_VALIDATE_BUG_ON(p->l4.type != PACKET_L4_SCTP);
+    return p->l4.hdrs.sctph;
+}
+
+static inline bool PacketIsSCTP(const Packet *p)
+{
+    return p->l4.type == PACKET_L4_SCTP;
 }
 
 /** \brief Structure to hold thread specific data for all decode modules */

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -93,9 +93,9 @@ int DefragPolicyGetHostTimeout(Packet *p)
 {
     int timeout = 0;
 
-    if (PKT_IS_IPV4(p))
+    if (PacketIsIPv4(p))
         timeout = DefragPolicyGetIPv4HostTimeout((uint8_t *)GET_IPV4_DST_ADDR_PTR(p));
-    else if (PKT_IS_IPV6(p))
+    else if (PacketIsIPv6(p))
         timeout = DefragPolicyGetIPv6HostTimeout((uint8_t *)GET_IPV6_DST_ADDR(p));
 
     if (timeout <= 0)

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -134,7 +134,7 @@ static void DefragTrackerInit(DefragTracker *dt, Packet *p)
         dt->id = (int32_t)IPV6_EXTHDR_GET_FH_ID(p);
         dt->af = AF_INET6;
     }
-    dt->proto = IP_GET_IPPROTO(p);
+    dt->proto = PacketGetIPProto(p);
     memcpy(&dt->vlan_id[0], &p->vlan_id[0], sizeof(dt->vlan_id));
     dt->policy = DefragGetOsPolicy(p);
     dt->host_timeout = DefragPolicyGetHostTimeout(p);
@@ -443,7 +443,7 @@ static inline uint32_t DefragHashGetKey(Packet *p)
 #define CMP_DEFRAGTRACKER(d1, d2, id)                                                              \
     (((CMP_ADDR(&(d1)->src_addr, &(d2)->src) && CMP_ADDR(&(d1)->dst_addr, &(d2)->dst)) ||          \
              (CMP_ADDR(&(d1)->src_addr, &(d2)->dst) && CMP_ADDR(&(d1)->dst_addr, &(d2)->src))) &&  \
-            (d1)->proto == IP_GET_IPPROTO(d2) && (d1)->id == (id) &&                               \
+            (d1)->proto == PacketGetIPProto(d2) && (d1)->id == (id) &&                             \
             (d1)->vlan_id[0] == (d2)->vlan_id[0] && (d1)->vlan_id[1] == (d2)->vlan_id[1] &&        \
             (d1)->vlan_id[2] == (d2)->vlan_id[2])
 

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -127,7 +127,7 @@ static void DefragTrackerInit(DefragTracker *dt, Packet *p)
     COPY_ADDRESS(&p->src, &dt->src_addr);
     COPY_ADDRESS(&p->dst, &dt->dst_addr);
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         dt->id = (int32_t)IPV4_GET_IPID(p);
         dt->af = AF_INET;
     } else {
@@ -450,7 +450,7 @@ static inline uint32_t DefragHashGetKey(Packet *p)
 static inline int DefragTrackerCompare(DefragTracker *t, Packet *p)
 {
     uint32_t id;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         id = (uint32_t)IPV4_GET_IPID(p);
     } else {
         id = IPV6_EXTHDR_GET_FH_ID(p);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -929,10 +929,9 @@ DefragGetOsPolicy(Packet *p)
 {
     int policy = -1;
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         policy = SCHInfoGetIPv4HostOSFlavour((uint8_t *)GET_IPV4_DST_ADDR_PTR(p));
-    }
-    else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         policy = SCHInfoGetIPv6HostOSFlavour((uint8_t *)GET_IPV6_DST_ADDR(p));
     }
 
@@ -1011,17 +1010,15 @@ Defrag(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
     DefragTracker *tracker;
     int af;
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         af = AF_INET;
         more_frags = IPV4_GET_MF(p);
         frag_offset = IPV4_GET_IPOFFSET(p);
-    }
-    else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         af = AF_INET6;
         frag_offset = IPV6_EXTHDR_GET_FH_OFFSET(p);
         more_frags = IPV6_EXTHDR_GET_FH_FLAG(p);
-    }
-    else {
+    } else {
         return NULL;
     }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -309,12 +309,12 @@ Defrag4Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
                 goto error_remove_tracker;
 
             hlen = frag->hlen;
-            ip_hdr_offset = frag->ip_hdr_offset;
+            ip_hdr_offset = tracker->ip_hdr_offset;
 
             /* This is the start of the fragmentable portion of the
              * first packet.  All fragment offsets are relative to
              * this. */
-            fragmentable_offset = frag->ip_hdr_offset + frag->hlen;
+            fragmentable_offset = tracker->ip_hdr_offset + frag->hlen;
             fragmentable_len = frag->data_len;
         }
         else {
@@ -457,7 +457,7 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
                 frag->pkt + frag->frag_hdr_offset + sizeof(IPV6FragHdr),
                 frag->data_len) == -1)
                 goto error_remove_tracker;
-            ip_hdr_offset = frag->ip_hdr_offset;
+            ip_hdr_offset = tracker->ip_hdr_offset;
 
             /* This is the start of the fragmentable portion of the
              * first packet.  All fragment offsets are relative to
@@ -488,7 +488,7 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
         }
     }
 
-    rp->ip6h = (IPV6Hdr *)(GET_PKT_DATA(rp) + ip_hdr_offset);
+    rp->ip6h = (IPV6Hdr *)(GET_PKT_DATA(rp) + tracker->ip_hdr_offset);
     DEBUG_VALIDATE_BUG_ON(unfragmentable_len > UINT16_MAX - fragmentable_len);
     rp->ip6h->s_ip6_plen = htons(fragmentable_len + unfragmentable_len);
     /* if we have no unfragmentable part, so no ext hdrs before the frag
@@ -857,13 +857,13 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     new->offset = frag_offset + ltrim;
     new->data_offset = data_offset;
     new->data_len = data_len - ltrim;
-    new->ip_hdr_offset = ip_hdr_offset;
     new->frag_hdr_offset = frag_hdr_offset;
     new->more_frags = more_frags;
 #ifdef DEBUG
     new->pcap_cnt = pcap_cnt;
 #endif
     if (frag_offset == 0) {
+        tracker->ip_hdr_offset = ip_hdr_offset;
         tracker->datalink = p->datalink;
     }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -423,10 +423,12 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
         }
     }
 
+    const IPV6Hdr *oip6h = PacketGetIPv6(p);
+
     /* Allocate a Packet for the reassembled packet.  On failure we
      * SCFree all the resources held by this tracker. */
-    rp = PacketDefragPktSetup(p, (uint8_t *)p->ip6h,
-            IPV6_GET_PLEN(p) + sizeof(IPV6Hdr), 0);
+    rp = PacketDefragPktSetup(
+            p, (const uint8_t *)oip6h, IPV6_GET_RAW_PLEN(oip6h) + sizeof(IPV6Hdr), 0);
     if (rp == NULL) {
         goto error_remove_tracker;
     }
@@ -489,15 +491,15 @@ Defrag6Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
         }
     }
 
-    rp->ip6h = (IPV6Hdr *)(GET_PKT_DATA(rp) + tracker->ip_hdr_offset);
+    IPV6Hdr *ip6h = (IPV6Hdr *)(GET_PKT_DATA(rp) + tracker->ip_hdr_offset);
     DEBUG_VALIDATE_BUG_ON(unfragmentable_len > UINT16_MAX - fragmentable_len);
-    rp->ip6h->s_ip6_plen = htons(fragmentable_len + unfragmentable_len);
+    ip6h->s_ip6_plen = htons(fragmentable_len + unfragmentable_len);
     /* if we have no unfragmentable part, so no ext hdrs before the frag
      * header, we need to update the ipv6 headers next header field. This
      * points to the frag header, and we will make it point to the layer
      * directly after the frag header. */
     if (unfragmentable_len == 0)
-        rp->ip6h->s_ip6_nxt = next_hdr;
+        ip6h->s_ip6_nxt = next_hdr;
     SET_PKT_LEN(rp, ip_hdr_offset + sizeof(IPV6Hdr) +
             unfragmentable_len + fragmentable_len);
 
@@ -539,7 +541,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
     Packet *r = NULL;
     uint16_t ltrim = 0;
 
-    uint8_t more_frags;
+    bool more_frags;
     uint16_t frag_offset;
 
     /* IPv4 header length - IPv4 only. */
@@ -592,13 +594,14 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
         }
     }
     else if (tracker->af == AF_INET6) {
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
         more_frags = IPV6_EXTHDR_GET_FH_FLAG(p);
         frag_offset = IPV6_EXTHDR_GET_FH_OFFSET(p);
-        data_offset = p->ip6eh.fh_data_offset;
-        data_len = p->ip6eh.fh_data_len;
+        data_offset = p->l3.vars.ip6.eh.fh_data_offset;
+        data_len = p->l3.vars.ip6.eh.fh_data_len;
         frag_end = frag_offset + data_len;
-        ip_hdr_offset = (uint16_t)((uint8_t *)p->ip6h - GET_PKT_DATA(p));
-        frag_hdr_offset = p->ip6eh.fh_header_offset;
+        ip_hdr_offset = (uint16_t)((uint8_t *)ip6h - GET_PKT_DATA(p));
+        frag_hdr_offset = p->l3.vars.ip6.eh.fh_header_offset;
 
         SCLogDebug("mf %s frag_offset %u data_offset %u, data_len %u, "
                 "frag_end %u, ip_hdr_offset %u, frag_hdr_offset %u",
@@ -614,7 +617,7 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
              * relative to the buffer start */
 
             /* store offset and FH 'next' value for updating frag buffer below */
-            ip6_nh_set_offset = p->ip6eh.fh_prev_hdr_offset;
+            ip6_nh_set_offset = p->l3.vars.ip6.eh.fh_prev_hdr_offset;
             ip6_nh_set_value = IPV6_EXTHDR_GET_FH_NH(p);
             SCLogDebug("offset %d, value %u", ip6_nh_set_offset, ip6_nh_set_value);
         }
@@ -896,8 +899,10 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
             r = Defrag6Reassemble(tv, tracker, p);
             if (r != NULL && tv != NULL && dtv != NULL) {
                 StatsIncr(tv, dtv->counter_defrag_ipv6_reassembled);
-                if (DecodeIPV6(tv, dtv, r, (uint8_t *)r->ip6h,
-                            IPV6_GET_PLEN(r) + IPV6_HEADER_LEN) != TM_ECODE_OK) {
+                const uint32_t len = GET_PKT_LEN(r) - (uint32_t)tracker->ip_hdr_offset;
+                DEBUG_VALIDATE_BUG_ON(len > UINT16_MAX);
+                if (DecodeIPV6(tv, dtv, r, GET_PKT_DATA(r) + tracker->ip_hdr_offset,
+                            (uint16_t)len) != TM_ECODE_OK) {
                     r->root = NULL;
                     TmqhOutputPacketpool(tv, r);
                     r = NULL;
@@ -1190,8 +1195,8 @@ static Packet *IPV6BuildTestPacket(uint8_t proto, uint32_t id, uint16_t off,
     /* copy content_len crap, we need full length */
     PacketCopyData(p, (uint8_t *)&ip6h, sizeof(IPV6Hdr));
 
-    p->ip6h = (IPV6Hdr *)GET_PKT_DATA(p);
-    IPV6_SET_RAW_VER(p->ip6h, 6);
+    IPV6Hdr *ip6p = PacketSetIPV6(p, GET_PKT_DATA(p));
+    IPV6_SET_RAW_VER(ip6p, 6);
     /* Fragmentation header. */
     IPV6FragHdr *fh = (IPV6FragHdr *)(GET_PKT_DATA(p) + sizeof(IPV6Hdr));
     fh->ip6fh_nxt = proto;
@@ -1208,17 +1213,17 @@ static Packet *IPV6BuildTestPacket(uint8_t proto, uint32_t id, uint16_t off,
     SET_PKT_LEN(p, sizeof(IPV6Hdr) + sizeof(IPV6FragHdr) + content_len);
     SCFree(pcontent);
 
-    p->ip6h->s_ip6_plen = htons(sizeof(IPV6FragHdr) + content_len);
+    ip6p->s_ip6_plen = htons(sizeof(IPV6FragHdr) + content_len);
 
-    SET_IPV6_SRC_ADDR(p, &p->src);
-    SET_IPV6_DST_ADDR(p, &p->dst);
+    SET_IPV6_SRC_ADDR(ip6p, &p->src);
+    SET_IPV6_DST_ADDR(ip6p, &p->dst);
 
     /* Self test. */
-    if (IPV6_GET_VER(p) != 6)
+    if (IPV6_GET_RAW_VER(ip6p) != 6)
         goto error;
-    if (IPV6_GET_NH(p) != 44)
+    if (IPV6_GET_RAW_NH(ip6p) != 44)
         goto error;
-    if (IPV6_GET_PLEN(p) != sizeof(IPV6FragHdr) + content_len)
+    if (IPV6_GET_RAW_PLEN(ip6p) != sizeof(IPV6FragHdr) + content_len)
         goto error;
 
     return p;
@@ -1366,7 +1371,8 @@ static int IPV6DefragInOrderSimpleTest(void)
     reassembled = Defrag(&tv, &dtv, p3);
     FAIL_IF_NULL(reassembled);
 
-    FAIL_IF(IPV6_GET_PLEN(reassembled) != 19);
+    const IPV6Hdr *ip6h = PacketGetIPv6(reassembled);
+    FAIL_IF(IPV6_GET_RAW_PLEN(ip6h) != 19);
 
     /* 40 bytes in we should find 8 bytes of A. */
     for (int i = 40; i < 40 + 8; i++) {
@@ -1662,7 +1668,7 @@ static int IPV6DefragDoSturgesNovakTest(int policy, u_char *expected,
     FAIL_IF_NULL(reassembled);
     FAIL_IF(memcmp(GET_PKT_DATA(reassembled) + 40, expected, expected_len) != 0);
 
-    FAIL_IF(IPV6_GET_PLEN(reassembled) != 192);
+    FAIL_IF(IPV6_GET_RAW_PLEN(PacketGetIPv6(reassembled)) != 192);
 
     SCFree(reassembled);
 
@@ -2460,7 +2466,7 @@ static int DefragMfIpv6Test(void)
 
     /* For IPv6 the expected length is just the length of the payload
      * of 2 fragments, so 16. */
-    FAIL_IF(IPV6_GET_PLEN(p) != 16);
+    FAIL_IF(IPV6_GET_RAW_PLEN(PacketGetIPv6(p)) != 16);
 
     SCFree(p1);
     SCFree(p2);

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -54,8 +54,6 @@ typedef struct Frag_ {
     uint8_t more_frags:4;       /**< More frags? */
     uint8_t skip:4;             /**< Skip this fragment during re-assembly. */
 
-    uint16_t ip_hdr_offset;     /**< Offset in the packet where the IP
-                                 * header starts. */
     uint16_t frag_hdr_offset;   /**< Offset in the packet where the frag
                                  * header starts. */
 
@@ -88,6 +86,8 @@ typedef struct DefragTracker_ {
                            * this tracker. */
 
     uint16_t vlan_id[VLAN_MAX_LAYERS]; /**< VLAN ID tracker applies to. */
+    uint16_t ip_hdr_offset;            /**< Offset in the packet where the IP
+                                        * header starts. */
 
     uint32_t id; /**< IP ID for this tracker.  32 bits for IPv6, 16
                   * for IPv4. */

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -682,7 +682,7 @@ static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || p->icmpv4h == NULL || p->proto != IPPROTO_ICMP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv4(p) || !PKT_IS_ICMPV4(p) || p->proto != IPPROTO_ICMP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -328,7 +328,7 @@ static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || !PKT_IS_TCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv4(p) || !PacketIsTCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {
@@ -417,7 +417,7 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || !PKT_IS_TCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || !PacketIsTCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -335,14 +335,15 @@ static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        p->level4_comp_csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
+        p->l4.csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
                 (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+        p->l4.csum_set = true;
     }
-    if (p->level4_comp_csum == 0 && cd->valid == 1)
+    if (p->l4.csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != 0 && cd->valid == 0)
+    else if (p->l4.csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -423,15 +424,16 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV6Hdr *ip6h = PacketGetIPv6(p);
-        p->level4_comp_csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
+        p->l4.csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
                 (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+        p->l4.csum_set = true;
     }
 
-    if (p->level4_comp_csum == 0 && cd->valid == 1)
+    if (p->l4.csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != 0 && cd->valid == 0)
+    else if (p->l4.csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -513,14 +515,15 @@ static int DetectUDPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        p->level4_comp_csum = UDPV4Checksum(ip4h->s_ip_addrs, (uint16_t *)p->udph,
+        p->l4.csum = UDPV4Checksum(ip4h->s_ip_addrs, (uint16_t *)p->udph,
                 (p->payload_len + UDP_HEADER_LEN), p->udph->uh_sum);
+        p->l4.csum_set = true;
     }
-    if (p->level4_comp_csum == 0 && cd->valid == 1)
+    if (p->l4.csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != 0 && cd->valid == 0)
+    else if (p->l4.csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -601,14 +604,15 @@ static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV6Hdr *ip6h = PacketGetIPv6(p);
-        p->level4_comp_csum = UDPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->udph,
+        p->l4.csum = UDPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->udph,
                 (p->payload_len + UDP_HEADER_LEN), p->udph->uh_sum);
+        p->l4.csum_set = true;
     }
-    if (p->level4_comp_csum == 0 && cd->valid == 1)
+    if (p->l4.csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != 0 && cd->valid == 0)
+    else if (p->l4.csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -689,14 +693,15 @@ static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        p->level4_comp_csum = ICMPV4CalculateChecksum(
+        p->l4.csum = ICMPV4CalculateChecksum(
                 (uint16_t *)p->icmpv4h, IPV4_GET_RAW_IPLEN(ip4h) - IPV4_GET_RAW_HLEN(ip4h));
+        p->l4.csum_set = true;
     }
-    if (p->level4_comp_csum == p->icmpv4h->checksum && cd->valid == 1)
+    if (p->l4.csum == p->icmpv4h->checksum && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != p->icmpv4h->checksum && cd->valid == 0)
+    else if (p->l4.csum != p->icmpv4h->checksum && cd->valid == 0)
         return 1;
     else
         return 0;
@@ -780,17 +785,17 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         const IPV6Hdr *ip6h = PacketGetIPv6(p);
         uint16_t len = IPV6_GET_RAW_PLEN(ip6h) -
                        (uint16_t)((uint8_t *)p->icmpv6h - (uint8_t *)ip6h - IPV6_HEADER_LEN);
-        p->level4_comp_csum =
-                ICMPV6CalculateChecksum(ip6h->s_ip6_addrs, (uint16_t *)p->icmpv6h, len);
+        p->l4.csum = ICMPV6CalculateChecksum(ip6h->s_ip6_addrs, (uint16_t *)p->icmpv6h, len);
+        p->l4.csum_set = true;
     }
 
-    if (p->level4_comp_csum == p->icmpv6h->csum && cd->valid == 1)
+    if (p->l4.csum == p->icmpv6h->csum && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != p->icmpv6h->csum && cd->valid == 0)
+    else if (p->l4.csum != p->icmpv6h->csum && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -686,7 +686,7 @@ static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || !PKT_IS_ICMPV4(p) || p->proto != IPPROTO_ICMP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv4(p) || !PacketIsICMPv4(p) || p->proto != IPPROTO_ICMP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -775,7 +775,7 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || !PKT_IS_ICMPV6(p) || p->proto != IPPROTO_ICMPV6 ||
+    if (!PacketIsIPv6(p) || !PacketIsICMPv6(p) || p->proto != IPPROTO_ICMPV6 ||
             PKT_IS_PSEUDOPKT(p) ||
             (GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p))) <= 0) {
         return 0;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -693,15 +693,16 @@ static int DetectICMPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
+    const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
     if (!p->l4.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
         p->l4.csum = ICMPV4CalculateChecksum(
-                (uint16_t *)p->icmpv4h, IPV4_GET_RAW_IPLEN(ip4h) - IPV4_GET_RAW_HLEN(ip4h));
+                (uint16_t *)icmpv4h, IPV4_GET_RAW_IPLEN(ip4h) - IPV4_GET_RAW_HLEN(ip4h));
         p->l4.csum_set = true;
     }
-    if (p->l4.csum == p->icmpv4h->checksum && cd->valid == 1)
+    if (p->l4.csum == icmpv4h->checksum && cd->valid == 1)
         return 1;
-    else if (p->l4.csum != p->icmpv4h->checksum && cd->valid == 0)
+    else if (p->l4.csum != icmpv4h->checksum && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -417,7 +417,7 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (p->ip6h == NULL || p->tcph == NULL || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || p->tcph == NULL || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {
@@ -597,7 +597,7 @@ static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (p->ip6h == NULL || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {
@@ -775,8 +775,9 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (p->ip6h == NULL || p->icmpv6h == NULL || p->proto != IPPROTO_ICMPV6 || PKT_IS_PSEUDOPKT(p) ||
-        (GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p))) <= 0) {
+    if (!PacketIsIPv6(p) || p->icmpv6h == NULL || p->proto != IPPROTO_ICMPV6 ||
+            PKT_IS_PSEUDOPKT(p) ||
+            (GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p))) <= 0) {
         return 0;
     }
 

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -327,7 +327,7 @@ static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || p->tcph == NULL || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv4(p) || !PKT_IS_TCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {
@@ -415,7 +415,7 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || p->tcph == NULL || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || !PKT_IS_TCP(p) || p->proto != IPPROTO_TCP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {
@@ -504,7 +504,7 @@ static int DetectUDPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p) ||
+    if (!PacketIsIPv4(p) || !PKT_IS_UDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p) ||
             p->udph->uh_sum == 0)
         return 0;
 
@@ -593,7 +593,7 @@ static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || p->udph == NULL || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || !PKT_IS_UDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -507,7 +507,7 @@ static int DetectUDPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv4(p) || !PKT_IS_UDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p) ||
+    if (!PacketIsIPv4(p) || !PacketIsUDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p) ||
             p->udph->uh_sum == 0)
         return 0;
 
@@ -597,7 +597,7 @@ static int DetectUDPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || !PKT_IS_UDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv6(p) || !PacketIsUDP(p) || p->proto != IPPROTO_UDP || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (p->flags & PKT_IGNORE_CHECKSUM) {

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -775,7 +775,7 @@ static int DetectICMPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 {
     const DetectCsumData *cd = (const DetectCsumData *)ctx;
 
-    if (!PacketIsIPv6(p) || p->icmpv6h == NULL || p->proto != IPPROTO_ICMPV6 ||
+    if (!PacketIsIPv6(p) || !PKT_IS_ICMPV6(p) || p->proto != IPPROTO_ICMPV6 ||
             PKT_IS_PSEUDOPKT(p) ||
             (GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p))) <= 0) {
         return 0;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -246,14 +246,15 @@ static int DetectIPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->l3.comp_csum == -1) {
+    if (!p->l3.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        p->l3.comp_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), ip4h->ip_csum);
+        p->l3.csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), ip4h->ip_csum);
+        p->l3.csum_set = true;
     }
 
-    if (p->l3.comp_csum == 0 && cd->valid == 1)
+    if (p->l3.csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->l3.comp_csum != 0 && cd->valid == 0)
+    else if (p->l3.csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -337,8 +337,9 @@ static int DetectTCPV4CsumMatch(DetectEngineThreadCtx *det_ctx,
 
     if (!p->l4.csum_set) {
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
-        p->l4.csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
-                (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+        const TCPHdr *tcph = PacketGetTCP(p);
+        p->l4.csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)tcph,
+                (p->payload_len + TCP_GET_RAW_HLEN(tcph)), tcph->th_sum);
         p->l4.csum_set = true;
     }
     if (p->l4.csum == 0 && cd->valid == 1)
@@ -426,8 +427,9 @@ static int DetectTCPV6CsumMatch(DetectEngineThreadCtx *det_ctx,
 
     if (!p->l4.csum_set) {
         const IPV6Hdr *ip6h = PacketGetIPv6(p);
-        p->l4.csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
-                (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+        const TCPHdr *tcph = PacketGetTCP(p);
+        p->l4.csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)tcph,
+                (p->payload_len + TCP_GET_RAW_HLEN(tcph)), tcph->th_sum);
         p->l4.csum_set = true;
     }
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -77,7 +77,7 @@ static int PacketAlertHandle(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det
     const DetectThresholdData *td = NULL;
     const SigMatchData *smd;
 
-    if (!(PKT_IS_IPV4(p) || PKT_IS_IPV6(p))) {
+    if (!(PacketIsIPv4(p) || PacketIsIPv6(p))) {
         SCReturnInt(1);
     }
 

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -422,7 +422,7 @@ PacketCreateMask(Packet *p, SignatureMask *mask, AppProto alproto,
         (*mask) |= SIG_MASK_REQUIRE_ENGINE_EVENT;
     }
 
-    if (!(PKT_IS_PSEUDOPKT(p)) && PKT_IS_TCP(p)) {
+    if (!(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p)) {
         if ((p->tcph->th_flags & MASK_TCP_INITDEINIT_FLAGS) != 0) {
             (*mask) |= SIG_MASK_REQUIRE_FLAGS_INITDEINIT;
         }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -423,10 +423,11 @@ PacketCreateMask(Packet *p, SignatureMask *mask, AppProto alproto,
     }
 
     if (!(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p)) {
-        if ((p->tcph->th_flags & MASK_TCP_INITDEINIT_FLAGS) != 0) {
+        const TCPHdr *tcph = PacketGetTCP(p);
+        if ((tcph->th_flags & MASK_TCP_INITDEINIT_FLAGS) != 0) {
             (*mask) |= SIG_MASK_REQUIRE_FLAGS_INITDEINIT;
         }
-        if ((p->tcph->th_flags & MASK_TCP_UNUSUAL_FLAGS) != 0) {
+        if ((tcph->th_flags & MASK_TCP_UNUSUAL_FLAGS) != 0) {
             (*mask) |= SIG_MASK_REQUIRE_FLAGS_UNUSUAL;
         }
     }

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1057,7 +1057,7 @@ void IPOnlyMatchPacket(ThreadVars *tv, const DetectEngineCtx *de_ctx,
                     SCLogDebug("ip version didn't match");
                     continue;
                 }
-                if (DetectProtoContainsProto(&s->proto, IP_GET_IPPROTO(p)) == 0) {
+                if (DetectProtoContainsProto(&s->proto, PacketGetIPProto(p)) == 0) {
                     SCLogDebug("proto didn't match");
                     continue;
                 }

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1049,11 +1049,11 @@ void IPOnlyMatchPacket(ThreadVars *tv, const DetectEngineCtx *de_ctx,
             if (bitarray & 0x01) {
                 const Signature *s = de_ctx->sig_array[io_ctx->sig_mapping[u * 8 + i]];
 
-                if ((s->proto.flags & DETECT_PROTO_IPV4) && !PKT_IS_IPV4(p)) {
+                if ((s->proto.flags & DETECT_PROTO_IPV4) && !PacketIsIPv4(p)) {
                     SCLogDebug("ip version didn't match");
                     continue;
                 }
-                if ((s->proto.flags & DETECT_PROTO_IPV6) && !PKT_IS_IPV6(p)) {
+                if ((s->proto.flags & DETECT_PROTO_IPV6) && !PacketIsIPv6(p)) {
                     SCLogDebug("ip version didn't match");
                     continue;
                 }

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -1051,9 +1051,10 @@ static int SigGroupHeadTest06(void)
 
     Packet *p = UTHBuildPacketSrcDst(NULL, 0, IPPROTO_ICMP, "192.168.1.1", "1.2.3.4");
     FAIL_IF_NULL(p);
+    FAIL_IF_NOT(PacketIsICMPv4(p));
 
-    p->icmpv4h->type = 5;
-    p->icmpv4h->code = 1;
+    p->l4.hdrs.icmpv4h->type = 5;
+    p->l4.hdrs.icmpv4h->code = 1;
 
     /* originally ip's were
     p.src.addr_data32[0] = 0xe08102d3;

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -142,7 +142,7 @@ FragBitsMatch(const uint8_t pbits, const uint8_t modifier,
 static int DetectFragBitsMatch (DetectEngineThreadCtx *det_ctx,
         Packet *p, const Signature *s, const SigMatchCtx *ctx)
 {
-    if (!ctx || !PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
+    if (!ctx || !PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     uint8_t fragbits = 0;
@@ -321,7 +321,7 @@ PrefilterPacketFragBitsMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const vo
 {
     const PrefilterPacketHeaderCtx *ctx = pectx;
 
-    if (!PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
+    if (!PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p))
         return;
 
     uint8_t fragbits = 0;

--- a/src/detect-fragbits.c
+++ b/src/detect-fragbits.c
@@ -147,11 +147,12 @@ static int DetectFragBitsMatch (DetectEngineThreadCtx *det_ctx,
 
     uint8_t fragbits = 0;
     const DetectFragBitsData *de = (const DetectFragBitsData *)ctx;
-    if(IPV4_GET_MF(p))
+    const IPV4Hdr *ip4h = PacketGetIPv4(p);
+    if (IPV4_GET_RAW_FLAG_MF(ip4h))
         fragbits |= FRAGBITS_HAVE_MF;
-    if(IPV4_GET_DF(p))
+    if (IPV4_GET_RAW_FLAG_DF(ip4h))
         fragbits |= FRAGBITS_HAVE_DF;
-    if(IPV4_GET_RF(p))
+    if (IPV4_GET_RAW_FLAG_RF(ip4h))
         fragbits |= FRAGBITS_HAVE_RF;
 
     return FragBitsMatch(fragbits, de->modifier, de->fragbits);
@@ -325,11 +326,12 @@ PrefilterPacketFragBitsMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const vo
         return;
 
     uint8_t fragbits = 0;
-    if (IPV4_GET_MF(p))
+    const IPV4Hdr *ip4h = PacketGetIPv4(p);
+    if (IPV4_GET_RAW_FLAG_MF(ip4h))
         fragbits |= FRAGBITS_HAVE_MF;
-    if (IPV4_GET_DF(p))
+    if (IPV4_GET_RAW_FLAG_DF(ip4h))
         fragbits |= FRAGBITS_HAVE_DF;
-    if (IPV4_GET_RF(p))
+    if (IPV4_GET_RAW_FLAG_RF(ip4h))
         fragbits |= FRAGBITS_HAVE_RF;
 
     if (FragBitsMatch(fragbits, ctx->v1.u8[0], ctx->v1.u8[1]))

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -115,7 +115,8 @@ static int DetectFragOffsetMatch (DetectEngineThreadCtx *det_ctx,
         return 0;
 
     if (PacketIsIPv4(p)) {
-        frag = IPV4_GET_IPOFFSET(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        frag = IPV4_GET_RAW_FRAGOFFSET(ip4h);
     } else if (PacketIsIPv6(p)) {
         if (IPV6_EXTHDR_ISSET_FH(p)) {
             frag = IPV6_EXTHDR_GET_FH_OFFSET(p);
@@ -269,7 +270,8 @@ PrefilterPacketFragOffsetMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const 
     uint16_t frag;
 
     if (PacketIsIPv4(p)) {
-        frag = IPV4_GET_IPOFFSET(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        frag = IPV4_GET_RAW_FRAGOFFSET(ip4h);
     } else if (PacketIsIPv6(p)) {
         if (IPV6_EXTHDR_ISSET_FH(p)) {
             frag = IPV6_EXTHDR_GET_FH_OFFSET(p);
@@ -407,7 +409,7 @@ static int DetectFragOffsetMatchTest01 (void)
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
     ip4h.ip_off = 0x2222;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -114,9 +114,9 @@ static int DetectFragOffsetMatch (DetectEngineThreadCtx *det_ctx,
     if (PKT_IS_PSEUDOPKT(p))
         return 0;
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         frag = IPV4_GET_IPOFFSET(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         if (IPV6_EXTHDR_ISSET_FH(p)) {
             frag = IPV6_EXTHDR_GET_FH_OFFSET(p);
         } else {
@@ -268,9 +268,9 @@ PrefilterPacketFragOffsetMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const 
 
     uint16_t frag;
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         frag = IPV4_GET_IPOFFSET(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         if (IPV6_EXTHDR_ISSET_FH(p)) {
             frag = IPV6_EXTHDR_GET_FH_OFFSET(p);
         } else {

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -253,8 +253,7 @@ static int DetectGeoipMatch(DetectEngineThreadCtx *det_ctx,
     if (PKT_IS_PSEUDOPKT(p))
         return 0;
 
-    if (PKT_IS_IPV4(p))
-    {
+    if (PacketIsIPv4(p)) {
         if (geoipdata->flags & ( GEOIP_MATCH_SRC_FLAG | GEOIP_MATCH_BOTH_FLAG ))
         {
             if (CheckGeoMatchIPv4(geoipdata, GET_IPV4_SRC_ADDR_U32(p)))

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -79,7 +79,7 @@ static inline bool GetIcmpId(Packet *p, uint16_t *id)
         return false;
 
     uint16_t pid;
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         switch (ICMPV4_GET_TYPE(p)){
             case ICMP_ECHOREPLY:
             case ICMP_ECHO:

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -99,7 +99,7 @@ static inline bool GetIcmpId(Packet *p, uint16_t *id)
                 SCLogDebug("Packet has no id field");
                 return false;
         }
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         switch (ICMPV6_GET_TYPE(p)) {
             case ICMP6_ECHO_REQUEST:
             case ICMP6_ECHO_REPLY:

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -100,7 +100,7 @@ static inline bool GetIcmpId(Packet *p, uint16_t *id)
                 return false;
         }
     } else if (PacketIsICMPv6(p)) {
-        switch (ICMPV6_GET_TYPE(p)) {
+        switch (ICMPV6_GET_TYPE(PacketGetICMPv6(p))) {
             case ICMP6_ECHO_REQUEST:
             case ICMP6_ECHO_REPLY:
                 SCLogDebug("ICMPV6_GET_ID(p) %"PRIu16" (network byte order), "

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -490,7 +490,7 @@ static int DetectIcmpIdMatchTest02 (void)
 
     ip4h.s_ip_src.s_addr = p->src.addr_data32[0];
     ip4h.s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DecodeICMPV4(&th_v, &dtv, p, raw_icmpv4, sizeof(raw_icmpv4));
 

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -80,7 +80,7 @@ static inline bool GetIcmpId(Packet *p, uint16_t *id)
 
     uint16_t pid;
     if (PacketIsICMPv4(p)) {
-        switch (ICMPV4_GET_TYPE(p)){
+        switch (p->icmp_s.type) {
             case ICMP_ECHOREPLY:
             case ICMP_ECHO:
             case ICMP_TIMESTAMP:
@@ -407,7 +407,7 @@ static int DetectIcmpIdMatchTest01 (void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     p = UTHBuildPacket(NULL, 0, IPPROTO_ICMP);
-    p->icmpv4vars.id = htons(21781);
+    p->l4.vars.icmpv4.id = htons(21781);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -99,7 +99,7 @@ static inline bool GetIcmpSeq(Packet *p, uint16_t *seq)
                 SCLogDebug("Packet has no seq field");
                 return false;
         }
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
 
         switch (ICMPV6_GET_TYPE(p)) {
             case ICMP6_ECHO_REQUEST:

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -100,8 +100,7 @@ static inline bool GetIcmpSeq(Packet *p, uint16_t *seq)
                 return false;
         }
     } else if (PacketIsICMPv6(p)) {
-
-        switch (ICMPV6_GET_TYPE(p)) {
+        switch (ICMPV6_GET_TYPE(PacketGetICMPv6(p))) {
             case ICMP6_ECHO_REQUEST:
             case ICMP6_ECHO_REPLY:
                 SCLogDebug("ICMPV6_GET_SEQ(p) %"PRIu16" (network byte order), "

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -80,7 +80,7 @@ static inline bool GetIcmpSeq(Packet *p, uint16_t *seq)
         return false;
 
     if (PacketIsICMPv4(p)) {
-        switch (ICMPV4_GET_TYPE(p)){
+        switch (p->icmp_s.type) {
             case ICMP_ECHOREPLY:
             case ICMP_ECHO:
             case ICMP_TIMESTAMP:

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -79,7 +79,7 @@ static inline bool GetIcmpSeq(Packet *p, uint16_t *seq)
     if (PKT_IS_PSEUDOPKT(p))
         return false;
 
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         switch (ICMPV4_GET_TYPE(p)){
             case ICMP_ECHOREPLY:
             case ICMP_ECHO:

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -95,7 +95,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 {
     SCEnter();
 
-    if (!PKT_IS_ICMPV4(p)) {
+    if (!PacketIsICMPv4(p)) {
         SCReturnPtr(NULL, "InspectionBuffer");
     }
 

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -101,16 +101,17 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
+        const ICMPV4Hdr *icmpv4h = PacketGetICMPv4(p);
         uint16_t hlen = ICMPV4_GET_HLEN_ICMPV4H(p);
-        if (((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen) >
+        if (((uint8_t *)icmpv4h + (ptrdiff_t)hlen) >
                 ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
-            SCLogDebug("data out of range: %p > %p", ((uint8_t *)p->icmpv4h + (ptrdiff_t)hlen),
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)icmpv4h + (ptrdiff_t)hlen),
                     ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
             SCReturnPtr(NULL, "InspectionBuffer");
         }
 
         const uint32_t data_len = hlen;
-        const uint8_t *data = (const uint8_t *)p->icmpv4h;
+        const uint8_t *data = (const uint8_t *)icmpv4h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -95,7 +95,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 {
     SCEnter();
 
-    if (p->icmpv4h == NULL) {
+    if (!PKT_IS_ICMPV4(p)) {
         SCReturnPtr(NULL, "InspectionBuffer");
     }
 

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -66,12 +66,13 @@ static inline int DetectICMPv6mtuGetValue(Packet *p, uint32_t *picmpv6mtu)
 {
     if (!(PacketIsICMPv6(p)) || PKT_IS_PSEUDOPKT(p))
         return 0;
-    if (ICMPV6_GET_CODE(p) != 0)
+    const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+    if (ICMPV6_GET_CODE(icmpv6h) != 0)
         return 0;
-    if (!(ICMPV6_HAS_MTU(p)))
+    if (!(ICMPV6_HAS_MTU(icmpv6h)))
         return 0;
 
-    *picmpv6mtu = ICMPV6_GET_MTU(p);
+    *picmpv6mtu = ICMPV6_GET_MTU(icmpv6h);
     return 1;
 }
 

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -64,7 +64,7 @@ void DetectICMPv6mtuRegister(void)
 // returns 0 on no mtu, and 1 if mtu
 static inline int DetectICMPv6mtuGetValue(Packet *p, uint32_t *picmpv6mtu)
 {
-    if (!(PKT_IS_ICMPV6(p)) || PKT_IS_PSEUDOPKT(p))
+    if (!(PacketIsICMPv6(p)) || PKT_IS_PSEUDOPKT(p))
         return 0;
     if (ICMPV6_GET_CODE(p) != 0)
         return 0;

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -105,7 +105,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         uint32_t hlen = ICMPV6_HEADER_LEN;
-        if (p->icmpv6h == NULL) {
+        if (!PKT_IS_ICMPV6(p)) {
             // DETECT_PROTO_IPV6 does not prefilter
             return NULL;
         }

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -105,7 +105,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         uint32_t hlen = ICMPV6_HEADER_LEN;
-        if (!PKT_IS_ICMPV6(p)) {
+        if (!PacketIsICMPv6(p)) {
             // DETECT_PROTO_IPV6 does not prefilter
             return NULL;
         }

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -109,17 +109,16 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             // DETECT_PROTO_IPV6 does not prefilter
             return NULL;
         }
-        if (((uint8_t *)p->icmpv6h + (ptrdiff_t)hlen) >
-                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)))
-        {
-            SCLogDebug("data out of range: %p > %p",
-                    ((uint8_t *)p->icmpv6h + (ptrdiff_t)hlen),
+        const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+        if (((uint8_t *)icmpv6h + (ptrdiff_t)hlen) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)icmpv6h + (ptrdiff_t)hlen),
                     ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
             SCReturnPtr(NULL, "InspectionBuffer");
         }
 
         const uint32_t data_len = hlen;
-        const uint8_t *data = (const uint8_t *)p->icmpv6h;
+        const uint8_t *data = (const uint8_t *)icmpv6h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -94,7 +94,8 @@ static int DetectICodeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
     } else if (PacketIsICMPv6(p)) {
-        picode = ICMPV6_GET_CODE(p);
+        const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+        picode = ICMPV6_GET_CODE(icmpv6h);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
         return 0;
@@ -159,7 +160,8 @@ static void PrefilterPacketICodeMatch(DetectEngineThreadCtx *det_ctx,
     if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
     } else if (PacketIsICMPv6(p)) {
-        picode = ICMPV6_GET_CODE(p);
+        const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+        picode = ICMPV6_GET_CODE(icmpv6h);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
         return;

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -93,7 +93,7 @@ static int DetectICodeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     uint8_t picode;
     if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         picode = ICMPV6_GET_CODE(p);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
@@ -158,7 +158,7 @@ static void PrefilterPacketICodeMatch(DetectEngineThreadCtx *det_ctx,
     uint8_t picode;
     if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         picode = ICMPV6_GET_CODE(p);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -92,7 +92,7 @@ static int DetectICodeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
     uint8_t picode;
     if (PacketIsICMPv4(p)) {
-        picode = ICMPV4_GET_CODE(p);
+        picode = p->icmp_s.code;
     } else if (PacketIsICMPv6(p)) {
         const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
         picode = ICMPV6_GET_CODE(icmpv6h);
@@ -158,7 +158,7 @@ static void PrefilterPacketICodeMatch(DetectEngineThreadCtx *det_ctx,
 
     uint8_t picode;
     if (PacketIsICMPv4(p)) {
-        picode = ICMPV4_GET_CODE(p);
+        picode = p->icmp_s.code;
     } else if (PacketIsICMPv6(p)) {
         const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
         picode = ICMPV6_GET_CODE(icmpv6h);
@@ -335,17 +335,16 @@ static int DetectICodeParseTest09(void)
  */
 static int DetectICodeMatchTest01(void)
 {
-
-    Packet *p = NULL;
     Signature *s = NULL;
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
 
     memset(&th_v, 0, sizeof(th_v));
 
-    p = UTHBuildPacket(NULL, 0, IPPROTO_ICMP);
-
-    p->icmpv4h->code = 10;
+    Packet *p = UTHBuildPacket(NULL, 0, IPPROTO_ICMP);
+    FAIL_IF_NULL(p);
+    FAIL_IF_NOT(PacketIsICMPv4(p));
+    p->icmp_s.code = p->l4.hdrs.icmpv4h->code = 10;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -91,7 +91,7 @@ static int DetectICodeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
 
     uint8_t picode;
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
     } else if (PKT_IS_ICMPV6(p)) {
         picode = ICMPV6_GET_CODE(p);
@@ -156,7 +156,7 @@ static void PrefilterPacketICodeMatch(DetectEngineThreadCtx *det_ctx,
     }
 
     uint8_t picode;
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         picode = ICMPV4_GET_CODE(p);
     } else if (PKT_IS_ICMPV6(p)) {
         picode = ICMPV6_GET_CODE(p);

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -98,7 +98,7 @@ static int DetectIdMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     /**
      * To match a ipv4 packet with a "id" rule
      */
-    if (!PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p)) {
+    if (!PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p)) {
         return 0;
     }
 
@@ -225,7 +225,7 @@ PrefilterPacketIdMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pe
 {
     const PrefilterPacketHeaderCtx *ctx = pectx;
 
-    if (!PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p)) {
+    if (!PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p)) {
         return;
     }
 

--- a/src/detect-id.c
+++ b/src/detect-id.c
@@ -102,7 +102,8 @@ static int DetectIdMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
     }
 
-    if (id_d->id == IPV4_GET_IPID(p)) {
+    const IPV4Hdr *ip4h = PacketGetIPv4(p);
+    if (id_d->id == IPV4_GET_RAW_IPID(ip4h)) {
         SCLogDebug("IPV4 Proto and matched with ip_id: %u.\n",
                     id_d->id);
         return 1;
@@ -232,8 +233,8 @@ PrefilterPacketIdMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pe
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if (IPV4_GET_IPID(p) == ctx->v1.u16[0])
-    {
+    const IPV4Hdr *ip4h = PacketGetIPv4(p);
+    if (ctx->v1.u16[0] == IPV4_GET_RAW_IPID(ip4h)) {
         SCLogDebug("packet matches IP id %u", ctx->v1.u16[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
@@ -356,13 +357,13 @@ static int DetectIdTestMatch01(void)
     FAIL_IF_NULL(p[2]);
 
     /* TCP IP id = 1234 */
-    p[0]->ip4h->ip_id = htons(1234);
+    p[0]->l3.hdrs.ip4h->ip_id = htons(1234);
 
     /* UDP IP id = 5678 */
-    p[1]->ip4h->ip_id = htons(5678);
+    p[1]->l3.hdrs.ip4h->ip_id = htons(5678);
 
     /* UDP IP id = 91011 */
-    p[2]->ip4h->ip_id = htons(5101);
+    p[2]->l3.hdrs.ip4h->ip_id = htons(5101);
 
     const char *sigs[3];
     sigs[0]= "alert ip any any -> any any (msg:\"Testing id 1\"; id:1234; sid:1;)";

--- a/src/detect-ipaddr.c
+++ b/src/detect-ipaddr.c
@@ -120,10 +120,10 @@ static InspectionBuffer *GetDataSrc(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             /* Suricata stores the IPv4 at the beginning of the field */
             InspectionBufferSetup(det_ctx, list_id, buffer, p->src.address.address_un_data8, 4);
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             InspectionBufferSetup(det_ctx, list_id, buffer, p->src.address.address_un_data8, 16);
         } else {
             return NULL;
@@ -144,10 +144,10 @@ static InspectionBuffer *GetDataDst(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             /* Suricata stores the IPv4 at the beginning of the field */
             InspectionBufferSetup(det_ctx, list_id, buffer, p->dst.address.address_un_data8, 4);
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             InspectionBufferSetup(det_ctx, list_id, buffer, p->dst.address.address_un_data8, 16);
         } else {
             return NULL;

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -159,7 +159,7 @@ static int DetectIpOptsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 {
     const DetectIpOptsData *de = (const DetectIpOptsData *)ctx;
 
-    if (!de || !PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
+    if (!de || !PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     return (p->ip4vars.opts_set & de->ipopt) == de->ipopt;

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -31,6 +31,7 @@
 
 #include "detect-ipopts.h"
 #include "util-unittest.h"
+#include "util-unittest-helper.h"
 
 static int DetectIpOptsMatch (DetectEngineThreadCtx *, Packet *,
         const Signature *, const SigMatchCtx *);
@@ -162,7 +163,7 @@ static int DetectIpOptsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     if (!de || !PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
-    return (p->ip4vars.opts_set & de->ipopt) == de->ipopt;
+    return (p->l3.vars.ip4.opts_set & de->ipopt) == de->ipopt;
 }
 
 /**
@@ -292,8 +293,8 @@ static int IpOptsTestParse03 (void)
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
-    p->ip4h = &ip4h;
-    p->ip4vars.opts_set = IPV4_OPT_FLAG_RR;
+    UTHSetIPV4Hdr(p, &ip4h);
+    p->l3.vars.ip4.opts_set = IPV4_OPT_FLAG_RR;
 
     DetectIpOptsData *de = DetectIpOptsParse("rr");
     FAIL_IF_NULL(de);
@@ -326,8 +327,8 @@ static int IpOptsTestParse04 (void)
     memset(&tv, 0, sizeof(ThreadVars));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
-    p->ip4h = &ip4h;
-    p->ip4vars.opts_set = IPV4_OPT_FLAG_RR;
+    UTHSetIPV4Hdr(p, &ip4h);
+    p->l3.vars.ip4.opts_set = IPV4_OPT_FLAG_RR;
 
     DetectIpOptsData *de = DetectIpOptsParse("lsrr");
     FAIL_IF_NULL(de);

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -100,8 +100,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (p->ip6h == NULL) {
-            // DETECT_PROTO_IPV6 does not prefilter
+        if (!PacketIsIPv6(p)) {
             return NULL;
         }
         uint32_t hlen = IPV6_HEADER_LEN + IPV6_GET_EXTHDRS_LEN(p);

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -103,19 +103,19 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (!PacketIsIPv6(p)) {
             return NULL;
         }
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
         uint32_t hlen = IPV6_HEADER_LEN + IPV6_GET_EXTHDRS_LEN(p);
-        if (((uint8_t *)p->ip6h + (ptrdiff_t)hlen) >
-                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)))
-        {
+        if (((uint8_t *)ip6h + (ptrdiff_t)hlen) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
             SCLogDebug("data out of range: %p > %p (exthdrs_len %u)",
-                    ((uint8_t *)p->ip6h + (ptrdiff_t)hlen),
+                    ((uint8_t *)ip6h + (ptrdiff_t)hlen),
                     ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)),
                     IPV6_GET_EXTHDRS_LEN(p));
             SCReturnPtr(NULL, "InspectionBuffer");
         }
 
         const uint32_t data_len = hlen;
-        const uint8_t *data = (const uint8_t *)p->ip6h;
+        const uint8_t *data = (const uint8_t *)ip6h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -88,7 +88,7 @@ static int DetectITypeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
 
     uint8_t pitype;
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
     } else if (PKT_IS_ICMPV6(p)) {
         pitype = ICMPV6_GET_TYPE(p);
@@ -172,7 +172,7 @@ static void PrefilterPacketITypeMatch(DetectEngineThreadCtx *det_ctx,
     }
 
     uint8_t pitype;
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
     } else if (PKT_IS_ICMPV6(p)) {
         pitype = ICMPV6_GET_TYPE(p);

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -90,7 +90,7 @@ static int DetectITypeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     uint8_t pitype;
     if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         pitype = ICMPV6_GET_TYPE(p);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
@@ -174,7 +174,7 @@ static void PrefilterPacketITypeMatch(DetectEngineThreadCtx *det_ctx,
     uint8_t pitype;
     if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         pitype = ICMPV6_GET_TYPE(p);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -91,7 +91,8 @@ static int DetectITypeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
     } else if (PacketIsICMPv6(p)) {
-        pitype = ICMPV6_GET_TYPE(p);
+        const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+        pitype = ICMPV6_GET_TYPE(icmpv6h);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
         return 0;
@@ -175,7 +176,8 @@ static void PrefilterPacketITypeMatch(DetectEngineThreadCtx *det_ctx,
     if (PacketIsICMPv4(p)) {
         pitype = ICMPV4_GET_TYPE(p);
     } else if (PacketIsICMPv6(p)) {
-        pitype = ICMPV6_GET_TYPE(p);
+        const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
+        pitype = ICMPV6_GET_TYPE(icmpv6h);
     } else {
         /* Packet not ICMPv4 nor ICMPv6 */
         return;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -89,7 +89,7 @@ static int DetectITypeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
     uint8_t pitype;
     if (PacketIsICMPv4(p)) {
-        pitype = ICMPV4_GET_TYPE(p);
+        pitype = p->icmp_s.type;
     } else if (PacketIsICMPv6(p)) {
         const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
         pitype = ICMPV6_GET_TYPE(icmpv6h);
@@ -174,7 +174,7 @@ static void PrefilterPacketITypeMatch(DetectEngineThreadCtx *det_ctx,
 
     uint8_t pitype;
     if (PacketIsICMPv4(p)) {
-        pitype = ICMPV4_GET_TYPE(p);
+        pitype = p->icmp_s.type;
     } else if (PacketIsICMPv6(p)) {
         const ICMPV6Hdr *icmpv6h = PacketGetICMPv6(p);
         pitype = ICMPV6_GET_TYPE(icmpv6h);

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -192,7 +192,7 @@ static int DetectL3protoTestSig2(void)
     p->src.family = AF_INET6;
     p->dst.family = AF_INET6;
     p->proto = IPPROTO_TCP;
-    p->ip6h = &ip6h;
+    UTHSetIPV6Hdr(p, &ip6h);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
@@ -252,7 +252,7 @@ static int DetectL3protoTestSig3(void)
     p->src.family = AF_INET6;
     p->dst.family = AF_INET6;
     p->proto = IPPROTO_TCP;
-    p->ip6h = &ip6h;
+    UTHSetIPV6Hdr(p, &ip6h);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -131,7 +131,7 @@ static int DetectL3protoTestSig1(void)
     p->src.family = AF_INET;
     p->dst.family = AF_INET;
     p->proto = IPPROTO_TCP;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -96,7 +96,7 @@ static int DetectRpcMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     const DetectRpcData *rd = (const DetectRpcData *)ctx;
     char *rpcmsg = (char *)p->payload;
 
-    if (PKT_IS_TCP(p)) {
+    if (PacketIsTCP(p)) {
         /* if Rpc msg too small */
         if (p->payload_len < 28) {
             SCLogDebug("TCP packet to small for the rpc msg (%u)", p->payload_len);

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -103,7 +103,7 @@ static int DetectRpcMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
             return 0;
         }
         rpcmsg += 4;
-    } else if (PKT_IS_UDP(p)) {
+    } else if (PacketIsUDP(p)) {
         /* if Rpc msg too small */
         if (p->payload_len < 24) {
             SCLogDebug("UDP packet to small for the rpc msg (%u)", p->payload_len);

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -121,7 +121,7 @@ static int DetectStreamSizeMatch(
 
     const DetectStreamSizeData *sd = (const DetectStreamSizeData *)ctx;
 
-    if (!(PKT_IS_TCP(p)))
+    if (!(PacketIsTCP(p)))
         return 0;
     if (p->flow == NULL || p->flow->protoctx == NULL)
         return 0;
@@ -170,7 +170,7 @@ void DetectStreamSizeFree(DetectEngineCtx *de_ctx, void *ptr)
 static void PrefilterPacketStreamsizeMatch(
         DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p))
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p))
         return;
 
     if (p->flow == NULL || p->flow->protoctx == NULL)

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -331,7 +331,7 @@ static int DetectStreamSizeParseTest03 (void)
     ssn.client = client;
     f.protoctx = &ssn;
     p->flow = &f;
-    p->tcph = &tcph;
+    PacketSetTCP(p, (uint8_t *)&tcph);
     sm.ctx = (SigMatchCtx*)sd;
 
     result = DetectStreamSizeMatch(&dtx, p, &s, sm.ctx);

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -26,6 +26,7 @@
 #include "suricata-common.h"
 #include "stream-tcp.h"
 #include "util-unittest.h"
+#include "util-unittest-helper.h"
 
 #include "detect.h"
 #include "detect-parse.h"
@@ -391,7 +392,7 @@ static int DetectStreamSizeParseTest04 (void)
     ssn.client = client;
     f.protoctx = &ssn;
     p->flow = &f;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
     sm.ctx = (SigMatchCtx*)sd;
 
     if (!DetectStreamSizeMatch(&dtx, p, &s, sm.ctx))

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -88,7 +88,7 @@ static int DetectAckMatch(DetectEngineThreadCtx *det_ctx,
     const DetectAckData *data = (const DetectAckData *)ctx;
 
     /* This is only needed on TCP packets */
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p)) {
         return 0;
     }
 
@@ -156,7 +156,7 @@ PrefilterPacketAckMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PKT_IS_TCP(p) &&
+    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p) &&
             (TCP_GET_ACK(p) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP ack %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -92,7 +92,7 @@ static int DetectAckMatch(DetectEngineThreadCtx *det_ctx,
         return 0;
     }
 
-    return (data->ack == TCP_GET_ACK(p)) ? 1 : 0;
+    return (data->ack == TCP_GET_RAW_ACK(PacketGetTCP(p))) ? 1 : 0;
 }
 
 /**
@@ -157,7 +157,7 @@ PrefilterPacketAckMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
         return;
 
     if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p) &&
-            (TCP_GET_ACK(p) == ctx->v1.u32[0])) {
+            (TCP_GET_RAW_ACK(PacketGetTCP(p)) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP ack %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
@@ -218,11 +218,11 @@ static int DetectAckSigTest01(void)
 
     /* TCP w/ack=42 */
     p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
-    p1->tcph->th_ack = htonl(42);
+    p1->l4.hdrs.tcph->th_ack = htonl(42);
 
     /* TCP w/ack=100 */
     p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
-    p2->tcph->th_ack = htonl(100);
+    p2->l4.hdrs.tcph->th_ack = htonl(100);
 
     /* ICMP */
     p3 = UTHBuildPacket(NULL, 0, IPPROTO_ICMP);

--- a/src/detect-tcp-ack.c
+++ b/src/detect-tcp-ack.c
@@ -156,9 +156,8 @@ PrefilterPacketAckMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if ((p->proto) == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) &&
-        (p->tcph != NULL) && (TCP_GET_ACK(p) == ctx->v1.u32[0]))
-    {
+    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PKT_IS_TCP(p) &&
+            (TCP_GET_ACK(p) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP ack %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -156,7 +156,8 @@ static int DetectFlagsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     }
 
     const DetectFlagsData *de = (const DetectFlagsData *)ctx;
-    const uint8_t flags = p->tcph->th_flags;
+    const TCPHdr *tcph = PacketGetTCP(p);
+    const uint8_t flags = tcph->th_flags;
 
     return FlagsMatch(flags, de->modifier, de->flags, de->ignored_flags);
 }
@@ -560,7 +561,8 @@ PrefilterPacketFlagsMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void 
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    const uint8_t flags = p->tcph->th_flags;
+    const TCPHdr *tcph = PacketGetTCP(p);
+    const uint8_t flags = tcph->th_flags;
     if (FlagsMatch(flags, ctx->v1.u8[0], ctx->v1.u8[1], ctx->v1.u8[2]))
     {
         SCLogDebug("packet matches TCP flags %02x", ctx->v1.u8[1]);
@@ -671,8 +673,8 @@ static int FlagsTestParse03 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
+    tcph.th_flags = TH_ACK | TH_PUSH | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("AP+");
 
@@ -725,8 +727,8 @@ static int FlagsTestParse04 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN;
+    tcph.th_flags = TH_SYN;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("A");
 
@@ -780,8 +782,8 @@ static int FlagsTestParse05 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
+    tcph.th_flags = TH_ACK | TH_PUSH | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("+AP,SR");
 
@@ -835,8 +837,8 @@ static int FlagsTestParse06 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
+    tcph.th_flags = TH_ACK | TH_PUSH | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("+AP,UR");
 
@@ -889,8 +891,8 @@ static int FlagsTestParse07 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN|TH_RST;
+    tcph.th_flags = TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("*AP");
 
@@ -944,8 +946,8 @@ static int FlagsTestParse08 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN|TH_RST;
+    tcph.th_flags = TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("*SA");
 
@@ -998,8 +1000,8 @@ static int FlagsTestParse09 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN|TH_RST;
+    tcph.th_flags = TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("!PA");
 
@@ -1052,8 +1054,8 @@ static int FlagsTestParse10 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN|TH_RST;
+    tcph.th_flags = TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("!AP");
 
@@ -1106,8 +1108,8 @@ static int FlagsTestParse11 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN|TH_RST|TH_URG;
+    tcph.th_flags = TH_SYN | TH_RST | TH_URG;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("*AP,SR");
 
@@ -1161,8 +1163,8 @@ static int FlagsTestParse12 (void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_SYN;
+    tcph.th_flags = TH_SYN;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("0");
 
@@ -1247,8 +1249,8 @@ static int FlagsTestParse15(void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ECN | TH_CWR | TH_SYN | TH_RST;
+    tcph.th_flags = TH_ECN | TH_CWR | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("EC+");
 
@@ -1299,8 +1301,8 @@ static int FlagsTestParse16(void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ECN | TH_SYN | TH_RST;
+    tcph.th_flags = TH_ECN | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("EC*");
 
@@ -1354,8 +1356,8 @@ static int FlagsTestParse17(void)
     memset(&tcph, 0, sizeof(TCPHdr));
 
     UTHSetIPV4Hdr(p, &ipv4h);
-    p->tcph = &tcph;
-    p->tcph->th_flags = TH_ECN | TH_SYN | TH_RST;
+    tcph.th_flags = TH_ECN | TH_SYN | TH_RST;
+    UTHSetTCPHdr(p, &tcph);
 
     de = DetectFlagsParse("EC+");
 

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -37,6 +37,7 @@
 
 #include "detect-tcp-flags.h"
 #include "util-unittest.h"
+#include "util-unittest-helper.h"
 
 #include "util-debug.h"
 
@@ -669,7 +670,7 @@ static int FlagsTestParse03 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
 
@@ -723,7 +724,7 @@ static int FlagsTestParse04 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN;
 
@@ -778,7 +779,7 @@ static int FlagsTestParse05 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
 
@@ -833,7 +834,7 @@ static int FlagsTestParse06 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ACK|TH_PUSH|TH_SYN|TH_RST;
 
@@ -887,7 +888,7 @@ static int FlagsTestParse07 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN|TH_RST;
 
@@ -942,7 +943,7 @@ static int FlagsTestParse08 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN|TH_RST;
 
@@ -996,7 +997,7 @@ static int FlagsTestParse09 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN|TH_RST;
 
@@ -1050,7 +1051,7 @@ static int FlagsTestParse10 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN|TH_RST;
 
@@ -1104,7 +1105,7 @@ static int FlagsTestParse11 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN|TH_RST|TH_URG;
 
@@ -1159,7 +1160,7 @@ static int FlagsTestParse12 (void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_SYN;
 
@@ -1245,7 +1246,7 @@ static int FlagsTestParse15(void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ECN | TH_CWR | TH_SYN | TH_RST;
 
@@ -1297,7 +1298,7 @@ static int FlagsTestParse16(void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ECN | TH_SYN | TH_RST;
 
@@ -1352,7 +1353,7 @@ static int FlagsTestParse17(void)
     memset(&ipv4h, 0, sizeof(IPV4Hdr));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     p->tcph = &tcph;
     p->tcph->th_flags = TH_ECN | TH_SYN | TH_RST;
 

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -151,7 +151,7 @@ static int DetectFlagsMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 {
     SCEnter();
 
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p)) {
         SCReturnInt(0);
     }
 
@@ -552,7 +552,7 @@ int DetectFlagsSignatureNeedsSynOnlyPackets(const Signature *s)
 static void
 PrefilterPacketFlagsMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p)) {
         SCReturn;
     }
 

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -151,9 +151,8 @@ PrefilterPacketSeqMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if ((p->proto) == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) &&
-        (p->tcph != NULL) && (TCP_GET_SEQ(p) == ctx->v1.u32[0]))
-    {
+    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PKT_IS_TCP(p) &&
+            (TCP_GET_SEQ(p) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP seq %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -84,7 +84,7 @@ static int DetectSeqMatch(DetectEngineThreadCtx *det_ctx,
     const DetectSeqData *data = (const DetectSeqData *)ctx;
 
     /* This is only needed on TCP packets */
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p)) {
         return 0;
     }
 
@@ -151,7 +151,7 @@ PrefilterPacketSeqMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PKT_IS_TCP(p) &&
+    if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p) &&
             (TCP_GET_SEQ(p) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP seq %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);

--- a/src/detect-tcp-seq.c
+++ b/src/detect-tcp-seq.c
@@ -88,7 +88,7 @@ static int DetectSeqMatch(DetectEngineThreadCtx *det_ctx,
         return 0;
     }
 
-    return (data->seq == TCP_GET_SEQ(p)) ? 1 : 0;
+    return (data->seq == TCP_GET_RAW_SEQ(PacketGetTCP(p))) ? 1 : 0;
 }
 
 /**
@@ -152,7 +152,7 @@ PrefilterPacketSeqMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
         return;
 
     if (p->proto == IPPROTO_TCP && !(PKT_IS_PSEUDOPKT(p)) && PacketIsTCP(p) &&
-            (TCP_GET_SEQ(p) == ctx->v1.u32[0])) {
+            (TCP_GET_RAW_SEQ(PacketGetTCP(p)) == ctx->v1.u32[0])) {
         SCLogDebug("packet matches TCP seq %u", ctx->v1.u32[0]);
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
@@ -257,10 +257,10 @@ static int DetectSeqSigTest02(void)
         goto end;
 
     /* TCP w/seq=42 */
-    p[0]->tcph->th_seq = htonl(42);
+    p[0]->l4.hdrs.tcph->th_seq = htonl(42);
 
     /* TCP w/seq=100 */
-    p[1]->tcph->th_seq = htonl(100);
+    p[1]->l4.hdrs.tcph->th_seq = htonl(100);
 
     const char *sigs[2];
     sigs[0]= "alert tcp any any -> any any (msg:\"Testing seq\"; seq:41; sid:1;)";

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -91,7 +91,8 @@ static int DetectWindowMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
     }
 
-    if ( (!wd->negated && wd->size == TCP_GET_WINDOW(p)) || (wd->negated && wd->size != TCP_GET_WINDOW(p))) {
+    const uint16_t window = TCP_GET_RAW_WINDOW(PacketGetTCP(p));
+    if ((!wd->negated && wd->size == window) || (wd->negated && wd->size != window)) {
         return 1;
     }
 
@@ -287,10 +288,10 @@ static int DetectWindowTestPacket01 (void)
     FAIL_IF(p[0] == NULL || p[1] == NULL || p[2] == NULL);
 
     /* TCP wwindow = 40 */
-    p[0]->tcph->th_win = htons(40);
+    p[0]->l4.hdrs.tcph->th_win = htons(40);
 
     /* TCP window = 41 */
-    p[1]->tcph->th_win = htons(41);
+    p[1]->l4.hdrs.tcph->th_win = htons(41);
 
     const char *sigs[2];
     sigs[0]= "alert tcp any any -> any any (msg:\"Testing window 1\"; window:40; sid:1;)";

--- a/src/detect-tcp-window.c
+++ b/src/detect-tcp-window.c
@@ -87,7 +87,7 @@ static int DetectWindowMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
 {
     const DetectWindowData *wd = (const DetectWindowData *)ctx;
 
-    if ( !(PKT_IS_TCP(p)) || wd == NULL || PKT_IS_PSEUDOPKT(p)) {
+    if (!(PacketIsTCP(p)) || wd == NULL || PKT_IS_PSEUDOPKT(p)) {
         return 0;
     }
 

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -106,18 +106,17 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             // for instance with invalid header length
             return NULL;
         }
-        uint32_t hlen = TCP_GET_HLEN(p);
-        if (((uint8_t *)p->tcph + (ptrdiff_t)hlen) >
-                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)))
-        {
-            SCLogDebug("data out of range: %p > %p",
-                    ((uint8_t *)p->tcph + (ptrdiff_t)hlen),
+        const TCPHdr *tcph = PacketGetTCP(p);
+        const uint32_t hlen = TCP_GET_RAW_HLEN(tcph);
+        if (((uint8_t *)tcph + (ptrdiff_t)hlen) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)tcph + (ptrdiff_t)hlen),
                     ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
             return NULL;
         }
 
         const uint32_t data_len = hlen;
-        const uint8_t *data = (const uint8_t *)p->tcph;
+        const uint8_t *data = (const uint8_t *)tcph;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -101,7 +101,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (!PKT_IS_TCP(p)) {
+        if (!PacketIsTCP(p)) {
             // may happen when DecodeTCPPacket fails
             // for instance with invalid header length
             return NULL;

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -101,7 +101,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (p->tcph == NULL) {
+        if (!PKT_IS_TCP(p)) {
             // may happen when DecodeTCPPacket fails
             // for instance with invalid header length
             return NULL;

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -77,7 +77,7 @@ static int DetectTcpmssMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         const Signature *s, const SigMatchCtx *ctx)
 {
 
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p))
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
     if (!(TCP_HAS_MSS(p)))
@@ -130,7 +130,7 @@ void DetectTcpmssFree(DetectEngineCtx *de_ctx, void *ptr)
 static void
 PrefilterPacketTcpmssMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
-    if (!(PKT_IS_TCP(p)) || PKT_IS_PSEUDOPKT(p))
+    if (!(PacketIsTCP(p)) || PKT_IS_PSEUDOPKT(p))
         return;
 
     if (!(TCP_HAS_MSS(p)))

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -96,9 +96,9 @@ static int DetectTemplateMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         /* fake pkt */
     }
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         /* ipv4 pkt */
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         /* ipv6 pkt */
     } else {
         SCLogDebug("packet is of not IPv4 or IPv6");

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -87,7 +87,8 @@ static int DetectTemplate2Match (DetectEngineThreadCtx *det_ctx, Packet *p,
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
         ptemplate2 = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
-        ptemplate2 = IPV6_GET_HLIM(p);
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        ptemplate2 = IPV6_GET_RAW_HLIM(ip6h);
     } else {
         SCLogDebug("Packet is of not IPv4 or IPv6");
         return 0;
@@ -148,7 +149,8 @@ PrefilterPacketTemplate2Match(DetectEngineThreadCtx *det_ctx, Packet *p, const v
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
         ptemplate2 = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
-        ptemplate2 = IPV6_GET_HLIM(p);
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        ptemplate2 = IPV6_GET_RAW_HLIM(ip6h);
     } else {
         SCLogDebug("Packet is of not IPv4 or IPv6");
         return;

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -83,9 +83,9 @@ static int DetectTemplate2Match (DetectEngineThreadCtx *det_ctx, Packet *p,
 
     /* TODO replace this */
     uint8_t ptemplate2;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         ptemplate2 = IPV4_GET_IPTTL(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         ptemplate2 = IPV6_GET_HLIM(p);
     } else {
         SCLogDebug("Packet is of not IPv4 or IPv6");
@@ -143,9 +143,9 @@ PrefilterPacketTemplate2Match(DetectEngineThreadCtx *det_ctx, Packet *p, const v
 
     uint8_t ptemplate2;
 /* TODO update */
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         ptemplate2 = IPV4_GET_IPTTL(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         ptemplate2 = IPV6_GET_HLIM(p);
     } else {
         SCLogDebug("Packet is of not IPv4 or IPv6");

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -84,7 +84,8 @@ static int DetectTemplate2Match (DetectEngineThreadCtx *det_ctx, Packet *p,
     /* TODO replace this */
     uint8_t ptemplate2;
     if (PacketIsIPv4(p)) {
-        ptemplate2 = IPV4_GET_IPTTL(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        ptemplate2 = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
         ptemplate2 = IPV6_GET_HLIM(p);
     } else {
@@ -144,7 +145,8 @@ PrefilterPacketTemplate2Match(DetectEngineThreadCtx *det_ctx, Packet *p, const v
     uint8_t ptemplate2;
 /* TODO update */
     if (PacketIsIPv4(p)) {
-        ptemplate2 = IPV4_GET_IPTTL(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        ptemplate2 = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
         ptemplate2 = IPV6_GET_HLIM(p);
     } else {

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -100,8 +100,9 @@ static int DetectTosMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
     }
 
-    if (tosd->tos == IPV4_GET_IPTOS(p)) {
-        SCLogDebug("tos match found for %d\n", tosd->tos);
+    const IPV4Hdr *ip4h = PacketGetIPv4(p);
+    if (tosd->tos == IPV4_GET_RAW_IPTOS(ip4h)) {
+        SCLogDebug("tos match found for %d", tosd->tos);
         result = 1;
     }
 
@@ -328,7 +329,7 @@ static int DetectTosTest12(void)
     if (p == NULL)
         goto end;
 
-    IPV4_SET_RAW_IPTOS(p->ip4h, 10);
+    p->l3.hdrs.ip4h->ip_tos = 10;
 
     const char *sigs[4];
     sigs[0]= "alert ip any any -> any any (msg:\"Testing id 1\"; tos: 10 ; sid:1;)";

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -96,7 +96,7 @@ static int DetectTosMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
     const DetectTosData *tosd = (const DetectTosData *)ctx;
     int result = 0;
 
-    if (!PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p)) {
+    if (!PacketIsIPv4(p) || PKT_IS_PSEUDOPKT(p)) {
         return 0;
     }
 

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -87,9 +87,9 @@ static int DetectTtlMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         return 0;
 
     uint8_t pttl;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         pttl = IPV4_GET_IPTTL(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         pttl = IPV6_GET_HLIM(p);
     } else {
         SCLogDebug("Packet is not IPv4 or IPv6");
@@ -145,9 +145,9 @@ PrefilterPacketTtlMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
     }
 
     uint8_t pttl;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         pttl = IPV4_GET_IPTTL(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         pttl = IPV6_GET_HLIM(p);
     } else {
         SCLogDebug("Packet is not IPv4 or IPv6");

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -91,7 +91,8 @@ static int DetectTtlMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
         pttl = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
-        pttl = IPV6_GET_HLIM(p);
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        pttl = IPV6_GET_RAW_HLIM(ip6h);
     } else {
         SCLogDebug("Packet is not IPv4 or IPv6");
         return 0;
@@ -150,7 +151,8 @@ PrefilterPacketTtlMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
         const IPV4Hdr *ip4h = PacketGetIPv4(p);
         pttl = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
-        pttl = IPV6_GET_HLIM(p);
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        pttl = IPV6_GET_RAW_HLIM(ip6h);
     } else {
         SCLogDebug("Packet is not IPv4 or IPv6");
         return;

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -88,7 +88,8 @@ static int DetectTtlMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 
     uint8_t pttl;
     if (PacketIsIPv4(p)) {
-        pttl = IPV4_GET_IPTTL(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        pttl = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
         pttl = IPV6_GET_HLIM(p);
     } else {
@@ -146,7 +147,8 @@ PrefilterPacketTtlMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *p
 
     uint8_t pttl;
     if (PacketIsIPv4(p)) {
-        pttl = IPV4_GET_IPTTL(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        pttl = IPV4_GET_RAW_IPTTL(ip4h);
     } else if (PacketIsIPv6(p)) {
         pttl = IPV6_GET_HLIM(p);
     } else {

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -102,17 +102,16 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (!PacketIsUDP(p)) {
             return NULL;
         }
-        if (((uint8_t *)p->udph + (ptrdiff_t)UDP_HEADER_LEN) >
-                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)))
-        {
-            SCLogDebug("data out of range: %p > %p",
-                    ((uint8_t *)p->udph + (ptrdiff_t)UDP_HEADER_LEN),
+        const UDPHdr *udph = PacketGetUDP(p);
+        if (((uint8_t *)udph + (ptrdiff_t)UDP_HEADER_LEN) >
+                ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p))) {
+            SCLogDebug("data out of range: %p > %p", ((uint8_t *)udph + (ptrdiff_t)UDP_HEADER_LEN),
                     ((uint8_t *)GET_PKT_DATA(p) + (ptrdiff_t)GET_PKT_LEN(p)));
             return NULL;
         }
 
         const uint32_t data_len = UDP_HEADER_LEN;
-        const uint8_t *data = (const uint8_t *)p->udph;
+        const uint8_t *data = (const uint8_t *)udph;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -99,7 +99,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (!PKT_IS_UDP(p)) {
+        if (!PacketIsUDP(p)) {
             return NULL;
         }
         if (((uint8_t *)p->udph + (ptrdiff_t)UDP_HEADER_LEN) >

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -99,7 +99,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        if (p->udph == NULL) {
+        if (!PKT_IS_UDP(p)) {
             return NULL;
         }
         if (((uint8_t *)p->udph + (ptrdiff_t)UDP_HEADER_LEN) >

--- a/src/detect.c
+++ b/src/detect.c
@@ -534,7 +534,7 @@ static inline void DetectRunGetRuleGroup(
 
             /* HACK: prevent the wrong sgh (or NULL) from being stored in the
              * flow's sgh pointers */
-            if (PKT_IS_ICMPV4(p) && ICMPV4_DEST_UNREACH_IS_VALID(p)) {
+            if (PacketIsICMPv4(p) && ICMPV4_DEST_UNREACH_IS_VALID(p)) {
                 ; /* no-op */
             } else {
                 /* store the found sgh (or NULL) in the flow to save us

--- a/src/detect.c
+++ b/src/detect.c
@@ -407,7 +407,7 @@ static inline void DetectPrefilterBuildNonPrefilterList(
 static inline void
 DetectPrefilterSetNonPrefilterList(const Packet *p, DetectEngineThreadCtx *det_ctx, DetectRunScratchpad *scratch)
 {
-    if ((p->proto == IPPROTO_TCP) && (p->tcph != NULL) && (p->tcph->th_flags & TH_SYN)) {
+    if ((p->proto == IPPROTO_TCP) && PKT_IS_TCP(p) && (p->tcph->th_flags & TH_SYN)) {
         det_ctx->non_pf_store_ptr = scratch->sgh->non_pf_syn_store_array;
         det_ctx->non_pf_store_cnt = scratch->sgh->non_pf_syn_store_cnt;
     } else {

--- a/src/detect.c
+++ b/src/detect.c
@@ -407,7 +407,7 @@ static inline void DetectPrefilterBuildNonPrefilterList(
 static inline void
 DetectPrefilterSetNonPrefilterList(const Packet *p, DetectEngineThreadCtx *det_ctx, DetectRunScratchpad *scratch)
 {
-    if ((p->proto == IPPROTO_TCP) && PacketIsTCP(p) && (p->tcph->th_flags & TH_SYN)) {
+    if ((p->proto == IPPROTO_TCP) && PacketIsTCP(p) && (PacketGetTCP(p)->th_flags & TH_SYN)) {
         det_ctx->non_pf_store_ptr = scratch->sgh->non_pf_syn_store_array;
         det_ctx->non_pf_store_cnt = scratch->sgh->non_pf_syn_store_cnt;
     } else {

--- a/src/detect.c
+++ b/src/detect.c
@@ -232,7 +232,7 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx,
     /* select the flow_gh */
     const int dir = (p->flowflags & FLOW_PKT_TOCLIENT) == 0;
 
-    int proto = IP_GET_IPPROTO(p);
+    int proto = PacketGetIPProto(p);
     if (proto == IPPROTO_TCP) {
         DetectPort *list = de_ctx->flow_gh[dir].tcp;
         SCLogDebug("tcp toserver %p, tcp toclient %p: going to use %p", de_ctx->flow_gh[1].tcp,
@@ -513,7 +513,7 @@ static inline void DetectRunGetRuleGroup(
         bool use_flow_sgh = false;
         /* Get the stored sgh from the flow (if any). Make sure we're not using
          * the sgh for icmp error packets part of the same stream. */
-        if (IP_GET_IPPROTO(p) == pflow->proto) { /* filter out icmp */
+        if (PacketGetIPProto(p) == pflow->proto) { /* filter out icmp */
             PACKET_PROFILING_DETECT_START(p, PROF_DETECT_GETSGH);
             if ((p->flowflags & FLOW_PKT_TOSERVER) && (pflow->flags & FLOW_SGH_TOSERVER)) {
                 sgh = pflow->sgh_toserver;
@@ -617,7 +617,7 @@ static inline bool DetectRunInspectRuleHeader(const Packet *p, const Flow *f, co
         return false;
     }
 
-    if (DetectProtoContainsProto(&s->proto, IP_GET_IPPROTO(p)) == 0) {
+    if (DetectProtoContainsProto(&s->proto, PacketGetIPProto(p)) == 0) {
         SCLogDebug("proto didn't match");
         return false;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -407,7 +407,7 @@ static inline void DetectPrefilterBuildNonPrefilterList(
 static inline void
 DetectPrefilterSetNonPrefilterList(const Packet *p, DetectEngineThreadCtx *det_ctx, DetectRunScratchpad *scratch)
 {
-    if ((p->proto == IPPROTO_TCP) && PKT_IS_TCP(p) && (p->tcph->th_flags & TH_SYN)) {
+    if ((p->proto == IPPROTO_TCP) && PacketIsTCP(p) && (p->tcph->th_flags & TH_SYN)) {
         det_ctx->non_pf_store_ptr = scratch->sgh->non_pf_syn_store_array;
         det_ctx->non_pf_store_cnt = scratch->sgh->non_pf_syn_store_cnt;
     } else {

--- a/src/detect.c
+++ b/src/detect.c
@@ -223,7 +223,7 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx,
     if (p->proto == 0 && p->events.cnt > 0) {
         SCReturnPtr(de_ctx->decoder_event_sgh, "SigGroupHead");
     } else if (p->proto == 0) {
-        if (!(PKT_IS_IPV4(p) || PKT_IS_IPV6(p))) {
+        if (!(PacketIsIPv4(p) || PacketIsIPv6(p))) {
             /* not IP, so nothing to do */
             SCReturnPtr(NULL, "SigGroupHead");
         }
@@ -608,11 +608,11 @@ static inline bool DetectRunInspectRuleHeader(const Packet *p, const Flow *f, co
         }
     }
 
-    if ((s_proto_flags & DETECT_PROTO_IPV4) && !PKT_IS_IPV4(p)) {
+    if ((s_proto_flags & DETECT_PROTO_IPV4) && !PacketIsIPv4(p)) {
         SCLogDebug("ip version didn't match");
         return false;
     }
-    if ((s_proto_flags & DETECT_PROTO_IPV6) && !PKT_IS_IPV6(p)) {
+    if ((s_proto_flags & DETECT_PROTO_IPV6) && !PacketIsIPv6(p)) {
         SCLogDebug("ip version didn't match");
         return false;
     }
@@ -649,20 +649,20 @@ static inline bool DetectRunInspectRuleHeader(const Packet *p, const Flow *f, co
 
     /* check the destination address */
     if (!(sflags & SIG_FLAG_DST_ANY)) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             if (DetectAddressMatchIPv4(s->addr_dst_match4, s->addr_dst_match4_cnt, &p->dst) == 0)
                 return false;
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             if (DetectAddressMatchIPv6(s->addr_dst_match6, s->addr_dst_match6_cnt, &p->dst) == 0)
                 return false;
         }
     }
     /* check the source address */
     if (!(sflags & SIG_FLAG_SRC_ANY)) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             if (DetectAddressMatchIPv4(s->addr_src_match4, s->addr_src_match4_cnt, &p->src) == 0)
                 return false;
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             if (DetectAddressMatchIPv6(s->addr_src_match6, s->addr_src_match6_cnt, &p->src) == 0)
                 return false;
         }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -116,7 +116,7 @@ typedef struct FlowHashKey6_ {
 uint32_t FlowGetIpPairProtoHash(const Packet *p)
 {
     uint32_t hash = 0;
-    if (p->ip4h != NULL) {
+    if (PacketIsIPv4(p)) {
         FlowHashKey4 fhk = {
             .pad[0] = 0,
         };
@@ -137,7 +137,7 @@ uint32_t FlowGetIpPairProtoHash(const Packet *p)
         fhk.vlan_id[2] = p->vlan_id[2] & g_vlan_mask;
 
         hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
-    } else if (p->ip6h != NULL) {
+    } else if (PacketIsIPv6(p)) {
         FlowHashKey6 fhk = {
             .pad[0] = 0,
         };
@@ -191,7 +191,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 {
     uint32_t hash = 0;
 
-    if (p->ip4h != NULL) {
+    if (PacketIsIPv4(p)) {
         if (p->tcph != NULL || p->udph != NULL) {
             FlowHashKey4 fhk = { .pad[0] = 0 };
 
@@ -257,7 +257,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
 
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
         }
-    } else if (p->ip6h != NULL) {
+    } else if (PacketIsIPv6(p)) {
         FlowHashKey6 fhk = { .pad[0] = 0 };
         if (FlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
             fhk.src[0] = p->src.addr_data32[0];

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -192,7 +192,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
     uint32_t hash = 0;
 
     if (PacketIsIPv4(p)) {
-        if (PKT_IS_TCP(p) || PKT_IS_UDP(p)) {
+        if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
             FlowHashKey4 fhk = { .pad[0] = 0 };
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);
@@ -550,7 +550,7 @@ static inline int FlowCreateCheck(const Packet *p, const bool emerg)
     /* if we're in emergency mode, don't try to create a flow for a TCP
      * that is not a TCP SYN packet. */
     if (emerg) {
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             if (((p->tcph->th_flags & (TH_SYN | TH_ACK | TH_RST | TH_FIN)) == TH_SYN) ||
                     !stream_config.midstream) {
                 ;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -514,7 +514,8 @@ static inline int FlowCompareESP(Flow *f, const Packet *p)
 
     return CmpAddrs(f_src, p_src) && CmpAddrs(f_dst, p_dst) && f->proto == p->proto &&
            f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id) &&
-           f->esp.spi == ESP_GET_SPI(p) && (f->livedev == p->livedev || g_livedev_mask == 0);
+           f->esp.spi == ESP_GET_SPI(PacketGetESP(p)) &&
+           (f->livedev == p->livedev || g_livedev_mask == 0);
 }
 
 void FlowSetupPacket(Packet *p)
@@ -527,7 +528,7 @@ static inline int FlowCompare(Flow *f, const Packet *p)
 {
     if (p->proto == IPPROTO_ICMP) {
         return FlowCompareICMPv4(f, p);
-    } else if (p->proto == IPPROTO_ESP) {
+    } else if (PacketIsESP(p)) {
         return FlowCompareESP(f, p);
     } else {
         return CmpFlowPacket(f, p);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -226,9 +226,9 @@ static inline uint32_t FlowGetHash(const Packet *p)
             fhk.addrs[1-ai] = psrc;
             fhk.addrs[ai] = pdst;
 
-            const int pi = (p->icmpv4vars.emb_sport > p->icmpv4vars.emb_dport);
-            fhk.ports[1-pi] = p->icmpv4vars.emb_sport;
-            fhk.ports[pi] = p->icmpv4vars.emb_dport;
+            const int pi = (p->l4.vars.icmpv4.emb_sport > p->l4.vars.icmpv4.emb_dport);
+            fhk.ports[1 - pi] = p->l4.vars.icmpv4.emb_sport;
+            fhk.ports[pi] = p->l4.vars.icmpv4.emb_dport;
 
             fhk.proto = ICMPV4_GET_EMB_PROTO(p);
             fhk.recur = p->recursion_level;
@@ -470,7 +470,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
          * response to the clients traffic */
         if ((f->src.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p))) &&
                 (f->dst.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
-                f->sp == p->icmpv4vars.emb_sport && f->dp == p->icmpv4vars.emb_dport &&
+                f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) && f->recursion_level == p->recursion_level &&
                 CmpVlanIds(f->vlan_id, p->vlan_id) &&
                 (f->livedev == p->livedev || g_livedev_mask == 0)) {
@@ -480,7 +480,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
          * a packet from the server. */
         } else if ((f->dst.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p))) &&
                    (f->src.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
-                   f->dp == p->icmpv4vars.emb_sport && f->sp == p->icmpv4vars.emb_dport &&
+                   f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id) &&
                    (f->livedev == p->livedev || g_livedev_mask == 0)) {
@@ -562,7 +562,7 @@ static inline int FlowCreateCheck(const Packet *p, const bool emerg)
     }
 
     if (PacketIsICMPv4(p)) {
-        if (ICMPV4_IS_ERROR_MSG(p)) {
+        if (ICMPV4_IS_ERROR_MSG(p->icmp_s.type)) {
             return 0;
         }
     }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -192,7 +192,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
     uint32_t hash = 0;
 
     if (PacketIsIPv4(p)) {
-        if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
+        if (PacketIsTCP(p) || PacketIsUDP(p)) {
             FlowHashKey4 fhk = { .pad[0] = 0 };
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -560,7 +560,7 @@ static inline int FlowCreateCheck(const Packet *p, const bool emerg)
         }
     }
 
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         if (ICMPV4_IS_ERROR_MSG(p)) {
             return 0;
         }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -218,8 +218,8 @@ static inline uint32_t FlowGetHash(const Packet *p)
             hash = hashword(fhk.u32, ARRAY_SIZE(fhk.u32), flow_config.hash_rand);
 
         } else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
-            uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
-            uint32_t pdst = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
+            uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p));
+            uint32_t pdst = IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p));
             FlowHashKey4 fhk = { .pad[0] = 0 };
 
             const int ai = (psrc > pdst);
@@ -468,8 +468,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
         /* first check the direction of the flow, in other words, the client ->
          * server direction as it's most likely the ICMP error will be a
          * response to the clients traffic */
-        if ((f->src.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p))) &&
-                (f->dst.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
+        if ((f->src.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p))) &&
+                (f->dst.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p))) &&
                 f->sp == p->l4.vars.icmpv4.emb_sport && f->dp == p->l4.vars.icmpv4.emb_dport &&
                 f->proto == ICMPV4_GET_EMB_PROTO(p) && f->recursion_level == p->recursion_level &&
                 CmpVlanIds(f->vlan_id, p->vlan_id) &&
@@ -478,8 +478,8 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
 
         /* check the less likely case where the ICMP error was a response to
          * a packet from the server. */
-        } else if ((f->dst.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p))) &&
-                   (f->src.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p))) &&
+        } else if ((f->dst.addr_data32[0] == IPV4_GET_RAW_IPSRC_U32(PacketGetICMPv4EmbIPv4(p))) &&
+                   (f->src.addr_data32[0] == IPV4_GET_RAW_IPDST_U32(PacketGetICMPv4EmbIPv4(p))) &&
                    f->dp == p->l4.vars.icmpv4.emb_sport && f->sp == p->l4.vars.icmpv4.emb_dport &&
                    f->proto == ICMPV4_GET_EMB_PROTO(p) &&
                    f->recursion_level == p->recursion_level && CmpVlanIds(f->vlan_id, p->vlan_id) &&

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -552,7 +552,8 @@ static inline int FlowCreateCheck(const Packet *p, const bool emerg)
      * that is not a TCP SYN packet. */
     if (emerg) {
         if (PacketIsTCP(p)) {
-            if (((p->tcph->th_flags & (TH_SYN | TH_ACK | TH_RST | TH_FIN)) == TH_SYN) ||
+            const TCPHdr *tcph = PacketGetTCP(p);
+            if (((tcph->th_flags & (TH_SYN | TH_ACK | TH_RST | TH_FIN)) == TH_SYN) ||
                     !stream_config.midstream) {
                 ;
             } else {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -192,7 +192,7 @@ static inline uint32_t FlowGetHash(const Packet *p)
     uint32_t hash = 0;
 
     if (PacketIsIPv4(p)) {
-        if (p->tcph != NULL || p->udph != NULL) {
+        if (PKT_IS_TCP(p) || PKT_IS_UDP(p)) {
             FlowHashKey4 fhk = { .pad[0] = 0 };
 
             int ai = (p->src.addr_data32[0] > p->dst.addr_data32[0]);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -132,22 +132,22 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
             }
         }
         /* set the ip header */
-        p->ip4h = (IPV4Hdr *)GET_PKT_DATA(p);
+        IPV4Hdr *ip4h = PacketSetIPV4(p, GET_PKT_DATA(p));
         /* version 4 and length 20 bytes for the tcp header */
-        p->ip4h->ip_verhl = 0x45;
-        p->ip4h->ip_tos = 0;
-        p->ip4h->ip_len = htons(40);
-        p->ip4h->ip_id = 0;
-        p->ip4h->ip_off = 0;
-        p->ip4h->ip_ttl = 64;
-        p->ip4h->ip_proto = IPPROTO_TCP;
+        ip4h->ip_verhl = 0x45;
+        ip4h->ip_tos = 0;
+        ip4h->ip_len = htons(40);
+        ip4h->ip_id = 0;
+        ip4h->ip_off = 0;
+        ip4h->ip_ttl = 64;
+        ip4h->ip_proto = IPPROTO_TCP;
         //p->ip4h->ip_csum =
         if (direction == 0) {
-            p->ip4h->s_ip_src.s_addr = f->src.addr_data32[0];
-            p->ip4h->s_ip_dst.s_addr = f->dst.addr_data32[0];
+            ip4h->s_ip_src.s_addr = f->src.addr_data32[0];
+            ip4h->s_ip_dst.s_addr = f->dst.addr_data32[0];
         } else {
-            p->ip4h->s_ip_src.s_addr = f->dst.addr_data32[0];
-            p->ip4h->s_ip_dst.s_addr = f->src.addr_data32[0];
+            ip4h->s_ip_src.s_addr = f->dst.addr_data32[0];
+            ip4h->s_ip_dst.s_addr = f->src.addr_data32[0];
         }
 
         /* set the tcp header */
@@ -233,12 +233,11 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
     }
 
     if (FLOW_IS_IPV4(f)) {
-        p->tcph->th_sum = TCPChecksum(p->ip4h->s_ip_addrs,
-                                               (uint16_t *)p->tcph, 20, 0);
+        IPV4Hdr *ip4h = p->l3.hdrs.ip4h;
+        p->tcph->th_sum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph, 20, 0);
         /* calc ipv4 csum as we may log it and barnyard might reject
          * a wrong checksum */
-        p->ip4h->ip_csum = IPV4Checksum((uint16_t *)p->ip4h,
-                IPV4_GET_RAW_HLEN(p->ip4h), 0);
+        ip4h->ip_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), 0);
     } else if (FLOW_IS_IPV6(f)) {
         p->tcph->th_sum = TCPChecksum(p->ip6h->s_ip6_addrs,
                                               (uint16_t *)p->tcph, 20, 0);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -177,31 +177,31 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
             }
         }
         /* set the ip header */
-        p->ip6h = (IPV6Hdr *)GET_PKT_DATA(p);
+        IPV6Hdr *ip6h = PacketSetIPV6(p, GET_PKT_DATA(p));
         /* version 6 */
-        p->ip6h->s_ip6_vfc = 0x60;
-        p->ip6h->s_ip6_flow = 0;
-        p->ip6h->s_ip6_nxt = IPPROTO_TCP;
-        p->ip6h->s_ip6_plen = htons(20);
-        p->ip6h->s_ip6_hlim = 64;
+        ip6h->s_ip6_vfc = 0x60;
+        ip6h->s_ip6_flow = 0;
+        ip6h->s_ip6_nxt = IPPROTO_TCP;
+        ip6h->s_ip6_plen = htons(20);
+        ip6h->s_ip6_hlim = 64;
         if (direction == 0) {
-            p->ip6h->s_ip6_src[0] = f->src.addr_data32[0];
-            p->ip6h->s_ip6_src[1] = f->src.addr_data32[1];
-            p->ip6h->s_ip6_src[2] = f->src.addr_data32[2];
-            p->ip6h->s_ip6_src[3] = f->src.addr_data32[3];
-            p->ip6h->s_ip6_dst[0] = f->dst.addr_data32[0];
-            p->ip6h->s_ip6_dst[1] = f->dst.addr_data32[1];
-            p->ip6h->s_ip6_dst[2] = f->dst.addr_data32[2];
-            p->ip6h->s_ip6_dst[3] = f->dst.addr_data32[3];
+            ip6h->s_ip6_src[0] = f->src.addr_data32[0];
+            ip6h->s_ip6_src[1] = f->src.addr_data32[1];
+            ip6h->s_ip6_src[2] = f->src.addr_data32[2];
+            ip6h->s_ip6_src[3] = f->src.addr_data32[3];
+            ip6h->s_ip6_dst[0] = f->dst.addr_data32[0];
+            ip6h->s_ip6_dst[1] = f->dst.addr_data32[1];
+            ip6h->s_ip6_dst[2] = f->dst.addr_data32[2];
+            ip6h->s_ip6_dst[3] = f->dst.addr_data32[3];
         } else {
-            p->ip6h->s_ip6_src[0] = f->dst.addr_data32[0];
-            p->ip6h->s_ip6_src[1] = f->dst.addr_data32[1];
-            p->ip6h->s_ip6_src[2] = f->dst.addr_data32[2];
-            p->ip6h->s_ip6_src[3] = f->dst.addr_data32[3];
-            p->ip6h->s_ip6_dst[0] = f->src.addr_data32[0];
-            p->ip6h->s_ip6_dst[1] = f->src.addr_data32[1];
-            p->ip6h->s_ip6_dst[2] = f->src.addr_data32[2];
-            p->ip6h->s_ip6_dst[3] = f->src.addr_data32[3];
+            ip6h->s_ip6_src[0] = f->dst.addr_data32[0];
+            ip6h->s_ip6_src[1] = f->dst.addr_data32[1];
+            ip6h->s_ip6_src[2] = f->dst.addr_data32[2];
+            ip6h->s_ip6_src[3] = f->dst.addr_data32[3];
+            ip6h->s_ip6_dst[0] = f->src.addr_data32[0];
+            ip6h->s_ip6_dst[1] = f->src.addr_data32[1];
+            ip6h->s_ip6_dst[2] = f->src.addr_data32[2];
+            ip6h->s_ip6_dst[3] = f->src.addr_data32[3];
         }
 
         /* set the tcp header */
@@ -239,8 +239,8 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
          * a wrong checksum */
         ip4h->ip_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), 0);
     } else if (FLOW_IS_IPV6(f)) {
-        p->tcph->th_sum = TCPChecksum(p->ip6h->s_ip6_addrs,
-                                              (uint16_t *)p->tcph, 20, 0);
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        p->tcph->th_sum = TCPChecksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph, 20, 0);
     }
 
     p->ts = TimeGet();

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -174,8 +174,8 @@ void FlowInit(Flow *f, const Packet *p)
         SET_TCP_SRC_PORT(p,&f->sp);
         SET_TCP_DST_PORT(p,&f->dp);
     } else if (PacketIsUDP(p)) {
-        SET_UDP_SRC_PORT(p,&f->sp);
-        SET_UDP_DST_PORT(p,&f->dp);
+        f->sp = p->sp;
+        f->dp = p->dp;
     } else if (PacketIsICMPv4(p)) {
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -154,9 +154,10 @@ void FlowInit(Flow *f, const Packet *p)
     f->livedev = p->livedev;
 
     if (PacketIsIPv4(p)) {
-        FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);
-        FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->dst);
-        f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_IPTTL((p));
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(ip4h, &f->src);
+        FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(ip4h, &f->dst);
+        f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_RAW_IPTTL(ip4h);
         f->flags |= FLOW_IPV4;
     } else if (PacketIsIPv6(p)) {
         FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -153,12 +153,12 @@ void FlowInit(Flow *f, const Packet *p)
     f->vlan_idx = p->vlan_idx;
     f->livedev = p->livedev;
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &f->src);
         FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &f->dst);
         f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_IPTTL((p));
         f->flags |= FLOW_IPV4;
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);
         FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->dst);
         f->min_ttl_toserver = f->max_ttl_toserver = IPV6_GET_HLIM((p));

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -187,8 +187,8 @@ void FlowInit(Flow *f, const Packet *p)
     } else if (PacketIsSCTP(p)) {
         f->sp = p->sp;
         f->dp = p->dp;
-    } else if (p->esph != NULL) {
-        f->esp.spi = ESP_GET_SPI(p);
+    } else if (PacketIsESP(p)) {
+        f->esp.spi = ESP_GET_SPI(PacketGetESP(p));
     } else {
         /* nothing to do for this IP proto. */
         SCLogDebug("no special setup for IP proto %u", p->proto);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -176,7 +176,7 @@ void FlowInit(Flow *f, const Packet *p)
     } else if (PKT_IS_UDP(p)) {
         SET_UDP_SRC_PORT(p,&f->sp);
         SET_UDP_DST_PORT(p,&f->dp);
-    } else if (p->icmpv4h != NULL) {
+    } else if (PKT_IS_ICMPV4(p)) {
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv4CounterPart(f);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -173,7 +173,7 @@ void FlowInit(Flow *f, const Packet *p)
     if (PacketIsTCP(p)) {
         SET_TCP_SRC_PORT(p,&f->sp);
         SET_TCP_DST_PORT(p,&f->dp);
-    } else if (PKT_IS_UDP(p)) {
+    } else if (PacketIsUDP(p)) {
         SET_UDP_SRC_PORT(p,&f->sp);
         SET_UDP_DST_PORT(p,&f->dp);
     } else if (PKT_IS_ICMPV4(p)) {

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -184,9 +184,9 @@ void FlowInit(Flow *f, const Packet *p)
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv6CounterPart(f);
-    } else if (p->sctph != NULL) { /* XXX MACRO */
-        SET_SCTP_SRC_PORT(p,&f->sp);
-        SET_SCTP_DST_PORT(p,&f->dp);
+    } else if (PacketIsSCTP(p)) {
+        f->sp = p->sp;
+        f->dp = p->dp;
     } else if (p->esph != NULL) {
         f->esp.spi = ESP_GET_SPI(p);
     } else {

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -176,7 +176,7 @@ void FlowInit(Flow *f, const Packet *p)
     } else if (PacketIsUDP(p)) {
         SET_UDP_SRC_PORT(p,&f->sp);
         SET_UDP_DST_PORT(p,&f->dp);
-    } else if (PKT_IS_ICMPV4(p)) {
+    } else if (PacketIsICMPv4(p)) {
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv4CounterPart(f);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -180,7 +180,7 @@ void FlowInit(Flow *f, const Packet *p)
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv4CounterPart(f);
-    } else if (p->icmpv6h != NULL) {
+    } else if (PKT_IS_ICMPV6(p)) {
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv6CounterPart(f);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -170,7 +170,7 @@ void FlowInit(Flow *f, const Packet *p)
         DEBUG_VALIDATE_BUG_ON(1);
     }
 
-    if (PKT_IS_TCP(p)) {
+    if (PacketIsTCP(p)) {
         SET_TCP_SRC_PORT(p,&f->sp);
         SET_TCP_DST_PORT(p,&f->dp);
     } else if (PKT_IS_UDP(p)) {

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -170,10 +170,7 @@ void FlowInit(Flow *f, const Packet *p)
         DEBUG_VALIDATE_BUG_ON(1);
     }
 
-    if (PacketIsTCP(p)) {
-        SET_TCP_SRC_PORT(p,&f->sp);
-        SET_TCP_DST_PORT(p,&f->dp);
-    } else if (PacketIsUDP(p)) {
+    if (PacketIsTCP(p) || PacketIsUDP(p)) {
         f->sp = p->sp;
         f->dp = p->dp;
     } else if (PacketIsICMPv4(p)) {

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -180,7 +180,7 @@ void FlowInit(Flow *f, const Packet *p)
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv4CounterPart(f);
-    } else if (PKT_IS_ICMPV6(p)) {
+    } else if (PacketIsICMPv6(p)) {
         f->icmp_s.type = p->icmp_s.type;
         f->icmp_s.code = p->icmp_s.code;
         FlowSetICMPv6CounterPart(f);

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -160,9 +160,10 @@ void FlowInit(Flow *f, const Packet *p)
         f->min_ttl_toserver = f->max_ttl_toserver = IPV4_GET_RAW_IPTTL(ip4h);
         f->flags |= FLOW_IPV4;
     } else if (PacketIsIPv6(p)) {
-        FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &f->src);
-        FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &f->dst);
-        f->min_ttl_toserver = f->max_ttl_toserver = IPV6_GET_HLIM((p));
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(ip6h, &f->src);
+        FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(ip6h, &f->dst);
+        f->min_ttl_toserver = f->max_ttl_toserver = IPV6_GET_RAW_HLIM(ip6h);
         f->flags |= FLOW_IPV6;
     } else {
         SCLogDebug("neither IPv4 or IPv6, weird");

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -170,10 +170,10 @@ void FlowInit(Flow *f, const Packet *p)
         DEBUG_VALIDATE_BUG_ON(1);
     }
 
-    if (p->tcph != NULL) { /* XXX MACRO */
+    if (PKT_IS_TCP(p)) {
         SET_TCP_SRC_PORT(p,&f->sp);
         SET_TCP_DST_PORT(p,&f->dp);
-    } else if (p->udph != NULL) { /* XXX MACRO */
+    } else if (PKT_IS_UDP(p)) {
         SET_UDP_SRC_PORT(p,&f->sp);
         SET_UDP_DST_PORT(p,&f->dp);
     } else if (p->icmpv4h != NULL) {

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -430,7 +430,7 @@ static void FlowWorkerFlowTimeout(ThreadVars *tv, Packet *p, FlowWorkerThreadDat
     DEBUG_VALIDATE_BUG_ON(p->pkt_src != PKT_SRC_FFR);
 
     SCLogDebug("packet %"PRIu64" is TCP. Direction %s", p->pcap_cnt, PKT_IS_TOSERVER(p) ? "TOSERVER" : "TOCLIENT");
-    DEBUG_VALIDATE_BUG_ON(!(p->flow && PKT_IS_TCP(p)));
+    DEBUG_VALIDATE_BUG_ON(!(p->flow && PacketIsTCP(p)));
     DEBUG_ASSERT_FLOW_LOCKED(p->flow);
 
     /* handle TCP and app layer */
@@ -583,7 +583,7 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     /* handle TCP and app layer */
     if (p->flow) {
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             SCLogDebug("packet %" PRIu64 " is TCP. Direction %s", p->pcap_cnt,
                     PKT_IS_TOSERVER(p) ? "TOSERVER" : "TOCLIENT");
             DEBUG_ASSERT_FLOW_LOCKED(p->flow);

--- a/src/flow.c
+++ b/src/flow.c
@@ -456,7 +456,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
             const IPV4Hdr *ip4h = PacketGetIPv4(p);
             FlowUpdateTtlTS(f, p, IPV4_GET_RAW_IPTTL(ip4h));
         } else if (PacketIsIPv6(p)) {
-            FlowUpdateTtlTS(f, p, IPV6_GET_HLIM(p));
+            const IPV6Hdr *ip6h = PacketGetIPv6(p);
+            FlowUpdateTtlTS(f, p, IPV6_GET_RAW_HLIM(ip6h));
         }
     } else {
         f->tosrcpktcnt++;
@@ -479,7 +480,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
             const IPV4Hdr *ip4h = PacketGetIPv4(p);
             FlowUpdateTtlTC(f, p, IPV4_GET_RAW_IPTTL(ip4h));
         } else if (PacketIsIPv6(p)) {
-            FlowUpdateTtlTC(f, p, IPV6_GET_HLIM(p));
+            const IPV6Hdr *ip6h = PacketGetIPv6(p);
+            FlowUpdateTtlTC(f, p, IPV6_GET_RAW_HLIM(ip6h));
         }
     }
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -453,7 +453,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         FlowUpdateEthernet(tv, dtv, f, p->ethh, true);
         /* update flow's ttl fields if needed */
         if (PacketIsIPv4(p)) {
-            FlowUpdateTtlTS(f, p, IPV4_GET_IPTTL(p));
+            const IPV4Hdr *ip4h = PacketGetIPv4(p);
+            FlowUpdateTtlTS(f, p, IPV4_GET_RAW_IPTTL(ip4h));
         } else if (PacketIsIPv6(p)) {
             FlowUpdateTtlTS(f, p, IPV6_GET_HLIM(p));
         }
@@ -475,7 +476,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         FlowUpdateEthernet(tv, dtv, f, p->ethh, false);
         /* update flow's ttl fields if needed */
         if (PacketIsIPv4(p)) {
-            FlowUpdateTtlTC(f, p, IPV4_GET_IPTTL(p));
+            const IPV4Hdr *ip4h = PacketGetIPv4(p);
+            FlowUpdateTtlTC(f, p, IPV4_GET_RAW_IPTTL(ip4h));
         } else if (PacketIsIPv6(p)) {
             FlowUpdateTtlTC(f, p, IPV6_GET_HLIM(p));
         }

--- a/src/flow.c
+++ b/src/flow.c
@@ -452,9 +452,9 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         }
         FlowUpdateEthernet(tv, dtv, f, p->ethh, true);
         /* update flow's ttl fields if needed */
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             FlowUpdateTtlTS(f, p, IPV4_GET_IPTTL(p));
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             FlowUpdateTtlTS(f, p, IPV6_GET_HLIM(p));
         }
     } else {
@@ -474,9 +474,9 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         }
         FlowUpdateEthernet(tv, dtv, f, p->ethh, false);
         /* update flow's ttl fields if needed */
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             FlowUpdateTtlTC(f, p, IPV4_GET_IPTTL(p));
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             FlowUpdateTtlTC(f, p, IPV6_GET_HLIM(p));
         }
     }

--- a/src/flow.c
+++ b/src/flow.c
@@ -372,10 +372,11 @@ static inline void FlowUpdateTtlTC(Flow *f, Packet *p, uint8_t ttl)
     f->max_ttl_toclient = MAX(f->max_ttl_toclient, ttl);
 }
 
-static inline void FlowUpdateEthernet(ThreadVars *tv, DecodeThreadVars *dtv,
-                                      Flow *f, EthernetHdr *ethh, bool toserver)
+static inline void FlowUpdateEthernet(
+        ThreadVars *tv, DecodeThreadVars *dtv, Flow *f, const Packet *p, bool toserver)
 {
-    if (ethh && MacSetFlowStorageEnabled()) {
+    if (PacketIsEthernet(p) && MacSetFlowStorageEnabled()) {
+        const EthernetHdr *ethh = PacketGetEthernet(p);
         MacSet *ms = FlowGetStorageById(f, MacSetGetFlowStorageID());
         if (ms != NULL) {
             if (toserver) {
@@ -450,7 +451,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
             f->flags &= ~FLOW_PROTO_DETECT_TS_DONE;
             p->flags |= PKT_PROTO_DETECT_TS_DONE;
         }
-        FlowUpdateEthernet(tv, dtv, f, p->ethh, true);
+        FlowUpdateEthernet(tv, dtv, f, p, true);
         /* update flow's ttl fields if needed */
         if (PacketIsIPv4(p)) {
             const IPV4Hdr *ip4h = PacketGetIPv4(p);
@@ -474,7 +475,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
             f->flags &= ~FLOW_PROTO_DETECT_TC_DONE;
             p->flags |= PKT_PROTO_DETECT_TC_DONE;
         }
-        FlowUpdateEthernet(tv, dtv, f, p->ethh, false);
+        FlowUpdateEthernet(tv, dtv, f, p, false);
         /* update flow's ttl fields if needed */
         if (PacketIsIPv4(p)) {
             const IPV4Hdr *ip4h = PacketGetIPv4(p);

--- a/src/flow.c
+++ b/src/flow.c
@@ -344,7 +344,7 @@ int FlowGetPacketDirection(const Flow *f, const Packet *p)
 static inline int FlowUpdateSeenFlag(const Packet *p)
 {
     if (PacketIsICMPv4(p)) {
-        if (ICMPV4_IS_ERROR_MSG(p)) {
+        if (ICMPV4_IS_ERROR_MSG(p->icmp_s.type)) {
             return 0;
         }
     }

--- a/src/flow.c
+++ b/src/flow.c
@@ -343,7 +343,7 @@ int FlowGetPacketDirection(const Flow *f, const Packet *p)
  */
 static inline int FlowUpdateSeenFlag(const Packet *p)
 {
-    if (PKT_IS_ICMPV4(p)) {
+    if (PacketIsICMPv4(p)) {
         if (ICMPV4_IS_ERROR_MSG(p)) {
             return 0;
         }

--- a/src/flow.h
+++ b/src/flow.h
@@ -189,18 +189,20 @@ typedef struct AppLayerParserState_ AppLayerParserState;
  *
  * We set the rest of the struct to 0 so we can
  * prevent using memset. */
-#define FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, a) do {             \
-        (a)->addr_data32[0] = (uint32_t)(p)->ip4h->s_ip_src.s_addr; \
-        (a)->addr_data32[1] = 0;                                  \
-        (a)->addr_data32[2] = 0;                                  \
-        (a)->addr_data32[3] = 0;                                  \
+#define FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(ip4h, a)                                                \
+    do {                                                                                           \
+        (a)->addr_data32[0] = (uint32_t)(ip4h)->s_ip_src.s_addr;                                   \
+        (a)->addr_data32[1] = 0;                                                                   \
+        (a)->addr_data32[2] = 0;                                                                   \
+        (a)->addr_data32[3] = 0;                                                                   \
     } while (0)
 
-#define FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, a) do {             \
-        (a)->addr_data32[0] = (uint32_t)(p)->ip4h->s_ip_dst.s_addr; \
-        (a)->addr_data32[1] = 0;                                  \
-        (a)->addr_data32[2] = 0;                                  \
-        (a)->addr_data32[3] = 0;                                  \
+#define FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(ip4h, a)                                                \
+    do {                                                                                           \
+        (a)->addr_data32[0] = (uint32_t)(ip4h)->s_ip_dst.s_addr;                                   \
+        (a)->addr_data32[1] = 0;                                                                   \
+        (a)->addr_data32[2] = 0;                                                                   \
+        (a)->addr_data32[3] = 0;                                                                   \
     } while (0)
 
 /* Set the IPv6 addressesinto the Addrs of the Packet.

--- a/src/flow.h
+++ b/src/flow.h
@@ -207,18 +207,20 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 
 /* Set the IPv6 addressesinto the Addrs of the Packet.
  * Make sure p->ip6h is initialized and validated. */
-#define FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, a) do {   \
-        (a)->addr_data32[0] = (p)->ip6h->s_ip6_src[0];  \
-        (a)->addr_data32[1] = (p)->ip6h->s_ip6_src[1];  \
-        (a)->addr_data32[2] = (p)->ip6h->s_ip6_src[2];  \
-        (a)->addr_data32[3] = (p)->ip6h->s_ip6_src[3];  \
+#define FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(ip6h, a)                                                \
+    do {                                                                                           \
+        (a)->addr_data32[0] = (ip6h)->s_ip6_src[0];                                                \
+        (a)->addr_data32[1] = (ip6h)->s_ip6_src[1];                                                \
+        (a)->addr_data32[2] = (ip6h)->s_ip6_src[2];                                                \
+        (a)->addr_data32[3] = (ip6h)->s_ip6_src[3];                                                \
     } while (0)
 
-#define FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, a) do {   \
-        (a)->addr_data32[0] = (p)->ip6h->s_ip6_dst[0];  \
-        (a)->addr_data32[1] = (p)->ip6h->s_ip6_dst[1];  \
-        (a)->addr_data32[2] = (p)->ip6h->s_ip6_dst[2];  \
-        (a)->addr_data32[3] = (p)->ip6h->s_ip6_dst[3];  \
+#define FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(ip6h, a)                                                \
+    do {                                                                                           \
+        (a)->addr_data32[0] = (ip6h)->s_ip6_dst[0];                                                \
+        (a)->addr_data32[1] = (ip6h)->s_ip6_dst[1];                                                \
+        (a)->addr_data32[2] = (ip6h)->s_ip6_dst[2];                                                \
+        (a)->addr_data32[3] = (ip6h)->s_ip6_dst[3];                                                \
     } while (0)
 
 /* pkt flow flags */

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -492,9 +492,9 @@ int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, v
     }
 
     int r = 0;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         r = LogHttpLogIPWrapper(tv, thread_data, p, f, (HtpState *)state, (htp_tx_t *)tx, tx_id, AF_INET);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         r = LogHttpLogIPWrapper(tv, thread_data, p, f, (HtpState *)state, (htp_tx_t *)tx, tx_id, AF_INET6);
     }
 

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -487,7 +487,7 @@ int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, v
 {
     SCEnter();
 
-    if (!(PKT_IS_TCP(p))) {
+    if (!(PacketIsTCP(p))) {
         SCReturnInt(TM_ECODE_OK);
     }
 

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -651,7 +651,7 @@ static int PcapLog (ThreadVars *t, void *thread_data, const Packet *p)
     /* if we are using alerted logging and if packet is first one with alert in flow
      * then we need to dump in the pcap the stream acked by the packet */
     if ((p->flags & PKT_FIRST_ALERTS) && (td->pcap_log->conditional != LOGMODE_COND_ALL)) {
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             /* dump fake packets for all segments we have on acked by packet */
 #ifdef HAVE_LIBLZ4
             PcapLogDumpSegments(td, comp, p);

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -478,7 +478,7 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 {
     LogTlsLogThread *aft = (LogTlsLogThread *)thread_data;
     LogTlsFileCtx *hlog = aft->tlslog_ctx;
-    int ipproto = (PKT_IS_IPV4(p)) ? AF_INET : AF_INET6;
+    int ipproto = (PacketIsIPv4(p)) ? AF_INET : AF_INET6;
 
     SSLState *ssl_state = (SSLState *)state;
     if (unlikely(ssl_state == NULL)) {

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -173,7 +173,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
             goto end_fwrite_fpmeta;
         if (fprintf(fpmeta, "PROTO:             %" PRIu32 "\n", p->proto) < 0)
             goto end_fwrite_fpmeta;
-        if (PKT_IS_TCP(p) || PKT_IS_UDP(p)) {
+        if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
             if (fprintf(fpmeta, "SRC PORT:          %" PRIu16 "\n", sp) < 0)
                 goto end_fwrite_fpmeta;
             if (fprintf(fpmeta, "DST PORT:          %" PRIu16 "\n", dp) < 0)
@@ -233,7 +233,7 @@ static bool LogTlsStoreCondition(
         return false;
     }
 
-    if (!(PKT_IS_TCP(p))) {
+    if (!(PacketIsTCP(p))) {
         return false;
     }
 

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -259,7 +259,7 @@ static int LogTlsStoreLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                              Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     LogTlsStoreLogThread *aft = (LogTlsStoreLogThread *)thread_data;
-    int ipproto = (PKT_IS_IPV4(p)) ? AF_INET : AF_INET6;
+    int ipproto = (PacketIsIPv4(p)) ? AF_INET : AF_INET6;
 
     SSLState *ssl_state = (SSLState *)state;
     if (unlikely(ssl_state == NULL)) {

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -173,7 +173,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
             goto end_fwrite_fpmeta;
         if (fprintf(fpmeta, "PROTO:             %" PRIu32 "\n", p->proto) < 0)
             goto end_fwrite_fpmeta;
-        if (PacketIsTCP(p) || PKT_IS_UDP(p)) {
+        if (PacketIsTCP(p) || PacketIsUDP(p)) {
             if (fprintf(fpmeta, "SRC PORT:          %" PRIu16 "\n", sp) < 0)
                 goto end_fwrite_fpmeta;
             if (fprintf(fpmeta, "DST PORT:          %" PRIu16 "\n", dp) < 0)

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -322,10 +322,11 @@ static int EveStreamLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     jb_open_object(js, "packet");
 
     if (PacketIsIPv4(p)) {
-        jb_set_uint(js, "len", IPV4_GET_IPLEN(p));
-        jb_set_uint(js, "tos", IPV4_GET_IPTOS(p));
-        jb_set_uint(js, "ttl", IPV4_GET_IPTTL(p));
-        jb_set_uint(js, "ipid", IPV4_GET_IPID(p));
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        jb_set_uint(js, "len", IPV4_GET_RAW_IPLEN(ip4h));
+        jb_set_uint(js, "tos", IPV4_GET_RAW_IPTOS(ip4h));
+        jb_set_uint(js, "ttl", IPV4_GET_RAW_IPTTL(ip4h));
+        jb_set_uint(js, "ipid", IPV4_GET_RAW_IPID(ip4h));
     } else if (PacketIsIPv6(p)) {
         jb_set_uint(js, "len", IPV6_GET_PLEN(p));
         jb_set_uint(js, "tc", IPV6_GET_CLASS(p));

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -321,12 +321,12 @@ static int EveStreamLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     jb_open_object(js, "stream_tcp");
     jb_open_object(js, "packet");
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         jb_set_uint(js, "len", IPV4_GET_IPLEN(p));
         jb_set_uint(js, "tos", IPV4_GET_IPTOS(p));
         jb_set_uint(js, "ttl", IPV4_GET_IPTTL(p));
         jb_set_uint(js, "ipid", IPV4_GET_IPID(p));
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         jb_set_uint(js, "len", IPV6_GET_PLEN(p));
         jb_set_uint(js, "tc", IPV6_GET_CLASS(p));
         jb_set_uint(js, "hoplimit", IPV6_GET_HLIM(p));

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -334,7 +334,7 @@ static int EveStreamLogger(ThreadVars *tv, void *thread_data, const Packet *p)
         jb_set_uint(js, "hoplimit", IPV6_GET_RAW_HLIM(ip6h));
         jb_set_uint(js, "flowlbl", IPV6_GET_RAW_FLOW(ip6h));
     }
-    if (PKT_IS_TCP(p)) {
+    if (PacketIsTCP(p)) {
         jb_set_uint(js, "tcpseq", TCP_GET_SEQ(p));
         jb_set_uint(js, "tcpack", TCP_GET_ACK(p));
         jb_set_uint(js, "tcpwin", TCP_GET_WINDOW(p));

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -328,10 +328,11 @@ static int EveStreamLogger(ThreadVars *tv, void *thread_data, const Packet *p)
         jb_set_uint(js, "ttl", IPV4_GET_RAW_IPTTL(ip4h));
         jb_set_uint(js, "ipid", IPV4_GET_RAW_IPID(ip4h));
     } else if (PacketIsIPv6(p)) {
-        jb_set_uint(js, "len", IPV6_GET_PLEN(p));
-        jb_set_uint(js, "tc", IPV6_GET_CLASS(p));
-        jb_set_uint(js, "hoplimit", IPV6_GET_HLIM(p));
-        jb_set_uint(js, "flowlbl", IPV6_GET_FLOW(p));
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        jb_set_uint(js, "len", IPV6_GET_RAW_PLEN(ip6h));
+        jb_set_uint(js, "tc", IPV6_GET_RAW_CLASS(ip6h));
+        jb_set_uint(js, "hoplimit", IPV6_GET_RAW_HLIM(ip6h));
+        jb_set_uint(js, "flowlbl", IPV6_GET_RAW_FLOW(ip6h));
     }
     if (PKT_IS_TCP(p)) {
         jb_set_uint(js, "tcpseq", TCP_GET_SEQ(p));

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -764,7 +764,7 @@ static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonAlertLogThread *aft = thread_data;
 
-    if (PKT_IS_IPV4(p) || PKT_IS_IPV6(p)) {
+    if (PacketIsIPv4(p) || PacketIsIPv6(p)) {
         return AlertJson(tv, aft, p);
     } else if (p->alerts.cnt > 0) {
         return AlertJsonDecoderEvent(tv, aft, p);

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -147,7 +147,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             if (PacketIsICMPv4(p)) {
                 jb_set_uint(js, "icmp_id", ICMPV4_GET_ID(p));
                 jb_set_uint(js, "icmp_seq", ICMPV4_GET_SEQ(p));
-            } else if (PKT_IS_ICMPV6(p)) {
+            } else if (PacketIsICMPv6(p)) {
                 jb_set_uint(js, "icmp_id", ICMPV6_GET_ID(p));
                 jb_set_uint(js, "icmp_seq", ICMPV6_GET_SEQ(p));
             }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -107,13 +107,13 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     jb_open_object(js, "drop");
 
     uint16_t proto = 0;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         jb_set_uint(js, "len", IPV4_GET_IPLEN(p));
         jb_set_uint(js, "tos", IPV4_GET_IPTOS(p));
         jb_set_uint(js, "ttl", IPV4_GET_IPTTL(p));
         jb_set_uint(js, "ipid", IPV4_GET_IPID(p));
         proto = IPV4_GET_IPPROTO(p);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         jb_set_uint(js, "len", IPV6_GET_PLEN(p));
         jb_set_uint(js, "tc", IPV6_GET_CLASS(p));
         jb_set_uint(js, "hoplimit", IPV6_GET_HLIM(p));

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -115,10 +115,11 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
         jb_set_uint(js, "ipid", IPV4_GET_RAW_IPID(ip4h));
         proto = IPV4_GET_RAW_IPPROTO(ip4h);
     } else if (PacketIsIPv6(p)) {
-        jb_set_uint(js, "len", IPV6_GET_PLEN(p));
-        jb_set_uint(js, "tc", IPV6_GET_CLASS(p));
-        jb_set_uint(js, "hoplimit", IPV6_GET_HLIM(p));
-        jb_set_uint(js, "flowlbl", IPV6_GET_FLOW(p));
+        const IPV6Hdr *ip6h = PacketGetIPv6(p);
+        jb_set_uint(js, "len", IPV6_GET_RAW_PLEN(ip6h));
+        jb_set_uint(js, "tc", IPV6_GET_RAW_CLASS(ip6h));
+        jb_set_uint(js, "hoplimit", IPV6_GET_RAW_HLIM(ip6h));
+        jb_set_uint(js, "flowlbl", IPV6_GET_RAW_FLOW(ip6h));
         proto = IPV6_GET_L4PROTO(p);
     }
     switch (proto) {

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -124,7 +124,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     }
     switch (proto) {
         case IPPROTO_TCP:
-            if (PKT_IS_TCP(p)) {
+            if (PacketIsTCP(p)) {
                 jb_set_uint(js, "tcpseq", TCP_GET_SEQ(p));
                 jb_set_uint(js, "tcpack", TCP_GET_ACK(p));
                 jb_set_uint(js, "tcpwin", TCP_GET_WINDOW(p));

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -140,7 +140,8 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             break;
         case IPPROTO_UDP:
             if (PacketIsUDP(p)) {
-                jb_set_uint(js, "udplen", UDP_GET_LEN(p));
+                const UDPHdr *udph = PacketGetUDP(p);
+                jb_set_uint(js, "udplen", UDP_GET_RAW_LEN(udph));
             }
             break;
         case IPPROTO_ICMP:

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -144,10 +144,10 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             }
             break;
         case IPPROTO_ICMP:
-            if (PKT_IS_ICMPV4(p)) {
+            if (PacketIsICMPv4(p)) {
                 jb_set_uint(js, "icmp_id", ICMPV4_GET_ID(p));
                 jb_set_uint(js, "icmp_seq", ICMPV4_GET_SEQ(p));
-            } else if(PKT_IS_ICMPV6(p)) {
+            } else if (PKT_IS_ICMPV6(p)) {
                 jb_set_uint(js, "icmp_id", ICMPV6_GET_ID(p));
                 jb_set_uint(js, "icmp_seq", ICMPV6_GET_SEQ(p));
             }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -108,11 +108,12 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 
     uint16_t proto = 0;
     if (PacketIsIPv4(p)) {
-        jb_set_uint(js, "len", IPV4_GET_IPLEN(p));
-        jb_set_uint(js, "tos", IPV4_GET_IPTOS(p));
-        jb_set_uint(js, "ttl", IPV4_GET_IPTTL(p));
-        jb_set_uint(js, "ipid", IPV4_GET_IPID(p));
-        proto = IPV4_GET_IPPROTO(p);
+        const IPV4Hdr *ip4h = PacketGetIPv4(p);
+        jb_set_uint(js, "len", IPV4_GET_RAW_IPLEN(ip4h));
+        jb_set_uint(js, "tos", IPV4_GET_RAW_IPTOS(ip4h));
+        jb_set_uint(js, "ttl", IPV4_GET_RAW_IPTTL(ip4h));
+        jb_set_uint(js, "ipid", IPV4_GET_RAW_IPID(ip4h));
+        proto = IPV4_GET_RAW_IPPROTO(ip4h);
     } else if (PacketIsIPv6(p)) {
         jb_set_uint(js, "len", IPV6_GET_PLEN(p));
         jb_set_uint(js, "tc", IPV6_GET_CLASS(p));

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -139,7 +139,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
             }
             break;
         case IPPROTO_UDP:
-            if (PKT_IS_UDP(p)) {
+            if (PacketIsUDP(p)) {
                 jb_set_uint(js, "udplen", UDP_GET_LEN(p));
             }
             break;

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -125,17 +125,18 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     switch (proto) {
         case IPPROTO_TCP:
             if (PacketIsTCP(p)) {
-                jb_set_uint(js, "tcpseq", TCP_GET_SEQ(p));
-                jb_set_uint(js, "tcpack", TCP_GET_ACK(p));
-                jb_set_uint(js, "tcpwin", TCP_GET_WINDOW(p));
-                jb_set_bool(js, "syn", TCP_ISSET_FLAG_SYN(p) ? true : false);
-                jb_set_bool(js, "ack", TCP_ISSET_FLAG_ACK(p) ? true : false);
-                jb_set_bool(js, "psh", TCP_ISSET_FLAG_PUSH(p) ? true : false);
-                jb_set_bool(js, "rst", TCP_ISSET_FLAG_RST(p) ? true : false);
-                jb_set_bool(js, "urg", TCP_ISSET_FLAG_URG(p) ? true : false);
-                jb_set_bool(js, "fin", TCP_ISSET_FLAG_FIN(p) ? true : false);
-                jb_set_uint(js, "tcpres",  TCP_GET_RAW_X2(p->tcph));
-                jb_set_uint(js, "tcpurgp", TCP_GET_URG_POINTER(p));
+                const TCPHdr *tcph = PacketGetTCP(p);
+                jb_set_uint(js, "tcpseq", TCP_GET_RAW_SEQ(tcph));
+                jb_set_uint(js, "tcpack", TCP_GET_RAW_ACK(tcph));
+                jb_set_uint(js, "tcpwin", TCP_GET_RAW_WINDOW(tcph));
+                jb_set_bool(js, "syn", TCP_ISSET_FLAG_RAW_SYN(tcph) ? true : false);
+                jb_set_bool(js, "ack", TCP_ISSET_FLAG_RAW_ACK(tcph) ? true : false);
+                jb_set_bool(js, "psh", TCP_ISSET_FLAG_RAW_PUSH(tcph) ? true : false);
+                jb_set_bool(js, "rst", TCP_ISSET_FLAG_RAW_RST(tcph) ? true : false);
+                jb_set_bool(js, "urg", TCP_ISSET_FLAG_RAW_URG(tcph) ? true : false);
+                jb_set_bool(js, "fin", TCP_ISSET_FLAG_RAW_FIN(tcph) ? true : false);
+                jb_set_uint(js, "tcpres", TCP_GET_RAW_X2(tcph));
+                jb_set_uint(js, "tcpurgp", TCP_GET_RAW_URG_POINTER(tcph));
             }
             break;
         case IPPROTO_UDP:

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -854,9 +854,9 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
             }
             break;
         case IPPROTO_ICMPV6:
-            if (p->icmpv6h) {
-                jb_set_uint(js, "icmp_type", p->icmpv6h->type);
-                jb_set_uint(js, "icmp_code", p->icmpv6h->code);
+            if (PacketIsICMPv6(p)) {
+                jb_set_uint(js, "icmp_type", PacketGetICMPv6(p)->type);
+                jb_set_uint(js, "icmp_code", PacketGetICMPv6(p)->code);
             }
             break;
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -848,9 +848,9 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
     /* icmp */
     switch (p->proto) {
         case IPPROTO_ICMP:
-            if (p->icmpv4h) {
-                jb_set_uint(js, "icmp_type", p->icmpv4h->type);
-                jb_set_uint(js, "icmp_code", p->icmpv4h->code);
+            if (PacketIsICMPv4(p)) {
+                jb_set_uint(js, "icmp_type", p->icmp_s.type);
+                jb_set_uint(js, "icmp_code", p->icmp_s.code);
             }
             break;
         case IPPROTO_ICMPV6:

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -747,10 +747,11 @@ static int CreateJSONEther(JsonBuilder *js, const Packet *p, const Flow *f)
 {
     if (p != NULL) {
         /* this is a packet context, so we need to add scalar fields */
-        if (p->ethh != NULL) {
+        if (PacketIsEthernet(p)) {
+            const EthernetHdr *ethh = PacketGetEthernet(p);
             jb_open_object(js, "ether");
-            uint8_t *src = p->ethh->eth_src;
-            uint8_t *dst = p->ethh->eth_dst;
+            const uint8_t *src = ethh->eth_src;
+            const uint8_t *dst = ethh->eth_dst;
             JSONFormatAndAddMACAddr(js, "src_mac", src, false);
             JSONFormatAndAddMACAddr(js, "dest_mac", dst, false);
             jb_close(js);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -580,10 +580,10 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
             break;
     }
 
-    if (SCProtoNameValid(IP_GET_IPPROTO(p))) {
-        strlcpy(addr->proto, known_proto[IP_GET_IPPROTO(p)], sizeof(addr->proto));
+    if (SCProtoNameValid(PacketGetIPProto(p))) {
+        strlcpy(addr->proto, known_proto[PacketGetIPProto(p)], sizeof(addr->proto));
     } else {
-        snprintf(addr->proto, sizeof(addr->proto), "%" PRIu32, IP_GET_IPPROTO(p));
+        snprintf(addr->proto, sizeof(addr->proto), "%" PRIu32, PacketGetIPProto(p));
     }
 }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -481,12 +481,12 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
 
     switch (dir) {
         case LOG_DIR_PACKET:
-            if (PKT_IS_IPV4(p)) {
+            if (PacketIsIPv4(p)) {
                 PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                         srcip, sizeof(srcip));
                 PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                         dstip, sizeof(dstip));
-            } else if (PKT_IS_IPV6(p)) {
+            } else if (PacketIsIPv6(p)) {
                 PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                         srcip, sizeof(srcip));
                 PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
@@ -501,12 +501,12 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
         case LOG_DIR_FLOW:
         case LOG_DIR_FLOW_TOSERVER:
             if ((PKT_IS_TOSERVER(p))) {
-                if (PKT_IS_IPV4(p)) {
+                if (PacketIsIPv4(p)) {
                     PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                             dstip, sizeof(dstip));
-                } else if (PKT_IS_IPV6(p)) {
+                } else if (PacketIsIPv6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
@@ -515,12 +515,12 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
                 sp = p->sp;
                 dp = p->dp;
             } else {
-                if (PKT_IS_IPV4(p)) {
+                if (PacketIsIPv4(p)) {
                     PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                             dstip, sizeof(dstip));
-                } else if (PKT_IS_IPV6(p)) {
+                } else if (PacketIsIPv6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
@@ -532,12 +532,12 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
             break;
         case LOG_DIR_FLOW_TOCLIENT:
             if ((PKT_IS_TOCLIENT(p))) {
-                if (PKT_IS_IPV4(p)) {
+                if (PacketIsIPv4(p)) {
                     PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                             dstip, sizeof(dstip));
-                } else if (PKT_IS_IPV6(p)) {
+                } else if (PacketIsIPv6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
@@ -546,12 +546,12 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
                 sp = p->sp;
                 dp = p->dp;
             } else {
-                if (PKT_IS_IPV4(p)) {
+                if (PacketIsIPv4(p)) {
                     PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
                             dstip, sizeof(dstip));
-                } else if (PKT_IS_IPV6(p)) {
+                } else if (PacketIsIPv6(p)) {
                     PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
                             srcip, sizeof(srcip));
                     PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -175,7 +175,7 @@ static int LuaPacketLoggerAlerts(ThreadVars *tv, void *thread_data, const Packet
     char timebuf[64];
     CreateTimeString(p->ts, timebuf, sizeof(timebuf));
 
-    if (!(PKT_IS_IPV4(p)) && !(PKT_IS_IPV6(p))) {
+    if (!(PacketIsIPv4(p)) && !(PacketIsIPv6(p))) {
         /* decoder event */
         goto not_supported;
     }
@@ -237,7 +237,7 @@ static int LuaPacketLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 
     char timebuf[64];
 
-    if ((!(PKT_IS_IPV4(p))) && (!(PKT_IS_IPV6(p)))) {
+    if ((!(PacketIsIPv4(p))) && (!(PacketIsIPv6(p)))) {
         goto not_supported;
     }
 
@@ -281,7 +281,7 @@ static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, con
     SCEnter();
     LogLuaThreadCtx *td = (LogLuaThreadCtx *)thread_data;
 
-    if ((!(PKT_IS_IPV4(p))) && (!(PKT_IS_IPV6(p))))
+    if ((!(PacketIsIPv4(p))) && (!(PacketIsIPv6(p))))
         return 0;
 
     BUG_ON(ff->flags & FILE_LOGGED);

--- a/src/packet.c
+++ b/src/packet.c
@@ -121,9 +121,6 @@ void PacketReinit(Packet *p)
     if (p->udph != NULL) {
         CLEAR_UDP_PACKET(p);
     }
-    if (p->sctph != NULL) {
-        CLEAR_SCTP_PACKET(p);
-    }
     if (p->esph != NULL) {
         CLEAR_ESP_PACKET(p);
     }

--- a/src/packet.c
+++ b/src/packet.c
@@ -121,7 +121,6 @@ void PacketReinit(Packet *p)
     if (p->udph != NULL) {
         CLEAR_UDP_PACKET(p);
     }
-    p->pppoesh = NULL;
     p->pppoedh = NULL;
     p->payload = NULL;
     p->payload_len = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -118,9 +118,6 @@ void PacketReinit(Packet *p)
     if (p->tcph != NULL) {
         CLEAR_TCP_PACKET(p);
     }
-    if (p->udph != NULL) {
-        CLEAR_UDP_PACKET(p);
-    }
     p->payload = NULL;
     p->payload_len = 0;
     p->BypassPacketsFlow = NULL;

--- a/src/packet.c
+++ b/src/packet.c
@@ -121,9 +121,6 @@ void PacketReinit(Packet *p)
     if (p->udph != NULL) {
         CLEAR_UDP_PACKET(p);
     }
-    if (p->esph != NULL) {
-        CLEAR_ESP_PACKET(p);
-    }
     if (p->icmpv4h != NULL) {
         CLEAR_ICMPV4_PACKET(p);
     }

--- a/src/packet.c
+++ b/src/packet.c
@@ -121,7 +121,6 @@ void PacketReinit(Packet *p)
     if (p->udph != NULL) {
         CLEAR_UDP_PACKET(p);
     }
-    p->pppoedh = NULL;
     p->payload = NULL;
     p->payload_len = 0;
     p->BypassPacketsFlow = NULL;

--- a/src/packet.c
+++ b/src/packet.c
@@ -132,7 +132,6 @@ void PacketReinit(Packet *p)
     }
     p->pppoesh = NULL;
     p->pppoedh = NULL;
-    p->greh = NULL;
     p->payload = NULL;
     p->payload_len = 0;
     p->BypassPacketsFlow = NULL;

--- a/src/packet.c
+++ b/src/packet.c
@@ -115,9 +115,6 @@ void PacketReinit(Packet *p)
     PacketClearL2(p);
     PacketClearL3(p);
     PacketClearL4(p);
-    if (p->tcph != NULL) {
-        CLEAR_TCP_PACKET(p);
-    }
     p->payload = NULL;
     p->payload_len = 0;
     p->BypassPacketsFlow = NULL;

--- a/src/packet.c
+++ b/src/packet.c
@@ -124,9 +124,6 @@ void PacketReinit(Packet *p)
     if (p->icmpv4h != NULL) {
         CLEAR_ICMPV4_PACKET(p);
     }
-    if (p->icmpv6h != NULL) {
-        CLEAR_ICMPV6_PACKET(p);
-    }
     p->pppoesh = NULL;
     p->pppoedh = NULL;
     p->payload = NULL;

--- a/src/packet.c
+++ b/src/packet.c
@@ -63,7 +63,6 @@ void PacketInit(Packet *p)
 {
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
-    PACKET_RESET_CHECKSUMS(p);
     p->livedev = NULL;
 }
 
@@ -115,6 +114,7 @@ void PacketReinit(Packet *p)
     }
     p->ethh = NULL;
     PacketClearL3(p);
+    PacketClearL4(p);
     if (p->tcph != NULL) {
         CLEAR_TCP_PACKET(p);
     }
@@ -155,7 +155,6 @@ void PacketReinit(Packet *p)
     p->tunnel_verdicted = false;
     p->root = NULL;
     p->livedev = NULL;
-    PACKET_RESET_CHECKSUMS(p);
     PACKET_PROFILING_RESET(p);
     p->tenant_id = 0;
     p->nb_decoded_layers = 0;

--- a/src/packet.c
+++ b/src/packet.c
@@ -112,7 +112,7 @@ void PacketReinit(Packet *p)
         PktVarFree(p->pktvar);
         p->pktvar = NULL;
     }
-    p->ethh = NULL;
+    PacketClearL2(p);
     PacketClearL3(p);
     PacketClearL4(p);
     if (p->tcph != NULL) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -64,6 +64,7 @@ void PacketInit(Packet *p)
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
     PACKET_RESET_CHECKSUMS(p);
+    p->l3.comp_csum = -1;
     p->livedev = NULL;
 }
 
@@ -114,12 +115,8 @@ void PacketReinit(Packet *p)
         p->pktvar = NULL;
     }
     p->ethh = NULL;
-    if (p->ip4h != NULL) {
-        CLEAR_IPV4_PACKET(p);
-    }
-    if (p->ip6h != NULL) {
-        CLEAR_IPV6_PACKET(p);
-    }
+    PacketClearL3(p);
+    p->l3.comp_csum = -1;
     if (p->tcph != NULL) {
         CLEAR_TCP_PACKET(p);
     }

--- a/src/packet.c
+++ b/src/packet.c
@@ -64,7 +64,6 @@ void PacketInit(Packet *p)
     SCSpinInit(&p->persistent.tunnel_lock, 0);
     p->alerts.alerts = PacketAlertCreate();
     PACKET_RESET_CHECKSUMS(p);
-    p->l3.comp_csum = -1;
     p->livedev = NULL;
 }
 
@@ -116,7 +115,6 @@ void PacketReinit(Packet *p)
     }
     p->ethh = NULL;
     PacketClearL3(p);
-    p->l3.comp_csum = -1;
     if (p->tcph != NULL) {
         CLEAR_TCP_PACKET(p);
     }

--- a/src/packet.c
+++ b/src/packet.c
@@ -121,9 +121,6 @@ void PacketReinit(Packet *p)
     if (p->udph != NULL) {
         CLEAR_UDP_PACKET(p);
     }
-    if (p->icmpv4h != NULL) {
-        CLEAR_ICMPV4_PACKET(p);
-    }
     p->pppoesh = NULL;
     p->pppoedh = NULL;
     p->payload = NULL;

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -149,9 +149,9 @@ uint8_t SRepCIDRGetIPRepSrc(SRepCIDRTree *cidr_ctx, Packet *p, uint8_t cat, uint
 {
     uint8_t rep = 0;
 
-    if (PKT_IS_IPV4(p))
+    if (PacketIsIPv4(p))
         rep = SRepCIDRGetIPv4IPRep(cidr_ctx, (uint8_t *)GET_IPV4_SRC_ADDR_PTR(p), cat);
-    else if (PKT_IS_IPV6(p))
+    else if (PacketIsIPv6(p))
         rep = SRepCIDRGetIPv6IPRep(cidr_ctx, (uint8_t *)GET_IPV6_SRC_ADDR(p), cat);
 
     return rep;
@@ -161,9 +161,9 @@ uint8_t SRepCIDRGetIPRepDst(SRepCIDRTree *cidr_ctx, Packet *p, uint8_t cat, uint
 {
     uint8_t rep = 0;
 
-    if (PKT_IS_IPV4(p))
+    if (PacketIsIPv4(p))
         rep = SRepCIDRGetIPv4IPRep(cidr_ctx, (uint8_t *)GET_IPV4_DST_ADDR_PTR(p), cat);
-    else if (PKT_IS_IPV6(p))
+    else if (PacketIsIPv6(p))
         rep = SRepCIDRGetIPv6IPRep(cidr_ctx, (uint8_t *)GET_IPV6_DST_ADDR(p), cat);
 
     return rep;

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -282,7 +282,7 @@ int RejectSendLibnet11IPv4TCP(ThreadVars *tv, Packet *p, void *data, enum Reject
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (p->tcph == NULL)
+    if (!PKT_IS_TCP(p))
         return 1;
 
     libnet_t *c = GetCtx(p, LIBNET_RAW4);
@@ -425,8 +425,8 @@ int RejectSendLibnet11IPv6TCP(ThreadVars *tv, Packet *p, void *data, enum Reject
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (p->tcph == NULL)
-       return 1;
+    if (!PKT_IS_TCP(p))
+        return 1;
 
     libnet_t *c = GetCtx(p, LIBNET_RAW6);
     if (c == NULL)

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -282,7 +282,7 @@ int RejectSendLibnet11IPv4TCP(ThreadVars *tv, Packet *p, void *data, enum Reject
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (!PKT_IS_TCP(p))
+    if (!PacketIsTCP(p))
         return 1;
 
     libnet_t *c = GetCtx(p, LIBNET_RAW4);
@@ -425,7 +425,7 @@ int RejectSendLibnet11IPv6TCP(ThreadVars *tv, Packet *p, void *data, enum Reject
     lpacket.flow = 0;
     lpacket.class = 0;
 
-    if (!PKT_IS_TCP(p))
+    if (!PacketIsTCP(p))
         return 1;
 
     libnet_t *c = GetCtx(p, LIBNET_RAW6);

--- a/src/respond-reject-libnet11.c
+++ b/src/respond-reject-libnet11.c
@@ -80,7 +80,7 @@ typedef struct Libnet11Packet_ {
     uint32_t src4, dst4;
     uint16_t sp, dp;
     uint16_t len;
-    uint8_t *smac, *dmac;
+    const uint8_t *smac, *dmac;
 } Libnet11Packet;
 
 static inline libnet_t *GetCtx(const Packet *p, int injection_type)
@@ -236,15 +236,16 @@ static inline int BuildIPv6(libnet_t *c, Libnet11Packet *lpacket, const uint8_t 
 
 static inline void SetupEthernet(Packet *p, Libnet11Packet *lpacket, enum RejectDirection dir)
 {
+    const EthernetHdr *ethh = PacketGetEthernet(p);
     switch (dir) {
         case REJECT_DIR_SRC:
-            lpacket->smac = p->ethh->eth_dst;
-            lpacket->dmac = p->ethh->eth_src;
+            lpacket->smac = ethh->eth_dst;
+            lpacket->dmac = ethh->eth_src;
             break;
         case REJECT_DIR_DST:
         default:
-            lpacket->smac = p->ethh->eth_src;
-            lpacket->dmac = p->ethh->eth_dst;
+            lpacket->smac = ethh->eth_src;
+            lpacket->dmac = ethh->eth_dst;
             break;
     }
 }

--- a/src/respond-reject.c
+++ b/src/respond-reject.c
@@ -74,13 +74,13 @@ static TmEcode RespondRejectFunc(ThreadVars *tv, Packet *p, void *data)
     }
 
     if (PacketIsIPv4(p)) {
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             (void)RejectSendIPv4TCP(tv, p, data);
         } else {
             (void)RejectSendIPv4ICMP(tv, p, data);
         }
     } else if (PacketIsIPv6(p)) {
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             (void)RejectSendIPv6TCP(tv, p, data);
         } else {
             (void)RejectSendIPv6ICMP(tv, p, data);

--- a/src/respond-reject.c
+++ b/src/respond-reject.c
@@ -73,13 +73,13 @@ static TmEcode RespondRejectFunc(ThreadVars *tv, Packet *p, void *data)
         return TM_ECODE_OK;
     }
 
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         if (PKT_IS_TCP(p)) {
             (void)RejectSendIPv4TCP(tv, p, data);
         } else {
             (void)RejectSendIPv4ICMP(tv, p, data);
         }
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         if (PKT_IS_TCP(p)) {
             (void)RejectSendIPv6TCP(tv, p, data);
         } else {

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -108,6 +108,7 @@
 #include "decode-chdlc.h"
 #include "decode-geneve.h"
 #include "decode-nsh.h"
+#include "decode-pppoe.h"
 #include "decode-raw.h"
 #include "decode-vntag.h"
 #include "decode-vxlan.h"

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -112,6 +112,7 @@
 #include "decode-raw.h"
 #include "decode-vntag.h"
 #include "decode-vxlan.h"
+#include "decode-pppoe.h"
 
 #include "output-json-stats.h"
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2197,7 +2197,7 @@ static int AFPBypassCallback(Packet *p)
     if (PacketIsTunnel(p)) {
         return 0;
     }
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         SCLogDebug("add an IPv4");
         if (p->afp_v.v4_map_fd == -1) {
             return 0;
@@ -2254,8 +2254,7 @@ static int AFPBypassCallback(Packet *p)
         return AFPSetFlowStorage(p, p->afp_v.v4_map_fd, keys[0], keys[1], AF_INET);
     }
     /* For IPv6 case we don't handle extended header in eBPF */
-    if (PKT_IS_IPV6(p) &&
-        ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
+    if (PacketIsIPv6(p) && ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
         int i;
         if (p->afp_v.v6_map_fd == -1) {
             return 0;
@@ -2352,7 +2351,7 @@ static int AFPXDPBypassCallback(Packet *p)
     if (PacketIsTunnel(p)) {
         return 0;
     }
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         struct flowv4_keys *keys[2];
         keys[0]= SCCalloc(1, sizeof(struct flowv4_keys));
         if (keys[0] == NULL) {
@@ -2409,8 +2408,7 @@ static int AFPXDPBypassCallback(Packet *p)
         return AFPSetFlowStorage(p, p->afp_v.v4_map_fd, keys[0], keys[1], AF_INET);
     }
     /* For IPv6 case we don't handle extended header in eBPF */
-    if (PKT_IS_IPV6(p) &&
-        ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
+    if (PacketIsIPv6(p) && ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
         SCLogDebug("add an IPv6");
         if (p->afp_v.v6_map_fd == -1) {
             return 0;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2181,7 +2181,7 @@ static int AFPBypassCallback(Packet *p)
 {
     SCLogDebug("Calling af_packet callback function");
     /* Only bypass TCP and UDP */
-    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
         return 0;
     }
 
@@ -2335,7 +2335,7 @@ static int AFPXDPBypassCallback(Packet *p)
 {
     SCLogDebug("Calling af_packet callback function");
     /* Only bypass TCP and UDP */
-    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
         return 0;
     }
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -659,17 +659,18 @@ static void AFPWritePacket(Packet *p, int version)
         }
     }
 
-    if (p->ethh == NULL) {
+    if (!PacketIsEthernet(p)) {
         SCLogWarning("packet should have an ethernet header");
         return;
     }
 
+    const EthernetHdr *ethh = PacketGetEthernet(p);
     /* Index of the network device */
     socket_address.sll_ifindex = SC_ATOMIC_GET(p->afp_v.peer->if_idx);
     /* Address length*/
     socket_address.sll_halen = ETH_ALEN;
     /* Destination MAC */
-    memcpy(socket_address.sll_addr, p->ethh, 6);
+    memcpy(socket_address.sll_addr, ethh, 6);
 
     /* Send packet, locking the socket if necessary */
     if (p->afp_v.peer->flags & AFP_SOCK_PROTECT)
@@ -2684,7 +2685,7 @@ static void UpdateRawDataForVLANHdr(Packet *p)
         /* update the packet raw data pointer to start at the new offset */
         (void)PacketSetData(p, pstart, plen);
         /* update ethernet header pointer to point to the new start of the data */
-        p->ethh = (void *)pstart;
+        p->l2.hdrs.ethh = (void *)pstart;
     }
 }
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2210,13 +2210,13 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[0]->src = htonl(GET_IPV4_SRC_ADDR_U32(p));
         keys[0]->dst = htonl(GET_IPV4_DST_ADDR_U32(p));
-        keys[0]->port16[0] = GET_TCP_SRC_PORT(p);
-        keys[0]->port16[1] = GET_TCP_DST_PORT(p);
+        keys[0]->port16[0] = p->sp;
+        keys[0]->port16[1] = p->dp;
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
         keys[0]->vlan2 = p->vlan_id[2];
 
-        if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
+        if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
             keys[0]->ip_proto = 0;
@@ -2236,8 +2236,8 @@ static int AFPBypassCallback(Packet *p)
         }
         keys[1]->src = htonl(GET_IPV4_DST_ADDR_U32(p));
         keys[1]->dst = htonl(GET_IPV4_SRC_ADDR_U32(p));
-        keys[1]->port16[0] = GET_TCP_DST_PORT(p);
-        keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
+        keys[1]->port16[0] = p->dp;
+        keys[1]->port16[1] = p->sp;
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
         keys[1]->vlan2 = p->vlan_id[2];
@@ -2255,7 +2255,7 @@ static int AFPBypassCallback(Packet *p)
         return AFPSetFlowStorage(p, p->afp_v.v4_map_fd, keys[0], keys[1], AF_INET);
     }
     /* For IPv6 case we don't handle extended header in eBPF */
-    if (PacketIsIPv6(p) && ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
+    if (PacketIsIPv6(p) && ((p->proto == IPPROTO_TCP) || (p->proto == IPPROTO_UDP))) {
         int i;
         if (p->afp_v.v6_map_fd == -1) {
             return 0;
@@ -2271,13 +2271,13 @@ static int AFPBypassCallback(Packet *p)
             keys[0]->src[i] = ntohl(GET_IPV6_SRC_ADDR(p)[i]);
             keys[0]->dst[i] = ntohl(GET_IPV6_DST_ADDR(p)[i]);
         }
-        keys[0]->port16[0] = GET_TCP_SRC_PORT(p);
-        keys[0]->port16[1] = GET_TCP_DST_PORT(p);
+        keys[0]->port16[0] = p->sp;
+        keys[0]->port16[1] = p->dp;
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
         keys[0]->vlan2 = p->vlan_id[2];
 
-        if (IPV6_GET_NH(p) == IPPROTO_TCP) {
+        if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
             keys[0]->ip_proto = 0;
@@ -2299,8 +2299,8 @@ static int AFPBypassCallback(Packet *p)
             keys[1]->src[i] = ntohl(GET_IPV6_DST_ADDR(p)[i]);
             keys[1]->dst[i] = ntohl(GET_IPV6_SRC_ADDR(p)[i]);
         }
-        keys[1]->port16[0] = GET_TCP_DST_PORT(p);
-        keys[1]->port16[1] = GET_TCP_SRC_PORT(p);
+        keys[1]->port16[0] = p->dp;
+        keys[1]->port16[1] = p->sp;
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
         keys[1]->vlan2 = p->vlan_id[2];
@@ -2372,7 +2372,7 @@ static int AFPXDPBypassCallback(Packet *p)
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
         keys[0]->vlan2 = p->vlan_id[2];
-        if (IPV4_GET_IPPROTO(p) == IPPROTO_TCP) {
+        if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
             keys[0]->ip_proto = 0;
@@ -2409,7 +2409,7 @@ static int AFPXDPBypassCallback(Packet *p)
         return AFPSetFlowStorage(p, p->afp_v.v4_map_fd, keys[0], keys[1], AF_INET);
     }
     /* For IPv6 case we don't handle extended header in eBPF */
-    if (PacketIsIPv6(p) && ((IPV6_GET_NH(p) == IPPROTO_TCP) || (IPV6_GET_NH(p) == IPPROTO_UDP))) {
+    if (PacketIsIPv6(p) && ((p->proto == IPPROTO_TCP) || (p->proto == IPPROTO_UDP))) {
         SCLogDebug("add an IPv6");
         if (p->afp_v.v6_map_fd == -1) {
             return 0;
@@ -2425,12 +2425,12 @@ static int AFPXDPBypassCallback(Packet *p)
             keys[0]->src[i] = GET_IPV6_SRC_ADDR(p)[i];
             keys[0]->dst[i] = GET_IPV6_DST_ADDR(p)[i];
         }
-        keys[0]->port16[0] = htons(GET_TCP_SRC_PORT(p));
-        keys[0]->port16[1] = htons(GET_TCP_DST_PORT(p));
+        keys[0]->port16[0] = htons(p->sp);
+        keys[0]->port16[1] = htons(p->dp);
         keys[0]->vlan0 = p->vlan_id[0];
         keys[0]->vlan1 = p->vlan_id[1];
         keys[0]->vlan2 = p->vlan_id[2];
-        if (IPV6_GET_NH(p) == IPPROTO_TCP) {
+        if (p->proto == IPPROTO_TCP) {
             keys[0]->ip_proto = 1;
         } else {
             keys[0]->ip_proto = 0;
@@ -2452,8 +2452,8 @@ static int AFPXDPBypassCallback(Packet *p)
             keys[1]->src[i] = GET_IPV6_DST_ADDR(p)[i];
             keys[1]->dst[i] = GET_IPV6_SRC_ADDR(p)[i];
         }
-        keys[1]->port16[0] = htons(GET_TCP_DST_PORT(p));
-        keys[1]->port16[1] = htons(GET_TCP_SRC_PORT(p));
+        keys[1]->port16[0] = htons(p->dp);
+        keys[1]->port16[1] = htons(p->sp);
         keys[1]->vlan0 = p->vlan_id[0];
         keys[1]->vlan1 = p->vlan_id[1];
         keys[1]->vlan2 = p->vlan_id[2];

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2181,7 +2181,7 @@ static int AFPBypassCallback(Packet *p)
 {
     SCLogDebug("Calling af_packet callback function");
     /* Only bypass TCP and UDP */
-    if (!(PKT_IS_TCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
         return 0;
     }
 
@@ -2335,7 +2335,7 @@ static int AFPXDPBypassCallback(Packet *p)
 {
     SCLogDebug("Calling af_packet callback function");
     /* Only bypass TCP and UDP */
-    if (!(PKT_IS_TCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
         return 0;
     }
 

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -366,7 +366,7 @@ static void DPDKReleasePacket(Packet *p)
     if ((p->dpdk_v.copy_mode == DPDK_COPY_MODE_TAP ||
                 (p->dpdk_v.copy_mode == DPDK_COPY_MODE_IPS && !PacketCheckAction(p, ACTION_DROP)))
 #if defined(RTE_LIBRTE_I40E_PMD) || defined(RTE_LIBRTE_IXGBE_PMD) || defined(RTE_LIBRTE_ICE_PMD)
-            && !(PacketIsICMPv6(p) && p->icmpv6h->type == 143)
+            && !(PacketIsICMPv6(p) && PacketGetICMPv6(p)->type == 143)
 #endif
     ) {
         BUG_ON(PKT_IS_PSEUDOPKT(p));

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -494,7 +494,8 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
             if ((ol_flags & RTE_MBUF_F_RX_IP_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_BAD) {
                 SCLogDebug("HW detected BAD IP checksum");
                 // chsum recalc will not be triggered but rule keyword check will be
-                p->l3.comp_csum = 0;
+                p->l3.csum_set = true;
+                p->l3.csum = 0;
             }
             if ((ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_L4_CKSUM_BAD) {
                 SCLogDebug("HW detected BAD L4 chsum");

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -494,7 +494,7 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
             if ((ol_flags & RTE_MBUF_F_RX_IP_CKSUM_MASK) == RTE_MBUF_F_RX_IP_CKSUM_BAD) {
                 SCLogDebug("HW detected BAD IP checksum");
                 // chsum recalc will not be triggered but rule keyword check will be
-                p->level3_comp_csum = 0;
+                p->l3.comp_csum = 0;
             }
             if ((ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_L4_CKSUM_BAD) {
                 SCLogDebug("HW detected BAD L4 chsum");

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -499,7 +499,8 @@ static inline Packet *PacketInitFromMbuf(DPDKThreadVars *ptv, struct rte_mbuf *m
             }
             if ((ol_flags & RTE_MBUF_F_RX_L4_CKSUM_MASK) == RTE_MBUF_F_RX_L4_CKSUM_BAD) {
                 SCLogDebug("HW detected BAD L4 chsum");
-                p->level4_comp_csum = 0;
+                p->l4.csum_set = true;
+                p->l4.csum = 0;
             }
         }
     }

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -366,7 +366,7 @@ static void DPDKReleasePacket(Packet *p)
     if ((p->dpdk_v.copy_mode == DPDK_COPY_MODE_TAP ||
                 (p->dpdk_v.copy_mode == DPDK_COPY_MODE_IPS && !PacketCheckAction(p, ACTION_DROP)))
 #if defined(RTE_LIBRTE_I40E_PMD) || defined(RTE_LIBRTE_IXGBE_PMD) || defined(RTE_LIBRTE_ICE_PMD)
-            && !(PKT_IS_ICMPV6(p) && p->icmpv6h->type == 143)
+            && !(PacketIsICMPv6(p) && p->icmpv6h->type == 143)
 #endif
     ) {
         BUG_ON(PKT_IS_PSEUDOPKT(p));

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -462,9 +462,9 @@ static int ProgramFlow(Packet *p, int inline_mode)
     SC_ATOMIC_ADD(flow_callback_cnt, 1);
 
     /* Only bypass TCP and UDP */
-    if (PKT_IS_TCP(p)) {
+    if (PacketIsTCP(p)) {
         SC_ATOMIC_ADD(flow_callback_tcp_pkts, 1);
-    } else if PKT_IS_UDP(p) {
+    } else if PKT_IS_UDP (p) {
         SC_ATOMIC_ADD(flow_callback_udp_pkts, 1);
     } else {
         SC_ATOMIC_ADD(flow_callback_unhandled_pkts, 1);

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -464,7 +464,7 @@ static int ProgramFlow(Packet *p, int inline_mode)
     /* Only bypass TCP and UDP */
     if (PacketIsTCP(p)) {
         SC_ATOMIC_ADD(flow_callback_tcp_pkts, 1);
-    } else if PKT_IS_UDP (p) {
+    } else if PacketIsUDP (p) {
         SC_ATOMIC_ADD(flow_callback_udp_pkts, 1);
     } else {
         SC_ATOMIC_ADD(flow_callback_unhandled_pkts, 1);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -305,7 +305,7 @@ static int PfringBypassCallback(Packet *p)
     hw_filtering_rule r;
 
     /* Only bypass TCP and UDP */
-    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PacketIsUDP(p))) {
         return 0;
     }
 

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -305,7 +305,7 @@ static int PfringBypassCallback(Packet *p)
     hw_filtering_rule r;
 
     /* Only bypass TCP and UDP */
-    if (!(PKT_IS_TCP(p) || PKT_IS_UDP(p))) {
+    if (!(PacketIsTCP(p) || PKT_IS_UDP(p))) {
         return 0;
     }
 

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -63,7 +63,8 @@ int StreamTcpInlineSegmentCompare(const TcpStream *stream,
     if (seg_data == NULL || seg_datalen == 0)
         SCReturnInt(0);
 
-    const uint32_t pkt_seq = TCP_GET_SEQ(p);
+    const TCPHdr *tcph = PacketGetTCP(p);
+    const uint32_t pkt_seq = TCP_GET_RAW_SEQ(tcph);
 
     if (SEQ_EQ(pkt_seq, seg->seq) && p->payload_len == seg_datalen) {
         int r = SCMemcmp(p->payload, seg_data, seg_datalen);
@@ -122,7 +123,8 @@ void StreamTcpInlineSegmentReplacePacket(const TcpStream *stream,
 {
     SCEnter();
 
-    uint32_t pseq = TCP_GET_SEQ(p);
+    const TCPHdr *tcph = PacketGetTCP(p);
+    const uint32_t pseq = TCP_GET_RAW_SEQ(tcph);
     uint32_t tseq = seg->seq;
 
     /* check if segment is within the packet */

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -276,7 +276,7 @@ enum TcpState {
         } else {                                                                                   \
             SCLogDebug("setting event %d on pkt %p (%" PRIu64 ")", (e), p, (p)->pcap_cnt);         \
             ENGINE_SET_EVENT((p), (e));                                                            \
-            p->tcpvars.stream_pkt_flags |= STREAM_PKT_FLAG_EVENTSET;                               \
+            p->l4.vars.tcp.stream_pkt_flags |= STREAM_PKT_FLAG_EVENTSET;                           \
         }                                                                                          \
     }
 
@@ -321,6 +321,6 @@ typedef struct TcpSession_ {
 #define STREAM_PKT_FLAG_TCP_ZERO_WIN_PROBE      BIT_U16(11)
 #define STREAM_PKT_FLAG_TCP_ZERO_WIN_PROBE_ACK  BIT_U16(12)
 
-#define STREAM_PKT_FLAG_SET(p, f) (p)->tcpvars.stream_pkt_flags |= (f)
+#define STREAM_PKT_FLAG_SET(p, f) (p)->l4.vars.tcp.stream_pkt_flags |= (f)
 
 #endif /* SURICATA_STREAM_TCP_PRIVATE_H */

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1958,7 +1958,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
 {
     SCEnter();
 
-    DEBUG_VALIDATE_BUG_ON(!PKT_IS_TCP(p));
+    DEBUG_VALIDATE_BUG_ON(!PacketIsTCP(p));
 
     SCLogDebug("ssn %p, stream %p, p %p, p->payload_len %"PRIu16"",
                 ssn, stream, p, p->payload_len);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1958,7 +1958,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
 {
     SCEnter();
 
-    DEBUG_VALIDATE_BUG_ON(p->tcph == NULL);
+    DEBUG_VALIDATE_BUG_ON(!PKT_IS_TCP(p));
 
     SCLogDebug("ssn %p, stream %p, p %p, p->payload_len %"PRIu16"",
                 ssn, stream, p, p->payload_len);

--- a/src/stream-tcp-util.c
+++ b/src/stream-tcp-util.c
@@ -100,8 +100,8 @@ int StreamTcpUTAddPayload(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, TcpSes
     if (p == NULL) {
         return -1;
     }
-    p->tcph->th_seq = htonl(seq);
-    p->tcph->th_ack = htonl(31);
+    p->l4.hdrs.tcph->th_seq = htonl(seq);
+    p->l4.hdrs.tcph->th_ack = htonl(31);
 
     if (StreamTcpReassembleHandleSegmentHandleData(tv, ra_ctx, ssn, stream, p) < 0)
         return -1;
@@ -124,9 +124,10 @@ int StreamTcpUTAddSegmentWithPayload(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
     if (p == NULL) {
         return -1;
     }
-    p->tcph->th_seq = htonl(seq);
+    p->l4.hdrs.tcph->th_seq = htonl(seq);
 
-    if (StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, s, p, TCP_GET_SEQ(p), p->payload, p->payload_len) < 0)
+    if (StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, s, p, TCP_GET_RAW_SEQ(p->l4.hdrs.tcph),
+                p->payload, p->payload_len) < 0)
         return -1;
 
     UTHFreePacket(p);
@@ -149,9 +150,10 @@ int StreamTcpUTAddSegmentWithByte(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx
     if (p == NULL) {
         return -1;
     }
-    p->tcph->th_seq = htonl(seq);
+    p->l4.hdrs.tcph->th_seq = htonl(seq);
 
-    if (StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, s, p, TCP_GET_SEQ(p), p->payload, p->payload_len) < 0)
+    if (StreamTcpReassembleInsertSegment(tv, ra_ctx, stream, s, p, TCP_GET_RAW_SEQ(p->l4.hdrs.tcph),
+                p->payload, p->payload_len) < 0)
         return -1;
     UTHFreePacket(p);
     return 0;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5680,11 +5680,9 @@ static inline int StreamTcpValidateChecksum(Packet *p)
 
     if (p->level4_comp_csum == -1) {
         if (PacketIsIPv4(p)) {
-            p->level4_comp_csum = TCPChecksum(p->ip4h->s_ip_addrs,
-                                              (uint16_t *)p->tcph,
-                                              (p->payload_len +
-                                                  TCP_GET_HLEN(p)),
-                                              p->tcph->th_sum);
+            const IPV4Hdr *ip4h = PacketGetIPv4(p);
+            p->level4_comp_csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
+                    (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
         } else if (PacketIsIPv6(p)) {
             p->level4_comp_csum = TCPV6Checksum(p->ip6h->s_ip6_addrs,
                                                 (uint16_t *)p->tcph,
@@ -6730,21 +6728,21 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
             }
         }
         /* set the ip header */
-        np->ip4h = (IPV4Hdr *)GET_PKT_DATA(np);
+        IPV4Hdr *ip4h = PacketSetIPV4(np, GET_PKT_DATA(np));
         /* version 4 and length 20 bytes for the tcp header */
-        np->ip4h->ip_verhl = 0x45;
-        np->ip4h->ip_tos = 0;
-        np->ip4h->ip_len = htons(40);
-        np->ip4h->ip_id = 0;
-        np->ip4h->ip_off = 0;
-        np->ip4h->ip_ttl = 64;
-        np->ip4h->ip_proto = IPPROTO_TCP;
+        ip4h->ip_verhl = 0x45;
+        ip4h->ip_tos = 0;
+        ip4h->ip_len = htons(40);
+        ip4h->ip_id = 0;
+        ip4h->ip_off = 0;
+        ip4h->ip_ttl = 64;
+        ip4h->ip_proto = IPPROTO_TCP;
         if (dir == 0) {
-            np->ip4h->s_ip_src.s_addr = f->src.addr_data32[0];
-            np->ip4h->s_ip_dst.s_addr = f->dst.addr_data32[0];
+            ip4h->s_ip_src.s_addr = f->src.addr_data32[0];
+            ip4h->s_ip_dst.s_addr = f->dst.addr_data32[0];
         } else {
-            np->ip4h->s_ip_src.s_addr = f->dst.addr_data32[0];
-            np->ip4h->s_ip_dst.s_addr = f->src.addr_data32[0];
+            ip4h->s_ip_src.s_addr = f->dst.addr_data32[0];
+            ip4h->s_ip_dst.s_addr = f->src.addr_data32[0];
         }
 
         /* set the tcp header */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -940,7 +940,7 @@ static void StreamTcpPacketSetState(Packet *p, TcpSession *ssn,
  */
 void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
 {
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         /* Get the OS policy based on destination IP address, as destination
            OS will decide how to react on the anomalies of newly received
            packets */
@@ -950,7 +950,7 @@ void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
         else
             stream->os_policy = OS_POLICY_DEFAULT;
 
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         /* Get the OS policy based on destination IP address, as destination
            OS will decide how to react on the anomalies of newly received
            packets */
@@ -5679,13 +5679,13 @@ static inline int StreamTcpValidateChecksum(Packet *p)
         return ret;
 
     if (p->level4_comp_csum == -1) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             p->level4_comp_csum = TCPChecksum(p->ip4h->s_ip_addrs,
                                               (uint16_t *)p->tcph,
                                               (p->payload_len +
                                                   TCP_GET_HLEN(p)),
                                               p->tcph->th_sum);
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             p->level4_comp_csum = TCPV6Checksum(p->ip6h->s_ip6_addrs,
                                                 (uint16_t *)p->tcph,
                                                 (p->payload_len +

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5679,19 +5679,21 @@ static inline int StreamTcpValidateChecksum(Packet *p)
     if (p->flags & PKT_IGNORE_CHECKSUM)
         return ret;
 
-    if (p->level4_comp_csum == -1) {
+    if (!p->l4.csum_set) {
         if (PacketIsIPv4(p)) {
             const IPV4Hdr *ip4h = PacketGetIPv4(p);
-            p->level4_comp_csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
+            p->l4.csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
                     (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+            p->l4.csum_set = true;
         } else if (PacketIsIPv6(p)) {
             const IPV6Hdr *ip6h = PacketGetIPv6(p);
-            p->level4_comp_csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
+            p->l4.csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
                     (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
+            p->l4.csum_set = true;
         }
     }
 
-    if (p->level4_comp_csum != 0) {
+    if (p->l4.csum != 0) {
         ret = 0;
         if (p->livedev) {
             (void) SC_ATOMIC_ADD(p->livedev->invalid_checksums, 1);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5684,11 +5684,9 @@ static inline int StreamTcpValidateChecksum(Packet *p)
             p->level4_comp_csum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->tcph,
                     (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
         } else if (PacketIsIPv6(p)) {
-            p->level4_comp_csum = TCPV6Checksum(p->ip6h->s_ip6_addrs,
-                                                (uint16_t *)p->tcph,
-                                                (p->payload_len +
-                                                    TCP_GET_HLEN(p)),
-                                                p->tcph->th_sum);
+            const IPV6Hdr *ip6h = PacketGetIPv6(p);
+            p->level4_comp_csum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->tcph,
+                    (p->payload_len + TCP_GET_HLEN(p)), p->tcph->th_sum);
         }
     }
 
@@ -6772,31 +6770,31 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
             }
         }
         /* set the ip header */
-        np->ip6h = (IPV6Hdr *)GET_PKT_DATA(np);
+        IPV6Hdr *ip6h = PacketSetIPV6(np, GET_PKT_DATA(np));
         /* version 6 */
-        np->ip6h->s_ip6_vfc = 0x60;
-        np->ip6h->s_ip6_flow = 0;
-        np->ip6h->s_ip6_nxt = IPPROTO_TCP;
-        np->ip6h->s_ip6_plen = htons(20);
-        np->ip6h->s_ip6_hlim = 64;
+        ip6h->s_ip6_vfc = 0x60;
+        ip6h->s_ip6_flow = 0;
+        ip6h->s_ip6_nxt = IPPROTO_TCP;
+        ip6h->s_ip6_plen = htons(20);
+        ip6h->s_ip6_hlim = 64;
         if (dir == 0) {
-            np->ip6h->s_ip6_src[0] = f->src.addr_data32[0];
-            np->ip6h->s_ip6_src[1] = f->src.addr_data32[1];
-            np->ip6h->s_ip6_src[2] = f->src.addr_data32[2];
-            np->ip6h->s_ip6_src[3] = f->src.addr_data32[3];
-            np->ip6h->s_ip6_dst[0] = f->dst.addr_data32[0];
-            np->ip6h->s_ip6_dst[1] = f->dst.addr_data32[1];
-            np->ip6h->s_ip6_dst[2] = f->dst.addr_data32[2];
-            np->ip6h->s_ip6_dst[3] = f->dst.addr_data32[3];
+            ip6h->s_ip6_src[0] = f->src.addr_data32[0];
+            ip6h->s_ip6_src[1] = f->src.addr_data32[1];
+            ip6h->s_ip6_src[2] = f->src.addr_data32[2];
+            ip6h->s_ip6_src[3] = f->src.addr_data32[3];
+            ip6h->s_ip6_dst[0] = f->dst.addr_data32[0];
+            ip6h->s_ip6_dst[1] = f->dst.addr_data32[1];
+            ip6h->s_ip6_dst[2] = f->dst.addr_data32[2];
+            ip6h->s_ip6_dst[3] = f->dst.addr_data32[3];
         } else {
-            np->ip6h->s_ip6_src[0] = f->dst.addr_data32[0];
-            np->ip6h->s_ip6_src[1] = f->dst.addr_data32[1];
-            np->ip6h->s_ip6_src[2] = f->dst.addr_data32[2];
-            np->ip6h->s_ip6_src[3] = f->dst.addr_data32[3];
-            np->ip6h->s_ip6_dst[0] = f->src.addr_data32[0];
-            np->ip6h->s_ip6_dst[1] = f->src.addr_data32[1];
-            np->ip6h->s_ip6_dst[2] = f->src.addr_data32[2];
-            np->ip6h->s_ip6_dst[3] = f->src.addr_data32[3];
+            ip6h->s_ip6_src[0] = f->dst.addr_data32[0];
+            ip6h->s_ip6_src[1] = f->dst.addr_data32[1];
+            ip6h->s_ip6_src[2] = f->dst.addr_data32[2];
+            ip6h->s_ip6_src[3] = f->dst.addr_data32[3];
+            ip6h->s_ip6_dst[0] = f->src.addr_data32[0];
+            ip6h->s_ip6_dst[1] = f->src.addr_data32[1];
+            ip6h->s_ip6_dst[2] = f->src.addr_data32[2];
+            ip6h->s_ip6_dst[3] = f->src.addr_data32[3];
         }
 
         /* set the tcp header */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5851,7 +5851,7 @@ static int TcpSessionReuseDoneEnough(const Packet *p, const Flow *f, const TcpSe
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn)
 {
-    if (p->proto == IPPROTO_TCP && PKT_IS_TCP(p)) {
+    if (p->proto == IPPROTO_TCP && PacketIsTCP(p)) {
         if (TcpSessionPacketIsStreamStarter(p) == 1) {
             if (TcpSessionReuseDoneEnough(p, f, tcp_ssn) == 1) {
                 return 1;
@@ -5876,7 +5876,7 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueueNoLock *pq)
             PktSrcToString(p->pkt_src));
     t_pcapcnt = p->pcap_cnt;
 
-    if (!(PKT_IS_TCP(p))) {
+    if (!(PacketIsTCP(p))) {
         return TM_ECODE_OK;
     }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1366,8 +1366,9 @@ static int StreamTcpPacketStateNone(
             ssn->flags |= STREAMTCP_FLAG_TCP_FAST_OPEN;
             if (p->payload_len) {
                 StreamTcpUpdateNextSeq(ssn, &ssn->client, (ssn->client.next_seq + p->payload_len));
-                SCLogDebug("ssn: %p (TFO) [len: %d] isn %u base_seq %u next_seq %u payload len %u",
-                        ssn, p->tcpvars.tfo.len, ssn->client.isn, ssn->client.base_seq, ssn->client.next_seq, p->payload_len);
+                SCLogDebug("ssn: %p (TFO) isn %u base_seq %u next_seq %u payload len %u", ssn,
+                        ssn->client.isn, ssn->client.base_seq, ssn->client.next_seq,
+                        p->payload_len);
                 StreamTcpReassembleHandleSegment(tv, stt->ra_ctx, ssn, &ssn->client, p);
             }
         }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5849,7 +5849,7 @@ static int TcpSessionReuseDoneEnough(const Packet *p, const Flow *f, const TcpSe
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn)
 {
-    if (p->proto == IPPROTO_TCP && p->tcph != NULL) {
+    if (p->proto == IPPROTO_TCP && PKT_IS_TCP(p)) {
         if (TcpSessionPacketIsStreamStarter(p) == 1) {
             if (TcpSessionReuseDoneEnough(p, f, tcp_ssn) == 1) {
                 return 1;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1305,7 +1305,7 @@ static int StreamTcpPacketStateNone(
             ssn->client.last_ts = 0;
         }
 
-        if (TCP_GET_SACKOK(p) == 1) {
+        if (TCP_GET_SACKOK(p)) {
             ssn->flags |= STREAMTCP_FLAG_SACKOK;
             SCLogDebug("ssn %p: SYN/ACK with SACK permitted, assuming "
                     "SACK permitted for both sides", ssn);
@@ -1357,7 +1357,7 @@ static int StreamTcpPacketStateNone(
             ssn->server.wscale = TCP_GET_WSCALE(p);
         }
 
-        if (TCP_GET_SACKOK(p) == 1) {
+        if (TCP_GET_SACKOK(p)) {
             ssn->flags |= STREAMTCP_FLAG_CLIENT_SACKOK;
             SCLogDebug("ssn %p: SACK permitted on SYN packet", ssn);
         }
@@ -1490,7 +1490,7 @@ static inline void StreamTcp3whsSynAckToStateQueue(Packet *p, TcpStateQueue *q)
     q->ack = TCP_GET_ACK(p);
     q->pkt_ts = SCTIME_SECS(p->ts);
 
-    if (TCP_GET_SACKOK(p) == 1)
+    if (TCP_GET_SACKOK(p))
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
 
     if (TCP_HAS_WSCALE(p)) {
@@ -1751,7 +1751,7 @@ static void TcpStateQueueInitFromPktSyn(const Packet *p, TcpStateQueue *q)
     q->win = TCP_GET_WINDOW(p);
     q->pkt_ts = SCTIME_SECS(p->ts);
 
-    if (TCP_GET_SACKOK(p) == 1) {
+    if (TCP_GET_SACKOK(p)) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
     }
     if (TCP_HAS_WSCALE(p)) {
@@ -1783,7 +1783,7 @@ static void TcpStateQueueInitFromPktSynAck(const Packet *p, TcpStateQueue *q)
     q->win = TCP_GET_WINDOW(p);
     q->pkt_ts = SCTIME_SECS(p->ts);
 
-    if (TCP_GET_SACKOK(p) == 1) {
+    if (TCP_GET_SACKOK(p)) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
     }
     if (TCP_HAS_WSCALE(p)) {
@@ -2039,7 +2039,7 @@ static int StreamTcpPacketStateSynSent(
             ssn->server.wscale = 0;
         }
 
-        if ((ssn->flags & STREAMTCP_FLAG_CLIENT_SACKOK) && TCP_GET_SACKOK(p) == 1) {
+        if ((ssn->flags & STREAMTCP_FLAG_CLIENT_SACKOK) && TCP_GET_SACKOK(p)) {
             ssn->flags |= STREAMTCP_FLAG_SACKOK;
             SCLogDebug("ssn %p: SACK permitted for 4WHS session", ssn);
         }
@@ -2137,7 +2137,7 @@ static int StreamTcpPacketStateSynSent(
                 ssn->server.wscale = 0;
             }
 
-            if (TCP_GET_SACKOK(p) == 1) {
+            if (TCP_GET_SACKOK(p)) {
                 ssn->flags |= STREAMTCP_FLAG_CLIENT_SACKOK;
             } else {
                 ssn->flags &= ~STREAMTCP_FLAG_CLIENT_SACKOK;

--- a/src/tests/detect-http-uri.c
+++ b/src/tests/detect-http-uri.c
@@ -1571,7 +1571,7 @@ static int UriTestSig16(void)
 
     Packet *p = UTHBuildPacket(http_buf1, http_buf1_len, IPPROTO_TCP);
     FAIL_IF_NULL(p);
-    p->tcph->th_seq = htonl(1000);
+    p->l4.hdrs.tcph->th_seq = htonl(1000);
     Flow *f = UTHBuildFlow(AF_INET, "192.168.1.5", "192.168.1.1", 41424, 80);
     FAIL_IF_NULL(f);
     f->proto = IPPROTO_TCP;

--- a/src/tests/detect-ttl.c
+++ b/src/tests/detect-ttl.c
@@ -172,7 +172,7 @@ static int DetectTtlTestSig1(void)
     p->dst.family = AF_INET;
     p->proto = IPPROTO_TCP;
     ip4h.ip_ttl = 15;
-    p->ip4h = &ip4h;
+    UTHSetIPV4Hdr(p, &ip4h);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -2170,7 +2170,7 @@ static int SigTest28TCPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
+    PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -2183,7 +2183,7 @@ static int SigTest28TCPV6Keyword(void)
     }
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
+    PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2296,7 +2296,7 @@ static int SigTest29NegativeTCPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
+    PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -2309,7 +2309,7 @@ static int SigTest29NegativeTCPV6Keyword(void)
     }
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
+    PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2633,21 +2633,21 @@ static int SigTest32UDPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
+    PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
-    p1->payload_len = IPV6_GET_PLEN((p1)) - UDP_HEADER_LEN;
+    p1->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
+    PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
-    p2->payload_len = IPV6_GET_PLEN((p2)) - UDP_HEADER_LEN;
+    p2->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p2)) - UDP_HEADER_LEN;
     p2->proto = IPPROTO_UDP;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
@@ -2732,21 +2732,21 @@ static int SigTest33NegativeUDPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip6h = (IPV6Hdr *)(valid_raw_ipv6 + 14);
+    PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
-    p1->payload_len = IPV6_GET_PLEN((p1)) - UDP_HEADER_LEN;
+    p1->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip6h = (IPV6Hdr *)(invalid_raw_ipv6 + 14);
+    PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
-    p2->payload_len = IPV6_GET_PLEN((p2)) - UDP_HEADER_LEN;
+    p2->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p2)) - UDP_HEADER_LEN;
     p2->proto = IPPROTO_UDP;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -3073,7 +3073,7 @@ static int SigTest38(void)
     }
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    p1->ethh = (EthernetHdr *)raw_eth;
+    PacketSetEthernet(p1, raw_eth);
     PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;
     p1->src.family = AF_INET;
@@ -3188,7 +3188,7 @@ static int SigTest39(void)
     FAIL_IF(PacketCopyDataOffset(p1, ethlen + ipv4len + tcplen, buf, buflen) == -1);
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    p1->ethh = (EthernetHdr *)raw_eth;
+    PacketSetEthernet(p1, raw_eth);
     PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;
     p1->src.family = AF_INET;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -1511,16 +1511,14 @@ static int SigTest24IPV4Keyword(void)
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
-    p1->ip4h = (IPV4Hdr *)valid_raw_ipv4;
-
+    PacketSetIPV4(p1, valid_raw_ipv4);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
     p1->payload_len = buflen;
     p1->proto = IPPROTO_TCP;
 
-    p2->ip4h = (IPV4Hdr *)invalid_raw_ipv4;
-
+    PacketSetIPV4(p2, invalid_raw_ipv4);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -1613,16 +1611,14 @@ static int SigTest25NegativeIPV4Keyword(void)
     PACKET_RESET_CHECKSUMS(p1);
     PACKET_RESET_CHECKSUMS(p2);
 
-    p1->ip4h = (IPV4Hdr *)valid_raw_ipv4;
-
+    PacketSetIPV4(p1, valid_raw_ipv4);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
     p1->payload_len = buflen;
     p1->proto = IPPROTO_TCP;
 
-    p2->ip4h = (IPV4Hdr *)invalid_raw_ipv4;
-
+    PacketSetIPV4(p2, invalid_raw_ipv4);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -1723,7 +1719,7 @@ static int SigTest26TCPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
+    PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -1732,7 +1728,7 @@ static int SigTest26TCPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
+    PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -1821,7 +1817,7 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
+    PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -1830,7 +1826,7 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
+    PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -1945,7 +1941,7 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
+    PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -1954,7 +1950,7 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
+    PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2056,7 +2052,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)GET_PKT_DATA(p1);
+    PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -2065,7 +2061,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)GET_PKT_DATA(p2);
+    PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2420,7 +2416,7 @@ static int SigTest30UDPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p1, raw_ipv4);
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -2429,7 +2425,7 @@ static int SigTest30UDPV4Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p2, raw_ipv4);
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2526,7 +2522,7 @@ static int SigTest31NegativeUDPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p1, raw_ipv4);
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -2535,7 +2531,7 @@ static int SigTest31NegativeUDPV4Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p2, raw_ipv4);
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
@@ -2852,9 +2848,9 @@ static int SigTest34ICMPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
-    p1->ip4h->ip_verhl = 69;
-    p1->icmpv4h = (ICMPV4Hdr *) (valid_raw_ipv4 + IPV4_GET_RAW_HLEN(p1->ip4h) * 4);
+    IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
+    ip4h->ip_verhl = 69;
+    p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2862,9 +2858,9 @@ static int SigTest34ICMPV4Keyword(void)
     p1->proto = IPPROTO_ICMP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)(invalid_raw_ipv4);
-    p2->ip4h->ip_verhl = 69;
-    p2->icmpv4h = (ICMPV4Hdr *) (invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(p2->ip4h) * 4);
+    ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
+    ip4h->ip_verhl = 69;
+    p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -2970,9 +2966,9 @@ static int SigTest35NegativeICMPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PACKET_RESET_CHECKSUMS(p1);
-    p1->ip4h = (IPV4Hdr *)(valid_raw_ipv4);
-    p1->ip4h->ip_verhl = 69;
-    p1->icmpv4h = (ICMPV4Hdr *) (valid_raw_ipv4 + IPV4_GET_RAW_HLEN(p1->ip4h) * 4);
+    IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
+    ip4h->ip_verhl = 69;
+    p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2980,9 +2976,9 @@ static int SigTest35NegativeICMPV4Keyword(void)
     p1->proto = IPPROTO_ICMP;
 
     PACKET_RESET_CHECKSUMS(p2);
-    p2->ip4h = (IPV4Hdr *)(invalid_raw_ipv4);
-    p2->ip4h->ip_verhl = 69;
-    p2->icmpv4h = (ICMPV4Hdr *) (invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(p2->ip4h) * 4);
+    ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
+    ip4h->ip_verhl = 69;
+    p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -3107,7 +3103,7 @@ static int SigTest38(void)
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
-    p1->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
@@ -3223,7 +3219,7 @@ static int SigTest39(void)
 
     PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
-    p1->ip4h = (IPV4Hdr *)raw_ipv4;
+    PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -2825,7 +2825,7 @@ static int SigTest34ICMPV4Keyword(void)
 
     IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
     ip4h->ip_verhl = 69;
-    p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
+    (void)PacketSetICMPv4(p1, valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2834,7 +2834,7 @@ static int SigTest34ICMPV4Keyword(void)
 
     ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
     ip4h->ip_verhl = 69;
-    p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
+    (void)PacketSetICMPv4(p2, invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -2941,7 +2941,7 @@ static int SigTest35NegativeICMPV4Keyword(void)
 
     IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
     ip4h->ip_verhl = 69;
-    p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
+    (void)PacketSetICMPv4(p1, valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2950,7 +2950,7 @@ static int SigTest35NegativeICMPV4Keyword(void)
 
     ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
     ip4h->ip_verhl = 69;
-    p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
+    (void)PacketSetICMPv4(p2, invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -1715,7 +1715,7 @@ static int SigTest26TCPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
-    p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
+    PacketSetTCP(p1, (GET_PKT_DATA(p1) + sizeof(raw_ipv4)));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = (uint8_t *)GET_PKT_DATA(p1) + sizeof(raw_ipv4) + 20;
@@ -1723,7 +1723,7 @@ static int SigTest26TCPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
-    p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
+    PacketSetTCP(p2, (GET_PKT_DATA(p2) + sizeof(raw_ipv4)));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = (uint8_t *)GET_PKT_DATA(p2) + sizeof(raw_ipv4) + 20;
@@ -1811,7 +1811,7 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
-    p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
+    PacketSetTCP(p1, (GET_PKT_DATA(p1) + sizeof(raw_ipv4)));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = (uint8_t *)GET_PKT_DATA(p1) + sizeof(raw_ipv4) + 20;
@@ -1819,7 +1819,7 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
-    p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
+    PacketSetTCP(p2, (GET_PKT_DATA(p2) + sizeof(raw_ipv4)));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = (uint8_t *)GET_PKT_DATA(p2) + sizeof(raw_ipv4) + 20;
@@ -1933,7 +1933,7 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
-    p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
+    PacketSetTCP(p1, (GET_PKT_DATA(p1) + sizeof(raw_ipv4)));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = (uint8_t *)GET_PKT_DATA(p1) + sizeof(raw_ipv4) + 20 + 24;
@@ -1941,7 +1941,7 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
-    p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
+    PacketSetTCP(p2, (GET_PKT_DATA(p2) + sizeof(raw_ipv4)));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = (uint8_t *)GET_PKT_DATA(p2) + sizeof(raw_ipv4) + 20 + 24;
@@ -2042,7 +2042,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
-    p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
+    PacketSetTCP(p1, (GET_PKT_DATA(p1) + sizeof(raw_ipv4)));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = (uint8_t *)GET_PKT_DATA(p1) + sizeof(raw_ipv4) + 20;
@@ -2050,7 +2050,7 @@ static int SigTest27NegativeTCPV4Keyword(void)
     p1->proto = IPPROTO_TCP;
 
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
-    p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
+    PacketSetTCP(p2, (GET_PKT_DATA(p2) + sizeof(raw_ipv4)));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = (uint8_t *)GET_PKT_DATA(p2) + sizeof(raw_ipv4) + 20;
@@ -2158,26 +2158,26 @@ static int SigTest28TCPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
-    p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
+    PacketSetTCP(p1, (valid_raw_ipv6 + 54));
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = valid_raw_ipv6 + 54 + 20;
     p1->payload_len = 12;
     p1->proto = IPPROTO_TCP;
 
-    if (TCP_GET_HLEN(p1) != 20) {
+    if (TCP_GET_RAW_HLEN(PacketGetTCP(p1)) != 20) {
         BUG_ON(1);
     }
 
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
-    p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
+    PacketSetTCP(p2, (invalid_raw_ipv6 + 54));
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = invalid_raw_ipv6 + 54 + 20;
     p2->payload_len = 12;
     p2->proto = IPPROTO_TCP;
 
-    if (TCP_GET_HLEN(p2) != 20) {
+    if (TCP_GET_RAW_HLEN(PacketGetTCP(p2)) != 20) {
         BUG_ON(1);
     }
 
@@ -2282,28 +2282,26 @@ static int SigTest29NegativeTCPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
-    p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
+    PacketSetTCP(p1, valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = valid_raw_ipv6 + 54 + 20;
     p1->payload_len = 12;
     p1->proto = IPPROTO_TCP;
 
-    if (TCP_GET_HLEN(p1) != 20) {
+    if (TCP_GET_RAW_HLEN(PacketGetTCP(p1)) != 20) {
         BUG_ON(1);
     }
 
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
-    p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
+    PacketSetTCP(p2, invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = invalid_raw_ipv6 + 54 + 20;
     p2->payload_len = 12;
     p2->proto = IPPROTO_TCP;
 
-    if (TCP_GET_HLEN(p2) != 20) {
-        BUG_ON(1);
-    }
+    FAIL_IF(TCP_GET_RAW_HLEN(PacketGetTCP(p2)) != 20);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {
@@ -3075,7 +3073,7 @@ static int SigTest38(void)
 
     PacketSetEthernet(p1, raw_eth);
     PacketSetIPV4(p1, raw_ipv4);
-    p1->tcph = (TCPHdr *)raw_tcp;
+    PacketSetTCP(p1, raw_tcp);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = GET_PKT_DATA(p1) + ethlen + ipv4len + tcplen;
@@ -3190,7 +3188,7 @@ static int SigTest39(void)
 
     PacketSetEthernet(p1, raw_eth);
     PacketSetIPV4(p1, raw_ipv4);
-    p1->tcph = (TCPHdr *)raw_tcp;
+    PacketSetTCP(p1, raw_tcp);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = GET_PKT_DATA(p1) + ethlen + ipv4len + tcplen;
@@ -3507,7 +3505,7 @@ static int SigTest40NoPacketInspection01(void)
     p->sp = 21;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flags |= PKT_NOPACKET_INSPECTION;
-    p->tcph = &tcphdr;
+    PacketSetTCP(p, (uint8_t *)&tcphdr);
     p->flow = &f;
 
     FLOW_INITIALIZE(&f);

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -2400,7 +2400,7 @@ static int SigTest30UDPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV4(p1, raw_ipv4);
-    p1->udph = (UDPHdr *)valid_raw_udp;
+    PacketSetUDP(p1, valid_raw_udp);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2408,7 +2408,7 @@ static int SigTest30UDPV4Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PacketSetIPV4(p2, raw_ipv4);
-    p2->udph = (UDPHdr *)invalid_raw_udp;
+    PacketSetUDP(p2, invalid_raw_udp);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -2504,7 +2504,7 @@ static int SigTest31NegativeUDPV4Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV4(p1, raw_ipv4);
-    p1->udph = (UDPHdr *)valid_raw_udp;
+    PacketSetUDP(p1, valid_raw_udp);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2512,7 +2512,7 @@ static int SigTest31NegativeUDPV4Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PacketSetIPV4(p2, raw_ipv4);
-    p2->udph = (UDPHdr *)invalid_raw_udp;
+    PacketSetUDP(p2, invalid_raw_udp);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -2613,7 +2613,7 @@ static int SigTest32UDPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
-    p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
+    PacketSetUDP(p1, valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2621,7 +2621,7 @@ static int SigTest32UDPV6Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
-    p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
+    PacketSetUDP(p2, invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;
@@ -2710,7 +2710,7 @@ static int SigTest33NegativeUDPV6Keyword(void)
     memset(&th_v, 0, sizeof(ThreadVars));
 
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
-    p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
+    PacketSetUDP(p1, valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
     p1->dst.family = AF_INET;
     p1->payload = buf;
@@ -2718,7 +2718,7 @@ static int SigTest33NegativeUDPV6Keyword(void)
     p1->proto = IPPROTO_UDP;
 
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
-    p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
+    PacketSetUDP(p2, invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
     p2->dst.family = AF_INET;
     p2->payload = buf;

--- a/src/tests/detect.c
+++ b/src/tests/detect.c
@@ -1508,8 +1508,6 @@ static int SigTest24IPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    PACKET_RESET_CHECKSUMS(p1);
-    PACKET_RESET_CHECKSUMS(p2);
 
     PacketSetIPV4(p1, valid_raw_ipv4);
     p1->src.family = AF_INET;
@@ -1608,8 +1606,6 @@ static int SigTest25NegativeIPV4Keyword(void)
     uint16_t buflen = strlen((char *)buf);
 
     memset(&th_v, 0, sizeof(ThreadVars));
-    PACKET_RESET_CHECKSUMS(p1);
-    PACKET_RESET_CHECKSUMS(p2);
 
     PacketSetIPV4(p1, valid_raw_ipv4);
     p1->src.family = AF_INET;
@@ -1718,7 +1714,6 @@ static int SigTest26TCPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -1727,7 +1722,6 @@ static int SigTest26TCPV4Keyword(void)
     p1->payload_len = 20;
     p1->proto = IPPROTO_TCP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -1816,7 +1810,6 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -1825,7 +1818,6 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     p1->payload_len = 20;
     p1->proto = IPPROTO_TCP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -1940,7 +1932,6 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -1949,7 +1940,6 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     p1->payload_len = 0;
     p1->proto = IPPROTO_TCP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -2051,7 +2041,6 @@ static int SigTest27NegativeTCPV4Keyword(void)
     PacketCopyData(p2, raw_ipv4, sizeof(raw_ipv4));
     PacketCopyDataOffset(p2, GET_PKT_LEN(p2), invalid_raw_tcp, sizeof(invalid_raw_tcp));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, GET_PKT_DATA(p1));
     p1->tcph = (TCPHdr *)(GET_PKT_DATA(p1) + sizeof(raw_ipv4));
     p1->src.family = AF_INET;
@@ -2060,7 +2049,6 @@ static int SigTest27NegativeTCPV4Keyword(void)
     p1->payload_len = 20;
     p1->proto = IPPROTO_TCP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, GET_PKT_DATA(p2));
     p2->tcph = (TCPHdr *)(GET_PKT_DATA(p2) + sizeof(raw_ipv4));
     p2->src.family = AF_INET;
@@ -2169,7 +2157,6 @@ static int SigTest28TCPV6Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -2182,7 +2169,6 @@ static int SigTest28TCPV6Keyword(void)
         BUG_ON(1);
     }
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -2295,7 +2281,6 @@ static int SigTest29NegativeTCPV6Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->tcph = (TCPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -2308,7 +2293,6 @@ static int SigTest29NegativeTCPV6Keyword(void)
         BUG_ON(1);
     }
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->tcph = (TCPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -2415,7 +2399,6 @@ static int SigTest30UDPV4Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, raw_ipv4);
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
@@ -2424,7 +2407,6 @@ static int SigTest30UDPV4Keyword(void)
     p1->payload_len = sizeof(valid_raw_udp) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, raw_ipv4);
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
@@ -2521,7 +2503,6 @@ static int SigTest31NegativeUDPV4Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV4(p1, raw_ipv4);
     p1->udph = (UDPHdr *)valid_raw_udp;
     p1->src.family = AF_INET;
@@ -2530,7 +2511,6 @@ static int SigTest31NegativeUDPV4Keyword(void)
     p1->payload_len = sizeof(valid_raw_udp) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV4(p2, raw_ipv4);
     p2->udph = (UDPHdr *)invalid_raw_udp;
     p2->src.family = AF_INET;
@@ -2632,7 +2612,6 @@ static int SigTest32UDPV6Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -2641,7 +2620,6 @@ static int SigTest32UDPV6Keyword(void)
     p1->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -2731,7 +2709,6 @@ static int SigTest33NegativeUDPV6Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     PacketSetIPV6(p1, valid_raw_ipv6 + 14);
     p1->udph = (UDPHdr *) (valid_raw_ipv6 + 54);
     p1->src.family = AF_INET;
@@ -2740,7 +2717,6 @@ static int SigTest33NegativeUDPV6Keyword(void)
     p1->payload_len = IPV6_GET_RAW_PLEN(PacketGetIPv6(p1)) - UDP_HEADER_LEN;
     p1->proto = IPPROTO_UDP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     PacketSetIPV6(p2, invalid_raw_ipv6 + 14);
     p2->udph = (UDPHdr *) (invalid_raw_ipv6 + 54);
     p2->src.family = AF_INET;
@@ -2847,7 +2823,6 @@ static int SigTest34ICMPV4Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
     ip4h->ip_verhl = 69;
     p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
@@ -2857,7 +2832,6 @@ static int SigTest34ICMPV4Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
     ip4h->ip_verhl = 69;
     p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
@@ -2965,7 +2939,6 @@ static int SigTest35NegativeICMPV4Keyword(void)
 
     memset(&th_v, 0, sizeof(ThreadVars));
 
-    PACKET_RESET_CHECKSUMS(p1);
     IPV4Hdr *ip4h = PacketSetIPV4(p1, valid_raw_ipv4);
     ip4h->ip_verhl = 69;
     p1->icmpv4h = (ICMPV4Hdr *)(valid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
@@ -2975,7 +2948,6 @@ static int SigTest35NegativeICMPV4Keyword(void)
     p1->payload_len = buflen;
     p1->proto = IPPROTO_ICMP;
 
-    PACKET_RESET_CHECKSUMS(p2);
     ip4h = PacketSetIPV4(p2, invalid_raw_ipv4);
     ip4h->ip_verhl = 69;
     p2->icmpv4h = (ICMPV4Hdr *)(invalid_raw_ipv4 + IPV4_GET_RAW_HLEN(ip4h));
@@ -3101,7 +3073,6 @@ static int SigTest38(void)
     }
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
     PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;
@@ -3217,7 +3188,6 @@ static int SigTest39(void)
     FAIL_IF(PacketCopyDataOffset(p1, ethlen + ipv4len + tcplen, buf, buflen) == -1);
     SET_PKT_LEN(p1, ethlen + ipv4len + tcplen + buflen);
 
-    PACKET_RESET_CHECKSUMS(p1);
     p1->ethh = (EthernetHdr *)raw_eth;
     PacketSetIPV4(p1, raw_ipv4);
     p1->tcph = (TCPHdr *)raw_tcp;

--- a/src/tests/stream-tcp-inline.c
+++ b/src/tests/stream-tcp-inline.c
@@ -63,8 +63,8 @@ static int VALIDATE(TcpStream *stream, uint8_t *data, uint32_t data_len)
     p = UTHBuildPacketReal(                                                                        \
             (uint8_t *)(seg), (seglen), IPPROTO_TCP, "1.1.1.1", "2.2.2.2", 1024, 80);              \
     FAIL_IF(p == NULL);                                                                            \
-    p->tcph->th_seq = htonl(stream->isn + (rseq));                                                 \
-    p->tcph->th_ack = htonl(31);                                                                   \
+    p->l4.hdrs.tcph->th_seq = htonl(stream->isn + (rseq));                                         \
+    p->l4.hdrs.tcph->th_ack = htonl(31);                                                           \
     FAIL_IF(StreamTcpReassembleHandleSegmentHandleData(&tv, ra_ctx, &ssn, stream, p) < 0);         \
     FAIL_IF(memcmp(p->payload, packet, MIN((packetlen), p->payload_len)) != 0);                    \
     UTHFreePacket(p);

--- a/src/tests/stream-tcp.c
+++ b/src/tests/stream-tcp.c
@@ -25,6 +25,7 @@
 #include "../util-streaming-buffer.h"
 #include "../util-print.h"
 #include "../util-unittest.h"
+#include "../util-unittest-helper.h"
 
 #define SET_ISN(stream, setseq)                                                                    \
     (stream)->isn = (setseq);                                                                      \
@@ -1138,7 +1139,7 @@ static int StreamTcpTest14(void)
     p->tcph = &tcph;
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, sizeof(payload)); /*AAA*/
     p->payload = payload;
@@ -1528,7 +1529,7 @@ static int StreamTcpTest15(void)
     p->tcph = &tcph;
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, sizeof(payload)); /*AAA*/
     p->payload = payload;
@@ -1690,7 +1691,7 @@ static int StreamTcpTest16(void)
     p->tcph = &tcph;
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, sizeof(payload)); /*AAA*/
     p->payload = payload;
@@ -1853,7 +1854,7 @@ static int StreamTcpTest17(void)
     p->tcph = &tcph;
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, sizeof(payload)); /*AAA*/
     p->payload = payload;
@@ -1992,7 +1993,7 @@ static int StreamTcpTest18(void)
     SCHInfoAddHostOSInfo(os_policy_name, ip_addr, -1);
 
     p->dst.family = AF_INET;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     addr.s_addr = inet_addr("192.168.1.1");
     p->dst.address.address_un_data32[0] = addr.s_addr;
     StreamTcpSetOSPolicy(&stream, p);
@@ -2039,7 +2040,7 @@ static int StreamTcpTest19(void)
     SCHInfoAddHostOSInfo(os_policy_name, ip_addr, -1);
 
     p->dst.family = AF_INET;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     addr.s_addr = inet_addr("192.168.0.30");
     p->dst.address.address_un_data32[0] = addr.s_addr;
     StreamTcpSetOSPolicy(&stream, p);
@@ -2089,7 +2090,7 @@ static int StreamTcpTest20(void)
     SCHInfoAddHostOSInfo(os_policy_name, ip_addr, -1);
 
     p->dst.family = AF_INET;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     addr.s_addr = inet_addr("192.168.0.1");
     p->dst.address.address_un_data32[0] = addr.s_addr;
     StreamTcpSetOSPolicy(&stream, p);
@@ -2139,7 +2140,7 @@ static int StreamTcpTest21(void)
     SCHInfoAddHostOSInfo(os_policy_name, ip_addr, -1);
 
     p->dst.family = AF_INET;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     addr.s_addr = inet_addr("192.168.1.30");
     p->dst.address.address_un_data32[0] = addr.s_addr;
     StreamTcpSetOSPolicy(&stream, p);
@@ -2189,7 +2190,7 @@ static int StreamTcpTest22(void)
     SCHInfoAddHostOSInfo(os_policy_name, ip_addr, -1);
 
     p->dst.family = AF_INET;
-    p->ip4h = &ipv4h;
+    UTHSetIPV4Hdr(p, &ipv4h);
     addr.s_addr = inet_addr("123.231.2.1");
     p->dst.address.address_un_data32[0] = addr.s_addr;
     StreamTcpSetOSPolicy(&stream, p);

--- a/src/tests/stream-tcp.c
+++ b/src/tests/stream-tcp.c
@@ -41,8 +41,11 @@
 static int StreamTcpTest01(void)
 {
     StreamTcpThread stt;
+    TCPHdr tcph;
+    memset(&tcph, 0, sizeof(TCPHdr));
     Packet *p = PacketGetFromAlloc();
     FAIL_IF_NULL(p);
+    UTHSetTCPHdr(p, &tcph);
     Flow f;
     memset(&f, 0, sizeof(Flow));
     FLOW_INITIALIZE(&f);
@@ -88,29 +91,29 @@ static int StreamTcpTest02(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpUTInit(&stt.ra_ctx);
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -122,9 +125,9 @@ static int StreamTcpTest02(void)
     p->flowflags = FLOW_PKT_TOCLIENT;
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(6);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -176,23 +179,23 @@ static int StreamTcpTest03(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_SYN | TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     int ret = 0;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(19);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(19);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -250,16 +253,16 @@ static int StreamTcpTest04(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     int ret = 0;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(9);
-    p->tcph->th_ack = htonl(19);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(9);
+    tcph.th_ack = htonl(19);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -318,7 +321,7 @@ static int StreamTcpTest05(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
     p->payload = payload;
@@ -327,9 +330,9 @@ static int StreamTcpTest05(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -339,9 +342,9 @@ static int StreamTcpTest05(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(13);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(13);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, 4); /*CCC*/
@@ -351,9 +354,9 @@ static int StreamTcpTest05(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(19);
-    p->tcph->th_ack = htonl(16);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(19);
+    tcph.th_ack = htonl(16);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x44, 3, 4); /*DDD*/
@@ -415,7 +418,7 @@ static int StreamTcpTest06(void)
     StreamTcpUTInit(&stt.ra_ctx);
 
     tcph.th_flags = TH_FIN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     /* StreamTcpPacket returns -1 on unsolicited FIN */
     if (StreamTcpPacket(&tv, p, &stt, &pq) != -1) {
@@ -428,7 +431,7 @@ static int StreamTcpTest06(void)
         goto end;
     }
 
-    p->tcph->th_flags = TH_RST;
+    tcph.th_flags = TH_RST;
     /* StreamTcpPacket returns -1 on unsolicited RST */
     if (StreamTcpPacket(&tv, p, &stt, &pq) != -1) {
         printf("StreamTcpPacket failed (2): ");
@@ -480,23 +483,23 @@ static int StreamTcpTest07(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
-    p->tcpvars.ts_set = true;
-    p->tcpvars.ts_val = 10;
-    p->tcpvars.ts_ecr = 11;
+    p->l4.vars.tcp.ts_set = true;
+    p->l4.vars.tcp.ts_val = 10;
+    p->l4.vars.tcp.ts_ecr = 11;
 
     p->payload = payload;
     p->payload_len = 1;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
-    p->tcpvars.ts_val = 2;
+    p->l4.vars.tcp.ts_val = 2;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) != -1);
 
@@ -541,23 +544,23 @@ static int StreamTcpTest08(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
-    p->tcpvars.ts_set = true;
-    p->tcpvars.ts_val = 10;
-    p->tcpvars.ts_ecr = 11;
+    p->l4.vars.tcp.ts_set = true;
+    p->l4.vars.tcp.ts_val = 10;
+    p->l4.vars.tcp.ts_ecr = 11;
 
     p->payload = payload;
     p->payload_len = 1;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(20);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(20);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
-    p->tcpvars.ts_val = 12;
+    p->l4.vars.tcp.ts_val = 12;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
@@ -603,16 +606,16 @@ static int StreamTcpTest09(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     p->payload = payload;
     p->payload_len = 1;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(12);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(12);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     FAIL_IF(p->flow->protoctx == NULL);
@@ -621,9 +624,9 @@ static int StreamTcpTest09(void)
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
@@ -671,20 +674,20 @@ static int StreamTcpTest10(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = 0;
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -693,9 +696,9 @@ static int StreamTcpTest10(void)
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(6);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -750,20 +753,20 @@ static int StreamTcpTest11(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(1);
     tcph.th_flags = TH_SYN | TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -772,9 +775,9 @@ static int StreamTcpTest11(void)
 
     FAIL_IF(StreamTcpPacket(&tv, p, &stt, &pq) == -1);
 
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(2);
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -828,15 +831,15 @@ static int StreamTcpTest12(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(11);
     tcph.th_flags = TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     int ret = 0;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(10);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(10);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -846,9 +849,9 @@ static int StreamTcpTest12(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(6);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -922,15 +925,15 @@ static int StreamTcpTest13(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(11);
     tcph.th_flags = TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     int ret = 0;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(10);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(10);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -940,9 +943,9 @@ static int StreamTcpTest13(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(6);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -967,9 +970,9 @@ static int StreamTcpTest13(void)
         goto end;
     }
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(9);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(9);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -1136,7 +1139,7 @@ static int StreamTcpTest14(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
     UTHSetIPV4Hdr(p, &ipv4h);
@@ -1148,9 +1151,9 @@ static int StreamTcpTest14(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, sizeof(payload)); /*BBB*/
@@ -1160,9 +1163,9 @@ static int StreamTcpTest14(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(15);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(15);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1172,9 +1175,9 @@ static int StreamTcpTest14(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(14);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(14);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1185,9 +1188,9 @@ static int StreamTcpTest14(void)
         goto end;
 
     addr.s_addr = inet_addr("192.168.0.2");
-    p->tcph->th_seq = htonl(25);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(25);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->dst.address.address_un_data32[0] = addr.s_addr;
 
@@ -1198,9 +1201,9 @@ static int StreamTcpTest14(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(24);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(24);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x44, 3, sizeof(payload)); /*DDD*/
@@ -1278,14 +1281,14 @@ static int StreamTcp4WHSTest01(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = 0;
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = 0;
-    p->tcph->th_flags = TH_SYN;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = 0;
+    tcph.th_flags = TH_SYN;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -1296,17 +1299,17 @@ static int StreamTcp4WHSTest01(void)
         goto end;
     }
 
-    p->tcph->th_seq = htonl(10);
-    p->tcph->th_ack = htonl(21); /* the SYN/ACK uses the SEQ from the first SYN pkt */
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(10);
+    tcph.th_ack = htonl(21); /* the SYN/ACK uses the SEQ from the first SYN pkt */
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(21);
-    p->tcph->th_ack = htonl(10);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_seq = htonl(21);
+    tcph.th_ack = htonl(10);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -1358,14 +1361,14 @@ static int StreamTcp4WHSTest02(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = 0;
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = 0;
-    p->tcph->th_flags = TH_SYN;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = 0;
+    tcph.th_flags = TH_SYN;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -1376,9 +1379,9 @@ static int StreamTcp4WHSTest02(void)
         goto end;
     }
 
-    p->tcph->th_seq = htonl(30);
-    p->tcph->th_ack = htonl(21); /* the SYN/ACK uses the SEQ from the first SYN pkt */
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(30);
+    tcph.th_ack = htonl(21); /* the SYN/ACK uses the SEQ from the first SYN pkt */
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) != -1) {
@@ -1427,14 +1430,14 @@ static int StreamTcp4WHSTest03(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = 0;
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = 0;
-    p->tcph->th_flags = TH_SYN;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = 0;
+    tcph.th_flags = TH_SYN;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -1445,17 +1448,17 @@ static int StreamTcp4WHSTest03(void)
         goto end;
     }
 
-    p->tcph->th_seq = htonl(30);
-    p->tcph->th_ack = htonl(11);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(30);
+    tcph.th_ack = htonl(11);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(11);
-    p->tcph->th_ack = htonl(31);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_seq = htonl(11);
+    tcph.th_ack = htonl(31);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -1526,7 +1529,7 @@ static int StreamTcpTest15(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
     UTHSetIPV4Hdr(p, &ipv4h);
@@ -1538,9 +1541,9 @@ static int StreamTcpTest15(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, sizeof(payload)); /*BBB*/
@@ -1550,9 +1553,9 @@ static int StreamTcpTest15(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(15);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(15);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1562,9 +1565,9 @@ static int StreamTcpTest15(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(14);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(14);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1575,9 +1578,9 @@ static int StreamTcpTest15(void)
         goto end;
 
     addr.s_addr = inet_addr("192.168.1.20");
-    p->tcph->th_seq = htonl(25);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(25);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->dst.address.address_un_data32[0] = addr.s_addr;
 
@@ -1588,9 +1591,9 @@ static int StreamTcpTest15(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(24);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(24);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x44, 3, sizeof(payload)); /*DDD*/
@@ -1688,7 +1691,7 @@ static int StreamTcpTest16(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
     UTHSetIPV4Hdr(p, &ipv4h);
@@ -1700,9 +1703,9 @@ static int StreamTcpTest16(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, sizeof(payload)); /*BBB*/
@@ -1712,9 +1715,9 @@ static int StreamTcpTest16(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(15);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(15);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1724,9 +1727,9 @@ static int StreamTcpTest16(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(14);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(14);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1737,9 +1740,9 @@ static int StreamTcpTest16(void)
         goto end;
 
     addr.s_addr = inet_addr("192.168.1.1");
-    p->tcph->th_seq = htonl(25);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(25);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->dst.address.address_un_data32[0] = addr.s_addr;
 
@@ -1750,9 +1753,9 @@ static int StreamTcpTest16(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(24);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(24);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x44, 3, sizeof(payload)); /*DDD*/
@@ -1851,7 +1854,7 @@ static int StreamTcpTest17(void)
     tcph.th_seq = htonl(10);
     tcph.th_ack = htonl(20);
     tcph.th_flags = TH_ACK | TH_PUSH;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->dst.family = AF_INET;
     p->dst.address.address_un_data32[0] = addr.s_addr;
     UTHSetIPV4Hdr(p, &ipv4h);
@@ -1863,9 +1866,9 @@ static int StreamTcpTest17(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(20);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(20);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, sizeof(payload)); /*BBB*/
@@ -1875,9 +1878,9 @@ static int StreamTcpTest17(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(15);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(15);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1887,9 +1890,9 @@ static int StreamTcpTest17(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(14);
-    p->tcph->th_ack = htonl(23);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(14);
+    tcph.th_ack = htonl(23);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x43, 3, sizeof(payload)); /*CCC*/
@@ -1900,9 +1903,9 @@ static int StreamTcpTest17(void)
         goto end;
 
     addr.s_addr = inet_addr("10.1.1.1");
-    p->tcph->th_seq = htonl(25);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(25);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
     p->dst.address.address_un_data32[0] = addr.s_addr;
 
@@ -1913,9 +1916,9 @@ static int StreamTcpTest17(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_seq = htonl(24);
-    p->tcph->th_ack = htonl(13);
-    p->tcph->th_flags = TH_ACK | TH_PUSH;
+    tcph.th_seq = htonl(24);
+    tcph.th_ack = htonl(13);
+    tcph.th_flags = TH_ACK | TH_PUSH;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x44, 3, sizeof(payload)); /*DDD*/
@@ -2238,25 +2241,25 @@ static int StreamTcpTest23(void)
     p->flow = &f;
     tcph.th_win = 5480;
     tcph.th_flags = TH_PUSH | TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload = packet;
     SET_ISN(&ssn.client, 3184324452UL);
 
-    p->tcph->th_seq = htonl(3184324453UL);
-    p->tcph->th_ack = htonl(3373419609UL);
+    tcph.th_seq = htonl(3184324453UL);
+    tcph.th_ack = htonl(3373419609UL);
     p->payload_len = 2;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
 
-    p->tcph->th_seq = htonl(3184324455UL);
-    p->tcph->th_ack = htonl(3373419621UL);
+    tcph.th_seq = htonl(3184324455UL);
+    tcph.th_ack = htonl(3373419621UL);
     p->payload_len = 2;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
 
-    p->tcph->th_seq = htonl(3184324453UL);
-    p->tcph->th_ack = htonl(3373419621UL);
+    tcph.th_seq = htonl(3184324453UL);
+    tcph.th_ack = htonl(3373419621UL);
     p->payload_len = 6;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
@@ -2300,26 +2303,26 @@ static int StreamTcpTest24(void)
     p->flow = &f;
     tcph.th_win = 5480;
     tcph.th_flags = TH_PUSH | TH_ACK;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
     p->payload = packet;
     // ssn.client.ra_app_base_seq = ssn.client.ra_raw_base_seq = ssn.client.last_ack = 3184324453UL;
     SET_ISN(&ssn.client, 3184324453UL);
 
-    p->tcph->th_seq = htonl(3184324455UL);
-    p->tcph->th_ack = htonl(3373419621UL);
+    tcph.th_seq = htonl(3184324455UL);
+    tcph.th_ack = htonl(3373419621UL);
     p->payload_len = 4;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
 
-    p->tcph->th_seq = htonl(3184324459UL);
-    p->tcph->th_ack = htonl(3373419633UL);
+    tcph.th_seq = htonl(3184324459UL);
+    tcph.th_ack = htonl(3373419633UL);
     p->payload_len = 2;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
 
-    p->tcph->th_seq = htonl(3184324459UL);
-    p->tcph->th_ack = htonl(3373419657UL);
+    tcph.th_seq = htonl(3184324459UL);
+    tcph.th_ack = htonl(3373419657UL);
     p->payload_len = 4;
 
     FAIL_IF(StreamTcpReassembleHandleSegment(&tv, stt.ra_ctx, &ssn, &ssn.client, p) == -1);
@@ -2363,31 +2366,31 @@ static int StreamTcpTest25(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN | TH_CWR;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
     StreamTcpUTInit(&stt.ra_ctx);
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2401,9 +2404,9 @@ static int StreamTcpTest25(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(6);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -2454,7 +2457,7 @@ static int StreamTcpTest26(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN | TH_ECN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -2462,24 +2465,24 @@ static int StreamTcpTest26(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2493,9 +2496,9 @@ static int StreamTcpTest26(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(6);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -2546,7 +2549,7 @@ static int StreamTcpTest27(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN | TH_CWR | TH_ECN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -2554,24 +2557,24 @@ static int StreamTcpTest27(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2585,9 +2588,9 @@ static int StreamTcpTest27(void)
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL)
         goto end;
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(6);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(6);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x42, 3, 4); /*BBB*/
@@ -2663,7 +2666,7 @@ static int StreamTcpTest37(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -2673,8 +2676,8 @@ static int StreamTcpTest37(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL) {
@@ -2682,9 +2685,9 @@ static int StreamTcpTest37(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL) {
@@ -2697,9 +2700,9 @@ static int StreamTcpTest37(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(2);
-    p->tcph->th_seq = htonl(4);
-    p->tcph->th_flags = TH_ACK | TH_FIN;
+    tcph.th_ack = htonl(2);
+    tcph.th_seq = htonl(4);
+    tcph.th_flags = TH_ACK | TH_FIN;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1 || (TcpSession *)p->flow->protoctx == NULL) {
@@ -2712,9 +2715,9 @@ static int StreamTcpTest37(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2726,9 +2729,9 @@ static int StreamTcpTest37(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(4);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(4);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_ACK;
     p->payload_len = 0;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
@@ -2780,7 +2783,7 @@ static int StreamTcpTest38(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpUTInit(&stt.ra_ctx);
@@ -2789,8 +2792,8 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1) {
@@ -2798,9 +2801,9 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1) {
@@ -2808,9 +2811,9 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(29847);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(29847);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2830,9 +2833,9 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x41, 127, 128); /*AAA*/
@@ -2850,9 +2853,9 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(256); // in window, but beyond next_seq
-    p->tcph->th_seq = htonl(5);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(256); // in window, but beyond next_seq
+    tcph.th_seq = htonl(5);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2872,9 +2875,9 @@ static int StreamTcpTest38(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(128);
-    p->tcph->th_seq = htonl(8);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(128);
+    tcph.th_seq = htonl(8);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2933,7 +2936,7 @@ static int StreamTcpTest39(void)
     p->flow = &f;
     tcph.th_win = htons(5480);
     tcph.th_flags = TH_SYN;
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     p->flowflags = FLOW_PKT_TOSERVER;
     int ret = 0;
 
@@ -2944,8 +2947,8 @@ static int StreamTcpTest39(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1) {
@@ -2953,9 +2956,9 @@ static int StreamTcpTest39(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1) {
@@ -2963,9 +2966,9 @@ static int StreamTcpTest39(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(1);
-    p->tcph->th_seq = htonl(1);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(1);
+    tcph.th_seq = htonl(1);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -2983,9 +2986,9 @@ static int StreamTcpTest39(void)
         goto end;
     }
 
-    p->tcph->th_ack = htonl(4);
-    p->tcph->th_seq = htonl(2);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_ack = htonl(4);
+    tcph.th_seq = htonl(2);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -3005,9 +3008,9 @@ static int StreamTcpTest39(void)
         goto end;
     }
 
-    p->tcph->th_seq = htonl(4);
-    p->tcph->th_ack = htonl(5);
-    p->tcph->th_flags = TH_PUSH | TH_ACK;
+    tcph.th_seq = htonl(4);
+    tcph.th_ack = htonl(5);
+    tcph.th_flags = TH_PUSH | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     StreamTcpCreateTestPacket(payload, 0x41, 3, 4); /*AAA*/
@@ -3059,7 +3062,7 @@ static int StreamTcpTest42(void)
     StreamTcpUTInit(&stt.ra_ctx);
 
     FLOW_INITIALIZE(&f);
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     tcph.th_win = htons(5480);
     p->flow = &f;
 
@@ -3072,27 +3075,27 @@ static int StreamTcpTest42(void)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(500);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(500);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(1000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(1000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* ACK */
-    p->tcph->th_ack = htonl(501);
-    p->tcph->th_seq = htonl(101);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(501);
+    tcph.th_seq = htonl(101);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -3146,7 +3149,7 @@ static int StreamTcpTest43(void)
     StreamTcpUTInit(&stt.ra_ctx);
 
     FLOW_INITIALIZE(&f);
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     tcph.th_win = htons(5480);
     p->flow = &f;
 
@@ -3159,27 +3162,27 @@ static int StreamTcpTest43(void)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(500);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(500);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(1000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(1000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* ACK */
-    p->tcph->th_ack = htonl(1001);
-    p->tcph->th_seq = htonl(101);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1001);
+    tcph.th_seq = htonl(101);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
@@ -3233,7 +3236,7 @@ static int StreamTcpTest44(void)
     StreamTcpUTInit(&stt.ra_ctx);
 
     FLOW_INITIALIZE(&f);
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     tcph.th_win = htons(5480);
     p->flow = &f;
 
@@ -3246,27 +3249,27 @@ static int StreamTcpTest44(void)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(500);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(500);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(1000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(1000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* ACK */
-    p->tcph->th_ack = htonl(3001);
-    p->tcph->th_seq = htonl(101);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(3001);
+    tcph.th_seq = htonl(101);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) != -1)
@@ -3317,7 +3320,7 @@ static int StreamTcpTest45(void)
     stream_config.max_synack_queued = 2;
 
     FLOW_INITIALIZE(&f);
-    p->tcph = &tcph;
+    UTHSetTCPHdr(p, &tcph);
     tcph.th_win = htons(5480);
     p->flow = &f;
 
@@ -3330,45 +3333,45 @@ static int StreamTcpTest45(void)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(500);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(500);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(1000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(1000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(2000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(2000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)
         goto end;
 
     /* SYN/ACK */
-    p->tcph->th_seq = htonl(3000);
-    p->tcph->th_ack = htonl(101);
-    p->tcph->th_flags = TH_SYN | TH_ACK;
+    tcph.th_seq = htonl(3000);
+    tcph.th_ack = htonl(101);
+    tcph.th_flags = TH_SYN | TH_ACK;
     p->flowflags = FLOW_PKT_TOCLIENT;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) != -1)
         goto end;
 
     /* ACK */
-    p->tcph->th_ack = htonl(1001);
-    p->tcph->th_seq = htonl(101);
-    p->tcph->th_flags = TH_ACK;
+    tcph.th_ack = htonl(1001);
+    tcph.th_seq = htonl(101);
+    tcph.th_flags = TH_ACK;
     p->flowflags = FLOW_PKT_TOSERVER;
 
     if (StreamTcpPacket(&tv, p, &stt, &pq) == -1)

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -282,8 +282,8 @@ static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
 
     if (p->flags & PKT_WANTS_FLOW) {
         uint32_t hash = p->flow_hash;
-        if (PKT_IS_TCP(p) && ((p->sp >= 1024 && p->dp >= 1024) || p->dp == 21 || p->sp == 21 ||
-                                     p->dp == 20 || p->sp == 20)) {
+        if (PacketIsTCP(p) && ((p->sp >= 1024 && p->dp >= 1024) || p->dp == 21 || p->sp == 21 ||
+                                      p->dp == 20 || p->sp == 20)) {
             hash = FlowGetIpPairProtoHash(p);
         }
         qid = hash % ctx->size;

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -282,8 +282,8 @@ static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
 
     if (p->flags & PKT_WANTS_FLOW) {
         uint32_t hash = p->flow_hash;
-        if (p->tcph != NULL && ((p->sp >= 1024 && p->dp >= 1024) || p->dp == 21 || p->sp == 21 ||
-                                       p->dp == 20 || p->sp == 20)) {
+        if (PKT_IS_TCP(p) && ((p->sp >= 1024 && p->dp >= 1024) || p->dp == 21 || p->sp == 21 ||
+                                     p->dp == 20 || p->sp == 20)) {
             hash = FlowGetIpPairProtoHash(p);
         }
         qid = hash % ctx->size;

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -35,7 +35,7 @@ int ReCalculateChecksum(Packet *p)
             p->tcph->th_sum = 0;
             p->tcph->th_sum = TCPChecksum(
                     ip4h->s_ip_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
-        } else if (PKT_IS_UDP(p)) {
+        } else if (PacketIsUDP(p)) {
             p->udph->uh_sum = 0;
             p->udph->uh_sum = UDPV4Checksum(
                     ip4h->s_ip_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
@@ -49,7 +49,7 @@ int ReCalculateChecksum(Packet *p)
             p->tcph->th_sum = 0;
             p->tcph->th_sum = TCPV6Checksum(
                     ip6h->s_ip6_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
-        } else if (PKT_IS_UDP(p)) {
+        } else if (PacketIsUDP(p)) {
             p->udph->uh_sum = 0;
             p->udph->uh_sum = UDPV6Checksum(
                     ip6h->s_ip6_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -32,9 +32,9 @@ int ReCalculateChecksum(Packet *p)
         IPV4Hdr *ip4h = p->l3.hdrs.ip4h;
         if (PacketIsTCP(p)) {
             /* TCP */
-            p->tcph->th_sum = 0;
-            p->tcph->th_sum = TCPChecksum(
-                    ip4h->s_ip_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
+            p->l4.hdrs.tcph->th_sum = 0;
+            p->l4.hdrs.tcph->th_sum = TCPChecksum(ip4h->s_ip_addrs, (uint16_t *)p->l4.hdrs.tcph,
+                    (p->payload_len + TCP_GET_RAW_HLEN(p->l4.hdrs.tcph)), 0);
         } else if (PacketIsUDP(p)) {
             p->l4.hdrs.udph->uh_sum = 0;
             p->l4.hdrs.udph->uh_sum = UDPV4Checksum(ip4h->s_ip_addrs, (uint16_t *)p->l4.hdrs.udph,
@@ -46,9 +46,9 @@ int ReCalculateChecksum(Packet *p)
     } else if (PacketIsIPv6(p)) {
         IPV6Hdr *ip6h = p->l3.hdrs.ip6h;
         if (PacketIsTCP(p)) {
-            p->tcph->th_sum = 0;
-            p->tcph->th_sum = TCPV6Checksum(
-                    ip6h->s_ip6_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
+            p->l4.hdrs.tcph->th_sum = 0;
+            p->l4.hdrs.tcph->th_sum = TCPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->l4.hdrs.tcph,
+                    (p->payload_len + TCP_GET_RAW_HLEN(p->l4.hdrs.tcph)), 0);
         } else if (PacketIsUDP(p)) {
             p->l4.hdrs.udph->uh_sum = 0;
             p->l4.hdrs.udph->uh_sum = UDPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->l4.hdrs.udph,

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -29,20 +29,20 @@
 int ReCalculateChecksum(Packet *p)
 {
     if (PacketIsIPv4(p)) {
+        IPV4Hdr *ip4h = p->l3.hdrs.ip4h;
         if (PKT_IS_TCP(p)) {
             /* TCP */
             p->tcph->th_sum = 0;
-            p->tcph->th_sum = TCPChecksum(p->ip4h->s_ip_addrs,
-                    (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
+            p->tcph->th_sum = TCPChecksum(
+                    ip4h->s_ip_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
         } else if (PKT_IS_UDP(p)) {
             p->udph->uh_sum = 0;
-            p->udph->uh_sum = UDPV4Checksum(p->ip4h->s_ip_addrs,
-                    (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
+            p->udph->uh_sum = UDPV4Checksum(
+                    ip4h->s_ip_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
         }
         /* IPV4 */
-        p->ip4h->ip_csum = 0;
-        p->ip4h->ip_csum = IPV4Checksum((uint16_t *)p->ip4h,
-                IPV4_GET_RAW_HLEN(p->ip4h), 0);
+        ip4h->ip_csum = 0;
+        ip4h->ip_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), 0);
     } else if (PacketIsIPv6(p)) {
         /* just TCP for IPV6 */
         if (PKT_IS_TCP(p)) {

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -44,15 +44,15 @@ int ReCalculateChecksum(Packet *p)
         ip4h->ip_csum = 0;
         ip4h->ip_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), 0);
     } else if (PacketIsIPv6(p)) {
-        /* just TCP for IPV6 */
+        IPV6Hdr *ip6h = p->l3.hdrs.ip6h;
         if (PKT_IS_TCP(p)) {
             p->tcph->th_sum = 0;
-            p->tcph->th_sum = TCPV6Checksum(p->ip6h->s_ip6_addrs,
-                    (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
+            p->tcph->th_sum = TCPV6Checksum(
+                    ip6h->s_ip6_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
         } else if (PKT_IS_UDP(p)) {
             p->udph->uh_sum = 0;
-            p->udph->uh_sum = UDPV6Checksum(p->ip6h->s_ip6_addrs,
-                    (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
+            p->udph->uh_sum = UDPV6Checksum(
+                    ip6h->s_ip6_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
         }
     }
 

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -36,9 +36,9 @@ int ReCalculateChecksum(Packet *p)
             p->tcph->th_sum = TCPChecksum(
                     ip4h->s_ip_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
         } else if (PacketIsUDP(p)) {
-            p->udph->uh_sum = 0;
-            p->udph->uh_sum = UDPV4Checksum(
-                    ip4h->s_ip_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
+            p->l4.hdrs.udph->uh_sum = 0;
+            p->l4.hdrs.udph->uh_sum = UDPV4Checksum(ip4h->s_ip_addrs, (uint16_t *)p->l4.hdrs.udph,
+                    (p->payload_len + UDP_HEADER_LEN), 0);
         }
         /* IPV4 */
         ip4h->ip_csum = 0;
@@ -50,9 +50,9 @@ int ReCalculateChecksum(Packet *p)
             p->tcph->th_sum = TCPV6Checksum(
                     ip6h->s_ip6_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
         } else if (PacketIsUDP(p)) {
-            p->udph->uh_sum = 0;
-            p->udph->uh_sum = UDPV6Checksum(
-                    ip6h->s_ip6_addrs, (uint16_t *)p->udph, (p->payload_len + UDP_HEADER_LEN), 0);
+            p->l4.hdrs.udph->uh_sum = 0;
+            p->l4.hdrs.udph->uh_sum = UDPV6Checksum(ip6h->s_ip6_addrs, (uint16_t *)p->l4.hdrs.udph,
+                    (p->payload_len + UDP_HEADER_LEN), 0);
         }
     }
 

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -30,7 +30,7 @@ int ReCalculateChecksum(Packet *p)
 {
     if (PacketIsIPv4(p)) {
         IPV4Hdr *ip4h = p->l3.hdrs.ip4h;
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             /* TCP */
             p->tcph->th_sum = 0;
             p->tcph->th_sum = TCPChecksum(
@@ -45,7 +45,7 @@ int ReCalculateChecksum(Packet *p)
         ip4h->ip_csum = IPV4Checksum((uint16_t *)ip4h, IPV4_GET_RAW_HLEN(ip4h), 0);
     } else if (PacketIsIPv6(p)) {
         IPV6Hdr *ip6h = p->l3.hdrs.ip6h;
-        if (PKT_IS_TCP(p)) {
+        if (PacketIsTCP(p)) {
             p->tcph->th_sum = 0;
             p->tcph->th_sum = TCPV6Checksum(
                     ip6h->s_ip6_addrs, (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -28,7 +28,7 @@
 
 int ReCalculateChecksum(Packet *p)
 {
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         if (PKT_IS_TCP(p)) {
             /* TCP */
             p->tcph->th_sum = 0;
@@ -43,7 +43,7 @@ int ReCalculateChecksum(Packet *p)
         p->ip4h->ip_csum = 0;
         p->ip4h->ip_csum = IPV4Checksum((uint16_t *)p->ip4h,
                 IPV4_GET_RAW_HLEN(p->ip4h), 0);
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         /* just TCP for IPV6 */
         if (PKT_IS_TCP(p)) {
             p->tcph->th_sum = 0;

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -328,9 +328,9 @@ static int LuaCallbackFlowHasAlerts(lua_State *luastate)
 static int LuaCallbackTuplePushToStackFromPacket(lua_State *luastate, const Packet *p)
 {
     int ipver = 0;
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         ipver = 4;
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         ipver = 6;
     }
     lua_pushinteger(luastate, ipver);
@@ -338,10 +338,10 @@ static int LuaCallbackTuplePushToStackFromPacket(lua_State *luastate, const Pack
         return 1;
 
     char srcip[46] = "", dstip[46] = "";
-    if (PKT_IS_IPV4(p)) {
+    if (PacketIsIPv4(p)) {
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
-    } else if (PKT_IS_IPV6(p)) {
+    } else if (PacketIsIPv6(p)) {
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
     }

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -893,7 +893,7 @@ static void SCProfilingUpdatePacketDetectRecords(Packet *p)
         PktProfilingDetectData *pdt = &p->profile->detect[i];
 
         if (pdt->ticks_spent > 0) {
-            if (PKT_IS_IPV4(p)) {
+            if (PacketIsIPv4(p)) {
                 SCProfilingUpdatePacketDetectRecord(i, p->proto, pdt, 4);
             } else {
                 SCProfilingUpdatePacketDetectRecord(i, p->proto, pdt, 6);
@@ -951,7 +951,7 @@ static void SCProfilingUpdatePacketAppRecords(Packet *p)
         PktProfilingAppData *pdt = &p->profile->app[i];
 
         if (pdt->ticks_spent > 0) {
-            if (PKT_IS_IPV4(p)) {
+            if (PacketIsIPv4(p)) {
                 SCProfilingUpdatePacketAppRecord(i, p->proto, pdt, 4);
             } else {
                 SCProfilingUpdatePacketAppRecord(i, p->proto, pdt, 6);
@@ -960,7 +960,7 @@ static void SCProfilingUpdatePacketAppRecords(Packet *p)
     }
 
     if (p->profile->proto_detect > 0) {
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             SCProfilingUpdatePacketAppPdRecord(p->proto, p->profile->proto_detect, 4);
         } else {
             SCProfilingUpdatePacketAppPdRecord(p->proto, p->profile->proto_detect, 6);
@@ -1011,7 +1011,7 @@ static void SCProfilingUpdatePacketTmmRecords(Packet *p)
             continue;
         }
 
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             SCProfilingUpdatePacketTmmRecord(i, p->proto, pdt, 4);
         } else {
             SCProfilingUpdatePacketTmmRecord(i, p->proto, pdt, 6);
@@ -1052,7 +1052,7 @@ static void SCProfilingUpdatePacketGenericRecords(Packet *p, PktProfilingData *p
         struct ProfileProtoRecords *r = &records[i];
         SCProfilePacketData *store = NULL;
 
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             store = &(r->records4[p->proto]);
         } else {
             store = &(r->records6[p->proto]);
@@ -1092,7 +1092,7 @@ static void SCProfilingUpdatePacketLogRecords(Packet *p)
         PktProfilingLoggerData *pdt = &p->profile->logger[i];
 
         if (pdt->ticks_spent > 0) {
-            if (PKT_IS_IPV4(p)) {
+            if (PacketIsIPv4(p)) {
                 SCProfilingUpdatePacketLogRecord(i, p->proto, pdt, 4);
             } else {
                 SCProfilingUpdatePacketLogRecord(i, p->proto, pdt, 6);
@@ -1111,7 +1111,7 @@ void SCProfilingAddPacket(Packet *p)
     pthread_mutex_lock(&packet_profile_lock);
     {
 
-        if (PKT_IS_IPV4(p)) {
+        if (PacketIsIPv4(p)) {
             SCProfilePacketData *pd = &packet_profile_data4[p->proto];
 
             uint64_t delta = p->profile->ticks_end - p->profile->ticks_start;
@@ -1147,7 +1147,7 @@ void SCProfilingAddPacket(Packet *p)
             SCProfilingUpdatePacketDetectRecords(p);
             SCProfilingUpdatePacketLogRecords(p);
 
-        } else if (PKT_IS_IPV6(p)) {
+        } else if (PacketIsIPv6(p)) {
             SCProfilePacketData *pd = &packet_profile_data6[p->proto];
 
             uint64_t delta = p->profile->ticks_end - p->profile->ticks_start;

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -310,13 +310,14 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
             p->tcph->th_dport = htons(dport);
             hdr_offset += sizeof(TCPHdr);
             break;
-        case IPPROTO_ICMP:
-            p->icmpv4h = (ICMPV4Hdr *)(GET_PKT_DATA(p) + sizeof(IPV4Hdr));
-            if (p->icmpv4h == NULL)
+        case IPPROTO_ICMP: {
+            ICMPV4Hdr *icmpv4h = PacketSetICMPv4(p, (GET_PKT_DATA(p) + sizeof(IPV4Hdr)));
+            if (icmpv4h == NULL)
                 goto error;
 
             hdr_offset += sizeof(ICMPV4Hdr);
             break;
+        }
         default:
             break;
         /* TODO: Add more protocols */

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -292,15 +292,16 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
 
     int hdr_offset = sizeof(IPV4Hdr);
     switch (ipproto) {
-        case IPPROTO_UDP:
-            p->udph = (UDPHdr *)(GET_PKT_DATA(p) + sizeof(IPV4Hdr));
-            if (p->udph == NULL)
+        case IPPROTO_UDP: {
+            UDPHdr *udph = PacketSetUDP(p, (GET_PKT_DATA(p) + sizeof(IPV4Hdr)));
+            if (udph == NULL)
                 goto error;
 
-            p->udph->uh_sport = sport;
-            p->udph->uh_dport = dport;
+            udph->uh_sport = sport;
+            udph->uh_dport = dport;
             hdr_offset += sizeof(UDPHdr);
             break;
+        }
         case IPPROTO_TCP:
             p->tcph = (TCPHdr *)(GET_PKT_DATA(p) + sizeof(IPV4Hdr));
             if (p->tcph == NULL)
@@ -926,14 +927,16 @@ static int CheckUTHTestPacket(Packet *p, uint8_t ipproto)
         return 0;
 
     switch(ipproto) {
-        case IPPROTO_UDP:
-            if (p->udph == NULL)
+        case IPPROTO_UDP: {
+            const UDPHdr *udph = PacketGetUDP(p);
+            if (udph == NULL)
                 return 0;
-            if (p->udph->uh_sport != sport)
+            if (udph->uh_sport != sport)
                 return 0;
-            if (p->udph->uh_dport != dport)
+            if (udph->uh_dport != dport)
                 return 0;
         break;
+        }
         case IPPROTO_TCP:
             if (p->tcph == NULL)
                 return 0;

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -133,6 +133,11 @@ void UTHSetIPV6Hdr(Packet *p, IPV6Hdr *ip6h)
     PacketSetIPV6(p, (uint8_t *)ip6h);
 }
 
+void UTHSetTCPHdr(Packet *p, TCPHdr *tcph)
+{
+    PacketSetTCP(p, (uint8_t *)tcph);
+}
+
 /**
  *  \brief return the uint32_t for a ipv4 address string
  *
@@ -169,6 +174,7 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
                            uint16_t sport, uint16_t dport)
 {
     uint32_t in[4];
+    TCPHdr *tcph = NULL;
 
     Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
@@ -213,12 +219,13 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     ip6h->s_ip6_dst[2] = in[2];
     ip6h->s_ip6_dst[3] = in[3];
 
-    p->tcph = SCMalloc(sizeof(TCPHdr));
-    if (p->tcph == NULL)
+    tcph = SCMalloc(sizeof(TCPHdr));
+    if (tcph == NULL)
         goto error;
-    memset(p->tcph, 0, sizeof(TCPHdr));
-    p->tcph->th_sport = htons(sport);
-    p->tcph->th_dport = htons(dport);
+    memset(tcph, 0, sizeof(TCPHdr));
+    tcph->th_sport = htons(sport);
+    tcph->th_dport = htons(dport);
+    UTHSetTCPHdr(p, tcph);
 
     SET_PKT_LEN(p, sizeof(IPV6Hdr) + sizeof(TCPHdr) + payload_len);
     return p;
@@ -228,8 +235,8 @@ error:
         if (ip6h != NULL) {
             SCFree(ip6h);
         }
-        if (p->tcph != NULL) {
-            SCFree(p->tcph);
+        if (tcph != NULL) {
+            SCFree(tcph);
         }
         SCFree(p);
     }
@@ -302,15 +309,16 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
             hdr_offset += sizeof(UDPHdr);
             break;
         }
-        case IPPROTO_TCP:
-            p->tcph = (TCPHdr *)(GET_PKT_DATA(p) + sizeof(IPV4Hdr));
-            if (p->tcph == NULL)
+        case IPPROTO_TCP: {
+            TCPHdr *tcph = PacketSetTCP(p, GET_PKT_DATA(p) + sizeof(IPV4Hdr));
+            if (tcph == NULL)
                 goto error;
 
-            p->tcph->th_sport = htons(sport);
-            p->tcph->th_dport = htons(dport);
+            tcph->th_sport = htons(sport);
+            tcph->th_dport = htons(dport);
             hdr_offset += sizeof(TCPHdr);
             break;
+        }
         case IPPROTO_ICMP: {
             ICMPV4Hdr *icmpv4h = PacketSetICMPv4(p, (GET_PKT_DATA(p) + sizeof(IPV4Hdr)));
             if (icmpv4h == NULL)
@@ -937,14 +945,16 @@ static int CheckUTHTestPacket(Packet *p, uint8_t ipproto)
                 return 0;
         break;
         }
-        case IPPROTO_TCP:
-            if (p->tcph == NULL)
+        case IPPROTO_TCP: {
+            const TCPHdr *tcph = PacketGetTCP(p);
+            if (tcph == NULL)
                 return 0;
-            if (SCNtohs(p->tcph->th_sport) != sport)
+            if (SCNtohs(tcph->th_sport) != sport)
                 return 0;
-            if (SCNtohs(p->tcph->th_dport) != dport)
+            if (SCNtohs(tcph->th_dport) != dport)
                 return 0;
-        break;
+            break;
+        }
     }
     return 1;
 }

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -128,6 +128,11 @@ void UTHSetIPV4Hdr(Packet *p, IPV4Hdr *ip4h)
     PacketSetIPV4(p, (uint8_t *)ip4h);
 }
 
+void UTHSetIPV6Hdr(Packet *p, IPV6Hdr *ip6h)
+{
+    PacketSetIPV6(p, (uint8_t *)ip6h);
+}
+
 /**
  *  \brief return the uint32_t for a ipv4 address string
  *
@@ -177,12 +182,12 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     p->payload_len = payload_len;
     p->proto = ipproto;
 
-    p->ip6h = SCMalloc(sizeof(IPV6Hdr));
-    if (p->ip6h == NULL)
+    IPV6Hdr *ip6h = SCCalloc(1, sizeof(IPV6Hdr));
+    if (ip6h == NULL)
         goto error;
-    memset(p->ip6h, 0, sizeof(IPV6Hdr));
-    p->ip6h->s_ip6_nxt = ipproto;
-    p->ip6h->s_ip6_plen = htons(payload_len + sizeof(TCPHdr));
+    ip6h->s_ip6_nxt = ipproto;
+    ip6h->s_ip6_plen = htons(payload_len + sizeof(TCPHdr));
+    UTHSetIPV6Hdr(p, ip6h);
 
     if (inet_pton(AF_INET6, src, &in) != 1)
         goto error;
@@ -191,10 +196,10 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     p->src.addr_data32[2] = in[2];
     p->src.addr_data32[3] = in[3];
     p->sp = sport;
-    p->ip6h->s_ip6_src[0] = in[0];
-    p->ip6h->s_ip6_src[1] = in[1];
-    p->ip6h->s_ip6_src[2] = in[2];
-    p->ip6h->s_ip6_src[3] = in[3];
+    ip6h->s_ip6_src[0] = in[0];
+    ip6h->s_ip6_src[1] = in[1];
+    ip6h->s_ip6_src[2] = in[2];
+    ip6h->s_ip6_src[3] = in[3];
 
     if (inet_pton(AF_INET6, dst, &in) != 1)
         goto error;
@@ -203,10 +208,10 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     p->dst.addr_data32[2] = in[2];
     p->dst.addr_data32[3] = in[3];
     p->dp = dport;
-    p->ip6h->s_ip6_dst[0] = in[0];
-    p->ip6h->s_ip6_dst[1] = in[1];
-    p->ip6h->s_ip6_dst[2] = in[2];
-    p->ip6h->s_ip6_dst[3] = in[3];
+    ip6h->s_ip6_dst[0] = in[0];
+    ip6h->s_ip6_dst[1] = in[1];
+    ip6h->s_ip6_dst[2] = in[2];
+    ip6h->s_ip6_dst[3] = in[3];
 
     p->tcph = SCMalloc(sizeof(TCPHdr));
     if (p->tcph == NULL)
@@ -220,8 +225,8 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
 
 error:
     if (p != NULL) {
-        if (p->ip6h != NULL) {
-            SCFree(p->ip6h);
+        if (ip6h != NULL) {
+            SCFree(ip6h);
         }
         if (p->tcph != NULL) {
             SCFree(p->tcph);

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -123,6 +123,10 @@ int TestHelperBufferToFile(const char *name, const uint8_t *data, size_t size)
 
 #endif
 #ifdef UNITTESTS
+void UTHSetIPV4Hdr(Packet *p, IPV4Hdr *ip4h)
+{
+    PacketSetIPV4(p, (uint8_t *)ip4h);
+}
 
 /**
  *  \brief return the uint32_t for a ipv4 address string
@@ -271,14 +275,14 @@ Packet *UTHBuildPacketReal(uint8_t *payload, uint16_t payload_len,
     if (ipproto == IPPROTO_TCP || ipproto == IPPROTO_UDP || ipproto == IPPROTO_SCTP)
         p->dp = dport;
 
-    p->ip4h = (IPV4Hdr *)GET_PKT_DATA(p);
-    if (p->ip4h == NULL)
+    IPV4Hdr *ip4h = PacketSetIPV4(p, GET_PKT_DATA(p));
+    if (ip4h == NULL)
         goto error;
 
-    p->ip4h->s_ip_src.s_addr = p->src.addr_data32[0];
-    p->ip4h->s_ip_dst.s_addr = p->dst.addr_data32[0];
-    p->ip4h->ip_proto = ipproto;
-    p->ip4h->ip_verhl = sizeof(IPV4Hdr);
+    ip4h->s_ip_src.s_addr = p->src.addr_data32[0];
+    ip4h->s_ip_dst.s_addr = p->dst.addr_data32[0];
+    ip4h->ip_proto = ipproto;
+    ip4h->ip_verhl = sizeof(IPV4Hdr);
     p->proto = ipproto;
 
     int hdr_offset = sizeof(IPV4Hdr);

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -37,6 +37,7 @@ int TestHelperBufferToFile(const char *name, const uint8_t *data, size_t size);
 #endif
 #ifdef UNITTESTS
 void UTHSetIPV4Hdr(Packet *p, IPV4Hdr *ip4h);
+void UTHSetIPV6Hdr(Packet *p, IPV6Hdr *ip6h);
 
 uint32_t UTHSetIPv4Address(const char *);
 

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -38,6 +38,7 @@ int TestHelperBufferToFile(const char *name, const uint8_t *data, size_t size);
 #ifdef UNITTESTS
 void UTHSetIPV4Hdr(Packet *p, IPV4Hdr *ip4h);
 void UTHSetIPV6Hdr(Packet *p, IPV6Hdr *ip6h);
+void UTHSetTCPHdr(Packet *p, TCPHdr *tcph);
 
 uint32_t UTHSetIPv4Address(const char *);
 

--- a/src/util-unittest-helper.h
+++ b/src/util-unittest-helper.h
@@ -36,6 +36,8 @@ Flow *TestHelperBuildFlow(int family, const char *src, const char *dst, Port sp,
 int TestHelperBufferToFile(const char *name, const uint8_t *data, size_t size);
 #endif
 #ifdef UNITTESTS
+void UTHSetIPV4Hdr(Packet *p, IPV4Hdr *ip4h);
+
 uint32_t UTHSetIPv4Address(const char *);
 
 Packet *UTHBuildPacketReal(uint8_t *, uint16_t, uint8_t ipproto, const char *, const char *, uint16_t, uint16_t);

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -79,7 +79,7 @@
                 } else if ((p)->proto == IPPROTO_ICMP) {                                           \
                     BUG_ON((p)->icmpv4h == NULL);                                                  \
                 } else if ((p)->proto == IPPROTO_SCTP) {                                           \
-                    BUG_ON((p)->sctph == NULL);                                                    \
+                    BUG_ON(PacketGetSCTP((p)) == NULL);                                            \
                 } else if ((p)->proto == IPPROTO_ICMPV6) {                                         \
                     BUG_ON((p)->icmpv6h == NULL);                                                  \
                 }                                                                                  \

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -81,7 +81,7 @@
                 } else if ((p)->proto == IPPROTO_SCTP) {                                           \
                     BUG_ON(PacketGetSCTP((p)) == NULL);                                            \
                 } else if ((p)->proto == IPPROTO_ICMPV6) {                                         \
-                    BUG_ON((p)->icmpv6h == NULL);                                                  \
+                    BUG_ON(PacketGetICMPv6((p)) == NULL);                                          \
                 }                                                                                  \
             }                                                                                      \
             if ((p)->payload_len > 0) {                                                            \

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -77,7 +77,7 @@
                 } else if ((p)->proto == IPPROTO_UDP) {                                            \
                     BUG_ON((p)->udph == NULL);                                                     \
                 } else if ((p)->proto == IPPROTO_ICMP) {                                           \
-                    BUG_ON((p)->icmpv4h == NULL);                                                  \
+                    BUG_ON(PacketGetICMPv4((p)) == NULL);                                          \
                 } else if ((p)->proto == IPPROTO_SCTP) {                                           \
                     BUG_ON(PacketGetSCTP((p)) == NULL);                                            \
                 } else if ((p)->proto == IPPROTO_ICMPV6) {                                         \

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -75,7 +75,7 @@
                 if ((p)->proto == IPPROTO_TCP) {                                                   \
                     BUG_ON((p)->tcph == NULL);                                                     \
                 } else if ((p)->proto == IPPROTO_UDP) {                                            \
-                    BUG_ON((p)->udph == NULL);                                                     \
+                    BUG_ON(PacketGetUDP((p)) == NULL);                                             \
                 } else if ((p)->proto == IPPROTO_ICMP) {                                           \
                     BUG_ON(PacketGetICMPv4((p)) == NULL);                                          \
                 } else if ((p)->proto == IPPROTO_SCTP) {                                           \

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -65,33 +65,32 @@
  *
  *  BUG_ON's on problems
  */
-#define DEBUG_VALIDATE_PACKET(p) do {               \
-    if ((p) != NULL) {                              \
-        if ((p)->flow != NULL) {                    \
-            DEBUG_VALIDATE_FLOW((p)->flow);         \
-        }                                           \
-        if (!((p)->flags & (PKT_IS_FRAGMENT|PKT_IS_INVALID))) {          \
-            if ((p)->proto == IPPROTO_TCP) {            \
-                BUG_ON((p)->tcph == NULL);              \
-            } else if ((p)->proto == IPPROTO_UDP) {     \
-                BUG_ON((p)->udph == NULL);              \
-            } else if ((p)->proto == IPPROTO_ICMP) {    \
-                BUG_ON((p)->icmpv4h == NULL);           \
-            } else if ((p)->proto == IPPROTO_SCTP) {    \
-                BUG_ON((p)->sctph == NULL);             \
-            } else if ((p)->proto == IPPROTO_ICMPV6) {  \
-                BUG_ON((p)->icmpv6h == NULL);           \
-            }                                           \
-        }                                           \
-        if ((p)->payload_len > 0) {                 \
-            BUG_ON((p)->payload == NULL);           \
-        }                                           \
-        BUG_ON((p)->ip4h != NULL && (p)->ip6h != NULL);     \
-        BUG_ON((p)->flowflags != 0 && (p)->flow == NULL);   \
-        BUG_ON((p)->flowflags & FLOW_PKT_TOSERVER &&\
-               (p)->flowflags & FLOW_PKT_TOCLIENT); \
-    }                                               \
-} while(0)
+#define DEBUG_VALIDATE_PACKET(p)                                                                   \
+    do {                                                                                           \
+        if ((p) != NULL) {                                                                         \
+            if ((p)->flow != NULL) {                                                               \
+                DEBUG_VALIDATE_FLOW((p)->flow);                                                    \
+            }                                                                                      \
+            if (!((p)->flags & (PKT_IS_FRAGMENT | PKT_IS_INVALID))) {                              \
+                if ((p)->proto == IPPROTO_TCP) {                                                   \
+                    BUG_ON((p)->tcph == NULL);                                                     \
+                } else if ((p)->proto == IPPROTO_UDP) {                                            \
+                    BUG_ON((p)->udph == NULL);                                                     \
+                } else if ((p)->proto == IPPROTO_ICMP) {                                           \
+                    BUG_ON((p)->icmpv4h == NULL);                                                  \
+                } else if ((p)->proto == IPPROTO_SCTP) {                                           \
+                    BUG_ON((p)->sctph == NULL);                                                    \
+                } else if ((p)->proto == IPPROTO_ICMPV6) {                                         \
+                    BUG_ON((p)->icmpv6h == NULL);                                                  \
+                }                                                                                  \
+            }                                                                                      \
+            if ((p)->payload_len > 0) {                                                            \
+                BUG_ON((p)->payload == NULL);                                                      \
+            }                                                                                      \
+            BUG_ON((p)->flowflags != 0 && (p)->flow == NULL);                                      \
+            BUG_ON((p)->flowflags &FLOW_PKT_TOSERVER && (p)->flowflags & FLOW_PKT_TOCLIENT);       \
+        }                                                                                          \
+    } while (0)
 
 #define DEBUG_VALIDATE_BUG_ON(exp) BUG_ON((exp))
 

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -73,7 +73,7 @@
             }                                                                                      \
             if (!((p)->flags & (PKT_IS_FRAGMENT | PKT_IS_INVALID))) {                              \
                 if ((p)->proto == IPPROTO_TCP) {                                                   \
-                    BUG_ON((p)->tcph == NULL);                                                     \
+                    BUG_ON(PacketGetTCP((p)) == NULL);                                             \
                 } else if ((p)->proto == IPPROTO_UDP) {                                            \
                     BUG_ON(PacketGetUDP((p)) == NULL);                                             \
                 } else if ((p)->proto == IPPROTO_ICMP) {                                           \


### PR DESCRIPTION
Redo much of the header pointer logic, cleaning up macro's and unifying various pointers that are mutually exclusive into unions.

Reduces size of the Packet struct from almost 600 bytes to around 450 bytes.

Replaces #10796:
- rebase
- some, but not all review comments addressed