### PR TITLE
Threshold cache/v6

### DIFF
--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -132,10 +132,8 @@ static inline bool ContainerValueRangeTimeout(void *data, const SCTime_t ts)
     HttpRangeContainerFile *cu = data;
     // we only timeout if we have no flow referencing us
     if ((uint32_t)SCTIME_SECS(ts) > cu->expire || cu->error) {
-        if (SC_ATOMIC_GET(cu->hdata->use_cnt) == 0) {
-            DEBUG_VALIDATE_BUG_ON(cu->files == NULL);
-            return true;
-        }
+        DEBUG_VALIDATE_BUG_ON(cu->files == NULL);
+        return true;
     }
     return false;
 }
@@ -188,49 +186,7 @@ void HttpRangeContainersDestroy(void)
 
 uint32_t HttpRangeContainersTimeoutHash(const SCTime_t ts)
 {
-    SCLogDebug("timeout: starting");
-    uint32_t cnt = 0;
-
-    for (uint32_t i = 0; i < ContainerUrlRangeList.ht->config.hash_size; i++) {
-        THashHashRow *hb = &ContainerUrlRangeList.ht->array[i];
-
-        if (HRLOCK_TRYLOCK(hb) != 0)
-            continue;
-        /* hash bucket is now locked */
-        THashData *h = hb->head;
-        while (h) {
-            DEBUG_VALIDATE_BUG_ON(SC_ATOMIC_GET(h->use_cnt) > (uint32_t)INT_MAX);
-            THashData *n = h->next;
-            THashDataLock(h);
-            if (ContainerValueRangeTimeout(h->data, ts)) {
-                /* remove from the hash */
-                if (h->prev != NULL)
-                    h->prev->next = h->next;
-                if (h->next != NULL)
-                    h->next->prev = h->prev;
-                if (hb->head == h)
-                    hb->head = h->next;
-                if (hb->tail == h)
-                    hb->tail = h->prev;
-                h->next = NULL;
-                h->prev = NULL;
-                // we should log the timed out file somehow...
-                // but it does not belong to any flow...
-                SCLogDebug("timeout: removing range %p", h);
-                ContainerUrlRangeFree(h->data); // TODO do we need a "RECYCLE" func?
-                DEBUG_VALIDATE_BUG_ON(SC_ATOMIC_GET(h->use_cnt) > (uint32_t)INT_MAX);
-                THashDataUnlock(h);
-                THashDataMoveToSpare(ContainerUrlRangeList.ht, h);
-            } else {
-                THashDataUnlock(h);
-            }
-            h = n;
-        }
-        HRLOCK_UNLOCK(hb);
-    }
-
-    SCLogDebug("timeout: ending");
-    return cnt;
+    return THashExpire(ContainerUrlRangeList.ht, ts);
 }
 
 /**

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -127,8 +127,9 @@ static void ContainerUrlRangeFree(void *s)
     }
 }
 
-static inline bool ContainerValueRangeTimeout(HttpRangeContainerFile *cu, const SCTime_t ts)
+static inline bool ContainerValueRangeTimeout(void *data, const SCTime_t ts)
 {
+    HttpRangeContainerFile *cu = data;
     // we only timeout if we have no flow referencing us
     if ((uint32_t)SCTIME_SECS(ts) > cu->expire || cu->error) {
         if (SC_ATOMIC_GET(cu->hdata->use_cnt) == 0) {
@@ -171,10 +172,10 @@ void HttpRangeContainersInit(void)
         }
     }
 
-    ContainerUrlRangeList.ht =
-            THashInit("app-layer.protocols.http.byterange", sizeof(HttpRangeContainerFile),
-                    ContainerUrlRangeSet, ContainerUrlRangeFree, ContainerUrlRangeHash,
-                    ContainerUrlRangeCompare, false, memcap, CONTAINER_URLRANGE_HASH_SIZE);
+    ContainerUrlRangeList.ht = THashInit("app-layer.protocols.http.byterange",
+            sizeof(HttpRangeContainerFile), ContainerUrlRangeSet, ContainerUrlRangeFree,
+            ContainerUrlRangeHash, ContainerUrlRangeCompare, ContainerValueRangeTimeout, false,
+            memcap, CONTAINER_URLRANGE_HASH_SIZE);
     ContainerUrlRangeList.timeout = timeout;
 
     SCLogDebug("containers started");

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -700,7 +700,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
     switch (type) {
         case DATASET_TYPE_MD5:
             set->hash = THashInit(cnf_name, sizeof(Md5Type), Md5StrSet, Md5StrFree, Md5StrHash,
-                    Md5StrCompare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
+                    Md5StrCompare, NULL, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;
@@ -709,7 +709,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
         case DATASET_TYPE_STRING:
             set->hash = THashInit(cnf_name, sizeof(StringType), StringSet, StringFree, StringHash,
-                    StringCompare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
+                    StringCompare, NULL, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;
@@ -718,7 +718,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
         case DATASET_TYPE_SHA256:
             set->hash = THashInit(cnf_name, sizeof(Sha256Type), Sha256StrSet, Sha256StrFree,
-                    Sha256StrHash, Sha256StrCompare, load != NULL ? 1 : 0,
+                    Sha256StrHash, Sha256StrCompare, NULL, load != NULL ? 1 : 0,
                     memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
@@ -728,7 +728,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
         case DATASET_TYPE_IPV4:
             set->hash = THashInit(cnf_name, sizeof(IPv4Type), IPv4Set, IPv4Free, IPv4Hash,
-                    IPv4Compare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
+                    IPv4Compare, NULL, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;
@@ -737,7 +737,7 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
             break;
         case DATASET_TYPE_IPV6:
             set->hash = THashInit(cnf_name, sizeof(IPv6Type), IPv6Set, IPv6Free, IPv6Hash,
-                    IPv6Compare, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
+                    IPv6Compare, NULL, load != NULL ? 1 : 0, memcap > 0 ? memcap : default_memcap,
                     hashsize > 0 ? hashsize : default_hashsize);
             if (set->hash == NULL)
                 goto out_err;

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -375,7 +375,7 @@ static int DetectDetectionFilterTestSig1(void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
 
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -415,7 +415,7 @@ static int DetectDetectionFilterTestSig1(void)
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
-    HostShutdown();
+    ThresholdDestroy();
 
     PASS;
 }
@@ -432,7 +432,7 @@ static int DetectDetectionFilterTestSig2(void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
 
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -477,7 +477,7 @@ static int DetectDetectionFilterTestSig2(void)
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
-    HostShutdown();
+    ThresholdDestroy();
 
     PASS;
 }
@@ -490,7 +490,7 @@ static int DetectDetectionFilterTestSig3(void)
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx;
 
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     memset(&th_v, 0, sizeof(th_v));
 
@@ -553,7 +553,7 @@ static int DetectDetectionFilterTestSig3(void)
     DetectEngineCtxFree(de_ctx);
 
     UTHFreePackets(&p, 1);
-    HostShutdown();
+    ThresholdDestroy();
 
     PASS;
 }

--- a/src/detect-engine-address-ipv6.c
+++ b/src/detect-engine-address-ipv6.c
@@ -49,7 +49,7 @@
  * \retval 1 If a < b.
  * \retval 0 Otherwise, i.e. a >= b.
  */
-int AddressIPv6Lt(Address *a, Address *b)
+int AddressIPv6Lt(const Address *a, const Address *b)
 {
     int i = 0;
 
@@ -87,7 +87,7 @@ int AddressIPv6LtU32(uint32_t *a, uint32_t *b)
  * \retval 1 If a > b.
  * \retval 0 Otherwise, i.e. a <= b.
  */
-int AddressIPv6Gt(Address *a, Address *b)
+int AddressIPv6Gt(const Address *a, const Address *b)
 {
     int i = 0;
 
@@ -125,7 +125,7 @@ int AddressIPv6GtU32(uint32_t *a, uint32_t *b)
  * \retval 1 If a == b.
  * \retval 0 Otherwise.
  */
-int AddressIPv6Eq(Address *a, Address *b)
+int AddressIPv6Eq(const Address *a, const Address *b)
 {
     int i = 0;
 
@@ -159,7 +159,7 @@ int AddressIPv6EqU32(uint32_t *a, uint32_t *b)
  * \retval 1 If a <= b.
  * \retval 0 Otherwise, i.e. a > b.
  */
-int AddressIPv6Le(Address *a, Address *b)
+int AddressIPv6Le(const Address *a, const Address *b)
 {
 
     if (AddressIPv6Eq(a, b) == 1)
@@ -191,7 +191,7 @@ int AddressIPv6LeU32(uint32_t *a, uint32_t *b)
  * \retval 1 If a >= b.
  * \retval 0 Otherwise, i.e. a < b.
  */
-int AddressIPv6Ge(Address *a, Address *b)
+int AddressIPv6Ge(const Address *a, const Address *b)
 {
 
     if (AddressIPv6Eq(a, b) == 1)

--- a/src/detect-engine-address-ipv6.h
+++ b/src/detect-engine-address-ipv6.h
@@ -24,11 +24,11 @@
 #ifndef SURICATA_DETECT_ENGINE_ADDRESS_IPV6_H
 #define SURICATA_DETECT_ENGINE_ADDRESS_IPV6_H
 
-int AddressIPv6Lt(Address *, Address *);
-int AddressIPv6Gt(Address *, Address *);
-int AddressIPv6Eq(Address *, Address *);
-int AddressIPv6Le(Address *, Address *);
-int AddressIPv6Ge(Address *, Address *);
+int AddressIPv6Lt(const Address *, const Address *);
+int AddressIPv6Gt(const Address *, const Address *);
+int AddressIPv6Eq(const Address *, const Address *);
+int AddressIPv6Le(const Address *, const Address *);
+int AddressIPv6Ge(const Address *, const Address *);
 
 int AddressIPv6LeU32(uint32_t *a, uint32_t *b);
 int AddressIPv6LtU32(uint32_t *a, uint32_t *b);

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -2207,8 +2207,6 @@ int SigGroupBuild(DetectEngineCtx *de_ctx)
     SCProfilingRuleInitCounters(de_ctx);
 #endif
 
-    ThresholdHashAllocate(de_ctx);
-
     if (!DetectEngineMultiTenantEnabled()) {
         VarNameStoreActivate();
     }

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -415,9 +415,8 @@ int ThresholdIPPairTimeoutCheck(IPPair *pair, SCTime_t ts)
     return new_head == NULL;
 }
 
-static DetectThresholdEntry *
-DetectThresholdEntryAlloc(const DetectThresholdData *td, Packet *p,
-                          uint32_t sid, uint32_t gid)
+static DetectThresholdEntry *DetectThresholdEntryAlloc(
+        const DetectThresholdData *td, uint32_t sid, uint32_t gid)
 {
     SCEnter();
 
@@ -629,7 +628,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     ret = 1;
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
+                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
 
                 ret = 1;
             }
@@ -656,7 +655,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                 if (td->count == 1)  {
                     ret = 1;
                 } else {
-                    *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
+                    *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
                 }
             }
             break;
@@ -692,7 +691,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     }
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
+                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
 
                 /* for the first match we return 1 to
                  * indicate we should alert */
@@ -721,7 +720,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
                     lookup_tsh->current_count = 1;
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
+                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
             }
             break;
         }
@@ -733,7 +732,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts)) {
                 RateFilterSetAction(p, pa, td->new_action);
             } else if (!lookup_tsh) {
-                *new_tsh = DetectThresholdEntryAlloc(td, p, sid, gid);
+                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
             }
             break;
         }

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -70,34 +70,150 @@
 
 #include "action-globals.h"
 
-static HostStorageId host_threshold_id = { .id = -1 };     /**< host storage id for thresholds */
-static IPPairStorageId ippair_threshold_id = { .id = -1 }; /**< ip pair storage id for thresholds */
+#include "util-thash.h"
+#include "util-hash-lookup3.h"
 
-HostStorageId ThresholdHostStorageId(void)
-{
-    return host_threshold_id;
-}
+struct Thresholds {
+    THashTableContext *thash;
+} ctx;
+
+static int ThresholdsInit(struct Thresholds *t);
+static void ThresholdsDestroy(struct Thresholds *t);
 
 void ThresholdInit(void)
 {
-    host_threshold_id = HostStorageRegister("threshold", sizeof(void *), NULL, ThresholdListFree);
-    if (host_threshold_id.id == -1) {
-        FatalError("Can't initiate host storage for thresholding");
+    ThresholdsInit(&ctx);
+}
+
+void ThresholdDestroy(void)
+{
+    ThresholdsDestroy(&ctx);
+}
+
+typedef struct ThresholdEntry_ {
+    uint32_t sid; /**< Signature id */
+    uint32_t gid; /**< Signature group id */
+    int track;    /**< Track type: by_src, by_src */
+
+    uint32_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
+                                 its not "seconds", that define the time interval */
+    uint32_t seconds;       /**< Event seconds */
+    uint32_t current_count; /**< Var for count control */
+
+    SCTime_t tv1; /**< Var for time control */
+
+    Address addr;  /* used for src/dst/either tracking */
+    Address addr2; /* used for both tracking */
+} ThresholdEntry;
+
+static int ThresholdEntrySet(void *dst, void *src)
+{
+    const ThresholdEntry *esrc = src;
+    ThresholdEntry *edst = dst;
+    memset(edst, 0, sizeof(*edst));
+    *edst = *esrc;
+    return 0;
+}
+
+static void ThresholdEntryFree(void *ptr)
+{
+    // nothing to free, base data is part of hash
+}
+
+static inline uint32_t HashAddress(const Address *a)
+{
+    uint32_t key;
+
+    if (a->family == AF_INET) {
+        key = a->addr_data32[0];
+    } else if (a->family == AF_INET6) {
+        key = hashword(a->addr_data32, 4, 0);
+    } else
+        key = 0;
+
+    return key;
+}
+
+static inline int CompareAddress(const Address *a, const Address *b)
+{
+    if (a->family == b->family) {
+        switch (a->family) {
+            case AF_INET:
+                return (a->addr_data32[0] == b->addr_data32[0]);
+            case AF_INET6:
+                return CMP_ADDR(a, b);
+        }
     }
-    ippair_threshold_id = IPPairStorageRegister("threshold", sizeof(void *), NULL, ThresholdListFree);
-    if (ippair_threshold_id.id == -1) {
-        FatalError("Can't initiate IP pair storage for thresholding");
+    return 0;
+}
+
+static uint32_t ThresholdEntryHash(void *ptr)
+{
+    const ThresholdEntry *e = ptr;
+    uint32_t hash = e->sid + e->gid + e->track;
+    switch (e->track) {
+        case TRACK_BOTH:
+            hash += HashAddress(&e->addr2);
+            /* fallthrough */
+        case TRACK_SRC:
+        case TRACK_DST:
+            hash += HashAddress(&e->addr);
+            break;
+    }
+    return hash;
+}
+
+static bool ThresholdEntryCompare(void *a, void *b)
+{
+    const ThresholdEntry *e1 = a;
+    const ThresholdEntry *e2 = b;
+    SCLogDebug("sid1: %u sid2: %u", e1->sid, e2->sid);
+    if (!(e1->sid == e2->sid && e1->gid == e2->gid && e1->track == e2->track))
+        return false;
+    switch (e1->track) {
+        case TRACK_BOTH:
+            if (!(CompareAddress(&e1->addr2, &e2->addr2)))
+                return false;
+            /* fallthrough */
+        case TRACK_SRC:
+        case TRACK_DST:
+            if (!(CompareAddress(&e1->addr, &e2->addr)))
+                return false;
+            break;
+    }
+    return true;
+}
+
+static bool ThresholdEntryExpire(void *data, const SCTime_t ts)
+{
+    const ThresholdEntry *e = data;
+    const SCTime_t entry = SCTIME_ADD_SECS(e->tv1, e->seconds);
+    if (SCTIME_CMP_GT(ts, entry)) {
+        return true;
+    }
+    return false;
+}
+
+static int ThresholdsInit(struct Thresholds *t)
+{
+    uint64_t memcap = 16 * 1024 * 1024;
+    uint32_t hashsize = 16384;
+    t->thash = THashInit("thresholds", sizeof(ThresholdEntry), ThresholdEntrySet,
+            ThresholdEntryFree, ThresholdEntryHash, ThresholdEntryCompare, ThresholdEntryExpire, 0,
+            memcap, hashsize);
+    BUG_ON(t->thash == NULL);
+    return 0;
+}
+static void ThresholdsDestroy(struct Thresholds *t)
+{
+    if (t->thash) {
+        THashShutdown(t->thash);
     }
 }
 
-int ThresholdHostHasThreshold(Host *host)
+uint32_t ThresholdsExpire(const SCTime_t ts)
 {
-    return HostGetStorageById(host, host_threshold_id) ? 1 : 0;
-}
-
-int ThresholdIPPairHasThreshold(IPPair *pair)
-{
-    return IPPairGetStorageById(pair, ippair_threshold_id) ? 1 : 0;
+    return THashExpire(ctx.thash, ts);
 }
 
 #include "util-hash.h"
@@ -352,113 +468,6 @@ const DetectThresholdData *SigGetThresholdTypeIter(
     return NULL;
 }
 
-/**
- * \brief Remove timeout threshold hash elements
- *
- * \param head Current head element of storage
- * \param tv Current time
- *
- * \retval DetectThresholdEntry Return new head element or NULL if all expired
- *
- */
-
-static DetectThresholdEntry *ThresholdTimeoutCheck(DetectThresholdEntry *head, SCTime_t ts)
-{
-    DetectThresholdEntry *tmp = head;
-    DetectThresholdEntry *prev = NULL;
-    DetectThresholdEntry *new_head = head;
-
-    while (tmp != NULL) {
-        /* check if the 'check' timestamp is not before the creation ts.
-         * This can happen due to the async nature of the host timeout
-         * code that also calls this code from a management thread. */
-        SCTime_t entry = SCTIME_ADD_SECS(tmp->tv1, (time_t)tmp->seconds);
-        if (SCTIME_CMP_LTE(ts, entry)) {
-            prev = tmp;
-            tmp = tmp->next;
-            continue;
-        }
-
-        /* timed out */
-
-        DetectThresholdEntry *tde = tmp;
-        if (prev != NULL) {
-            prev->next = tmp->next;
-        }
-        else {
-            new_head = tmp->next;
-        }
-        tmp = tde->next;
-        SCFree(tde);
-    }
-
-    return new_head;
-}
-
-int ThresholdHostTimeoutCheck(Host *host, SCTime_t ts)
-{
-    DetectThresholdEntry* head = HostGetStorageById(host, host_threshold_id);
-    DetectThresholdEntry *new_head = ThresholdTimeoutCheck(head, ts);
-    if (new_head != head) {
-        HostSetStorageById(host, host_threshold_id, new_head);
-    }
-    return new_head == NULL;
-}
-
-int ThresholdIPPairTimeoutCheck(IPPair *pair, SCTime_t ts)
-{
-    DetectThresholdEntry* head = IPPairGetStorageById(pair, ippair_threshold_id);
-    DetectThresholdEntry *new_head = ThresholdTimeoutCheck(head, ts);
-    if (new_head != head) {
-        IPPairSetStorageById(pair, ippair_threshold_id, new_head);
-    }
-    return new_head == NULL;
-}
-
-static DetectThresholdEntry *DetectThresholdEntryAlloc(
-        const DetectThresholdData *td, uint32_t sid, uint32_t gid)
-{
-    SCEnter();
-
-    DetectThresholdEntry *ste = SCCalloc(1, sizeof(DetectThresholdEntry));
-    if (unlikely(ste == NULL)) {
-        SCReturnPtr(NULL, "DetectThresholdEntry");
-    }
-
-    ste->sid = sid;
-    ste->gid = gid;
-    ste->track = td->track;
-    ste->seconds = td->seconds;
-
-    SCReturnPtr(ste, "DetectThresholdEntry");
-}
-
-static DetectThresholdEntry *ThresholdHostLookupEntry(Host *h,
-        uint32_t sid, uint32_t gid)
-{
-    DetectThresholdEntry *e;
-
-    for (e = HostGetStorageById(h, host_threshold_id); e != NULL; e = e->next) {
-        if (e->sid == sid && e->gid == gid)
-            break;
-    }
-
-    return e;
-}
-
-static DetectThresholdEntry *ThresholdIPPairLookupEntry(IPPair *pair,
-        uint32_t sid, uint32_t gid)
-{
-    DetectThresholdEntry *e;
-
-    for (e = IPPairGetStorageById(pair, ippair_threshold_id); e != NULL; e = e->next) {
-        if (e->sid == sid && e->gid == gid)
-            break;
-    }
-
-    return e;
-}
-
 static int ThresholdHandlePacketSuppress(Packet *p,
         const DetectThresholdData *td, uint32_t sid, uint32_t gid)
 {
@@ -519,285 +528,208 @@ static inline void RateFilterSetAction(PacketAlert *pa, uint8_t new_action)
     }
 }
 
-/**
-* \brief Check if the entry reached threshold count limit
-*
-* \param lookup_tsh Current threshold entry
-* \param td Threshold settings
-* \param packet_time used to compare against previous detection and to set timeouts
-*
-* \retval int 1 if threshold reached for this entry
-*
-*/
-static int IsThresholdReached(
-        DetectThresholdEntry *lookup_tsh, const DetectThresholdData *td, SCTime_t packet_time)
+static int ThresholdSetup(const DetectThresholdData *td, ThresholdEntry *te,
+        const SCTime_t packet_time, const uint32_t sid, const uint32_t gid)
 {
-    int ret = 0;
+    te->sid = sid;
+    te->gid = gid;
+    te->track = td->track;
+    te->seconds = td->seconds;
 
-    /* Check if we have a timeout enabled, if so,
-    * we still matching (and enabling the new_action) */
-    if (lookup_tsh->tv_timeout != 0) {
-        if ((SCTIME_SECS(packet_time) - lookup_tsh->tv_timeout) > td->timeout) {
-            /* Ok, we are done, timeout reached */
-            lookup_tsh->tv_timeout = 0;
-        } else {
-            /* Already matching */
-            ret = 1;
-        } /* else - if ((packet_time - lookup_tsh->tv_timeout) > td->timeout) */
+    te->current_count = 1;
+    te->tv1 = packet_time;
+    te->tv_timeout = 0;
 
-    }
-    else {
-        /* Update the matching state with the timeout interval */
-        SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
-        if (SCTIME_CMP_LTE(packet_time, entry)) {
-            lookup_tsh->current_count++;
-            if (lookup_tsh->current_count > td->count) {
-                /* Then we must enable the new action by setting a
-                * timeout */
-                lookup_tsh->tv_timeout = SCTIME_SECS(packet_time);
-                ret = 1;
-            }
-        } else {
-            lookup_tsh->tv1 = packet_time;
-            lookup_tsh->current_count = 1;
-        }
-    } /* else - if (lookup_tsh->tv_timeout != 0) */
-
-    return ret;
-}
-
-static void AddEntryToHostStorage(Host *h, DetectThresholdEntry *e, SCTime_t packet_time)
-{
-    if (h && e) {
-        e->current_count = 1;
-        e->tv1 = packet_time;
-        e->tv_timeout = 0;
-        e->next = HostGetStorageById(h, host_threshold_id);
-        HostSetStorageById(h, host_threshold_id, e);
-    }
-}
-
-static void AddEntryToIPPairStorage(IPPair *pair, DetectThresholdEntry *e, SCTime_t packet_time)
-{
-    if (pair && e) {
-        e->current_count = 1;
-        e->tv1 = packet_time;
-        e->tv_timeout = 0;
-        e->next = IPPairGetStorageById(pair, ippair_threshold_id);
-        IPPairSetStorageById(pair, ippair_threshold_id, e);
-    }
-}
-
-/**
- *  \retval 2 silent match (no alert but apply actions)
- *  \retval 1 normal match
- *  \retval 0 no match
- *
- *  If a new DetectThresholdEntry is generated to track the threshold
- *  for this rule, then it will be returned in new_tsh.
- */
-static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
-        DetectThresholdEntry **new_tsh, const DetectThresholdData *td,
-        uint32_t sid, uint32_t gid, PacketAlert *pa)
-{
-    int ret = 0;
-
-    switch(td->type)   {
+    switch (td->type) {
         case TYPE_LIMIT:
-        {
+        case TYPE_RATE:
+            return 1;
+        case TYPE_THRESHOLD:
+        case TYPE_BOTH:
+            if (td->count == 1)
+                return 1;
+            return 0;
+        case TYPE_DETECTION:
+            return 0;
+    }
+    return 0;
+}
+
+static int ThresholdCheckUpdate(const DetectThresholdData *td, ThresholdEntry *te,
+        const Packet *p, // ts only? - cache too
+        const uint32_t sid, PacketAlert *pa)
+{
+    int ret = 0;
+    const SCTime_t packet_time = p->ts;
+    const SCTime_t entry = SCTIME_ADD_SECS(te->tv1, td->seconds);
+    switch (td->type) {
+        case TYPE_LIMIT:
             SCLogDebug("limit");
 
-            if (lookup_tsh != NULL)  {
-                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
-                if (SCTIME_CMP_LTE(p->ts, entry)) {
-                    lookup_tsh->current_count++;
+            if (SCTIME_CMP_LTE(p->ts, entry)) {
+                te->current_count++;
 
-                    if (lookup_tsh->current_count <= td->count) {
-                        ret = 1;
-                    } else {
-                        ret = 2;
-
-                        if (PKT_IS_IPV4(p)) {
-                            SetupCache(p, td->track, (int8_t)ret, sid, entry);
-                        }
-                    }
-                } else {
-                    lookup_tsh->tv1 = p->ts;
-                    lookup_tsh->current_count = 1;
-
+                if (te->current_count <= td->count) {
                     ret = 1;
+                } else {
+                    ret = 2;
+
+                    if (PKT_IS_IPV4(p)) {
+                        SetupCache(p, td->track, (int8_t)ret, sid, entry);
+                    }
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
-
+                /* entry expired, reset */
+                te->tv1 = p->ts;
+                te->current_count = 1;
                 ret = 1;
             }
             break;
-        }
         case TYPE_THRESHOLD:
-        {
-            SCLogDebug("threshold");
+            if (SCTIME_CMP_LTE(p->ts, entry)) {
+                te->current_count++;
 
-            if (lookup_tsh != NULL)  {
-                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
-                if (SCTIME_CMP_LTE(p->ts, entry)) {
-                    lookup_tsh->current_count++;
-
-                    if (lookup_tsh->current_count >= td->count) {
-                        ret = 1;
-                        lookup_tsh->current_count = 0;
-                    }
-                } else {
-                    lookup_tsh->tv1 = p->ts;
-                    lookup_tsh->current_count = 1;
+                if (te->current_count >= td->count) {
+                    ret = 1;
+                    te->current_count = 0;
                 }
             } else {
-                if (td->count == 1)  {
-                    ret = 1;
-                } else {
-                    *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
-                }
+                te->tv1 = p->ts;
+                te->current_count = 1;
             }
             break;
-        }
         case TYPE_BOTH:
-        {
-            SCLogDebug("both");
+            if (SCTIME_CMP_LTE(p->ts, entry)) {
+                /* within time limit */
 
-            if (lookup_tsh != NULL) {
-                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
-                if (SCTIME_CMP_LTE(p->ts, entry)) {
-                    /* within time limit */
+                te->current_count++;
+                if (te->current_count == td->count) {
+                    ret = 1;
+                } else if (te->current_count > td->count) {
+                    /* silent match */
+                    ret = 2;
 
-                    lookup_tsh->current_count++;
-                    if (lookup_tsh->current_count == td->count) {
-                        ret = 1;
-                    } else if (lookup_tsh->current_count > td->count) {
-                        /* silent match */
-                        ret = 2;
-
-                        if (PKT_IS_IPV4(p)) {
-                            SetupCache(p, td->track, (int8_t)ret, sid, entry);
-                        }
-                    }
-                } else {
-                    /* expired, so reset */
-                    lookup_tsh->tv1 = p->ts;
-                    lookup_tsh->current_count = 1;
-
-                    /* if we have a limit of 1, this is a match */
-                    if (lookup_tsh->current_count == td->count) {
-                        ret = 1;
+                    if (PKT_IS_IPV4(p)) {
+                        SetupCache(p, td->track, (int8_t)ret, sid, entry);
                     }
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
+                /* expired, so reset */
+                te->tv1 = p->ts;
+                te->current_count = 1;
 
-                /* for the first match we return 1 to
-                 * indicate we should alert */
-                if (td->count == 1)  {
+                /* if we have a limit of 1, this is a match */
+                if (te->current_count == td->count) {
                     ret = 1;
                 }
             }
             break;
-        }
-        /* detection_filter */
         case TYPE_DETECTION:
-        {
             SCLogDebug("detection_filter");
 
-            if (lookup_tsh != NULL) {
-                SCTime_t entry = SCTIME_ADD_SECS(lookup_tsh->tv1, td->seconds);
-                if (SCTIME_CMP_LTE(p->ts, entry)) {
-                    /* within timeout */
-                    lookup_tsh->current_count++;
-                    if (lookup_tsh->current_count > td->count) {
-                        ret = 1;
-                    }
-                } else {
-                    /* expired, reset */
-                    lookup_tsh->tv1 = p->ts;
-                    lookup_tsh->current_count = 1;
+            if (SCTIME_CMP_LTE(p->ts, entry)) {
+                /* within timeout */
+                te->current_count++;
+                if (te->current_count > td->count) {
+                    ret = 1;
                 }
             } else {
-                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
+                /* expired, reset */
+                te->tv1 = p->ts;
+                te->current_count = 1;
             }
             break;
-        }
-        /* rate_filter */
         case TYPE_RATE:
-        {
             SCLogDebug("rate_filter");
             ret = 1;
-            if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts)) {
-                RateFilterSetAction(pa, td->new_action);
-            } else if (!lookup_tsh) {
-                *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
+            /* Check if we have a timeout enabled, if so,
+             * we still matching (and enabling the new_action) */
+            if (te->tv_timeout != 0) {
+                if ((SCTIME_SECS(packet_time) - te->tv_timeout) > td->timeout) {
+                    /* Ok, we are done, timeout reached */
+                    te->tv_timeout = 0;
+                } else {
+                    /* Already matching */
+                    RateFilterSetAction(pa, td->new_action);
+                }
+            } else {
+                /* Update the matching state with the timeout interval */
+                if (SCTIME_CMP_LTE(packet_time, entry)) {
+                    te->current_count++;
+                    if (te->current_count > td->count) {
+                        /* Then we must enable the new action by setting a
+                         * timeout */
+                        te->tv_timeout = SCTIME_SECS(packet_time);
+                        RateFilterSetAction(pa, td->new_action);
+                    }
+                } else {
+                    te->tv1 = packet_time;
+                    te->current_count = 1;
+                }
             }
             break;
+    }
+    return ret;
+}
+
+#include "detect-engine-address-ipv6.h"
+
+static int ThresholdGetFromHash(struct Thresholds *tctx, const Packet *p, const Signature *s,
+        const DetectThresholdData *td, PacketAlert *pa)
+{
+    /* fast track for count 1 threshold */
+    if (td->count == 1 && td->type == TYPE_THRESHOLD) {
+        return 1;
+    }
+
+    ThresholdEntry lookup;
+    memset(&lookup, 0, sizeof(lookup));
+    lookup.sid = s->id;
+    lookup.gid = s->gid;
+    lookup.track = td->track;
+    if (td->track == TRACK_SRC) {
+        COPY_ADDRESS(&p->src, &lookup.addr);
+    } else if (td->track == TRACK_DST) {
+        COPY_ADDRESS(&p->dst, &lookup.addr);
+    } else if (td->track == TRACK_BOTH) {
+        /* make sure lower ip address is first */
+        if (PKT_IS_IPV4(p)) {
+            if (SCNtohl(p->src.addr_data32[0]) < SCNtohl(p->dst.addr_data32[0])) {
+                COPY_ADDRESS(&p->src, &lookup.addr);
+                COPY_ADDRESS(&p->dst, &lookup.addr2);
+            } else {
+                COPY_ADDRESS(&p->dst, &lookup.addr);
+                COPY_ADDRESS(&p->src, &lookup.addr2);
+            }
+        } else {
+            if (AddressIPv6Lt(&p->src, &p->dst)) {
+                COPY_ADDRESS(&p->src, &lookup.addr);
+                COPY_ADDRESS(&p->dst, &lookup.addr2);
+            } else {
+                COPY_ADDRESS(&p->dst, &lookup.addr);
+                COPY_ADDRESS(&p->src, &lookup.addr2);
+            }
         }
-        /* case TYPE_SUPPRESS: is not handled here */
-        default:
-            SCLogError("type %d is not supported", td->type);
-    }
-    return ret;
-}
-
-static int ThresholdHandlePacketIPPair(IPPair *pair, Packet *p, const DetectThresholdData *td,
-    uint32_t sid, uint32_t gid, PacketAlert *pa)
-{
-    int ret = 0;
-
-    DetectThresholdEntry *lookup_tsh = ThresholdIPPairLookupEntry(pair, sid, gid);
-    SCLogDebug("ippair lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
-
-    DetectThresholdEntry *new_tsh = NULL;
-    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, sid, gid, pa);
-    if (new_tsh != NULL) {
-        AddEntryToIPPairStorage(pair, new_tsh, p->ts);
     }
 
-    return ret;
-}
+    struct THashDataGetResult res = THashGetFromHash(tctx->thash, &lookup);
+    if (res.data) {
+        SCLogDebug("found %p, is_new %s", res.data, BOOL2STR(res.is_new));
+        int r;
+        ThresholdEntry *te = res.data->data;
+        if (res.is_new) {
+            // new threshold, set up
+            r = ThresholdSetup(td, te, p->ts, s->id, s->gid);
+        } else {
+            // existing, check/update
+            r = ThresholdCheckUpdate(td, te, p, s->id, pa);
+        }
 
-/**
- *  \retval 2 silent match (no alert but apply actions)
- *  \retval 1 normal match
- *  \retval 0 no match
- */
-static int ThresholdHandlePacketHost(Host *h, Packet *p, const DetectThresholdData *td,
-        uint32_t sid, uint32_t gid, PacketAlert *pa)
-{
-    int ret = 0;
-    DetectThresholdEntry *lookup_tsh = ThresholdHostLookupEntry(h, sid, gid);
-    SCLogDebug("lookup_tsh %p sid %u gid %u", lookup_tsh, sid, gid);
-
-    DetectThresholdEntry *new_tsh = NULL;
-    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, sid, gid, pa);
-    if (new_tsh != NULL) {
-        AddEntryToHostStorage(h, new_tsh, p->ts);
+        (void)THashDecrUsecnt(res.data);
+        THashDataUnlock(res.data);
+        return r;
     }
-    return ret;
-}
-
-static int ThresholdHandlePacketRule(DetectEngineCtx *de_ctx, Packet *p,
-        const DetectThresholdData *td, const Signature *s, PacketAlert *pa)
-{
-    int ret = 0;
-
-    DetectThresholdEntry* lookup_tsh = (DetectThresholdEntry *)de_ctx->ths_ctx.th_entry[s->num];
-    SCLogDebug("by_rule lookup_tsh %p num %u", lookup_tsh, s->num);
-
-    DetectThresholdEntry *new_tsh = NULL;
-    ret = ThresholdHandlePacket(p, lookup_tsh, &new_tsh, td, s->id, s->gid, pa);
-    if (new_tsh != NULL) {
-        new_tsh->tv1 = p->ts;
-        new_tsh->current_count = 1;
-        new_tsh->tv_timeout = 0;
-        de_ctx->ths_ctx.th_entry[s->num] = new_tsh;
-    }
-
-    return ret;
+    return 0; // TODO error?
 }
 
 /**
@@ -831,11 +763,8 @@ int PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 SCReturnInt(cache_ret);
             }
         }
-        Host *src = HostGetHostFromHash(&p->src);
-        if (src) {
-            ret = ThresholdHandlePacketHost(src,p,td,s->id,s->gid,pa);
-            HostRelease(src);
-        }
+
+        ret = ThresholdGetFromHash(&ctx, p, s, td, pa);
     } else if (td->track == TRACK_DST) {
         if (PKT_IS_IPV4(p) && (td->type == TYPE_LIMIT || td->type == TYPE_BOTH)) {
             int cache_ret = CheckCache(p, td->track, s->id);
@@ -843,143 +772,15 @@ int PacketAlertThreshold(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 SCReturnInt(cache_ret);
             }
         }
-        Host *dst = HostGetHostFromHash(&p->dst);
-        if (dst) {
-            ret = ThresholdHandlePacketHost(dst,p,td,s->id,s->gid,pa);
-            HostRelease(dst);
-        }
+
+        ret = ThresholdGetFromHash(&ctx, p, s, td, pa);
     } else if (td->track == TRACK_BOTH) {
-        IPPair *pair = IPPairGetIPPairFromHash(&p->src, &p->dst);
-        if (pair) {
-            ret = ThresholdHandlePacketIPPair(pair, p, td, s->id, s->gid, pa);
-            IPPairRelease(pair);
-        }
+        ret = ThresholdGetFromHash(&ctx, p, s, td, pa);
     } else if (td->track == TRACK_RULE) {
-        SCMutexLock(&de_ctx->ths_ctx.threshold_table_lock);
-        ret = ThresholdHandlePacketRule(de_ctx,p,td,s,pa);
-        SCMutexUnlock(&de_ctx->ths_ctx.threshold_table_lock);
+        ret = ThresholdGetFromHash(&ctx, p, s, td, pa);
     }
 
     SCReturnInt(ret);
-}
-
-/**
- * \brief Init threshold context hash tables
- *
- * \param de_ctx Detection Context
- *
- */
-void ThresholdHashInit(DetectEngineCtx *de_ctx)
-{
-    if (SCMutexInit(&de_ctx->ths_ctx.threshold_table_lock, NULL) != 0) {
-        FatalError("Threshold: Failed to initialize hash table mutex.");
-    }
-}
-
-/**
- * \brief Allocate threshold context hash tables
- *
- * \param de_ctx Detection Context
- */
-void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
-{
-    const Signature *s = de_ctx->sig_list;
-    bool has_by_rule_tracking = false;
-
-    /* Find the signature with the highest signature number that is using
-       thresholding with by_rule tracking. */
-    uint32_t highest_signum = 0;
-    while (s != NULL) {
-        if (s->sm_arrays[DETECT_SM_LIST_SUPPRESS] != NULL) {
-            const SigMatchData *smd = NULL;
-            do {
-                const DetectThresholdData *td =
-                        SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_SUPPRESS);
-                if (td == NULL) {
-                    continue;
-                }
-                if (td->track != TRACK_RULE) {
-                    continue;
-                }
-                if (s->num >= highest_signum) {
-                    highest_signum = s->num;
-                    has_by_rule_tracking = true;
-                }
-            } while (smd != NULL);
-        }
-
-        if (s->sm_arrays[DETECT_SM_LIST_THRESHOLD] != NULL) {
-            const SigMatchData *smd = NULL;
-            do {
-                const DetectThresholdData *td =
-                        SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_THRESHOLD);
-                if (td == NULL) {
-                    continue;
-                }
-                if (td->track != TRACK_RULE) {
-                    continue;
-                }
-                if (s->num >= highest_signum) {
-                    highest_signum = s->num;
-                    has_by_rule_tracking = true;
-                }
-            } while (smd != NULL);
-        }
-
-        s = s->next;
-    }
-
-    /* Skip allocating if by_rule tracking is not used */
-    if (has_by_rule_tracking == false) {
-        return;
-    }
-
-    de_ctx->ths_ctx.th_size = highest_signum + 1;
-    de_ctx->ths_ctx.th_entry = SCCalloc(de_ctx->ths_ctx.th_size, sizeof(DetectThresholdEntry *));
-    if (de_ctx->ths_ctx.th_entry == NULL) {
-        FatalError(
-                "failed to allocate memory for \"by_rule\" thresholding (tried to allocate %" PRIu32
-                " entries)",
-                de_ctx->ths_ctx.th_size);
-    }
-}
-
-/**
- * \brief Destroy threshold context hash tables
- *
- * \param de_ctx Detection Context
- *
- */
-void ThresholdContextDestroy(DetectEngineCtx *de_ctx)
-{
-    if (de_ctx->ths_ctx.th_entry != NULL) {
-        for (uint32_t i = 0; i < de_ctx->ths_ctx.th_size; i++) {
-            if (de_ctx->ths_ctx.th_entry[i] != NULL) {
-                SCFree(de_ctx->ths_ctx.th_entry[i]);
-            }
-        }
-        SCFree(de_ctx->ths_ctx.th_entry);
-    }
-    SCMutexDestroy(&de_ctx->ths_ctx.threshold_table_lock);
-}
-
-/**
- * \brief this function will free all the entries of a list
- *        DetectTagDataEntry
- *
- * \param td pointer to DetectTagDataEntryList
- */
-void ThresholdListFree(void *ptr)
-{
-    if (ptr != NULL) {
-        DetectThresholdEntry *entry = ptr;
-
-        while (entry != NULL) {
-            DetectThresholdEntry *next_entry = entry->next;
-            SCFree(entry);
-            entry = next_entry;
-        }
-    }
 }
 
 /**

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -494,7 +494,7 @@ static int ThresholdHandlePacketSuppress(Packet *p,
     return ret;
 }
 
-static inline void RateFilterSetAction(Packet *p, PacketAlert *pa, uint8_t new_action)
+static inline void RateFilterSetAction(PacketAlert *pa, uint8_t new_action)
 {
     switch (new_action) {
         case TH_ACTION_ALERT:
@@ -730,7 +730,7 @@ static int ThresholdHandlePacket(Packet *p, DetectThresholdEntry *lookup_tsh,
             SCLogDebug("rate_filter");
             ret = 1;
             if (lookup_tsh && IsThresholdReached(lookup_tsh, td, p->ts)) {
-                RateFilterSetAction(p, pa, td->new_action);
+                RateFilterSetAction(pa, td->new_action);
             } else if (!lookup_tsh) {
                 *new_tsh = DetectThresholdEntryAlloc(td, sid, gid);
             }

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -884,19 +884,18 @@ void ThresholdHashInit(DetectEngineCtx *de_ctx)
  */
 void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
 {
-    Signature *s = de_ctx->sig_list;
+    const Signature *s = de_ctx->sig_list;
     bool has_by_rule_tracking = false;
-    const DetectThresholdData *td = NULL;
-    const SigMatchData *smd;
 
     /* Find the signature with the highest signature number that is using
        thresholding with by_rule tracking. */
     uint32_t highest_signum = 0;
     while (s != NULL) {
         if (s->sm_arrays[DETECT_SM_LIST_SUPPRESS] != NULL) {
-            smd = NULL;
+            const SigMatchData *smd = NULL;
             do {
-                td = SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_SUPPRESS);
+                const DetectThresholdData *td =
+                        SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_SUPPRESS);
                 if (td == NULL) {
                     continue;
                 }
@@ -911,9 +910,10 @@ void ThresholdHashAllocate(DetectEngineCtx *de_ctx)
         }
 
         if (s->sm_arrays[DETECT_SM_LIST_THRESHOLD] != NULL) {
-            smd = NULL;
+            const SigMatchData *smd = NULL;
             do {
-                td = SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_THRESHOLD);
+                const DetectThresholdData *td =
+                        SigGetThresholdTypeIter(s, &smd, DETECT_SM_LIST_THRESHOLD);
                 if (td == NULL) {
                     continue;
                 }

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -26,16 +26,12 @@
 #define SURICATA_DETECT_ENGINE_THRESHOLD_H
 
 #include "detect.h"
-#include "host.h"
-#include "ippair.h"
-#include "host-storage.h"
+#include "detect-threshold.h"
 
 void ThresholdInit(void);
+void ThresholdDestroy(void);
 
-HostStorageId ThresholdHostStorageId(void);
-int ThresholdHostHasThreshold(Host *);
-
-int ThresholdIPPairHasThreshold(IPPair *pair);
+uint32_t ThresholdsExpire(const SCTime_t ts);
 
 const DetectThresholdData *SigGetThresholdTypeIter(
         const Signature *, const SigMatchData **, int list);
@@ -43,12 +39,6 @@ int PacketAlertThreshold(DetectEngineCtx *, DetectEngineThreadCtx *,
         const DetectThresholdData *, Packet *,
         const Signature *, PacketAlert *);
 
-void ThresholdHashInit(DetectEngineCtx *);
-void ThresholdHashAllocate(DetectEngineCtx *);
-void ThresholdContextDestroy(DetectEngineCtx *);
-
-int ThresholdHostTimeoutCheck(Host *, SCTime_t);
-int ThresholdIPPairTimeoutCheck(IPPair *, SCTime_t);
 void ThresholdListFree(void *ptr);
 void ThresholdCacheThreadFree(void);
 

--- a/src/detect-engine-threshold.h
+++ b/src/detect-engine-threshold.h
@@ -50,5 +50,6 @@ void ThresholdContextDestroy(DetectEngineCtx *);
 int ThresholdHostTimeoutCheck(Host *, SCTime_t);
 int ThresholdIPPairTimeoutCheck(IPPair *, SCTime_t);
 void ThresholdListFree(void *ptr);
+void ThresholdCacheThreadFree(void);
 
 #endif /* SURICATA_DETECT_ENGINE_THRESHOLD_H */

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3449,6 +3449,8 @@ static void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
     AppLayerDecoderEventsFreeEvents(&det_ctx->decoder_events);
 
     SCFree(det_ctx);
+
+    ThresholdCacheThreadFree();
 }
 
 TmEcode DetectEngineThreadCtxDeinit(ThreadVars *tv, void *data)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2445,7 +2445,6 @@ static DetectEngineCtx *DetectEngineCtxInitReal(
 
     SigGroupHeadHashInit(de_ctx);
     MpmStoreInit(de_ctx);
-    ThresholdHashInit(de_ctx);
     DetectParseDupSigHashInit(de_ctx);
     DetectAddressMapInit(de_ctx);
     DetectMetadataHashInit(de_ctx);
@@ -2560,7 +2559,6 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     MpmStoreFree(de_ctx);
     DetectParseDupSigHashFree(de_ctx);
     SCSigSignatureOrderingModuleCleanup(de_ctx);
-    ThresholdContextDestroy(de_ctx);
     SigCleanSignatures(de_ctx);
     if (de_ctx->sig_array)
         SCFree(de_ctx->sig_array);

--- a/src/detect-threshold.h
+++ b/src/detect-threshold.h
@@ -61,6 +61,7 @@ typedef struct DetectThresholdData_ {
     DetectAddressHead addrs;
 } DetectThresholdData;
 
+#if 0
 typedef struct DetectThresholdEntry_ {
     uint32_t sid;           /**< Signature id */
     uint32_t gid;           /**< Signature group id */
@@ -74,7 +75,7 @@ typedef struct DetectThresholdEntry_ {
     SCTime_t tv1; /**< Var for time control */
     struct DetectThresholdEntry_ *next;
 } DetectThresholdEntry;
-
+#endif
 
 /**
  * Registration function for threshold: keyword

--- a/src/detect.h
+++ b/src/detect.h
@@ -777,17 +777,6 @@ typedef struct DetectEngineLookupFlow_ {
     struct SigGroupHead_ *sgh[256];
 } DetectEngineLookupFlow;
 
-#include "detect-threshold.h"
-
-/** \brief threshold ctx */
-typedef struct ThresholdCtx_    {
-    SCMutex threshold_table_lock;                   /**< Mutex for hash table */
-
-    /** to support rate_filter "by_rule" option */
-    DetectThresholdEntry **th_entry;
-    uint32_t th_size;
-} ThresholdCtx;
-
 typedef struct SigString_ {
     char *filename;
     char *sig_str;
@@ -878,7 +867,6 @@ typedef struct DetectEngineCtx_ {
     HashListTable *dup_sig_hash_table;
 
     DetectEngineIPOnlyCtx io_ctx;
-    ThresholdCtx ths_ctx;
 
     /* maximum recursion depth for content inspection */
     int inspection_recursion_limit;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -52,7 +52,7 @@
 
 #include "threads.h"
 #include "detect.h"
-#include "detect-engine-state.h"
+#include "detect-engine-threshold.h"
 #include "stream.h"
 
 #include "app-layer-parser.h"
@@ -905,6 +905,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
                 HostTimeoutHash(ts);
                 IPPairTimeoutHash(ts);
                 HttpRangeContainersTimeoutHash(ts);
+                ThresholdsExpire(ts);
                 other_last_sec = (uint32_t)SCTIME_SECS(ts);
             }
         }

--- a/src/host-timeout.c
+++ b/src/host-timeout.c
@@ -25,7 +25,6 @@
 #include "host.h"
 
 #include "detect-engine-tag.h"
-#include "detect-engine-threshold.h"
 
 #include "host-bit.h"
 #include "host-timeout.h"
@@ -53,7 +52,6 @@ static int HostHostTimedOut(Host *h, SCTime_t ts)
 
     busy |= (h->iprep && SRepHostTimedOut(h) == 0);
     busy |= (TagHostHasTag(h) && TagTimeoutCheck(h, ts) == 0);
-    busy |= (ThresholdHostHasThreshold(h) && ThresholdHostTimeoutCheck(h, ts) == 0);
     busy |= (HostHasHostBits(h) && HostBitsTimedoutCheck(h, ts) == 0);
     SCLogDebug("host %p %s", h, busy ? "still active" : "timed out");
     return !busy;

--- a/src/ippair-timeout.c
+++ b/src/ippair-timeout.c
@@ -25,7 +25,6 @@
 #include "ippair.h"
 #include "ippair-bit.h"
 #include "ippair-timeout.h"
-#include "detect-engine-threshold.h"
 
 /** \internal
  *  \brief See if we can really discard this ippair. Check use_cnt reference.
@@ -39,8 +38,6 @@
 static int IPPairTimedOut(IPPair *h, SCTime_t ts)
 {
     int vars = 0;
-    int thresholds = 0;
-
     /** never prune a ippair that is used by a packet
      *  we are currently processing in one of the threads */
     if (SC_ATOMIC_GET(h->use_cnt) > 0) {
@@ -50,12 +47,7 @@ static int IPPairTimedOut(IPPair *h, SCTime_t ts)
     if (IPPairHasBits(h) && IPPairBitsTimedoutCheck(h, ts) == 0) {
         vars = 1;
     }
-
-    if (ThresholdIPPairHasThreshold(h) && ThresholdIPPairTimeoutCheck(h, ts) == 0) {
-        thresholds = 1;
-    }
-
-    if (vars || thresholds) {
+    if (vars) {
         return 0;
     }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -368,6 +368,7 @@ void GlobalsInitPreConfig(void)
 void GlobalsDestroy(void)
 {
     SCInstance *suri = &suricata;
+    ThresholdDestroy();
     HostShutdown();
     HTPFreeConfig();
     HTPAtExitPrintStats();

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -294,7 +294,8 @@ static int THashInitConfig(THashTableContext *ctx, const char *cnf_prefix)
 
 THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
         int (*DataSet)(void *, void *), void (*DataFree)(void *), uint32_t (*DataHash)(void *),
-        bool (*DataCompare)(void *, void *), bool reset_memcap, uint64_t memcap, uint32_t hashsize)
+        bool (*DataCompare)(void *, void *), bool (*DataExpired)(void *, SCTime_t),
+        bool reset_memcap, uint64_t memcap, uint32_t hashsize)
 {
     THashTableContext *ctx = SCCalloc(1, sizeof(*ctx));
     BUG_ON(!ctx);
@@ -304,6 +305,7 @@ THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
     ctx->config.DataFree = DataFree;
     ctx->config.DataHash = DataHash;
     ctx->config.DataCompare = DataCompare;
+    ctx->config.DataExpired = DataExpired;
 
     /* set defaults */
     ctx->config.hash_rand = (uint32_t)RandomGet();
@@ -406,6 +408,58 @@ int THashWalk(THashTableContext *ctx, THashFormatFunc FormatterFunc, THashOutput
             return -1;
     }
     return 0;
+}
+
+/** \brief expire data from the hash
+ *  Walk the hash table and remove data that is exprired according to the
+ *  DataExpired callback.
+ *  \retval cnt number of items successfully expired/removed
+ */
+uint32_t THashExpire(THashTableContext *ctx, const SCTime_t ts)
+{
+    if (ctx->config.DataExpired == NULL)
+        return 0;
+
+    SCLogDebug("timeout: starting");
+    uint32_t cnt = 0;
+
+    for (uint32_t i = 0; i < ctx->config.hash_size; i++) {
+        THashHashRow *hb = &ctx->array[i];
+        if (HRLOCK_TRYLOCK(hb) != 0)
+            continue;
+        /* hash bucket is now locked */
+        THashData *h = hb->head;
+        while (h) {
+            THashData *next = h->next;
+            THashDataLock(h);
+            DEBUG_VALIDATE_BUG_ON(SC_ATOMIC_GET(h->use_cnt) > (uint32_t)INT_MAX);
+            /* only consider items with no references to it */
+            if (SC_ATOMIC_GET(h->use_cnt) == 0 && ctx->config.DataExpired(h->data, ts)) {
+                /* remove from the hash */
+                if (h->prev != NULL)
+                    h->prev->next = h->next;
+                if (h->next != NULL)
+                    h->next->prev = h->prev;
+                if (hb->head == h)
+                    hb->head = h->next;
+                if (hb->tail == h)
+                    hb->tail = h->prev;
+                h->next = NULL;
+                h->prev = NULL;
+                SCLogDebug("timeout: removing data %p", h);
+                ctx->config.DataFree(h->data);
+                THashDataUnlock(h);
+                THashDataMoveToSpare(ctx, h);
+            } else {
+                THashDataUnlock(h);
+            }
+            h = next;
+        }
+        HRLOCK_UNLOCK(hb);
+    }
+
+    SCLogDebug("timeout: ending: %u entries expired", cnt);
+    return cnt;
 }
 
 /** \brief Cleanup the thash engine

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -132,6 +132,7 @@ typedef struct THashDataConfig_ {
     void (*DataFree)(void *);
     uint32_t (*DataHash)(void *);
     bool (*DataCompare)(void *, void *);
+    bool (*DataExpired)(void *, SCTime_t ts);
 } THashConfig;
 
 #define THASH_DATA_SIZE(ctx) (sizeof(THashData) + (ctx)->config.data_size)
@@ -169,8 +170,9 @@ typedef struct THashTableContext_ {
 
 THashTableContext *THashInit(const char *cnf_prefix, size_t data_size,
         int (*DataSet)(void *dst, void *src), void (*DataFree)(void *),
-        uint32_t (*DataHash)(void *), bool (*DataCompare)(void *, void *), bool reset_memcap,
-        uint64_t memcap, uint32_t hashsize);
+        uint32_t (*DataHash)(void *), bool (*DataCompare)(void *, void *),
+        bool (*DataExpired)(void *, SCTime_t), bool reset_memcap, uint64_t memcap,
+        uint32_t hashsize);
 
 void THashShutdown(THashTableContext *ctx);
 
@@ -197,5 +199,6 @@ int THashWalk(THashTableContext *, THashFormatFunc, THashOutputFunc, void *);
 int THashRemoveFromHash (THashTableContext *ctx, void *data);
 void THashConsolidateMemcap(THashTableContext *ctx);
 void THashDataMoveToSpare(THashTableContext *ctx, THashData *h);
+uint32_t THashExpire(THashTableContext *ctx, const SCTime_t ts);
 
 #endif /* SURICATA_THASH_H */

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1532,7 +1532,7 @@ static int SCThresholdConfTest09(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
@@ -1601,7 +1601,7 @@ static int SCThresholdConfTest09(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -1613,7 +1613,7 @@ static int SCThresholdConfTest09(void)
  */
 static int SCThresholdConfTest10(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     /* Create two different packets falling to the same rule, and
     *  because count:3, we should drop on match #4.
@@ -1683,15 +1683,15 @@ static int SCThresholdConfTest10(void)
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
     FAIL_IF(PacketTestAction(p1, ACTION_DROP));
     FAIL_IF(PacketAlertCheck(p1, 10) != 1);
-
+#if 0
     /* Ensure that a Threshold entry was installed at the sig */
     FAIL_IF_NULL(de_ctx->ths_ctx.th_entry[s->num]);
-
+#endif
     UTHFreePacket(p1);
     UTHFreePacket(p2);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -1703,7 +1703,7 @@ static int SCThresholdConfTest10(void)
  */
 static int SCThresholdConfTest11(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
@@ -1796,7 +1796,7 @@ static int SCThresholdConfTest11(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -1808,7 +1808,7 @@ static int SCThresholdConfTest11(void)
  */
 static int SCThresholdConfTest12(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacket((uint8_t*)"lalala", 6, IPPROTO_TCP);
     FAIL_IF_NULL(p);
@@ -1901,7 +1901,7 @@ static int SCThresholdConfTest12(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -1946,7 +1946,7 @@ static int SCThresholdConfTest13(void)
  */
 static int SCThresholdConfTest14(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p1 = UTHBuildPacketReal((uint8_t*)"lalala", 6, IPPROTO_TCP, "192.168.0.10",
                                     "192.168.0.100", 1234, 24);
@@ -1995,7 +1995,7 @@ static int SCThresholdConfTest14(void)
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
 
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2007,7 +2007,7 @@ static int SCThresholdConfTest14(void)
  */
 static int SCThresholdConfTest15(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacketReal((uint8_t*)"lalala", 6, IPPROTO_TCP, "192.168.0.10",
                                     "192.168.0.100", 1234, 24);
@@ -2043,7 +2043,7 @@ static int SCThresholdConfTest15(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2055,7 +2055,7 @@ static int SCThresholdConfTest15(void)
  */
 static int SCThresholdConfTest16(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacketReal((uint8_t*)"lalala", 6, IPPROTO_TCP, "192.168.1.1",
                                     "192.168.0.100", 1234, 24);
@@ -2090,7 +2090,7 @@ static int SCThresholdConfTest16(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2102,7 +2102,7 @@ static int SCThresholdConfTest16(void)
  */
 static int SCThresholdConfTest17(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
 
     Packet *p = UTHBuildPacketReal((uint8_t*)"lalala", 6, IPPROTO_TCP, "192.168.0.10",
                                     "192.168.0.100", 1234, 24);
@@ -2138,7 +2138,7 @@ static int SCThresholdConfTest17(void)
     UTHFreePacket(p);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2169,7 +2169,7 @@ static FILE *SCThresholdConfGenerateInvalidDummyFD12(void)
  */
 static int SCThresholdConfTest18(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
@@ -2190,7 +2190,7 @@ static int SCThresholdConfTest18(void)
     FAIL_IF_NOT(de->type == TYPE_SUPPRESS && de->track == TRACK_DST);
 
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2221,7 +2221,7 @@ static FILE *SCThresholdConfGenerateInvalidDummyFD13(void)
  */
 static int SCThresholdConfTest19(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
@@ -2239,7 +2239,7 @@ static int SCThresholdConfTest19(void)
     FAIL_IF_NULL(de);
     FAIL_IF_NOT(de->type == TYPE_SUPPRESS && de->track == TRACK_DST);
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2271,7 +2271,7 @@ static FILE *SCThresholdConfGenerateValidDummyFD20(void)
  */
 static int SCThresholdConfTest20(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
@@ -2304,7 +2304,7 @@ static int SCThresholdConfTest20(void)
     FAIL_IF_NOT(smd->is_last);
 
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2317,7 +2317,7 @@ static int SCThresholdConfTest20(void)
  */
 static int SCThresholdConfTest21(void)
 {
-    HostInitConfig(HOST_QUIET);
+    ThresholdInit();
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
@@ -2349,7 +2349,7 @@ static int SCThresholdConfTest21(void)
     FAIL_IF_NOT(smd->is_last);
 
     DetectEngineCtxFree(de_ctx);
-    HostShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2382,7 +2382,7 @@ static int SCThresholdConfTest22(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    IPPairInitConfig(IPPAIR_QUIET);
+    ThresholdInit();
 
     /* This packet will cause rate_filter */
     Packet *p1 = UTHBuildPacketSrcDst((uint8_t*)"lalala", 6, IPPROTO_TCP, "172.26.0.1", "172.26.0.10");
@@ -2485,7 +2485,7 @@ static int SCThresholdConfTest22(void)
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    IPPairShutdown();
+    ThresholdDestroy();
     PASS;
 }
 
@@ -2519,7 +2519,7 @@ static int SCThresholdConfTest23(void)
     ThreadVars th_v;
     memset(&th_v, 0, sizeof(th_v));
 
-    IPPairInitConfig(IPPAIR_QUIET);
+    ThresholdInit();
 
     /* Create two packets between same addresses in opposite direction */
     Packet *p1 = UTHBuildPacketSrcDst((uint8_t*)"lalala", 6, IPPROTO_TCP, "172.26.0.1", "172.26.0.10");
@@ -2566,7 +2566,7 @@ static int SCThresholdConfTest23(void)
 
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
-    IPPairShutdown();
+    ThresholdDestroy();
     PASS;
 }
 #endif /* UNITTESTS */


### PR DESCRIPTION
Replaces #9488.

Reimplements per host and per ippair threshold tracking. Instead of using the Host and IPPair tables, use a dedicated THash. The reason is that if many signatures use per host thresholding, there was a lot of contention on the Host object, even if the thresholds per that host were unrelated.

The THash uses a hash key that includes the sid, the threshold type and the host/ippair info, reducing contentions.

Additionally, it has the caching support from #9488.