### PR TITLE
pkt-data: add userguide entry, fix typo - v1

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -852,7 +852,7 @@ Suricata has its own specific pcre modifiers. These are:
 .. _pcre-update-v1-to-v2:
 
 Changes from PCRE1 to PCRE2
-===========================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The upgrade from PCRE1 to PCRE2 changes the behavior for some
 PCRE expressions.

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -5,6 +5,8 @@ Payload Keywords
 Payload keywords inspect the content of the payload of a packet or
 stream.
 
+.. _content:
+
 content
 -------
 
@@ -691,11 +693,25 @@ the reassembled stream.
 The checksums will be recalculated by Suricata and changed after the
 replace keyword is being used.
 
+.. _pkt-data:
+
+pkt_data
+--------
+
+``pkt_data`` is a sticky buffer that allows for payload inspection from the
+beginning of the normalized packet data. As a sticky buffer, ``pkt_data``
+requires the usage of the :ref:`content` keyword for the buffer inspection.
+
+Example of ``pkt_data`` in a signature:
+
+.. container:: example-rule
+
+   alert tftp any any -> any any (msg:"TFTP Test Rule"; :example-rule-emphasis:`pkt_data; content:"rfc1350";` sid:1; rev:1;)
+
 .. _pcre:
 
 pcre (Perl Compatible Regular Expressions)
 ------------------------------------------
-.. role:: example-rule-emphasis
 
 The keyword pcre matches specific on regular expressions. More
 information about regular expressions can be found here
@@ -851,4 +867,3 @@ PCRE expressions.
   ``PCRE2_ERROR_UNSET`` instead of ``pcre_copy_substring`` returning
   no error and giving an empty string. If the behavior of some use
   case is no longer the expected one, please let us know.
-

--- a/src/detect-pkt-data.c
+++ b/src/detect-pkt-data.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2012-2020 Open Information Security Foundation
+/* Copyright (C) 2012-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -48,7 +48,7 @@ static void DetectPktDataTestRegister(void);
 #endif
 
 /**
- * \brief Registration function for keyword: file_data
+ * \brief Registration function for keyword: pkt_data
  */
 void DetectPktDataRegister(void)
 {
@@ -57,6 +57,7 @@ void DetectPktDataRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_PKT_DATA].RegisterTests = DetectPktDataTestRegister;
 #endif
+    sigmatch_table[DETECT_PKT_DATA].url = "/rules/payload-keywords.html#pkt-data";
     sigmatch_table[DETECT_PKT_DATA].flags = SIGMATCH_NOOPT;
 }
 


### PR DESCRIPTION
While working for alert metadata testing for PGSQL, I was looking for more info on `pkt-data` and realized we didn't have a rules-guide entry for it. The description here is based on what I saw in https://docs.snort.org/rules/options/payload/, considering we mention pkt_data in some sections of our documentation that mention Snort.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: none

Describe changes:
- add `pkt_data` keyword section to userguide/rules/payload-keywords
- Updated the comment description for the registering function, replacing `file_data` with `pkt_data`.
- Fix section title formatting for section about PCRE1 and PCRE2 differences