### PR TITLE
rule: Don't drop flow if rule matches on packet properties. 

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -326,6 +326,13 @@ static inline void FlowApplySignatureActions(
         if ((pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH)) ||
                 (s->flags & (SIG_FLAG_IPONLY | SIG_FLAG_LIKE_IPONLY | SIG_FLAG_PDONLY |
                                     SIG_FLAG_APPLAYER))) {
+
+            /* No action when the signature doesn't require a stream */
+            if ((s->flags &
+                        (SIG_FLAG_APPLAYER | SIG_FLAG_REQUIRE_PACKET | SIG_FLAG_REQUIRE_STREAM)) ==
+                    (SIG_FLAG_APPLAYER | SIG_FLAG_REQUIRE_PACKET))
+                return;
+
             pa->flags |= PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW;
             SCLogDebug("packet %" PRIu64 " sid %u action %02x alert_flags %02x (set "
                        "PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW)",


### PR DESCRIPTION
Continuation of #9664
  
This commit modifies the logic used to determine the disposition of a
flow/packet.

If the rule doesn't require a stream and only contains properties for
packet matching, then the alert is not marked as applying to the
flow and hence, the flow won't be dropped.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [5578](https://redmine.openinfosecfoundation.org/issues/5578)

Describe changes:
- When deciding how to handle the `drop` action, check if the rule applies to packet properties.

Updates:
- Commit update

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1795