### PR TITLE
fuzz: add target for DecodeBase64

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,7 +3,7 @@ if BUILD_FUZZTARGETS
     bin_PROGRAMS += fuzz_applayerprotodetectgetproto \
     fuzz_applayerparserparse fuzz_siginit \
     fuzz_confyamlloadstring fuzz_decodepcapfile \
-    fuzz_sigpcap fuzz_mimedecparseline
+    fuzz_sigpcap fuzz_mimedecparseline fuzz_decodebase64
 if HAS_FUZZPCAP
     bin_PROGRAMS += fuzz_sigpcap_aware fuzz_predefpcap_aware
 endif
@@ -1414,6 +1414,17 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_predefpcap_aware_SOURCES = force-cxx-linking.cxx
 endif
+
+fuzz_decodebase64_SOURCES = tests/fuzz/fuzz_decodebase64.c
+fuzz_decodebase64_LDFLAGS = $(LDFLAGS_FUZZ)
+fuzz_decodebase64_LDADD = $(LDADD_FUZZ)
+if HAS_FUZZLDFLAGS
+    fuzz_decodebase64_LDFLAGS += $(LIB_FUZZING_ENGINE)
+else
+    fuzz_decodebase64_SOURCES += tests/fuzz/onefile.c
+endif
+# force usage of CXX for linker
+nodist_EXTRA_fuzz_decodebase64_SOURCES = force-cxx-linking.cxx
 
 fuzz_mimedecparseline_SOURCES = tests/fuzz/fuzz_mimedecparseline.c
 fuzz_mimedecparseline_LDFLAGS = $(LDFLAGS_FUZZ)

--- a/src/tests/fuzz/fuzz_decodebase64.c
+++ b/src/tests/fuzz/fuzz_decodebase64.c
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * @author Shivani Bhardwaj <shivani@oisf.net>
+ * fuzz target for DecodeBase64
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "util-base64.h"
+
+#define BLK_SIZE 2
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+static int initialized = 0;
+
+static void Base64FuzzTest(const uint8_t *src, size_t len, size_t dest_size)
+{
+    uint8_t *dest = malloc(dest_size);
+    if (dest == NULL)
+        return;
+
+    for (uint8_t mode = BASE64_MODE_RELAX; mode <= BASE64_MODE_RFC4648; mode++) {
+        uint32_t consumed_bytes = 0;
+        uint32_t decoded_bytes = 0;
+
+        DecodeBase64(dest, dest_size, src, len, &consumed_bytes, &decoded_bytes, mode);
+    }
+
+    free(dest);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (initialized == 0) {
+        // Redirects logs to /dev/null
+        setenv("SC_LOG_OP_IFACE", "file", 0);
+        setenv("SC_LOG_FILE", "/dev/null", 0);
+        // global init
+        InitGlobal();
+        SCRunmodeSet(RUNMODE_UNITTEST);
+        initialized = 1;
+    }
+
+    if (size < BLK_SIZE)
+        return;
+
+    uint32_t dest_size = (uint32_t)(data[0] << 8) | (uint32_t)(data[1]);
+    Base64FuzzTest(data + BLK_SIZE, size - BLK_SIZE, dest_size);
+
+    return 0;
+}


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6050

Previous PR: https://github.com/OISF/suricata/pull/10776

Changes since v7:
- changes incorporated
- rebased
- defensive check commit removed as they're already in master now