### PR TITLE
output: Add linktype description

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2790,6 +2790,9 @@
             "properties": {
                 "linktype": {
                     "type": "integer"
+                },
+                "linktype_name": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -439,6 +439,10 @@ void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
     if (!jb_set_uint(js, "linktype", p->datalink)) {
         return;
     }
+    const char *dl_name = pcap_datalink_val_to_name(p->datalink);
+    if (!jb_set_string(js, "linktype_name", dl_name == NULL ? "n/a" : dl_name)) {
+        return;
+    }
     jb_close(js);
 }
 


### PR DESCRIPTION
Amend the linktype output with the linktype name (when available).

The linktype name is included alongside linktype when `alert.packet` is enabled. The name is retrieved from pcap_datalink_val_to_name with the thought being that the pcap library in use can also translate the linktype value into a descriptive value.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6954](https://redmine.openinfosecfoundation.org/issues/6954)

Describe changes:
- Include the linktype name alongside linktype
- Update the schema with linktype_name

### Provide values to any of the below to override the defaults.


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1798

