### PR TITLE
detect: log relevant frames app-layer metdata

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -437,6 +437,7 @@ impl DNSState {
             input,
             input.len() as i64,
             DnsFrameType::Pdu as u8,
+            None,
         );
         self.parse_request(input, false)
     }
@@ -449,6 +450,7 @@ impl DNSState {
             input,
             input.len() as i64,
             DnsFrameType::Pdu as u8,
+            None,
         );
         self.parse_response(input, false)
     }
@@ -547,6 +549,7 @@ impl DNSState {
                     msg,
                     msg.len() as i64,
                     DnsFrameType::Pdu as u8,
+                    None,
                 );
                 if self.parse_request(msg, true) {
                     cur_i = &cur_i[(size + 2)..];
@@ -609,6 +612,7 @@ impl DNSState {
                     msg,
                     msg.len() as i64,
                     DnsFrameType::Pdu as u8,
+                    None,
                 );
                 if self.parse_response(msg, true) {
                     cur_i = &cur_i[(size + 2)..];

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -59,7 +59,7 @@ impl Frame {
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn new(
         flow: *const Flow, stream_slice: &StreamSlice, frame_start: &[u8], frame_len: i64,
-        frame_type: u8,
+        frame_type: u8, tx_id: Option<u64>,
     ) -> Option<Self> {
         let offset = frame_start.as_ptr() as usize - stream_slice.as_slice().as_ptr() as usize;
         SCLogDebug!("offset {} stream_slice.len() {} frame_start.len() {}", offset, stream_slice.len(), frame_start.len());
@@ -75,10 +75,16 @@ impl Frame {
         };
         let id = unsafe { AppLayerFrameGetId(frame) };
         if id > 0 {
-            Some(Self {
+            let r = Self {
                 id,
                 direction: Direction::from(stream_slice.flags()),
-            })
+            };
+            if let Some(tx_id) = tx_id {
+                unsafe {
+                    AppLayerFrameSetTxIdById(flow, r.direction(), id, tx_id);
+                };
+            }
+            Some(r)
         } else {
             None
         }

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -96,7 +96,7 @@ impl Frame {
     #[cfg(test)]
     pub fn new(
         _flow: *const Flow, _stream_slice: &StreamSlice, _frame_start: &[u8], _frame_len: i64,
-        _frame_type: u8,
+        _frame_type: u8, _tx_id: Option<u64>,
     ) -> Option<Self> {
         None
     }

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -436,6 +436,7 @@ impl MQTTState {
                         current,
                         (current.len() - rem.len()) as i64,
                         MQTTFrameType::Pdu as u8,
+                        None,
                     );
                     SCLogDebug!("request msg {:?}", msg);
                     if let MQTTOperation::TRUNCATED(ref trunc) = msg.op {
@@ -521,6 +522,7 @@ impl MQTTState {
                         current,
                         (current.len() - rem.len()) as i64,
                         MQTTFrameType::Pdu as u8,
+                        None,
                     );
 
                     SCLogDebug!("response msg {:?}", msg);
@@ -595,7 +597,7 @@ impl MQTTState {
     ) {
         let hdr = stream_slice.as_slice();
         //MQTT payload has a fixed header of 2 bytes
-        let _mqtt_hdr = Frame::new(flow, stream_slice, hdr, 2, MQTTFrameType::Header as u8);
+        let _mqtt_hdr = Frame::new(flow, stream_slice, hdr, 2, MQTTFrameType::Header as u8, None);
         SCLogDebug!("mqtt_hdr Frame {:?}", _mqtt_hdr);
         let rem_length = input.header.remaining_length as usize;
         let data = &hdr[2..rem_length + 2];
@@ -605,6 +607,7 @@ impl MQTTState {
             data,
             rem_length as i64,
             MQTTFrameType::Data as u8,
+            None,
         );
         SCLogDebug!("mqtt_data Frame {:?}", _mqtt_data);
     }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -499,68 +499,68 @@ impl NFSState {
     }
 
     fn add_rpc_udp_ts_pdu(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_len: i64) -> Option<Frame> {
-        let rpc_udp_ts_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8);
+        let rpc_udp_ts_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8, None);
         SCLogDebug!("rpc_udp_pdu ts frame {:?}", rpc_udp_ts_pdu);
         rpc_udp_ts_pdu
     }
 
     fn add_rpc_udp_ts_creds(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], creds_len: i64) {
-        let _rpc_udp_ts_creds = Frame::new(flow, stream_slice, input, creds_len, NFSFrameType::RPCCreds as u8);
+        let _rpc_udp_ts_creds = Frame::new(flow, stream_slice, input, creds_len, NFSFrameType::RPCCreds as u8, None);
         SCLogDebug!("rpc_creds ts frame {:?}", _rpc_udp_ts_creds);
     }
 
     fn add_rpc_tcp_ts_pdu(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_len: i64) -> Option<Frame> {
-        let rpc_tcp_ts_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8);
+        let rpc_tcp_ts_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8, None);
         SCLogDebug!("rpc_tcp_pdu ts frame {:?}", rpc_tcp_ts_pdu);
         rpc_tcp_ts_pdu
     }
 
     fn add_rpc_tcp_ts_creds(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], creds_len: i64) {
-        let _rpc_tcp_ts_creds = Frame::new(flow, stream_slice, input, creds_len, NFSFrameType::RPCCreds as u8);
+        let _rpc_tcp_ts_creds = Frame::new(flow, stream_slice, input, creds_len, NFSFrameType::RPCCreds as u8, None);
         SCLogDebug!("rpc_tcp_ts_creds {:?}", _rpc_tcp_ts_creds);
     }
 
     fn add_nfs_ts_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs_len: i64) {
-        let _nfs_req_pdu = Frame::new(flow, stream_slice, input, nfs_len, NFSFrameType::NFSPdu as u8);
+        let _nfs_req_pdu = Frame::new(flow, stream_slice, input, nfs_len, NFSFrameType::NFSPdu as u8, None);
         SCLogDebug!("nfs_ts_pdu Frame {:?}", _nfs_req_pdu);
     }
 
     fn add_nfs4_ts_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_len: i64) {
-        let _nfs4_ts_pdu = Frame::new(flow, stream_slice, input, nfs4_len, NFSFrameType::NFS4Pdu as u8);
+        let _nfs4_ts_pdu = Frame::new(flow, stream_slice, input, nfs4_len, NFSFrameType::NFS4Pdu as u8, None);
         SCLogDebug!("nfs4_ts_pdu Frame: {:?}", _nfs4_ts_pdu);
         if nfs4_len > 8 {
-            let _nfs4_ts_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::NFS4Hdr as u8);
+            let _nfs4_ts_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::NFS4Hdr as u8, None);
             SCLogDebug!("nfs4_ts_hdr Frame {:?}", _nfs4_ts_hdr);
-            let _nfs4_ts_ops = Frame::new(flow, stream_slice, &input[8..], nfs4_len - 8, NFSFrameType::NFS4Ops as u8);
+            let _nfs4_ts_ops = Frame::new(flow, stream_slice, &input[8..], nfs4_len - 8, NFSFrameType::NFS4Ops as u8, None);
             SCLogDebug!("nfs4_ts_ops Frame {:?}", _nfs4_ts_ops);
         }
     }
 
     fn add_rpc_udp_tc_pdu(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_len: i64) -> Option<Frame> {
-        let rpc_udp_tc_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8);
+        let rpc_udp_tc_pdu = Frame::new(flow, stream_slice, input, rpc_len, NFSFrameType::RPCPdu as u8, None);
         SCLogDebug!("rpc_tc_pdu frame {:?}", rpc_udp_tc_pdu);
         rpc_udp_tc_pdu
     }
 
     fn add_rpc_udp_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_len: i64) {
         if rpc_len > 8 {
-            let _rpc_udp_tc_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::RPCHdr as u8);
-            let _rpc_udp_tc_data = Frame::new(flow, stream_slice, &input[8..], rpc_len - 8, NFSFrameType::RPCData as u8);
+            let _rpc_udp_tc_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::RPCHdr as u8, None);
+            let _rpc_udp_tc_data = Frame::new(flow, stream_slice, &input[8..], rpc_len - 8, NFSFrameType::RPCData as u8, None);
             SCLogDebug!("rpc_udp_tc_hdr frame {:?}", _rpc_udp_tc_hdr);
             SCLogDebug!("rpc_udp_tc_data frame {:?}", _rpc_udp_tc_data);
         }
     }
 
     fn add_rpc_tcp_tc_pdu(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_tcp_len: i64) -> Option<Frame> {
-        let rpc_tcp_tc_pdu = Frame::new(flow, stream_slice, input, rpc_tcp_len, NFSFrameType::RPCPdu as u8);
+        let rpc_tcp_tc_pdu = Frame::new(flow, stream_slice, input, rpc_tcp_len, NFSFrameType::RPCPdu as u8, None);
         SCLogDebug!("rpc_tcp_pdu tc frame {:?}", rpc_tcp_tc_pdu);
         rpc_tcp_tc_pdu
     }
 
     fn add_rpc_tcp_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], rpc_tcp_len: i64) {
         if rpc_tcp_len > 12 {
-            let _rpc_tcp_tc_hdr = Frame::new(flow, stream_slice, input, 12, NFSFrameType::RPCHdr as u8);
-            let _rpc_tcp_tc_data = Frame::new(flow, stream_slice, &input[12..], rpc_tcp_len - 12, NFSFrameType::RPCData as u8);
+            let _rpc_tcp_tc_hdr = Frame::new(flow, stream_slice, input, 12, NFSFrameType::RPCHdr as u8, None);
+            let _rpc_tcp_tc_data = Frame::new(flow, stream_slice, &input[12..], rpc_tcp_len - 12, NFSFrameType::RPCData as u8, None);
             SCLogDebug!("rpc_tcp_tc_hdr frame {:?}", _rpc_tcp_tc_hdr);
             SCLogDebug!("rpc_tcp_tc_data frame {:?}", _rpc_tcp_tc_data);
         }
@@ -568,24 +568,24 @@ impl NFSState {
 
     fn add_nfs_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs_len: i64) {
         if nfs_len > 0 {
-            let _nfs_tc_pdu = Frame::new(flow, stream_slice, input, nfs_len, NFSFrameType::NFSPdu as u8);
+            let _nfs_tc_pdu = Frame::new(flow, stream_slice, input, nfs_len, NFSFrameType::NFSPdu as u8, None);
             SCLogDebug!("nfs_tc_pdu frame {:?}", _nfs_tc_pdu);
-            let _nfs_res_status = Frame::new(flow, stream_slice, input, 4, NFSFrameType::NFSStatus as u8);
+            let _nfs_res_status = Frame::new(flow, stream_slice, input, 4, NFSFrameType::NFSStatus as u8, None);
             SCLogDebug!("nfs_tc_status frame {:?}", _nfs_res_status);
         }
     }
 
     fn add_nfs4_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nfs4_len: i64) {
         if nfs4_len > 0 {
-            let _nfs4_tc_pdu = Frame::new(flow, stream_slice, input, nfs4_len, NFSFrameType::NFS4Pdu as u8);
+            let _nfs4_tc_pdu = Frame::new(flow, stream_slice, input, nfs4_len, NFSFrameType::NFS4Pdu as u8, None);
             SCLogDebug!("nfs4_tc_pdu frame {:?}", _nfs4_tc_pdu);
-            let _nfs4_tc_status = Frame::new(flow, stream_slice, input, 4, NFSFrameType::NFS4Status as u8);
+            let _nfs4_tc_status = Frame::new(flow, stream_slice, input, 4, NFSFrameType::NFS4Status as u8, None);
             SCLogDebug!("nfs4_tc_status frame {:?}", _nfs4_tc_status);
         }
         if nfs4_len > 8 {
-            let _nfs4_tc_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::NFS4Hdr as u8);
+            let _nfs4_tc_hdr = Frame::new(flow, stream_slice, input, 8, NFSFrameType::NFS4Hdr as u8, None);
             SCLogDebug!("nfs4_tc_hdr frame {:?}", _nfs4_tc_hdr);
-            let _nfs4_tc_ops = Frame::new(flow, stream_slice, &input[8..], nfs4_len - 8, NFSFrameType::NFS4Ops as u8);
+            let _nfs4_tc_ops = Frame::new(flow, stream_slice, &input[8..], nfs4_len - 8, NFSFrameType::NFS4Ops as u8, None);
             SCLogDebug!("nfs4_tc_ops frame {:?}", _nfs4_tc_ops);
         }
     }

--- a/rust/src/rfb/rfb.rs
+++ b/rust/src/rfb/rfb.rs
@@ -194,6 +194,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -235,6 +236,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -293,6 +295,7 @@ impl RFBState {
                             current,
                             consumed as i64,
                             RFBFrameType::Pdu as u8,
+                            None,
                         );
 
                         current = rem;
@@ -330,6 +333,7 @@ impl RFBState {
                             current,
                             consumed as i64,
                             RFBFrameType::Pdu as u8,
+                            None,
                         );
 
                         current = rem;
@@ -413,6 +417,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -449,6 +454,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -503,6 +509,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -566,6 +573,7 @@ impl RFBState {
                             current,
                             consumed as i64,
                             RFBFrameType::Pdu as u8,
+                            None,
                         );
 
                         current = rem;
@@ -604,6 +612,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;
@@ -684,6 +693,7 @@ impl RFBState {
                                 current,
                                 consumed as i64,
                                 RFBFrameType::Pdu as u8,
+                                None,
                             );
 
                             current = rem;

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1196,53 +1196,53 @@ impl SMBState {
     }
 
     fn add_nbss_ts_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
-        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
+        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8, None);
         SCLogDebug!("NBSS PDU frame {:?}", nbss_pdu);
-        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4_i64, SMBFrameType::NBSSHdr as u8);
+        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4_i64, SMBFrameType::NBSSHdr as u8, None);
         SCLogDebug!("NBSS HDR frame {:?}", nbss_hdr_frame);
-        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
+        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8, None);
         SCLogDebug!("NBSS DATA frame {:?}", nbss_data_frame);
         (nbss_pdu, nbss_hdr_frame, nbss_data_frame)
     }
 
     fn add_smb1_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8, None);
         SCLogDebug!("SMB PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb1_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb1_hdr = Frame::new(flow, stream_slice, input, 32_i64, SMBFrameType::SMB1Hdr as u8);
+        let _smb1_hdr = Frame::new(flow, stream_slice, input, 32_i64, SMBFrameType::SMB1Hdr as u8, None);
         SCLogDebug!("SMBv1 HDR frame {:?}", _smb1_hdr);
         if input.len() > 32 {
-            let _smb1_data = Frame::new(flow, stream_slice, &input[32..], nbss_len - 32, SMBFrameType::SMB1Data as u8);
+            let _smb1_data = Frame::new(flow, stream_slice, &input[32..], nbss_len - 32, SMBFrameType::SMB1Data as u8, None);
             SCLogDebug!("SMBv1 DATA frame {:?}", _smb1_data);
         }
     }
 
     fn add_smb2_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8, None);
         SCLogDebug!("SMBv2 PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb2_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64, hdr_len: i64) {
-        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
+        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8, None);
         SCLogDebug!("SMBv2 HDR frame {:?}", _smb2_hdr);
         if input.len() > hdr_len as usize {
-            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
+            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8, None);
             SCLogDebug!("SMBv2 DATA frame {:?}", _smb2_data);
         }
     }
 
     fn add_smb3_ts_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8, None);
         SCLogDebug!("SMBv3 PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb3_ts_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52_i64, SMBFrameType::SMB3Hdr as u8);
+        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52_i64, SMBFrameType::SMB3Hdr as u8, None);
         SCLogDebug!("SMBv3 HDR frame {:?}", _smb3_hdr);
         if input.len() > 52 {
-            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], nbss_len - 52, SMBFrameType::SMB3Data as u8);
+            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], nbss_len - 52, SMBFrameType::SMB3Data as u8, None);
             SCLogDebug!("SMBv3 DATA frame {:?}", _smb3_data);
         }
     }
@@ -1532,53 +1532,53 @@ impl SMBState {
     }
 
     fn add_nbss_tc_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> (Option<Frame>, Option<Frame>, Option<Frame>) {
-        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8);
+        let nbss_pdu = Frame::new(flow, stream_slice, input, nbss_len + 4, SMBFrameType::NBSSPdu as u8, None);
         SCLogDebug!("NBSS PDU frame {:?}", nbss_pdu);
-        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4_i64, SMBFrameType::NBSSHdr as u8);
+        let nbss_hdr_frame = Frame::new(flow, stream_slice, input, 4_i64, SMBFrameType::NBSSHdr as u8, None);
         SCLogDebug!("NBSS HDR frame {:?}", nbss_hdr_frame);
-        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8);
+        let nbss_data_frame = Frame::new(flow, stream_slice, &input[4..], nbss_len, SMBFrameType::NBSSData as u8, None);
         SCLogDebug!("NBSS DATA frame {:?}", nbss_data_frame);
         (nbss_pdu, nbss_hdr_frame, nbss_data_frame)
     }
 
     fn add_smb1_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB1Pdu as u8, None);
         SCLogDebug!("SMB PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb1_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb1_hdr = Frame::new(flow, stream_slice, input, SMB1_HEADER_SIZE as i64, SMBFrameType::SMB1Hdr as u8);
+        let _smb1_hdr = Frame::new(flow, stream_slice, input, SMB1_HEADER_SIZE as i64, SMBFrameType::SMB1Hdr as u8, None);
         SCLogDebug!("SMBv1 HDR frame {:?}", _smb1_hdr);
         if input.len() > SMB1_HEADER_SIZE {
             let _smb1_data = Frame::new(flow, stream_slice, &input[SMB1_HEADER_SIZE..], nbss_len - SMB1_HEADER_SIZE as i64,
-                    SMBFrameType::SMB1Data as u8);
+                    SMBFrameType::SMB1Data as u8, None);
             SCLogDebug!("SMBv1 DATA frame {:?}", _smb1_data);
         }
     }
 
     fn add_smb2_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) -> Option<Frame> {
-        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8);
+        let smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB2Pdu as u8, None);
         SCLogDebug!("SMBv2 PDU frame {:?}", smb_pdu);
         smb_pdu
     }
     fn add_smb2_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64, hdr_len: i64) {
-        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8);
+        let _smb2_hdr = Frame::new(flow, stream_slice, input, hdr_len, SMBFrameType::SMB2Hdr as u8, None);
         SCLogDebug!("SMBv2 HDR frame {:?}", _smb2_hdr);
         if input.len() > hdr_len as usize {
-            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize ..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8);
+            let _smb2_data = Frame::new(flow, stream_slice, &input[hdr_len as usize ..], nbss_len - hdr_len, SMBFrameType::SMB2Data as u8, None);
             SCLogDebug!("SMBv2 DATA frame {:?}", _smb2_data);
         }
     }
 
     fn add_smb3_tc_pdu_frame(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8);
+        let _smb_pdu = Frame::new(flow, stream_slice, input, nbss_len, SMBFrameType::SMB3Pdu as u8, None);
         SCLogDebug!("SMBv3 PDU frame {:?}", _smb_pdu);
     }
     fn add_smb3_tc_hdr_data_frames(&mut self, flow: *const Flow, stream_slice: &StreamSlice, input: &[u8], nbss_len: i64) {
-        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52_i64, SMBFrameType::SMB3Hdr as u8);
+        let _smb3_hdr = Frame::new(flow, stream_slice, input, 52_i64, SMBFrameType::SMB3Hdr as u8, None);
         SCLogDebug!("SMBv3 HDR frame {:?}", _smb3_hdr);
         if input.len() > 52 {
-            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], nbss_len - 52, SMBFrameType::SMB3Data as u8);
+            let _smb3_data = Frame::new(flow, stream_slice, &input[52..], nbss_len - 52, SMBFrameType::SMB3Data as u8, None);
             SCLogDebug!("SMBv3 DATA frame {:?}", _smb3_data);
         }
     }

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -164,6 +164,7 @@ impl TelnetState {
                     start,
                     -1_i64,
                     TelnetFrameType::Pdu as u8,
+                    None,
                 );
             }
             if self.request_specific_frame.is_none() {
@@ -175,6 +176,7 @@ impl TelnetState {
                             start,
                             -1_i64,
                             TelnetFrameType::Ctl as u8,
+                            None,
                         )
                     } else {
                         Frame::new(
@@ -183,6 +185,7 @@ impl TelnetState {
                             start,
                             -1_i64,
                             TelnetFrameType::Data as u8,
+                            None,
                         )
                     // app-layer-frame-documentation tag end: parse_request
                     };
@@ -266,14 +269,14 @@ impl TelnetState {
         let mut start = input;
         while !start.is_empty() {
             if self.response_frame.is_none() {
-                self.response_frame = Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Pdu as u8);
+                self.response_frame = Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Pdu as u8, None);
             }
             if self.response_specific_frame.is_none() {
                 if let Ok((_, is_ctl)) = parser::peek_message_is_ctl(start) {
                     self.response_specific_frame = if is_ctl {
-                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Ctl as u8)
+                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Ctl as u8, None)
                     } else {
-                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Data as u8)
+                        Frame::new(flow, stream_slice, start, -1_i64, TelnetFrameType::Data as u8, None)
                     };
                 }
             }

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -158,12 +158,14 @@ impl WebSocketState {
         while !start.is_empty() {
             match parser::parse_message(start, max_pl_size) {
                 Ok((rem, pdu)) => {
+                    let mut tx = self.new_tx(direction);
                     let _pdu = Frame::new(
                         flow,
                         &stream_slice,
                         start,
                         (start.len() - rem.len() - pdu.payload.len()) as i64,
                         WebSocketFrameType::Header as u8,
+                        Some(tx.tx_id),
                     );
                     let _pdu = Frame::new(
                         flow,
@@ -171,9 +173,9 @@ impl WebSocketState {
                         start,
                         (start.len() - rem.len()) as i64,
                         WebSocketFrameType::Pdu as u8,
+                        Some(tx.tx_id),
                     );
                     start = rem;
-                    let mut tx = self.new_tx(direction);
                     if pdu.to_skip > 0 {
                         if direction == Direction::ToClient {
                             self.to_skip_tc = pdu.to_skip;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1721,12 +1721,14 @@ static void DetectRunFrames(ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngin
                     /* match */
                     DetectRunPostMatch(tv, det_ctx, p, s);
 
-                    const uint8_t alert_flags =
-                            (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
+                    uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
                     det_ctx->flags |= DETECT_ENGINE_THREAD_CTX_FRAME_ID_SET;
                     det_ctx->frame_id = frame->id;
                     SCLogDebug(
                             "%p/%" PRIi64 " sig %u (%u) matched", frame, frame->id, s->id, s->num);
+                    if (frame->flags & FRAME_FLAG_TX_ID_SET) {
+                        alert_flags |= PACKET_ALERT_FLAG_TX;
+                    }
                     AlertQueueAppend(det_ctx, s, p, frame->tx_id, alert_flags);
                 }
             }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6973

Describe changes:
- detect: log relevant frames app-layer metdata
- frames: change rust API to make tx_id mandatory
- frames: set right tx_id for SIP and websocket

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1801

https://github.com/OISF/suricata/pull/10924 with additional commit and SV test
