### PR TITLE
github-ci: add ubuntu 24.04 build with coccci - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -802,7 +802,7 @@ jobs:
 
   # Fedora 39 build using Clang.
   fedora-39-clang:
-    name: Fedora 39 (clang, cocci, debug, asan, wshadow, rust-strict, systemd)
+    name: Fedora 39 (clang, debug, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
     container: fedora:39
     needs: [prepare-deps]
@@ -833,7 +833,6 @@ jobs:
                 cbindgen \
                 ccache \
                 clang \
-                coccinelle \
                 diffutils \
                 file-devel \
                 gcc \
@@ -875,10 +874,8 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared  --enable-coccinelle
-      - name: Running unit tests and cocci checks
-        # Set the concurrency level for cocci.
-        run: CONCURRENCY_LEVEL=${{ env.CPUS }} make check
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
+      - run: make check
       - run: make distclean
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-lua
         env:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1348,6 +1348,81 @@ jobs:
             exit 0
           fi
 
+  ubuntu-24-04:
+    name: Ubuntu 24.04 (cocci)
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    needs: [prepare-deps]
+    steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                autoconf \
+                automake \
+                build-essential \
+                cargo \
+                cbindgen \
+                clang-14 \
+                coccinelle \
+                dpdk-dev \
+                git \
+                jq \
+                libcap-ng-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libhiredis-dev \
+                libhyperscan-dev \
+                libjansson-dev \
+                liblua5.4-dev \
+                libmagic-dev \
+                libnet1-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libnuma-dev \
+                libpcap-dev \
+                libpcre2-dev \
+                libpython3.12 \
+                libtool \
+                libyaml-dev \
+                llvm-14-dev \
+                make \
+                parallel \
+                python-is-python3 \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: ./configure --enable-unittests --enable-coccinelle
+      - run: make -j ${{ env.CPUS }}
+      - run: CONCURRENCY_LEVEL=${{ env.CPUS }} make check
+      - run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: make install
+      - run: make install-headers
+      - run: make install-library
+
   ubuntu-22-04-cov-ut:
     name: Ubuntu 22.04 (unittests coverage)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Commit 480955b1f8657ca6261d6f0124fc04cac2720f82 updated the Cocci build from Fedora 38 to Fedora 39, but Cocci in Fedora 39 appears to be broken, it gets stuck in `detect-bytetest.c`, and the same happens in Fedora 40.  Unfortunately `spatch` does have much for debugging output, so I'm not sure why.

Instead, add an Ubuntu 24.04 build and enable Cocci there where it runs successfully.

Appears this might be an OCaml issue:
- Ubuntu 24.04: `spatch version 1.1.1 compiled with OCaml version 4.14.1`
- Fedora 39: `spatch version 1.1.1 compiled with OCaml version 5.0.1+dev0-2022-12-15`
- Fedora 38: `spatch version 1.1.1 compiled with OCaml version 4.14.0`
