### PR TITLE
dns: ffi and visibility cleanups - v1

### DIFF
--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -23,7 +23,7 @@ use crate::detect::uint::{detect_match_uint, DetectUintData};
 ///
 /// 1 will be returned on match, otherwise 0 will be returned.
 #[no_mangle]
-pub extern "C" fn rs_dns_opcode_match(
+pub extern "C" fn SCDnsDetectOpcodeMatch(
     tx: &mut DNSTransaction, detect: &mut DetectUintData<u8>, flags: u8,
 ) -> u8 {
     let header_flags = if flags & Direction::ToServer as u8 != 0 {
@@ -54,7 +54,7 @@ pub extern "C" fn rs_dns_opcode_match(
 ///
 /// 1 will be returned on match, otherwise 0 will be returned.
 #[no_mangle]
-pub extern "C" fn rs_dns_rcode_match(
+pub extern "C" fn SCDnsDetectRcodeMatch(
     tx: &mut DNSTransaction, detect: &mut DetectUintData<u8>, flags: u8,
 ) -> u8 {
     let header_flags = if flags & Direction::ToServer as u8 != 0 {
@@ -80,7 +80,7 @@ pub extern "C" fn rs_dns_rcode_match(
 /// Perform the DNS rrtype match.
 /// 1 will be returned on match, otherwise 0 will be returned.
 #[no_mangle]
-pub extern "C" fn rs_dns_rrtype_match(
+pub extern "C" fn SCDnsDetectRrtypeMatch(
     tx: &mut DNSTransaction, detect: &mut DetectUintData<u16>, flags: u8,
 ) -> u16 {
     if flags & Direction::ToServer as u8 != 0 {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -636,7 +636,7 @@ fn dns_log_query(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_query(
+pub extern "C" fn SCDnsLogJsonQuery(
     tx: &mut DNSTransaction, i: u16, flags: u64, jb: &mut JsonBuilder,
 ) -> bool {
     match dns_log_query(tx, i, flags, jb) {
@@ -650,7 +650,7 @@ pub extern "C" fn rs_dns_log_json_query(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_log_json_answer(
+pub extern "C" fn SCDnsLogJsonAnswer(
     tx: &mut DNSTransaction, flags: u64, js: &mut JsonBuilder,
 ) -> bool {
     if let Some(response) = &tx.response {
@@ -664,7 +664,7 @@ pub extern "C" fn rs_dns_log_json_answer(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_do_log_answer(tx: &mut DNSTransaction, flags: u64) -> bool {
+pub extern "C" fn SCDnsLogAnswerEnabled(tx: &mut DNSTransaction, flags: u64) -> bool {
     if let Some(response) = &tx.response {
         for query in &response.queries {
             if dns_log_rrtype_enabled(query.rrtype, flags) {

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -22,14 +22,14 @@ use crate::dns::log::*;
 use crate::lua::*;
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_tx_id(clua: &mut CLuaState, tx: &mut DNSTransaction) {
+pub extern "C" fn SCDnsLuaGetTxId(clua: &mut CLuaState, tx: &mut DNSTransaction) {
     let lua = LuaState { lua: clua };
 
     lua.pushinteger(tx.tx_id() as i64);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
+pub extern "C" fn SCDnsLuaGetRrname(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
     let lua = LuaState { lua: clua };
 
     if let Some(request) = &tx.request {
@@ -48,7 +48,7 @@ pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState, tx: &mut DNSTransa
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_rcode(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
+pub extern "C" fn SCDnsLuaGetRcode(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
     let lua = LuaState { lua: clua };
 
     let rcode = tx.rcode();
@@ -61,9 +61,7 @@ pub extern "C" fn rs_dns_lua_get_rcode(clua: &mut CLuaState, tx: &mut DNSTransac
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_query_table(
-    clua: &mut CLuaState, tx: &mut DNSTransaction,
-) -> c_int {
+pub extern "C" fn SCDnsLuaGetQueryTable(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
     let lua = LuaState { lua: clua };
 
     let mut i: i64 = 0;
@@ -116,9 +114,7 @@ pub extern "C" fn rs_dns_lua_get_query_table(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_answer_table(
-    clua: &mut CLuaState, tx: &mut DNSTransaction,
-) -> c_int {
+pub extern "C" fn SCDnsLuaGetAnswerTable(clua: &mut CLuaState, tx: &mut DNSTransaction) -> c_int {
     let lua = LuaState { lua: clua };
 
     let mut i: i64 = 0;
@@ -195,7 +191,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dns_lua_get_authority_table(
+pub extern "C" fn SCDnsLuaGetAuthorityTable(
     clua: &mut CLuaState, tx: &mut DNSTransaction,
 ) -> c_int {
     let lua = LuaState { lua: clua };

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -29,7 +29,7 @@ use nom7::{error_position, Err, IResult};
 /// Parameters:
 ///   start: the start of the name
 ///   message: the complete message that start is a part of with the DNS header
-pub fn dns_parse_name<'b>(start: &'b [u8], message: &'b [u8]) -> IResult<&'b [u8], Vec<u8>> {
+fn dns_parse_name<'b>(start: &'b [u8], message: &'b [u8]) -> IResult<&'b [u8], Vec<u8>> {
     let mut pos = start;
     let mut pivot = start;
     let mut name: Vec<u8> = Vec::with_capacity(32);
@@ -175,7 +175,7 @@ fn dns_parse_answer<'a>(
 /// Arguments are suitable for using with call!:
 ///
 ///    call!(complete_dns_message_buffer)
-pub fn dns_parse_query<'a>(input: &'a [u8], message: &'a [u8]) -> IResult<&'a [u8], DNSQueryEntry> {
+fn dns_parse_query<'a>(input: &'a [u8], message: &'a [u8]) -> IResult<&'a [u8], DNSQueryEntry> {
     let i = input;
     let (i, name) = dns_parse_name(i, message)?;
     let (i, rrtype) = be_u16(i)?;
@@ -286,7 +286,7 @@ fn dns_parse_rdata_unknown(input: &[u8]) -> IResult<&[u8], DNSRData> {
     rest(input).map(|(input, data)| (input, DNSRData::Unknown(data.to_vec())))
 }
 
-pub fn dns_parse_rdata<'a>(
+fn dns_parse_rdata<'a>(
     input: &'a [u8], message: &'a [u8], rrtype: u16,
 ) -> IResult<&'a [u8], DNSRData> {
     match rrtype {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1731,8 +1731,8 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterFTPParsers();
     RegisterSSHParsers();
     RegisterSMTPParsers();
-    rs_dns_udp_register_parser();
-    rs_dns_tcp_register_parser();
+    SCRegisterDnsUdpParser();
+    SCRegisterDnsTcpParser();
     rs_bittorrent_dht_udp_register_parser();
     RegisterModbusParsers();
     RegisterENIPUDPParsers();

--- a/src/detect-dns-opcode.c
+++ b/src/detect-dns-opcode.c
@@ -67,7 +67,7 @@ static int DetectDnsOpcodeMatch(DetectEngineThreadCtx *det_ctx,
     Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
     const SigMatchCtx *ctx)
 {
-    return rs_dns_opcode_match(txv, (void *)ctx, flags);
+    return SCDnsDetectOpcodeMatch(txv, (void *)ctx, flags);
 }
 
 void DetectDnsOpcodeRegister(void)

--- a/src/detect-dns-rcode.c
+++ b/src/detect-dns-rcode.c
@@ -62,7 +62,7 @@ static void DetectDnsRcodeFree(DetectEngineCtx *de_ctx, void *ptr)
 static int DetectDnsRcodeMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags, void *state,
         void *txv, const Signature *s, const SigMatchCtx *ctx)
 {
-    return rs_dns_rcode_match(txv, (void *)ctx, flags);
+    return SCDnsDetectRcodeMatch(txv, (void *)ctx, flags);
 }
 
 void DetectDnsRcodeRegister(void)

--- a/src/detect-dns-rrtype.c
+++ b/src/detect-dns-rrtype.c
@@ -62,7 +62,7 @@ static void DetectDnsRrtypeFree(DetectEngineCtx *de_ctx, void *ptr)
 static int DetectDnsRrtypeMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags, void *state,
         void *txv, const Signature *s, const SigMatchCtx *ctx)
 {
-    return rs_dns_rrtype_match(txv, (void *)ctx, flags);
+    return SCDnsDetectRrtypeMatch(txv, (void *)ctx, flags);
 }
 
 void DetectDnsRrtypeRegister(void)

--- a/src/util-lua-dns.c
+++ b/src/util-lua-dns.c
@@ -65,7 +65,7 @@ static int DnsGetDnsRrname(lua_State *luastate)
     if (tx == NULL) {
         return LuaCallbackError(luastate, "internal error: no tx");
     }
-    return rs_dns_lua_get_rrname(luastate, tx);
+    return SCDnsLuaGetRrname(luastate, tx);
 }
 
 static int DnsGetTxid(lua_State *luastate)
@@ -76,7 +76,7 @@ static int DnsGetTxid(lua_State *luastate)
     if (tx == NULL) {
         return LuaCallbackError(luastate, "internal error: no tx");
     }
-    rs_dns_lua_get_tx_id(luastate, tx);
+    SCDnsLuaGetTxId(luastate, tx);
     return 1;
 }
 
@@ -88,7 +88,7 @@ static int DnsGetRcode(lua_State *luastate)
     if (tx == NULL) {
         return LuaCallbackError(luastate, "internal error: no tx");
     }
-    return rs_dns_lua_get_rcode(luastate, tx);
+    return SCDnsLuaGetRcode(luastate, tx);
 }
 
 static int DnsGetRecursionDesired(lua_State *luastate)
@@ -99,7 +99,7 @@ static int DnsGetRecursionDesired(lua_State *luastate)
     if (tx == NULL) {
         return LuaCallbackError(luastate, "internal error: no tx");
     }
-    uint16_t flags = rs_dns_tx_get_response_flags(tx);
+    uint16_t flags = SCDnsTxGetResponseFlags(tx);
     int recursion_desired = flags & 0x0080 ? 1 : 0;
     lua_pushboolean(luastate, recursion_desired);
     return 1;
@@ -113,7 +113,7 @@ static int DnsGetQueryTable(lua_State *luastate)
     if (tx == NULL) {
         return LuaCallbackError(luastate, "internal error: no tx");
     }
-    return rs_dns_lua_get_query_table(luastate, tx);
+    return SCDnsLuaGetQueryTable(luastate, tx);
 }
 
 static int DnsGetAnswerTable(lua_State *luastate)
@@ -121,7 +121,7 @@ static int DnsGetAnswerTable(lua_State *luastate)
     if (!(LuaStateNeedProto(luastate, ALPROTO_DNS)))
         return LuaCallbackError(luastate, "error: protocol not dns");
     RSDNSTransaction *tx = LuaStateGetTX(luastate);
-    return rs_dns_lua_get_answer_table(luastate, tx);
+    return SCDnsLuaGetAnswerTable(luastate, tx);
 }
 
 static int DnsGetAuthorityTable(lua_State *luastate)
@@ -129,7 +129,7 @@ static int DnsGetAuthorityTable(lua_State *luastate)
     if (!(LuaStateNeedProto(luastate, ALPROTO_DNS)))
         return LuaCallbackError(luastate, "error: protocol not dns");
     RSDNSTransaction *tx = LuaStateGetTX(luastate);
-    return rs_dns_lua_get_authority_table(luastate, tx);
+    return SCDnsLuaGetAuthorityTable(luastate, tx);
 }
 
 /** \brief register http lua extensions in a luastate */


### PR DESCRIPTION
I often point to DNS as examples, so clean up the FFI..

- For no_mangle/extern functions, using C naming as these become part of our C API
- Remove no_mangle where not needed, for example, the function is only used by a pointer
- Remove pub where not needed.

I think some reorganization could help readability, but would mess up this diff. For example, group the no_mangle extern functions together, grouping the ones that are only used as function pointers, etc.  For another time tho.
