### PR TITLE
pgsql/logger: open json object from logger fn - v2

### DIFF
--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -96,7 +96,7 @@ impl TemplateState {
         let mut index = 0;
         for i in 0..len {
             let tx = &self.transactions[i];
-            if tx.tx_id == tx_id + 1 {
+            if tx.tx_id == tx_id {
                 found = true;
                 index = i;
                 break;
@@ -108,7 +108,7 @@ impl TemplateState {
     }
 
     pub fn get_tx(&mut self, tx_id: u64) -> Option<&TemplateTransaction> {
-        self.transactions.iter().find(|tx| tx.tx_id == tx_id + 1)
+        self.transactions.iter().find(|tx| tx.tx_id == tx_id)
     }
 
     fn new_tx(&mut self) -> TemplateTransaction {

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -27,6 +27,7 @@ use std;
 pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("pgsql")?;
     js.set_uint("tx_id", tx.tx_id)?;
     if let Some(request) = &tx.request {
         js.set_object("request", &log_request(request, flags)?)?;
@@ -35,12 +36,14 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
         // TODO Log anomaly event instead?
         js.set_bool("request", false)?;
         js.set_bool("response", false)?;
+        js.close()?;
         return Ok(());
     }
 
     if !tx.responses.is_empty() {
         js.set_object("response", &log_response_object(tx)?)?;
     }
+    js.close()?;
 
     Ok(())
 }

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -175,7 +175,7 @@ impl PgsqlState {
         let mut index = 0;
         for i in 0..len {
             let tx = &self.transactions[i];
-            if tx.tx_id == tx_id + 1 {
+            if tx.tx_id == tx_id {
                 found = true;
                 index = i;
                 break;
@@ -188,7 +188,7 @@ impl PgsqlState {
     }
 
     pub fn get_tx(&mut self, tx_id: u64) -> Option<&PgsqlTransaction> {
-        self.transactions.iter().find(|tx| tx.tx_id == tx_id + 1)
+        self.transactions.iter().find(|tx| tx.tx_id == tx_id)
     }
 
     fn new_tx(&mut self) -> PgsqlTransaction {

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -76,11 +76,9 @@ static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, F
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(jb, "pgsql");
     if (!rs_pgsql_logger(txptr, thread->pgsqllog_ctx->flags, jb)) {
         goto error;
     }
-    jb_close(jb);
 
     OutputJsonBuilderBuffer(jb, thread->ctx);
     jb_free(jb);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/10951

Changes from last PR:
- close JsonBuilder object in case of no pgsql transactions 
- adds a fix for [bug 7000](https://redmine.openinfosecfoundation.org/issues/7000) - pgsql tx_id handling
- proposes same fix to template.rs, as it has the same logic - and therefore, I imagine, could lead to same bug seen with pgsql (cf https://github.com/OISF/suricata-verify/pull/1796#discussion_r1583623450)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6983
https://redmine.openinfosecfoundation.org/issues/7000

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1810