### PR TITLE
Convert byte_extract keyword parser to Rust

### DIFF
--- a/rust/src/detect/byte_extract.rs
+++ b/rust/src/detect/byte_extract.rs
@@ -1,0 +1,464 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Jeff Lucovsky <jlucovsky@oisf.net>
+
+use crate::detect::error::RuleParseError;
+use crate::detect::parser::{parse_token, take_until_whitespace};
+use crate::detect::*;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+use nom7::bytes::complete::tag;
+use nom7::character::complete::multispace0;
+use nom7::sequence::preceded;
+use nom7::{Err, IResult};
+use std::str;
+
+pub const DETECT_BYTE_EXTRACT_FLAG_RELATIVE: u16 = 0x01;
+pub const DETECT_BYTE_EXTRACT_FLAG_STRING: u16 = 0x02;
+pub const DETECT_BYTE_EXTRACT_FLAG_ALIGN: u16 = 0x04;
+pub const DETECT_BYTE_EXTRACT_FLAG_ENDIAN: u16 = 0x08;
+pub const DETECT_BYTE_EXTRACT_FLAG_SLICE: u16 = 0x10;
+pub const DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER: u16 = 0x20;
+pub const DETECT_BYTE_EXTRACT_FLAG_NBYTES: u16 = 0x40;
+pub const DETECT_BYTE_EXTRACT_FLAG_OFFSET: u16 = 0x80;
+pub const DETECT_BYTE_EXTRACT_FLAG_BASE: u16 = 0x100;
+
+pub const DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT: u16 = 1;
+
+const BASE_DEFAULT: ByteBase = ByteBase::BaseDec;
+
+// Fixed position parameter count: bytes, offset, variable
+pub const DETECT_BYTE_EXTRACT_FIXED_PARAM_COUNT: usize = 3;
+// Optional parameters: endian, relative, string, dce, slice, align, multiplier
+pub const DETECT_BYTE_EXTRACT_MAX_PARAM_COUNT: usize = 10;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct SCDetectByteExtractData {
+    local_id: u8,
+    nbytes: u8,
+    offset: i16,
+    name: *const c_char,
+    flags: u16,
+    endian: ByteEndian, // big, little, dce
+    base: ByteBase,     // From string or dce
+    align_value: u8,
+    multiplier_value: u16,
+    id: u16,
+}
+
+impl Drop for SCDetectByteExtractData {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.name.is_null() {
+                let _ = CString::from_raw(self.name as *mut c_char);
+            }
+        }
+    }
+}
+
+impl Default for SCDetectByteExtractData {
+    fn default() -> Self {
+        SCDetectByteExtractData {
+            local_id: 0,
+            nbytes: 0,
+            offset: 0,
+            name: std::ptr::null_mut(),
+            flags: 0,
+            endian: ByteEndian::BigEndian, // big, little, dce
+            base: BASE_DEFAULT,            // From string or dce
+            align_value: 0,
+            multiplier_value: DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            id: 0,
+        }
+    }
+}
+
+fn parse_byteextract(input: &str) -> IResult<&str, SCDetectByteExtractData, RuleParseError<&str>> {
+    // Inner utility function for easy error creation.
+    fn make_error(reason: String) -> nom7::Err<RuleParseError<&'static str>> {
+        Err::Error(RuleParseError::InvalidByteExtract(reason))
+    }
+    let (_, values) = nom7::multi::separated_list1(
+        tag(","),
+        preceded(multispace0, nom7::bytes::complete::is_not(",")),
+    )(input)?;
+
+    if values.len() < DETECT_BYTE_EXTRACT_FIXED_PARAM_COUNT
+        || values.len() > DETECT_BYTE_EXTRACT_MAX_PARAM_COUNT
+    {
+        return Err(make_error(format!("Incorrect argument string; at least {} values must be specified but no more than {}: {:?}",
+            DETECT_BYTE_EXTRACT_FIXED_PARAM_COUNT, DETECT_BYTE_EXTRACT_MAX_PARAM_COUNT, input)));
+    }
+
+    let mut byte_extract = {
+        SCDetectByteExtractData {
+            nbytes: values[0]
+                .parse::<u8>()
+                .map_err(|_| make_error(format!("invalid nbytes value: {}", values[0])))?,
+            ..Default::default()
+        }
+    };
+
+    let value = values[1]
+        .parse::<i16>()
+        .map_err(|_| make_error(format!("invalid offset value: {}", values[1])))?;
+    if (i16::MIN..=i16::MAX).contains(&value) {
+        byte_extract.offset = value;
+    } else {
+        return Err(make_error(format!(
+            "invalid offset value: must be between {} and {}: {}",
+            i16::MIN,
+            i16::MAX,
+            value
+        )));
+    }
+
+    let (_, value) = parse_token(values[2])?;
+    if let Ok(newval) = CString::new(value) {
+        byte_extract.name = newval.into_raw();
+    } else {
+        return Err(make_error(
+            "parse string not safely convertible to C".to_string(),
+        ));
+    }
+
+    for value in values.iter().skip(DETECT_BYTE_EXTRACT_FIXED_PARAM_COUNT) {
+        let (mut val, mut name) = take_until_whitespace(value)?;
+        val = val.trim();
+        name = name.trim();
+        match name {
+            "align" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_ALIGN) {
+                    return Err(make_error("align already set".to_string()));
+                }
+                byte_extract.align_value = val
+                    .parse::<u8>()
+                    .map_err(|_| make_error(format!("invalid align value: {}", val)))?;
+                if !(byte_extract.align_value == 2 || byte_extract.align_value == 4) {
+                    return Err(make_error(format!(
+                        "invalid align value: must be 2 or 4: {}",
+                        val
+                    )));
+                }
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_ALIGN;
+            }
+            "slice" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_SLICE) {
+                    return Err(make_error("slice already set".to_string()));
+                }
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_SLICE;
+            }
+            "dce" | "big" | "little" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) {
+                    return Err(make_error("endianess already set".to_string()));
+                }
+                byte_extract.endian = match get_endian_value(name) {
+                    Ok(val) => val,
+                    Err(_) => {
+                        return Err(make_error(format!("invalid endian value: {}", val)));
+                    }
+                };
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_ENDIAN;
+            }
+            "string" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_STRING) {
+                    return Err(make_error("string already set".to_string()));
+                }
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_BASE) {
+                    return Err(make_error(
+                        "base specified before string; use \"string, base\"".to_string(),
+                    ));
+                }
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_STRING;
+            }
+            "oct" | "dec" | "hex" => {
+                if 0 == (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_STRING) {
+                    return Err(make_error("string must be set first".to_string()));
+                }
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_BASE) {
+                    return Err(make_error("base already set".to_string()));
+                }
+                byte_extract.base = match get_string_value(name) {
+                    Ok(val) => val,
+                    Err(_) => {
+                        return Err(make_error(format!("invalid string value: {}", val)));
+                    }
+                };
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_BASE;
+            }
+            "relative" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
+                    return Err(make_error("relative already set".to_string()));
+                }
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_RELATIVE;
+            }
+            "multiplier" => {
+                if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) {
+                    return Err(make_error("multiplier already set".to_string()));
+                }
+                let mult = val
+                    .parse::<u32>()
+                    .map_err(|_| make_error(format!("invalid multiplier value: {}", val)))?;
+                if mult == 0 || mult > u16::MAX.into() {
+                    return Err(make_error(format!(
+                        "invalid multiplier value: must be between 0 and {}: {}",
+                        u16::MAX,
+                        val
+                    )));
+                }
+                byte_extract.multiplier_value = mult as u16;
+                byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER;
+            }
+            _ => {
+                return Err(make_error(format!("unknown byte_extract option: {}", name)));
+            }
+        };
+    }
+
+    // string w/out base: default is set to decimal so no error
+
+    // base w/out string
+    if 0 != byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_BASE
+        && (0 == byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_STRING)
+    {
+        return Err(make_error("must specify string with base".to_string()));
+    }
+
+    if 0 != byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_STRING
+        && 0 != byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN
+    {
+        return Err(make_error(
+            "can't specify string and an endian value".to_string(),
+        ));
+    }
+
+    if (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_SLICE)
+        == (byte_extract.flags & (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_SLICE))
+    {
+        return Err(make_error(
+            "string and slice are mutually exclusive".to_string(),
+        ));
+    }
+
+    Ok((input, byte_extract))
+}
+
+/// Intermediary function between the C code and the parsing functions.
+#[no_mangle]
+pub unsafe extern "C" fn SCByteExtractParse(c_arg: *const c_char) -> *mut SCDetectByteExtractData {
+    if c_arg.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let arg = match CStr::from_ptr(c_arg).to_str() {
+        Ok(arg) => arg,
+        Err(_) => {
+            return std::ptr::null_mut();
+        }
+    };
+    match parse_byteextract(arg) {
+        Ok((_, detect)) => return Box::into_raw(Box::new(detect)),
+        Err(_) => return std::ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCByteExtractFree(ptr: *mut SCDetectByteExtractData) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // structure equality only used by test cases
+    impl PartialEq for SCDetectByteExtractData {
+        fn eq(&self, other: &Self) -> bool {
+            let mut res: bool = false;
+
+            if !self.name.is_null() && !other.name.is_null() {
+                let s_val = unsafe { CStr::from_ptr(self.name) };
+                let o_val = unsafe { CStr::from_ptr(other.name) };
+                res = s_val == o_val;
+            } else if !self.name.is_null() || !other.name.is_null() {
+                return false;
+            }
+
+            res && self.local_id == other.local_id
+                && self.nbytes == other.nbytes
+                && self.offset == other.offset
+                && self.flags == other.flags
+                && self.endian == other.endian
+                && self.base == other.base
+                && self.align_value == other.align_value
+                && self.multiplier_value == other.multiplier_value
+                && self.id == other.id
+        }
+    }
+
+    fn valid_test(
+        args: &str, nbytes: u8, offset: i16, var_name_str: &str, base: ByteBase,
+        endian: ByteEndian, align_value: u8, multiplier_value: u16, flags: u16,
+    ) {
+        let bed = SCDetectByteExtractData {
+            nbytes,
+            offset,
+            name: if !var_name_str.is_empty() {
+                CString::new(var_name_str).unwrap().into_raw()
+            } else {
+                std::ptr::null_mut()
+            },
+            base,
+            endian,
+            align_value,
+            multiplier_value,
+            flags,
+            ..Default::default()
+        };
+
+        let (_, val) = parse_byteextract(args).unwrap();
+        assert_eq!(val, bed);
+    }
+
+    #[test]
+    fn parser_valid() {
+        assert!(parse_byteextract("4, 2, one").is_ok());
+        assert!(parse_byteextract("4, 2, one, relative").is_ok());
+        assert!(parse_byteextract("4, 2, one, relative, multiplier 10").is_ok());
+        assert!(parse_byteextract("4, 2, one, big").is_ok());
+        assert!(parse_byteextract("4, 2, one, little").is_ok());
+        assert!(parse_byteextract("4, 2, one, dce").is_ok());
+        assert!(parse_byteextract("4, 2, one, string").is_ok());
+        assert!(parse_byteextract("4, 2, one, string, hex").is_ok());
+        assert!(parse_byteextract("4, 2, one, string, dec").is_ok());
+        assert!(parse_byteextract("4, 2, one, string, oct").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4, relative").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 2, relative").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4, relative, big").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4, relative, dce").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4, relative, little").is_ok());
+        assert!(parse_byteextract("4, 2, one, align 4, relative, little, multiplier 2").is_ok());
+        assert!(
+            parse_byteextract("4, 2, one, align 4, relative, little, multiplier 2, slice").is_ok()
+        );
+    }
+    #[test]
+    // Invalid token combinations
+    fn parser_invalid() {
+        assert!(parse_byteextract("4").is_err());
+        assert!(parse_byteextract("4, 2").is_err());
+        assert!(parse_byteextract("4, 605536").is_err());
+        assert!(parse_byteextract("4, -605536").is_err());
+        assert!(parse_byteextract("4, 65536").is_err());
+        assert!(parse_byteextract("4, -65536").is_err());
+        assert!(parse_byteextract("4, 2, one, align 4, align 4").is_err());
+        assert!(parse_byteextract("4, 2, one, relative, relative").is_err());
+        assert!(parse_byteextract("4, 2, one, hex").is_err());
+        assert!(parse_byteextract("4, 2, one, dec").is_err());
+        assert!(parse_byteextract("4, 2, one, oct").is_err());
+        assert!(parse_byteextract("4, 2, one, little, little").is_err());
+        assert!(parse_byteextract("4, 2, one, slice, slice").is_err());
+        assert!(parse_byteextract("4, 2, one, multiplier").is_err());
+        assert!(parse_byteextract("4, 2, one, multiplier 0").is_err());
+        assert!(parse_byteextract("4, 2, one, multiplier 65536").is_err());
+        assert!(parse_byteextract("4, 2, one, multiplier -1").is_err());
+        assert!(parse_byteextract("4, 2, one, multiplier 2, multiplier 2").is_err());
+        assert!(parse_byteextract(
+            "4, 2, one, align 4, relative, little, multiplier 2, string hex"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_parser_valid() {
+        valid_test(
+            "4, 2, one",
+            4,
+            2,
+            "one",
+            BASE_DEFAULT,
+            ByteEndian::BigEndian,
+            0,
+            DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            0,
+        );
+        valid_test(
+            "4, 2, one, relative",
+            4,
+            2,
+            "one",
+            BASE_DEFAULT,
+            ByteEndian::BigEndian,
+            0,
+            DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            DETECT_BYTE_EXTRACT_FLAG_RELATIVE,
+        );
+        valid_test(
+            "4, 2, one, string",
+            4,
+            2,
+            "one",
+            BASE_DEFAULT,
+            ByteEndian::BigEndian,
+            0,
+            DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            DETECT_BYTE_EXTRACT_FLAG_STRING,
+        );
+        valid_test(
+            "4, 2, one, string, hex",
+            4,
+            2,
+            "one",
+            ByteBase::BaseHex,
+            ByteEndian::BigEndian,
+            0,
+            DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING,
+        );
+        valid_test(
+            "4, 2, one, dce",
+            4,
+            2,
+            "one",
+            BASE_DEFAULT,
+            ByteEndian::EndianDCE,
+            0,
+            DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT,
+            DETECT_BYTE_EXTRACT_FLAG_ENDIAN,
+        );
+        valid_test(
+            "4, 2, one, align 4, relative, little, multiplier 2, slice",
+            4,
+            2,
+            "one",
+            ByteBase::BaseDec,
+            ByteEndian::LittleEndian,
+            4,
+            2,
+            DETECT_BYTE_EXTRACT_FLAG_ENDIAN
+                | DETECT_BYTE_EXTRACT_FLAG_RELATIVE
+                | DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER
+                | DETECT_BYTE_EXTRACT_FLAG_ALIGN
+                | DETECT_BYTE_EXTRACT_FLAG_SLICE,
+        );
+    }
+}

--- a/rust/src/detect/byte_extract.rs
+++ b/rust/src/detect/byte_extract.rs
@@ -169,11 +169,10 @@ fn parse_byteextract(input: &str) -> IResult<&str, SCDetectByteExtractData, Rule
                 if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) {
                     return Err(make_error("endianess already set".to_string()));
                 }
-                byte_extract.endian = match get_endian_value(name) {
-                    Ok(val) => val,
-                    Err(_) => {
-                        return Err(make_error(format!("invalid endian value: {}", val)));
-                    }
+                if let Some(endian) = get_endian_value(name) {
+                    byte_extract.endian = endian;
+                } else {
+                    return Err(make_error(format!("invalid endian value: {}", val)));
                 };
                 byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_ENDIAN;
             }
@@ -195,11 +194,10 @@ fn parse_byteextract(input: &str) -> IResult<&str, SCDetectByteExtractData, Rule
                 if 0 != (byte_extract.flags & DETECT_BYTE_EXTRACT_FLAG_BASE) {
                     return Err(make_error("base already set".to_string()));
                 }
-                byte_extract.base = match get_string_value(name) {
-                    Ok(val) => val,
-                    Err(_) => {
-                        return Err(make_error(format!("invalid string value: {}", val)));
-                    }
+                if let Some(base) = get_string_value(name) {
+                    byte_extract.base = base;
+                } else {
+                    return Err(make_error(format!("invalid string value: {}", val)));
                 };
                 byte_extract.flags |= DETECT_BYTE_EXTRACT_FLAG_BASE;
             }

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -19,6 +19,7 @@
 
 use crate::detect::error::RuleParseError;
 use crate::detect::parser::{parse_token, take_until_whitespace};
+use crate::detect::{get_endian_value, get_string_value, ByteBase, ByteEndian};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
@@ -60,26 +61,9 @@ pub enum ByteMathOperator {
     RightShift = 7,
 }
 
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-// endian <big|little|dce>
-pub enum ByteMathEndian {
-    _EndianNone = 0,
-    BigEndian = 1,
-    LittleEndian = 2,
-    EndianDCE = 3,
-}
-pub const DETECT_BYTEMATH_ENDIAN_DEFAULT: ByteMathEndian = ByteMathEndian::BigEndian;
+pub const DETECT_BYTEMATH_ENDIAN_DEFAULT: ByteEndian = ByteEndian::BigEndian;
 
-#[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ByteMathBase {
-    _BaseNone = 0,
-    BaseOct = 8,
-    BaseDec = 10,
-    BaseHex = 16,
-}
-const BASE_DEFAULT: ByteMathBase = ByteMathBase::BaseDec;
+const BASE_DEFAULT: ByteBase = ByteBase::BaseDec;
 
 // Fixed position parameter count: bytes, offset, oper, rvalue, result
 // result is not parsed with the fixed position parameters as it's
@@ -109,8 +93,8 @@ pub struct DetectByteMathData {
     local_id: u8,
     nbytes: u8,
     oper: ByteMathOperator,
-    endian: ByteMathEndian, // big, little, dce
-    base: ByteMathBase,     // From string or dce
+    endian: ByteEndian, // big, little, dce
+    base: ByteBase,     // From string or dce
 }
 
 impl Drop for DetectByteMathData {
@@ -158,17 +142,6 @@ impl DetectByteMathData {
     }
 }
 
-fn get_string_value(value: &str) -> Result<ByteMathBase, ()> {
-    let res = match value {
-        "hex" => ByteMathBase::BaseHex,
-        "oct" => ByteMathBase::BaseOct,
-        "dec" => ByteMathBase::BaseDec,
-        _ => return Err(()),
-    };
-
-    Ok(res)
-}
-
 fn get_oper_value(value: &str) -> Result<ByteMathOperator, ()> {
     let res = match value {
         "+" => ByteMathOperator::Addition,
@@ -177,17 +150,6 @@ fn get_oper_value(value: &str) -> Result<ByteMathOperator, ()> {
         "*" => ByteMathOperator::Multiplication,
         "<<" => ByteMathOperator::LeftShift,
         ">>" => ByteMathOperator::RightShift,
-        _ => return Err(()),
-    };
-
-    Ok(res)
-}
-
-fn get_endian_value(value: &str) -> Result<ByteMathEndian, ()> {
-    let res = match value {
-        "big" => ByteMathEndian::BigEndian,
-        "little" => ByteMathEndian::LittleEndian,
-        "dce" => ByteMathEndian::EndianDCE,
         _ => return Err(()),
     };
 
@@ -310,7 +272,7 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
                     return Err(make_error("endianess already set".to_string()));
                 }
                 byte_math.flags |= DETECT_BYTEMATH_FLAG_ENDIAN;
-                byte_math.endian = ByteMathEndian::EndianDCE;
+                byte_math.endian = ByteEndian::EndianDCE;
             }
             "string" => {
                 if 0 != (byte_math.flags & DETECT_BYTEMATH_FLAG_STRING) {
@@ -491,8 +453,9 @@ mod tests {
     }
 
     fn valid_test(
-        args: &str, nbytes: u8, offset: i32, oper: ByteMathOperator, rvalue_str: &str, nbytes_str: &str, rvalue: u32,
-        result: &str, base: ByteMathBase, endian: ByteMathEndian, bitmask_val: u32, flags: u8,
+        args: &str, nbytes: u8, offset: i32, oper: ByteMathOperator, rvalue_str: &str,
+        nbytes_str: &str, rvalue: u32, result: &str, base: ByteBase, endian: ByteEndian,
+        bitmask_val: u32, flags: u8,
     ) {
         let bmd = DetectByteMathData {
             nbytes,
@@ -532,8 +495,8 @@ mod tests {
             "",
             0,
             "myresult",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::EndianDCE,
+            ByteBase::BaseDec,
+            ByteEndian::EndianDCE,
             0,
             DETECT_BYTEMATH_FLAG_RVALUE_VAR
                 | DETECT_BYTEMATH_FLAG_STRING
@@ -549,8 +512,8 @@ mod tests {
             "",
             99,
             "other",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::EndianDCE,
+            ByteBase::BaseDec,
+            ByteEndian::EndianDCE,
             0,
             DETECT_BYTEMATH_FLAG_STRING | DETECT_BYTEMATH_FLAG_ENDIAN,
         );
@@ -565,7 +528,7 @@ mod tests {
             0,
             "foo",
             BASE_DEFAULT,
-            ByteMathEndian::BigEndian,
+            ByteEndian::BigEndian,
             0,
             DETECT_BYTEMATH_FLAG_RVALUE_VAR,
         );
@@ -580,7 +543,7 @@ mod tests {
             0,
             "foo",
             BASE_DEFAULT,
-            ByteMathEndian::BigEndian,
+            ByteEndian::BigEndian,
             0,
             DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_NBYTES_VAR,
         );
@@ -595,8 +558,8 @@ mod tests {
             "",
             99,
             "other",
-            ByteMathBase::BaseDec,
-            ByteMathEndian::BigEndian,
+            ByteBase::BaseDec,
+            ByteEndian::BigEndian,
             0,
             DETECT_BYTEMATH_FLAG_STRING | DETECT_BYTEMATH_FLAG_ENDIAN,
         );
@@ -612,53 +575,50 @@ mod tests {
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
             endian: DETECT_BYTEMATH_ENDIAN_DEFAULT,
-            base: ByteMathBase::BaseDec,
+            base: ByteBase::BaseDec,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING,
             ..Default::default()
         };
 
-        let (_, val) = parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string dec",
-        ).unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string dec")
+                .unwrap();
         assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
         bmd.base = BASE_DEFAULT;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING;
-        bmd.base = ByteMathBase::BaseHex;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex").unwrap();
+        bmd.base = ByteBase::BaseHex;
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex")
+                .unwrap();
         assert_eq!(val, bmd);
 
-        bmd.base = ByteMathBase::BaseOct;
-        let (_, val) = parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct",
-        ).unwrap();
+        bmd.base = ByteBase::BaseOct;
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct")
+                .unwrap();
         assert_eq!(val, bmd);
     }
 
     #[test]
     fn test_parser_string_invalid() {
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string decimal"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hexadecimal"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string octal"
-            )
-            .is_err()
-        );
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string decimal"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hexadecimal"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string octal"
+        )
+        .is_err());
     }
 
     #[test]
@@ -680,50 +640,38 @@ mod tests {
 
     #[test]
     fn test_parser_bitmask_invalid() {
-        assert!(
-            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x")
-                .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask x12345678"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask X12345678"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x123456789012"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0q")
-                .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask maple"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0xGHIJKLMN"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask #*#*@-"
-            )
-            .is_err()
-        );
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask x12345678"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask X12345678"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x123456789012"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0q"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask maple"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0xGHIJKLMN"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask #*#*@-"
+        )
+        .is_err());
     }
 
     #[test]
@@ -735,7 +683,7 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteEndian::BigEndian,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_BITMASK,
             ..Default::default()
@@ -744,23 +692,23 @@ mod tests {
         bmd.bitmask_val = 0x12345678;
         let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x12345678",
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(val, bmd);
-
 
         bmd.bitmask_val = 0xffff1234;
         let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask ffff1234",
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(val, bmd);
-
 
         bmd.bitmask_val = 0xffff1234;
         let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0Xffff1234",
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(val, bmd);
-
     }
     #[test]
     fn test_parser_endian_valid() {
@@ -771,71 +719,61 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteEndian::BigEndian,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_ENDIAN,
             ..Default::default()
         };
 
-        let (_, val) = parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big",
-        ).unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big")
+                .unwrap();
         assert_eq!(val, bmd);
 
-
-        bmd.endian = ByteMathEndian::LittleEndian;
+        bmd.endian = ByteEndian::LittleEndian;
         let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian little",
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(val, bmd);
 
-
-        bmd.endian = ByteMathEndian::EndianDCE;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce").unwrap();
+        bmd.endian = ByteEndian::EndianDCE;
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce")
+                .unwrap();
         assert_eq!(val, bmd);
-
 
         bmd.endian = DETECT_BYTEMATH_ENDIAN_DEFAULT;
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
-
     }
 
     #[test]
     fn test_parser_endian_invalid() {
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian bigger"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian smaller"
-            )
-            .is_err()
-        );
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian bigger"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian smaller"
+        )
+        .is_err());
 
         // endianess can only be specified once
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big, dce"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, endian big"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, dce"
-            )
-            .is_err()
-        );
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big, dce"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, endian big"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian small, dce"
+        )
+        .is_err());
     }
 
     #[test]
@@ -847,59 +785,50 @@ mod tests {
             rvalue_str: CString::new("myrvalue").unwrap().into_raw(),
             rvalue: 0,
             result: CString::new("foo").unwrap().into_raw(),
-            endian: ByteMathEndian::BigEndian,
+            endian: ByteEndian::BigEndian,
             base: BASE_DEFAULT,
             flags: DETECT_BYTEMATH_FLAG_RVALUE_VAR,
             ..Default::default()
         };
 
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
-
 
         bmd.oper = ByteMathOperator::Subtraction;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
 
-
         bmd.oper = ByteMathOperator::Multiplication;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
 
         bmd.oper = ByteMathOperator::Division;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
 
         bmd.oper = ByteMathOperator::RightShift;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
 
         bmd.oper = ByteMathOperator::LeftShift;
-        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
-
     }
 
     #[test]
     fn test_parser_oper_invalid() {
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper !, rvalue myvalue, result foo").is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper ^, rvalue myvalue, result foo").is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper <>, rvalue myvalue, result foo").is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper ><, rvalue myvalue, result foo").is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper <, rvalue myvalue, result foo").is_err()
-        );
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper >, rvalue myvalue, result foo").is_err()
-        );
+        assert!(parse_bytemath("bytes 4, offset 0, oper !, rvalue myvalue, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper ^, rvalue myvalue, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper <>, rvalue myvalue, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper ><, rvalue myvalue, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper <, rvalue myvalue, result foo").is_err());
+        assert!(parse_bytemath("bytes 4, offset 0, oper >, rvalue myvalue, result foo").is_err());
     }
 
     #[test]
@@ -916,18 +845,20 @@ mod tests {
             ..Default::default()
         };
 
-        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo")
+                .unwrap();
         assert_eq!(val, bmd);
 
-
         bmd.rvalue = 1;
-        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo").unwrap();
         assert_eq!(val, bmd);
 
         bmd.rvalue = 0;
-        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo").unwrap();
         assert_eq!(val, bmd);
-
     }
 
     #[test]
@@ -952,14 +883,14 @@ mod tests {
             ..Default::default()
         };
 
-        let (_, val) = parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
-
 
         bmd.offset = 65535;
-        let (_, val) = parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo").unwrap();
+        let (_, val) =
+            parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo").unwrap();
         assert_eq!(val, bmd);
-
     }
 
     #[test]
@@ -993,9 +924,7 @@ mod tests {
             parse_bytemath("bytes 4, offset 3933, endian big, rvalue myrvalue, result foo")
                 .is_err()
         );
-        assert!(
-            parse_bytemath("bytes 4, offset 3933, oper +, endian big, result foo").is_err()
-        );
+        assert!(parse_bytemath("bytes 4, offset 3933, oper +, endian big, result foo").is_err());
         assert!(
             parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, endian big").is_err()
         );
@@ -1007,35 +936,30 @@ mod tests {
         assert!(parse_bytemath("bytes nan").is_err());
         assert!(parse_bytemath("bytes 4, offset nan").is_err());
         assert!(parse_bytemath("bytes 4, offset 0, three 3, four 4, five 5, six 6, seven 7, eight 8, nine 9, ten 10, eleven 11").is_err());
-        assert!(
-            parse_bytemath("bytes 4, offset 0, oper ><, rvalue myrvalue").is_err()
-        );
+        assert!(parse_bytemath("bytes 4, offset 0, oper ><, rvalue myrvalue").is_err());
         assert!(
             parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, endian endian").is_err()
         );
     }
     #[test]
     fn test_parser_multiple() {
-        assert!(
-            parse_bytemath(
-                "bytes 4, bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 0, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
-            )
-            .is_err()
-        );
-        assert!(
-            parse_bytemath(
-                "bytes 4, offset 0, oper +, oper +, rvalue myrvalue, result myresult, endian big"
-            )
-            .is_err()
-        );
+        assert!(parse_bytemath(
+            "bytes 4, bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 0, offset 0, oper +, rvalue myrvalue, result myresult, endian big"
+        )
+        .is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 0, oper +, oper +, rvalue myrvalue, result myresult, endian big"
+        )
+        .is_err());
         assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, rvalue myrvalue, result myresult, endian big").is_err());
         assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, result myresult, endian big").is_err());
-        assert!(parse_bytemath("bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big, endian big").is_err());
+        assert!(parse_bytemath(
+            "bytes 4, offset 0, oper +, rvalue myrvalue, result myresult, endian big, endian big"
+        )
+        .is_err());
     }
 }

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -259,11 +259,10 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
                 if 0 != (byte_math.flags & DETECT_BYTEMATH_FLAG_ENDIAN) {
                     return Err(make_error("endianess already set".to_string()));
                 }
-                byte_math.endian = match get_endian_value(val) {
-                    Ok(val) => val,
-                    Err(_) => {
-                        return Err(make_error(format!("invalid endian value: {}", val)));
-                    }
+                if let Some(endian) = get_endian_value(val) {
+                    byte_math.endian = endian;
+                } else {
+                    return Err(make_error(format!("invalid endian value: {}", val)));
                 };
                 byte_math.flags |= DETECT_BYTEMATH_FLAG_ENDIAN;
             }
@@ -278,11 +277,10 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
                 if 0 != (byte_math.flags & DETECT_BYTEMATH_FLAG_STRING) {
                     return Err(make_error("string already set".to_string()));
                 }
-                byte_math.base = match get_string_value(val) {
-                    Ok(val) => val,
-                    Err(_) => {
-                        return Err(make_error(format!("invalid string value: {}", val)));
-                    }
+                if let Some(base) = get_string_value(val) {
+                    byte_math.base = base;
+                } else {
+                    return Err(make_error(format!("invalid string value: {}", val)));
                 };
                 byte_math.flags |= DETECT_BYTEMATH_FLAG_STRING;
             }

--- a/rust/src/detect/error.rs
+++ b/rust/src/detect/error.rs
@@ -23,6 +23,7 @@ use nom7::error::{ErrorKind, ParseError};
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuleParseError<I> {
     InvalidByteMath(String),
+    InvalidByteExtract(String),
 
     Nom(I, ErrorKind),
 }

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -21,10 +21,10 @@ pub mod byte_math;
 pub mod error;
 pub mod iprep;
 pub mod parser;
+pub mod requires;
 pub mod stream_size;
 pub mod uint;
 pub mod uri;
-pub mod requires;
 pub mod tojson;
 
 /// EnumString trait that will be implemented on enums that
@@ -41,6 +41,46 @@ pub trait EnumString<T> {
 
     /// Get an enum variant from parsing a string.
     fn from_str(s: &str) -> Option<Self> where Self: Sized;
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+// endian <big|little|dce>
+pub enum ByteEndian {
+    BigEndian = 1,
+    LittleEndian = 2,
+    EndianDCE = 3,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ByteBase {
+    _BaseNone = 0,
+    BaseOct = 8,
+    BaseDec = 10,
+    BaseHex = 16,
+}
+
+fn get_string_value(value: &str) -> Result<ByteBase, ()> {
+    let res = match value {
+        "hex" => ByteBase::BaseHex,
+        "oct" => ByteBase::BaseOct,
+        "dec" => ByteBase::BaseDec,
+        _ => return Err(()),
+    };
+
+    Ok(res)
+}
+
+fn get_endian_value(value: &str) -> Result<ByteEndian, ()> {
+    let res = match value {
+        "big" => ByteEndian::BigEndian,
+        "little" => ByteEndian::LittleEndian,
+        "dce" => ByteEndian::EndianDCE,
+        _ => return Err(()),
+    };
+
+    Ok(res)
 }
 
 #[cfg(test)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -17,6 +17,7 @@
 
 //! Module for rule parsing.
 
+pub mod byte_extract;
 pub mod byte_math;
 pub mod error;
 pub mod iprep;

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -62,26 +62,26 @@ pub enum ByteBase {
     BaseHex = 16,
 }
 
-fn get_string_value(value: &str) -> Result<ByteBase, ()> {
+fn get_string_value(value: &str) -> Option<ByteBase> {
     let res = match value {
-        "hex" => ByteBase::BaseHex,
-        "oct" => ByteBase::BaseOct,
-        "dec" => ByteBase::BaseDec,
-        _ => return Err(()),
+        "hex" => Some(ByteBase::BaseHex),
+        "oct" => Some(ByteBase::BaseOct),
+        "dec" => Some(ByteBase::BaseDec),
+        _ => None,
     };
 
-    Ok(res)
+    res
 }
 
-fn get_endian_value(value: &str) -> Result<ByteEndian, ()> {
+fn get_endian_value(value: &str) -> Option<ByteEndian> {
     let res = match value {
-        "big" => ByteEndian::BigEndian,
-        "little" => ByteEndian::LittleEndian,
-        "dce" => ByteEndian::EndianDCE,
-        _ => return Err(()),
+        "big" => Some(ByteEndian::BigEndian),
+        "little" => Some(ByteEndian::LittleEndian),
+        "dce" => Some(ByteEndian::EndianDCE),
+        _ => None,
     };
 
-    Ok(res)
+    res
 }
 
 #[cfg(test)]

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -22,14 +22,10 @@
  */
 
 #include "suricata-common.h"
-#include "threads.h"
 #include "decode.h"
 
 #include "detect.h"
-#include "detect-parse.h"
 #include "detect-engine.h"
-#include "detect-engine-mpm.h"
-#include "detect-engine-state.h"
 #include "detect-content.h"
 #include "detect-pcre.h"
 #include "detect-bytejump.h"
@@ -38,27 +34,21 @@
 #include "detect-isdataat.h"
 #include "detect-engine-build.h"
 
-#include "app-layer-protos.h"
+#include "rust.h"
 
-#include "flow.h"
-#include "flow-var.h"
-#include "flow-util.h"
+#include "app-layer-protos.h"
 
 #include "util-byte.h"
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
-#include "util-spm.h"
-
-/* the default value of endianness to be used, if none's specified */
-#define DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT DETECT_BYTE_EXTRACT_ENDIAN_BIG
 
 /* the base to be used if string mode is specified.  These options would be
  * specified in DetectByteParseData->base */
 #define DETECT_BYTE_EXTRACT_BASE_NONE 0
-#define DETECT_BYTE_EXTRACT_BASE_HEX  16
-#define DETECT_BYTE_EXTRACT_BASE_DEC  10
-#define DETECT_BYTE_EXTRACT_BASE_OCT   8
+#define DETECT_BYTE_EXTRACT_BASE_HEX  (uint8_t) BaseHex
+#define DETECT_BYTE_EXTRACT_BASE_DEC  (uint8_t) BaseDec
+#define DETECT_BYTE_EXTRACT_BASE_OCT  (uint8_t) BaseOct
 
 /* the default value for multiplier.  Either ways we always store a
  * multiplier, 1 or otherwise, so that we can always multiply the extracted
@@ -75,19 +65,6 @@
 #define STRING_MAX_BYTES_TO_EXTRACT_FOR_HEX 14
 /* the max no of bytes that can be extracted in non-string mode */
 #define NO_STRING_MAX_BYTES_TO_EXTRACT 8
-
-#define PARSE_REGEX "^"                                                  \
-    "\\s*([0-9]+)\\s*"                                                   \
-    ",\\s*(-?[0-9]+)\\s*"                                               \
-    ",\\s*([^\\s,]+)\\s*"                                                \
-    "(?:(?:,\\s*([^\\s,]+)\\s*)|(?:,\\s*([^\\s,]+)\\s+([^\\s,]+)\\s*))?" \
-    "(?:(?:,\\s*([^\\s,]+)\\s*)|(?:,\\s*([^\\s,]+)\\s+([^\\s,]+)\\s*))?" \
-    "(?:(?:,\\s*([^\\s,]+)\\s*)|(?:,\\s*([^\\s,]+)\\s+([^\\s,]+)\\s*))?" \
-    "(?:(?:,\\s*([^\\s,]+)\\s*)|(?:,\\s*([^\\s,]+)\\s+([^\\s,]+)\\s*))?" \
-    "(?:(?:,\\s*([^\\s,]+)\\s*)|(?:,\\s*([^\\s,]+)\\s+([^\\s,]+)\\s*))?" \
-    "$"
-
-static DetectParseRegex parse_regex;
 
 static int DetectByteExtractSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
@@ -109,19 +86,12 @@ void DetectByteExtractRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_BYTE_EXTRACT].RegisterTests = DetectByteExtractRegisterTests;
 #endif
-    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }
 
 int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData *smd,
         const Signature *s, const uint8_t *payload, uint32_t payload_len, uint64_t *value,
         uint8_t endian)
 {
-    DetectByteExtractData *data = (DetectByteExtractData *)smd->ctx;
-    const uint8_t *ptr = NULL;
-    int32_t len = 0;
-    uint64_t val = 0;
-    int extbytes;
-
     if (payload_len == 0) {
         return 0;
     }
@@ -129,6 +99,9 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
     /* Calculate the ptr value for the bytetest and length remaining in
      * the packet from that point.
      */
+    const uint8_t *ptr;
+    int32_t len;
+    SCDetectByteExtractData *data = (SCDetectByteExtractData *)smd->ctx;
     if (data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
         SCLogDebug("relative, working with det_ctx->buffer_offset %"PRIu32", "
                    "data->offset %"PRIu32"", det_ctx->buffer_offset, data->offset);
@@ -159,6 +132,8 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
     }
 
     /* Extract the byte data */
+    uint64_t val = 0;
+    int extbytes;
     if (data->flags & DETECT_BYTE_EXTRACT_FLAG_STRING) {
         extbytes = ByteExtractStringUint64(&val, data->base,
                                            data->nbytes, (const char *)ptr);
@@ -174,8 +149,7 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
             }
         }
     } else {
-        int endianness = (endian == DETECT_BYTE_EXTRACT_ENDIAN_BIG) ?
-                          BYTE_BIG_ENDIAN : BYTE_LITTLE_ENDIAN;
+        int endianness = (endian == BigEndian) ? BYTE_BIG_ENDIAN : BYTE_LITTLE_ENDIAN;
         extbytes = ByteExtractUint64(&val, endianness, data->nbytes, ptr);
         if (extbytes != data->nbytes) {
             SCLogDebug("error extracting %d bytes of numeric data: %d",
@@ -211,255 +185,20 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
  * \param bed On success an instance containing the parsed data.
  *            On failure, NULL.
  */
-static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_ctx, const char *arg)
+static inline SCDetectByteExtractData *DetectByteExtractParse(
+        DetectEngineCtx *de_ctx, const char *arg)
 {
-    DetectByteExtractData *bed = NULL;
-    int res = 0;
-    size_t pcre2len;
-    int i = 0;
-    pcre2_match_data *match = NULL;
-
-    int ret = DetectParsePcreExec(&parse_regex, &match, arg, 0, 0);
-    if (ret < 3 || ret > 19) {
-        SCLogError("parse error, ret %" PRId32 ", string \"%s\"", ret, arg);
-        SCLogError("Invalid arg to byte_extract : %s "
-                   "for byte_extract",
-                arg);
+    SCDetectByteExtractData *bed = SCByteExtractParse(arg);
+    if (bed == NULL) {
+        SCLogError("invalid byte_extract values");
         goto error;
     }
 
-    bed = SCCalloc(1, sizeof(DetectByteExtractData));
-    if (unlikely(bed == NULL))
-        goto error;
-
-    /* no of bytes to extract */
-    char nbytes_str[64] = "";
-    pcre2len = sizeof(nbytes_str);
-    res = pcre2_substring_copy_bynumber(match, 1, (PCRE2_UCHAR8 *)nbytes_str, &pcre2len);
-    if (res < 0) {
-        SCLogError("pcre2_substring_copy_bynumber failed "
-                   "for arg 1 for byte_extract");
+    if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_SLICE) {
+        SCLogError("byte_extract slice not yet supported");
         goto error;
     }
-    if (StringParseUint8(&bed->nbytes, 10, 0,
-                               (const char *)nbytes_str) < 0) {
-        SCLogError("Invalid value for number of bytes"
-                   " to be extracted: \"%s\".",
-                nbytes_str);
-        goto error;
-    }
-
-    /* offset */
-    char offset_str[64] = "";
-    pcre2len = sizeof(offset_str);
-    res = pcre2_substring_copy_bynumber(match, 2, (PCRE2_UCHAR8 *)offset_str, &pcre2len);
-    if (res < 0) {
-        SCLogError("pcre2_substring_copy_bynumber failed "
-                   "for arg 2 for byte_extract");
-        goto error;
-    }
-    int32_t offset;
-    if (StringParseI32RangeCheck(&offset, 10, 0, (const char *)offset_str, -65535, 65535) < 0) {
-        SCLogError("Invalid value for offset: \"%s\".", offset_str);
-        goto error;
-    }
-    bed->offset = offset;
-
-    /* var name */
-    char varname_str[256] = "";
-    pcre2len = sizeof(varname_str);
-    res = pcre2_substring_copy_bynumber(match, 3, (PCRE2_UCHAR8 *)varname_str, &pcre2len);
-    if (res < 0) {
-        SCLogError("pcre2_substring_copy_bynumber failed "
-                   "for arg 3 for byte_extract");
-        goto error;
-    }
-    bed->name = SCStrdup(varname_str);
-    if (bed->name == NULL)
-        goto error;
-
-    /* check out other optional args */
-    for (i = 4; i < ret; i++) {
-        char opt_str[64] = "";
-        pcre2len = sizeof(opt_str);
-        res = SC_Pcre2SubstringCopy(match, i, (PCRE2_UCHAR8 *)opt_str, &pcre2len);
-        if (res < 0) {
-            SCLogError("pcre2_substring_copy_bynumber failed "
-                       "for arg %d for byte_extract with %d",
-                    i, res);
-            goto error;
-        }
-
-        if (strcmp("relative", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
-                SCLogError("relative specified more "
-                           "than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_RELATIVE;
-        } else if (strcmp("multiplier", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) {
-                SCLogError("multiplier specified more "
-                           "than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER;
-            i++;
-
-            char multiplier_str[16] = "";
-            pcre2len = sizeof(multiplier_str);
-            res = pcre2_substring_copy_bynumber(
-                    match, i, (PCRE2_UCHAR8 *)multiplier_str, &pcre2len);
-            if (res < 0) {
-                SCLogError("pcre2_substring_copy_bynumber failed "
-                           "for arg %d for byte_extract",
-                        i);
-                goto error;
-            }
-            uint16_t multiplier;
-            if (StringParseU16RangeCheck(&multiplier, 10, 0, (const char *)multiplier_str,
-                        DETECT_BYTE_EXTRACT_MULTIPLIER_MIN_LIMIT,
-                        DETECT_BYTE_EXTRACT_MULTIPLIER_MAX_LIMIT) < 0) {
-                SCLogError("Invalid value for"
-                           "multiplier: \"%s\".",
-                        multiplier_str);
-                goto error;
-            }
-            bed->multiplier_value = multiplier;
-        } else if (strcmp("big", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) {
-                SCLogError("endian option specified "
-                           "more than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_ENDIAN;
-            bed->endian = DETECT_BYTE_EXTRACT_ENDIAN_BIG;
-        } else if (strcmp("little", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) {
-                SCLogError("endian option specified "
-                           "more than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_ENDIAN;
-            bed->endian = DETECT_BYTE_EXTRACT_ENDIAN_LITTLE;
-        } else if (strcmp("dce", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) {
-                SCLogError("endian option specified "
-                           "more than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_ENDIAN;
-            bed->endian = DETECT_BYTE_EXTRACT_ENDIAN_DCE;
-        } else if (strcmp("string", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_STRING) {
-                SCLogError("string specified more "
-                           "than once for byte_extract");
-                goto error;
-            }
-            if (bed->base != DETECT_BYTE_EXTRACT_BASE_NONE) {
-                SCLogError("The right way to specify "
-                           "base is (string, base) and not (base, string) "
-                           "for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_STRING;
-        } else if (strcmp("hex", opt_str) == 0) {
-            if (!(bed->flags & DETECT_BYTE_EXTRACT_FLAG_STRING)) {
-                SCLogError("Base(hex) specified "
-                           "without specifying string.  The right way is "
-                           "(string, base) and not (base, string)");
-                goto error;
-            }
-            if (bed->base != DETECT_BYTE_EXTRACT_BASE_NONE) {
-                SCLogError("More than one base "
-                           "specified for byte_extract");
-                goto error;
-            }
-            bed->base = DETECT_BYTE_EXTRACT_BASE_HEX;
-        } else if (strcmp("oct", opt_str) == 0) {
-            if (!(bed->flags & DETECT_BYTE_EXTRACT_FLAG_STRING)) {
-                SCLogError("Base(oct) specified "
-                           "without specifying string.  The right way is "
-                           "(string, base) and not (base, string)");
-                goto error;
-            }
-            if (bed->base != DETECT_BYTE_EXTRACT_BASE_NONE) {
-                SCLogError("More than one base "
-                           "specified for byte_extract");
-                goto error;
-            }
-            bed->base = DETECT_BYTE_EXTRACT_BASE_OCT;
-        } else if (strcmp("dec", opt_str) == 0) {
-            if (!(bed->flags & DETECT_BYTE_EXTRACT_FLAG_STRING)) {
-                SCLogError("Base(dec) specified "
-                           "without specifying string.  The right way is "
-                           "(string, base) and not (base, string)");
-                goto error;
-            }
-            if (bed->base != DETECT_BYTE_EXTRACT_BASE_NONE) {
-                SCLogError("More than one base "
-                           "specified for byte_extract");
-                goto error;
-            }
-            bed->base = DETECT_BYTE_EXTRACT_BASE_DEC;
-        } else if (strcmp("align", opt_str) == 0) {
-            if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_ALIGN) {
-                SCLogError("Align specified more "
-                           "than once for byte_extract");
-                goto error;
-            }
-            bed->flags |= DETECT_BYTE_EXTRACT_FLAG_ALIGN;
-            i++;
-
-            char align_str[16] = "";
-            pcre2len = sizeof(align_str);
-            res = pcre2_substring_copy_bynumber(match, i, (PCRE2_UCHAR8 *)align_str, &pcre2len);
-            if (res < 0) {
-                SCLogError("pcre2_substring_copy_bynumber failed "
-                           "for arg %d in byte_extract",
-                        i);
-                goto error;
-            }
-            if (StringParseUint8(&bed->align_value, 10, 0,
-                                       (const char *)align_str) < 0) {
-                SCLogError("Invalid align_value: "
-                           "\"%s\".",
-                        align_str);
-                goto error;
-            }
-            if (!(bed->align_value == 2 || bed->align_value == 4)) {
-                SCLogError("Invalid align_value for "
-                           "byte_extract - \"%d\"",
-                        bed->align_value);
-                goto error;
-            }
-        } else if (strcmp("", opt_str) == 0) {
-            ;
-        } else {
-            SCLogError("Invalid option - \"%s\" "
-                       "specified in byte_extract",
-                    opt_str);
-            goto error;
-        }
-    } /* for (i = 4; i < ret; i++) */
-
-    /* validation */
-    if (!(bed->flags & DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER)) {
-        /* default value */
-        bed->multiplier_value = DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT;
-    }
-
     if (bed->flags & DETECT_BYTE_EXTRACT_FLAG_STRING) {
-        if (bed->base == DETECT_BYTE_EXTRACT_BASE_NONE) {
-            /* Default to decimal if base not specified. */
-            bed->base = DETECT_BYTE_EXTRACT_BASE_DEC;
-        }
-        if (bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE) {
-            SCLogError("byte_extract can't have "
-                       "endian \"big\" or \"little\" specified along with "
-                       "\"string\"");
-            goto error;
-        }
         if (bed->base == DETECT_BYTE_EXTRACT_BASE_OCT) {
             /* if are dealing with octal nos, the max no that can fit in a 8
              * byte value is 01777777777777777777777 */
@@ -500,18 +239,13 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
         /* if string has not been specified and no endian option has been
          * specified, then set the default endian level of BIG */
         if (!(bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN))
-            bed->endian = DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT;
+            bed->endian = BigEndian;
     }
-
-    pcre2_match_data_free(match);
-
     return bed;
+
  error:
     if (bed != NULL)
         DetectByteExtractFree(de_ctx, bed);
-    if (match) {
-        pcre2_match_data_free(match);
-    }
     return NULL;
 }
 
@@ -531,7 +265,7 @@ static inline DetectByteExtractData *DetectByteExtractParse(DetectEngineCtx *de_
 static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
     SigMatch *prev_pm = NULL;
-    DetectByteExtractData *data = NULL;
+    SCDetectByteExtractData *data = NULL;
     int ret = -1;
 
     data = DetectByteExtractParse(de_ctx, arg);
@@ -545,7 +279,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         if (data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
             prev_pm = DetectGetLastSMFromLists(s, DETECT_CONTENT, DETECT_PCRE, -1);
         }
-    } else if (data->endian == DETECT_BYTE_EXTRACT_ENDIAN_DCE) {
+    } else if (data->endian == EndianDCE) {
         if (data->flags & DETECT_BYTE_EXTRACT_FLAG_RELATIVE) {
             prev_pm = DetectGetLastSMFromLists(s, DETECT_CONTENT, DETECT_PCRE,
                     DETECT_BYTETEST, DETECT_BYTEJUMP, DETECT_BYTE_EXTRACT,
@@ -581,14 +315,12 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
         sm_list = DETECT_SM_LIST_PMATCH;
     }
 
-    if (data->endian == DETECT_BYTE_EXTRACT_ENDIAN_DCE) {
+    if (data->endian == EndianDCE) {
         if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) != 0)
             goto error;
 
-        if ((data->flags & DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-            (data->base == DETECT_BYTE_EXTRACT_BASE_DEC) ||
-            (data->base == DETECT_BYTE_EXTRACT_BASE_HEX) ||
-            (data->base == DETECT_BYTE_EXTRACT_BASE_OCT) ) {
+        if ((DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING) ==
+                (data->flags & (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING))) {
             SCLogError("Invalid option. "
                        "A byte_jump keyword with dce holds other invalid modifiers.");
             goto error;
@@ -600,7 +332,7 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     if (prev_bed_sm == NULL)
         data->local_id = 0;
     else
-        data->local_id = ((DetectByteExtractData *)prev_bed_sm->ctx)->local_id + 1;
+        data->local_id = ((SCDetectByteExtractData *)prev_bed_sm->ctx)->local_id + 1;
     if (data->local_id > de_ctx->byte_extract_max_local_id)
         de_ctx->byte_extract_max_local_id = data->local_id;
 
@@ -632,20 +364,13 @@ static int DetectByteExtractSetup(DetectEngineCtx *de_ctx, Signature *s, const c
 }
 
 /**
- * \brief Used to free instances of DetectByteExtractData.
+ * \brief Used to free instances of SCDetectByteExtractData.
  *
- * \param ptr Instance of DetectByteExtractData to be freed.
+ * \param ptr Instance of SCDetectByteExtractData to be freed.
  */
 static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    if (ptr != NULL) {
-        DetectByteExtractData *bed = ptr;
-        if (bed->name != NULL)
-            SCFree((void *)bed->name);
-        SCFree(bed);
-    }
-
-    return;
+    SCByteExtractFree(ptr);
 }
 
 /**
@@ -662,7 +387,7 @@ SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, const Signature *s)
         SigMatch *sm = s->init_data->buffers[x].head;
         while (sm != NULL) {
             if (sm->type == DETECT_BYTE_EXTRACT) {
-                const DetectByteExtractData *bed = (const DetectByteExtractData *)sm->ctx;
+                const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
                 if (strcmp(bed->name, arg) == 0) {
                     return sm;
                 }
@@ -675,7 +400,7 @@ SigMatch *DetectByteExtractRetrieveSMVar(const char *arg, const Signature *s)
         SigMatch *sm = s->init_data->smlists[list];
         while (sm != NULL) {
             if (sm->type == DETECT_BYTE_EXTRACT) {
-                const DetectByteExtractData *bed = (const DetectByteExtractData *)sm->ctx;
+                const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)sm->ctx;
                 if (strcmp(bed->name, arg) == 0) {
                     return sm;
                 }
@@ -698,18 +423,13 @@ static int DetectByteExtractTest01(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != 0 ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 || bed->flags != 0 ||
+            bed->endian != BigEndian || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -724,18 +444,14 @@ static int DetectByteExtractTest02(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, relative");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, relative");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_RELATIVE ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_RELATIVE || bed->endian != BigEndian ||
+            bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -750,18 +466,13 @@ static int DetectByteExtractTest03(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, multiplier 10");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, multiplier 10");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != 10) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER || bed->endian != BigEndian ||
+            bed->align_value != 0 || bed->multiplier_value != 10) {
         goto end;
     }
 
@@ -776,19 +487,15 @@ static int DetectByteExtractTest04(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, relative, multiplier 10");
+    SCDetectByteExtractData *bed =
+            DetectByteExtractParse(NULL, "4, 2, one, relative, multiplier 10");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != 10) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags !=
+                    (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) ||
+            bed->endian != BigEndian || bed->align_value != 0 || bed->multiplier_value != 10) {
         goto end;
     }
 
@@ -803,18 +510,14 @@ static int DetectByteExtractTest05(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, big");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, big");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_BIG ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN || bed->endian != BigEndian ||
+            bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -829,18 +532,14 @@ static int DetectByteExtractTest06(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, little");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, little");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_LITTLE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN || bed->endian != LittleEndian ||
+            bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -855,18 +554,14 @@ static int DetectByteExtractTest07(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, dce");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, dce");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DCE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_ENDIAN || bed->endian != EndianDCE ||
+            bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -881,18 +576,14 @@ static int DetectByteExtractTest08(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, hex");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, hex");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -907,18 +598,14 @@ static int DetectByteExtractTest09(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, oct");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, oct");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_OCT ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_OCT || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -933,18 +620,13 @@ static int DetectByteExtractTest10(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, dec");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string, dec");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_DEC ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_DEC || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -959,18 +641,14 @@ static int DetectByteExtractTest11(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_ALIGN ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != DETECT_BYTE_EXTRACT_FLAG_ALIGN || bed->endian != BigEndian ||
+            bed->align_value != 4 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -985,19 +663,14 @@ static int DetectByteExtractTest12(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN |
-                       DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN | DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed->endian != BigEndian || bed->align_value != 4 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1012,20 +685,16 @@ static int DetectByteExtractTest13(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, big");
+    SCDetectByteExtractData *bed =
+            DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, big");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN |
-                       DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
-                       DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_BIG ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN | DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
+                                  DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed->endian != BigEndian || bed->align_value != 4 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1040,20 +709,16 @@ static int DetectByteExtractTest14(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, dce");
+    SCDetectByteExtractData *bed =
+            DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, dce");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN |
-                       DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
-                       DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DCE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN | DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
+                                  DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed->endian != EndianDCE || bed->align_value != 4 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1068,20 +733,16 @@ static int DetectByteExtractTest15(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little");
+    SCDetectByteExtractData *bed =
+            DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN |
-                       DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
-                       DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_LITTLE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN | DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
+                                  DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed->endian != LittleEndian || bed->align_value != 4 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1096,21 +757,16 @@ static int DetectByteExtractTest16(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little, multiplier 2");
+    SCDetectByteExtractData *bed =
+            DetectByteExtractParse(NULL, "4, 2, one, align 4, relative, little, multiplier 2");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN |
-                       DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
-                       DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_LITTLE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 4 ||
-        bed->multiplier_value != 2) {
+    if (bed->nbytes != 4 || bed->offset != 2 || strcmp(bed->name, "one") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_ALIGN | DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
+                                  DETECT_BYTE_EXTRACT_FLAG_ENDIAN |
+                                  DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER) ||
+            bed->endian != LittleEndian || bed->align_value != 4 || bed->multiplier_value != 2) {
         goto end;
     }
 
@@ -1125,9 +781,9 @@ static int DetectByteExtractTest17(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "relative, little, "
-                                                        "multiplier 2, string hex");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "relative, little, "
+                                                                "multiplier 2, string hex");
     if (bed != NULL)
         goto end;
 
@@ -1142,10 +798,10 @@ static int DetectByteExtractTest18(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "relative, little, "
-                                                        "multiplier 2, "
-                                                        "relative");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "relative, little, "
+                                                                "multiplier 2, "
+                                                                "relative");
     if (bed != NULL)
         goto end;
 
@@ -1160,10 +816,10 @@ static int DetectByteExtractTest19(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "relative, little, "
-                                                        "multiplier 2, "
-                                                        "little");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "relative, little, "
+                                                                "multiplier 2, "
+                                                                "little");
     if (bed != NULL)
         goto end;
 
@@ -1178,10 +834,10 @@ static int DetectByteExtractTest20(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "relative, "
-                                                        "multiplier 2, "
-                                                        "align 2");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "relative, "
+                                                                "multiplier 2, "
+                                                                "align 2");
     if (bed != NULL)
         goto end;
 
@@ -1196,10 +852,10 @@ static int DetectByteExtractTest21(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "multiplier 2, "
-                                                        "relative, "
-                                                        "multiplier 2");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "multiplier 2, "
+                                                                "relative, "
+                                                                "multiplier 2");
     if (bed != NULL)
         goto end;
 
@@ -1214,10 +870,10 @@ static int DetectByteExtractTest22(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "string hex, "
-                                                        "relative, "
-                                                        "string hex");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "string hex, "
+                                                                "relative, "
+                                                                "string hex");
     if (bed != NULL)
         goto end;
 
@@ -1232,10 +888,10 @@ static int DetectByteExtractTest23(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "string hex, "
-                                                        "relative, "
-                                                        "string oct");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "string hex, "
+                                                                "relative, "
+                                                                "string oct");
     if (bed != NULL)
         goto end;
 
@@ -1250,9 +906,9 @@ static int DetectByteExtractTest24(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, align 4, "
-                                                        "string hex, "
-                                                        "relative");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, align 4, "
+                                                                "string hex, "
+                                                                "relative");
     if (bed != NULL)
         goto end;
 
@@ -1267,9 +923,9 @@ static int DetectByteExtractTest25(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "9, 2, one, align 4, "
-                                                        "little, "
-                                                        "relative");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "9, 2, one, align 4, "
+                                                                "little, "
+                                                                "relative");
     if (bed != NULL)
         goto end;
 
@@ -1284,10 +940,10 @@ static int DetectByteExtractTest26(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "little, "
-                                                        "relative, "
-                                                        "multiplier 65536");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "little, "
+                                                                "relative, "
+                                                                "multiplier 65536");
     if (bed != NULL)
         goto end;
 
@@ -1302,10 +958,10 @@ static int DetectByteExtractTest27(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
-                                                        "little, "
-                                                        "relative, "
-                                                        "multiplier 0");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, align 4, "
+                                                                "little, "
+                                                                "relative, "
+                                                                "multiplier 0");
     if (bed != NULL)
         goto end;
 
@@ -1320,7 +976,7 @@ static int DetectByteExtractTest28(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "23, 2, one, string, oct");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "23, 2, one, string, oct");
     if (bed == NULL)
         goto end;
 
@@ -1335,7 +991,7 @@ static int DetectByteExtractTest29(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, string, oct");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "24, 2, one, string, oct");
     if (bed != NULL)
         goto end;
 
@@ -1350,7 +1006,7 @@ static int DetectByteExtractTest30(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "20, 2, one, string, dec");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "20, 2, one, string, dec");
     if (bed == NULL)
         goto end;
 
@@ -1365,7 +1021,7 @@ static int DetectByteExtractTest31(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "21, 2, one, string, dec");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "21, 2, one, string, dec");
     if (bed != NULL)
         goto end;
 
@@ -1380,7 +1036,7 @@ static int DetectByteExtractTest32(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "14, 2, one, string, hex");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "14, 2, one, string, hex");
     if (bed == NULL)
         goto end;
 
@@ -1395,7 +1051,7 @@ static int DetectByteExtractTest33(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "15, 2, one, string, hex");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "15, 2, one, string, hex");
     if (bed != NULL)
         goto end;
 
@@ -1413,7 +1069,7 @@ static int DetectByteExtractTest34(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1459,16 +1115,12 @@ static int DetectByteExtractTest34(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strncmp(bed->name, "two", cd->content_len) != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 2 || strncmp(bed->name, "two", cd->content_len) != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1490,7 +1142,7 @@ static int DetectByteExtractTest35(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectPcreData *pd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1547,16 +1199,12 @@ static int DetectByteExtractTest35(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1601,12 +1249,12 @@ static int DetectByteExtractTest36(void)
     FAIL_IF(bjd->flags != 0);
     sm = sm->next;
     FAIL_IF(sm->type != DETECT_BYTE_EXTRACT);
-    DetectByteExtractData *bed = (DetectByteExtractData *)sm->ctx;
+    SCDetectByteExtractData *bed = (SCDetectByteExtractData *)sm->ctx;
     FAIL_IF(bed->nbytes != 4);
     FAIL_IF(bed->offset != 0);
     FAIL_IF(strcmp(bed->name, "two") != 0);
-    FAIL_IF(bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_STRING));
-    FAIL_IF(bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE);
+    FAIL_IF(bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING));
     FAIL_IF(bed->base != DETECT_BYTE_EXTRACT_BASE_HEX);
     FAIL_IF(bed->align_value != 0);
     FAIL_IF(bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT);
@@ -1623,7 +1271,7 @@ static int DetectByteExtractTest37(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectContentData *ud = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1693,16 +1341,12 @@ static int DetectByteExtractTest37(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1724,7 +1368,7 @@ static int DetectByteExtractTest38(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectContentData *ud = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1770,15 +1414,11 @@ static int DetectByteExtractTest38(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags !=DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1824,7 +1464,7 @@ static int DetectByteExtractTest39(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectContentData *ud = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1894,16 +1534,12 @@ static int DetectByteExtractTest39(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -1925,7 +1561,7 @@ static int DetectByteExtractTest40(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectContentData *ud = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -1971,15 +1607,11 @@ static int DetectByteExtractTest40(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags !=DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -2024,7 +1656,7 @@ static int DetectByteExtractTest41(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2071,15 +1703,11 @@ static int DetectByteExtractTest41(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2092,15 +1720,11 @@ static int DetectByteExtractTest41(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "three") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "three") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 1) {
@@ -2126,7 +1750,7 @@ static int DetectByteExtractTest42(void)
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
     DetectContentData *ud = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2175,15 +1799,11 @@ static int DetectByteExtractTest42(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2196,15 +1816,11 @@ static int DetectByteExtractTest42(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "five") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "five") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 1) {
@@ -2239,16 +1855,12 @@ static int DetectByteExtractTest42(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "four") != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE |
-                       DETECT_BYTE_EXTRACT_FLAG_STRING) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "four") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_RELATIVE | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2276,7 +1888,7 @@ static int DetectByteExtractTest43(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2323,15 +1935,11 @@ static int DetectByteExtractTest43(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2374,8 +1982,8 @@ static int DetectByteExtractTest44(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2424,15 +2032,11 @@ static int DetectByteExtractTest44(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -2445,7 +2049,7 @@ static int DetectByteExtractTest44(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_CONTENT) {
@@ -2497,7 +2101,7 @@ static int DetectByteExtractTest45(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2544,15 +2148,11 @@ static int DetectByteExtractTest45(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2596,8 +2196,8 @@ static int DetectByteExtractTest46(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2646,15 +2246,11 @@ static int DetectByteExtractTest46(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -2667,7 +2263,7 @@ static int DetectByteExtractTest46(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_CONTENT) {
@@ -2719,7 +2315,7 @@ static int DetectByteExtractTest47(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2766,15 +2362,11 @@ static int DetectByteExtractTest47(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -2819,8 +2411,8 @@ static int DetectByteExtractTest48(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2869,15 +2461,11 @@ static int DetectByteExtractTest48(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -2890,7 +2478,7 @@ static int DetectByteExtractTest48(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_CONTENT) {
@@ -2947,7 +2535,7 @@ static int DetectByteExtractTest49(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -2994,15 +2582,11 @@ static int DetectByteExtractTest49(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -3048,8 +2632,8 @@ static int DetectByteExtractTest50(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -3098,15 +2682,11 @@ static int DetectByteExtractTest50(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3119,7 +2699,7 @@ static int DetectByteExtractTest50(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_CONTENT) {
@@ -3178,7 +2758,7 @@ static int DetectByteExtractTest51(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
     DetectBytetestData *btd = NULL;
 
     de_ctx = DetectEngineCtxInit();
@@ -3226,15 +2806,11 @@ static int DetectByteExtractTest51(void)
         result = 0;
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 0 ||
-        strcmp(bed->name, "two") != 0 ||
-        bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 0 || strcmp(bed->name, "two") != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed->local_id != 0) {
@@ -3276,7 +2852,7 @@ static int DetectByteExtractTest52(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
     DetectBytetestData *btd = NULL;
 
     de_ctx = DetectEngineCtxInit();
@@ -3326,15 +2902,11 @@ static int DetectByteExtractTest52(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3412,13 +2984,12 @@ static int DetectByteExtractTest53(void)
     sm = sm->next;
     FAIL_IF_NULL(sm);
     FAIL_IF(sm->type != DETECT_BYTE_EXTRACT);
-    DetectByteExtractData *bed = (DetectByteExtractData *)sm->ctx;
+    SCDetectByteExtractData *bed = (SCDetectByteExtractData *)sm->ctx;
 
     FAIL_IF(bed->nbytes != 4);
     FAIL_IF(bed->offset != 0);
     FAIL_IF(strcmp(bed->name, "two") != 0);
-    FAIL_IF(bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING);
-    FAIL_IF(bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE);
+    FAIL_IF(bed->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING));
     FAIL_IF(bed->base != DETECT_BYTE_EXTRACT_BASE_HEX);
     FAIL_IF(bed->align_value != 0);
     FAIL_IF(bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT);
@@ -3444,7 +3015,7 @@ static int DetectByteExtractTest54(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
     DetectBytejumpData *bjd = NULL;
 
     de_ctx = DetectEngineCtxInit();
@@ -3494,15 +3065,11 @@ static int DetectByteExtractTest54(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3560,8 +3127,8 @@ static int DetectByteExtractTest55(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -3606,15 +3173,11 @@ static int DetectByteExtractTest55(void)
     if (sm->type != DETECT_BYTE_EXTRACT) {
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3625,7 +3188,7 @@ static int DetectByteExtractTest55(void)
     if (sm->type != DETECT_BYTE_EXTRACT) {
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_BYTE_EXTRACT) {
@@ -3674,8 +3237,8 @@ static int DetectByteExtractTest56(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -3748,15 +3311,11 @@ static int DetectByteExtractTest56(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3769,7 +3328,7 @@ static int DetectByteExtractTest56(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
 
     sm = sm->next;
     if (sm->type != DETECT_BYTE_EXTRACT) {
@@ -3822,10 +3381,10 @@ static int DetectByteExtractTest57(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
-    DetectByteExtractData *bed2 = NULL;
-    DetectByteExtractData *bed3 = NULL;
-    DetectByteExtractData *bed4 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed2 = NULL;
+    SCDetectByteExtractData *bed3 = NULL;
+    SCDetectByteExtractData *bed4 = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -3898,16 +3457,12 @@ static int DetectByteExtractTest57(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING |
-                        DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                   DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -3920,7 +3475,7 @@ static int DetectByteExtractTest57(void)
         result = 0;
         goto end;
     }
-    bed2 = (DetectByteExtractData *)sm->ctx;
+    bed2 = (SCDetectByteExtractData *)sm->ctx;
     if (bed2->local_id != 1) {
         result = 0;
         goto end;
@@ -3931,7 +3486,7 @@ static int DetectByteExtractTest57(void)
         result = 0;
         goto end;
     }
-    bed3 = (DetectByteExtractData *)sm->ctx;
+    bed3 = (SCDetectByteExtractData *)sm->ctx;
     if (bed3->local_id != 2) {
         result = 0;
         goto end;
@@ -3942,7 +3497,7 @@ static int DetectByteExtractTest57(void)
         result = 0;
         goto end;
     }
-    bed4 = (DetectByteExtractData *)sm->ctx;
+    bed4 = (SCDetectByteExtractData *)sm->ctx;
     if (bed4->local_id != 3) {
         result = 0;
         goto end;
@@ -3987,7 +3542,7 @@ static int DetectByteExtractTest58(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
     DetectBytejumpData *bjd = NULL;
     DetectIsdataatData *isdd = NULL;
 
@@ -4039,15 +3594,11 @@ static int DetectByteExtractTest58(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -4145,12 +3696,13 @@ static int DetectByteExtractTest59(void)
     FAIL_IF_NULL(sm);
     FAIL_IF(sm->type != DETECT_BYTE_EXTRACT);
 
-    DetectByteExtractData *bed1 = (DetectByteExtractData *)sm->ctx;
+    SCDetectByteExtractData *bed1 = (SCDetectByteExtractData *)sm->ctx;
     FAIL_IF(bed1->nbytes != 4);
     FAIL_IF(bed1->offset != 0);
     FAIL_IF(strcmp(bed1->name, "two") != 0);
-    FAIL_IF(bed1->flags != DETECT_BYTE_EXTRACT_FLAG_STRING);
-    FAIL_IF(bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE);
+    printf("a\n");
+    FAIL_IF(bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_BASE | DETECT_BYTE_EXTRACT_FLAG_STRING));
+    printf("b\n");
     FAIL_IF(bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX);
     FAIL_IF(bed1->align_value != 0);
     FAIL_IF(bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT);
@@ -4197,7 +3749,7 @@ static int DetectByteExtractTest60(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
     DetectIsdataatData *isdd = NULL;
 
     de_ctx = DetectEngineCtxInit();
@@ -4247,16 +3799,12 @@ static int DetectByteExtractTest60(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING |
-                        DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                   DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -4302,16 +3850,12 @@ static int DetectByteExtractTest60(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "four") != 0 ||
-        bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING |
-                        DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "four") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                   DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -4339,7 +3883,7 @@ static int DetectByteExtractTest61(void)
     Signature *s = NULL;
     SigMatch *sm = NULL;
     DetectContentData *cd = NULL;
-    DetectByteExtractData *bed1 = NULL;
+    SCDetectByteExtractData *bed1 = NULL;
     DetectIsdataatData *isdd = NULL;
 
     de_ctx = DetectEngineCtxInit();
@@ -4389,16 +3933,12 @@ static int DetectByteExtractTest61(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "two") != 0 ||
-        bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING |
-                        DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "two") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                   DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -4431,16 +3971,12 @@ static int DetectByteExtractTest61(void)
         result = 0;
         goto end;
     }
-    bed1 = (DetectByteExtractData *)sm->ctx;
-    if (bed1->nbytes != 4 ||
-        bed1->offset != 0 ||
-        strcmp(bed1->name, "four") != 0 ||
-        bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING |
-                        DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed1->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed1->align_value != 0 ||
-        bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed1 = (SCDetectByteExtractData *)sm->ctx;
+    if (bed1->nbytes != 4 || bed1->offset != 0 || strcmp(bed1->name, "four") != 0 ||
+            bed1->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                   DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed1->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed1->align_value != 0 ||
+            bed1->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
     if (bed1->local_id != 0) {
@@ -4481,7 +4017,7 @@ static int DetectByteExtractTest62(void)
     int result = 0;
     Signature *s = NULL;
     SigMatch *sm = NULL;
-    DetectByteExtractData *bed = NULL;
+    SCDetectByteExtractData *bed = NULL;
 
     de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL)
@@ -4502,15 +4038,12 @@ static int DetectByteExtractTest62(void)
     if (sm->type != DETECT_BYTE_EXTRACT) {
         goto end;
     }
-    bed = (DetectByteExtractData *)sm->ctx;
-    if (bed->nbytes != 4 ||
-        bed->offset != 2 ||
-        strncmp(bed->name, "two", 3) != 0 ||
-        bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_HEX ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    bed = (SCDetectByteExtractData *)sm->ctx;
+    if (bed->nbytes != 4 || bed->offset != 2 || strncmp(bed->name, "two", 3) != 0 ||
+            bed->flags != (DETECT_BYTE_EXTRACT_FLAG_STRING | DETECT_BYTE_EXTRACT_FLAG_BASE |
+                                  DETECT_BYTE_EXTRACT_FLAG_RELATIVE) ||
+            bed->base != DETECT_BYTE_EXTRACT_BASE_HEX || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -4528,18 +4061,13 @@ static int DetectByteExtractTest63(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, -2, one");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, -2, one");
     if (bed == NULL)
         goto end;
 
-    if (bed->nbytes != 4 ||
-        bed->offset != -2 ||
-        strcmp(bed->name, "one") != 0 ||
-        bed->flags != 0 ||
-        bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_DEFAULT ||
-        bed->base != DETECT_BYTE_EXTRACT_BASE_NONE ||
-        bed->align_value != 0 ||
-        bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
+    if (bed->nbytes != 4 || bed->offset != -2 || strcmp(bed->name, "one") != 0 || bed->flags != 0 ||
+            bed->endian != BigEndian || bed->align_value != 0 ||
+            bed->multiplier_value != DETECT_BYTE_EXTRACT_MULTIPLIER_DEFAULT) {
         goto end;
     }
 
@@ -4554,7 +4082,7 @@ static int DetectByteExtractTestParseNoBase(void)
 {
     int result = 0;
 
-    DetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string");
+    SCDetectByteExtractData *bed = DetectByteExtractParse(NULL, "4, 2, one, string");
     if (bed == NULL)
         goto end;
 
@@ -4568,9 +4096,6 @@ static int DetectByteExtractTestParseNoBase(void)
         goto end;
     }
     if (bed->flags != DETECT_BYTE_EXTRACT_FLAG_STRING) {
-        goto end;
-    }
-    if (bed->endian != DETECT_BYTE_EXTRACT_ENDIAN_NONE) {
         goto end;
     }
     if (bed->base != DETECT_BYTE_EXTRACT_BASE_DEC) {

--- a/src/detect-byte-extract.h
+++ b/src/detect-byte-extract.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -23,41 +23,6 @@
 
 #ifndef SURICATA_DETECT_BYTEEXTRACT_H
 #define SURICATA_DETECT_BYTEEXTRACT_H
-
-/* flags */
-#define DETECT_BYTE_EXTRACT_FLAG_RELATIVE   0x01
-#define DETECT_BYTE_EXTRACT_FLAG_MULTIPLIER 0x02
-#define DETECT_BYTE_EXTRACT_FLAG_STRING     0x04
-#define DETECT_BYTE_EXTRACT_FLAG_ALIGN      0x08
-#define DETECT_BYTE_EXTRACT_FLAG_ENDIAN     0x10
-
-/* endian value to be used.  Would be stored in DetectByteParseData->endian */
-#define DETECT_BYTE_EXTRACT_ENDIAN_NONE    0
-#define DETECT_BYTE_EXTRACT_ENDIAN_BIG     1
-#define DETECT_BYTE_EXTRACT_ENDIAN_LITTLE  2
-#define DETECT_BYTE_EXTRACT_ENDIAN_DCE     3
-
-/**
- * \brief Holds data related to byte_extract keyword.
- */
-typedef struct DetectByteExtractData_ {
-    /* local id used by other keywords in the sig to reference this */
-    uint8_t local_id;
-
-    uint8_t nbytes;
-    int16_t pad;
-    int32_t offset;
-    const char *name;
-    uint8_t flags;
-    uint8_t endian;
-    uint8_t base;
-    uint8_t align_value;
-
-    uint16_t multiplier_value;
-    /* unique id used to reference this byte_extract keyword */
-    uint16_t id;
-
-} DetectByteExtractData;
 
 void DetectByteExtractRegister(void);
 

--- a/src/detect-byte.c
+++ b/src/detect-byte.c
@@ -41,7 +41,7 @@ bool DetectByteRetrieveSMVar(const char *arg, const Signature *s, DetectByteInde
 {
     SigMatch *bed_sm = DetectByteExtractRetrieveSMVar(arg, s);
     if (bed_sm != NULL) {
-        *index = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
+        *index = ((SCDetectByteExtractData *)bed_sm->ctx)->local_id;
         return true;
     }
 

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -146,7 +146,7 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const DetectByteMathDa
             }
         }
     } else {
-        ByteMathEndian bme = endian;
+        ByteEndian bme = endian;
         int endianness = (bme == BigEndian) ? BYTE_BIG_ENDIAN : BYTE_LITTLE_ENDIAN;
         extbytes = ByteExtractUint64(&val, endianness, nbytes, ptr);
         if (extbytes != nbytes) {

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -543,19 +543,17 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
 
     } else if (smd->type == DETECT_BYTE_EXTRACT) {
 
-        const DetectByteExtractData *bed = (const DetectByteExtractData *)smd->ctx;
+        const SCDetectByteExtractData *bed = (const SCDetectByteExtractData *)smd->ctx;
         uint8_t endian = bed->endian;
 
         /* if we have dce enabled we will have to use the endianness
          * specified by the dce header */
-        if ((bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) &&
-            endian == DETECT_BYTE_EXTRACT_ENDIAN_DCE &&
-            flags & (DETECT_CI_FLAGS_DCE_LE|DETECT_CI_FLAGS_DCE_BE)) {
+        if ((bed->flags & DETECT_BYTE_EXTRACT_FLAG_ENDIAN) && endian == EndianDCE &&
+                flags & (DETECT_CI_FLAGS_DCE_LE | DETECT_CI_FLAGS_DCE_BE)) {
 
             /* enable the endianness flag temporarily.  once we are done
              * processing we reset the flags to the original value*/
-            endian |= ((flags & DETECT_CI_FLAGS_DCE_LE) ?
-                       DETECT_BYTE_EXTRACT_ENDIAN_LITTLE : DETECT_BYTE_EXTRACT_ENDIAN_BIG);
+            endian |= ((flags & DETECT_CI_FLAGS_DCE_LE) ? LittleEndian : BigEndian);
         }
 
         if (DetectByteExtractDoMatch(det_ctx, smd, s, buffer, buffer_len,


### PR DESCRIPTION
Continuation of #11017 

Convert the byte_extract option parser from C to Rust.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [6873](https://redmine.openinfosecfoundation.org/issues/6873)

Describe changes:
- Refactor code in rust/src/detect to support re-usability
- Implement the byte_extract parser in Rust, with unittests
- Modify the existing byte_extract module to use the Rust parser

Updates:
- Address clippy warning

### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
