### PR TITLE
rust: fix compilation error on MSRV

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -29,7 +29,7 @@ crc = "1.8"
 memchr = "~ 2.3"
 num = "0.2"
 num-derive = "0.2"
-num-traits = "0.2"
+num-traits = "=0.2.18"
 widestring = "0.4"
 md5 = "0.7.0"
 flate2 = { version = "1.0", optional = true }


### PR DESCRIPTION
Caused by:
  failed to parse manifest at `/builds/inliniac/suricata-ci/suricata/rust/vendor/num-traits/Cargo.toml`

Caused by:
  failed to parse the `edition` key

Caused by:
  supported edition values are `2015` or `2018`, but `2021` is unknown

Lock to last working version 0.2.18.

Ticket: #7007.
