### PR TITLE
lua rule errors/v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5166,6 +5166,16 @@
                         "alerts_suppressed": {
                             "type": "integer"
                         },
+                        "lua": {
+                            "type": "object",
+                            "properties": {
+                                "errors": {
+                                    "description": "Errors encountered while running Lua scripts",
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "mpm_list": {
                             "type": "integer"
                         },

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3276,6 +3276,10 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
+
+    /* Register counter for Lua rule errors. */
+    det_ctx->lua_rule_errors = StatsRegisterCounter("detect.lua.errors", tv);
+
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     det_ctx->counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1227,6 +1227,9 @@ typedef struct DetectEngineThreadCtx_ {
     AppLayerDecoderEvents *decoder_events;
     uint16_t events;
 
+    /** stats id for lua rule errors */
+    uint16_t lua_rule_errors;
+
 #ifdef DEBUG
     uint64_t pkt_stream_add_cnt;
     uint64_t payload_mpm_cnt;


### PR DESCRIPTION
- **sdp: fix logging medias**
  As introduced by bff790b6ac6f0e5ddf6bd0fe0085881473935c2c
  
  Also handles errors in the caller
  
  Ticket: 6994
  

- **detect/iprep: minor code cleanups**
  

- **detect/iprep: allow 0 as a reputation value**
  Rules would allow checking against value 0, but internally the value
  was used to indicate "no value". To address this, the internals now
  return negative values for not found. This way value 0 can be fully
  supported.
  
  Bug: #6834.
  

- **detect/iprep: update doc about 0 value**
  A value of 0 was already allowed by the rule parser, but didn't
  actually work.
  
  Bug: #6834.
  

- **util/base64: remove coverity reported dead code**
  New defect(s) Reported-by: Coverity Scan
  Showing 1 of 1 defect(s)
  
  ** CID 1596621:  Control flow issues  (DEADCODE)
  /src/util-base64.c: 238 in DecodeBase64RFC4648()
  
  ________________________________________________________________________________________________________
  *** CID 1596621:  Control flow issues  (DEADCODE)
  /src/util-base64.c: 238 in DecodeBase64RFC4648()
  232         DEBUG_VALIDATE_BUG_ON(bbidx == B64_BLOCK);
  233
  234         /* Handle any leftover bytes by adding padding to them as long as they do not
  235          * violate the destination buffer size */
  236         if (bbidx > 0) {
  237             padding = bbidx > 1 ? B64_BLOCK - bbidx : 2;
  >>>     CID 1596621:  Control flow issues  (DEADCODE)
  >>>     Execution cannot reach the expression "3U" inside this statement: "numDecoded_blk = 3U - ((pad...".
  238             uint32_t numDecoded_blk = ASCII_BLOCK - (padding < B64_BLOCK ? padding : ASCII_BLOCK);
  239             if (dest_size < *decoded_bytes + numDecoded_blk) {
  240                 SCLogDebug("Destination buffer full");
  241                 return BASE64_ECODE_BUF;
  242             }
  243             /* Decode base-64 block into ascii block and move pointer */
  
  Also, add a comment explaining the padding logic for leftover data.
  
  Bug 6985
  

- **github-ci: add af-packet and dpdk codecov builds**
  Adds live tests for DPDK and AF_PACKET, with support for code coverage.
  

- **github-actions: add dpdk ids live test script**
  

- **github-actions: convert dpdk tests to use script**
  

- **github-actions: bump codecov/codecov-action from 4.1.1 to 4.3.1**
  Bumps [codecov/codecov-action](https://github.com/codecov/codecov-action) from 4.1.1 to 4.3.1.
  - [Release notes](https://github.com/codecov/codecov-action/releases)
  - [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
  - [Commits](https://github.com/codecov/codecov-action/compare/c16abc29c95fcf9174b58eb7e1abf4c866893bc8...5ecb98a3c6b747ed38dc09f787459979aebb39be)
  
  ---
  updated-dependencies:
  - dependency-name: codecov/codecov-action
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>

- **github-actions: bump actions/download-artifact from 4.1.4 to 4.1.7**
  Bumps [actions/download-artifact](https://github.com/actions/download-artifact) from 4.1.4 to 4.1.7.
  - [Release notes](https://github.com/actions/download-artifact/releases)
  - [Commits](https://github.com/actions/download-artifact/compare/c850b930e6ba138125429b7e5c93fc707a7f8427...65a9edc5881444af0b9093a5e628f2fe47ea3b2e)
  
  ---
  updated-dependencies:
  - dependency-name: actions/download-artifact
    dependency-type: direct:production
    update-type: version-update:semver-patch
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>

- **github-actions: bump github/codeql-action from 3.24.9 to 3.25.3**
  Bumps [github/codeql-action](https://github.com/github/codeql-action) from 3.24.9 to 3.25.3.
  - [Release notes](https://github.com/github/codeql-action/releases)
  - [Commits](https://github.com/github/codeql-action/compare/v3.24.9...v3.25.3)
  
  ---
  updated-dependencies:
  - dependency-name: github/codeql-action
    dependency-type: direct:production
    update-type: version-update:semver-minor
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>

- **github-actions: bump actions/upload-artifact from 4.3.1 to 4.3.3**
  Bumps [actions/upload-artifact](https://github.com/actions/upload-artifact) from 4.3.1 to 4.3.3.
  - [Release notes](https://github.com/actions/upload-artifact/releases)
  - [Commits](https://github.com/actions/upload-artifact/compare/5d5d22a31266ced268874388b861e4b58bb5c2f3...65462800fd760344b1a7b4382951275a0abb4808)
  
  ---
  updated-dependencies:
  - dependency-name: actions/upload-artifact
    dependency-type: direct:production
    update-type: version-update:semver-patch
  ...
  
  Signed-off-by: dependabot[bot] <support@github.com>

- **snmp: remove community keyword unit test**
  Ticket: 3725
  
  This test was moved to suricata-verify snmp-community
  

- **eve/stats: add description for transactions**
  Ticket 6434
  

- **eve/stats: add description for ips**
  Ticket 6434
  

- **doc: add http.connection ref and fix location**
  Signed-off-by: jason taylor <jtfas90@gmail.com>
  

- **doc: update normalization notes**
  Ticket: #6781
  
  Signed-off-by: jason taylor <jtfas90@gmail.com>
  

- **detect/lua: don't treat a crashed script as no match**
  If a rule script crashed, the return value was treated as a no
  match. This would make a negation of the rule match and alert.
  
  Instead cleanup and exit early if the rule script crashed and don't
  run negation logic.
  
  A stat, detect.lua_errors has been added to count how many times a
  script crashes.
  
  Also consolidates the running of the Lua script and return value
  handling to a common function.
  
  Bug: #6940
  

- **detect-lua: small cleanups**
  - remove unused headers
  - cleanup/rename flags
  