### PR TITLE
detect/lua: don't treat a crashed script as no match - v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5166,6 +5166,16 @@
                         "alerts_suppressed": {
                             "type": "integer"
                         },
+                        "lua": {
+                            "type": "object",
+                            "properties": {
+                                "errors": {
+                                    "description": "Errors encountered while running Lua scripts",
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "mpm_list": {
                             "type": "integer"
                         },

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -16,6 +16,10 @@ name = "suricata"
 [profile.release]
 debug = true
 
+[profile.dev]
+debug = true
+debug-assertions = false
+
 [features]
 lua = []
 lua_int8 = ["lua"]

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3276,6 +3276,10 @@ TmEcode DetectEngineThreadCtxInit(ThreadVars *tv, void *initdata, void **data)
     det_ctx->counter_alerts = StatsRegisterCounter("detect.alert", tv);
     det_ctx->counter_alerts_overflow = StatsRegisterCounter("detect.alert_queue_overflow", tv);
     det_ctx->counter_alerts_suppressed = StatsRegisterCounter("detect.alerts_suppressed", tv);
+
+    /* Register counter for Lua rule errors. */
+    det_ctx->lua_rule_errors = StatsRegisterCounter("detect.lua.errors", tv);
+
 #ifdef PROFILING
     det_ctx->counter_mpm_list = StatsRegisterAvgCounter("detect.mpm_list", tv);
     det_ctx->counter_nonmpm_list = StatsRegisterAvgCounter("detect.nonmpm_list", tv);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1227,6 +1227,9 @@ typedef struct DetectEngineThreadCtx_ {
     AppLayerDecoderEvents *decoder_events;
     uint16_t events;
 
+    /** stats id for lua rule errors */
+    uint16_t lua_rule_errors;
+
 #ifdef DEBUG
     uint64_t pkt_stream_add_cnt;
     uint64_t payload_mpm_cnt;


### PR DESCRIPTION
If a rule script crashed, the return value was treated as a no
match. This would make a negation of the rule match and alert.

Instead cleanup and exit early if the rule script crashed and don't
run negation logic.

A stat, detect.lua_errors has been added to count how many times a
script crashes.

Also consolidates the running of the Lua script and return value
handling to a common function.

Bug: https://redmine.openinfosecfoundation.org/issues/6940

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1826