### PR TITLE
config/ja3: Eliminate warnings when JA3 is disabled

### DIFF
--- a/rust/src/ja4.rs
+++ b/rust/src/ja4.rs
@@ -23,7 +23,9 @@ use digest::Digest;
 use libc::c_uchar;
 #[cfg(feature = "ja4")]
 use sha2::Sha256;
-use std::{cmp::min, os::raw::c_char};
+#[cfg(feature = "ja4")]
+use std::cmp::min;
+use std::os::raw::c_char;
 use tls_parser::{TlsCipherSuiteID, TlsExtensionType, TlsVersion};
 
 #[derive(Debug, PartialEq)]

--- a/src/detect-ja4-hash.c
+++ b/src/detect-ja4-hash.c
@@ -46,6 +46,7 @@ static int DetectJA4SetupNoSupport(DetectEngineCtx *a, Signature *b, const char 
 }
 #endif /* HAVE_JA4 */
 
+#ifdef HAVE_JA4
 static int DetectJa4HashSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
@@ -56,6 +57,7 @@ static InspectionBuffer *Ja4DetectGetHash(DetectEngineThreadCtx *det_ctx,
         const int list_id);
 
 static int g_ja4_hash_buffer_id = 0;
+#endif
 
 /**
  * \brief Registration function for keyword: ja4.hash
@@ -93,6 +95,7 @@ void DetectJa4HashRegister(void)
 #endif /* HAVE_JA4 */
 }
 
+#ifdef HAVE_JA4
 /**
  * \brief this function setup the ja4.hash modifier keyword used in the rule
  *
@@ -171,3 +174,4 @@ static InspectionBuffer *Ja4DetectGetHash(DetectEngineThreadCtx *det_ctx,
     }
     return buffer;
 }
+#endif

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -64,6 +64,7 @@ static int DetectJA3SetupNoSupport(DetectEngineCtx *a, Signature *b, const char 
 }
 #endif
 
+#ifdef HAVE_JA3
 static int DetectTlsJa3HashSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
@@ -74,6 +75,7 @@ static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
 static bool DetectTlsJa3HashValidateCallback(const Signature *s,
        const char **sigerror);
 static int g_tls_ja3_hash_buffer_id = 0;
+#endif
 
 /**
  * \brief Registration function for keyword: ja3_hash
@@ -117,6 +119,7 @@ void DetectTlsJa3HashRegister(void)
 #endif /* HAVE_JA3 */
 }
 
+#ifdef HAVE_JA3
 /**
  * \brief this function setup the ja3.hash modifier keyword used in the rule
  *
@@ -239,3 +242,4 @@ static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
         }
     }
 }
+#endif

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -64,12 +64,14 @@ static int DetectJA3SetupNoSupport(DetectEngineCtx *a, Signature *b, const char 
 }
 #endif /* HAVE_JA3 */
 
+#ifdef HAVE_JA3
 static int DetectTlsJa3StringSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
 static int g_tls_ja3_str_buffer_id = 0;
+#endif
 
 /**
  * \brief Registration function for keyword: ja3.string
@@ -107,6 +109,7 @@ void DetectTlsJa3StringRegister(void)
 #endif /* HAVE_JA3 */
 }
 
+#ifdef HAVE_JA3
 /**
  * \brief this function setup the ja3.string modifier keyword used in the rule
  *
@@ -164,3 +167,4 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     return buffer;
 }
+#endif

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -64,6 +64,7 @@ static int DetectJA3SetupNoSupport(DetectEngineCtx *a, Signature *b, const char 
 }
 #endif /* HAVE_JA3 */
 
+#ifdef HAVE_JA3
 static int DetectTlsJa3SHashSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
@@ -74,6 +75,7 @@ static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
 static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
        const char **sigerror);
 static int g_tls_ja3s_hash_buffer_id = 0;
+#endif
 
 /**
  * \brief Registration function for keyword: ja3s.hash
@@ -116,6 +118,7 @@ void DetectTlsJa3SHashRegister(void)
 #endif /* HAVE_JA3 */
 }
 
+#ifdef HAVE_JA3
 /**
  * \brief this function setup the ja3s.hash modifier keyword used in the rule
  *
@@ -237,3 +240,4 @@ static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
         }
     }
 }
+#endif

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -64,12 +64,14 @@ static int DetectJA3SetupNoSupport(DetectEngineCtx *a, Signature *b, const char 
 }
 #endif /* HAVE_JA3 */
 
+#ifdef HAVE_JA3
 static int DetectTlsJa3SStringSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
 static int g_tls_ja3s_str_buffer_id = 0;
+#endif
 
 /**
  * \brief Registration function for keyword: ja3s.string
@@ -107,6 +109,7 @@ void DetectTlsJa3SStringRegister(void)
 #endif /*  HAVE_JA3 */
 }
 
+#ifdef HAVE_JA3
 /**
  * \brief this function setup the ja3s.string modifier keyword used in the rule
  *
@@ -164,3 +167,4 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
     return buffer;
 }
+#endif


### PR DESCRIPTION
This commit eliminates warnings when either ja3, ja4 or both are disabled.

This requires explicit disablement when using `configure`:
```
$ ./configure --disable-ja4 --disable-ja3
```

Describe changes:
- Add ifdefs around code that's only used if JA3/JA4 is compiled
- Update rust module to build cleanly when JA3/JA4 are disabled


### Provide values to any of the below to override the defaults.

To use a pull request use a branch name like `pr/N` where `N` is the
pull request number.

Alternatively, `SV_BRANCH` may also be a link to an
OISF/suricata-verify pull-request.

```
SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
```
