### PR TITLE
mqtt: enable limiting of logged message length

### DIFF
--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -410,28 +410,31 @@ pub extern "C" fn rs_mqtt_tx_unsuback_has_reason_code(tx: &MQTTTransaction, code
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::core::Direction;
     use crate::mqtt::mqtt::MQTTTransaction;
     use crate::mqtt::mqtt_message::*;
     use crate::mqtt::parser::FixedHeader;
-    use crate::core::Direction;
     use std;
 
     #[test]
     fn test_multi_unsubscribe() {
-        let mut t = MQTTTransaction::new(MQTTMessage {
-            header: FixedHeader {
-                message_type: MQTTTypeCode::UNSUBSCRIBE,
-                dup_flag: false,
-                qos_level: 0,
-                retain: false,
-                remaining_length: 0,
+        let mut t = MQTTTransaction::new(
+            MQTTMessage {
+                header: FixedHeader {
+                    message_type: MQTTTypeCode::UNSUBSCRIBE,
+                    dup_flag: false,
+                    qos_level: 0,
+                    retain: false,
+                    remaining_length: 0,
+                },
+                op: MQTTOperation::UNSUBSCRIBE(MQTTUnsubscribeData {
+                    message_id: 1,
+                    topics: vec!["foo".to_string(), "baar".to_string()],
+                    properties: None,
+                }),
             },
-            op: MQTTOperation::UNSUBSCRIBE(MQTTUnsubscribeData {
-                message_id: 1,
-                topics: vec!["foo".to_string(), "baar".to_string()],
-                properties: None,
-            }),
-        }, Direction::ToServer);
+            Direction::ToServer,
+        );
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::UNSUBSCRIBE,
@@ -470,29 +473,32 @@ mod test {
 
     #[test]
     fn test_multi_subscribe() {
-        let mut t = MQTTTransaction::new(MQTTMessage {
-            header: FixedHeader {
-                message_type: MQTTTypeCode::SUBSCRIBE,
-                dup_flag: false,
-                qos_level: 0,
-                retain: false,
-                remaining_length: 0,
+        let mut t = MQTTTransaction::new(
+            MQTTMessage {
+                header: FixedHeader {
+                    message_type: MQTTTypeCode::SUBSCRIBE,
+                    dup_flag: false,
+                    qos_level: 0,
+                    retain: false,
+                    remaining_length: 0,
+                },
+                op: MQTTOperation::SUBSCRIBE(MQTTSubscribeData {
+                    message_id: 1,
+                    topics: vec![
+                        MQTTSubscribeTopicData {
+                            topic_name: "foo".to_string(),
+                            qos: 0,
+                        },
+                        MQTTSubscribeTopicData {
+                            topic_name: "baar".to_string(),
+                            qos: 1,
+                        },
+                    ],
+                    properties: None,
+                }),
             },
-            op: MQTTOperation::SUBSCRIBE(MQTTSubscribeData {
-                message_id: 1,
-                topics: vec![
-                    MQTTSubscribeTopicData {
-                        topic_name: "foo".to_string(),
-                        qos: 0,
-                    },
-                    MQTTSubscribeTopicData {
-                        topic_name: "baar".to_string(),
-                        qos: 1,
-                    },
-                ],
-                properties: None,
-            }),
-        }, Direction::ToServer);
+            Direction::ToServer,
+        );
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::SUBSCRIBE,

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -142,7 +142,7 @@ impl MQTTState {
             connected: false,
             skip_request: 0,
             skip_response: 0,
-            max_msg_len: unsafe { MAX_MSG_LEN},
+            max_msg_len: unsafe { MAX_MSG_LEN },
             tx_index_completed: 0,
         }
     }

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -242,8 +242,7 @@ fn parse_connack(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTC
 
 #[inline]
 fn parse_publish(
-    protocol_version: u8,
-    has_id: bool,
+    protocol_version: u8, has_id: bool,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTPublishData> {
     move |i: &[u8]| {
         let (i, topic) = parse_mqtt_string(i)?;
@@ -414,8 +413,7 @@ fn parse_unsuback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTT
 
 #[inline]
 fn parse_disconnect(
-    remaining_len: usize,
-    protocol_version: u8,
+    remaining_len: usize, protocol_version: u8,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTDisconnectData> {
     move |input: &[u8]| {
         if protocol_version < 5 {
@@ -486,11 +484,7 @@ fn parse_auth(i: &[u8]) -> IResult<&[u8], MQTTAuthData> {
 
 #[inline]
 fn parse_remaining_message<'a>(
-    full: &'a [u8],
-    len: usize,
-    skiplen: usize,
-    header: FixedHeader,
-    message_type: MQTTTypeCode,
+    full: &'a [u8], len: usize, skiplen: usize, header: FixedHeader, message_type: MQTTTypeCode,
     protocol_version: u8,
 ) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], MQTTMessage> {
     move |input: &'a [u8]| {
@@ -632,9 +626,7 @@ fn parse_remaining_message<'a>(
 }
 
 pub fn parse_message(
-    input: &[u8],
-    protocol_version: u8,
-    max_msg_size: u32,
+    input: &[u8], protocol_version: u8, max_msg_size: u32,
 ) -> IResult<&[u8], MQTTMessage> {
     // Parse the fixed header first. This is identical across versions and can
     // be between 2 and 5 bytes long.
@@ -939,7 +931,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v5() {
         let buf = [
-            0x00, 0x01,   /* Message Identifier: 1 */
+            0x00, 0x01, /* Message Identifier: 1 */
             0x00, /* Reason Code: 0 */
             0x00, /* Properties */
             0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34, 0x33, 0x45, 0x38, 0x30,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -310,6 +310,9 @@ outputs:
         - ssh
         - mqtt:
             # passwords: yes           # enable output of passwords
+            # msg-log-limit: 0         # limit size of logged messages in bytes.
+                                       # Can be specified in kb, mb, gb. Just a number
+                                       # is parsed as bytes. Default is 0 (no limit)
         - http2
         - pgsql:
             enabled: no


### PR DESCRIPTION
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/6984

Describe changes:
- Add an `msg-log-limit` option to enable optional truncation of the message payloads in MQTT.

```
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1828
```
