### PR TITLE
Rustc 178 fixes 7013 v4

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -16,10 +16,6 @@ name = "suricata"
 [profile.release]
 debug = true
 
-[profile.dev]
-debug = true
-debug-assertions = false
-
 [features]
 lua = []
 lua_int8 = ["lua"]

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -58,6 +58,9 @@ impl StreamSlice {
         self.input_len
     }
     pub fn as_slice(&self) -> &[u8] {
+        if self.input.is_null() && self.input_len == 0 {
+            return &[];
+        }
         unsafe { std::slice::from_raw_parts(self.input, self.input_len as usize) }
     }
     pub fn is_empty(&self) -> bool {

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1293,7 +1293,7 @@ pub unsafe extern "C" fn rs_dcerpc_probe_tcp(_f: *const core::Flow, direction: u
                                       len: u32, rdir: *mut u8) -> AppProto
 {
     SCLogDebug!("Probing packet for DCERPC");
-    if len == 0 {
+    if len == 0 || input.is_null() {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -310,7 +310,7 @@ pub unsafe extern "C" fn rs_dcerpc_probe_udp(_f: *const core::Flow, direction: u
                                       len: u32, rdir: *mut u8) -> core::AppProto
 {
     SCLogDebug!("Probing the packet for DCERPC/UDP");
-    if len == 0 {
+    if len == 0 || input.is_null() {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -184,7 +184,7 @@ pub unsafe extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto
 {
-    if input_len < DHCP_MIN_FRAME_LEN {
+    if input_len < DHCP_MIN_FRAME_LEN || input.is_null() {
         return ALPROTO_UNKNOWN;
     }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -886,7 +886,7 @@ pub extern "C" fn SCDnsTxGetResponseFlags(tx: &mut DNSTransaction) -> u16 {
 unsafe extern "C" fn probe_udp(
     _flow: *const core::Flow, _dir: u8, input: *const u8, len: u32, rdir: *mut u8,
 ) -> AppProto {
-    if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
@@ -906,7 +906,7 @@ unsafe extern "C" fn probe_udp(
 unsafe extern "C" fn c_probe_tcp(
     _flow: *const core::Flow, direction: u8, input: *const u8, len: u32, rdir: *mut u8,
 ) -> AppProto {
-    if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -364,6 +364,9 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     let alproto = ALPROTO_KRB5;
     if slice.len() <= 10 { return ALPROTO_FAILED; }
@@ -403,6 +406,9 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         input:*const u8, input_len: u32,
         rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     if slice.len() <= 14 { return ALPROTO_FAILED; }
     match be_u32(slice) as IResult<&[u8],u32> {

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -274,6 +274,9 @@ impl ModbusState {
 pub extern "C" fn rs_modbus_probe(
     _flow: *const core::Flow, _direction: u8, input: *const u8, len: u32, _rdir: *mut u8,
 ) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(input as *mut u8, len as usize) };
     match MODBUS_PARSER.probe(slice, Direction::Unknown) {
         Status::Recognized => unsafe { ALPROTO_MODBUS },

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -616,6 +616,9 @@ impl MQTTState {
 pub unsafe extern "C" fn rs_mqtt_probing_parser(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let buf = build_slice!(input, input_len as usize);
     match parse_fixed_header(buf) {
         Ok((_, hdr)) => {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1861,6 +1861,9 @@ pub unsafe extern "C" fn rs_nfs_probe_ms(
         direction: u8, input: *const u8,
         len: u32, rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     SCLogDebug!("rs_nfs_probe_ms: probing direction {:02x}", direction);
     let mut adirection : u8 = 0;
@@ -1900,6 +1903,9 @@ pub unsafe extern "C" fn rs_nfs_probe(_f: *const Flow,
                                _rdir: *mut u8)
     -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     SCLogDebug!("rs_nfs_probe: running probe");
     match nfs_probe(slice, direction.into()) {
@@ -1918,6 +1924,9 @@ pub unsafe extern "C" fn rs_nfs_probe_udp_ts(_f: *const Flow,
                                _rdir: *mut u8)
     -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     match nfs_probe_udp(slice, Direction::ToServer) {
         1 => { ALPROTO_NFS },
@@ -1935,6 +1944,9 @@ pub unsafe extern "C" fn rs_nfs_probe_udp_tc(_f: *const Flow,
                                _rdir: *mut u8)
     -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     match nfs_probe_udp(slice, Direction::ToClient) {
         1 => { ALPROTO_NFS },

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -245,6 +245,9 @@ pub extern "C" fn ntp_probing_parser(_flow: *const Flow,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(input as *mut u8, input_len as usize) };
     let alproto = unsafe{ ALPROTO_NTP };
     match parse_ntp(slice) {

--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -376,6 +376,9 @@ pub unsafe extern "C" fn rs_quic_state_tx_free(state: *mut std::os::raw::c_void,
 pub unsafe extern "C" fn rs_quic_probing_parser(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input, input_len as usize);
 
     if QuicHeader::from_bytes(slice, DEFAULT_DCID_LEN).is_ok() {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2115,7 +2115,7 @@ pub unsafe extern "C" fn rs_smb_probe_begins_tcp(_f: *const Flow,
                                    flags: u8, input: *const u8, len: u32, rdir: *mut u8)
     -> AppProto
 {
-    if len < MIN_REC_SIZE as u32 {
+    if len < MIN_REC_SIZE as u32 || input.is_null() {
         return ALPROTO_UNKNOWN;
     }
     let slice = build_slice!(input, len as usize);
@@ -2129,7 +2129,7 @@ pub unsafe extern "C" fn rs_smb_probe_tcp(_f: *const Flow,
                                    flags: u8, input: *const u8, len: u32, rdir: *mut u8)
     -> AppProto
 {
-    if len < MIN_REC_SIZE as u32 {
+    if len < MIN_REC_SIZE as u32 || input.is_null() {
         return ALPROTO_UNKNOWN;
     }
     let slice = build_slice!(input, len as usize);

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -357,6 +357,9 @@ pub unsafe extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
                                          input:*const u8,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     let alproto = ALPROTO_SNMP;
     if slice.len() < 4 { return ALPROTO_FAILED; }

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -311,7 +311,6 @@ static int DetectICodeParseTest08(void)
     DetectU8Data *icd = DetectU8Parse("> 8 <> 20");
     FAIL_IF_NOT_NULL(icd);
 
-    DetectICodeFree(NULL, icd);
     PASS;
 }
 
@@ -324,7 +323,6 @@ static int DetectICodeParseTest09(void)
     DetectU8Data *icd = DetectU8Parse("8<<20");
     FAIL_IF_NOT_NULL(icd);
 
-    DetectICodeFree(NULL, icd);
     PASS;
 }
 

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -334,7 +334,6 @@ static int DetectITypeParseTest08(void)
     DetectU8Data *itd = NULL;
     itd = DetectITypeParse(NULL, "> 8 <> 20");
     FAIL_IF_NOT_NULL(itd);
-    DetectITypeFree(NULL, itd);
 
     PASS;
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/7013

Describe changes:
- Fix build with rustc 1.78
- do not bother to free a null pointer in tests
- rust: return empty slice without using from_raw_parts fro StreamSlice
- protocol detection/probing : consistently check for NULL input (was done for half of the protocols)

#11041 with code review taken into account
+ revert of temporary 14ab9aa763d44dda0f4c831047966b595f5630c1 cc @jasonish what was the purpose of this commit ?