### PR TITLE
websocket: fix opcodes values for ping/pong

### DIFF
--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -28,8 +28,9 @@ pub enum WebSocketOpcode {
     Continuation = 0,
     Text = 1,
     Binary = 2,
-    Ping = 8,
-    Pong = 9,
+    Close = 8,
+    Ping = 9,
+    Pong = 10,
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7025

Describe changes:
- websocket: fix opcodes values for ping/pong and also set close

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1829
