### PR TITLE
base64: readd the check for destination space

### DIFF
--- a/src/util-base64.c
+++ b/src/util-base64.c
@@ -143,6 +143,8 @@ static inline Base64Ecode DecodeBase64RFC2045(uint8_t *dest, uint32_t dest_size,
                 SCLogDebug("Destination buffer full");
                 return BASE64_ECODE_BUF;
             }
+            if (dest_size - *decoded_bytes < ASCII_BLOCK)
+                return BASE64_ECODE_BUF;
             /* Decode base-64 block into ascii block and move pointer */
             DecodeBase64Block(dptr, b64);
             dptr += numDecoded_blk;
@@ -216,6 +218,8 @@ static inline Base64Ecode DecodeBase64RFC4648(uint8_t *dest, uint32_t dest_size,
                 SCLogDebug("Destination buffer full");
                 return BASE64_ECODE_BUF;
             }
+            if (dest_size - *decoded_bytes < ASCII_BLOCK)
+                return BASE64_ECODE_BUF;
 
             /* Decode base-64 block into ascii block and move pointer */
             DecodeBase64Block(dptr, b64);
@@ -253,6 +257,8 @@ static inline Base64Ecode DecodeBase64RFC4648(uint8_t *dest, uint32_t dest_size,
             SCLogDebug("Destination buffer full");
             return BASE64_ECODE_BUF;
         }
+        if (dest_size - *decoded_bytes < ASCII_BLOCK)
+            return BASE64_ECODE_BUF;
         /* Decode base-64 block into ascii block and move pointer */
         DecodeBase64Block(dptr, b64);
         *decoded_bytes += numDecoded_blk;


### PR DESCRIPTION
No stable branches are affected. This issue only exists in `master`.
Thanks to analysis by @catenacyber !