### PR TITLE
src: remove some unused parameters

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -275,6 +275,7 @@ impl HTTP2Transaction {
                     range::http2_range_append(sfcm, self.file_range, decompressed)
                 }
             }
+            println!("lolh {} {}", decompressed.len(), input.len());
             self.ft_tc.new_chunk(
                 sfcm,
                 b"",

--- a/src/app-layer-expectation.c
+++ b/src/app-layer-expectation.c
@@ -386,7 +386,6 @@ void AppLayerExpectationClean(Flow *f)
 out:
     if (ipp)
         IPPairRelease(ipp);
-    return;
 }
 
 /**

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -155,13 +155,11 @@ static void FTPParseMemcap(void)
 static void FTPIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(ftp_memuse, size);
-    return;
 }
 
 static void FTPDecrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_SUB(ftp_memuse, size);
-    return;
 }
 
 uint64_t FTPMemuseGlobalCounter(void)
@@ -283,8 +281,6 @@ static void FTPLocalStorageFree(void *ptr)
 
         SCFree(td);
     }
-
-    return;
 }
 static FTPTransaction *FTPTransactionCreate(FtpState *state)
 {

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -154,12 +154,12 @@ static void FTPParseMemcap(void)
 
 static void FTPIncrMemuse(uint64_t size)
 {
-    (void) SC_ATOMIC_ADD(ftp_memuse, size);
+    (void)SC_ATOMIC_ADD(ftp_memuse, size);
 }
 
 static void FTPDecrMemuse(uint64_t size)
 {
-    (void) SC_ATOMIC_SUB(ftp_memuse, size);
+    (void)SC_ATOMIC_SUB(ftp_memuse, size);
 }
 
 uint64_t FTPMemuseGlobalCounter(void)

--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -70,12 +70,12 @@ void HTPParseMemcap(void)
 
 static void HTPIncrMemuse(uint64_t size)
 {
-    (void) SC_ATOMIC_ADD(htp_memuse, size);
+    (void)SC_ATOMIC_ADD(htp_memuse, size);
 }
 
 static void HTPDecrMemuse(uint64_t size)
 {
-    (void) SC_ATOMIC_SUB(htp_memuse, size);
+    (void)SC_ATOMIC_SUB(htp_memuse, size);
 }
 
 uint64_t HTPMemuseGlobalCounter(void)

--- a/src/app-layer-htp-mem.c
+++ b/src/app-layer-htp-mem.c
@@ -71,13 +71,11 @@ void HTPParseMemcap(void)
 static void HTPIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(htp_memuse, size);
-    return;
 }
 
 static void HTPDecrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_SUB(htp_memuse, size);
-    return;
 }
 
 uint64_t HTPMemuseGlobalCounter(void)

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2552,7 +2552,6 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
     htp_config_set_field_limits(cfg_prec->cfg,
             (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_SOFT,
             (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_HARD);
-    return;
 }
 
 /* hack: htp random range code expects random values in range of 0-RAND_MAX,
@@ -2608,7 +2607,6 @@ static void HTPConfigSetDefaultsPhase2(const char *name, HTPCfgRec *cfg_prec)
     }
 
     htp_config_register_request_line(cfg_prec->cfg, HTPCallbackRequestLine);
-    return;
 }
 
 static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
@@ -2990,7 +2988,6 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
         }
     } /* TAILQ_FOREACH(p, &default_config->head, next) */
 
-    return;
 }
 
 void HTPConfigure(void)
@@ -3318,14 +3315,12 @@ void HtpConfigCreateBackup(void)
 {
     cfglist_backup = cfglist;
 
-    return;
 }
 
 void HtpConfigRestoreBackup(void)
 {
     cfglist = cfglist_backup;
 
-    return;
 }
 
 /** \test Test case where chunks are sent in smaller chunks and check the

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2549,8 +2549,7 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
      * config, we have to set the soft limit as well. If libhtp starts using
      * the soft limit in the future, we at least make sure we control what
      * it's value is. */
-    htp_config_set_field_limits(cfg_prec->cfg,
-            (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_SOFT,
+    htp_config_set_field_limits(cfg_prec->cfg, (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_SOFT,
             (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_HARD);
 }
 
@@ -2987,7 +2986,6 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                     p->name);
         }
     } /* TAILQ_FOREACH(p, &default_config->head, next) */
-
 }
 
 void HTPConfigure(void)
@@ -3314,13 +3312,11 @@ static HTPCfgRec cfglist_backup;
 void HtpConfigCreateBackup(void)
 {
     cfglist_backup = cfglist;
-
 }
 
 void HtpConfigRestoreBackup(void)
 {
     cfglist = cfglist_backup;
-
 }
 
 /** \test Test case where chunks are sent in smaller chunks and check the

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1772,7 +1772,6 @@ void AppLayerParserRegisterProtocolParsers(void)
     }
 
     ValidateParsers();
-    return;
 }
 
 

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -50,7 +50,6 @@ void RegisterSMBParsers(void)
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_SMB, SMBParserRegisterTests);
 #endif
-
 }
 
 #ifdef UNITTESTS

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -51,7 +51,6 @@ void RegisterSMBParsers(void)
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_SMB, SMBParserRegisterTests);
 #endif
 
-    return;
 }
 
 #ifdef UNITTESTS

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1600,7 +1600,6 @@ static void SMTPLocalStorageFree(void *ptr)
         SCFree(td);
     }
 
-    return;
 }
 
 static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
@@ -1654,7 +1653,6 @@ static void SMTPStateFree(void *p)
 
     SCFree(smtp_state);
 
-    return;
 }
 
 static void SMTPSetMpmState(void)
@@ -1912,7 +1910,6 @@ void RegisterSMTPParsers(void)
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_SMTP, SMTPParserRegisterTests);
 #endif
-    return;
 }
 
 /**
@@ -4267,5 +4264,4 @@ void SMTPParserRegisterTests(void)
     UtRegisterTest("SMTPParserTest14", SMTPParserTest14);
 #endif /* UNITTESTS */
 
-    return;
 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1599,7 +1599,6 @@ static void SMTPLocalStorageFree(void *ptr)
 
         SCFree(td);
     }
-
 }
 
 static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
@@ -1652,7 +1651,6 @@ static void SMTPStateFree(void *p)
     }
 
     SCFree(smtp_state);
-
 }
 
 static void SMTPSetMpmState(void)
@@ -1673,7 +1671,6 @@ static void SMTPSetMpmState(void)
     }
 
     mpm_table[SMTP_MPM].Prepare(smtp_mpm_ctx);
-
 }
 
 static void SMTPFreeMpmState(void)
@@ -1789,7 +1786,6 @@ static void *SMTPStateGetTx(void *state, uint64_t id)
         }
     }
     return NULL;
-
 }
 
 static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
@@ -4263,5 +4259,4 @@ void SMTPParserRegisterTests(void)
     UtRegisterTest("SMTPParserTest13", SMTPParserTest13);
     UtRegisterTest("SMTPParserTest14", SMTPParserTest14);
 #endif /* UNITTESTS */
-
 }

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2907,7 +2907,6 @@ static void SSLStateFree(void *p)
 
     SCFree(ssl_state);
 
-    return;
 }
 
 static void SSLStateTransactionFree(void *state, uint64_t tx_id)
@@ -3303,7 +3302,6 @@ void RegisterSSLParsers(void)
         SCLogConfig("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
 
-    return;
 }
 
 /**

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2906,7 +2906,6 @@ static void SSLStateFree(void *p)
     TAILQ_INIT(&ssl_state->client_connp.certs);
 
     SCFree(ssl_state);
-
 }
 
 static void SSLStateTransactionFree(void *state, uint64_t tx_id)
@@ -3301,7 +3300,6 @@ void RegisterSSLParsers(void)
     } else {
         SCLogConfig("Parser disabled for %s protocol. Protocol detection still on.", proto_name);
     }
-
 }
 
 /**

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -354,7 +354,6 @@ static void TCPProtoDetectCheckBailConditions(ThreadVars *tv,
 
 failure:
     DisableAppLayer(tv, f, p);
-    return;
 }
 
 static int TCPProtoDetectTriggerOpposingSide(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -121,21 +121,15 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv);
 
 void AppLayerProfilingResetInternal(AppLayerThreadCtx *app_tctx);
 
-static inline void AppLayerProfilingReset(AppLayerThreadCtx *app_tctx)
-{
-#ifdef PROFILING
-    AppLayerProfilingResetInternal(app_tctx);
-#endif
-}
-
 void AppLayerProfilingStoreInternal(AppLayerThreadCtx *app_tctx, Packet *p);
 
-static inline void AppLayerProfilingStore(AppLayerThreadCtx *app_tctx, Packet *p)
-{
 #ifdef PROFILING
-    AppLayerProfilingStoreInternal(app_tctx, p);
+#define AppLayerProfilingReset(app_tctx)    AppLayerProfilingResetInternal(app_tctx)
+#define AppLayerProfilingStore(app_tctx, p) AppLayerProfilingStoreInternal(app_tctx, p)
+#else
+#define AppLayerProfilingReset(app_tctx)
+#define AppLayerProfilingStore(app_tctx, p)
 #endif
-}
 
 void AppLayerRegisterGlobalCounters(void);
 

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -71,7 +71,6 @@ Mangle(char *string)
 
     while ((c = strchr(string, '_')))
         *c = '-';
-
 }
 
 /**

--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -72,7 +72,6 @@ Mangle(char *string)
     while ((c = strchr(string, '_')))
         *c = '-';
 
-    return;
 }
 
 /**

--- a/src/conf.c
+++ b/src/conf.c
@@ -456,7 +456,6 @@ int ConfGetChildValueInt(const ConfNode *base, const char *name, intmax_t *val)
 
     *val = tmpint;
     return 1;
-
 }
 
 int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt,
@@ -671,7 +670,6 @@ void ConfCreateContextBackup(void)
 {
     root_backup = root;
     root = NULL;
-
 }
 
 /**
@@ -682,7 +680,6 @@ void ConfRestoreContextBackup(void)
 {
     root = root_backup;
     root_backup = NULL;
-
 }
 
 /**

--- a/src/conf.c
+++ b/src/conf.c
@@ -672,7 +672,6 @@ void ConfCreateContextBackup(void)
     root_backup = root;
     root = NULL;
 
-    return;
 }
 
 /**
@@ -684,7 +683,6 @@ void ConfRestoreContextBackup(void)
     root = root_backup;
     root_backup = NULL;
 
-    return;
 }
 
 /**

--- a/src/counters.c
+++ b/src/counters.c
@@ -222,7 +222,6 @@ void StatsSetUI64(ThreadVars *tv, uint16_t id, uint64_t x)
     }
 
     pca->head[id].updates++;
-
 }
 
 static ConfNode *GetConfig(void) {
@@ -366,7 +365,6 @@ static void StatsReleaseCtx(void)
     }
     memset(&stats_table, 0, sizeof(stats_table));
     SCMutexUnlock(&stats_table_mutex);
-
 }
 
 /**
@@ -563,7 +561,6 @@ static void StatsReleaseCounter(StatsCounter *pc)
     if (pc != NULL) {
         SCFree(pc);
     }
-
 }
 
 /**

--- a/src/counters.c
+++ b/src/counters.c
@@ -155,7 +155,6 @@ void StatsAddUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 #endif
     pca->head[id].value += x;
     pca->head[id].updates++;
-    return;
 }
 
 /**
@@ -176,7 +175,6 @@ void StatsIncr(ThreadVars *tv, uint16_t id)
 #endif
     pca->head[id].value++;
     pca->head[id].updates++;
-    return;
 }
 
 /**
@@ -197,7 +195,6 @@ void StatsDecr(ThreadVars *tv, uint16_t id)
 #endif
     pca->head[id].value--;
     pca->head[id].updates++;
-    return;
 }
 
 /**
@@ -226,7 +223,6 @@ void StatsSetUI64(ThreadVars *tv, uint16_t id, uint64_t x)
 
     pca->head[id].updates++;
 
-    return;
 }
 
 static ConfNode *GetConfig(void) {
@@ -371,7 +367,6 @@ static void StatsReleaseCtx(void)
     memset(&stats_table, 0, sizeof(stats_table));
     SCMutexUnlock(&stats_table_mutex);
 
-    return;
 }
 
 /**
@@ -569,7 +564,6 @@ static void StatsReleaseCounter(StatsCounter *pc)
         SCFree(pc);
     }
 
-    return;
 }
 
 /**
@@ -653,7 +647,6 @@ static void StatsCopyCounterValue(StatsLocalCounter *pcae)
 
     pc->value = pcae->value;
     pc->updates = pcae->updates;
-    return;
 }
 
 /**

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -139,7 +139,6 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
                s, d, IPV6_GET_RAW_CLASS(icmp6_ip6h), IPV6_GET_RAW_FLOW(icmp6_ip6h),
                IPV6_GET_RAW_NH(icmp6_ip6h), IPV6_GET_RAW_PLEN(icmp6_ip6h), IPV6_GET_RAW_HLIM(icmp6_ip6h));
 #endif
-
 }
 
 /** \retval type counterpart type or -1 */

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -140,7 +140,6 @@ static void DecodePartialIPV6(Packet *p, uint8_t *partial_packet, uint16_t len )
                IPV6_GET_RAW_NH(icmp6_ip6h), IPV6_GET_RAW_PLEN(icmp6_ip6h), IPV6_GET_RAW_HLIM(icmp6_ip6h));
 #endif
 
-    return;
 }
 
 /** \retval type counterpart type or -1 */

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -59,7 +59,6 @@ static void DecodeIPv4inIPv6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, c
     } else {
         ENGINE_SET_EVENT(p, IPV4_IN_IPV6_WRONG_IP_VER);
     }
-    return;
 }
 
 /**

--- a/src/decode.c
+++ b/src/decode.c
@@ -728,7 +728,6 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
                     DEvents[i].event_name, tv);
         }
     }
-
 }
 
 void DecodeUpdatePacketCounters(ThreadVars *tv,

--- a/src/decode.c
+++ b/src/decode.c
@@ -729,7 +729,6 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
         }
     }
 
-    return;
 }
 
 void DecodeUpdatePacketCounters(ThreadVars *tv,

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -36,7 +36,6 @@ static void DefragPolicyFreeUserData(void *data)
 {
     if (data != NULL)
         SCFree(data);
-
 }
 
 static void DefragPolicyAddHostInfo(char *host_ip_range, uint64_t timeout)

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -37,7 +37,6 @@ static void DefragPolicyFreeUserData(void *data)
     if (data != NULL)
         SCFree(data);
 
-    return;
 }
 
 static void DefragPolicyAddHostInfo(char *host_ip_range, uint64_t timeout)

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -289,7 +289,6 @@ void DefragInitConfig(bool quiet)
                 SC_ATOMIC_GET(defrag_memuse), SC_ATOMIC_GET(defrag_config.memcap));
     }
 
-    return;
 }
 
 /** \brief print some defrag stats
@@ -331,7 +330,6 @@ void DefragHashShutdown(void)
     }
     (void) SC_ATOMIC_SUB(defrag_memuse, defrag_config.hash_size * sizeof(DefragTrackerHashRow));
     DefragTrackerQueueDestroy(&defragtracker_spare_q);
-    return;
 }
 
 /** \brief compare two raw ipv6 addrs

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -288,7 +288,6 @@ void DefragInitConfig(bool quiet)
         SCLogConfig("defrag memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(defrag_memuse), SC_ATOMIC_GET(defrag_config.memcap));
     }
-
 }
 
 /** \brief print some defrag stats

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -183,7 +183,6 @@ error:
 static void DetectAppLayerProtocolFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCFree(ptr);
-    return;
 }
 
 /** \internal
@@ -281,7 +280,6 @@ void DetectAppLayerProtocolRegister(void)
         PrefilterSetupAppProto;
     sigmatch_table[DETECT_AL_APP_LAYER_PROTOCOL].SupportsPrefilter =
         PrefilterAppProtoIsPrefilterable;
-    return;
 }
 
 /**********************************Unittests***********************************/

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -279,7 +279,7 @@ void DetectAppLayerProtocolRegister(void)
     sigmatch_table[DETECT_AL_APP_LAYER_PROTOCOL].SetupPrefilter =
         PrefilterSetupAppProto;
     sigmatch_table[DETECT_AL_APP_LAYER_PROTOCOL].SupportsPrefilter =
-        PrefilterAppProtoIsPrefilterable;
+            PrefilterAppProtoIsPrefilterable;
 }
 
 /**********************************Unittests***********************************/

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -645,7 +645,6 @@ static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
         SCFree(bed);
     }
 
-    return;
 }
 
 /**

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -644,7 +644,6 @@ static void DetectByteExtractFree(DetectEngineCtx *de_ctx, void *ptr)
             SCFree((void *)bed->name);
         SCFree(bed);
     }
-
 }
 
 /**

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -305,7 +305,6 @@ static void DetectIPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -395,7 +394,6 @@ static void DetectTCPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -486,7 +484,6 @@ static void DetectTCPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -579,7 +576,6 @@ static void DetectUDPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -669,7 +665,6 @@ static void DetectUDPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -759,7 +754,6 @@ static void DetectICMPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /**
@@ -854,7 +848,6 @@ static void DetectICMPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
     if (cd != NULL)
         SCFree(cd);
 
-    return;
 }
 
 /* ---------------------------------- Unit Tests --------------------------- */

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -304,7 +304,6 @@ static void DetectIPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -393,7 +392,6 @@ static void DetectTCPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -483,7 +481,6 @@ static void DetectTCPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -575,7 +572,6 @@ static void DetectUDPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -664,7 +660,6 @@ static void DetectUDPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -753,7 +748,6 @@ static void DetectICMPV4CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /**
@@ -847,7 +841,6 @@ static void DetectICMPV6CsumFree(DetectEngineCtx *de_ctx, void *ptr)
 
     if (cd != NULL)
         SCFree(cd);
-
 }
 
 /* ---------------------------------- Unit Tests --------------------------- */

--- a/src/detect-datarep.c
+++ b/src/detect-datarep.c
@@ -238,7 +238,6 @@ static void GetDirName(const char *in, char *out, size_t outs)
     char *dir = dirname(tmp);
     BUG_ON(dir == NULL);
     strlcpy(out, dir, outs);
-    return;
 }
 
 static int SetupLoadPath(const DetectEngineCtx *de_ctx,

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -252,7 +252,6 @@ static void GetDirName(const char *in, char *out, size_t outs)
     char *dir = dirname(tmp);
     BUG_ON(dir == NULL);
     strlcpy(out, dir, outs);
-    return;
 }
 
 static int SetupLoadPath(const DetectEngineCtx *de_ctx,

--- a/src/detect-engine-address-ipv6.c
+++ b/src/detect-engine-address-ipv6.c
@@ -296,7 +296,6 @@ static void AddressCutIPv6CopySubOne(uint32_t *a, uint32_t *b)
     b[1] = htonl(b[1]);
     b[2] = htonl(b[2]);
     b[3] = htonl(b[3]);
-
 }
 
 /**
@@ -333,7 +332,6 @@ static void AddressCutIPv6CopyAddOne(uint32_t *a, uint32_t *b)
     b[1] = htonl(b[1]);
     b[2] = htonl(b[2]);
     b[3] = htonl(b[3]);
-
 }
 
 /**
@@ -350,7 +348,6 @@ static void AddressCutIPv6Copy(uint32_t *a, uint32_t *b)
     b[1] = htonl(a[1]);
     b[2] = htonl(a[2]);
     b[3] = htonl(a[3]);
-
 }
 
 int DetectAddressCutIPv6(DetectEngineCtx *de_ctx, DetectAddress *a,
@@ -1919,5 +1916,4 @@ void DetectAddressIPv6Tests(void)
     UtRegisterTest("AddressTestIPv6CutNot04", AddressTestIPv6CutNot04);
     UtRegisterTest("AddressTestIPv6CutNot05", AddressTestIPv6CutNot05);
 #endif /* UNITTESTS */
-
 }

--- a/src/detect-engine-address-ipv6.c
+++ b/src/detect-engine-address-ipv6.c
@@ -297,7 +297,6 @@ static void AddressCutIPv6CopySubOne(uint32_t *a, uint32_t *b)
     b[2] = htonl(b[2]);
     b[3] = htonl(b[3]);
 
-    return;
 }
 
 /**
@@ -335,7 +334,6 @@ static void AddressCutIPv6CopyAddOne(uint32_t *a, uint32_t *b)
     b[2] = htonl(b[2]);
     b[3] = htonl(b[3]);
 
-    return;
 }
 
 /**
@@ -353,7 +351,6 @@ static void AddressCutIPv6Copy(uint32_t *a, uint32_t *b)
     b[2] = htonl(a[2]);
     b[3] = htonl(a[3]);
 
-    return;
 }
 
 int DetectAddressCutIPv6(DetectEngineCtx *de_ctx, DetectAddress *a,
@@ -1923,5 +1920,4 @@ void DetectAddressIPv6Tests(void)
     UtRegisterTest("AddressTestIPv6CutNot05", AddressTestIPv6CutNot05);
 #endif /* UNITTESTS */
 
-    return;
 }

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -85,7 +85,6 @@ void DetectAddressFree(DetectAddress *ag)
         return;
 
     SCFree(ag);
-    return;
 }
 
 /**
@@ -1342,7 +1341,6 @@ void DetectAddressMapFree(DetectEngineCtx *de_ctx)
 
     HashListTableFree(de_ctx->address_table);
     de_ctx->address_table = NULL;
-    return;
 }
 
 static bool DetectAddressMapAdd(DetectEngineCtx *de_ctx, const char *string,
@@ -1488,7 +1486,6 @@ void DetectAddressHeadCleanup(DetectAddressHead *gh)
         }
     }
 
-    return;
 }
 
 /**
@@ -1788,7 +1785,6 @@ static void DetectAddressPrint(DetectAddress *gr)
 //        printf("%s/%s", ip, mask);
     }
 
-    return;
 }
 #endif
 

--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1485,7 +1485,6 @@ void DetectAddressHeadCleanup(DetectAddressHead *gh)
             gh->ipv6_head = NULL;
         }
     }
-
 }
 
 /**
@@ -1784,7 +1783,6 @@ static void DetectAddressPrint(DetectAddress *gr)
         SCLogDebug("%s/%s", ip, mask);
 //        printf("%s/%s", ip, mask);
     }
-
 }
 #endif
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -303,7 +303,6 @@ void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet
 
     SCLogDebug("Appending sid %" PRIu32 ", s->num %" PRIu32 " to alert queue", s->id, s->num);
     det_ctx->alert_queue_size++;
-    return;
 }
 
 /** \internal

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -455,7 +455,6 @@ static void CleanupFPAnalyzer(DetectEngineCtx *de_ctx)
 
     fclose(de_ctx->ea->rule_engine_analysis_fp);
     de_ctx->ea->rule_engine_analysis_fp = NULL;
-
 }
 
 static void CleanupRuleAnalyzer(DetectEngineCtx *de_ctx)
@@ -615,7 +614,6 @@ static void EngineAnalysisRulesPrintFP(const DetectEngineCtx *de_ctx, const Sign
         fprintf(ea_ctx->rule_engine_analysis_fp, "(with %d transform(s)) ", bt->transforms.cnt);
     }
     fprintf(ea_ctx->rule_engine_analysis_fp, "buffer.\n");
-
 }
 
 void EngineAnalysisRulesFailure(const DetectEngineCtx *de_ctx, char *line, char *file, int lineno)

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -285,7 +285,6 @@ void EngineAnalysisFP(const DetectEngineCtx *de_ctx, const Signature *s, char *l
     SCFree(pat);
 
     fprintf(fp, "\n");
-    return;
 }
 
 /**
@@ -457,7 +456,6 @@ static void CleanupFPAnalyzer(DetectEngineCtx *de_ctx)
     fclose(de_ctx->ea->rule_engine_analysis_fp);
     de_ctx->ea->rule_engine_analysis_fp = NULL;
 
-    return;
 }
 
 static void CleanupRuleAnalyzer(DetectEngineCtx *de_ctx)
@@ -618,7 +616,6 @@ static void EngineAnalysisRulesPrintFP(const DetectEngineCtx *de_ctx, const Sign
     }
     fprintf(ea_ctx->rule_engine_analysis_fp, "buffer.\n");
 
-    return;
 }
 
 void EngineAnalysisRulesFailure(const DetectEngineCtx *de_ctx, char *line, char *file, int lineno)
@@ -1830,5 +1827,4 @@ void EngineAnalysisRules(const DetectEngineCtx *de_ctx,
         }
         fprintf(fp, "\n");
     }
-    return;
 }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -955,7 +955,6 @@ static void RulesDumpGrouping(const DetectEngineCtx *de_ctx,
     fprintf(fp, "%s\n", js_s);
     free(js_s);
     fclose(fp);
-    return;
 }
 
 static int RulesGroupByProto(DetectEngineCtx *de_ctx)

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -2537,6 +2537,4 @@ void IPOnlyRegisterTests(void)
     UtRegisterTest("IPOnlyTestBug5168v1", IPOnlyTestBug5168v1);
     UtRegisterTest("IPOnlyTestBug5168v2", IPOnlyTestBug5168v2);
 #endif
-
 }
-

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -2538,6 +2538,5 @@ void IPOnlyRegisterTests(void)
     UtRegisterTest("IPOnlyTestBug5168v2", IPOnlyTestBug5168v2);
 #endif
 
-    return;
 }
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -974,7 +974,6 @@ static void PopulateMpmHelperAddPattern(MpmCtx *mpm_ctx, const DetectContentData
                             cd->id, s->num, flags|MPM_PATTERN_CTX_OWNS_ID);
         }
     }
-
 }
 
 #define SGH_PROTO(sgh, p) ((sgh)->init->protos[(p)] == 1)

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -975,7 +975,6 @@ static void PopulateMpmHelperAddPattern(MpmCtx *mpm_ctx, const DetectContentData
         }
     }
 
-    return;
 }
 
 #define SGH_PROTO(sgh, p) ((sgh)->init->protos[(p)] == 1)
@@ -1007,7 +1006,6 @@ static void SetMpm(Signature *s, SigMatch *mpm_sm, const int mpm_sm_list)
     cd->flags |= DETECT_CONTENT_MPM;
     s->init_data->mpm_sm_list = mpm_sm_list;
     s->init_data->mpm_sm = mpm_sm;
-    return;
 }
 
 static SigMatch *GetMpmForList(const Signature *s, SigMatch *list, SigMatch *mpm_sm,
@@ -1249,7 +1247,6 @@ void RetrieveFPForSig(const DetectEngineCtx *de_ctx, Signature *s)
 #endif
     /* assign to signature */
     SetMpm(s, mpm_sm, mpm_sm_list);
-    return;
 }
 
 /** \internal
@@ -1509,7 +1506,6 @@ void MpmStoreFree(DetectEngineCtx *de_ctx)
 
     HashListTableFree(de_ctx->mpm_hash_table);
     de_ctx->mpm_hash_table = NULL;
-    return;
 }
 
 static void MpmStoreSetup(const DetectEngineCtx *de_ctx, MpmStore *ms)

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -1180,5 +1180,4 @@ void PayloadRegisterTests(void)
     UtRegisterTest("PayloadTestSig34", PayloadTestSig34);
 #endif /* UNITTESTS */
 
-    return;
 }

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -1179,5 +1179,4 @@ void PayloadRegisterTests(void)
     UtRegisterTest("PayloadTestSig33", PayloadTestSig33);
     UtRegisterTest("PayloadTestSig34", PayloadTestSig34);
 #endif /* UNITTESTS */
-
 }

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1426,7 +1426,6 @@ void DetectPortHashFree(DetectEngineCtx *de_ctx)
     HashListTableFree(de_ctx->dport_hash_table);
     de_ctx->dport_hash_table = NULL;
 
-    return;
 }
 
 /*---------------------- Unittests -------------------------*/

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1425,7 +1425,6 @@ void DetectPortHashFree(DetectEngineCtx *de_ctx)
 
     HashListTableFree(de_ctx->dport_hash_table);
     de_ctx->dport_hash_table = NULL;
-
 }
 
 /*---------------------- Unittests -------------------------*/
@@ -2373,4 +2372,3 @@ void DetectPortTests(void)
 }
 
 #endif /* UNITTESTS */
-

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -186,7 +186,6 @@ void SigGroupHeadFree(const DetectEngineCtx *de_ctx, SigGroupHead *sgh)
     PrefilterCleanupRuleGroup(de_ctx, sgh);
     SCFree(sgh);
 
-    return;
 }
 
 /**
@@ -317,7 +316,6 @@ void SigGroupHeadHashFree(DetectEngineCtx *de_ctx)
     HashListTableFree(de_ctx->sgh_hash_table);
     de_ctx->sgh_hash_table = NULL;
 
-    return;
 }
 
 /**
@@ -471,7 +469,6 @@ void SigGroupHeadSetSigCnt(SigGroupHead *sgh, uint32_t max_idx)
     }
     sgh->init->sig_cnt = cnt;
 #endif
-    return;
 }
 
 /**
@@ -623,7 +620,6 @@ void SigGroupHeadSetupFiles(const DetectEngineCtx *de_ctx, SigGroupHead *sgh)
         }
     }
 
-    return;
 }
 
 /** \brief build an array of rule id's for sigs with no prefilter

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -185,7 +185,6 @@ void SigGroupHeadFree(const DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 
     PrefilterCleanupRuleGroup(de_ctx, sgh);
     SCFree(sgh);
-
 }
 
 /**
@@ -315,7 +314,6 @@ void SigGroupHeadHashFree(DetectEngineCtx *de_ctx)
 
     HashListTableFree(de_ctx->sgh_hash_table);
     de_ctx->sgh_hash_table = NULL;
-
 }
 
 /**
@@ -619,7 +617,6 @@ void SigGroupHeadSetupFiles(const DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             sgh->filestore_cnt++;
         }
     }
-
 }
 
 /** \brief build an array of rule id's for sigs with no prefilter

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -110,7 +110,6 @@ static void SCSigRegisterSignatureOrderingFunc(DetectEngineCtx *de_ctx,
     else
         prev->next = temp;
 
-    return;
 }
 
 /**

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -109,7 +109,6 @@ static void SCSigRegisterSignatureOrderingFunc(DetectEngineCtx *de_ctx,
         de_ctx->sc_sig_order_funcs = temp;
     else
         prev->next = temp;
-
 }
 
 /**

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -184,13 +184,11 @@ void DetectEngineStateFree(DetectEngineState *state)
         }
     }
     SCFree(state);
-
 }
 
 static void StoreFileNoMatchCnt(DetectEngineState *de_state, uint16_t file_no_match, uint8_t direction)
 {
     de_state->dir_state[(direction & STREAM_TOSERVER) ? 0 : 1].filestore_cnt += file_no_match;
-
 }
 
 static bool StoreFilestoreSigsCantMatch(const SigGroupHead *sgh, const DetectEngineState *de_state, uint8_t direction)
@@ -1459,7 +1457,6 @@ void DeStateRegisterTests(void)
     UtRegisterTest("DeStateSigTest09", DeStateSigTest09);
     UtRegisterTest("DeStateSigTest10", DeStateSigTest10);
 #endif
-
 }
 
 /**

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -185,14 +185,12 @@ void DetectEngineStateFree(DetectEngineState *state)
     }
     SCFree(state);
 
-    return;
 }
 
 static void StoreFileNoMatchCnt(DetectEngineState *de_state, uint16_t file_no_match, uint8_t direction)
 {
     de_state->dir_state[(direction & STREAM_TOSERVER) ? 0 : 1].filestore_cnt += file_no_match;
 
-    return;
 }
 
 static bool StoreFilestoreSigsCantMatch(const SigGroupHead *sgh, const DetectEngineState *de_state, uint8_t direction)
@@ -1462,7 +1460,6 @@ void DeStateRegisterTests(void)
     UtRegisterTest("DeStateSigTest10", DeStateSigTest10);
 #endif
 
-    return;
 }
 
 /**

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2477,7 +2477,6 @@ error:
         DetectEngineCtxFree(de_ctx);
     }
     return NULL;
-
 }
 
 DetectEngineCtx *DetectEngineCtxInitStubForMT(void)
@@ -4867,7 +4866,6 @@ static void DetectEngineDeInitYamlConf(void)
 {
     ConfDeInit();
     ConfRestoreContextBackup();
-
 }
 
 static int DetectEngineTest01(void)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -976,7 +976,6 @@ static void DetectBufferTypeFree(void)
 
     HashListTableFree(g_buffer_type_hash);
     g_buffer_type_hash = NULL;
-    return;
 }
 #endif
 static int DetectBufferTypeAdd(const char *string)
@@ -4869,7 +4868,6 @@ static void DetectEngineDeInitYamlConf(void)
     ConfDeInit();
     ConfRestoreContextBackup();
 
-    return;
 }
 
 static int DetectEngineTest01(void)
@@ -5067,5 +5065,4 @@ void DetectEngineRegisterTests(void)
     UtRegisterTest("DetectEngineTest08", DetectEngineTest08);
     UtRegisterTest("DetectEngineTest09", DetectEngineTest09);
 #endif
-    return;
 }

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -117,7 +117,6 @@ static void Add(SCFPSupportSMList **list, const int list_id, const int priority)
         new->next = ip->next;
         ip->next = new;
     }
-    return;
 }
 
 /**

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -127,7 +127,6 @@ void DetectFilemagicRegister(void)
 
     g_file_magic_buffer_id = DetectBufferTypeGetByName("file.magic");
 	SCLogDebug("registering filemagic rule option");
-    return;
 }
 
 #define FILEMAGIC_MIN_SIZE  512

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -126,7 +126,7 @@ void DetectFilemagicRegister(void)
     DetectBufferTypeSupportsMultiInstance("file.magic");
 
     g_file_magic_buffer_id = DetectBufferTypeGetByName("file.magic");
-	SCLogDebug("registering filemagic rule option");
+    SCLogDebug("registering filemagic rule option");
 }
 
 #define FILEMAGIC_MIN_SIZE  512

--- a/src/detect-filemd5.c
+++ b/src/detect-filemd5.c
@@ -55,7 +55,6 @@ void DetectFileMd5Register(void)
     g_file_match_list_id = DetectBufferTypeRegister("files");
 
     SCLogDebug("registering filemd5 rule option");
-    return;
 }
 
 /**

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -118,7 +118,6 @@ void DetectFilenameRegister(void)
     filehandler_table[DETECT_FILE_NAME].Callback = DetectEngineInspectFilename;
 
     DetectBufferTypeSupportsMultiInstance("file.name");
-    return;
 }
 
 static int DetectFileextSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)

--- a/src/detect-filesha1.c
+++ b/src/detect-filesha1.c
@@ -55,7 +55,6 @@ void DetectFileSha1Register(void)
     g_file_match_list_id = DetectBufferTypeRegister("files");
 
     SCLogDebug("registering filesha1 rule option");
-    return;
 }
 
 /**

--- a/src/detect-filesha256.c
+++ b/src/detect-filesha256.c
@@ -56,7 +56,6 @@ void DetectFileSha256Register(void)
     g_file_match_list_id = DetectBufferTypeRegister("files");
 
     SCLogDebug("registering filesha256 rule option");
-    return;
 }
 
 /**

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -196,7 +196,6 @@ void DetectHttp2Register(void)
             "http2", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
 
     g_http2_match_buffer_id = DetectBufferTypeRegister("http2");
-    return;
 }
 
 /**

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -62,7 +62,6 @@ void DetectIcmpv4HdrRegister(void)
     DetectPktMpmRegister("icmpv4.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
     DetectPktInspectEngineRegister("icmpv4.hdr", GetData, DetectEngineInspectPktBufferGeneric);
-
 }
 
 /**

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -63,7 +63,6 @@ void DetectIcmpv4HdrRegister(void)
 
     DetectPktInspectEngineRegister("icmpv4.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 
-    return;
 }
 
 /**

--- a/src/detect-icmpv6-mtu.c
+++ b/src/detect-icmpv6-mtu.c
@@ -58,7 +58,6 @@ void DetectICMPv6mtuRegister(void)
 #endif
     sigmatch_table[DETECT_ICMPV6MTU].SupportsPrefilter = PrefilterIcmpv6mtuIsPrefilterable;
     sigmatch_table[DETECT_ICMPV6MTU].SetupPrefilter = PrefilterSetupIcmpv6mtu;
-    return;
 }
 
 // returns 0 on no mtu, and 1 if mtu

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -66,9 +66,7 @@ void DetectICMPv6hdrRegister(void)
 
     DetectPktMpmRegister("icmpv6.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
-    DetectPktInspectEngineRegister("icmpv6.hdr", GetData,
-            DetectEngineInspectPktBufferGeneric);
-
+    DetectPktInspectEngineRegister("icmpv6.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 }
 
 /**

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -69,7 +69,6 @@ void DetectICMPv6hdrRegister(void)
     DetectPktInspectEngineRegister("icmpv6.hdr", GetData,
             DetectEngineInspectPktBufferGeneric);
 
-    return;
 }
 
 /**

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -441,7 +441,6 @@ void DetectIPProtoRemoveAllSMs(DetectEngineCtx *de_ctx, Signature *s)
         SigMatchFree(de_ctx, sm);
         sm = tmp_sm;
     }
-
 }
 
 static void DetectIPProtoFree(DetectEngineCtx *de_ctx, void *ptr)
@@ -927,7 +926,6 @@ static int DetectIPProtoTestSetup15(void)
  end:
     SigFree(NULL, sig);
     return result;
-
 }
 
 static int DetectIPProtoTestSetup16(void)
@@ -965,7 +963,6 @@ static int DetectIPProtoTestSetup16(void)
  end:
     SigFree(NULL, sig);
     return result;
-
 }
 
 static int DetectIPProtoTestSetup17(void)
@@ -1003,7 +1000,6 @@ static int DetectIPProtoTestSetup17(void)
  end:
     SigFree(NULL, sig);
     return result;
-
 }
 
 static int DetectIPProtoTestSetup18(void)
@@ -1041,7 +1037,6 @@ static int DetectIPProtoTestSetup18(void)
  end:
     SigFree(NULL, sig);
     return result;
-
 }
 
 static int DetectIPProtoTestSetup19(void)

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -442,7 +442,6 @@ void DetectIPProtoRemoveAllSMs(DetectEngineCtx *de_ctx, Signature *s)
         sm = tmp_sm;
     }
 
-    return;
 }
 
 static void DetectIPProtoFree(DetectEngineCtx *de_ctx, void *ptr)

--- a/src/detect-ipv4hdr.c
+++ b/src/detect-ipv4hdr.c
@@ -65,9 +65,7 @@ void DetectIpv4hdrRegister(void)
 
     DetectPktMpmRegister("ipv4.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
-    DetectPktInspectEngineRegister("ipv4.hdr", GetData,
-            DetectEngineInspectPktBufferGeneric);
-
+    DetectPktInspectEngineRegister("ipv4.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 }
 
 /**

--- a/src/detect-ipv4hdr.c
+++ b/src/detect-ipv4hdr.c
@@ -68,7 +68,6 @@ void DetectIpv4hdrRegister(void)
     DetectPktInspectEngineRegister("ipv4.hdr", GetData,
             DetectEngineInspectPktBufferGeneric);
 
-    return;
 }
 
 /**

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -68,7 +68,6 @@ void DetectIpv6hdrRegister(void)
     DetectPktInspectEngineRegister("ipv6.hdr", GetData,
             DetectEngineInspectPktBufferGeneric);
 
-    return;
 }
 
 /**

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -65,9 +65,7 @@ void DetectIpv6hdrRegister(void)
 
     DetectPktMpmRegister("ipv6.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
-    DetectPktInspectEngineRegister("ipv6.hdr", GetData,
-            DetectEngineInspectPktBufferGeneric);
-
+    DetectPktInspectEngineRegister("ipv6.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 }
 
 /**

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -85,7 +85,6 @@ void DetectLuaRegister(void)
     sigmatch_table[DETECT_LUA].flags = SIGMATCH_NOT_BUILT;
 
 	SCLogDebug("registering lua rule option");
-    return;
 }
 
 #else /* HAVE_LUA */
@@ -129,7 +128,6 @@ void DetectLuaRegister(void)
             DetectEngineInspectGenericList, NULL);
 
     SCLogDebug("registering lua rule option");
-    return;
 }
 
 #define DATATYPE_PACKET  BIT_U32(0)

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -84,7 +84,7 @@ void DetectLuaRegister(void)
     sigmatch_table[DETECT_LUA].Free  = NULL;
     sigmatch_table[DETECT_LUA].flags = SIGMATCH_NOT_BUILT;
 
-	SCLogDebug("registering lua rule option");
+    SCLogDebug("registering lua rule option");
 }
 
 #else /* HAVE_LUA */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -549,7 +549,6 @@ void SigMatchRemoveSMFromList(Signature *s, SigMatch *sm, int sm_list)
         sm->prev->next = sm->next;
     if (sm->next != NULL)
         sm->next->prev = sm->prev;
-
 }
 
 /**
@@ -812,7 +811,6 @@ static void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
         sm->next = NULL;
         *dst_sm_list_tail = sm;
     }
-
 }
 
 int SigMatchListSMBelongsTo(const Signature *s, const SigMatch *key_sm)
@@ -2361,7 +2359,6 @@ static void DetectParseDupSigFreeFunc(void *data)
 {
     if (data != NULL)
         SCFree(data);
-
 }
 
 /**
@@ -2440,7 +2437,6 @@ void DetectParseDupSigHashFree(DetectEngineCtx *de_ctx)
         HashListTableFree(de_ctx->dup_sig_hash_table);
 
     de_ctx->dup_sig_hash_table = NULL;
-
 }
 
 /**

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -550,7 +550,6 @@ void SigMatchRemoveSMFromList(Signature *s, SigMatch *sm, int sm_list)
     if (sm->next != NULL)
         sm->next->prev = sm->prev;
 
-    return;
 }
 
 /**
@@ -814,7 +813,6 @@ static void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
         *dst_sm_list_tail = sm;
     }
 
-    return;
 }
 
 int SigMatchListSMBelongsTo(const Signature *s, const SigMatch *key_sm)
@@ -2364,7 +2362,6 @@ static void DetectParseDupSigFreeFunc(void *data)
     if (data != NULL)
         SCFree(data);
 
-    return;
 }
 
 /**
@@ -2444,7 +2441,6 @@ void DetectParseDupSigHashFree(DetectEngineCtx *de_ctx)
 
     de_ctx->dup_sig_hash_table = NULL;
 
-    return;
 }
 
 /**

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -155,7 +155,6 @@ void DetectPcreRegister (void)
     }
 #endif
 
-    return;
 }
 
 /**
@@ -973,7 +972,6 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
     }
     SCFree(pd);
 
-    return;
 }
 
 #ifdef UNITTESTS /* UNITTESTS */

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -154,7 +154,6 @@ void DetectPcreRegister (void)
         pcre2_use_jit = 0;
     }
 #endif
-
 }
 
 /**
@@ -971,7 +970,6 @@ static void DetectPcreFree(DetectEngineCtx *de_ctx, void *ptr)
         VarNameStoreUnregister(pd->capids[i], pd->captypes[i]);
     }
     SCFree(pd);
-
 }
 
 #ifdef UNITTESTS /* UNITTESTS */
@@ -2064,6 +2062,5 @@ static void DetectPcreRegisterTests(void)
 
     UtRegisterTest("DetectPcreParseHttpHost", DetectPcreParseHttpHost);
     UtRegisterTest("DetectPcreParseCaptureTest", DetectPcreParseCaptureTest);
-
 }
 #endif /* UNITTESTS */

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -332,7 +332,6 @@ static void DetectSslStateFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL)
         SCFree(ptr);
-
 }
 
 #ifdef UNITTESTS

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -333,7 +333,6 @@ static void DetectSslStateFree(DetectEngineCtx *de_ctx, void *ptr)
     if (ptr != NULL)
         SCFree(ptr);
 
-    return;
 }
 
 #ifdef UNITTESTS

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -68,7 +68,6 @@ void DetectTcphdrRegister(void)
     DetectPktInspectEngineRegister("tcp.hdr", GetData,
             DetectEngineInspectPktBufferGeneric);
 
-    return;
 }
 
 /**

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -65,9 +65,7 @@ void DetectTcphdrRegister(void)
 
     DetectPktMpmRegister("tcp.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
-    DetectPktInspectEngineRegister("tcp.hdr", GetData,
-            DetectEngineInspectPktBufferGeneric);
-
+    DetectPktInspectEngineRegister("tcp.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 }
 
 /**

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -58,7 +58,6 @@ void DetectTcpmssRegister(void)
     sigmatch_table[DETECT_TCPMSS].Free = DetectTcpmssFree;
     sigmatch_table[DETECT_TCPMSS].SupportsPrefilter = PrefilterTcpmssIsPrefilterable;
     sigmatch_table[DETECT_TCPMSS].SetupPrefilter = PrefilterSetupTcpmss;
-
 }
 
 /**

--- a/src/detect-tcpmss.c
+++ b/src/detect-tcpmss.c
@@ -59,7 +59,6 @@ void DetectTcpmssRegister(void)
     sigmatch_table[DETECT_TCPMSS].SupportsPrefilter = PrefilterTcpmssIsPrefilterable;
     sigmatch_table[DETECT_TCPMSS].SetupPrefilter = PrefilterSetupTcpmss;
 
-    return;
 }
 
 /**

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -59,7 +59,6 @@ void DetectTemplate2Register(void)
     sigmatch_table[DETECT_TEMPLATE2].SupportsPrefilter = PrefilterTemplate2IsPrefilterable;
     sigmatch_table[DETECT_TEMPLATE2].SetupPrefilter = PrefilterSetupTemplate2;
 
-    return;
 }
 
 /**

--- a/src/detect-template2.c
+++ b/src/detect-template2.c
@@ -58,7 +58,6 @@ void DetectTemplate2Register(void)
     sigmatch_table[DETECT_TEMPLATE2].Free = DetectTemplate2Free;
     sigmatch_table[DETECT_TEMPLATE2].SupportsPrefilter = PrefilterTemplate2IsPrefilterable;
     sigmatch_table[DETECT_TEMPLATE2].SetupPrefilter = PrefilterSetupTemplate2;
-
 }
 
 /**

--- a/src/detect-tos.c
+++ b/src/detect-tos.c
@@ -364,6 +364,5 @@ void DetectTosRegisterTests(void)
     UtRegisterTest("DetectTosTest09", DetectTosTest09);
     UtRegisterTest("DetectTosTest10", DetectTosTest10);
     UtRegisterTest("DetectTosTest12", DetectTosTest12);
-    return;
 }
 #endif

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -64,7 +64,6 @@ void DetectTtlRegister(void)
 #endif
     sigmatch_table[DETECT_TTL].SupportsPrefilter = PrefilterTtlIsPrefilterable;
     sigmatch_table[DETECT_TTL].SetupPrefilter = PrefilterSetupTtl;
-
 }
 
 /**

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -65,7 +65,6 @@ void DetectTtlRegister(void)
     sigmatch_table[DETECT_TTL].SupportsPrefilter = PrefilterTtlIsPrefilterable;
     sigmatch_table[DETECT_TTL].SetupPrefilter = PrefilterSetupTtl;
 
-    return;
 }
 
 /**

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -66,7 +66,6 @@ void DetectUdphdrRegister(void)
 
     DetectPktInspectEngineRegister("udp.hdr", GetData,
             DetectEngineInspectPktBufferGeneric);
-    return;
 }
 
 /**

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -64,8 +64,7 @@ void DetectUdphdrRegister(void)
 
     DetectPktMpmRegister("udp.hdr", 2, PrefilterGenericMpmPktRegister, GetData);
 
-    DetectPktInspectEngineRegister("udp.hdr", GetData,
-            DetectEngineInspectPktBufferGeneric);
+    DetectPktInspectEngineRegister("udp.hdr", GetData, DetectEngineInspectPktBufferGeneric);
 }
 
 /**

--- a/src/detect.c
+++ b/src/detect.c
@@ -1804,7 +1804,6 @@ static void DetectNoFlow(ThreadVars *tv,
 
     /* see if the packet matches one or more of the sigs */
     DetectRun(tv, de_ctx, det_ctx, p);
-    return;
 }
 
 /** \brief Detection engine thread wrapper.

--- a/src/detect.c
+++ b/src/detect.c
@@ -1911,4 +1911,3 @@ void SigMatchSignatures(
 #ifdef UNITTESTS
 #include "tests/detect.c"
 #endif
-

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -174,7 +174,6 @@ again:
 
     /* reset count, so we can kill and respawn (unix socket) */
     SC_ATOMIC_SET(flowmgr_cnt, 0);
-    return;
 }
 
 /** \internal
@@ -962,7 +961,6 @@ void FlowManagerThreadSpawn(void)
             FatalError("flow manager thread spawn failed");
         }
     }
-    return;
 }
 
 typedef struct FlowRecyclerThreadData_ {
@@ -1163,7 +1161,6 @@ void FlowRecyclerThreadSpawn(void)
             FatalError("flow recycler thread spawn failed");
         }
     }
-    return;
 }
 
 /**
@@ -1230,7 +1227,6 @@ again:
 
     /* reset count, so we can kill and respawn (unix socket) */
     SC_ATOMIC_SET(flowrec_cnt, 0);
-    return;
 }
 
 void TmModuleFlowManagerRegister (void)

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -409,7 +409,6 @@ static inline void FlowForceReassemblyForHash(void)
         }
         FBLOCK_UNLOCK(fb);
     }
-    return;
 }
 
 /**
@@ -419,5 +418,4 @@ void FlowForceReassembly(void)
 {
     /* Carry out flow reassembly for unattended flows */
     FlowForceReassemblyForHash();
-    return;
 }

--- a/src/flow.c
+++ b/src/flow.c
@@ -141,7 +141,6 @@ void FlowCleanupAppLayer(Flow *f)
     AppLayerParserStateCleanup(f, f->alstate, f->alparser);
     f->alstate = NULL;
     f->alparser = NULL;
-    return;
 }
 
 /** \brief Set the IPOnly scanned flag for 'direction'.
@@ -153,7 +152,6 @@ void FlowSetIPOnlyFlag(Flow *f, int direction)
 {
     direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) :
         (f->flags |= FLOW_TOCLIENT_IPONLY_SET);
-    return;
 }
 
 /** \brief Set flag to indicate that flow has alerts
@@ -651,7 +649,6 @@ void FlowInitConfig(bool quiet)
     SCLogConfig("flow size %u, memcap allows for %" PRIu64 " flows. Per hash row in perfect "
                 "conditions %" PRIu64,
             sz, flow_memcap_copy / sz, (flow_memcap_copy / sz) / flow_config.hash_size);
-    return;
 }
 
 void FlowReset(void)
@@ -708,7 +705,6 @@ void FlowShutdown(void)
     (void) SC_ATOMIC_SUB(flow_memuse, flow_config.hash_size * sizeof(FlowBucket));
     FlowQueueDestroy(&flow_recycle_q);
     FlowSparePoolDestroy();
-    return;
 }
 
 /**
@@ -1079,7 +1075,6 @@ void FlowInitFlowProto(void)
                 d->new_timeout, d->est_timeout, d->closed_timeout, d->bypassed_timeout);
     }
 
-    return;
 }
 
 /**

--- a/src/flow.c
+++ b/src/flow.c
@@ -150,8 +150,7 @@ void FlowCleanupAppLayer(Flow *f)
   */
 void FlowSetIPOnlyFlag(Flow *f, int direction)
 {
-    direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) :
-        (f->flags |= FLOW_TOCLIENT_IPONLY_SET);
+    direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) : (f->flags |= FLOW_TOCLIENT_IPONLY_SET);
 }
 
 /** \brief Set flag to indicate that flow has alerts
@@ -1074,7 +1073,6 @@ void FlowInitFlowProto(void)
         SCLogDebug("deltas: new: -%u est: -%u closed: -%u bypassed: -%u",
                 d->new_timeout, d->est_timeout, d->closed_timeout, d->bypassed_timeout);
     }
-
 }
 
 /**

--- a/src/host.c
+++ b/src/host.c
@@ -278,7 +278,6 @@ void HostInitConfig(bool quiet)
                 SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
     }
 
-    return;
 }
 
 /** \brief print some host stats
@@ -291,7 +290,6 @@ void HostPrintStats (void)
 #endif /* HOSTBITS_STATS */
     SCLogPerf("host memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
             SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
-    return;
 }
 
 /** \brief shutdown the flow engine
@@ -325,7 +323,6 @@ void HostShutdown(void)
     }
     (void) SC_ATOMIC_SUB(host_memuse, host_config.hash_size * sizeof(HostHashRow));
     HostQueueDestroy(&host_spare_q);
-    return;
 }
 
 /** \brief Cleanup the host engine
@@ -367,7 +364,6 @@ void HostCleanup(void)
         }
     }
 
-    return;
 }
 
 /* calculate the hash key for this packet

--- a/src/host.c
+++ b/src/host.c
@@ -277,7 +277,6 @@ void HostInitConfig(bool quiet)
         SCLogConfig("host memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
     }
-
 }
 
 /** \brief print some host stats
@@ -288,8 +287,8 @@ void HostPrintStats (void)
     SCLogPerf("hostbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
         hostbits_added, hostbits_removed, hostbits_memuse_max);
 #endif /* HOSTBITS_STATS */
-    SCLogPerf("host memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
-            SC_ATOMIC_GET(host_memuse), SC_ATOMIC_GET(host_config.memcap));
+    SCLogPerf("host memory usage: %" PRIu64 " bytes, maximum: %" PRIu64, SC_ATOMIC_GET(host_memuse),
+            SC_ATOMIC_GET(host_config.memcap));
 }
 
 /** \brief shutdown the flow engine
@@ -363,7 +362,6 @@ void HostCleanup(void)
             HRLOCK_UNLOCK(hb);
         }
     }
-
 }
 
 /* calculate the hash key for this packet
@@ -720,4 +718,3 @@ void HostRegisterUnittests(void)
 {
     RegisterHostStorageTests();
 }
-

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -275,7 +275,6 @@ void IPPairInitConfig(bool quiet)
                 SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
     }
 
-    return;
 }
 
 /** \brief print some ippair stats
@@ -288,7 +287,6 @@ void IPPairPrintStats (void)
 #endif /* IPPAIRBITS_STATS */
     SCLogPerf("ippair memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
             SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
-    return;
 }
 
 /** \brief shutdown the flow engine
@@ -323,7 +321,6 @@ void IPPairShutdown(void)
     }
     (void) SC_ATOMIC_SUB(ippair_memuse, ippair_config.hash_size * sizeof(IPPairHashRow));
     IPPairQueueDestroy(&ippair_spare_q);
-    return;
 }
 
 /** \brief Cleanup the ippair engine
@@ -365,7 +362,6 @@ void IPPairCleanup(void)
         }
     }
 
-    return;
 }
 
 /** \brief compare two raw ipv6 addrs

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -274,7 +274,6 @@ void IPPairInitConfig(bool quiet)
         SCLogConfig("ippair memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
     }
-
 }
 
 /** \brief print some ippair stats
@@ -285,7 +284,7 @@ void IPPairPrintStats (void)
     SCLogPerf("ippairbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
         ippairbits_added, ippairbits_removed, ippairbits_memuse_max);
 #endif /* IPPAIRBITS_STATS */
-    SCLogPerf("ippair memory usage: %"PRIu64" bytes, maximum: %"PRIu64,
+    SCLogPerf("ippair memory usage: %" PRIu64 " bytes, maximum: %" PRIu64,
             SC_ATOMIC_GET(ippair_memuse), SC_ATOMIC_GET(ippair_config.memcap));
 }
 
@@ -361,7 +360,6 @@ void IPPairCleanup(void)
             HRLOCK_UNLOCK(hb);
         }
     }
-
 }
 
 /** \brief compare two raw ipv6 addrs

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -214,7 +214,6 @@ void PcapLogRegister(void)
     PcapLogProfileSetup();
     SC_ATOMIC_INIT(thread_cnt);
     SC_ATOMIC_SET(thread_cnt, 1); /* first id is 1 */
-    return;
 }
 
 #define PCAPLOG_PROFILE_START \
@@ -324,7 +323,6 @@ static void PcapFileNameFree(PcapFileName *pf)
         SCFree(pf);
     }
 
-    return;
 }
 
 /**
@@ -1653,7 +1651,6 @@ static void PcapLogFileDeInitCtx(OutputCtx *output_ctx)
     pcre2_code_free(pcre_timestamp_code);
     pcre2_match_data_free(pcre_timestamp_match);
 
-    return;
 }
 
 /**

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -322,7 +322,6 @@ static void PcapFileNameFree(PcapFileName *pf)
         }
         SCFree(pf);
     }
-
 }
 
 /**
@@ -1650,7 +1649,6 @@ static void PcapLogFileDeInitCtx(OutputCtx *output_ctx)
 
     pcre2_code_free(pcre_timestamp_code);
     pcre2_match_data_free(pcre_timestamp_match);
-
 }
 
 /**

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -413,5 +413,4 @@ void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx)
             }
         }
     }
-    return;
 }

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -74,7 +74,6 @@ static void SRepCIDRFreeUserData(void *data)
     if (data != NULL)
         SCFree(data);
 
-    return;
 }
 
 static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8_t value)

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -73,7 +73,6 @@ static void SRepCIDRFreeUserData(void *data)
 {
     if (data != NULL)
         SCFree(data);
-
 }
 
 static void SRepCIDRAddNetblock(SRepCIDRTree *cidr_ctx, char *ip, int cat, uint8_t value)
@@ -263,7 +262,6 @@ static int SRepCatSplitLine(char *line, uint8_t *cat, char *shortname, size_t sh
     *cat = (uint8_t)c;
     strlcpy(shortname, ptrs[1], shortname_len);
     return 0;
-
 }
 
 /**
@@ -431,7 +429,6 @@ static int SRepLoadFile(SRepCIDRTree *cidr_ctx, char *filename)
     fclose(fp);
     fp = NULL;
     return r;
-
 }
 
 int SRepLoadFileFromFD(SRepCIDRTree *cidr_ctx, FILE *fp)

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -146,7 +146,6 @@ void RunModeIdsAFPRegister(void)
             "each flow are assigned to a single detect "
             "thread.",
             RunModeIdsAFPAutoFp, AFPRunModeEnableIPS);
-    return;
 }
 
 

--- a/src/runmode-af-xdp.c
+++ b/src/runmode-af-xdp.c
@@ -78,7 +78,6 @@ void RunModeIdsAFXDPRegister(void)
             " tasks from acquisition to logging",
             RunModeIdsAFXDPWorkers, NULL);
 
-    return;
 }
 
 #ifdef HAVE_AF_XDP

--- a/src/runmode-af-xdp.c
+++ b/src/runmode-af-xdp.c
@@ -77,7 +77,6 @@ void RunModeIdsAFXDPRegister(void)
             "Workers af-xdp mode, each thread does all"
             " tasks from acquisition to logging",
             RunModeIdsAFXDPWorkers, NULL);
-
 }
 
 #ifdef HAVE_AF_XDP

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -63,7 +63,6 @@ void RunModeErfDagRegister(void)
             " tasks from acquisition to logging",
             RunModeIdsErfDagWorkers, NULL);
 
-    return;
 }
 
 int RunModeIdsErfDagSingle(void)

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -62,7 +62,6 @@ void RunModeErfDagRegister(void)
             "Workers DAG mode, each thread does all "
             " tasks from acquisition to logging",
             RunModeIdsErfDagWorkers, NULL);
-
 }
 
 int RunModeIdsErfDagSingle(void)

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -45,7 +45,6 @@ void RunModeErfFileRegister(void)
             "Multi threaded ERF file mode.  Packets from "
             "each flow are assigned to a single detect thread",
             RunModeErfFileAutoFp, NULL);
-
 }
 
 int RunModeErfFileSingle(void)

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -46,7 +46,6 @@ void RunModeErfFileRegister(void)
             "each flow are assigned to a single detect thread",
             RunModeErfFileAutoFp, NULL);
 
-    return;
 }
 
 int RunModeErfFileSingle(void)

--- a/src/runmode-ipfw.c
+++ b/src/runmode-ipfw.c
@@ -54,7 +54,6 @@ void RunModeIpsIPFWRegister(void)
     RunModeRegisterNewRunMode(RUNMODE_IPFW, "workers",
             "Multi queue IPFW IPS mode with one thread per queue", RunModeIpsIPFWWorker, NULL);
 
-    return;
 }
 
 int RunModeIpsIPFWAutoFp(void)

--- a/src/runmode-ipfw.c
+++ b/src/runmode-ipfw.c
@@ -53,7 +53,6 @@ void RunModeIpsIPFWRegister(void)
 
     RunModeRegisterNewRunMode(RUNMODE_IPFW, "workers",
             "Multi queue IPFW IPS mode with one thread per queue", RunModeIpsIPFWWorker, NULL);
-
 }
 
 int RunModeIpsIPFWAutoFp(void)

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -137,7 +137,6 @@ void RunModeIdsNetmapRegister(void)
             "each flow are assigned to a single detect "
             "thread.",
             RunModeIdsNetmapAutoFp, NetmapRunModeEnableIPS);
-    return;
 }
 
 #ifdef HAVE_NETMAP

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -218,5 +218,4 @@ void RunModeIdsNflogRegister(void)
             RUNMODE_NFLOG, "single", "Single threaded nflog mode", RunModeIdsNflogSingle, NULL);
     RunModeRegisterNewRunMode(
             RUNMODE_NFLOG, "workers", "Workers nflog mode", RunModeIdsNflogWorkers, NULL);
-    return;
 }

--- a/src/runmode-nfq.c
+++ b/src/runmode-nfq.c
@@ -51,7 +51,6 @@ void RunModeIpsNFQRegister(void)
 
     RunModeRegisterNewRunMode(RUNMODE_NFQ, "workers",
             "Multi queue NFQ IPS mode with one thread per queue", RunModeIpsNFQWorker, NULL);
-    return;
 }
 
 int RunModeIpsNFQAutoFp(void)

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -45,7 +45,6 @@ void RunModeFilePcapRegister(void)
             "Multi-threaded pcap file mode. Packets from each flow are assigned to a consistent "
             "detection thread",
             RunModeFilePcapAutoFp, NULL);
-
 }
 
 /**

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -46,7 +46,6 @@ void RunModeFilePcapRegister(void)
             "detection thread",
             RunModeFilePcapAutoFp, NULL);
 
-    return;
 }
 
 /**

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -48,7 +48,6 @@ void RunModeIdsPcapRegister(void)
             "Workers pcap live mode, each thread does all"
             " tasks from acquisition to logging",
             RunModeIdsPcapWorkers, NULL);
-
 }
 
 static void PcapDerefConfig(void *conf)

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -49,7 +49,6 @@ void RunModeIdsPcapRegister(void)
             " tasks from acquisition to logging",
             RunModeIdsPcapWorkers, NULL);
 
-    return;
 }
 
 static void PcapDerefConfig(void *conf)

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -63,7 +63,6 @@ void RunModeIdsPfringRegister(void)
             "Workers pfring mode, each thread does all"
             " tasks from acquisition to logging",
             RunModeIdsPfringWorkers, NULL);
-    return;
 }
 
 #ifdef HAVE_PFRING

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -247,7 +247,6 @@ void RunModeRegisterRunModes(void)
 #ifdef UNITTESTS
     UtRunModeRegister();
 #endif
-    return;
 }
 
 /**
@@ -291,7 +290,6 @@ void RunModeListRunmodes(void)
         }
     }
 
-    return;
 }
 
 static const char *RunModeGetConfOrDefault(int capture_mode, const char *capture_plugin_name)
@@ -521,7 +519,6 @@ void RunModeRegisterNewRunMode(enum RunModes runmode, const char *name, const ch
     mode->RunModeFunc = RunModeFunc;
     mode->RunModeIsIPSEnabled = RunModeIsIPSEnabled;
 
-    return;
 }
 
 /**

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -289,7 +289,6 @@ void RunModeListRunmodes(void)
                    "-----------------------\n");
         }
     }
-
 }
 
 static const char *RunModeGetConfOrDefault(int capture_mode, const char *capture_plugin_name)
@@ -518,7 +517,6 @@ void RunModeRegisterNewRunMode(enum RunModes runmode, const char *name, const ch
     }
     mode->RunModeFunc = RunModeFunc;
     mode->RunModeIsIPSEnabled = RunModeIsIPSEnabled;
-
 }
 
 /**

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -115,7 +115,6 @@ void StreamTcpReassembleIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(ra_memuse, size);
     SCLogDebug("REASSEMBLY %"PRIu64", incr %"PRIu64, StreamTcpReassembleMemuseGlobalCounter(), size);
-    return;
 }
 
 /**
@@ -142,7 +141,6 @@ void StreamTcpReassembleDecrMemuse(uint64_t size)
     }
 #endif
     SCLogDebug("REASSEMBLY %"PRIu64", decr %"PRIu64, StreamTcpReassembleMemuseGlobalCounter(), size);
-    return;
 }
 
 uint64_t StreamTcpReassembleMemuseGlobalCounter(void)

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -114,7 +114,8 @@ void StreamTcpReassembleInitMemuse(void)
 void StreamTcpReassembleIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(ra_memuse, size);
-    SCLogDebug("REASSEMBLY %"PRIu64", incr %"PRIu64, StreamTcpReassembleMemuseGlobalCounter(), size);
+    SCLogDebug("REASSEMBLY %" PRIu64 ", incr %" PRIu64, StreamTcpReassembleMemuseGlobalCounter(),
+            size);
 }
 
 /**
@@ -140,7 +141,8 @@ void StreamTcpReassembleDecrMemuse(uint64_t size)
         BUG_ON(postsize > presize);
     }
 #endif
-    SCLogDebug("REASSEMBLY %"PRIu64", decr %"PRIu64, StreamTcpReassembleMemuseGlobalCounter(), size);
+    SCLogDebug("REASSEMBLY %" PRIu64 ", decr %" PRIu64, StreamTcpReassembleMemuseGlobalCounter(),
+            size);
 }
 
 uint64_t StreamTcpReassembleMemuseGlobalCounter(void)

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1131,7 +1131,7 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
  *  Call this when the app layer didn't get data at the requested
  *  offset.
  */
-static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
+static inline bool CheckGap(TcpSession *ssn, TcpStream *stream)
 {
     const uint64_t app_progress = STREAM_APP_PROGRESS(stream);
     const int ackadded = (ssn->state >= TCP_FIN_WAIT1) ? 1 : 0;
@@ -1245,7 +1245,7 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
         /* make sure to only deal with ACK'd data */
         mydata_len = AdjustToAcked(p, ssn, *stream, app_progress, mydata_len);
         DEBUG_VALIDATE_BUG_ON(mydata_len > (uint32_t)INT_MAX);
-        if (mydata == NULL && mydata_len > 0 && CheckGap(ssn, *stream, p)) {
+        if (mydata == NULL && mydata_len > 0 && CheckGap(ssn, *stream)) {
             SCLogDebug("sending GAP to app-layer (size: %u)", mydata_len);
 
             int r = AppLayerHandleTCPData(tv, ra_ctx, p, p->flow, ssn, stream, NULL, mydata_len,

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1131,7 +1131,7 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
  *  Call this when the app layer didn't get data at the requested
  *  offset.
  */
-static inline bool CheckGap(TcpSession *ssn, TcpStream *stream)
+static inline bool CheckGap(TcpSession *ssn, TcpStream *stream, Packet *p)
 {
     const uint64_t app_progress = STREAM_APP_PROGRESS(stream);
     const int ackadded = (ssn->state >= TCP_FIN_WAIT1) ? 1 : 0;
@@ -1245,7 +1245,7 @@ static int ReassembleUpdateAppLayer (ThreadVars *tv,
         /* make sure to only deal with ACK'd data */
         mydata_len = AdjustToAcked(p, ssn, *stream, app_progress, mydata_len);
         DEBUG_VALIDATE_BUG_ON(mydata_len > (uint32_t)INT_MAX);
-        if (mydata == NULL && mydata_len > 0 && CheckGap(ssn, *stream)) {
+        if (mydata == NULL && mydata_len > 0 && CheckGap(ssn, *stream, p)) {
             SCLogDebug("sending GAP to app-layer (size: %u)", mydata_len);
 
             int r = AppLayerHandleTCPData(tv, ra_ctx, p, p->flow, ssn, stream, NULL, mydata_len,

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -229,7 +229,6 @@ void StreamTcpIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(st_memuse, size);
     SCLogDebug("STREAM %"PRIu64", incr %"PRIu64, StreamTcpMemuseCounter(), size);
-    return;
 }
 
 void StreamTcpDecrMemuse(uint64_t size)
@@ -250,7 +249,6 @@ void StreamTcpDecrMemuse(uint64_t size)
     }
 #endif
     SCLogDebug("STREAM %"PRIu64", decr %"PRIu64, StreamTcpMemuseCounter(), size);
-    return;
 }
 
 uint64_t StreamTcpMemuseCounter(void)
@@ -5103,7 +5101,6 @@ static void StreamTcpPacketCheckPostRst(TcpSession *ssn, Packet *p)
         StreamTcpSetEvent(p, STREAM_SUSPECTED_RST_INJECT);
         return;
     }
-    return;
 }
 
 /**
@@ -7070,7 +7067,6 @@ void TcpSessionSetReassemblyDepth(TcpSession *ssn, uint32_t size)
         ssn->reassembly_depth = size;
     }
 
-    return;
 }
 
 const char *StreamTcpStateAsString(const enum TcpState state)

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -228,7 +228,7 @@ void StreamTcpInitMemuse(void)
 void StreamTcpIncrMemuse(uint64_t size)
 {
     (void) SC_ATOMIC_ADD(st_memuse, size);
-    SCLogDebug("STREAM %"PRIu64", incr %"PRIu64, StreamTcpMemuseCounter(), size);
+    SCLogDebug("STREAM %" PRIu64 ", incr %" PRIu64, StreamTcpMemuseCounter(), size);
 }
 
 void StreamTcpDecrMemuse(uint64_t size)
@@ -248,7 +248,7 @@ void StreamTcpDecrMemuse(uint64_t size)
         BUG_ON(postsize > presize);
     }
 #endif
-    SCLogDebug("STREAM %"PRIu64", decr %"PRIu64, StreamTcpMemuseCounter(), size);
+    SCLogDebug("STREAM %" PRIu64 ", decr %" PRIu64, StreamTcpMemuseCounter(), size);
 }
 
 uint64_t StreamTcpMemuseCounter(void)
@@ -965,8 +965,7 @@ void StreamTcpSetOSPolicy(TcpStream *stream, Packet *p)
     else if (stream->os_policy == OS_POLICY_OLD_SOLARIS)
         stream->os_policy = OS_POLICY_SOLARIS;
 
-    SCLogDebug("Policy is %"PRIu8"", stream->os_policy);
-
+    SCLogDebug("Policy is %" PRIu8 "", stream->os_policy);
 }
 
 /**
@@ -7066,7 +7065,6 @@ void TcpSessionSetReassemblyDepth(TcpSession *ssn, uint32_t size)
     if (size > ssn->reassembly_depth || size == 0) {
         ssn->reassembly_depth = size;
     }
-
 }
 
 const char *StreamTcpStateAsString(const enum TcpState state)

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1174,7 +1174,6 @@ void TmThreadAppend(ThreadVars *tv, int type)
     }
 
     SCMutexUnlock(&tv_root_lock);
-
 }
 
 static bool ThreadStillHasPackets(ThreadVars *tv)
@@ -1562,7 +1561,6 @@ void TmThreadKillThreads(void)
     for (i = 0; i < TVT_MAX; i++) {
         TmThreadKillThreadsFamily(i);
     }
-
 }
 
 static void TmThreadFree(ThreadVars *tv)
@@ -1728,7 +1726,6 @@ void TmThreadInitMC(ThreadVars *tv)
         FatalError("Error initializing the tv->cond condition "
                    "variable");
     }
-
 }
 
 static void TmThreadDeinitMC(ThreadVars *tv)
@@ -1759,7 +1756,6 @@ void TmThreadTestThreadUnPaused(ThreadVars *tv)
         if (TmThreadsCheckFlag(tv, THV_KILL))
             break;
     }
-
 }
 
 /**
@@ -1773,7 +1769,6 @@ void TmThreadWaitForFlag(ThreadVars *tv, uint32_t flags)
     while (!TmThreadsCheckFlag(tv, flags)) {
         SleepUsec(100);
     }
-
 }
 
 /**

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -681,7 +681,6 @@ void TmSlotSetFuncAppend(ThreadVars *tv, TmModule *tm, const void *data)
             b->slot_next = slot;
         }
     }
-    return;
 }
 
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
@@ -1176,7 +1175,6 @@ void TmThreadAppend(ThreadVars *tv, int type)
 
     SCMutexUnlock(&tv_root_lock);
 
-    return;
 }
 
 static bool ThreadStillHasPackets(ThreadVars *tv)
@@ -1340,7 +1338,6 @@ again:
     }
 
     SCMutexUnlock(&tv_root_lock);
-    return;
 }
 
 /**
@@ -1455,7 +1452,6 @@ again:
      * don't process the last live packets together
      * with FFR packets */
     TmThreadDrainPacketThreads();
-    return;
 }
 
 #ifdef DEBUG_VALIDATION
@@ -1526,7 +1522,6 @@ again:
         }
     }
     SCMutexUnlock(&tv_root_lock);
-    return;
 }
 
 #define MIN_WAIT_TIME 100
@@ -1568,7 +1563,6 @@ void TmThreadKillThreads(void)
         TmThreadKillThreadsFamily(i);
     }
 
-    return;
 }
 
 static void TmThreadFree(ThreadVars *tv)
@@ -1735,7 +1729,6 @@ void TmThreadInitMC(ThreadVars *tv)
                    "variable");
     }
 
-    return;
 }
 
 static void TmThreadDeinitMC(ThreadVars *tv)
@@ -1748,7 +1741,6 @@ static void TmThreadDeinitMC(ThreadVars *tv)
         SCCtrlCondDestroy(tv->ctrl_cond);
         SCFree(tv->ctrl_cond);
     }
-    return;
 }
 
 /**
@@ -1768,7 +1760,6 @@ void TmThreadTestThreadUnPaused(ThreadVars *tv)
             break;
     }
 
-    return;
 }
 
 /**
@@ -1783,7 +1774,6 @@ void TmThreadWaitForFlag(ThreadVars *tv, uint32_t flags)
         SleepUsec(100);
     }
 
-    return;
 }
 
 /**
@@ -1794,7 +1784,6 @@ void TmThreadWaitForFlag(ThreadVars *tv, uint32_t flags)
 void TmThreadContinue(ThreadVars *tv)
 {
     TmThreadsUnsetFlag(tv, THV_PAUSE);
-    return;
 }
 
 /**
@@ -1915,7 +1904,6 @@ void TmThreadContinueThreads(void)
         }
     }
     SCMutexUnlock(&tv_root_lock);
-    return;
 }
 
 /**
@@ -1934,7 +1922,6 @@ void TmThreadCheckThreadState(void)
         }
     }
     SCMutexUnlock(&tv_root_lock);
-    return;
 }
 
 /**

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -139,7 +139,7 @@ TmEcode TmThreadsSlotVarRun(ThreadVars *tv, Packet *p, TmSlot *slot)
         /* handle error */
         if (unlikely(r == TM_ECODE_FAILED)) {
             /* Encountered error.  Return packets to packetpool and return */
-            TmThreadsSlotProcessPktFail(tv, s, NULL);
+            TmThreadsSlotProcessPktFail(tv, NULL);
             return TM_ECODE_FAILED;
         }
         if (s->tm_flags & TM_FLAG_DECODE_TM) {

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -141,7 +141,7 @@ static inline void TmThreadsCleanDecodePQ(PacketQueueNoLock *pq)
     }
 }
 
-static inline void TmThreadsSlotProcessPktFail(ThreadVars *tv, TmSlot *s, Packet *p)
+static inline void TmThreadsSlotProcessPktFail(ThreadVars *tv, Packet *p)
 {
     if (p != NULL) {
         TmqhOutputPacketpool(tv, p);
@@ -176,7 +176,7 @@ static inline bool TmThreadsHandleInjectedPackets(ThreadVars *tv)
 #endif
             TmEcode r = TmThreadsSlotVarRun(tv, extra_p, tv->tm_flowworker);
             if (r == TM_ECODE_FAILED) {
-                TmThreadsSlotProcessPktFail(tv, tv->tm_flowworker, extra_p);
+                TmThreadsSlotProcessPktFail(tv, extra_p);
                 break;
             }
             tv->tmqh_out(tv, extra_p);
@@ -199,7 +199,7 @@ static inline TmEcode TmThreadsSlotProcessPkt(ThreadVars *tv, TmSlot *s, Packet 
 
     TmEcode r = TmThreadsSlotVarRun(tv, p, s);
     if (unlikely(r == TM_ECODE_FAILED)) {
-        TmThreadsSlotProcessPktFail(tv, s, p);
+        TmThreadsSlotProcessPktFail(tv, p);
         return TM_ECODE_FAILED;
     }
 

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -79,7 +79,6 @@ void TmqhFlowRegister(void)
     } else {
         tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
     }
-
 }
 
 void TmqhFlowPrintAutofpHandler(void)
@@ -216,7 +215,6 @@ void TmqhOutputFlowFreeCtx(void *ctx)
               fctx->size);
     SCFree(fctx->queues);
     SCFree(fctx);
-
 }
 
 void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
@@ -239,7 +237,6 @@ void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
     PacketEnqueue(q, p);
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
-
 }
 
 /**
@@ -268,7 +265,6 @@ void TmqhOutputFlowIPPair(ThreadVars *tv, Packet *p)
     PacketEnqueue(q, p);
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
-
 }
 
 static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
@@ -295,7 +291,6 @@ static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
     PacketEnqueue(q, p);
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
-
 }
 
 #ifdef UNITTESTS
@@ -408,5 +403,4 @@ void TmqhFlowRegisterTests(void)
     UtRegisterTest("TmqhOutputFlowSetupCtxTest03",
                    TmqhOutputFlowSetupCtxTest03);
 #endif
-
 }

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -80,7 +80,6 @@ void TmqhFlowRegister(void)
         tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
     }
 
-    return;
 }
 
 void TmqhFlowPrintAutofpHandler(void)
@@ -218,7 +217,6 @@ void TmqhOutputFlowFreeCtx(void *ctx)
     SCFree(fctx->queues);
     SCFree(fctx);
 
-    return;
 }
 
 void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
@@ -242,7 +240,6 @@ void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
 
-    return;
 }
 
 /**
@@ -272,7 +269,6 @@ void TmqhOutputFlowIPPair(ThreadVars *tv, Packet *p)
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
 
-    return;
 }
 
 static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
@@ -300,7 +296,6 @@ static void TmqhOutputFlowFTPHash(ThreadVars *tv, Packet *p)
     SCCondSignal(&q->cond_q);
     SCMutexUnlock(&q->mutex_q);
 
-    return;
 }
 
 #ifdef UNITTESTS
@@ -414,5 +409,4 @@ void TmqhFlowRegisterTests(void)
                    TmqhOutputFlowSetupCtxTest03);
 #endif
 
-    return;
 }

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -439,7 +439,6 @@ void TmqhReleasePacketsToPacketPool(PacketQueue *pq)
         TmqhOutputPacketpool(NULL, p);
     }
 
-    return;
 }
 
 /** number of packets to keep reserved when calculating the pending

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -438,7 +438,6 @@ void TmqhReleasePacketsToPacketPool(PacketQueue *pq)
         DEBUG_VALIDATE_BUG_ON(p->flow != NULL);
         TmqhOutputPacketpool(NULL, p);
     }
-
 }
 
 /** number of packets to keep reserved when calculating the pending

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1205,7 +1205,6 @@ void UnixManagerThreadSpawn(int mode)
             FatalError("Unix socket init failed");
         }
     }
-    return;
 }
 
 // TODO can't think of a good name
@@ -1268,7 +1267,6 @@ again:
     }
 
     SCMutexUnlock(&tv_root_lock);
-    return;
 }
 
 #else /* BUILD_UNIX_SOCKET */
@@ -1276,17 +1274,14 @@ again:
 void UnixManagerThreadSpawn(int mode)
 {
     SCLogError("Unix socket is not compiled");
-    return;
 }
 
 void UnixSocketKillSocketThread(void)
 {
-    return;
 }
 
 void UnixManagerThreadSpawnNonRunmode(const bool unix_socket_enabled)
 {
-    return;
 }
 
 #endif /* BUILD_UNIX_SOCKET */

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -92,7 +92,6 @@ static void AffinitySetupInit(void)
         }
         SCMutexInit(&thread_affinity[i].taf_mutex, NULL);
     }
-    return;
 }
 
 void BuildCpusetWithCallback(const char *name, ConfNode *node,

--- a/src/util-atomic.c
+++ b/src/util-atomic.c
@@ -69,5 +69,4 @@ void SCAtomicRegisterTests(void)
 #ifdef UNITTESTS
     UtRegisterTest("SCAtomicTest01", SCAtomicTest01);
 #endif
-
 }

--- a/src/util-atomic.c
+++ b/src/util-atomic.c
@@ -70,5 +70,4 @@ void SCAtomicRegisterTests(void)
     UtRegisterTest("SCAtomicTest01", SCAtomicTest01);
 #endif
 
-    return;
 }

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -82,7 +82,6 @@ void MemBufferFree(MemBuffer *buffer)
 {
     SCFree(buffer);
 
-    return;
 }
 
 void MemBufferPrintToFP(MemBuffer *buffer, FILE *fp)

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -81,7 +81,6 @@ int MemBufferExpand(MemBuffer **buffer, uint32_t expand_by) {
 void MemBufferFree(MemBuffer *buffer)
 {
     SCFree(buffer);
-
 }
 
 void MemBufferPrintToFP(MemBuffer *buffer, FILE *fp)

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -178,7 +178,7 @@ static const char *SCClassConfGetConfFilename(const DetectEngineCtx *de_ctx)
 /**
  * \brief Releases resources used by the Classification Config API.
  */
-static void SCClassConfDeInitLocalResources(DetectEngineCtx *de_ctx, FILE *fd)
+static void SCClassConfDeInitLocalResources(FILE *fd)
 {
     if (fd != NULL) {
         fclose(fd);
@@ -549,7 +549,7 @@ bool SCClassConfLoadClassificationConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
         ret = false;
     }
 
-    SCClassConfDeInitLocalResources(de_ctx, fd);
+    SCClassConfDeInitLocalResources(fd);
 
     return ret;
 }

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -76,7 +76,6 @@ void SCClassConfInit(DetectEngineCtx *de_ctx)
     }
     de_ctx->class_conf_regex_match =
             pcre2_match_data_create_from_pattern(de_ctx->class_conf_regex, NULL);
-    return;
 }
 
 void SCClassConfDeinit(DetectEngineCtx *de_ctx)
@@ -195,7 +194,6 @@ void SCClassConfDeInitContext(DetectEngineCtx *de_ctx)
 
     de_ctx->class_conf_ht = NULL;
 
-    return;
 }
 
 /**
@@ -436,7 +434,6 @@ static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct)
         SCFree(ct);
     }
 
-    return;
 }
 
 /**
@@ -513,7 +510,6 @@ void SCClassConfClasstypeHashFree(void *ch)
 {
     SCClassConfDeAllocClasstype(ch);
 
-    return;
 }
 
 /**

--- a/src/util-classification-config.c
+++ b/src/util-classification-config.c
@@ -193,7 +193,6 @@ void SCClassConfDeInitContext(DetectEngineCtx *de_ctx)
         HashTableFree(de_ctx->class_conf_ht);
 
     de_ctx->class_conf_ht = NULL;
-
 }
 
 /**
@@ -433,7 +432,6 @@ static void SCClassConfDeAllocClasstype(SCClassConfClasstype *ct)
 
         SCFree(ct);
     }
-
 }
 
 /**
@@ -509,7 +507,6 @@ char SCClassConfClasstypeHashCompareFunc(void *data1, uint16_t datalen1,
 void SCClassConfClasstypeHashFree(void *ch)
 {
     SCClassConfDeAllocClasstype(ch);
-
 }
 
 /**

--- a/src/util-debug-filters.c
+++ b/src/util-debug-filters.c
@@ -379,7 +379,6 @@ void SCLogReleaseFGFilters(void)
         sc_log_fg_filters[i] = NULL;
     }
 
-    return;
 }
 
 /**
@@ -629,7 +628,6 @@ void SCLogCheckFDFilterExit(const char *function)
     if (thread_list != NULL)
         thread_list->entered--;
 
-    return;
 }
 
 /**
@@ -717,7 +715,6 @@ void SCLogReleaseFDFilters(void)
 
     SCMutexUnlock( &sc_log_fd_filters_m );
 
-    return;
 }
 
 /**
@@ -875,7 +872,6 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
     else
         fgf_file->next = fgf_file_temp;
 
-    return;
 }
 
 /**
@@ -922,7 +918,6 @@ void SCLogAddToFGFFuncList(SCLogFGFilterFile *fgf_file,
     else
         fgf_func->next = fgf_func_temp;
 
-    return;
 }
 
 /**
@@ -956,7 +951,6 @@ void SCLogAddToFGFLineList(SCLogFGFilterFunc *fgf_func,
     else
         fgf_line->next = fgf_line_temp;
 
-    return;
 }
 
 /**
@@ -972,6 +966,5 @@ void SCLogReleaseFDFilter(SCLogFDFilter *fdf)
         SCFree(fdf);
     }
 
-    return;
 }
 

--- a/src/util-debug-filters.c
+++ b/src/util-debug-filters.c
@@ -378,7 +378,6 @@ void SCLogReleaseFGFilters(void)
         SCMutexUnlock(&sc_log_fg_filters_m[i]);
         sc_log_fg_filters[i] = NULL;
     }
-
 }
 
 /**
@@ -627,7 +626,6 @@ void SCLogCheckFDFilterExit(const char *function)
 
     if (thread_list != NULL)
         thread_list->entered--;
-
 }
 
 /**
@@ -713,8 +711,7 @@ void SCLogReleaseFDFilters(void)
 
     sc_log_fd_filters = NULL;
 
-    SCMutexUnlock( &sc_log_fd_filters_m );
-
+    SCMutexUnlock(&sc_log_fd_filters_m);
 }
 
 /**
@@ -871,7 +868,6 @@ void SCLogAddToFGFFileList(SCLogFGFilterFile *fgf_file,
         sc_log_fg_filters[listtype] = fgf_file_temp;
     else
         fgf_file->next = fgf_file_temp;
-
 }
 
 /**
@@ -917,7 +913,6 @@ void SCLogAddToFGFFuncList(SCLogFGFilterFile *fgf_file,
         fgf_file->func = fgf_func_temp;
     else
         fgf_func->next = fgf_func_temp;
-
 }
 
 /**
@@ -950,7 +945,6 @@ void SCLogAddToFGFLineList(SCLogFGFilterFunc *fgf_func,
         fgf_func->line = fgf_line_temp;
     else
         fgf_line->next = fgf_line_temp;
-
 }
 
 /**
@@ -965,6 +959,4 @@ void SCLogReleaseFDFilter(SCLogFDFilter *fdf)
             SCFree(fdf->func);
         SCFree(fdf);
     }
-
 }
-

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -173,7 +173,6 @@ static inline void SCLogPrintToStream(FILE *fd, char *msg)
 #if defined (OS_WIN32)
 	SCMutexUnlock(&sc_log_stream_lock);
 #endif /* OS_WIN32 */
-
 }
 
 /**
@@ -192,7 +191,6 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
     //syslog_r(syslog_log_level, NULL, "%s", msg);
 
     syslog(syslog_log_level, "%s", msg);
-
 }
 
 /**
@@ -1029,7 +1027,6 @@ static inline void SCLogFreeLogOPIfaceCtx(SCLogOPIfaceCtx *iface_ctx)
 
         SCFree(temp);
     }
-
 }
 
 /**
@@ -1068,7 +1065,6 @@ static inline void SCLogSetLogLevel(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
 
     /* we also set it to a global var, as it is easier to access it */
     sc_log_global_log_level = sc_lc->log_level;
-
 }
 
 SCLogLevel SCLogGetLogLevel(void)
@@ -1126,7 +1122,6 @@ static inline void SCLogSetLogFormat(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
         printf("Error allocating memory\n");
         exit(EXIT_FAILURE);
     }
-
 }
 
 /**
@@ -1242,7 +1237,6 @@ static inline void SCLogSetOPFilter(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
         sc_lc->op_filter_regex_match =
                 pcre2_match_data_create_from_pattern(sc_lc->op_filter_regex, NULL);
     }
-
 }
 
 /**
@@ -1276,7 +1270,6 @@ static void SCLogFreeLogInitData(SCLogInitData *sc_lid)
         SCLogFreeLogOPIfaceCtx(sc_lid->op_ifaces);
         SCFree(sc_lid);
     }
-
 }
 #endif
 #endif
@@ -1302,7 +1295,6 @@ static inline void SCLogFreeLogConfig(SCLogConfig *sc_lc)
         SCLogFreeLogOPIfaceCtx(sc_lc->op_ifaces);
         SCFree(sc_lc);
     }
-
 }
 
 /**
@@ -1335,7 +1327,6 @@ void SCLogAppendOPIfaceCtx(SCLogOPIfaceCtx *iface_ctx, SCLogInitData *sc_lid)
         prev->next = iface_ctx;
 
     sc_lid->op_ifaces_cnt++;
-
 }
 
 #ifdef UNITTESTS
@@ -1621,7 +1612,6 @@ void SCLogDeInitLogModule(void)
 #if defined (OS_WIN32)
     SCMutexDestroy(&sc_log_stream_lock);
 #endif /* OS_WIN32 */
-
 }
 
 //------------------------------------Unit_Tests--------------------------------

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -174,7 +174,6 @@ static inline void SCLogPrintToStream(FILE *fd, char *msg)
 	SCMutexUnlock(&sc_log_stream_lock);
 #endif /* OS_WIN32 */
 
-    return;
 }
 
 /**
@@ -194,7 +193,6 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
 
     syslog(syslog_log_level, "%s", msg);
 
-    return;
 }
 
 /**
@@ -1032,7 +1030,6 @@ static inline void SCLogFreeLogOPIfaceCtx(SCLogOPIfaceCtx *iface_ctx)
         SCFree(temp);
     }
 
-    return;
 }
 
 /**
@@ -1072,7 +1069,6 @@ static inline void SCLogSetLogLevel(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
     /* we also set it to a global var, as it is easier to access it */
     sc_log_global_log_level = sc_lc->log_level;
 
-    return;
 }
 
 SCLogLevel SCLogGetLogLevel(void)
@@ -1131,7 +1127,6 @@ static inline void SCLogSetLogFormat(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
         exit(EXIT_FAILURE);
     }
 
-    return;
 }
 
 /**
@@ -1203,7 +1198,6 @@ static inline void SCLogSetOPIface(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
         sc_lc->op_ifaces = op_ifaces_ctx;
         sc_lc->op_ifaces_cnt++;
     }
-    return;
 }
 
 /**
@@ -1249,7 +1243,6 @@ static inline void SCLogSetOPFilter(SCLogInitData *sc_lid, SCLogConfig *sc_lc)
                 pcre2_match_data_create_from_pattern(sc_lc->op_filter_regex, NULL);
     }
 
-    return;
 }
 
 /**
@@ -1284,7 +1277,6 @@ static void SCLogFreeLogInitData(SCLogInitData *sc_lid)
         SCFree(sc_lid);
     }
 
-    return;
 }
 #endif
 #endif
@@ -1311,7 +1303,6 @@ static inline void SCLogFreeLogConfig(SCLogConfig *sc_lc)
         SCFree(sc_lc);
     }
 
-    return;
 }
 
 /**
@@ -1345,7 +1336,6 @@ void SCLogAppendOPIfaceCtx(SCLogOPIfaceCtx *iface_ctx, SCLogInitData *sc_lid)
 
     sc_lid->op_ifaces_cnt++;
 
-    return;
 }
 
 #ifdef UNITTESTS
@@ -1434,7 +1424,6 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
     //SCOutputPrint(sc_did->startup_message);
 
     rs_log_set_level(sc_log_global_log_level);
-    return;
 }
 
 void SCLogLoadConfig(int daemon, int verbose, uint32_t userid, uint32_t groupid)
@@ -1633,7 +1622,6 @@ void SCLogDeInitLogModule(void)
     SCMutexDestroy(&sc_log_stream_lock);
 #endif /* OS_WIN32 */
 
-    return;
 }
 
 //------------------------------------Unit_Tests--------------------------------

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -587,7 +587,6 @@ void EBPFBypassFree(void *data)
         SCFree(eb->key[1]);
     }
     SCFree(eb);
-    return;
 }
 
 /**

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -61,7 +61,7 @@ void SetMasterExceptionPolicy(void)
     g_eps_master_switch = ExceptionPolicyParse("exception-policy", true);
 }
 
-static enum ExceptionPolicy GetMasterExceptionPolicy(const char *option)
+static enum ExceptionPolicy GetMasterExceptionPolicy()
 {
     return g_eps_master_switch;
 }
@@ -208,7 +208,7 @@ static enum ExceptionPolicy ExceptionPolicyGetDefault(
 {
     enum ExceptionPolicy p = EXCEPTION_POLICY_NOT_SET;
     if (g_eps_have_exception_policy) {
-        p = GetMasterExceptionPolicy(option);
+        p = GetMasterExceptionPolicy();
 
         if (p == EXCEPTION_POLICY_AUTO) {
             p = ExceptionPolicyPickAuto(midstream, support_flow);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -662,6 +662,7 @@ static int FileStoreNoStoreCheck(File *ff)
 static int AppendData(
         const StreamingBufferConfig *sbcfg, File *file, const uint8_t *data, uint32_t data_len)
 {
+    printf("lol %d\n", data_len);
     DEBUG_VALIDATE_BUG_ON(
             data_len > BIT_U32(26)); // 64MiB as a limit per chunk seems already excessive
 

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -102,7 +102,6 @@ static void SCHInfoFreeUserDataOSPolicy(void *data)
     if (data != NULL)
         SCFree(data);
 
-    return;
 }
 
 /**
@@ -324,7 +323,6 @@ void SCHInfoCleanResources(void)
         sc_hinfo_tree = NULL;
     }
 
-    return;
 }
 
 /**
@@ -365,7 +363,6 @@ static void SCHInfoCreateContextBackup(void)
     sc_hinfo_tree_backup = sc_hinfo_tree;
     sc_hinfo_tree = NULL;
 
-    return;
 }
 
 static void SCHInfoRestoreContextBackup(void)
@@ -373,7 +370,6 @@ static void SCHInfoRestoreContextBackup(void)
     sc_hinfo_tree = sc_hinfo_tree_backup;
     sc_hinfo_tree_backup = NULL;
 
-    return;
 }
 
 /**

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -101,7 +101,6 @@ static void SCHInfoFreeUserDataOSPolicy(void *data)
 {
     if (data != NULL)
         SCFree(data);
-
 }
 
 /**
@@ -322,7 +321,6 @@ void SCHInfoCleanResources(void)
         SCRadixReleaseRadixTree(sc_hinfo_tree);
         sc_hinfo_tree = NULL;
     }
-
 }
 
 /**
@@ -362,14 +360,12 @@ static void SCHInfoCreateContextBackup(void)
 {
     sc_hinfo_tree_backup = sc_hinfo_tree;
     sc_hinfo_tree = NULL;
-
 }
 
 static void SCHInfoRestoreContextBackup(void)
 {
     sc_hinfo_tree = sc_hinfo_tree_backup;
     sc_hinfo_tree_backup = NULL;
-
 }
 
 /**
@@ -1633,5 +1629,4 @@ void SCHInfoRegisterTests(void)
     UtRegisterTest("SCHInfoTestLoadFromConfig04", SCHInfoTestLoadFromConfig04);
     UtRegisterTest("SCHInfoTestLoadFromConfig05", SCHInfoTestLoadFromConfig05);
 #endif /* UNITTESTS */
-
 }

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -200,5 +200,4 @@ void MaskIPNetblock(uint8_t *stream, int netmask, int key_bitlen)
         }
         stream[i] &= mask;
     }
-
 }

--- a/src/util-ip.c
+++ b/src/util-ip.c
@@ -201,5 +201,4 @@ void MaskIPNetblock(uint8_t *stream, int netmask, int key_bitlen)
         stream[i] &= mask;
     }
 
-    return;
 }

--- a/src/util-landlock.c
+++ b/src/util-landlock.c
@@ -33,7 +33,6 @@
 
 void LandlockSandboxing(SCInstance *suri)
 {
-    return;
 }
 
 #else /* HAVE_LINUX_LANDLOCK_H */

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -429,5 +429,4 @@ void MacSetRegisterTests(void)
     UtRegisterTest("MacSetTest05", MacSetTest05);
 #endif
 
-    return;
 }

--- a/src/util-macset.c
+++ b/src/util-macset.c
@@ -428,5 +428,4 @@ void MacSetRegisterTests(void)
     UtRegisterTest("MacSetTest04", MacSetTest04);
     UtRegisterTest("MacSetTest05", MacSetTest05);
 #endif
-
 }

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -109,7 +109,6 @@ static void SCACGetConfig(void)
 
     //ConfNode *pm = ConfGetNode("pattern-matcher");
 
-    return;
 }
 
 /**
@@ -275,7 +274,6 @@ static void SCACSetOutputState(int32_t state, uint32_t pid, MpmCtx *mpm_ctx)
 
     output_state->pids[output_state->no_of_entries - 1] = pid;
 
-    return;
 }
 
 /**
@@ -319,7 +317,6 @@ static inline void SCACEnter(uint8_t *pattern, uint16_t pattern_len, uint32_t pi
      * pattern ends in the trie */
     SCACSetOutputState(state, pid, mpm_ctx);
 
-    return;
 }
 
 /**
@@ -346,7 +343,6 @@ static inline void SCACCreateGotoTable(MpmCtx *mpm_ctx)
         }
     }
 
-    return;
 }
 
 static inline void SCACDetermineLevel1Gap(MpmCtx *mpm_ctx)
@@ -367,7 +363,6 @@ static inline void SCACDetermineLevel1Gap(MpmCtx *mpm_ctx)
         ctx->goto_table[0][u] = newstate;
     }
 
-    return;
 }
 
 static inline int SCACStateQueueIsEmpty(StateQueue *q)
@@ -397,7 +392,6 @@ static inline void SCACEnqueue(StateQueue *q, int32_t state)
         FatalError("Just ran out of space in the queue. Please file a bug report on this");
     }
 
-    return;
 }
 
 static inline int32_t SCACDequeue(StateQueue *q)
@@ -455,7 +449,6 @@ static inline void SCACClubOutputStates(int32_t dst_state, int32_t src_state,
         }
     }
 
-    return;
 }
 
 /**
@@ -513,7 +506,6 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
     }
     SCFree(q);
 
-    return;
 }
 
 /**
@@ -607,7 +599,6 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         SCFree(q);
     }
 
-    return;
 }
 
 static inline void SCACClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
@@ -637,7 +628,6 @@ static inline void SCACClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
         }
     }
 
-    return;
 }
 
 static inline void SCACInsertCaseSensitiveEntriesForPatterns(MpmCtx *mpm_ctx)
@@ -658,7 +648,6 @@ static inline void SCACInsertCaseSensitiveEntriesForPatterns(MpmCtx *mpm_ctx)
         }
     }
 
-    return;
 }
 
 #if 0
@@ -677,7 +666,6 @@ static void SCACPrintDeltaTable(MpmCtx *mpm_ctx)
         }
     }
 
-    return;
 }
 #endif
 
@@ -720,7 +708,6 @@ static void SCACPrepareStateTable(MpmCtx *mpm_ctx)
     SCFree(ctx->failure_table);
     ctx->failure_table = NULL;
 
-    return;
 }
 
 /**
@@ -922,7 +909,6 @@ void SCACDestroyCtx(MpmCtx *mpm_ctx)
     mpm_ctx->memory_cnt--;
     mpm_ctx->memory_size -= sizeof(SCACCtx);
 
-    return;
 }
 
 /**
@@ -1115,7 +1101,6 @@ void SCACPrintInfo(MpmCtx *mpm_ctx)
     printf("Total states in the state table:    %" PRIu32 "\n", ctx->state_count);
     printf("\n");
 
-    return;
 }
 
 
@@ -1138,7 +1123,6 @@ void MpmACRegister(void)
     mpm_table[MPM_AC].RegisterUnittests = SCACRegisterTests;
 #endif
     mpm_table[MPM_AC].feature_flags = MPM_FEATURE_FLAG_DEPTH | MPM_FEATURE_FLAG_OFFSET;
-    return;
 }
 
 /*************************************Unittests********************************/

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -107,8 +107,7 @@ static void SCACGetConfig(void)
     //ConfNode *ac_conf;
     //const char *hash_val = NULL;
 
-    //ConfNode *pm = ConfGetNode("pattern-matcher");
-
+    // ConfNode *pm = ConfGetNode("pattern-matcher");
 }
 
 /**
@@ -273,7 +272,6 @@ static void SCACSetOutputState(int32_t state, uint32_t pid, MpmCtx *mpm_ctx)
     output_state->pids = ptmp;
 
     output_state->pids[output_state->no_of_entries - 1] = pid;
-
 }
 
 /**
@@ -316,7 +314,6 @@ static inline void SCACEnter(uint8_t *pattern, uint16_t pattern_len, uint32_t pi
     /* add this pattern id, to the output table of the last state, where the
      * pattern ends in the trie */
     SCACSetOutputState(state, pid, mpm_ctx);
-
 }
 
 /**
@@ -342,7 +339,6 @@ static inline void SCACCreateGotoTable(MpmCtx *mpm_ctx)
             ctx->goto_table[0][ascii_code] = 0;
         }
     }
-
 }
 
 static inline void SCACDetermineLevel1Gap(MpmCtx *mpm_ctx)
@@ -362,7 +358,6 @@ static inline void SCACDetermineLevel1Gap(MpmCtx *mpm_ctx)
         int32_t newstate = SCACInitNewState(mpm_ctx);
         ctx->goto_table[0][u] = newstate;
     }
-
 }
 
 static inline int SCACStateQueueIsEmpty(StateQueue *q)
@@ -391,7 +386,6 @@ static inline void SCACEnqueue(StateQueue *q, int32_t state)
     if (q->top == q->bot) {
         FatalError("Just ran out of space in the queue. Please file a bug report on this");
     }
-
 }
 
 static inline int32_t SCACDequeue(StateQueue *q)
@@ -448,7 +442,6 @@ static inline void SCACClubOutputStates(int32_t dst_state, int32_t src_state,
                 output_src_state->pids[i];
         }
     }
-
 }
 
 /**
@@ -505,7 +498,6 @@ static inline void SCACCreateFailureTable(MpmCtx *mpm_ctx)
         }
     }
     SCFree(q);
-
 }
 
 /**
@@ -598,7 +590,6 @@ static inline void SCACCreateDeltaTable(MpmCtx *mpm_ctx)
         }
         SCFree(q);
     }
-
 }
 
 static inline void SCACClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
@@ -627,7 +618,6 @@ static inline void SCACClubOutputStatePresenceWithDeltaTable(MpmCtx *mpm_ctx)
             }
         }
     }
-
 }
 
 static inline void SCACInsertCaseSensitiveEntriesForPatterns(MpmCtx *mpm_ctx)
@@ -647,7 +637,6 @@ static inline void SCACInsertCaseSensitiveEntriesForPatterns(MpmCtx *mpm_ctx)
             }
         }
     }
-
 }
 
 #if 0
@@ -665,7 +654,6 @@ static void SCACPrintDeltaTable(MpmCtx *mpm_ctx)
             }
         }
     }
-
 }
 #endif
 
@@ -707,7 +695,6 @@ static void SCACPrepareStateTable(MpmCtx *mpm_ctx)
     ctx->goto_table = NULL;
     SCFree(ctx->failure_table);
     ctx->failure_table = NULL;
-
 }
 
 /**
@@ -908,7 +895,6 @@ void SCACDestroyCtx(MpmCtx *mpm_ctx)
     mpm_ctx->ctx = NULL;
     mpm_ctx->memory_cnt--;
     mpm_ctx->memory_size -= sizeof(SCACCtx);
-
 }
 
 /**
@@ -1100,7 +1086,6 @@ void SCACPrintInfo(MpmCtx *mpm_ctx)
     printf("Largest:         %" PRIu32 "\n", mpm_ctx->maxlen);
     printf("Total states in the state table:    %" PRIu32 "\n", ctx->state_count);
     printf("\n");
-
 }
 
 

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -1001,7 +1001,6 @@ int SCHSAddPatternCS(MpmCtx *mpm_ctx, uint8_t *pat, uint16_t patlen,
 
 void SCHSPrintSearchStats(MpmThreadCtx *mpm_thread_ctx)
 {
-    return;
 }
 
 void SCHSPrintInfo(MpmCtx *mpm_ctx)

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1216,7 +1216,6 @@ void NapatechStartStats(void)
     if (TmThreadSpawn(buf_monitor_tv) != 0) {
         FatalError("Failed to spawn thread for NapatechBufMonitor - Killing engine.");
     }
-
 }
 
 bool NapatechSetupNuma(uint32_t stream, uint32_t numa)

--- a/src/util-napatech.c
+++ b/src/util-napatech.c
@@ -1217,7 +1217,6 @@ void NapatechStartStats(void)
         FatalError("Failed to spawn thread for NapatechBufMonitor - Killing engine.");
     }
 
-    return;
 }
 
 bool NapatechSetupNuma(uint32_t stream, uint32_t numa)

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -389,7 +389,6 @@ static int PoolTestInitArg(void *data, void *allocdata)
 
 static void PoolTestFree(void *ptr)
 {
-    return;
 }
 
 static int PoolTestInit01 (void)

--- a/src/util-port-interval-tree.c
+++ b/src/util-port-interval-tree.c
@@ -300,7 +300,6 @@ error:
         DetectPortFree(de_ctx, new_port);
     if (stack != NULL)
         SCFree(stack);
-    return;
 }
 
 /**

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -107,7 +107,6 @@ void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen,
                             "\\x%02X", buf[u]);
         }
     }
-
 }
 
 void PrintRawDataFp(FILE *fp, const uint8_t *buf, uint32_t buflen)
@@ -191,7 +190,6 @@ void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
     }
     if (ch != 16)
         PrintBufferData((char *)dst_buf, dst_buf_offset_ptr, dst_buf_size, "\n");
-
 }
 
 void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
@@ -206,7 +204,6 @@ void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
         }
     }
     dst_buf[dst_buf_size - 1] = 0;
-
 }
 
 #ifndef s6_addr16

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -108,7 +108,6 @@ void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen,
         }
     }
 
-    return;
 }
 
 void PrintRawDataFp(FILE *fp, const uint8_t *buf, uint32_t buflen)
@@ -193,7 +192,6 @@ void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
     if (ch != 16)
         PrintBufferData((char *)dst_buf, dst_buf_offset_ptr, dst_buf_size, "\n");
 
-    return;
 }
 
 void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
@@ -209,7 +207,6 @@ void PrintStringsToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32
     }
     dst_buf[dst_buf_size - 1] = 0;
 
-    return;
 }
 
 #ifndef s6_addr16

--- a/src/util-profiling-locks.c
+++ b/src/util-profiling-locks.c
@@ -136,7 +136,6 @@ static void LockRecordAdd(ProfilingLock *l)
         lookup_fn->ticks_cnt++;
         lookup_fn->cont += l->cont;
     }
-
 }
 
 /** \param p void ptr to Packet struct */
@@ -238,4 +237,3 @@ void LockRecordFreeHash(void)
 
 #endif
 #endif
-

--- a/src/util-profiling-locks.c
+++ b/src/util-profiling-locks.c
@@ -137,7 +137,6 @@ static void LockRecordAdd(ProfilingLock *l)
         lookup_fn->cont += l->cont;
     }
 
-    return;
 }
 
 /** \param p void ptr to Packet struct */

--- a/src/util-proto-name.c
+++ b/src/util-proto-name.c
@@ -401,7 +401,6 @@ static void ProtoNameAddEntry(const char *proto_name, const uint8_t proto_number
                    "name: \"%s\"; number: %d",
                 proto_ent->name, proto_ent->number);
     }
-    return;
 }
 
 static void ProtoNameHashFreeFunc(void *data)

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -69,7 +69,6 @@ static void SCRadixDeAllocSCRadixUserData(SCRadixUserData *user_data)
 {
     SCFree(user_data);
 
-    return;
 }
 
 /**
@@ -109,7 +108,6 @@ static void SCRadixAppendToSCRadixUserDataList(SCRadixUserData *new,
         prev->next = new;
     }
 
-    return;
 }
 
 /**
@@ -188,7 +186,6 @@ static void SCRadixAddNetmaskUserDataToPrefix(SCRadixPrefix *prefix,
     SCRadixAppendToSCRadixUserDataList(SCRadixAllocSCRadixUserData(netmask, user),
                                        &prefix->user_data);
 
-    return;
 }
 
 /**
@@ -223,7 +220,6 @@ static void SCRadixRemoveNetmaskUserDataFromPrefix(SCRadixPrefix *prefix,
         temp = temp->next;
     }
 
-    return;
 }
 
 /**
@@ -364,7 +360,6 @@ static void SCRadixReleasePrefix(SCRadixPrefix *prefix, SCRadixTree *tree)
         SCFree(prefix);
     }
 
-    return;
 }
 
 /**
@@ -401,7 +396,6 @@ static void SCRadixReleaseNode(SCRadixNode *node, SCRadixTree *tree)
         SCFree(node);
     }
 
-    return;
 }
 
 /**
@@ -443,7 +437,6 @@ static void SCRadixReleaseRadixSubtree(SCRadixNode *node, SCRadixTree *tree)
         SCRadixReleaseNode(node, tree);
     }
 
-    return;
 }
 
 /**
@@ -459,7 +452,6 @@ void SCRadixReleaseRadixTree(SCRadixTree *tree)
     SCRadixReleaseRadixSubtree(tree->head, tree);
     tree->head = NULL;
     SCFree(tree);
-    return;
 }
 
 /**
@@ -1153,7 +1145,6 @@ static void SCRadixTransferNetmasksBWNodes(SCRadixNode *dest, SCRadixNode *src)
     for (i = dest->netmask_cnt, j = 0; j < src->netmask_cnt; i++, j++)
         dest->netmasks[i] = src->netmasks[j];
 
-    return;
 }
 
 /**
@@ -1215,7 +1206,6 @@ static void SCRadixRemoveNetblockEntry(SCRadixNode *node, uint8_t netmask)
     }
     node->netmasks = ptmp;
 
-    return;
 }
 
 /**
@@ -1352,7 +1342,6 @@ static void SCRadixRemoveKey(uint8_t *key_stream, uint16_t key_bitlen,
     SCRadixReleaseNode(node, tree);
     SCRadixReleasePrefix(prefix, tree);
 
-    return;
 }
 
 /**
@@ -1370,7 +1359,6 @@ void SCRadixRemoveKeyIPV4Netblock(uint8_t *key_stream, SCRadixTree *tree,
     SCRadixValidateIPv4Key(key_stream, netmask);
 #endif
     SCRadixRemoveKey(key_stream, 32, tree, netmask);
-    return;
 }
 
 /**
@@ -1386,7 +1374,6 @@ void SCRadixRemoveKeyIPV4Netblock(uint8_t *key_stream, SCRadixTree *tree,
 void SCRadixRemoveKeyIPV4(uint8_t *key_stream, SCRadixTree *tree)
 {
     SCRadixRemoveKey(key_stream, 32, tree, 32);
-    return;
 }
 
 /**
@@ -1404,7 +1391,6 @@ void SCRadixRemoveKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
     SCRadixValidateIPv6Key(key_stream, netmask);
 #endif
     SCRadixRemoveKey(key_stream, 128, tree, netmask);
-    return;
 }
 
 /**
@@ -1420,7 +1406,6 @@ void SCRadixRemoveKeyIPV6Netblock(uint8_t *key_stream, SCRadixTree *tree,
 void SCRadixRemoveKeyIPV6(uint8_t *key_stream, SCRadixTree *tree)
 {
     SCRadixRemoveKey(key_stream, 128, tree, 128);
-    return;
 }
 
 /**
@@ -1684,7 +1669,6 @@ void SCRadixPrintNodeInfo(SCRadixNode *node, int level,  void (*PrintData)(void*
         printf("inter_node)\n");
     }
 
-    return;
 }
 
 /**
@@ -1702,7 +1686,6 @@ static void SCRadixPrintRadixSubtree(SCRadixNode *node, int level, void (*PrintD
         SCRadixPrintRadixSubtree(node->right, level + 1, PrintData);
     }
 
-    return;
 }
 
 /**
@@ -1729,7 +1712,6 @@ void SCRadixPrintTree(SCRadixTree *tree)
 
     SCRadixPrintRadixSubtree(tree->head, 0, tree->PrintData);
 
-    return;
 }
 
 /*------------------------------------Unit_Tests------------------------------*/
@@ -3833,5 +3815,4 @@ void SCRadixRegisterTests(void)
                    SCRadixTestIPV4NetblockInsertion26);
 #endif
 
-    return;
 }

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -68,7 +68,6 @@ static SCRadixUserData *SCRadixAllocSCRadixUserData(uint8_t netmask, void *user)
 static void SCRadixDeAllocSCRadixUserData(SCRadixUserData *user_data)
 {
     SCFree(user_data);
-
 }
 
 /**
@@ -107,7 +106,6 @@ static void SCRadixAppendToSCRadixUserDataList(SCRadixUserData *new,
         new->next = prev->next;
         prev->next = new;
     }
-
 }
 
 /**
@@ -183,9 +181,8 @@ static void SCRadixAddNetmaskUserDataToPrefix(SCRadixPrefix *prefix,
         FatalError("prefix or user NULL");
     }
 
-    SCRadixAppendToSCRadixUserDataList(SCRadixAllocSCRadixUserData(netmask, user),
-                                       &prefix->user_data);
-
+    SCRadixAppendToSCRadixUserDataList(
+            SCRadixAllocSCRadixUserData(netmask, user), &prefix->user_data);
 }
 
 /**
@@ -219,7 +216,6 @@ static void SCRadixRemoveNetmaskUserDataFromPrefix(SCRadixPrefix *prefix,
         prev = temp;
         temp = temp->next;
     }
-
 }
 
 /**
@@ -359,7 +355,6 @@ static void SCRadixReleasePrefix(SCRadixPrefix *prefix, SCRadixTree *tree)
 
         SCFree(prefix);
     }
-
 }
 
 /**
@@ -395,7 +390,6 @@ static void SCRadixReleaseNode(SCRadixNode *node, SCRadixTree *tree)
 
         SCFree(node);
     }
-
 }
 
 /**
@@ -436,7 +430,6 @@ static void SCRadixReleaseRadixSubtree(SCRadixNode *node, SCRadixTree *tree)
         SCRadixReleaseRadixSubtree(node->right, tree);
         SCRadixReleaseNode(node, tree);
     }
-
 }
 
 /**
@@ -1144,7 +1137,6 @@ static void SCRadixTransferNetmasksBWNodes(SCRadixNode *dest, SCRadixNode *src)
 
     for (i = dest->netmask_cnt, j = 0; j < src->netmask_cnt; i++, j++)
         dest->netmasks[i] = src->netmasks[j];
-
 }
 
 /**
@@ -1205,7 +1197,6 @@ static void SCRadixRemoveNetblockEntry(SCRadixNode *node, uint8_t netmask)
         return;
     }
     node->netmasks = ptmp;
-
 }
 
 /**
@@ -1341,7 +1332,6 @@ static void SCRadixRemoveKey(uint8_t *key_stream, uint16_t key_bitlen,
     SCRadixReleaseNode(parent, tree);
     SCRadixReleaseNode(node, tree);
     SCRadixReleasePrefix(prefix, tree);
-
 }
 
 /**
@@ -1668,7 +1658,6 @@ void SCRadixPrintNodeInfo(SCRadixNode *node, int level,  void (*PrintData)(void*
     } else {
         printf("inter_node)\n");
     }
-
 }
 
 /**
@@ -1685,7 +1674,6 @@ static void SCRadixPrintRadixSubtree(SCRadixNode *node, int level, void (*PrintD
         SCRadixPrintRadixSubtree(node->left, level + 1, PrintData);
         SCRadixPrintRadixSubtree(node->right, level + 1, PrintData);
     }
-
 }
 
 /**
@@ -1711,7 +1699,6 @@ void SCRadixPrintTree(SCRadixTree *tree)
     printf("Printing the Radix Tree: \n");
 
     SCRadixPrintRadixSubtree(tree->head, 0, tree->PrintData);
-
 }
 
 /*------------------------------------Unit_Tests------------------------------*/
@@ -3814,5 +3801,4 @@ void SCRadixRegisterTests(void)
     UtRegisterTest("SCRadixTestIPV4NetblockInsertion26",
                    SCRadixTestIPV4NetblockInsertion26);
 #endif
-
 }

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -167,13 +167,11 @@ static const char *SCRConfGetConfFilename(const DetectEngineCtx *de_ctx)
 /**
  * \brief Releases local resources used by the Reference Config API.
  */
-static void SCRConfDeInitLocalResources(DetectEngineCtx *de_ctx, FILE *fd)
+static void SCRConfDeInitLocalResources(FILE *fd)
 {
     if (fd != NULL) {
         fclose(fd);
     }
-
-    return;
 }
 
 /**
@@ -506,7 +504,7 @@ int SCRConfLoadReferenceConfigFile(DetectEngineCtx *de_ctx, FILE *fd)
     }
 
     bool rc = SCRConfParseFile(de_ctx, fd);
-    SCRConfDeInitLocalResources(de_ctx, fd);
+    SCRConfDeInitLocalResources(fd);
 
     return rc ? 0 : -1;
 }

--- a/src/util-reference-config.c
+++ b/src/util-reference-config.c
@@ -67,7 +67,6 @@ void SCReferenceConfInit(DetectEngineCtx *de_ctx)
     }
     de_ctx->reference_conf_regex_match =
             pcre2_match_data_create_from_pattern(de_ctx->reference_conf_regex, NULL);
-    return;
 }
 
 void SCReferenceConfDeinit(DetectEngineCtx *de_ctx)
@@ -183,8 +182,6 @@ void SCRConfDeInitContext(DetectEngineCtx *de_ctx)
         HashTableFree(de_ctx->reference_conf_ht);
 
     de_ctx->reference_conf_ht = NULL;
-
-    return;
 }
 
 /**
@@ -395,8 +392,6 @@ void SCRConfDeAllocSCRConfReference(SCRConfReference *ref)
 
         SCFree(ref);
     }
-
-    return;
 }
 
 /**
@@ -472,8 +467,6 @@ char SCRConfReferenceHashCompareFunc(void *data1, uint16_t datalen1,
 void SCRConfReferenceHashFree(void *data)
 {
     SCRConfDeAllocSCRConfReference(data);
-
-    return;
 }
 
 /**
@@ -790,6 +783,4 @@ void SCRConfRegisterTests(void)
     UtRegisterTest("SCRConfTest05", SCRConfTest05);
     UtRegisterTest("SCRConfTest06", SCRConfTest06);
 #endif /* UNITTESTS */
-
-    return;
 }

--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -407,6 +407,4 @@ void SCRuleVarsRegisterTests(void)
 
     UtRegisterTest("SCRuleVarsMTest01", SCRuleVarsMTest01);
 #endif
-
-    return;
 }

--- a/src/util-signal.c
+++ b/src/util-signal.c
@@ -71,6 +71,4 @@ void UtilSignalHandlerSetup(int sig, void (*handler)(int))
     action.sa_flags = 0;
     sigaction(sig, &action, 0);
 #endif /* OS_WIN32 */
-
-    return;
 }

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -699,7 +699,7 @@ static inline uint32_t ToNextMultipleOf(const uint32_t in, const uint32_t m)
 
 static thread_local bool g2s_warn_once = false;
 
-static inline int WARN_UNUSED GrowRegionToSize(
+static inline int WARN_UNUSED GrowRegionToSize(StreamingBuffer *sb,
         const StreamingBufferConfig *cfg, StreamingBufferRegion *region, const uint32_t size)
 {
     DEBUG_VALIDATE_BUG_ON(region->buf_size > BIT_U32(30));
@@ -741,7 +741,7 @@ static inline int WARN_UNUSED GrowRegionToSize(
 static int WARN_UNUSED GrowToSize(
         StreamingBuffer *sb, const StreamingBufferConfig *cfg, uint32_t size)
 {
-    return GrowRegionToSize(cfg, &sb->region, size);
+    return GrowRegionToSize(sb, cfg, &sb->region, size);
 }
 
 static inline bool RegionBeforeOffset(const StreamingBufferRegion *r, const uint64_t o)
@@ -899,7 +899,7 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
                         goto just_main;
                     }
                     /* expand "next" to include relevant part of "start" */
-                    if (GrowRegionToSize(cfg, next, mem_size) != 0) {
+                    if (GrowRegionToSize(sb, cfg, next, mem_size) != 0) {
                         new_mem_size = new_data_size;
                         goto just_main;
                     }
@@ -935,7 +935,7 @@ static inline void StreamingBufferSlideToOffsetWithRegions(
                     goto done;
                 } else {
                     /* using "main", expand to include "next" */
-                    if (GrowRegionToSize(cfg, start, mem_size) != 0) {
+                    if (GrowRegionToSize(sb, cfg, start, mem_size) != 0) {
                         new_mem_size = new_data_size;
                         goto just_main;
                     }
@@ -1266,7 +1266,7 @@ static StreamingBufferRegion *BufferInsertAtRegionConsolidate(StreamingBuffer *s
     SCLogDebug("old_size %u, old_offset %u, dst_copy_offset %u", old_size, old_offset,
             dst_copy_offset);
 #endif
-    if ((retval = GrowRegionToSize(cfg, dst, dst_size)) != SC_OK) {
+    if ((retval = GrowRegionToSize(sb, cfg, dst, dst_size)) != SC_OK) {
         sc_errno = retval;
         return NULL;
     }

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -1682,7 +1682,6 @@ void StreamingBufferSBBGetData(const StreamingBuffer *sb,
     }
     *data = NULL;
     *data_len = 0;
-    return;
 }
 
 /** \brief get the data for one SBB */
@@ -1725,7 +1724,6 @@ void StreamingBufferSBBGetDataAtOffset(const StreamingBuffer *sb,
 
     *data = NULL;
     *data_len = 0;
-    return;
 }
 
 void StreamingBufferSegmentGetData(const StreamingBuffer *sb,
@@ -1755,7 +1753,6 @@ void StreamingBufferSegmentGetData(const StreamingBuffer *sb,
     }
     *data = NULL;
     *data_len = 0;
-    return;
 }
 
 /**

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -372,7 +372,6 @@ void THashShutdown(THashTableContext *ctx)
     (void) SC_ATOMIC_SUB(ctx->memuse, ctx->config.hash_size * sizeof(THashHashRow));
     THashDataQueueDestroy(&ctx->spare_q);
     SCFree(ctx);
-    return;
 }
 
 /** \brief Walk the hash
@@ -446,7 +445,6 @@ void THashCleanup(THashTableContext *ctx)
         }
         HRLOCK_UNLOCK(hb);
     }
-    return;
 }
 
 /* calculate the hash key for this packet

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -208,7 +208,6 @@ static void SCThresholdConfDeInitContext(DetectEngineCtx *de_ctx, FILE *fd)
 {
     if (fd != NULL)
         fclose(fd);
-    return;
 }
 
 /** \internal

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -283,8 +283,6 @@ void UtCleanup(void)
 void UtRunModeRegister(void)
 {
     RunModeRegisterNewRunMode(RUNMODE_UNITTEST, "unittest", "Unittest mode", NULL, NULL);
-
-    return;
 }
 
 /*


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just some cleanup

Describe changes:
- src: remove some unused function parameters

Found with `-Wunused-parameter` and focusing on static functions

Incomplete, but still useful

Inspired by https://github.com/OISF/suricata/pull/11026#discussion_r1600574165