### PR TITLE
ARP: implement decoder and logger v11

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -3011,3 +3011,47 @@ Example of DHCP log entry (extended logging enabled):
     "client_id":"54:ee:75:51:e0:66",
     "dns_servers":["192.168.1.50","192.168.1.49"]
   }
+
+Event type: ARP
+---------------
+
+Fields
+~~~~~~
+
+* "hw_type": network link protocol type
+* "proto_type": internetwork protocol for which the request is intended
+* "opcode": operation that the sender is performing (e.g. request, response)  
+* "src_mac": source MAC address
+* "src_ip": source IP address
+* "dest_mac": destination MAC address
+* "dest_ip": destination IP address
+
+Examples
+~~~~~~~~
+
+Example of ARP logging: request and response
+
+::
+
+  "arp": {
+    "hw_type": "ethernet",
+    "proto_type": "ipv4",
+    "opcode": "request",
+    "src_mac": "00:1a:6b:6c:0c:cc",
+    "src_ip": "10.10.10.2",
+    "dest_mac": "00:00:00:00:00:00",
+    "dest_ip": "10.10.10.1"
+  }
+
+::
+
+  "arp": {
+    "hw_type": "ethernet",
+    "proto_type": "ipv4",
+    "opcode": "reply",
+    "src_mac": "00:1a:6b:6c:0c:cc",
+    "src_ip": "10.10.10.2",
+    "dest_mac": "00:1d:09:f0:92:ab",
+    "dest_ip": "10.10.10.1"
+  }
+

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -266,6 +266,20 @@ enabled, then the log gets more verbose.
 
 By using ``custom`` it is possible to select which TLS fields to log.
 
+ARP
+~~~
+
+ARP records are logged as one entry for the request, and one entry for
+the response.
+
+YAML::
+
+        - arp:
+            enabled: no
+
+The logger is disabled by default since ARP can generate a large
+number of events.
+
 Drops
 ~~~~~
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -165,6 +165,8 @@ outputs:
         # BitTorrent DHT logging.
         - bittorrent-dht
         - ssh
+        - arp:
+            enabled: no
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -55,6 +55,8 @@ Major changes
 - SDP parser and logger have been introduced.
   Due to SDP being encapsulated within other protocols, such as SIP, they cannot be directly enabled or disabled.
   Instead, both the SDP parser and logger depend on being invoked by another parser (or logger).
+- ARP decoder and logger have been introduced.
+  Since ARP can be quite verbose and produce many events, the logger is disabled by default.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -334,6 +334,41 @@
             },
             "additionalProperties": false
         },
+        "arp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "hw_type": {
+                    "type": "string",
+                    "description": "Network link protocol type"
+                },
+                "proto_type": {
+                    "type": "string",
+                    "description": "Internetwork protocol for which the ARP request is intended"
+                },
+                "opcode": {
+                    "type": "string",
+                    "description": "Specifies the operation that the sender is performing"
+                },
+                "src_mac": {
+                    "type": "string",
+                    "description": "Physical address of the sender"
+                },
+                "src_ip": {
+                    "type": "string",
+                    "description": "Logical address of the sender"
+                },
+                "dest_mac": {
+                    "type": "string",
+                    "description": "Physical address of the intended receiver"
+                },
+                "dest_ip": {
+                    "type": "string",
+                    "description": "Logical address of the intended receiver"
+                }
+            },
+            "additionalProperties": false
+        },
         "bittorrent_dht": {
             "type": "object",
             "properties": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4579,6 +4579,33 @@
                         "event": {
                             "type": "object",
                             "properties": {
+                                "arp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_hardware": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_protocol": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "invalid_hardware_size": {
+                                            "type": "integer"
+                                        },
+                                        "invalid_protocol_size": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_opcode": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
                                 "chdlc": {
                                     "type": "object",
                                     "properties": {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -400,6 +400,7 @@ noinst_HEADERS = \
 	output.h \
 	output-json-alert.h \
 	output-json-anomaly.h \
+	output-json-arp.h \
 	output-json-dcerpc.h \
 	output-json-dhcp.h \
 	output-json-dnp3.h \
@@ -1006,6 +1007,7 @@ libsuricata_c_a_SOURCES = \
 	output-flow.c \
 	output-json-alert.c \
 	output-json-anomaly.c \
+	output-json-arp.c \
 	output-json.c \
 	output-json-common.c \
 	output-json-dcerpc.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,6 +56,7 @@ noinst_HEADERS = \
 	datasets-reputation.h \
 	datasets-sha256.h \
 	datasets-string.h \
+	decode-arp.h \
 	decode-chdlc.h \
 	decode-erspan.h \
 	decode-esp.h \
@@ -665,6 +666,7 @@ libsuricata_c_a_SOURCES = \
 	datasets-sha256.c \
 	datasets-string.c \
 	decode.c \
+	decode-arp.c \
 	decode-chdlc.c \
 	decode-erspan.c \
 	decode-esp.c \

--- a/src/decode-arp.c
+++ b/src/decode-arp.c
@@ -1,0 +1,89 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ */
+
+#include "suricata-common.h"
+#include "decode.h"
+#include "decode-arp.h"
+#include "decode-events.h"
+
+int DecodeARP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    StatsIncr(tv, dtv->counter_arp);
+
+    if (unlikely(len < ARP_HEADER_MIN_LEN)) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_PKT_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    if (!PacketIncreaseCheckLayers(p)) {
+        return TM_ECODE_FAILED;
+    }
+
+    const ARPHdr *arph = PacketSetARP(p, pkt);
+    if (unlikely(arph == NULL))
+        return TM_ECODE_FAILED;
+
+    if (SCNtohs(arph->hw_type) != ARP_HW_TYPE_ETHERNET) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_UNSUPPORTED_HARDWARE);
+        PacketClearL3(p);
+        return TM_ECODE_FAILED;
+    }
+
+    if (SCNtohs(arph->proto_type) != ETHERNET_TYPE_IP) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_UNSUPPORTED_PROTOCOL);
+        PacketClearL3(p);
+        return TM_ECODE_FAILED;
+    }
+
+    if (unlikely(len < ARP_HEADER_LEN)) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_INVALID_PKT);
+        PacketClearL3(p);
+        return TM_ECODE_FAILED;
+    }
+
+    if (arph->hw_size != ARP_HW_SIZE) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_INVALID_HARDWARE_SIZE);
+        PacketClearL3(p);
+        return TM_ECODE_FAILED;
+    }
+
+    if (arph->proto_size != ARP_PROTO_SIZE) {
+        ENGINE_SET_INVALID_EVENT(p, ARP_INVALID_PROTOCOL_SIZE);
+        PacketClearL3(p);
+        return TM_ECODE_FAILED;
+    }
+
+    switch (SCNtohs(arph->opcode)) {
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+            break;
+        default:
+            ENGINE_SET_INVALID_EVENT(p, ARP_UNSUPPORTED_OPCODE);
+            PacketClearL3(p);
+            return TM_ECODE_FAILED;
+    }
+
+    return TM_ECODE_OK;
+}

--- a/src/decode-arp.h
+++ b/src/decode-arp.h
@@ -1,0 +1,45 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ */
+
+#ifndef SURICATA_DECODE_ARP_H
+#define SURICATA_DECODE_ARP_H
+
+#define ARP_HEADER_MIN_LEN   8
+#define ARP_HEADER_LEN       28
+#define ARP_HW_TYPE_ETHERNET 0x01
+#define ARP_PROTO_TYPE_IP    0x0800
+#define ARP_HW_SIZE          6
+#define ARP_PROTO_SIZE       4
+
+typedef struct ARPHdr_ {
+    uint16_t hw_type;
+    uint16_t proto_type;
+    uint8_t hw_size;
+    uint8_t proto_size;
+    uint16_t opcode;
+    uint8_t source_mac[6];
+    uint8_t source_ip[4];
+    uint8_t dest_mac[6];
+    uint8_t dest_ip[4];
+} __attribute__((__packed__)) ARPHdr;
+
+#endif /* SURICATA_DECODE_ARP_H */

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -873,5 +873,35 @@ const struct DecodeEvents_ DEvents[] = {
             STREAM_REASSEMBLY_INSERT_INVALID,
     },
 
+    /* ARP EVENTS */
+    {
+            "decoder.arp.pkt_too_small",
+            ARP_PKT_TOO_SMALL,
+    },
+    {
+            "decoder.arp.unsupported_hardware",
+            ARP_UNSUPPORTED_HARDWARE,
+    },
+    {
+            "decoder.arp.unsupported_protocol",
+            ARP_UNSUPPORTED_PROTOCOL,
+    },
+    {
+            "decoder.arp.invalid_pkt",
+            ARP_INVALID_PKT,
+    },
+    {
+            "decoder.arp.invalid_hardware_size",
+            ARP_INVALID_HARDWARE_SIZE,
+    },
+    {
+            "decoder.arp.invalid_protocol_size",
+            ARP_INVALID_PROTOCOL_SIZE,
+    },
+    {
+            "decoder.arp.unsupported_opcode",
+            ARP_UNSUPPORTED_OPCODE,
+    },
+
     { NULL, 0 },
 };

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -297,6 +297,15 @@ enum {
     STREAM_REASSEMBLY_INSERT_LIMIT,
     STREAM_REASSEMBLY_INSERT_INVALID,
 
+    /* ARP EVENTS */
+    ARP_PKT_TOO_SMALL,         /**< arp packet smaller than minimum size */
+    ARP_UNSUPPORTED_HARDWARE,  /**< arp hw_type is not ethernet */
+    ARP_UNSUPPORTED_PROTOCOL,  /**< arp proto_type is not ipv4 */
+    ARP_INVALID_PKT,           /**< arp pkt len is not 28 */
+    ARP_INVALID_HARDWARE_SIZE, /**< arp hw size is 6 */
+    ARP_INVALID_PROTOCOL_SIZE, /**< arp proto size is not 4 */
+    ARP_UNSUPPORTED_OPCODE,    /**< arp opcode is not listed */
+
     /* should always be last! */
     DECODE_EVENT_MAX,
 };

--- a/src/decode-gre.c
+++ b/src/decode-gre.c
@@ -274,6 +274,16 @@ int DecodeGRE(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *p
             break;
         }
 
+        case ETHERNET_TYPE_ARP: {
+            Packet *tp = PacketTunnelPktSetup(
+                    tv, dtv, p, pkt + header_len, len - header_len, DECODE_TUNNEL_ARP);
+            if (tp != NULL) {
+                PKT_SET_SRC(tp, PKT_SRC_DECODER_GRE);
+                PacketEnqueueNoLock(&tv->decode_pq, tp);
+            }
+            break;
+        }
+
         default:
             return TM_ECODE_OK;
     }

--- a/src/decode.c
+++ b/src/decode.c
@@ -61,6 +61,7 @@
 #include "decode-geneve.h"
 #include "decode-erspan.h"
 #include "decode-teredo.h"
+#include "decode-arp.h"
 
 #include "defrag-hash.h"
 
@@ -177,6 +178,8 @@ static int DecodeTunnel(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const 
             return DecodeERSPANTypeI(tv, dtv, p, pkt, len);
         case DECODE_TUNNEL_NSH:
             return DecodeNSH(tv, dtv, p, pkt, len);
+        case DECODE_TUNNEL_ARP:
+            return DecodeARP(tv, dtv, p, pkt, len);
         default:
             SCLogDebug("FIXME: DecodeTunnel: protocol %" PRIu32 " not supported.", proto);
             break;

--- a/src/decode.h
+++ b/src/decode.h
@@ -1091,6 +1091,7 @@ enum DecodeTunnelProto {
     DECODE_TUNNEL_IPV6_TEREDO, /**< separate protocol for stricter error handling */
     DECODE_TUNNEL_PPP,
     DECODE_TUNNEL_NSH,
+    DECODE_TUNNEL_ARP,
     DECODE_TUNNEL_UNSET
 };
 

--- a/src/output-json-arp.c
+++ b/src/output-json-arp.c
@@ -1,0 +1,111 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ * Implement JSON/eve logging for ARP Protocol.
+ */
+
+#include "suricata-common.h"
+#include "detect.h"
+#include "flow.h"
+#include "conf.h"
+
+#include "threads.h"
+#include "tm-threads.h"
+#include "threadvars.h"
+#include "util-debug.h"
+
+#include "decode-ipv4.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "detect-reference.h"
+
+#include "output.h"
+#include "output-json.h"
+#include "output-json-arp.h"
+
+#include "util-classification-config.h"
+#include "util-privs.h"
+#include "util-print.h"
+#include "util-proto-name.h"
+#include "util-logopenfile.h"
+#include "util-time.h"
+#include "util-buffer.h"
+
+static const char *OpcodeToString(uint16_t opcode)
+{
+    switch (opcode) {
+        case 1:
+            return "request";
+        case 2:
+            return "reply";
+        case 3:
+            return "request_reverse";
+        case 4:
+            return "reply_reverse";
+        default:
+            return "unknown";
+    }
+}
+
+static int JsonArpLogger(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    OutputJsonThreadCtx *thread = thread_data;
+    char srcip[JSON_ADDR_LEN] = "";
+    char dstip[JSON_ADDR_LEN] = "";
+    const ARPHdr *arph = PacketGetARP(p);
+
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_PACKET, "arp", NULL, thread->ctx);
+    if (unlikely(jb == NULL)) {
+        return TM_ECODE_OK;
+    }
+
+    PrintInet(AF_INET, arph->source_ip, srcip, sizeof(srcip));
+    PrintInet(AF_INET, arph->dest_ip, dstip, sizeof(dstip));
+
+    jb_open_object(jb, "arp");
+    JB_SET_STRING(jb, "hw_type", "ethernet");
+    JB_SET_STRING(jb, "proto_type", "ipv4");
+    jb_set_string(jb, "opcode", OpcodeToString(ntohs(arph->opcode)));
+    JSONFormatAndAddMACAddr(jb, "src_mac", arph->source_mac, false);
+    jb_set_string(jb, "src_ip", srcip);
+    JSONFormatAndAddMACAddr(jb, "dest_mac", arph->dest_mac, false);
+    jb_set_string(jb, "dest_ip", dstip);
+    jb_close(jb); /* arp */
+    OutputJsonBuilderBuffer(jb, thread);
+    jb_free(jb);
+
+    return TM_ECODE_OK;
+}
+
+static bool JsonArpLogCondition(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    return PacketIsARP(p);
+}
+
+void JsonArpLogRegister(void)
+{
+    OutputRegisterPacketSubModule(LOGGER_JSON_ARP, "eve-log", "JsonArpLog", "eve-log.arp",
+            OutputJsonLogInitSub, JsonArpLogger, JsonArpLogCondition, JsonLogThreadInit,
+            JsonLogThreadDeinit, NULL);
+
+    SCLogDebug("ARP JSON logger registered.");
+}

--- a/src/output-json-arp.h
+++ b/src/output-json-arp.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ */
+
+#ifndef SURICATA_OUTPUT_JSON_ARP_H
+#define SURICATA_OUTPUT_JSON_ARP_H
+
+void JsonArpLogRegister(void);
+
+#endif /* SURICATA_OUTPUT_JSON_ARP_H */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -566,8 +566,10 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
         case IPPROTO_SCTP:
             addr->sp = sp;
             addr->dp = dp;
+            addr->log_port = true;
             break;
         default:
+            addr->log_port = false;
             break;
     }
 
@@ -830,11 +832,21 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         JsonAddrInfoInit(p, dir, &addr_info);
         addr = &addr_info;
     }
-    jb_set_string(js, "src_ip", addr->src_ip);
-    jb_set_uint(js, "src_port", addr->sp);
-    jb_set_string(js, "dest_ip", addr->dst_ip);
-    jb_set_uint(js, "dest_port", addr->dp);
-    jb_set_string(js, "proto", addr->proto);
+    if (addr->src_ip[0] != '\0') {
+        jb_set_string(js, "src_ip", addr->src_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "src_port", addr->sp);
+    }
+    if (addr->dst_ip[0] != '\0') {
+        jb_set_string(js, "dest_ip", addr->dst_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "dest_port", addr->dp);
+    }
+    if (addr->proto[0] != '\0') {
+        jb_set_string(js, "proto", addr->proto);
+    }
 
     /* icmp */
     switch (p->proto) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -705,8 +705,7 @@ void CreateEveFlowId(JsonBuilder *js, const Flow *f)
     }
 }
 
-static inline void JSONFormatAndAddMACAddr(
-        JsonBuilder *js, const char *key, const uint8_t *val, bool is_array)
+void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key, const uint8_t *val, bool is_array)
 {
     char eth_addr[19];
     (void) snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -116,5 +116,6 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
 void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
+void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key, const uint8_t *val, bool is_array);
 
 #endif /* SURICATA_OUTPUT_JSON_H */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -50,6 +50,8 @@ typedef struct JsonAddrInfo_ {
     Port sp;
     Port dp;
     char proto[JSON_PROTO_LEN];
+    // Ports are logged only when provided by the transport protocol.
+    bool log_port;
 } JsonAddrInfo;
 
 extern const JsonAddrInfo json_addr_info_zero;

--- a/src/output.c
+++ b/src/output.c
@@ -81,6 +81,7 @@
 #include "output-json-frame.h"
 #include "app-layer-parser.h"
 #include "output-filestore.h"
+#include "output-json-arp.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -1107,6 +1108,8 @@ void OutputRegisterLoggers(void)
                 "eve-log.bittorrent-dht", OutputJsonLogInitSub, ALPROTO_BITTORRENT_DHT,
                 JsonGenericDirPacketLogger, JsonLogThreadInit, JsonLogThreadDeinit, NULL);
     }
+    /* ARP JSON logger */
+    JsonArpLogRegister();
 }
 
 static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -491,6 +491,7 @@ typedef enum {
     LOGGER_JSON_FRAME,
     LOGGER_JSON_STREAM,
     LOGGER_SIZE,
+    LOGGER_JSON_ARP,
 } LoggerId;
 
 #ifndef HAVE_LUA

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1287,6 +1287,7 @@ const char *PacketProfileLoggerIdToString(LoggerId id)
         CASE_CODE(LOGGER_JSON_METADATA);
         CASE_CODE(LOGGER_JSON_FRAME);
         CASE_CODE(LOGGER_JSON_STREAM);
+        CASE_CODE(LOGGER_JSON_ARP);
 
         case LOGGER_SIZE:
             return "UNKNOWN";

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -300,6 +300,8 @@ outputs:
         - rfb
         - sip
         - quic
+        - arp:
+            enabled: no        # Many events can be logged. Disabled by default
         - dhcp:
             enabled: yes
             # When extended mode is on, all DHCP messages are logged


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6827

Describe changes:
- Make checks stricter (check the entire fixed part of a packet)
- Add `PacketClearL3(p);`
- Remove opcodes that don't work with ethernet
- Set an event if an opcode is not supported
- Accept ARP packets longer than 28 bytes without setting an event.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1807
