### PR TITLE
output/reference: Include reference information in alert (if configured)

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -69,6 +69,7 @@ Metadata::
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
             #packet: yes              # enable dumping of packet (without stream segments)
+            #reference: no            # include reference information, if present, in the alert
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -38,6 +38,7 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # reference: no            # include reference information, if present, in the alert
             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3350,12 +3350,14 @@
                         "email": {
                             "type": "string",
                             "optional": true,
-                            "description": "Email address for the person responsible for the conference"
+                            "description":
+                                    "Email address for the person responsible for the conference"
                         },
                         "phone_number": {
                             "type": "string",
                             "optional": true,
-                            "description": "Phone number for the person responsible for the conference"
+                            "description":
+                                    "Phone number for the person responsible for the conference"
                         },
                         "connection_data": {
                             "type": "string",
@@ -3384,12 +3386,14 @@
                         "timezone": {
                             "type": "string",
                             "optional": true,
-                            "description": "Timezone to specify adjustments for times and offsets from the base time"
+                            "description":
+                                    "Timezone to specify adjustments for times and offsets from the base time"
                         },
                         "encryption_key": {
                             "type": "string",
                             "optional": true,
-                            "description": "Field used to convey encryption keys if SDP is used over a secure channel"
+                            "description":
+                                    "Field used to convey encryption keys if SDP is used over a secure channel"
                         },
                         "attributes": {
                             "type": "array",
@@ -3416,7 +3420,8 @@
                                     "media_info": {
                                         "type": "string",
                                         "optional": true,
-                                        "description": "Media information primarily intended for labelling media streams"
+                                        "description":
+                                                "Media information primarily intended for labelling media streams"
                                     },
                                     "bandwidths": {
                                         "type": "array",
@@ -3434,7 +3439,8 @@
                                     },
                                     "attributes": {
                                         "type": "array",
-                                        "description": "A list of attributes specified for a media description",
+                                        "description":
+                                                "A list of attributes specified for a media description",
                                         "optional": true,
                                         "minItems": 1,
                                         "items": {

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -285,6 +285,13 @@
                     },
                     "additionalProperties": true
                 },
+                "references": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "source": {
                     "type": "object",
                     "properties": {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -248,11 +248,11 @@ void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuil
         AlertJsonSourceTarget(p, pa, js, addr);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_REFERENCE)) {
+    if ((flags & LOG_JSON_REFERENCE)) {
         AlertJsonReference(json_output_ctx, pa, js);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_RULE_METADATA)) {
+    if (flags & LOG_JSON_RULE_METADATA) {
         AlertJsonMetadata(json_output_ctx, pa, js);
     }
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -68,6 +68,7 @@
 #include "util-print.h"
 #include "util-optimize.h"
 #include "util-buffer.h"
+#include "util-reference-config.h"
 #include "util-validate.h"
 
 #include "action-globals.h"
@@ -87,6 +88,7 @@
 #define LOG_JSON_VERDICT           BIT_U16(10)
 #define LOG_JSON_WEBSOCKET_PAYLOAD        BIT_U16(11)
 #define LOG_JSON_WEBSOCKET_PAYLOAD_BASE64 BIT_U16(12)
+#define LOG_JSON_REFERENCE                BIT_U16(13)
 
 #define METADATA_DEFAULTS ( LOG_JSON_FLOW |                        \
             LOG_JSON_APP_LAYER  |                                  \
@@ -173,6 +175,27 @@ static void AlertJsonSourceTarget(const Packet *p, const PacketAlert *pa,
     jb_close(js);
 }
 
+static void AlertJsonReference(
+        AlertJsonOutputCtx *json_output_ctx, const PacketAlert *pa, JsonBuilder *jb)
+{
+    if (!pa->s->references) {
+        return;
+    }
+
+    const DetectReference *kv = pa->s->references;
+    jb_open_array(jb, "references");
+    while (kv) {
+        const size_t key_size = MIN(strlen(kv->key), REFERENCE_SYSTEM_NAME_MAX);
+        const size_t ref_size = MIN(strlen(kv->reference), REFERENCE_CONTENT_NAME_MAX);
+        const size_t size_needed = key_size + ref_size + 1;
+        char kv_store[size_needed];
+        snprintf(kv_store, size_needed, "%s%s", kv->key, kv->reference);
+        jb_append_string(jb, kv_store);
+        kv = kv->next;
+    }
+    jb_close(jb);
+}
+
 static void AlertJsonMetadata(AlertJsonOutputCtx *json_output_ctx,
         const PacketAlert *pa, JsonBuilder *js)
 {
@@ -223,6 +246,10 @@ void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuil
 
     if (addr && pa->s->flags & SIG_FLAG_HAS_TARGET) {
         AlertJsonSourceTarget(p, pa, js, addr);
+    }
+
+    if ((json_output_ctx != NULL) && (flags & LOG_JSON_REFERENCE)) {
+        AlertJsonReference(json_output_ctx, pa, js);
     }
 
     if ((json_output_ctx != NULL) && (flags & LOG_JSON_RULE_METADATA)) {
@@ -897,6 +924,7 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
         SetFlag(conf, "websocket-payload-printable", LOG_JSON_WEBSOCKET_PAYLOAD, &flags);
         SetFlag(conf, "websocket-payload", LOG_JSON_WEBSOCKET_PAYLOAD_BASE64, &flags);
         SetFlag(conf, "verdict", LOG_JSON_VERDICT, &flags);
+        SetFlag(conf, "reference", LOG_JSON_REFERENCE, &flags);
 
         /* Check for obsolete flags and warn that they have no effect. */
         static const char *deprecated_flags[] = { "http", "tls", "ssh", "smtp", "dnp3", "app-layer",

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -165,6 +165,7 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # reference: no            # include reference information, if present, in the alert
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of HTTP body in printable format


### PR DESCRIPTION
Continuation of #11079  

When configured, include the reference value in the alert. The configuration value is in the `alert` section:  types.alert.reference. The default value is off/no. Set to yes to include the expanded reference from the rule in the alert record.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4974](https://redmine.openinfosecfoundation.org/issues/4974)

Describe changes:
- Add `reference` value to suricata.yaml.in (default no/off)
- Set flag in output logger if the config setting is on
- Format the reference as a sequence, e.g., `references: [ "ref-1" [, "ref-2" [, ...]]]`

Updates: 
- Rebase (and s-v rebase)

### Provide values to any of the below to override the defaults.


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1808

