### PR TITLE
Iprep feature 6857/v2

### DIFF
--- a/rust/src/detect/error.rs
+++ b/rust/src/detect/error.rs
@@ -23,6 +23,7 @@ use nom7::error::{ErrorKind, ParseError};
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuleParseError<I> {
     InvalidByteMath(String),
+    InvalidIPRep(String),
 
     Nom(I, ErrorKind),
 }

--- a/rust/src/detect/iprep.rs
+++ b/rust/src/detect/iprep.rs
@@ -86,55 +86,56 @@ pub fn detect_parse_iprep(i: &str) -> IResult<&str, DetectIPRepData, RuleParseEr
         preceded(multispace0, nom7::bytes::complete::is_not(",")),
     )(i)?;
 
-    if values.len() == 4 {
-        let cmd = match DetectIPRepDataCmd::from_str(values[0].trim()) {
-            Ok(val) => val,
-            Err(_) => return Err(make_error("invalid command".to_string())),
+    let args = values.len();
+    if args == 4 || args == 3 {
+        let cmd = if let Ok(cmd) = DetectIPRepDataCmd::from_str(values[0].trim()) {
+            cmd
+        } else {
+            return Err(make_error("invalid command".to_string()));
         };
         let name = values[1].trim();
-        let mode = match detect_parse_uint_mode(values[2].trim()) {
-            Ok(val) => val.1,
-            Err(_) => return Err(make_error("invalid mode".to_string())),
+        let namez = if let Ok(name) = CString::new(name) {
+            name
+        } else {
+            return Err(make_error("invalid name".to_string()));
         };
+        let cat = unsafe { SRepCatGetByShortname(namez.as_ptr()) };
+        if cat == 0 {
+            return Err(make_error("unknown category".to_string()));
+        }
 
-        let namez = CString::new(name).unwrap();
-        let cat = unsafe { SRepCatGetByShortname(namez.as_ptr()) };
-        if cat == 0 {
-            return Err(make_error("unknown category".to_string()));
+        if values.len() == 4 {
+            let mode = match detect_parse_uint_mode(values[2].trim()) {
+                Ok(val) => val.1,
+                Err(_) => return Err(make_error("invalid mode".to_string())),
+            };
+
+            let arg1 = match values[3].trim().parse::<u8>() {
+                Ok(val) => val,
+                Err(_) => return Err(make_error("invalid value".to_string())),
+            };
+            let du8 = DetectUintData::<u8> {
+                arg1,
+                arg2: 0,
+                mode,
+            };
+            return Ok((i, DetectIPRepData { du8, cat, cmd }));
+        } else {
+            let (mode, arg1) = match values[2].trim() {
+                "isset" => { (DetectUintMode::DetectUintModeGte, 0)}, // any value means it's set
+                "isnotset" => { (DetectUintMode::DetectUintModeEqual, 255) }, // impossible value means not set
+                _ => { return Err(make_error("invalid mode".to_string())); },
+            };
+            let du8 = DetectUintData::<u8> {
+                arg1,
+                arg2: 0,
+                mode,
+            };
+            return Ok((i, DetectIPRepData { du8, cat, cmd }));
         }
-        let arg1 = match values[3].trim().parse::<u8>() {
-            Ok(val) => val,
-            Err(_) => return Err(make_error("invalid value".to_string())),
-        };
-        let du8 = DetectUintData::<u8> {
-            arg1,
-            arg2: 0,
-            mode,
-        };
-        return Ok((i, DetectIPRepData { du8, cat, cmd }));
-    } else if values.len() == 3 {
-        let cmd = match DetectIPRepDataCmd::from_str(values[0].trim()) {
-            Ok(val) => val,
-            Err(_) => return Err(make_error("invalid command".to_string())),
-        };
-        let name = values[1].trim();
-        let namez = CString::new(name).unwrap();
-        let cat = unsafe { SRepCatGetByShortname(namez.as_ptr()) };
-        if cat == 0 {
-            return Err(make_error("unknown category".to_string()));
-        }
-        let (mode, arg1) = match values[2].trim() {
-            "isset" => { (DetectUintMode::DetectUintModeGte, 0)}, // any value means it's set
-            "isnotset" => { (DetectUintMode::DetectUintModeEqual, 255) }, // impossible value means not set
-            _ => { return Err(make_error("invalid mode".to_string())); },
-        };
-        let du8 = DetectUintData::<u8> {
-            arg1,
-            arg2: 0,
-            mode,
-        };
-        return Ok((i, DetectIPRepData { du8, cat, cmd }));
-    } else {
+    } else if args < 3 {
+        return Err(make_error("too few arguments".to_string()));
+    } else  {
         return Err(make_error("too many arguments".to_string()));
     }
 

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -158,7 +158,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
     SCLogDebug("rd->cmd %u", rd->cmd);
     switch (rd->cmd) {
         case IPRepCmdAny:
-            if (!(rd->du8.arg1 == 255 && rd->du8.mode == DetectUintModeEqual)) {
+            if (!rd->isnotset) {
                 val = GetHostRepSrc(p, rd->cat, version);
                 if (val < 0)
                     val = SRepCIDRGetIPRepSrc(det_ctx->de_ctx->srepCIDR_ctx, p, rd->cat, version);
@@ -202,7 +202,7 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
                 return DetectU8Match((uint8_t)val, &rd->du8);
             }
             /* implied: no value found */
-            if (rd->du8.arg1 == 255 && rd->du8.mode == DetectUintModeEqual) {
+            if (rd->isnotset) {
                 return 1;
             }
             break;
@@ -216,13 +216,13 @@ static int DetectIPRepMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
                 return DetectU8Match((uint8_t)val, &rd->du8);
             }
             /* implied: no value found */
-            if (rd->du8.arg1 == 255 && rd->du8.mode == DetectUintModeEqual) {
+            if (rd->isnotset) {
                 return 1;
             }
             break;
 
         case IPRepCmdBoth:
-            if (!(rd->du8.arg1 == 255 && rd->du8.mode == DetectUintModeEqual)) {
+            if (!rd->isnotset) {
                 val = GetHostRepSrc(p, rd->cat, version);
                 if (val < 0)
                     val = SRepCIDRGetIPRepSrc(det_ctx->de_ctx->srepCIDR_ctx, p, rd->cat, version);

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -584,17 +584,11 @@ int SRepInit(DetectEngineCtx *de_ctx)
     ConfNode *file = NULL;
     const char *filename = NULL;
     int init = 0;
-    int i = 0;
 
     de_ctx->srepCIDR_ctx = (SRepCIDRTree *)SCCalloc(1, sizeof(SRepCIDRTree));
     if (de_ctx->srepCIDR_ctx == NULL)
         exit(EXIT_FAILURE);
     SRepCIDRTree *cidr_ctx = de_ctx->srepCIDR_ctx;
-
-    for (i = 0; i < SREP_MAX_CATS; i++) {
-        cidr_ctx->srepIPV4_tree[i] = NULL;
-        cidr_ctx->srepIPV6_tree[i] = NULL;
-    }
 
     if (SRepGetVersion() == 0) {
         SC_ATOMIC_INIT(srep_eversion);


### PR DESCRIPTION
Implementation of isset and isnotset for the iprep keyword.

https://redmine.openinfosecfoundation.org/issues/6857

Replaces #11057:
- rebase to master
- reimplement isnotset
- tidy up parsing code
- review comments

Draft because: commits need to be tightened up.