### PR TITLE
http: fix nul deref on memcap reached backport7

### DIFF
--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -351,8 +351,10 @@ static HttpRangeContainerBlock *HttpRangeOpenFile(HttpRangeContainerFile *c, uin
 {
     HttpRangeContainerBlock *r =
             HttpRangeOpenFileAux(c, start, end, total, sbcfg, name, name_len, flags);
-    if (HttpRangeAppendData(sbcfg, r, data, len) < 0) {
-        SCLogDebug("Failed to append data while opening");
+    if (r) {
+        if (HttpRangeAppendData(sbcfg, r, data, len) < 0) {
+            SCLogDebug("Failed to append data while opening");
+        }
     }
     return r;
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7033

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/11098 clean cherry-pick
