### PR TITLE
Output notx 6846 backport7 v3

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -272,7 +272,7 @@ static inline PacketAlert PacketAlertSet(
     pa.s = (Signature *)s;
     pa.flags = alert_flags;
     /* Set tx_id if the frame has it */
-    pa.tx_id = (tx_id == UINT64_MAX) ? 0 : tx_id;
+    pa.tx_id = tx_id;
     pa.frame_id = (alert_flags & PACKET_ALERT_FLAG_FRAME) ? det_ctx->frame_id : 0;
     return pa;
 }
@@ -317,10 +317,15 @@ static int AlertQueueSortHelper(const void *a, const void *b)
 {
     const PacketAlert *pa0 = a;
     const PacketAlert *pa1 = b;
-    if (pa1->num == pa0->num)
+    if (pa1->num == pa0->num) {
+        if (pa1->tx_id == PACKET_ALERT_NOTX) {
+            return -1;
+        } else if (pa0->tx_id == PACKET_ALERT_NOTX) {
+            return 1;
+        }
         return pa0->tx_id < pa1->tx_id ? 1 : -1;
-    else
-        return pa0->num > pa1->num ? 1 : -1;
+    }
+    return pa0->num > pa1->num ? 1 : -1;
 }
 
 /** \internal

--- a/src/detect.c
+++ b/src/detect.c
@@ -1727,12 +1727,14 @@ static void DetectRunFrames(ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngin
                     /* match */
                     DetectRunPostMatch(tv, det_ctx, p, s);
 
-                    const uint8_t alert_flags =
-                            (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
+                    uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
                     det_ctx->flags |= DETECT_ENGINE_THREAD_CTX_FRAME_ID_SET;
                     det_ctx->frame_id = frame->id;
                     SCLogDebug(
                             "%p/%" PRIi64 " sig %u (%u) matched", frame, frame->id, s->id, s->num);
+                    if (frame->flags & FRAME_FLAG_TX_ID_SET) {
+                        alert_flags |= PACKET_ALERT_FLAG_TX;
+                    }
                     AlertQueueAppend(det_ctx, s, p, frame->tx_id, alert_flags);
                 }
             }

--- a/src/detect.c
+++ b/src/detect.c
@@ -818,9 +818,11 @@ static inline void DetectRulePacketRules(
                 (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP)) {
             // if there is a stream match (TCP), or
             // a UDP specific app-layer signature,
-            // try to use the last tx
+            // try to use the good tx for the packet direction
             if (pflow->alstate) {
-                txid = AppLayerParserGetTxCnt(pflow, pflow->alstate) - 1;
+                uint8_t dir =
+                        (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
+                txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
                 alert_flags |= PACKET_ALERT_FLAG_TX;
             }
         }

--- a/src/detect.h
+++ b/src/detect.h
@@ -49,6 +49,9 @@
  *  classtype. */
 #define DETECT_DEFAULT_PRIO 3
 
+// tx_id value to use when there is no transaction
+#define PACKET_ALERT_NOTX UINT64_MAX
+
 /* forward declarations for the structures from detect-engine-sigorder.h */
 struct SCSigOrderFunc_;
 struct SCSigSignatureWrapper_;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -782,12 +782,14 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         }
 
         if (p->flow != NULL) {
-            if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
-                AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
-            }
-            /* including fileinfo data is configured by the metadata setting */
-            if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
-                AlertAddFiles(p, jb, pa->tx_id);
+            if (pa->flags & PACKET_ALERT_FLAG_TX) {
+                if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
+                    AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
+                }
+                /* including fileinfo data is configured by the metadata setting */
+                if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {
+                    AlertAddFiles(p, jb, pa->tx_id);
+                }
             }
 
             EveAddAppProto(p->flow, jb);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6848
https://redmine.openinfosecfoundation.org/issues/6975

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/10876 +
- Backport of follow-up https://github.com/OISF/suricata/pull/10891 (clean cherry-pick) +
- Backport of another follow-up https://github.com/OISF/suricata/pull/11064 but only its first commit (clean cherry-pick)

No backport of https://github.com/OISF/suricata/pull/11064 other commits as they bring in features (specifying transaction ids for frames), instead of fixing the bug that we were logging tx id 0 when irrelevant

First Commit 910f6af54fa37cde1790bbff46162b7dee864bb6 needed a small conflict fix in detect-engine-alert.c AlertQueueSortHelper, because of style 
```
if (a) 
    return x;
else
    return y;
```
was turned into
```
if (a) 
    return x;
return y;
```

https://github.com/OISF/suricata/pull/11082 rebased to get green CI