### PR TITLE
Rustc 178 fixes 7013 backport6 v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1341,6 +1341,7 @@ jobs:
           libnet \
           libtool \
           libyaml \
+          pyyaml \
           lua \
           nss \
           nspr \
@@ -1352,7 +1353,6 @@ jobs:
       - name: Install cbindgen
         run: cargo install --force --debug --version 0.14.1 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - run: pip3 install PyYAML
       - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748
       - name: Downloading prep archive
         uses: actions/download-artifact@v2
@@ -1362,8 +1362,8 @@ jobs:
       - run: tar xvf prep/libhtp.tar.gz
       - run: tar xvf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" CPPFLAGS="-I/usr/local/opt/libiconv/include" CXXFLAGS="-I/usr/local/opt/libiconv/include" LDFLAGS="-L/usr/local/opt/libiconv/lib" ./configure --enable-unittests
-      - run: make -j2
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --prefix="$HOME/.local/"
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make -j2
       # somehow it gets included by some C++ stdlib header (case unsensitive)
       - run: rm libhtp/VERSION && make check
       - run: tar xf prep/suricata-verify.tar.gz

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -263,7 +263,13 @@ pub struct RustParser {
 /// UNSAFE !
 #[macro_export]
 macro_rules! build_slice {
-    ($buf:ident, $len:expr) => ( unsafe{ std::slice::from_raw_parts($buf, $len) } );
+    ($buf:ident, $len:expr) => (
+        if $buf.is_null() && $len == 0 {
+             &[]
+        } else {
+            unsafe{ std::slice::from_raw_parts($buf, $len) }
+        }
+    );
 }
 
 /// Cast pointer to a variable, as a mutable reference to an object

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1351,7 +1351,7 @@ pub extern "C" fn rs_dcerpc_probe_tcp(direction: u8, input: *const u8,
                                       len: u32, rdir: *mut u8) -> i32
 {
     SCLogDebug!("Probing packet for DCERPC");
-    if len == 0 {
+    if len == 0 || input.is_null() {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = unsafe {

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -325,7 +325,7 @@ pub extern "C" fn rs_dcerpc_probe_udp(direction: u8, input: *const u8,
                                       len: u32, rdir: *mut u8) -> i32
 {
     SCLogDebug!("Probing the packet for DCERPC/UDP");
-    if len == 0 {
+    if len == 0 || input.is_null() {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = unsafe {

--- a/rust/src/dhcp/dhcp.rs
+++ b/rust/src/dhcp/dhcp.rs
@@ -231,7 +231,7 @@ pub extern "C" fn rs_dhcp_probing_parser(_flow: *const Flow,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto
 {
-    if input_len < DHCP_MIN_FRAME_LEN {
+    if input_len < DHCP_MIN_FRAME_LEN || input.is_null() {
         return ALPROTO_UNKNOWN;
     }
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -1063,7 +1063,7 @@ pub extern "C" fn rs_dns_probe(
     len: u32,
     rdir: *mut u8,
 ) -> AppProto {
-    if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = unsafe {
@@ -1092,7 +1092,7 @@ pub extern "C" fn rs_dns_probe_tcp(
     len: u32,
     rdir: *mut u8
 ) -> AppProto {
-    if len == 0 || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 + 2 {
         return core::ALPROTO_UNKNOWN;
     }
     let slice: &[u8] = unsafe {

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -417,6 +417,9 @@ pub extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     let alproto = unsafe{ ALPROTO_KRB5 };
     if slice.len() <= 10 { return unsafe{ALPROTO_FAILED}; }
@@ -455,6 +458,9 @@ pub extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         input:*const u8, input_len: u32,
         rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     if slice.len() <= 14 { return unsafe{ALPROTO_FAILED}; }
     match be_u32(slice) as IResult<&[u8],u32> {

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -604,6 +604,9 @@ pub extern "C" fn rs_mqtt_probing_parser(
     input_len: u32,
     _rdir: *mut u8,
 ) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let buf = build_slice!(input, input_len as usize);
     match parse_fixed_header(buf) {
         Ok((_, hdr)) => {

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1873,6 +1873,9 @@ pub extern "C" fn rs_nfs_probe_ms(
         direction: u8, input: *const u8,
         len: u32, rdir: *mut u8) -> i8
 {
+    if input.is_null() {
+        return 0;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     SCLogDebug!("rs_nfs_probe_ms: probing direction {:02x}", direction);
     let mut adirection : u8 = 0;
@@ -1907,6 +1910,9 @@ pub extern "C" fn rs_nfs_probe(direction: u8,
         input: *const u8, len: u32)
     -> i8
 {
+    if input.is_null() {
+        return 0;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     SCLogDebug!("rs_nfs_probe: running probe");
     return nfs_probe(slice, direction);
@@ -1917,6 +1923,9 @@ pub extern "C" fn rs_nfs_probe(direction: u8,
 pub extern "C" fn rs_nfs_probe_udp_ts(input: *const u8, len: u32)
                                -> i8
 {
+    if input.is_null() {
+        return 0;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     return nfs_probe_udp(slice, STREAM_TOSERVER);
 }
@@ -1926,6 +1935,9 @@ pub extern "C" fn rs_nfs_probe_udp_ts(input: *const u8, len: u32)
 pub extern "C" fn rs_nfs_probe_udp_tc(input: *const u8, len: u32)
                                -> i8
 {
+    if input.is_null() {
+        return 0;
+    }
     let slice: &[u8] = build_slice!(input, len as usize);
     return nfs_probe_udp(slice, STREAM_TOCLIENT);
 }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1471,7 +1471,7 @@ pub extern "C" fn rs_nfs_parse_request(flow: &mut Flow,
                                        _data: *mut std::os::raw::c_void)
                                        -> AppLayerResult
 {
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     state.update_ts(flow.get_last_time().as_secs());
@@ -1497,7 +1497,7 @@ pub extern "C" fn rs_nfs_parse_response(flow: &mut Flow,
                                         -> AppLayerResult
 {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
 
     state.update_ts(flow.get_last_time().as_secs());
     state.parse_tcp_data_tc(buf)
@@ -1522,7 +1522,7 @@ pub extern "C" fn rs_nfs_parse_request_udp(_flow: *mut Flow,
                                        _data: *mut std::os::raw::c_void)
                                        -> AppLayerResult
 {
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
     SCLogDebug!("parsing {} bytes of request data", input_len);
     state.parse_udp_ts(buf)
 }
@@ -1537,7 +1537,7 @@ pub extern "C" fn rs_nfs_parse_response_udp(_flow: *mut Flow,
                                         -> AppLayerResult
 {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
     state.parse_udp_tc(buf)
 }
 

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -361,6 +361,9 @@ pub extern "C" fn ntp_probing_parser(_flow: *const Flow,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
 {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice: &[u8] = unsafe { std::slice::from_raw_parts(input as *mut u8, input_len as usize) };
     let alproto = unsafe{ ALPROTO_NTP };
     match parse_ntp(slice) {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -1924,7 +1924,7 @@ pub extern "C" fn rs_smb_parse_request_tcp(flow: &mut Flow,
                                        flags: u8)
                                        -> AppLayerResult
 {
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
     SCLogDebug!("parsing {} bytes of request data", input_len);
 
     /* START with MISTREAM set: record might be starting the middle. */
@@ -1957,7 +1957,7 @@ pub extern "C" fn rs_smb_parse_response_tcp(flow: &mut Flow,
                                         -> AppLayerResult
 {
     SCLogDebug!("parsing {} bytes of response data", input_len);
-    let buf = unsafe{std::slice::from_raw_parts(input, input_len as usize)};
+    let buf = build_slice!(input, input_len as usize);
 
     /* START with MISTREAM set: record might be starting the middle. */
     if flags & (STREAM_START|STREAM_MIDSTREAM) == (STREAM_START|STREAM_MIDSTREAM) {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2055,7 +2055,7 @@ fn smb_probe_tcp(direction: u8, slice: &[u8], rdir: *mut u8, begins: bool) -> i8
 pub extern "C" fn rs_smb_probe_begins_tcp(direction: u8, input: *const u8, len: u32, rdir: *mut u8)
     -> i8
 {
-    if len < MIN_REC_SIZE as u32 {
+    if len < MIN_REC_SIZE as u32 || input.is_null() {
         return 0;
     }
     let slice = build_slice!(input, len as usize);
@@ -2068,7 +2068,7 @@ pub extern "C" fn rs_smb_probe_begins_tcp(direction: u8, input: *const u8, len: 
 pub extern "C" fn rs_smb_probe_tcp(direction: u8, input: *const u8, len: u32, rdir: *mut u8)
     -> i8
 {
-    if len < MIN_REC_SIZE as u32 {
+    if len < MIN_REC_SIZE as u32 || input.is_null() {
         return 0;
     }
     let slice = build_slice!(input, len as usize);

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -544,6 +544,9 @@ pub extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
                                          input:*const u8,
                                          input_len: u32,
                                          _rdir: *mut u8) -> AppProto {
+    if input.is_null() {
+        return ALPROTO_UNKNOWN;
+    }
     let slice = build_slice!(input,input_len as usize);
     let alproto = unsafe{ ALPROTO_SNMP };
     if slice.len() < 4 { return unsafe{ALPROTO_FAILED}; }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7014

Describe changes:
- Backport of #11062 

Commit [tests: do not bother to free a null pointer](https://github.com/OISF/suricata/pull/11096/commits/5a5fe36bfc3b55c55a04e697647cc958a4dfce59) was not needed as master6 does not use rust for generic integer detection
The other commits needed small adaptations

#11127 with complete fixes :
- fix smb and nfs to use `build_slice` to have the fix instead of using directly from_raw_parts
- add cherry-pick to fix MacOS build in CI