### PR TITLE
output: Add linktype description

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2825,6 +2825,9 @@
             "properties": {
                 "linktype": {
                     "type": "integer"
+                },
+                "linktype_name": {
+                    "type": "string"
                 }
             },
             "additionalProperties": false

--- a/src/decode.h
+++ b/src/decode.h
@@ -33,6 +33,7 @@
 #include "util-debug.h"
 #include "decode-events.h"
 #include "util-exception-policy-types.h"
+#include "util-datalink.h"
 #ifdef PROFILING
 #include "flow-worker.h"
 #include "app-layer-protos.h"
@@ -1215,45 +1216,6 @@ void DecodeUnregisterCounters(void);
 #ifndef IPPROTO_SHIM6
 #define IPPROTO_SHIM6 140
 #endif
-
-/* pcap provides this, but we don't want to depend on libpcap */
-#ifndef DLT_EN10MB
-#define DLT_EN10MB 1
-#endif
-
-#ifndef DLT_C_HDLC
-#define DLT_C_HDLC 104
-#endif
-
-/* taken from pcap's bpf.h */
-#ifndef DLT_RAW
-#ifdef __OpenBSD__
-#define DLT_RAW     14  /* raw IP */
-#else
-#define DLT_RAW     12  /* raw IP */
-#endif
-#endif
-
-#ifndef DLT_NULL
-#define DLT_NULL 0
-#endif
-
-/** libpcap shows us the way to linktype codes
- * \todo we need more & maybe put them in a separate file? */
-#define LINKTYPE_NULL        DLT_NULL
-#define LINKTYPE_ETHERNET    DLT_EN10MB
-#define LINKTYPE_LINUX_SLL   113
-#define LINKTYPE_PPP         9
-#define LINKTYPE_RAW         DLT_RAW
-/* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.
- * Libpcap on at least OpenBSD returns 101 as datalink type for RAW pcaps though. */
-#define LINKTYPE_RAW2        101
-#define LINKTYPE_IPV4        228
-#define LINKTYPE_IPV6        229
-#define LINKTYPE_GRE_OVER_IP 778
-#define LINKTYPE_CISCO_HDLC  DLT_C_HDLC
-#define PPP_OVER_GRE         11
-#define VLAN_OVER_GRE        13
 
 /* Packet Flags */
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -56,6 +56,7 @@
 #include "util-log-redis.h"
 #include "util-device.h"
 #include "util-validate.h"
+#include "util-datalink.h"
 
 #include "flow-var.h"
 #include "flow-bit.h"
@@ -437,6 +438,11 @@ void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
         return;
     }
     if (!jb_set_uint(js, "linktype", p->datalink)) {
+        return;
+    }
+
+    const char *dl_name = LinktypeName(p->datalink);
+    if (!jb_set_string(js, "linktype_name", dl_name == NULL ? "n/a" : dl_name)) {
         return;
     }
     jb_close(js);

--- a/src/util-datalink.h
+++ b/src/util-datalink.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2021-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,8 +18,90 @@
 #ifndef SURICATA_UTIL_DATALINK_H
 #define SURICATA_UTIL_DATALINK_H
 
+#include "util-debug.h"
+
+/* pcap provides this, but we don't want to depend on libpcap */
+#ifndef DLT_EN10MB
+#define DLT_EN10MB 1
+#endif
+
+#ifndef DLT_C_HDLC
+#define DLT_C_HDLC 104
+#endif
+
+/* taken from pcap's bpf.h */
+#ifndef DLT_RAW
+#ifdef __OpenBSD__
+#define DLT_RAW 14 /* raw IP */
+#else
+#define DLT_RAW 12 /* raw IP */
+#endif
+#endif
+
+#ifndef DLT_NULL
+#define DLT_NULL 0
+#endif
+
+/** libpcap shows us the way to linktype codes
+ * \todo we need more & maybe put them in a separate file? */
+#define LINKTYPE_NULL      DLT_NULL
+#define LINKTYPE_ETHERNET  DLT_EN10MB
+#define LINKTYPE_LINUX_SLL 113
+#define LINKTYPE_PPP       9
+#define LINKTYPE_RAW       DLT_RAW
+/* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.
+ * Libpcap on at least OpenBSD returns 101 as datalink type for RAW pcaps though. */
+#define LINKTYPE_RAW2        101
+#define LINKTYPE_IPV4        228
+#define LINKTYPE_IPV6        229
+#define LINKTYPE_GRE_OVER_IP 778
+#define LINKTYPE_CISCO_HDLC  DLT_C_HDLC
+
 void DatalinkSetGlobalType(int datalink);
 int DatalinkGetGlobalType(void);
 bool DatalinkHasMultipleValues(void);
+
+static inline const char *LinktypeName(const int datalink)
+{
+    /* call the decoder */
+    switch (datalink) {
+        case LINKTYPE_ETHERNET:
+            return "EN10MB";
+            break;
+        case LINKTYPE_LINUX_SLL:
+            return "LINUX_SLL";
+            break;
+        case LINKTYPE_PPP:
+            return "PPP";
+            break;
+        case LINKTYPE_RAW2:
+            return "RAW2";
+            break;
+        case LINKTYPE_RAW:
+            return "RAW";
+            break;
+        case LINKTYPE_GRE_OVER_IP:
+            return "GRE_RAW";
+            break;
+        case LINKTYPE_NULL:
+            return "NULL";
+            break;
+        case LINKTYPE_CISCO_HDLC:
+            return "C_HDLC";
+            break;
+        case LINKTYPE_IPV4:
+            return "IPv4";
+            break;
+        case LINKTYPE_IPV6:
+            return "IPv6";
+            break;
+        default:
+            SCLogError("datalink type "
+                       "%" PRId32 " not yet supported",
+                    datalink);
+            return "NULL";
+            break;
+    }
+}
 
 #endif /* SURICATA_UTIL_DATALINK_H */


### PR DESCRIPTION
Continuation of #11131 

Amend the linktype output with the linktype name (when available).

The linktype name is included alongside linktype when `alert.packet` is enabled. The name is retrieved from a new function that translates the DLT/linktypes recognized by Suricata into a string.

Issue: 6954

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6954

Describe changes:
- Include the linktype name alongside linktype
- Update the schema with linktype_name

Updates:
- Rebase

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1853
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
