### PR TITLE
tls store: client cert logging

### DIFF
--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -612,7 +612,7 @@ static int DetectTlsStorePostMatch (DetectEngineThreadCtx *det_ctx,
 
     SSLStateConnp *connp;
 
-    if (p->flow->flags & STREAM_TOSERVER) {
+    if (PKT_IS_TOSERVER(p)) {
         connp = &ssl_state->client_connp;
     } else {
         connp = &ssl_state->server_connp;

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -362,12 +362,8 @@ static OutputInitResult LogTlsStoreLogInitCtx(ConfNode *conf)
     output_ctx->data = NULL;
     output_ctx->DeInit = LogTlsStoreLogDeInitCtx;
 
-    /* FIXME we need to implement backward compatibility here */
-    const char *s_default_log_dir = NULL;
-    s_default_log_dir = ConfigGetLogDirectory();
-
-    const char *s_base_dir = NULL;
-    s_base_dir = ConfNodeLookupChildValue(conf, "certs-log-dir");
+    const char *s_default_log_dir = ConfigGetLogDirectory();
+    const char *s_base_dir = ConfNodeLookupChildValue(conf, "certs-log-dir");
     if (s_base_dir == NULL || strlen(s_base_dir) == 0) {
         strlcpy(tls_logfile_base_dir,
                 s_default_log_dir, sizeof(tls_logfile_base_dir));

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -463,6 +463,7 @@ typedef enum {
     /* TX loggers first for low logger IDs */
     LOGGER_HTTP,
     LOGGER_TLS_STORE,
+    LOGGER_TLS_STORE_CLIENT,
     LOGGER_TLS,
     LOGGER_JSON_TX,
     LOGGER_FILE,

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1266,6 +1266,7 @@ const char *PacketProfileLoggerIdToString(LoggerId id)
         CASE_CODE(LOGGER_UNDEFINED);
         CASE_CODE(LOGGER_HTTP);
         CASE_CODE(LOGGER_TLS_STORE);
+        CASE_CODE(LOGGER_TLS_STORE_CLIENT);
         CASE_CODE(LOGGER_TLS);
         CASE_CODE(LOGGER_JSON_TX);
         CASE_CODE(LOGGER_FILE);


### PR DESCRIPTION
STREAM_* flags are invalid for `Flow::flags`.

Fixes: dfcb4295240f ("detect/cert: Use client side certs")

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1856