### PR TITLE
tcp: fix 'broken ack' on flow timeout

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -221,7 +221,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
         p->l4.hdrs.tcph->th_dport = htons(f->dp);
 
         p->l4.hdrs.tcph->th_seq = htonl(ssn->client.next_seq);
-        p->l4.hdrs.tcph->th_ack = htonl(ssn->server.last_ack);
+        p->l4.hdrs.tcph->th_ack = 0;
 
         /* to client */
     } else {
@@ -229,7 +229,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(
         p->l4.hdrs.tcph->th_dport = htons(f->sp);
 
         p->l4.hdrs.tcph->th_seq = htonl(ssn->server.next_seq);
-        p->l4.hdrs.tcph->th_ack = htonl(ssn->client.last_ack);
+        p->l4.hdrs.tcph->th_ack = 0;
     }
 
     if (FLOW_IS_IPV4(f)) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5550,10 +5550,10 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
          * we care about reassembly here. */
         if (p->flags & PKT_PSEUDO_STREAM_END) {
             if (PKT_IS_TOCLIENT(p)) {
-                ssn->client.last_ack = TCP_GET_RAW_ACK(tcph);
+                // ssn->client.last_ack = TCP_GET_RAW_ACK(tcph);
                 StreamTcpReassembleHandleSegment(tv, stt->ra_ctx, ssn, &ssn->server, p);
             } else {
-                ssn->server.last_ack = TCP_GET_RAW_ACK(tcph);
+                // ssn->server.last_ack = TCP_GET_RAW_ACK(tcph);
                 StreamTcpReassembleHandleSegment(tv, stt->ra_ctx, ssn, &ssn->client, p);
             }
             /* straight to 'skip' as we already handled reassembly */


### PR DESCRIPTION
Don't set an ACK value if ACK flag is no longer set. This avoids a bogus `pkt_broken_ack` event set.

Fixes: ebf465a11bff ("tcp: do not assign TCP flags to pseudopackets")