### PR TITLE
runmodes: fix `--list-runmodes` output-V1

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -84,7 +84,14 @@ typedef struct RunMode_ {
     /* the runmode type */
     enum RunModes runmode;
     const char *name;
+    const char *default_runmode;
+    const char *supported_runmode;
+    const char *notes;
+    const char *yaml_section;
+    const char *commandline;
+    const char *supported_features;
     const char *description;
+    
     /* runmode function */
     int (*RunModeFunc)(void);
     int (*RunModeIsIPSEnabled)(void);


### PR DESCRIPTION
Modified the RunMode Struct to include fields for more informations about each runmode

Optimization: #6572

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [ :heavy_check_mark: ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [ :heavy_check_mark:  ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [  ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Added new fields to the RunMode struct to follow the suggested description as listed in the ticket [#6572 ](https://redmine.openinfosecfoundation.org/issues/6572). 
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
