### PR TITLE
Draft: enable output-specific metadata logging configuration in alerts

### DIFF
--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -33,7 +33,7 @@ fn log_template(tx: &TemplateTransaction, js: &mut JsonBuilder) -> Result<(), Js
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_template_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, TemplateTransaction);
     log_template(tx, js).is_ok()

--- a/rust/src/bittorrent_dht/logger.rs
+++ b/rust/src/bittorrent_dht/logger.rs
@@ -132,7 +132,7 @@ fn log_bittorrent_dht(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_bittorrent_dht_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, BitTorrentDHTTransaction);
     log_bittorrent_dht(tx, js).is_ok()

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -283,7 +283,7 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_log_json(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, HTTP2Transaction);
     if let Ok(x) = log_http2(tx, js) {

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -70,7 +70,7 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &mut KRB5Transaction) -> Result<
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(tx: &mut KRB5Transaction, jsb: &mut JsonBuilder) -> bool
+pub extern "C" fn rs_krb5_log_json_response(tx: &mut KRB5Transaction, jsb: &mut JsonBuilder, _: *mut std::os::raw::c_void) -> bool
 {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/modbus/log.rs
+++ b/rust/src/modbus/log.rs
@@ -21,7 +21,7 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use sawp_modbus::{Data, Message, Read, Write};
 
 #[no_mangle]
-pub extern "C" fn rs_modbus_to_json(tx: &mut ModbusTransaction, js: &mut JsonBuilder) -> bool {
+pub extern "C" fn rs_modbus_to_json(tx: &mut ModbusTransaction, js: &mut JsonBuilder, _: *mut std::os::raw::c_void) -> bool {
     log(tx, js).is_ok()
 }
 

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -155,7 +155,7 @@ fn log_quic(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError>
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_to_json(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, QuicTransaction);
     log_quic(tx, js).is_ok()

--- a/rust/src/rdp/log.rs
+++ b/rust/src/rdp/log.rs
@@ -24,7 +24,7 @@ use crate::rdp::windows;
 use x509_parser::prelude::{X509Certificate, FromDer};
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_to_json(tx: &mut RdpTransaction, js: &mut JsonBuilder) -> bool {
+pub extern "C" fn rs_rdp_to_json(tx: &mut RdpTransaction, js: &mut JsonBuilder, _: *mut std::os::raw::c_void) -> bool {
     log(tx, js).is_ok()
 }
 

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -128,7 +128,7 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_rfb_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, RFBTransaction);
     log_rfb(tx, js).is_ok()

--- a/rust/src/sip/log.rs
+++ b/rust/src/sip/log.rs
@@ -57,6 +57,6 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_log_json(tx: &mut SIPTransaction, js: &mut JsonBuilder) -> bool {
+pub extern "C" fn rs_sip_log_json(tx: &mut SIPTransaction, js: &mut JsonBuilder, _: *mut std::os::raw::c_void) -> bool {
     log(tx, js).is_ok()
 }

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -77,7 +77,7 @@ fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder) -> bool
+pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder, _: *mut std::os::raw::c_void) -> bool
 {
     snmp_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -64,7 +64,7 @@ fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _ctx: *mut std::os::raw::c_void) -> bool {
     let tx = cast_pointer!(tx, SSHTransaction);
     if let Ok(x) = log_ssh(tx, js) {
         return x;

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -38,7 +38,8 @@ fn tftp_log_request(tx: &mut TFTPTransaction,
 
 #[no_mangle]
 pub extern "C" fn rs_tftp_log_json_request(tx: &mut TFTPTransaction,
-                                           jb: &mut JsonBuilder)
+                                           jb: &mut JsonBuilder,
+                                           _: *mut std::os::raw::c_void)
                                            -> bool
 {
     tftp_log_request(tx, jb).is_ok()

--- a/rust/src/websocket/logger.rs
+++ b/rust/src/websocket/logger.rs
@@ -49,7 +49,7 @@ fn log_websocket(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_websocket_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder, _: *mut std::os::raw::c_void
 ) -> bool {
     let tx = cast_pointer!(tx, WebSocketTransaction);
     log_websocket(tx, js, false, false).is_ok()

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1412,7 +1412,7 @@ uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
     return c == NULL ? len : (uint16_t)(c - buffer + 1);
 }
 
-bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb)
+bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb, void *ctx)
 {
     const FtpDataState *ftp_state = (FtpDataState *)vtx;
     jb_open_object(jb, "ftp_data");

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -189,6 +189,6 @@ uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 
 uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len);
-bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb);
+bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb, void *ctx);
 
 #endif /* SURICATA_APP_LAYER_FTP_H */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -285,8 +285,8 @@ static void AlertAddPayload(AlertJsonOutputCtx *json_output_ctx, JsonBuilder *js
     }
 }
 
-static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
-        const uint64_t tx_id, const uint16_t option_flags)
+static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb, const uint64_t tx_id,
+        const uint16_t option_flags, OutputJsonCtx *ctx)
 {
     const AppProto proto = FlowGetAppProtocol(p->flow);
     EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(proto);
@@ -311,7 +311,7 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                             return;
                         }
                 }
-                if (!al->LogTx(tx, jb)) {
+                if (!al->LogTx(tx, jb, ctx->applayer_ctx[proto])) {
                     jb_restore_mark(jb, &mark);
                 }
             }
@@ -629,7 +629,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         if (p->flow != NULL) {
             if (pa->flags & PACKET_ALERT_FLAG_TX) {
                 if (json_output_ctx->flags & LOG_JSON_APP_LAYER) {
-                    AlertAddAppLayer(p, jb, pa->tx_id, json_output_ctx->flags);
+                    AlertAddAppLayer(
+                            p, jb, pa->tx_id, json_output_ctx->flags, json_output_ctx->eve_ctx);
                 }
                 /* including fileinfo data is configured by the metadata setting */
                 if (json_output_ctx->flags & LOG_JSON_RULE_METADATA) {

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -210,7 +210,7 @@ static void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 }
 
-bool AlertJsonDnp3(void *vtx, JsonBuilder *js)
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js, void *ctx)
 {
     DNP3Transaction *tx = (DNP3Transaction *)vtx;
     bool logged = false;

--- a/src/output-json-dnp3.h
+++ b/src/output-json-dnp3.h
@@ -21,6 +21,6 @@
 #include "app-layer-dnp3.h"
 
 void JsonDNP3LogRegister(void);
-bool AlertJsonDnp3(void *vtx, JsonBuilder *js);
+bool AlertJsonDnp3(void *vtx, JsonBuilder *js, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_DNP3_H */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -287,7 +287,7 @@ static JsonBuilder *JsonDNSLogAnswer(void *txptr)
     }
 }
 
-bool AlertJsonDns(void *txptr, JsonBuilder *js)
+bool AlertJsonDns(void *txptr, JsonBuilder *js, void *ctx)
 {
     bool r = false;
     jb_open_object(js, "dns");

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,6 +26,6 @@
 
 void JsonDnsLogRegister(void);
 
-bool AlertJsonDns(void *vtx, JsonBuilder *js);
+bool AlertJsonDns(void *vtx, JsonBuilder *js, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_DNS_H */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -180,7 +180,7 @@ JsonBuilder *JsonBuildFileInfoRecord(const Packet *p, const File *ff, void *tx,
                     tx = AppLayerParserGetTx(p->flow->proto, p->flow->alproto, state, tx_id);
                     if (tx) {
                         jb_get_mark(js, &mark);
-                        if (!al->LogTx(tx, js)) {
+                        if (!al->LogTx(tx, js, eve_ctx)) {
                             jb_restore_mark(js, &mark);
                         }
                     }

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -46,7 +46,7 @@
 #include "app-layer-ftp.h"
 #include "output-json-ftp.h"
 
-bool EveFTPLogCommand(void *vtx, JsonBuilder *jb)
+bool EveFTPLogCommand(void *vtx, JsonBuilder *jb, void *ctx)
 {
     FTPTransaction *tx = vtx;
     /* Preallocate array objects to simplify failure case */

--- a/src/output-json-ftp.h
+++ b/src/output-json-ftp.h
@@ -24,6 +24,6 @@
 #ifndef SURICATA_OUTPUT_JSON_FTP_H
 #define SURICATA_OUTPUT_JSON_FTP_H
 
-bool EveFTPLogCommand(void *vtx, JsonBuilder *js);
+bool EveFTPLogCommand(void *vtx, JsonBuilder *js, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_FTP_H */

--- a/src/output-json-mqtt.h
+++ b/src/output-json-mqtt.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Open Information Security Foundation
+/* Copyright (C) 2020-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,6 +25,6 @@
 #define SURICATA_OUTPUT_JSON_MQTT_H
 
 void JsonMQTTLogRegister(void);
-bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js);
+bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_MQTT_H */

--- a/src/output-json-pgsql.h
+++ b/src/output-json-pgsql.h
@@ -25,6 +25,6 @@
 #define SURICATA_OUTPUT_JSON_PGSQL_H
 
 void JsonPgsqlLogRegister(void);
-bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb);
+bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_PGSQL_H */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -465,7 +465,7 @@ static bool JsonTlsLogJSONExtendedAux(void *vtx, JsonBuilder *tjs)
     return true;
 }
 
-bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *tjs)
+bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *tjs, void *ctx)
 {
     jb_open_object(tjs, "tls");
     bool r = JsonTlsLogJSONExtendedAux(vtx, tjs);

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -29,6 +29,6 @@ void JsonTlsLogRegister(void);
 #include "app-layer-ssl.h"
 
 void JsonTlsLogJSONBasic(JsonBuilder *js, SSLState *ssl_state);
-bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js);
+bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js, void *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_TLS_H */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -84,6 +84,7 @@ typedef struct OutputJsonCtx_ {
     OutputJsonCommonSettings cfg;
     HttpXFFCfg *xff_cfg;
     SCEveFileType *filetype;
+    void *applayer_ctx[ALPROTO_MAX];
 } OutputJsonCtx;
 
 typedef struct OutputJsonThreadCtx_ {

--- a/src/output.c
+++ b/src/output.c
@@ -938,7 +938,7 @@ static int JsonGenericLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return TM_ECODE_FAILED;
     }
 
-    if (!al->LogTx(tx, js)) {
+    if (!al->LogTx(tx, js, thread->ctx)) {
         goto error;
     }
 

--- a/src/output.h
+++ b/src/output.h
@@ -189,7 +189,7 @@ void OutputLoggerExitPrintStats(ThreadVars *, void *);
 void OutputSetupActiveLoggers(void);
 void OutputClearActiveLoggers(void);
 
-typedef bool (*EveJsonSimpleTxLogFunc)(void *, struct JsonBuilder *);
+typedef bool (*EveJsonSimpleTxLogFunc)(void *, struct JsonBuilder *, void *);
 
 typedef struct EveJsonSimpleAppLayerLogger {
     AppProto proto;


### PR DESCRIPTION
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

This draft outlines a potential approach to making app-layer logging options (like `mqtt.msg-log-limit` (#11054)) available to metadata logging in alerts. The problem there was so far that there is no way of passing these settings to the metadata logging code, since a `EveJsonSimpleTxLogFunc` only gets the transaction and the `JsonBuilder` as parameters.
Using a global static data structure is only half a solution since it is well possible to have multiple EVE outputs that can have different settings for the same event type, and we would obviously like the alerts in EVE output A use the same options as all the app-layer logging in output A, and the same behaviour for different settings in EVE outpub B and C. With such a global variable we can't reflect that.

Describe changes:
- Introduce interface change for `EveJsonSimpleTxLogFunc` passing a metadata-specific context into the log function. This is done in the C function declaration and also in all current implementations, Rust and C.
- Add a new pointer array (one pointer per alproto) to the output-specific `OutputJsonCtx` to store metadata-specific context pointers.
- Use this construct to assign a struct with settings after parsing to that pointer array, and read and use it in `EveJsonSimpleTxLogFunc` if it is set. Memory-wise, the context struct is already handled (allocated and freed) using the regular `InitSub`/`DeinitCtxSub` and all access is expected to only occur during the lifetime defined through this mechanism.
