### PR TITLE
util:radix-tree: Fix possible dereference of nullptr

### DIFF
--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -715,6 +715,13 @@ static SCRadixNode *SCRadixAddKeyInternal(uint8_t *key_stream, uint8_t key_bitle
         return NULL;
     }
     new_node = SCRadixCreateNode();
+
+    if (new_node == NULL) {
+        SCRadixReleasePrefix(prefix, tree);
+        sc_errno = SC_ENOMEM;
+        return NULL;
+    }
+
     new_node->prefix = prefix;
     new_node->bit = prefix->bitlen;
 
@@ -745,6 +752,13 @@ static SCRadixNode *SCRadixAddKeyInternal(uint8_t *key_stream, uint8_t key_bitle
          * detail below) */
     } else {
         inter_node = SCRadixCreateNode();
+
+        if (inter_node == NULL) {
+            SCRadixReleaseNode(new_node, tree);
+            sc_errno = SC_ENOMEM;
+            return NULL;
+        }
+
         inter_node->prefix = NULL;
         inter_node->bit = differ_bit;
         inter_node->parent = node->parent;


### PR DESCRIPTION
Fix possible dereference of nullptr in case of unsuccessful allocation of memory memory for tree nodes

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7049

Describe changes:
- Add check of node pointers after allocation of memory;
- If memory allocated successfully, behavior do not change;
- If allocation fail, release already allocated memory and exit from function;

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
