### PR TITLE
Dns feature 7011 v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1101,6 +1101,9 @@
                 "authorities": {
                     "$ref": "#/$defs/dns.authorities"
                 },
+                "additionals": {
+                    "$ref": "#/$defs/dns.additionals"
+                },
                 "query": {
                     "type": "array",
                     "minItems": 1,
@@ -1172,6 +1175,9 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
+                        },
+                        "additionals": {
+                            "$ref": "#/$defs/dns.additionals"
                         }
                     },
                     "additionalProperties": false
@@ -1201,6 +1207,13 @@
                             }
                         },
                         "MX": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NS": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
@@ -6026,6 +6039,28 @@
                             }
                         },
                         "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "dns.additionals": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rdata": {
+                        "type": "string"
+                    },
+                    "rrname": {
+                        "type": "string"
+                    },
+                    "rrtype": {
+                        "type": "string"
+                    },
+                    "ttl": {
+                        "type": "integer"
                     }
                 },
                 "additionalProperties": false

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -226,6 +226,7 @@ pub struct DNSMessage {
     pub queries: Vec<DNSQueryEntry>,
     pub answers: Vec<DNSAnswerEntry>,
     pub authorities: Vec<DNSAnswerEntry>,
+    pub additionals: Vec<DNSAnswerEntry>,
 }
 
 #[derive(Debug, Default)]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -150,6 +150,15 @@ pub struct DNSQueryEntry {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct DNSRDataOPT {
+    /// Option Code
+    pub code: u16,
+    // Option Data Length omitted, reference "data" length
+    /// Option Data
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct DNSRDataSOA {
     /// Primary name server for this zone
     pub mname: Vec<u8>,
@@ -207,6 +216,7 @@ pub enum DNSRData {
     SOA(DNSRDataSOA),
     SRV(DNSRDataSRV),
     SSHFP(DNSRDataSSHFP),
+    OPT(Vec<DNSRDataOPT>),
     // RData for remaining types is sometimes ignored
     Unknown(Vec<u8>),
 }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -606,6 +606,15 @@ fn dns_log_json_answer(
         js.close()?;
     }
 
+    if !response.additionals.is_empty() {
+        js.open_array("additionals")?;
+        for add in &response.additionals {
+            let add_detail = dns_log_json_answer_detail(add)?;
+            js.append_object(&add_detail)?;
+        }
+        js.close()?;
+    }
+
     Ok(())
 }
 

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -180,6 +180,16 @@ pub extern "C" fn SCDnsLuaGetAnswerTable(clua: &mut CLuaState, tx: &mut DNSTrans
                     lua.pushstring(&String::from_utf8_lossy(&srv.target));
                     lua.settable(-3);
                 }
+                DNSRData::OPT(ref opt) => {
+                    if !opt.is_empty() {
+                        lua.pushstring("addr");
+                        for option in opt.iter() {
+                            lua.pushstring(&String::from_utf8_lossy(&option.code.to_be_bytes()));
+                            lua.pushstring(&String::from_utf8_lossy(&option.data));
+                        }
+                        lua.settable(-3);
+                    }
+                }
             }
             lua.settable(-3);
         }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -149,7 +149,7 @@ fn dns_parse_answer<'a>(
                         rrtype: val.rrtype,
                         rrclass: val.rrclass,
                         ttl: val.ttl,
-                        data: DNSRData::Unknown(Vec::new()),
+                        data: DNSRData::OPT(Vec::new()),
                     });
                     input = rem;
                     continue;
@@ -295,6 +295,22 @@ fn dns_parse_rdata_sshfp(input: &[u8]) -> IResult<&[u8], DNSRData> {
     ))
 }
 
+fn dns_parse_rdata_opt(input: &[u8]) -> IResult<&[u8], DNSRData> {
+    let mut dns_rdata_opt_vec = Vec::new();
+    let mut i = input;
+
+    while !i.is_empty() {
+        let (j, code) = be_u16(i)?;
+        let (j, data) = length_data(be_u16)(j)?;
+        i = j;
+        dns_rdata_opt_vec.push(DNSRDataOPT {
+            code,
+            data: data.to_vec(),
+        });
+    }
+    Ok((i, DNSRData::OPT(dns_rdata_opt_vec)))
+}
+
 fn dns_parse_rdata_unknown(input: &[u8]) -> IResult<&[u8], DNSRData> {
     rest(input).map(|(input, data)| (input, DNSRData::Unknown(data.to_vec())))
 }
@@ -314,6 +330,7 @@ fn dns_parse_rdata<'a>(
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
         DNS_RECORD_TYPE_SRV => dns_parse_rdata_srv(input, message),
+        DNS_RECORD_TYPE_OPT => dns_parse_rdata_opt(input),
         _ => dns_parse_rdata_unknown(input),
     }
 }
@@ -493,7 +510,7 @@ mod tests {
         let (body, header) = dns_parse_header(pkt).unwrap();
         let res = dns_parse_body(body, pkt, header);
         let (rem, request) = res.unwrap();
-        // The response should be fully parsed.
+        // The request should be fully parsed.
         assert!(rem.is_empty());
 
         assert_eq!(
@@ -517,15 +534,84 @@ mod tests {
 
         // verify additional section
         assert_eq!(request.additionals.len(), 1);
+
         let additional = &request.additionals[0];
         assert_eq!(
             additional,
             &DNSAnswerEntry {
                 name: vec![],
                 rrtype: DNS_RECORD_TYPE_OPT,
-                rrclass: 0x1000, // for OPT this is UDP payload size
+                rrclass: 0x1000,             // for OPT this is UDP payload size
+                ttl: 0,                      // for OPT this is extended RCODE and flags
+                data: DNSRData::OPT(vec![]), // empty rdata
+            }
+        );
+    }
+
+    #[test]
+    fn test_dns_parse_request_multi_opt() {
+        let pkt: &[u8] = &[
+            0x8d, 0x32, 0x01, 0x20, 0x00, 0x01, /* ...2. .. */
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x77, /* .......w */
+            0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, /* ww.suric */
+            0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
+            0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01, /* org..... */
+            0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, /* ..)..... */
+            0x00, 0x00, 0x10, /* total rdata len: 16 */
+            /* Option Cookie */
+            0x00, 0x0a, /* Code: 10 */
+            0x00, 0x08, /* Option len: 8 */
+            0x7f, 0x86, 0xcf, 0x8b, 0x81, 0xf6, 0xf9, 0x55, /* Option NSID */
+            0x00, 0x03, /* Code: 3 */
+            0x00, 0x00, /* option len: 0 */
+        ];
+
+        let (body, header) = dns_parse_header(pkt).unwrap();
+        let res = dns_parse_body(body, pkt, header);
+        let (rem, request) = res.unwrap();
+
+        assert!(rem.is_empty());
+        assert_eq!(
+            request.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x0120,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 0,
+                additional_rr: 1,
+            }
+        );
+
+        assert_eq!(request.queries.len(), 1);
+
+        let query = &request.queries[0];
+        assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(query.rrtype, 1);
+        assert_eq!(query.rrclass, 1);
+
+        // verify additional section
+        assert_eq!(request.additionals.len(), 1);
+
+        let additional = &request.additionals[0];
+        assert_eq!(
+            additional,
+            &DNSAnswerEntry {
+                name: vec![],
+                rrtype: DNS_RECORD_TYPE_OPT,
+                rrclass: 0x1000, // for OPT this is requestor's UDP payload size
                 ttl: 0,          // for OPT this is extended RCODE and flags
-                data: DNSRData::Unknown(vec![]), // empty rdata
+                // verify two options
+                data: DNSRData::OPT(vec![
+                    DNSRDataOPT {
+                        code: 0x000a,
+                        data: vec![0x7f, 0x86, 0xcf, 0x8b, 0x81, 0xf6, 0xf9, 0x55]
+                    },
+                    DNSRDataOPT {
+                        code: 0x0003,
+                        data: vec![]
+                    },
+                ])
             }
         );
     }
@@ -677,9 +763,9 @@ mod tests {
             &DNSAnswerEntry {
                 name: vec![],
                 rrtype: DNS_RECORD_TYPE_OPT,
-                rrclass: 0x0200, // for OPT this is UDP payload size
-                ttl: 0,          // for OPT this is extended RCODE and flags
-                data: DNSRData::Unknown(vec![]), // no rdata
+                rrclass: 0x0200,             // for OPT this is UDP payload size
+                ttl: 0,                      // for OPT this is extended RCODE and flags
+                data: DNSRData::OPT(vec![]), // no rdata
             }
         );
     }


### PR DESCRIPTION

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7011
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7017

Describe changes:
- Extend DNS parsing to include "additional" section.
- Add logging of DNS additional section. 
- Modify dns schema to support additional section, and grouped NS records
- Add DNSRData type for additional sections of type "OPT". Extend parsing to populate struct.

Replaces: https://github.com/OISF/suricata/pull/11134

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1862
