### PR TITLE
devguide: highlight commit message example - v1

### DIFF
--- a/doc/userguide/devguide/contributing/code-submission-process.rst
+++ b/doc/userguide/devguide/contributing/code-submission-process.rst
@@ -32,15 +32,17 @@ Information that needs to be part of a commit (if applicable):
 #. Coverity Scan issues addressed.
 #. Static analyzer error it fixes (cppcheck/scan-build/etc)
 
-When in doubt, check our git history for other messages or changes done to the
-same module your're working on. This is a good example of a `commit message
-<https://github.com/OISF/suricata/commit/33fca4d4db112b75ffa22eb2e6f14f038cbcc1f9>`_::
+.. note::
 
-    pcap/file: normalize file timestamps
+    When in doubt, check our git history for other messages or changes done to the
+    same module your're working on. This is a good example of a `commit message
+    <https://github.com/OISF/suricata/commit/33fca4d4db112b75ffa22eb2e6f14f038cbcc1f9>`_::
 
-    Normalize the timestamps that are too far in the past to epoch.
+       pcap/file: normalize file timestamps
 
-    Bug: #6240.
+       Normalize the timestamps that are too far in the past to epoch.
+
+       Bug: #6240.
 
 .. _pull-requests-criteria:
 


### PR DESCRIPTION
Although we have the example for a commit message in our Code Submission Process sub-chapter, seems that people still oversee it a lot. It was suggested that we put it in a note-box, to make it more visible.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- Put the section from the contribution process sub-chapter with a commit example in a note box, to make it more visible
