### PR TITLE
lua: use quoted include style to avoid system includes

### DIFF
--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -59,9 +59,9 @@ util_lua_dnp3_objects_c_template = """/* Copyright (C) 2015 Open Information Sec
 #include "app-layer-dnp3.h"
 #include "app-layer-dnp3-objects.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-dnp3-objects.h"

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -48,9 +48,9 @@
 #include "util-time.h"
 #include "util-conf.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-dnp3-objects.c
+++ b/src/util-lua-dnp3-objects.c
@@ -27,9 +27,9 @@
 #include "app-layer-dnp3.h"
 #include "app-layer-dnp3-objects.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-dnp3-objects.h"

--- a/src/util-lua-dnp3.c
+++ b/src/util-lua-dnp3.c
@@ -20,9 +20,9 @@
 #include "app-layer-dnp3.h"
 #include "app-layer-dnp3-objects.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-dns.c
+++ b/src/util-lua-dns.c
@@ -47,9 +47,9 @@
 #include "util-time.h"
 #include "rust.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-hassh.c
+++ b/src/util-lua-hassh.c
@@ -47,9 +47,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -46,9 +46,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-ja3.c
+++ b/src/util-lua-ja3.c
@@ -47,9 +47,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-smtp.c
+++ b/src/util-lua-smtp.c
@@ -36,8 +36,8 @@
 
 #include "app-layer-smtp.h"
 
-#include <lua.h>
-#include <lualib.h>
+#include "lua.h"
+#include "lualib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-ssh.c
+++ b/src/util-lua-ssh.c
@@ -48,9 +48,9 @@
 #include "util-time.h"
 #include "rust.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua-tls.c
+++ b/src/util-lua-tls.c
@@ -47,9 +47,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-common.h"

--- a/src/util-lua.c
+++ b/src/util-lua.c
@@ -47,9 +47,9 @@
 #include "util-logopenfile.h"
 #include "util-time.h"
 
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
 
 #include "util-lua.h"
 #include "util-lua-sandbox.h"


### PR DESCRIPTION
Use quoted include style for Lua includes ("lua.h" instead of <lua.h>)
as this could result in system includes being picked up instead of the
includes from our vendor directory.
