### PR TITLE
util/radix-tree: fix potential dereference of nullptr v2

### DIFF
--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -715,6 +715,13 @@ static SCRadixNode *SCRadixAddKeyInternal(uint8_t *key_stream, uint8_t key_bitle
         return NULL;
     }
     new_node = SCRadixCreateNode();
+
+    if (new_node == NULL) {
+        SCRadixReleasePrefix(prefix, tree);
+        sc_errno = SC_ENOMEM;
+        return NULL;
+    }
+
     new_node->prefix = prefix;
     new_node->bit = prefix->bitlen;
 
@@ -745,6 +752,13 @@ static SCRadixNode *SCRadixAddKeyInternal(uint8_t *key_stream, uint8_t key_bitle
          * detail below) */
     } else {
         inter_node = SCRadixCreateNode();
+
+        if (inter_node == NULL) {
+            SCRadixReleaseNode(new_node, tree);
+            sc_errno = SC_ENOMEM;
+            return NULL;
+        }
+
         inter_node->prefix = NULL;
         inter_node->bit = differ_bit;
         inter_node->parent = node->parent;


### PR DESCRIPTION
Fix potential dereferece of nullptr in case of
unsuccessful allocation of memory leak for tree nodes

Bug: #7049

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7049

Describe changes:
- Add check of node pointers after allocation of memory;
- If memory allocated successfully, behavior do not change;
- If allocation fail, release already allocated memory and exit from function;

Follows https://github.com/OISF/suricata/pull/11164 with transforming commit message
to proper state and removing unnecessary lines in commit body 
