### PR TITLE
pgsql/logger: open json object from logger fn - v5

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -27,6 +27,7 @@ use std;
 pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("pgsql")?;
     js.set_uint("tx_id", tx.tx_id)?;
     if let Some(request) = &tx.request {
         js.set_object("request", &log_request(request, flags)?)?;
@@ -35,12 +36,14 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
         // TODO Log anomaly event instead?
         js.set_bool("request", false)?;
         js.set_bool("response", false)?;
+        js.close()?;
         return Ok(());
     }
 
     if !tx.responses.is_empty() {
         js.set_object("response", &log_response_object(tx)?)?;
     }
+    js.close()?;
 
     Ok(())
 }

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -76,11 +76,9 @@ static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, F
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(jb, "pgsql");
     if (!rs_pgsql_logger(txptr, thread->pgsqllog_ctx->flags, jb)) {
         goto error;
     }
-    jb_close(jb);
 
     OutputJsonBuilderBuffer(jb, thread->ctx);
     jb_free(jb);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/11201

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6983
https://redmine.openinfosecfoundation.org/issues/7000

Describe changes:
- fix clippy errors (use Flow as Option, so unit tests that call parse_request without a flow)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1874
