### PR TITLE
eve: revert ethernet addresses when needed

### DIFF
--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -281,7 +281,7 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
     /* Close flow. */
     jb_close(jb);
 
-    EveAddCommonOptions(&aft->ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&aft->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW);
 
     /* TCP */
     if (f->proto == IPPROTO_TCP) {

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -275,7 +275,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(jb == NULL))
         return TM_ECODE_OK;
     NetFlowLogEveToServer(jb, f);
-    EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
+    EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW_TOSERVER);
     OutputJsonBuilderBuffer(jb, jhl);
     jb_free(jb);
 
@@ -285,7 +285,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
         if (unlikely(jb == NULL))
             return TM_ECODE_OK;
         NetFlowLogEveToClient(jb, f);
-        EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb);
+        EveAddCommonOptions(&jhl->ctx->cfg, NULL, f, jb, LOG_DIR_FLOW_TOCLIENT);
         OutputJsonBuilderBuffer(jb, jhl);
         jb_free(jb);
     }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -110,8 +110,8 @@ OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx);
 TmEcode JsonLogThreadInit(ThreadVars *t, const void *initdata, void **data);
 TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 
-void EveAddCommonOptions(const OutputJsonCommonSettings *cfg,
-        const Packet *p, const Flow *f, JsonBuilder *js);
+void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, const Flow *f,
+        JsonBuilder *js, enum OutputJsonLogDirection dir);
 void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6690

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/11205

Cherry-pick was not clean because need to use `p->ethh` instead of now `ethh = PacketGetEthernet(p);` in master

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1878
