### PR TITLE
Fix builds, to allow C code called from rust only, to prepare for dynamic register keywords 4683 v5.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1413,7 +1413,7 @@
             exit 1
         fi
         CFLAGS="${CFLAGS} `pkg-config --cflags libdpdk`"
-        LIBS="${LIBS} -Wl,-R,`pkg-config --libs-only-L libdpdk | cut -c 3-` -lnuma `pkg-config --libs libdpdk`"
+        LIBS="${LIBS} -lnuma `pkg-config --libs libdpdk`"
 
         if test ! -z "$(ldconfig -p | grep librte_net_bond)"; then
             AC_DEFINE([HAVE_DPDK_BOND],[1],(DPDK Bond PMD support enabled))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1333,6 +1333,7 @@ LDADD_FUZZ = libsuricata_c.a $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
 fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c
 fuzz_applayerprotodetectgetproto_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerprotodetectgetproto_LDADD = $(LDADD_FUZZ)
+fuzz_applayerprotodetectgetproto_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_applayerprotodetectgetproto_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1344,6 +1345,7 @@ nodist_EXTRA_fuzz_applayerprotodetectgetproto_SOURCES = force-cxx-linking.cxx
 fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c
 fuzz_applayerparserparse_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerparserparse_LDADD = $(LDADD_FUZZ)
+fuzz_applayerparserparse_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_applayerparserparse_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1355,6 +1357,7 @@ nodist_EXTRA_fuzz_applayerparserparse_SOURCES = force-cxx-linking.cxx
 fuzz_siginit_SOURCES = tests/fuzz/fuzz_siginit.c
 fuzz_siginit_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_siginit_LDADD = $(LDADD_FUZZ)
+fuzz_siginit_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_siginit_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1366,6 +1369,7 @@ nodist_EXTRA_fuzz_siginit_SOURCES = force-cxx-linking.cxx
 fuzz_confyamlloadstring_SOURCES = tests/fuzz/fuzz_confyamlloadstring.c
 fuzz_confyamlloadstring_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_confyamlloadstring_LDADD = $(LDADD_FUZZ)
+fuzz_confyamlloadstring_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_confyamlloadstring_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1377,6 +1381,7 @@ nodist_EXTRA_fuzz_confyamlloadstring_SOURCES = force-cxx-linking.cxx
 fuzz_decodepcapfile_SOURCES = tests/fuzz/fuzz_decodepcapfile.c
 fuzz_decodepcapfile_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_decodepcapfile_LDADD = $(LDADD_FUZZ)
+fuzz_decodepcapfile_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_decodepcapfile_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1388,6 +1393,7 @@ nodist_EXTRA_fuzz_decodepcapfile_SOURCES = force-cxx-linking.cxx
 fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c
 fuzz_sigpcap_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_LDADD = $(LDADD_FUZZ)
+fuzz_sigpcap_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_sigpcap_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1400,6 +1406,7 @@ if HAS_FUZZPCAP
 fuzz_sigpcap_aware_SOURCES = tests/fuzz/fuzz_sigpcap_aware.c
 fuzz_sigpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
+fuzz_sigpcap_aware_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_sigpcap_aware_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1411,6 +1418,7 @@ nodist_EXTRA_fuzz_sigpcap_aware_SOURCES = force-cxx-linking.cxx
 fuzz_predefpcap_aware_SOURCES = tests/fuzz/fuzz_predefpcap_aware.c
 fuzz_predefpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_predefpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
+fuzz_predefpcap_aware_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_predefpcap_aware_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1423,6 +1431,7 @@ endif
 fuzz_decodebase64_SOURCES = tests/fuzz/fuzz_decodebase64.c
 fuzz_decodebase64_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_decodebase64_LDADD = $(LDADD_FUZZ)
+fuzz_decodebase64_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_decodebase64_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else
@@ -1434,6 +1443,7 @@ nodist_EXTRA_fuzz_decodebase64_SOURCES = force-cxx-linking.cxx
 fuzz_mimedecparseline_SOURCES = tests/fuzz/fuzz_mimedecparseline.c
 fuzz_mimedecparseline_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_mimedecparseline_LDADD = $(LDADD_FUZZ)
+fuzz_mimedecparseline_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
 if HAS_FUZZLDFLAGS
     fuzz_mimedecparseline_LDFLAGS += $(LIB_FUZZING_ENGINE)
 else


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
Preliminary work for https://redmine.openinfosecfoundation.org/issues/4683

Describe changes:
- build: fix fuzz dependencies, and dpdk 

First commits of https://github.com/OISF/suricata/pull/11068

#11069 rebased to get attention (and also fixing fuzz base64 target)

cc @lukashino for DPDK