### PR TITLE
mqtt: enable limiting of logged message length - v4

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -280,6 +280,29 @@ YAML::
 The logger is disabled by default since ARP can generate a large
 number of events.
 
+MQTT
+~~~~
+
+EVE-JSON output for MQTT consists of one object per MQTT transaction, with some common and various type-specific fields.
+Two aspects can be configured:
+
+YAML::
+
+        - mqtt:
+            # passwords: yes           # enable output of passwords
+            # string-log-limit: 1kb    # limit size of logged strings in bytes.
+                                       # Can be specified in kb, mb, gb. Just a number
+                                       # is parsed as bytes. Default is 1KB.
+                                       # Use a value of 0 to disable limiting.
+                                       # Note that the size is also bounded by
+                                       # the maximum parsed message size (see
+                                       # app-layer configuration)
+
+The default is to output passwords in cleartext and not to limit the size of
+message payloads. Depending on the kind of context the parser is used in (public
+output, frequent binary transmissions, ...) this can be configured for regular
+``mqtt`` events.
+
 Drops
 ~~~~~
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -4,8 +4,8 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
-      # Enable for multi-threaded eve.json output; output files are amended
-      # with an identifier, e.g., eve.9.json
+      # Enable for multi-threaded eve.json output; output files are amended with
+      # an identifier, e.g., eve.9.json
       #threaded: false
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
@@ -13,6 +13,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #ethernet: no  # log ethernet header in events when available
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
@@ -24,13 +25,47 @@ outputs:
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network
       # connection at the cost of some memory. There is no flushing implemented
-      # so this setting as to be reserved to high traffic suricata.
+      # so this setting should be reserved to high traffic Suricata deployments.
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
-      #    batch-size: 10 ## number of entry to keep in buffer
+      #    batch-size: 10 ## number of entries to keep in buffer
 
       # Include top level metadata. Default yes.
       #metadata: no
+
+      # include the name of the input pcap file in pcap file processing mode
+      pcap-file: false
+
+      # Community Flow ID
+      # Adds a 'community_id' field to EVE records. These are meant to give
+      # records a predictable flow ID that can be used to match records to
+      # output of other tools such as Zeek (Bro).
+      #
+      # Takes a 'seed' that needs to be same across sensors and tools
+      # to make the id less predictable.
+
+      # enable/disable the community id feature.
+      community-id: false
+      # Seed value for the ID output. Valid values are 0-65535.
+      community-id-seed: 0
+
+      # HTTP X-Forwarded-For support by adding an extra field or overwriting
+      # the source or destination IP address (depending on flow direction)
+      # with the one reported in the X-Forwarded-For HTTP header. This is
+      # helpful when reviewing alerts for traffic that is being reverse
+      # or forward proxied.
+      xff:
+        enabled: no
+        # Two operation modes are available: "extra-data" and "overwrite".
+        mode: extra-data
+        # Two proxy deployments are supported: "reverse" and "forward". In
+        # a "reverse" deployment the IP address used is the last one, in a
+        # "forward" deployment the first IP address is used.
+        deployment: reverse
+        # Header name where the actual IP address will be reported. If more
+        # than one IP address is present, the last IP address will be the
+        # one taken into consideration.
+        header: X-Forwarded-For
 
       types:
         - alert:
@@ -38,66 +73,77 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            # http-body: yes           # Requires metadata; enable dumping of http body in Base64
-            # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
+            # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
+            # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64
+            # http-body-printable: yes # Requires metadata; enable dumping of HTTP body in printable format
+            # websocket-payload: yes   # Requires metadata; enable dumping of WebSocket Payload in Base64
+            # websocket-payload-printable: yes # Requires metadata; enable dumping of WebSocket Payload in printable format
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
             tagged-packets: yes
-
-            # Configure the metadata to be logged along with an
-            # alert. The following shows the default configuration
-            # which is used if this field is not provided or simply
-            # set to a truthful value. Setting of this section is only
-            # required if you wish to enable/disable specific fields.
-            #metadata:
-
-              # Include the decoded application layer (ie. http, dns)
-              app-layer: true
-
-              # Log the current state of the flow record.
-              flow: true
-
-              rule:
-                # Log the metadata field from the rule in a structured
-                # format.
-                metadata: true
-
-                # Log the raw rule text.
-                raw: false
-
-            # HTTP X-Forwarded-For support by adding an extra field or overwriting
-            # the source or destination IP address (depending on flow direction)
-            # with the one reported in the X-Forwarded-For HTTP header. This is
-            # helpful when reviewing alerts for traffic that is being reverse
-            # or forward proxied.
-            xff:
-              enabled: no
-              # Two operation modes are available, "extra-data" and "overwrite".
-              mode: extra-data
-              # Two proxy deployments are supported, "reverse" and "forward". In
-              # a "reverse" deployment the IP address used is the last one, in a
-              # "forward" deployment the first IP address is used.
-              deployment: reverse
-              # Header name where the actual IP address will be reported, if more
-              # than one IP address is present, the last IP address will be the
-              # one taken into consideration.
-              header: X-Forwarded-For
+            # Enable logging the final action taken on a packet by the engine
+            # (e.g: the alert may have action 'allowed' but the verdict be
+            # 'drop' due to another alert. That's the engine's verdict)
+            # verdict: yes
+        # app layer frames
+        - frame:
+            # disabled by default as this is very verbose.
+            enabled: no
+            # payload-buffer-size: 4kb # max size of frame payload buffer to output in eve-log
+        - anomaly:
+            # Anomaly log records describe unexpected conditions such
+            # as truncated packets, packets with invalid IP/UDP/TCP
+            # length values, and other events that render the packet
+            # invalid for further processing or describe unexpected
+            # behavior on an established stream. Networks which
+            # experience high occurrences of anomalies may experience
+            # packet processing degradation.
+            #
+            # Anomalies are reported for the following:
+            # 1. Decode: Values and conditions that are detected while
+            # decoding individual packets. This includes invalid or
+            # unexpected values for low-level protocol lengths as well
+            # as stream related events (TCP 3-way handshake issues,
+            # unexpected sequence number, etc).
+            # 2. Stream: This includes stream related events (TCP
+            # 3-way handshake issues, unexpected sequence number,
+            # etc).
+            # 3. Application layer: These denote application layer
+            # specific conditions that are unexpected, invalid or are
+            # unexpected given the application monitoring state.
+            #
+            # By default, anomaly logging is enabled. When anomaly
+            # logging is enabled, applayer anomaly reporting is
+            # also enabled.
+            enabled: yes
+            #
+            # Choose one or more types of anomaly logging and whether to enable
+            # logging of the packet header for packet anomalies.
+            types:
+              # decode: no
+              # stream: no
+              # applayer: yes
+            #packethdr: no
         - http:
             extended: yes     # enable this for extended logging information
-            # custom allows additional http fields to be included in eve-log
+            # custom allows additional HTTP fields to be included in eve-log.
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
+            # set this value to one and only one from {both, request, response}
+            # to dump all HTTP headers for every HTTP request and/or response
+            # dump-all-headers: none
         - dns:
-            # Use version 2 logging with the new format:
-            # dns answers will be logged in one single event
-            # rather than an event for each of the answers.
-            # Without setting a version the version
-            # will fallback to 1 for backwards compatibility.
-            version: 2
+            # This configuration uses the new DNS logging format,
+            # the old configuration is still available:
+            # https://docs.suricata.io/en/latest/output/eve/eve-json-output.html#dns-v1-format
+
+            # As of Suricata 5.0, version 2 of the eve dns output
+            # format is the default.
+            #version: 2
 
             # Enable/disable this logger. Default: enabled.
-            #enabled: no
+            #enabled: yes
 
             # Control logging of requests and responses:
             # - requests: enable logging of DNS queries
@@ -110,32 +156,18 @@ outputs:
             # - detailed: array item per answer
             # - grouped: answers aggregated by type
             # Default: all
-            #answer-format: [detailed, grouped]
+            #formats: [detailed, grouped]
 
-            # Answer types to log.
-            # Default: all
-            #answer-types: [a, aaaa, cname, mx, ns, ptr, txt]
-        - dns:
-            # Version 1 DNS logger.
-            # Deprecated: Will be removed by May 2022.
-            version: 1
-
-            enabled: no
-            # control logging of queries and answers
-            # default yes, no to disable
-            query: yes     # enable logging of DNS queries
-            answer: yes    # enable logging of DNS answers
-            # control which RR types are logged
-            # all enabled if custom not specified
-            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
+            # DNS record types to log, based on the query type.
+            # Default: all.
+            #types: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
             # output TLS transaction where the session is resumed using a
             # session id
             #session-resumption: no
-            # custom allows to control which tls fields that are included
-            # in eve-log
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain]
+            # custom controls which TLS fields that are included in eve-log
+            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,
@@ -145,6 +177,9 @@ outputs:
         #    alerts: yes      # log alerts that caused drops
         #    flows: all       # start or all: 'start' logs only a single drop
         #                     # per flow direction. All logs each dropped pkt.
+            # Enable logging the final action taken on a packet by the engine
+            # (will show more information in case of a drop caused by 'reject')
+            # verdict: yes
         - smtp:
             #extended: yes # enable this for extended logging information
             # this includes: bcc, message-id, subject, x_mailer, user-agent
@@ -158,34 +193,67 @@ outputs:
             # to yes
             #md5: [body, subject]
 
-        # NFS logging.
+        #- dnp3
+        - websocket
+        - ftp
+        - ftp-data
+        - rdp
         - nfs
-        # IKE logging.
+        - smb
+        - tftp
         - ike
-        # BitTorrent DHT logging.
+        - dcerpc
+        - krb5
         - bittorrent-dht
         - ssh
         - arp:
             enabled: no
-        - stats:
-            totals: yes       # stats for all threads merged together
-            threads: no       # per thread stats
-            deltas: no        # include delta values
-            # Don't log stats counters that are zero. Default: true
-            #null-values: false    # False will NOT log stats counters: 0
+        - snmp
+        - rfb
+        - sip
+        - quic
         - dhcp:
-            # DHCP logging.
             enabled: yes
             # When extended mode is on, all DHCP messages are logged
             # with full detail. When extended mode is off (the
             # default), just enough information to map a MAC address
             # to an IP address is logged.
             extended: no
+        - mqtt:
+            # passwords: yes           # enable output of passwords
+            # string-log-limit: 1kb    # limit size of logged strings in bytes.
+                                       # Can be specified in kb, mb, gb. Just a number
+                                       # is parsed as bytes. Default is 1KB.
+                                       # Use a value of 0 to disable limiting.
+                                       # Note that the size is also bounded by
+                                       # the maximum parsed message size (see
+                                       # app-layer configuration)
+        - http2
+        - pgsql:
+            enabled: no
+            # passwords: yes           # enable output of passwords. Disabled by default
+        - stats:
+            totals: yes       # stats for all threads merged together
+            threads: no       # per thread stats
+            deltas: no        # include delta values
+            # Don't log stats counters that are zero. Default: true
+            #null-values: false    # False will NOT log stats counters: 0
         # bi-directional flows
         - flow
         # uni-directional flows
         #- netflow
 
-        # An event for logging metadata, specifically pktvars when
-        # they are set, but will also include the full metadata object.
+        # Metadata event type. Triggered whenever a pktvar is saved
+        # and will include the pktvars, flowvars, flowbits and
+        # flowints.
         #- metadata
+
+        # EXPERIMENTAL per packet output giving TCP state tracking details
+        # including internal state, flags, etc.
+        # This output is experimental, meant for debugging and subject to
+        # change in both config and output without any notice.
+        #- stream:
+        #   all: false                      # log all TCP packets
+        #   event-set: false                # log packets that have a decoder/stream event
+        #   state-update: false             # log packets triggering a TCP state update
+        #   spurious-retransmission: false  # log spurious retransmission packets

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -562,7 +562,9 @@ impl JsonBuilder {
     }
 
     /// Set a key and a string value (from bytes) on an object, with a limited size
-    pub fn set_string_from_bytes_limited(&mut self, key: &str, val: &[u8], limit: usize) -> Result<&mut Self, JsonError> {
+    pub fn set_string_from_bytes_limited(
+        &mut self, key: &str, val: &[u8], limit: usize,
+    ) -> Result<&mut Self, JsonError> {
         let mut valtrunc = Vec::new();
         let val = if val.len() > limit {
             let additional_bytes = val.len() - limit;
@@ -723,12 +725,12 @@ impl JsonBuilder {
     }
 
     fn push_float(&mut self, val: f64) -> Result<(), JsonError> {
-	if val.is_nan() || val.is_infinite() {
-	    self.push_str("null")?;
-	} else {
-	    self.push_str(&val.to_string())?;
-	}
-	Ok(())
+        if val.is_nan() || val.is_infinite() {
+            self.push_str("null")?;
+        } else {
+            self.push_str(&val.to_string())?;
+        }
+        Ok(())
     }
 
     /// Encode a string into the buffer, escaping as needed.

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -410,28 +410,31 @@ pub extern "C" fn rs_mqtt_tx_unsuback_has_reason_code(tx: &MQTTTransaction, code
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::core::Direction;
     use crate::mqtt::mqtt::MQTTTransaction;
     use crate::mqtt::mqtt_message::*;
     use crate::mqtt::parser::FixedHeader;
-    use crate::core::Direction;
     use std;
 
     #[test]
     fn test_multi_unsubscribe() {
-        let mut t = MQTTTransaction::new(MQTTMessage {
-            header: FixedHeader {
-                message_type: MQTTTypeCode::UNSUBSCRIBE,
-                dup_flag: false,
-                qos_level: 0,
-                retain: false,
-                remaining_length: 0,
+        let mut t = MQTTTransaction::new(
+            MQTTMessage {
+                header: FixedHeader {
+                    message_type: MQTTTypeCode::UNSUBSCRIBE,
+                    dup_flag: false,
+                    qos_level: 0,
+                    retain: false,
+                    remaining_length: 0,
+                },
+                op: MQTTOperation::UNSUBSCRIBE(MQTTUnsubscribeData {
+                    message_id: 1,
+                    topics: vec!["foo".to_string(), "baar".to_string()],
+                    properties: None,
+                }),
             },
-            op: MQTTOperation::UNSUBSCRIBE(MQTTUnsubscribeData {
-                message_id: 1,
-                topics: vec!["foo".to_string(), "baar".to_string()],
-                properties: None,
-            }),
-        }, Direction::ToServer);
+            Direction::ToServer,
+        );
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::UNSUBSCRIBE,
@@ -470,29 +473,32 @@ mod test {
 
     #[test]
     fn test_multi_subscribe() {
-        let mut t = MQTTTransaction::new(MQTTMessage {
-            header: FixedHeader {
-                message_type: MQTTTypeCode::SUBSCRIBE,
-                dup_flag: false,
-                qos_level: 0,
-                retain: false,
-                remaining_length: 0,
+        let mut t = MQTTTransaction::new(
+            MQTTMessage {
+                header: FixedHeader {
+                    message_type: MQTTTypeCode::SUBSCRIBE,
+                    dup_flag: false,
+                    qos_level: 0,
+                    retain: false,
+                    remaining_length: 0,
+                },
+                op: MQTTOperation::SUBSCRIBE(MQTTSubscribeData {
+                    message_id: 1,
+                    topics: vec![
+                        MQTTSubscribeTopicData {
+                            topic_name: "foo".to_string(),
+                            qos: 0,
+                        },
+                        MQTTSubscribeTopicData {
+                            topic_name: "baar".to_string(),
+                            qos: 1,
+                        },
+                    ],
+                    properties: None,
+                }),
             },
-            op: MQTTOperation::SUBSCRIBE(MQTTSubscribeData {
-                message_id: 1,
-                topics: vec![
-                    MQTTSubscribeTopicData {
-                        topic_name: "foo".to_string(),
-                        qos: 0,
-                    },
-                    MQTTSubscribeTopicData {
-                        topic_name: "baar".to_string(),
-                        qos: 1,
-                    },
-                ],
-                properties: None,
-            }),
-        }, Direction::ToServer);
+            Direction::ToServer,
+        );
         t.msg.push(MQTTMessage {
             header: FixedHeader {
                 message_type: MQTTTypeCode::SUBSCRIBE,

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -26,7 +26,9 @@ use std;
 pub const MQTT_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 #[inline]
-fn log_mqtt_topic(js: &mut JsonBuilder, t: &MQTTSubscribeTopicData, max_log_len: usize ) -> Result<(), JsonError> {
+fn log_mqtt_topic(
+    js: &mut JsonBuilder, t: &MQTTSubscribeTopicData, max_log_len: usize,
+) -> Result<(), JsonError> {
     js.start_object()?;
     js.set_string_limited("topic", &t.topic_name, max_log_len)?;
     js.set_uint("qos", t.qos as u64)?;

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -142,7 +142,7 @@ impl MQTTState {
             connected: false,
             skip_request: 0,
             skip_response: 0,
-            max_msg_len: unsafe { MAX_MSG_LEN},
+            max_msg_len: unsafe { MAX_MSG_LEN },
             tx_index_completed: 0,
         }
     }
@@ -597,7 +597,14 @@ impl MQTTState {
     ) {
         let hdr = stream_slice.as_slice();
         //MQTT payload has a fixed header of 2 bytes
-        let _mqtt_hdr = Frame::new(flow, stream_slice, hdr, 2, MQTTFrameType::Header as u8, None);
+        let _mqtt_hdr = Frame::new(
+            flow,
+            stream_slice,
+            hdr,
+            2,
+            MQTTFrameType::Header as u8,
+            None,
+        );
         SCLogDebug!("mqtt_hdr Frame {:?}", _mqtt_hdr);
         let rem_length = input.header.remaining_length as usize;
         let data = &hdr[2..rem_length + 2];

--- a/rust/src/mqtt/mqtt_property.rs
+++ b/rust/src/mqtt/mqtt_property.rs
@@ -58,7 +58,7 @@ pub enum MQTTProperty {
 }
 
 impl crate::mqtt::mqtt_property::MQTTProperty {
-    pub fn set_json(&self, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    pub fn set_json(&self, js: &mut JsonBuilder, limit: usize) -> Result<(), JsonError> {
         match self {
             crate::mqtt::mqtt_property::MQTTProperty::PAYLOAD_FORMAT_INDICATOR(v) => {
                 js.set_uint("payload_format_indicator", *v as u64)?;
@@ -67,13 +67,13 @@ impl crate::mqtt::mqtt_property::MQTTProperty {
                 js.set_uint("message_expiry_interval", *v as u64)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::CONTENT_TYPE(v) => {
-                js.set_string("content_type", v)?;
+                js.set_string_limited("content_type", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::RESPONSE_TOPIC(v) => {
-                js.set_string("response_topic", v)?;
+                js.set_string_limited("response_topic", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::CORRELATION_DATA(v) => {
-                js.set_string_from_bytes("correlation_data", v)?;
+                js.set_string_from_bytes_limited("correlation_data", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::SUBSCRIPTION_IDENTIFIER(v) => {
                 js.set_uint("subscription_identifier", *v as u64)?;
@@ -82,16 +82,16 @@ impl crate::mqtt::mqtt_property::MQTTProperty {
                 js.set_uint("session_expiry_interval", *v as u64)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::ASSIGNED_CLIENT_IDENTIFIER(v) => {
-                js.set_string("assigned_client_identifier", v)?;
+                js.set_string_limited("assigned_client_identifier", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::SERVER_KEEP_ALIVE(v) => {
                 js.set_uint("server_keep_alive", *v as u64)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::AUTHENTICATION_METHOD(v) => {
-                js.set_string("authentication_method", v)?;
+                js.set_string_limited("authentication_method", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::AUTHENTICATION_DATA(v) => {
-                js.set_string_from_bytes("authentication_data", v)?;
+                js.set_string_from_bytes_limited("authentication_data", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::REQUEST_PROBLEM_INFORMATION(v) => {
                 js.set_uint("request_problem_information", *v as u64)?;
@@ -103,13 +103,13 @@ impl crate::mqtt::mqtt_property::MQTTProperty {
                 js.set_uint("request_response_information", *v as u64)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::RESPONSE_INFORMATION(v) => {
-                js.set_string("response_information", v)?;
+                js.set_string_limited("response_information", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::SERVER_REFERENCE(v) => {
-                js.set_string("server_reference", v)?;
+                js.set_string_limited("server_reference", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::REASON_STRING(v) => {
-                js.set_string("reason_string", v)?;
+                js.set_string_limited("reason_string", v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::RECEIVE_MAXIMUM(v) => {
                 js.set_uint("receive_maximum", *v as u64)?;
@@ -127,7 +127,7 @@ impl crate::mqtt::mqtt_property::MQTTProperty {
                 js.set_uint("retain_available", *v as u64)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::USER_PROPERTY((k, v)) => {
-                js.set_string(k, v)?;
+                js.set_string_limited(k, v, limit)?;
             }
             crate::mqtt::mqtt_property::MQTTProperty::MAXIMUM_PACKET_SIZE(v) => {
                 js.set_uint("maximum_packet_size", *v as u64)?;

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -242,8 +242,7 @@ fn parse_connack(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTC
 
 #[inline]
 fn parse_publish(
-    protocol_version: u8,
-    has_id: bool,
+    protocol_version: u8, has_id: bool,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTPublishData> {
     move |i: &[u8]| {
         let (i, topic) = parse_mqtt_string(i)?;
@@ -414,8 +413,7 @@ fn parse_unsuback(protocol_version: u8) -> impl Fn(&[u8]) -> IResult<&[u8], MQTT
 
 #[inline]
 fn parse_disconnect(
-    remaining_len: usize,
-    protocol_version: u8,
+    remaining_len: usize, protocol_version: u8,
 ) -> impl Fn(&[u8]) -> IResult<&[u8], MQTTDisconnectData> {
     move |input: &[u8]| {
         if protocol_version < 5 {
@@ -486,11 +484,7 @@ fn parse_auth(i: &[u8]) -> IResult<&[u8], MQTTAuthData> {
 
 #[inline]
 fn parse_remaining_message<'a>(
-    full: &'a [u8],
-    len: usize,
-    skiplen: usize,
-    header: FixedHeader,
-    message_type: MQTTTypeCode,
+    full: &'a [u8], len: usize, skiplen: usize, header: FixedHeader, message_type: MQTTTypeCode,
     protocol_version: u8,
 ) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], MQTTMessage> {
     move |input: &'a [u8]| {
@@ -632,9 +626,7 @@ fn parse_remaining_message<'a>(
 }
 
 pub fn parse_message(
-    input: &[u8],
-    protocol_version: u8,
-    max_msg_size: u32,
+    input: &[u8], protocol_version: u8, max_msg_size: u32,
 ) -> IResult<&[u8], MQTTMessage> {
     // Parse the fixed header first. This is identical across versions and can
     // be between 2 and 5 bytes long.
@@ -939,7 +931,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v5() {
         let buf = [
-            0x00, 0x01,   /* Message Identifier: 1 */
+            0x00, 0x01, /* Message Identifier: 1 */
             0x00, /* Reason Code: 0 */
             0x00, /* Properties */
             0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34, 0x33, 0x45, 0x38, 0x30,

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -34,6 +34,7 @@
 #include "util-buffer.h"
 #include "util-debug.h"
 #include "util-byte.h"
+#include "util-misc.h"
 
 #include "output.h"
 #include "output-json.h"
@@ -45,10 +46,11 @@
 #include "rust.h"
 
 #define MQTT_LOG_PASSWORDS BIT_U32(0)
-#define MQTT_DEFAULTS (MQTT_LOG_PASSWORDS)
+#define MQTT_DEFAULT_FLAGS     (MQTT_LOG_PASSWORDS)
+#define MQTT_DEFAULT_MAXLOGLEN 1024
 
 typedef struct LogMQTTFileCtx_ {
-    uint32_t    flags;
+    uint32_t flags, max_log_len;
     OutputJsonCtx *eve_ctx;
 } LogMQTTFileCtx;
 
@@ -60,7 +62,7 @@ typedef struct LogMQTTLogThread_ {
 
 bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js)
 {
-    return rs_mqtt_logger_log(vtx, MQTT_DEFAULTS, js);
+    return rs_mqtt_logger_log(vtx, MQTT_DEFAULT_FLAGS, MQTT_DEFAULT_MAXLOGLEN, js);
 }
 
 static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
@@ -80,7 +82,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    if (!rs_mqtt_logger_log(tx, thread->mqttlog_ctx->flags, js))
+    if (!rs_mqtt_logger_log(tx, thread->mqttlog_ctx->flags, thread->mqttlog_ctx->max_log_len, js))
         goto error;
 
     OutputJsonBuilderBuffer(js, thread->ctx);
@@ -112,6 +114,15 @@ static void JsonMQTTLogParseConfig(ConfNode *conf, LogMQTTFileCtx *mqttlog_ctx)
     } else {
         mqttlog_ctx->flags |= MQTT_LOG_PASSWORDS;
     }
+    uint32_t max_log_len = MQTT_DEFAULT_MAXLOGLEN;
+    query = ConfNodeLookupChildValue(conf, "string-log-limit");
+    if (query != NULL) {
+        if (ParseSizeStringU32(query, &max_log_len) < 0) {
+            SCLogError("Error parsing string-log-limit from config - %s, ", query);
+            exit(EXIT_FAILURE);
+        }
+    }
+    mqttlog_ctx->max_log_len = max_log_len;
 }
 
 static OutputInitResult OutputMQTTLogInitSub(ConfNode *conf,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -312,6 +312,13 @@ outputs:
         - ssh
         - mqtt:
             # passwords: yes           # enable output of passwords
+            # string-log-limit: 1kb    # limit size of logged strings in bytes.
+                                       # Can be specified in kb, mb, gb. Just a number
+                                       # is parsed as bytes. Default is 1KB.
+                                       # Use a value of 0 to disable limiting.
+                                       # Note that the size is also bounded by
+                                       # the maximum parsed message size (see
+                                       # app-layer configuration)
         - http2
         - pgsql:
             enabled: no


### PR DESCRIPTION
Previous PR: #11194 

Changes to previous PR:
* Handle splitting at all byte boundaries in a UTF-8 string in a way that avoids panics.
  Rust already has a function to deliver the longest string consisting of complete code points up to a given index
  (https://doc.rust-lang.org/std/primitive.str.html#method.floor_char_boundary) but it is only available in the nightly API.  I implemented a similar approach to ensure that we only try to slice strings at suitable boundaries before returning a truncated prefix, avoiding panics while still providing sensible output.
* Widen limiting functionality to strings in MQTT events in general.
* Reword the comment/documentation to refer to strings instead of messages to reflect the fact we limit more than just message payloads.
* Implement truncating arrays of topic names if the concatenation of the individual strings exceeds the log limit, even if each of the strings is shorter than the limit.


## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6984

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1880