### PR TITLE
doc: update eBPF/compilation instructions v7

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1334,6 +1334,68 @@ jobs:
           else
             exit 0
           fi
+  almalinux-9-minimal-recommended-dependecies:
+    name: AlmaLinux 9 (Minimal/Recommended Build)
+    runs-on: ubuntu-latest
+    container: almalinux:9
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install git dependencies
+        run: |
+          dnf -y install \
+            sudo \
+            git \
+            libtool \
+            which
+
+      - name: Install Almalinux 9 extra repositories
+        run : |
+          dnf -y update
+          dnf -y install dnf-plugins-core epel-release
+          dnf config-manager --set-enabled crb
+
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+      
+      - name: Install minimal dependencies
+        run: |
+          # install-guide-documentation tag start: Minimal RPM-based dependencies
+          sudo dnf install -y rustc cargo cbindgen
+          sudo dnf install -y gcc gcc-c++ jansson-devel libpcap-devel \
+            libyaml-devel make pcre2-devel zlib-devel
+          # install-guide-documentation tag end: Minimal RPM-based dependencies
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j ${{ env.CPUS }}
+      - run: ./src/suricata --build-info # check if we can run Suricata
 
   ubuntu-24-04:
     name: Ubuntu 24.04 (cocci)
@@ -2507,6 +2569,52 @@ jobs:
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-netmap
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info | grep -E "Netmap support:\s+yes"
+
+  ubuntu-22-04-minimal-recommended-build:
+    name: Ubuntu 22.04 (Minimal/Recommended Build)
+    needs: [prepare-deps, prepare-cbindgen]
+    runs-on: ubuntu-22.04
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install git dependencies
+        run: |
+          sudo apt update
+          sudo apt -y install \
+            sudo \
+            git \
+            libtool
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      
+      - name: Install minimal dependencies
+        run: |
+          # install-guide-documentation tag start: Minimal dependencies
+          sudo apt -y install autoconf automake build-essential cargo \
+            cbindgen libjansson-dev libpcap-dev libpcre2-dev libtool \
+            libyaml-dev make pkg-config rustc zlib1g-dev
+          # install-guide-documentation tag end: Minimal dependencies
+
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j ${{ env.CPUS }}
+      - run: ./src/suricata --build-info # check if we can run Suricata
 
   ubuntu-22-04-dpdk-build:
     name: Ubuntu 22.04 (DPDK Build)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2907,7 +2907,6 @@ jobs:
                 ccache \
                 curl \
                 git \
-                gosu \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \
@@ -2989,7 +2988,6 @@ jobs:
                 ccache \
                 curl \
                 git \
-                gosu \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
 	     lua \
 	     acsite.m4 \
 	     scripts/generate-images.sh \
+		 .github/workflows/builds.yml \
 	     examples/plugins
 SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib etc python ebpf \
           $(SURICATA_UPDATE_DIR)

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -80,15 +80,14 @@ Make sure you have ``clang`` (>=3.9) installed on the system  ::
 
  sudo apt install clang
 
-Some i386 headers will also be needed as eBPF is not x86_64 and some included headers
-are architecture specific ::
-
- sudo apt install libc6-dev-i386 --no-install-recommends
-
 libbpf
 ~~~~~~
 
 Suricata uses libbpf to interact with eBPF and XDP ::
+
+  sudo apt install libbpf-dev
+
+If the libbpf package is unavailable, it can be cloned from the repository ::
 
  git clone https://github.com/libbpf/libbpf.git
 
@@ -109,7 +108,7 @@ Compile and install Suricata
 To get Suricata source, you can use the usual ::
 
  git clone https://github.com/OISF/suricata.git
- cd suricata && git clone https://github.com/OISF/libhtp.git -b 0.5.x
+ cd suricata && ./scripts/bundle.sh
 
  ./autogen.sh
 

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -64,61 +64,20 @@ Common configure options
 
     Enables `DPDK <https://www.dpdk.org/>`_ packet capture method.
 
-Dependencies
-^^^^^^^^^^^^
-
-For Suricata's compilation you'll need the following libraries and their development headers installed::
-
-  libjansson, libpcap, libpcre2, libyaml, zlib
-
-The following tools are required::
-
-  make gcc (or clang) pkg-config rustc cargo
-
-Rust support::
-
-  rustc, cargo
-
-  Some distros don't provide or provide outdated Rust packages.
-  Rust can also be installed directly from the Rust project itself::
-
-    1) Install Rust https://www.rust-lang.org/en-US/install.html
-    2) Install cbindgen - if the cbindgen is not found in the repository
-       or the cbindgen version is lower than required, it can be
-       alternatively installed as: cargo install --force cbindgen
-    3) Make sure the cargo path is within your PATH environment
-        e.g. echo 'export PATH=”${PATH}:~/.cargo/bin”' >> ~/.bashrc
-        e.g. export PATH="${PATH}:/root/.cargo/bin"
+Dependencies and compilation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Ubuntu/Debian
 """""""""""""
 
 .. note:: The following instructions require ``sudo`` to be installed.
 
-Minimal::
-
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install build-essential git libjansson-dev libpcap-dev \
-                    libpcre2-dev libtool libyaml-dev make pkg-config zlib1g-dev
-    # On most distros installing cbindgen with package manager should be enough
-    sudo apt-get install cbindgen # alternative: cargo install --force cbindgen
-
-Recommended::
-
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install autoconf automake build-essential ccache clang curl git \
-                    gosu jq libbpf-dev libcap-ng0 libcap-ng-dev libelf-dev \
-                    libevent-dev libgeoip-dev libhiredis-dev libjansson-dev \
-                    libmagic-dev libnet1-dev libpcap-dev libpcre2-dev libtool \
-                    libyaml-0-2 libyaml-dev m4 make pkg-config python3 \
-                    python3-dev python3-yaml sudo zlib1g zlib1g-dev
-    cargo install --force cbindgen
-
-Extra for iptables/nftables IPS integration::
-
-    sudo apt-get install libnetfilter-queue-dev libnetfilter-queue1  \
-                    libnetfilter-log-dev libnetfilter-log1      \
-                    libnfnetlink-dev libnfnetlink0
+.. literalinclude:: ../../.github/workflows/builds.yml
+    :caption: Minimal dependencies for Ubuntu/Debian
+    :language: bash
+    :start-after: # install-guide-documentation tag start: Minimal dependencies
+    :end-before: # install-guide-documentation tag end: Minimal dependencies
+    :dedent: 10
 
 CentOS, AlmaLinux, RockyLinux, Fedora, etc
 """"""""""""""""""""""""""""""""""""""""""
@@ -130,46 +89,51 @@ repository in most distros. You can enable it possibly by
 one of the following ways::
 
     sudo dnf -y update
-    sudo dnf -y install dnf-plugins-core
-    # AlmaLinux 8
+    sudo dnf -y install epel-release dnf-plugins-core
+    # AlmaLinux 8 / RockyLinux 8
     sudo dnf config-manager --set-enabled powertools
-    # AlmaLinux 9
+    # AlmaLinux 9 / RockyLinux 9
     sudo dnf config-manager --set-enable crb
     # Oracle Linux 8
     sudo dnf config-manager --set-enable ol8_codeready_builder
     # Oracle Linux 9
     sudo dnf config-manager --set-enable ol9_codeready_builder
 
-Minimal::
-
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y gcc gcc-c++ git jansson-devel libpcap-devel libtool \
-                   libyaml-devel make pcre2-devel which zlib-devel
-    cargo install --force cbindgen
-
-Recommended::
-
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y autoconf automake diffutils file-devel gcc gcc-c++ git \
-                   jansson-devel jq libcap-ng-devel libevent-devel \
-                   libmaxminddb-devel libnet-devel libnetfilter_queue-devel \
-                   libnfnetlink-devel libpcap-devel libtool libyaml-devel \
-                   lua-devel lz4-devel make pcre2-devel pkgconfig \
-                   python3-devel python3-sphinx python3-yaml sudo which \
-                   zlib-devel
-    cargo install --force cbindgen
+.. literalinclude:: ../../.github/workflows/builds.yml
+    :caption: Minimal dependencies for RPM-based distributions
+    :language: bash
+    :start-after: # install-guide-documentation tag start: Minimal RPM-based dependencies
+    :end-before: # install-guide-documentation tag end: Minimal RPM-based dependencies
+    :dedent: 10
 
 Compilation
-^^^^^^^^^^^
+"""""""""""
 
 Follow these steps from your Suricata directory::
 
-    ./scripts/bundle.sh
-    ./autogen.sh
     ./configure # you may want to add additional parameters here
     # ./configure --help to get all available parameters
-    make -j8 # j is for paralleling, you may de/increase depending on your CPU
+    # j is for adding concurrency to make; the number indicates how much 
+    # concurrency so choose a number that is suitable for your build system
+    make -j8 
     make install # to install your Suricata compiled binary
+    # make install-full - installs configuration and rulesets as well
+
+Rust support
+""""""""""""
+
+  Rust packages can be found in package managers but some distributions
+  don't provide Rust or provide outdated Rust packages.
+  In case of insufficient version you can install Rust directly
+  from the Rust project itself::
+
+    1) Install Rust https://www.rust-lang.org/en-US/install.html
+    2) Install cbindgen - if the cbindgen is not found in the repository
+       or the cbindgen version is lower than required, it can be
+       alternatively installed as: cargo install --force cbindgen
+    3) Make sure the cargo path is within your PATH environment
+       echo 'export PATH="~/.cargo/bin:${PATH}"' >> ~/.bashrc
+       export PATH="~/.cargo/bin:${PATH}"
 
 Auto-Setup
 ^^^^^^^^^^


### PR DESCRIPTION
Follow-up of #11176   

Link to Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/6599
- https://redmine.openinfosecfoundation.org/issues/6686

Describe changes:
v7
- rebased on GitHub master branch

v6
- added epel-release as recommended dependency for RPM-based systems
- removed "Recommended" dependencies install command for both apt and dnf-based systems
- cbindgen is installed with dnf in dnf-based systems

v5
- inlined and shortened PATH variable edits in the RPM section
- added minimal/recommended builds to the GH workflow from Ubuntu and Almalinux
- added literalincludes to the docs from the Github builds
- removed gosu from Github builds
- added DPDK to the list of recommended dependencies

v4
- inlined and shortened PATH variable edits in the Rust section
- can *be* cloned - be added

v3 
- updates to the docs per Jeff's suggestions
- removed the instruction to install i386 headers for the eBPF 

v2
- remove recommended configure parameters

v1
- small edit in eBPF instructions to prefer libbpf-dev package to the cloning&compilation
- porting changes from the improved version of installation instructions that got merged into master-6.0.x