### PR TITLE
Tx iter 4083 v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -638,7 +638,7 @@ pub trait State<Tx: Transaction> {
                 index += 1;
                 continue;
             }
-            *state = index as u64;
+            *state = (index + 1) as u64;
             return AppLayerGetTxIterTuple::with_values(
                 tx as *const _ as *mut _,
                 tx.id() - 1,

--- a/src/detect.c
+++ b/src/detect.c
@@ -1612,9 +1612,9 @@ static void DetectRunTx(ThreadVars *tv,
 
             StoreDetectFlags(&tx, flow_flags, ipproto, alproto, new_detect_flags);
         }
-next:
         InspectionBufferClean(det_ctx);
 
+    next:
         if (!ires.has_next)
             break;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -1404,8 +1404,7 @@ static void DetectRunTx(ThreadVars *tv,
     const int tx_end_state = AppLayerParserGetStateProgressCompletionStatus(alproto, flow_flags);
 
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
-    AppLayerGetTxIterState state;
-    memset(&state, 0, sizeof(state));
+    AppLayerGetTxIterState state = { 0 };
 
     while (1) {
         AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, tx_id_min, total_txs, &state);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6987 or should there be a dedicated one ?

Describe changes:
- some optimizations for tx iterations

#11228 with unit test fixed by changing `AppLayerParserTransactionsCleanup` : do not remove txs from their list or whatever structure while iterating over it 