### PR TITLE
doc/userguide: fix rule container typo

### DIFF
--- a/doc/userguide/rules/smtp-keywords.rst
+++ b/doc/userguide/rules/smtp-keywords.rst
@@ -34,7 +34,7 @@ smtp.command_line
 A single line from the client to the server. Multi-line commands will have a frame per
 line. Lines part of the SMTP DATA transfer are excluded.
 
-.. container:: example fule
+.. container:: example-rule
 
   alert smtp any any -> any any ( \
   :example-rule-options:`frame:smtp.command_line; content:"MAIL|20|FROM:"; startswith;` \
@@ -45,7 +45,7 @@ smtp.response_line
 
 A single line from the server to the client. Multi-line commands will have a frame per line.
 
-.. container:: example fule
+.. container:: example-rule
 
   alert smtp any any -> any any ( \
   :example-rule-options:`frame:smtp.response_line; content:"354 go ahead"; startswith;` \
@@ -56,7 +56,7 @@ smtp.data
 
 A streaming buffer containing the DATA bytes sent from client to server.
 
-.. container:: example fule
+.. container:: example-rule
 
   alert smtp any any -> any any ( \
   :example-rule-options:`frame:smtp.data; content:"Reply-To:"; startswith; content:"Subject"; distance:0;` \
@@ -67,7 +67,7 @@ smtp.stream
 
 Streaming buffer of the entire TCP data for the SMTP session.
 
-.. container:: example fule
+.. container:: example-rule
 
   alert smtp any any -> any any (flow:to_client; \
   :example-rule-options:`frame:smtp.stream; content:"250 ok|0d 0a|354 go ahead";` \


### PR DESCRIPTION
Fixes: 8781e9352a6c ("doc/userguide: add documentation for SMTP frames")

Make sure these boxes are signed before submitting your Pull Request -- thank you.

replaces #11240