### PR TITLE
ci: fix and test with Wunused-macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2263,7 +2263,7 @@ fi
     ])
     AC_SUBST(RUST_FEATURES)
 
-    AC_ARG_ENABLE(enable_warnings,
+    AC_ARG_ENABLE(warnings,
            AS_HELP_STRING([--enable-warnings], [Enable supported C compiler warnings]),[enable_warnings=$enableval],[enable_warnings=no])
     AS_IF([test "x$enable_warnings" = "xyes"], [
         # check if our compiler supports -Wunused-macros

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -99,10 +99,6 @@ StreamingBufferConfig htp_sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
 /** Limit to the number of libhtp messages that can be handled */
 #define HTP_MAX_MESSAGES 512
 
-/** a boundary should be smaller in size */
-// RFC 2046 states that max boundary size is 70
-#define HTP_BOUNDARY_MAX 200U
-
 SC_ATOMIC_DECLARE(uint32_t, htp_config_flags);
 
 #ifdef DEBUG


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6937

Describe changes:
- Fix autotool `./configure --enable-warnings`
- Remove newly unused macro (HTP_BOUNDARY_MAX)
