### PR TITLE
backport 7.x add source verification docs v2 6910

### DIFF
--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -31,7 +31,8 @@ EXTRA_DIST = \
 	setting-up-ipsinline-for-windows.rst \
 	support-status.rst \
 	unix-socket.rst \
-	what-is-suricata.rst
+	what-is-suricata.rst \
+	verifying-source-files.rst
 
 if HAVE_SURICATA_MAN
 dist_man1_MANS = suricata.1 suricatasc.1 suricatactl.1 suricatactl-filestore.1

--- a/doc/userguide/index.rst
+++ b/doc/userguide/index.rst
@@ -34,3 +34,4 @@ This is the documentation for Suricata |version|.
    acknowledgements
    licenses/index.rst
    devguide/index.rst
+   verifying-source-files

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -16,10 +16,13 @@ Source
 
 Installing from the source distribution files gives the most control over the Suricata installation.
 
+The Suricata source distribution files should be verified before building
+the source, see :doc:`verifying-source-files`.
+
 Basic steps::
 
-    tar xzvf suricata-6.0.0.tar.gz
-    cd suricata-6.0.0
+    tar xzvf suricata-7.0.5.tar.gz
+    cd suricata-7.0.5
     ./configure
     make
     make install

--- a/doc/userguide/verifying-source-files.rst
+++ b/doc/userguide/verifying-source-files.rst
@@ -1,0 +1,86 @@
+Verifying Suricata Source Distribution Files
+============================================
+
+Once the Suricata release distribution file has been downloaded, the PGP
+signature should be verified. This can be done using the GPG application and
+is usually available on Linux/BSD systems without having to manually install
+any additional packages. For Mac or Windows systems installation packages can
+be found at `<https://gnupg.org/>`_.
+
+Verification Steps
+------------------
+
+These verification steps are for general guidance, the exact process and
+commands may vary between operating systems.
+
+Downloading the Signature File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The signature file needs to be downloaded as well as the distribution file.
+Both files can be found at `<https://suricata.io/download/>`_.
+
+Importing the OISF Signing Key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once both the signature file and Suricata distribution files are obtained, the
+OISF signing key should be imported to the local gpg keyring. This can be done
+by running the following command::
+
+  $ gpg --receive-keys 2BA9C98CCDF1E93A
+
+The above command should produce output similar to the following::
+
+  gpg: key 2BA9C98CCDF1E93A: public key "Open Information Security Foundation
+  (OISF) <releases@openinfosecfoundation.org>" imported
+  gpg: Total number processed: 1
+  gpg:               imported: 1
+
+Verifying the Suricata Distribution File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To verify the contents of the Suricata distribution file the following command
+could be ran on the Suricata 7.0.5 distribution file::
+
+  $ gpg --verify suricata-7.0.5.tar.gz.sig suricata-7.0.5.tar.gz
+
+Depending on the trust level assigned to the OISF signing keys, something
+similar to the following output should be seen::
+
+  $ gpg --verify suricata-7.0.5.tar.gz.sig suricata-7.0.5.tar.gz
+  gpg: Signature made Tue 23 Apr 2024 11:58:56 AM UTC
+  gpg:                using RSA key B36FDAF2607E10E8FFA89E5E2BA9C98CCDF1E93A
+  gpg: checking the trustdb
+  gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+  gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
+  gpg: next trustdb check due at 2025-08-06
+  gpg: Good signature from "Open Information Security Foundation (OISF)
+  <releases@openinfosecfoundation.org>" [ultimate]
+
+This indicates a valid signature and that the signing key is trusted.
+
+.. note:: If output from the `--verify` command is similar to the following::
+
+    gpg: Signature made Tue 23 Apr 2024 11:58:56 AM UTC
+    gpg:                using RSA key B36FDAF2607E10E8FFA89E5E2BA9C98CCDF1E93A
+    gpg: Can't check signature: No public key
+
+  This indicates that the OISF signing key was not imported to the local GPG
+  keyring.
+
+.. note:: If output from the `--verify` command is similar to the following::
+
+    gpg: Signature made Tue 23 Apr 2024 11:58:56 AM UTC
+    gpg:                using RSA key B36FDAF2607E10E8FFA89E5E2BA9C98CCDF1E93A
+    gpg: Good signature from "Open Information Security Foundation (OISF)
+    <releases@openinfosecfoundation.org>" [unknown]
+    gpg: WARNING: This key is not certified with a trusted signature!
+    gpg:          There is no indication that the signature belongs to the owner.
+    Primary key fingerprint: B36F DAF2 607E 10E8 FFA8  9E5E 2BA9 C98C CDF1 E93A
+
+  This indicates that the OISF signing key was imported and the signatures are
+  valid, but either the keys have not been marked as trusted OR the keys are
+  possibly a forgery.
+
+  If there are questions regarding the validity of the downloaded file, the
+  OISF team can be reached at `security @ oisf.net` (remove the spaces between
+  the `@` before sending).


### PR DESCRIPTION
Ticket: #6908

Signed-off-by: jason taylor <jtfas90@gmail.com>
(cherry picked from commit 47d6c3a3ab632dca72e60b753afa60521f0ea079)

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6910

Describe changes:
- addressed comments from previous PR #11216 
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
