### PR TITLE
App unused params 4083 v2

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -424,7 +424,7 @@ pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *
 pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
-pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, *mut c_void, u8) -> AppLayerGetFileState;
+pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, u8) -> AppLayerGetFileState;
 pub type GetTxIteratorFn    = unsafe extern "C" fn (ipproto: u8, alproto: AppProto,
                                              state: *mut c_void,
                                              min_tx_id: u64,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1319,7 +1319,6 @@ pub unsafe extern "C" fn rs_http2_tx_get_alstate_progress(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_getfiles(
-    _state: *mut std::os::raw::c_void,
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> AppLayerGetFileState {
     let tx = cast_pointer!(tx, HTTP2Transaction);

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -159,7 +159,7 @@ impl NFSTransactionFile {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_nfs_gettxfiles(_state: *mut std::ffi::c_void, tx: *mut std::ffi::c_void, direction: u8) -> AppLayerGetFileState {
+pub unsafe extern "C" fn rs_nfs_gettxfiles(tx: *mut std::ffi::c_void, direction: u8) -> AppLayerGetFileState {
     let tx = cast_pointer!(tx, NFSTransaction);
     if let Some(NFSTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
         let tx_dir : u8 = tdf.direction.into();

--- a/rust/src/smb/files.rs
+++ b/rust/src/smb/files.rs
@@ -230,7 +230,7 @@ impl SMBState {
 
 use crate::applayer::AppLayerGetFileState;
 #[no_mangle]
-pub unsafe extern "C" fn rs_smb_gettxfiles(_state: *mut std::ffi::c_void, tx: *mut std::ffi::c_void, direction: u8) -> AppLayerGetFileState {
+pub unsafe extern "C" fn rs_smb_gettxfiles(tx: *mut std::ffi::c_void, direction: u8) -> AppLayerGetFileState {
     let tx = cast_pointer!(tx, SMBTransaction);
     if let Some(SMBTransactionTypeData::FILE(ref mut tdf)) = tx.type_data {
         let tx_dir : u8 = tdf.direction.into();

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -66,9 +66,9 @@ static inline bool FrameConfigTypeIsEnabled(const AppProto p, const uint8_t type
     return enabled;
 }
 
+#ifdef DEBUG
 static void FrameDebug(const char *prefix, const Frames *frames, const Frame *frame)
 {
-#ifdef DEBUG
     const char *type_name = "unknown";
     if (frame->type == FRAME_STREAM_TYPE) {
         type_name = "stream";
@@ -80,8 +80,10 @@ static void FrameDebug(const char *prefix, const Frames *frames, const Frame *fr
             prefix, frames, frame, frame->type, type_name, frame->id, frame->flags, frame->offset,
             frame->len, frame->inspect_progress, frame->event_cnt, frame->events[0],
             frame->events[1], frame->events[2], frame->events[3]);
-#endif
 }
+#else
+#define FrameDebug(prefix, frames, frame)
+#endif
 
 /**
  * \note "open" means a frame that has no length set (len == -1)
@@ -223,6 +225,7 @@ static void FrameCopy(Frame *dst, Frame *src)
     memcpy(dst, src, sizeof(*dst));
 }
 
+#ifdef DEBUG
 static void AppLayerFrameDumpForFrames(const char *prefix, const Frames *frames)
 {
     SCLogDebug("prefix: %s", prefix);
@@ -238,6 +241,7 @@ static void AppLayerFrameDumpForFrames(const char *prefix, const Frames *frames)
     }
     SCLogDebug("prefix: %s", prefix);
 }
+#endif
 
 static inline uint64_t FrameLeftEdge(const TcpStream *stream, const Frame *frame)
 {
@@ -567,6 +571,7 @@ Frame *AppLayerFrameNewByRelativeOffset(Flow *f, const StreamSlice *stream_slice
 
 void AppLayerFrameDump(Flow *f)
 {
+#ifdef DEBUG
     if (f->proto == IPPROTO_TCP && f->protoctx && f->alparser) {
         FramesContainer *frames_container = AppLayerFramesGetContainer(f);
         if (frames_container != NULL) {
@@ -574,6 +579,7 @@ void AppLayerFrameDump(Flow *f)
             AppLayerFrameDumpForFrames("toclient::dump", &frames_container->toclient);
         }
     }
+#endif
 }
 
 /** \brief create new frame using the absolute offset from the start of the stream

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1216,7 +1216,7 @@ static int FTPDataGetAlstateProgress(void *tx, uint8_t direction)
         return FTPDATA_STATE_FINISHED;
 }
 
-static AppLayerGetFileState FTPDataStateGetTxFiles(void *_state, void *tx, uint8_t direction)
+static AppLayerGetFileState FTPDataStateGetTxFiles(void *tx, uint8_t direction)
 {
     FtpDataState *ftpdata_state = (FtpDataState *)tx;
     AppLayerGetFileState files = { .fc = NULL, .cfg = &sbcfg };

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -345,7 +345,7 @@ typedef struct FtpInput_ {
 } FtpInput;
 
 static AppLayerResult FTPGetLineForDirection(
-        FtpState *state, FtpLineState *line, FtpInput *input, bool *current_line_truncated)
+        FtpLineState *line, FtpInput *input, bool *current_line_truncated)
 {
     SCEnter();
 
@@ -507,7 +507,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
     uint8_t direction = STREAM_TOSERVER;
     AppLayerResult res;
     while (1) {
-        res = FTPGetLineForDirection(state, &line, &ftpi, &state->current_line_truncated_ts);
+        res = FTPGetLineForDirection(&line, &ftpi, &state->current_line_truncated_ts);
         if (res.status == 1) {
             return res;
         } else if (res.status == -1) {
@@ -630,7 +630,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
     SCReturnStruct(APP_LAYER_OK);
 }
 
-static int FTPParsePassiveResponse(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponse(FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port = rs_ftp_pasv_response(input, input_len);
     if (dyn_port == 0) {
@@ -645,7 +645,7 @@ static int FTPParsePassiveResponse(Flow *f, FtpState *state, const uint8_t *inpu
     return 0;
 }
 
-static int FTPParsePassiveResponseV6(Flow *f, FtpState *state, const uint8_t *input, uint32_t input_len)
+static int FTPParsePassiveResponseV6(FtpState *state, const uint8_t *input, uint32_t input_len)
 {
     uint16_t dyn_port = rs_ftp_epsv_response(input, input_len);
     if (dyn_port == 0) {
@@ -700,7 +700,7 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
     FTPTransaction *lasttx = TAILQ_FIRST(&state->tx_list);
     AppLayerResult res;
     while (1) {
-        res = FTPGetLineForDirection(state, &line, &ftpi, &state->current_line_truncated_tc);
+        res = FTPGetLineForDirection(&line, &ftpi, &state->current_line_truncated_tc);
         if (res.status == 1) {
             return res;
         } else if (res.status == -1) {
@@ -754,13 +754,13 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
 
             case FTP_COMMAND_PASV:
                 if (line.len >= 4 && SCMemcmp("227 ", line.buf, 4) == 0) {
-                    FTPParsePassiveResponse(f, ftp_state, line.buf, line.len);
+                    FTPParsePassiveResponse(ftp_state, line.buf, line.len);
                 }
                 break;
 
             case FTP_COMMAND_EPSV:
                 if (line.len >= 4 && SCMemcmp("229 ", line.buf, 4) == 0) {
-                    FTPParsePassiveResponseV6(f, ftp_state, line.buf, line.len);
+                    FTPParsePassiveResponseV6(ftp_state, line.buf, line.len);
                 }
                 break;
             default:

--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -45,8 +45,7 @@ extern StreamingBufferConfig htp_sbcfg;
  * \retval 0 ok
  * \retval -1 error
  */
-int HtpBodyAppendChunk(const HTPCfgDir *hcfg, HtpBody *body,
-                       const uint8_t *data, uint32_t len)
+int HtpBodyAppendChunk(HtpBody *body, const uint8_t *data, uint32_t len)
 {
     SCEnter();
 
@@ -97,7 +96,7 @@ int HtpBodyAppendChunk(const HTPCfgDir *hcfg, HtpBody *body,
  * \param body pointer to the HtpBody holding the list
  * \retval none
  */
-void HtpBodyFree(const HTPCfgDir *hcfg, HtpBody *body)
+void HtpBodyFree(HtpBody *body)
 {
     SCEnter();
 

--- a/src/app-layer-htp-body.h
+++ b/src/app-layer-htp-body.h
@@ -28,8 +28,8 @@
 #ifndef SURICATA_APP_LAYER_HTP_BODY_H
 #define SURICATA_APP_LAYER_HTP_BODY_H
 
-int HtpBodyAppendChunk(const HTPCfgDir *, HtpBody *, const uint8_t *, uint32_t);
-void HtpBodyFree(const HTPCfgDir *, HtpBody *);
+int HtpBodyAppendChunk(HtpBody *, const uint8_t *, uint32_t);
+void HtpBodyFree(HtpBody *);
 void HtpBodyPrune(HtpState *, HtpBody *, int);
 
 #endif /* SURICATA_APP_LAYER_HTP_BODY_H */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -360,8 +360,8 @@ static void *HTPStateAlloc(void *orig_state, AppProto proto_orig)
 static void HtpTxUserDataFree(HtpState *state, HtpTxUserData *htud)
 {
     if (likely(htud)) {
-        HtpBodyFree(&state->cfg->request, &htud->request_body);
-        HtpBodyFree(&state->cfg->response, &htud->response_body);
+        HtpBodyFree(&htud->request_body);
+        HtpBodyFree(&htud->response_body);
         bstr_free(htud->request_uri_normalized);
         if (htud->request_headers_raw)
             HTPFree(htud->request_headers_raw, htud->request_headers_raw_len);
@@ -1483,7 +1483,7 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *d)
                                                      (uint32_t)d->len);
         BUG_ON(len > (uint32_t)d->len);
 
-        HtpBodyAppendChunk(&hstate->cfg->request, &tx_ud->request_body, d->data, len);
+        HtpBodyAppendChunk(&tx_ud->request_body, d->data, len);
 
         const uint8_t *chunks_buffer = NULL;
         uint32_t chunks_buffer_len = 0;
@@ -1600,7 +1600,7 @@ static int HTPCallbackResponseBodyData(htp_tx_data_t *d)
                                                      (uint32_t)d->len);
         BUG_ON(len > (uint32_t)d->len);
 
-        HtpBodyAppendChunk(&hstate->cfg->response, &tx_ud->response_body, d->data, len);
+        HtpBodyAppendChunk(&tx_ud->response_body, d->data, len);
 
         HtpResponseBodyHandle(hstate, tx_ud, d->tx, (uint8_t *)d->data, len);
     } else {
@@ -5586,9 +5586,9 @@ static int HTPBodyReassemblyTest01(void)
     uint8_t chunk1[] = "--e5a320f21416a02493a0a6f561b1c494\r\nContent-Disposition: form-data; name=\"uploadfile\"; filename=\"D2GUef.jpg\"\r";
     uint8_t chunk2[] = "POST /uri HTTP/1.1\r\nHost: hostname.com\r\nKeep-Alive: 115\r\nAccept-Charset: utf-8\r\nUser-Agent: Mozilla/5.0 (X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\nConnection: keep-alive\r\nContent-length: 68102\r\nReferer: http://otherhost.com\r\nAccept-Encoding: gzip\r\nContent-Type: multipart/form-data; boundary=e5a320f21416a02493a0a6f561b1c494\r\nCookie: blah\r\nAccept-Language: us\r\n\r\n--e5a320f21416a02493a0a6f561b1c494\r\nContent-Disposition: form-data; name=\"uploadfile\"; filename=\"D2GUef.jpg\"\r";
 
-    int r = HtpBodyAppendChunk(NULL, &htud.request_body, chunk1, sizeof(chunk1)-1);
+    int r = HtpBodyAppendChunk(&htud.request_body, chunk1, sizeof(chunk1) - 1);
     BUG_ON(r != 0);
-    r = HtpBodyAppendChunk(NULL, &htud.request_body, chunk2, sizeof(chunk2)-1);
+    r = HtpBodyAppendChunk(&htud.request_body, chunk2, sizeof(chunk2) - 1);
     BUG_ON(r != 0);
 
     const uint8_t *chunks_buffer = NULL;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2637,7 +2637,7 @@ void AppLayerHtpPrintStats(void)
  *  \param direction flow direction
  *  \retval files files ptr
  */
-static AppLayerGetFileState HTPGetTxFiles(void *state, void *txv, uint8_t direction)
+static AppLayerGetFileState HTPGetTxFiles(void *txv, uint8_t direction)
 {
     AppLayerGetFileState files = { .fc = NULL, .cfg = &htp_sbcfg };
     htp_tx_t *tx = (htp_tx_t *)txv;
@@ -6502,7 +6502,7 @@ libhtp:\n\
     void *tx_ptr = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx_ptr);
 
-    AppLayerGetFileState files = HTPGetTxFiles(http_state, tx_ptr, STREAM_TOCLIENT);
+    AppLayerGetFileState files = HTPGetTxFiles(tx_ptr, STREAM_TOCLIENT);
     FileContainer *ffc = files.fc;
     FAIL_IF_NULL(ffc);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -88,7 +88,7 @@ typedef struct AppLayerParserProtoCtx_
 
     /** get FileContainer reference from the TX. MUST return a non-NULL reference if the TX
      *  has or may have files in the requested direction at some point. */
-    AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t);
+    AppLayerGetFileState (*GetTxFiles)(void *, uint8_t);
 
     int (*StateGetProgress)(void *alstate, uint8_t direction);
     uint64_t (*StateGetTxCnt)(void *alstate);
@@ -441,8 +441,8 @@ void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
-void AppLayerParserRegisterGetTxFilesFunc(uint8_t ipproto, AppProto alproto,
-        AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t))
+void AppLayerParserRegisterGetTxFilesFunc(
+        uint8_t ipproto, AppProto alproto, AppLayerGetFileState (*GetTxFiles)(void *, uint8_t))
 {
     SCEnter();
 
@@ -868,13 +868,12 @@ AppLayerDecoderEvents *AppLayerParserGetEventsByTx(uint8_t ipproto, AppProto alp
     SCReturnPtr(ptr, "AppLayerDecoderEvents *");
 }
 
-AppLayerGetFileState AppLayerParserGetTxFiles(
-        const Flow *f, void *state, void *tx, const uint8_t direction)
+AppLayerGetFileState AppLayerParserGetTxFiles(const Flow *f, void *tx, const uint8_t direction)
 {
     SCEnter();
 
     if (alp_ctx.ctxs[f->protomap][f->alproto].GetTxFiles != NULL) {
-        return alp_ctx.ctxs[f->protomap][f->alproto].GetTxFiles(state, tx, direction);
+        return alp_ctx.ctxs[f->protomap][f->alproto].GetTxFiles(tx, direction);
     }
 
     AppLayerGetFileState files = { .fc = NULL, .cfg = NULL };
@@ -884,7 +883,7 @@ AppLayerGetFileState AppLayerParserGetTxFiles(
 static void AppLayerParserFileTxHousekeeping(
         const Flow *f, void *tx, const uint8_t pkt_dir, const bool trunc)
 {
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, pkt_dir);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, tx, pkt_dir);
     if (files.fc) {
         FilesPrune(files.fc, files.cfg, trunc);
     }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -179,8 +179,8 @@ void AppLayerParserRegisterLocalStorageFunc(uint8_t ipproto, AppProto proto,
         void *(*LocalStorageAlloc)(void), void (*LocalStorageFree)(void *));
 // void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
 //     AppLayerDecoderEvents *(*StateGetEvents)(void *) __attribute__((nonnull)));
-void AppLayerParserRegisterGetTxFilesFunc(uint8_t ipproto, AppProto alproto,
-        AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t));
+void AppLayerParserRegisterGetTxFilesFunc(
+        uint8_t ipproto, AppProto alproto, AppLayerGetFileState (*GetTxFiles)(void *, uint8_t));
 void AppLayerParserRegisterLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserRegisterLoggerBits(uint8_t ipproto, AppProto alproto, LoggerId bits);
 void AppLayerParserRegisterTruncateFunc(uint8_t ipproto, AppProto alproto,
@@ -235,8 +235,7 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
 
 AppLayerDecoderEvents *AppLayerParserGetDecoderEvents(AppLayerParserState *pstate);
 AppLayerDecoderEvents *AppLayerParserGetEventsByTx(uint8_t ipproto, AppProto alproto, void *tx);
-AppLayerGetFileState AppLayerParserGetTxFiles(
-        const Flow *f, void *state, void *tx, const uint8_t direction);
+AppLayerGetFileState AppLayerParserGetTxFiles(const Flow *f, void *tx, const uint8_t direction);
 int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
                         void *alstate, uint8_t direction);
 uint64_t AppLayerParserGetTxCnt(const Flow *, void *alstate);

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -59,7 +59,7 @@ typedef struct AppLayerParser {
     void *(*LocalStorageAlloc)(void);
     void (*LocalStorageFree)(void *);
 
-    AppLayerGetFileState (*GetTxFiles)(void *, void *, uint8_t);
+    AppLayerGetFileState (*GetTxFiles)(void *, uint8_t);
 
     AppLayerGetTxIterTuple (*GetTxIterator)(const uint8_t ipproto,
             const AppProto alproto, void *alstate, uint64_t min_tx_id,

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1732,7 +1732,7 @@ static int SMTPStateGetAlstateProgress(void *vtx, uint8_t direction)
     return tx->done;
 }
 
-static AppLayerGetFileState SMTPGetTxFiles(void *state, void *txv, uint8_t direction)
+static AppLayerGetFileState SMTPGetTxFiles(void *txv, uint8_t direction)
 {
     AppLayerGetFileState files = { .fc = NULL, .cfg = &smtp_config.sbcfg };
     SMTPTransaction *tx = (SMTPTransaction *)txv;

--- a/src/detect-engine-file.c
+++ b/src/detect-engine-file.c
@@ -187,7 +187,7 @@ uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx 
     DEBUG_VALIDATE_BUG_ON(f->alstate != alstate);
 
     const uint8_t direction = flags & (STREAM_TOSERVER|STREAM_TOCLIENT);
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, tx, direction);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, tx, direction);
     FileContainer *ffc = files.fc;
     SCLogDebug("tx %p tx_id %" PRIu64 " ffc %p ffc->head %p sid %u", tx, tx_id, ffc,
             ffc ? ffc->head : NULL, s->id);

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -711,7 +711,7 @@ static int DeStateSigTest03(void)
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
     FAIL_IF(!(PacketAlertCheck(p, 1)));
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
 
@@ -791,7 +791,7 @@ static int DeStateSigTest04(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -866,7 +866,7 @@ static int DeStateSigTest05(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -952,7 +952,7 @@ static int DeStateSigTest06(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -1040,7 +1040,7 @@ static int DeStateSigTest07(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -1139,7 +1139,7 @@ static int DeStateSigTest08(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -1166,7 +1166,7 @@ static int DeStateSigTest08(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     fc = files.fc;
     FAIL_IF_NULL(fc);
     file = fc->head;
@@ -1267,7 +1267,7 @@ static int DeStateSigTest09(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -1294,7 +1294,7 @@ static int DeStateSigTest09(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     fc = files.fc;
     FAIL_IF_NULL(fc);
     file = fc->head;
@@ -1393,7 +1393,7 @@ static int DeStateSigTest10(void)
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     FileContainer *fc = files.fc;
     FAIL_IF_NULL(fc);
     File *file = fc->head;
@@ -1420,7 +1420,7 @@ static int DeStateSigTest10(void)
     tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
 
-    files = AppLayerParserGetTxFiles(p->flow, http_state, tx, STREAM_TOSERVER);
+    files = AppLayerParserGetTxFiles(p->flow, tx, STREAM_TOSERVER);
     fc = files.fc;
     FAIL_IF_NULL(fc);
     file = fc->head;

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -395,7 +395,7 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
         transforms = engine->v2.transforms;
     }
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
@@ -448,7 +448,7 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -305,7 +305,7 @@ static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngin
         transforms = engine->v2.transforms;
     }
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
@@ -358,7 +358,7 @@ static void PrefilterTxFilemagic(DetectEngineThreadCtx *det_ctx, const void *pec
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -242,7 +242,7 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
         transforms = engine->v2.transforms;
     }
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc == NULL) {
         return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES;
@@ -295,7 +295,7 @@ static void PrefilterTxFilename(DetectEngineThreadCtx *det_ctx, const void *pect
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     const int list_id = ctx->list_id;
 
-    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, f->alstate, txv, flags);
+    AppLayerGetFileState files = AppLayerParserGetTxFiles(f, txv, flags);
     FileContainer *ffc = files.fc;
     if (ffc != NULL) {
         int local_file_id = 0;

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -237,7 +237,7 @@ static int DetectFilestorePostMatch(DetectEngineThreadCtx *det_ctx,
                 p->flow->proto, p->flow->alproto, alstate, det_ctx->filestore[u].tx_id);
         DEBUG_VALIDATE_BUG_ON(txv == NULL);
         if (txv) {
-            AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, alstate, txv, flags);
+            AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, txv, flags);
             FileContainer *ffc_tx = files.fc;
             DEBUG_VALIDATE_BUG_ON(ffc_tx == NULL);
             if (ffc_tx) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -394,8 +394,7 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
     if (p->flow->alstate != NULL) {
         void *tx = AppLayerParserGetTx(p->flow->proto, p->flow->alproto, p->flow->alstate, tx_id);
         if (tx) {
-            AppLayerGetFileState files =
-                    AppLayerParserGetTxFiles(p->flow, p->flow->alstate, tx, direction);
+            AppLayerGetFileState files = AppLayerParserGetTxFiles(p->flow, tx, direction);
             ffc = files.fc;
         }
     }

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -167,11 +167,9 @@ static inline void OutputTxLogFiles(ThreadVars *tv, OutputFileLoggerThreadData *
             opposing_dir == STREAM_TOSERVER ? "TOSERVER" : "TOCLIENT", packet_dir_ready,
             opposing_dir_ready);
 
-    AppLayerGetFileState app_files =
-            AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, packet_dir);
+    AppLayerGetFileState app_files = AppLayerParserGetTxFiles(f, tx, packet_dir);
     FileContainer *ffc = app_files.fc;
-    AppLayerGetFileState app_files_opposing =
-            AppLayerParserGetTxFiles(f, FlowGetAppState(f), tx, opposing_dir);
+    AppLayerGetFileState app_files_opposing = AppLayerParserGetTxFiles(f, tx, opposing_dir);
     FileContainer *ffc_opposing = app_files_opposing.fc;
 
     /* see if opposing side is finished: if no file support in this direction, of is not


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4083
Generic code cleaning

Describe changes:
- remove some unused parameters in app-layer code
- remove `state` in GetTxFiles functions

https://github.com/OISF/suricata/pull/11250 no longer draft, should get green CI and clean git history