### PR TITLE
dns/tcp: trigger raw stream reassembly earlier - v1

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -57,6 +57,9 @@ Major changes
   Instead, both the SDP parser and logger depend on being invoked by another parser (or logger).
 - ARP decoder and logger have been introduced.
   Since ARP can be quite verbose and produce many events, the logger is disabled by default.
+- It is possible to see an increase of alerts, for the same rule-sets, if you
+  use many stream/payload rules, due to Suricata triggering TCP stream
+  reassembly earlier.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -549,6 +549,7 @@ impl DNSState {
             );
             if size > 0 && cur_i.len() >= size + 2 {
                 let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                 let frame = Frame::new(
                     flow,
                     &stream_slice,
@@ -612,6 +613,7 @@ impl DNSState {
             );
             if size > 0 && cur_i.len() >= size + 2 {
                 let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                 let frame = Frame::new(
                     flow,
                     &stream_slice,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7018

Describe changes:
- trigger raw stream reassembly earlier for dns/tcp
- add note to Upgrading section about possible increase of alerts for stream rules

SV-BRANCH=https://github.com/OISF/suricata-verify/pull/1897