### PR TITLE
Smtp to comma quote 7060 v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1327,11 +1327,34 @@
                 "body_md5": {
                     "type": "string"
                 },
+                "cc": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "date": {
                     "type": "string"
                 },
                 "from": {
                     "type": "string"
+                },
+                "has_exe_url": {
+                    "type": "boolean"
+                },
+                "has_ipv4_url": {
+                    "type": "boolean"
+                },
+                "has_ipv6_url": {
+                    "type": "boolean"
+                },
+                "received": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "status": {
                     "type": "string"
@@ -1342,8 +1365,12 @@
                 "subject_md5": {
                     "type": "string"
                 },
-                "x_mailer": {
-                    "type": "string"
+                "to": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "url": {
                     "type": "array",
@@ -1352,28 +1379,15 @@
                         "type": "string"
                     }
                 },
+                "x_mailer": {
+                    "type": "string"
+                },
                 "attachment": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
                     }
-                },
-                "to": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "has_ipv6_url": {
-                    "type": "boolean"
-                },
-                "has_ipv4_url": {
-                    "type": "boolean"
-                },
-                "has_exe_url": {
-                    "type": "boolean"
                 },
                 "message_id": {
                     "type": "string"

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -993,6 +993,10 @@ static int SMTPProcessReply(SMTPState *state, Flow *f, AppLayerParserState *psta
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
         } else {
             /* decoder event */
+            if (state->parser_state & SMTP_PARSER_STATE_PIPELINING_SERVER) {
+                // reset data mode if we had entered it prematurely
+                state->parser_state &= ~SMTP_PARSER_STATE_COMMAND_DATA_MODE;
+            }
             SMTPSetEvent(state, SMTP_DECODER_EVENT_DATA_COMMAND_REJECTED);
         }
     } else if (IsReplyToCommand(state, SMTP_COMMAND_RSET)) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7060

Describe changes:
- Needed clean cherry-pick of https://redmine.openinfosecfoundation.org/issues/6906
- Needed clean cherry-pick for json schema addition of missing fields
- smtp: log split by commas with respecting quotes

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1885

#11232 rebased to get green CI