### PR TITLE
output/reference: Include reference information in alert (if configured)

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -69,6 +69,7 @@ Metadata::
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
             #packet: yes              # enable dumping of packet (without stream segments)
+            #reference: no            # include reference information, if present, in the alert
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -38,6 +38,7 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # reference: no            # include reference information, if present, in the alert
             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format
 

--- a/etc/reference.config
+++ b/etc/reference.config
@@ -1,26 +1,42 @@
 # config reference: system URL
 
-config reference: bugtraq   http://www.securityfocus.com/bid/
-config reference: bid	    http://www.securityfocus.com/bid/
-config reference: cve       http://cve.mitre.org/cgi-bin/cvename.cgi?name=
-#config reference: cve       http://cvedetails.com/cve/
-config reference: secunia   http://www.secunia.com/advisories/
+##############################
+# Referenced by ET/Open ET/Pro
+##############################
+
+#  resolves, works as intended
+config reference: cve       https://cve.mitre.org/cgi-bin/cvename.cgi?name=
+config reference: nessus    https://www.tenable.com/plugins/nessus/
+config reference: url       https://
 
 #whitehats is unfortunately gone
-config reference: arachNIDS http://www.whitehats.com/info/IDS
+#
+#  no longer resolves
+config reference: McAfee    https://vil.nai.com/vil/content/v_
+config reference: bid	    https://www.securityfocus.com/bid/
+config reference: bugtraq   https://www.securityfocus.com/bid/
+config reference: md5	    https://www.threatexpert.com/report.aspx?md5=
 
-config reference: McAfee    http://vil.nai.com/vil/content/v_
-config reference: nessus    http://cgi.nessus.org/plugins/dump.php3?id=
-config reference: url       http://
-config reference: et        http://doc.emergingthreats.net/
-config reference: etpro     http://doc.emergingthreatspro.com/
-config reference: telus     http://
-config reference: osvdb     http://osvdb.org/show/osvdb/
-config reference: threatexpert http://www.threatexpert.com/report.aspx?md5=
-config reference: md5	    http://www.threatexpert.com/report.aspx?md5=
-config reference: exploitdb http://www.exploit-db.com/exploits/
-config reference: openpacket https://www.openpacket.org/capture/grab/
-config reference: securitytracker http://securitytracker.com/id?
-config reference: secunia   http://secunia.com/advisories/
-config reference: xforce    http://xforce.iss.net/xforce/xfdb/
-config reference: msft      http://technet.microsoft.com/security/bulletin/
+#  resolves, but non-useful page
+config reference: secunia   https://www.secunia.com/advisories/
+config reference: arachNIDS https://www.whitehats.com/info/IDS
+
+###################################################
+# No longer referenced from ET/Open ET/Pro rulesets
+###################################################
+
+#  resolves
+# config reference: exploitdb https://www.exploit-db.com/exploits/
+# config reference: msft      https://technet.microsoft.com/security/bulletin/
+
+#  resolves, but non-useful page
+#config reference: et        https://doc.emergingthreats.net/
+#config reference: etpro     http://doc.emergingthreatspro.com/
+#config reference: telus     https://
+
+#  no longer resolves
+#config reference: xforce    http://xforce.iss.net/xforce/xfdb/
+#config reference: osvdb     http://osvdb.org/show/osvdb/
+#config reference: threatexpert http://www.threatexpert.com/report.aspx?md5=
+#config reference: openpacket https://www.openpacket.org/capture/grab/
+#config reference: securitytracker http://securitytracker.com/id?

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -285,6 +285,13 @@
                     },
                     "additionalProperties": true
                 },
+                "references": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "source": {
                     "type": "object",
                     "properties": {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -248,11 +248,11 @@ void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuil
         AlertJsonSourceTarget(p, pa, js, addr);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_REFERENCE)) {
+    if ((flags & LOG_JSON_REFERENCE)) {
         AlertJsonReference(json_output_ctx, pa, js);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_RULE_METADATA)) {
+    if (flags & LOG_JSON_RULE_METADATA) {
         AlertJsonMetadata(json_output_ctx, pa, js);
     }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -165,6 +165,7 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # reference: no            # include reference information, if present, in the alert
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of HTTP body in printable format


### PR DESCRIPTION
Continuation of #11089  

When configured, include the reference value in the alert. The configuration value is in the `alert` section:  types.alert.reference. The default value is off/no. Set to yes to include the expanded reference from the rule in the alert record.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4974](https://redmine.openinfosecfoundation.org/issues/4974)

Describe changes:
- Add `reference` value to suricata.yaml.in (default no/off)
- Set flag in output logger if the config setting is on
- Format the reference as a sequence, e.g., `references: [ "ref-1" [, "ref-2" [, ...]]]`

Updates: 
- Update reference.config (see commit)

### Provide values to any of the below to override the defaults.


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1808

