### PR TITLE
bypass: really bypass udp flow from first packet

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -482,7 +482,13 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         SCLogDebug("pkt %p FLOW_PKT_ESTABLISHED", p);
         p->flowflags |= FLOW_PKT_ESTABLISHED;
 
-        FlowUpdateState(f, FLOW_STATE_ESTABLISHED);
+        if (
+#ifdef CAPTURE_OFFLOAD
+                (f->flow_state != FLOW_STATE_CAPTURE_BYPASSED) &&
+#endif
+                (f->flow_state != FLOW_STATE_LOCAL_BYPASSED)) {
+            FlowUpdateState(f, FLOW_STATE_ESTABLISHED);
+        }
     }
 
     if (f->flags & FLOW_ACTION_DROP) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7053

Describe changes:
- bypass: really bypass udp flow from first packet

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1940

#11182 rebased if we want to backport this for 7.0.6