### PR TITLE
enip: remove unnecessary unsafe

### DIFF
--- a/rust/src/enip/enip.rs
+++ b/rust/src/enip/enip.rs
@@ -634,13 +634,11 @@ pub unsafe extern "C" fn SCEnipRegisterParsers() {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }
         SCLogDebug!("Rust enip parser registered for UDP.");
-        unsafe {
-            AppLayerParserRegisterParserAcceptableDataDirection(
-                IPPROTO_UDP,
-                ALPROTO_ENIP,
-                STREAM_TOSERVER | STREAM_TOCLIENT,
-            );
-        }
+        AppLayerParserRegisterParserAcceptableDataDirection(
+            IPPROTO_UDP,
+            ALPROTO_ENIP,
+            STREAM_TOSERVER | STREAM_TOCLIENT,
+        );
         AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_ENIP);
     } else {
         SCLogDebug!("Protocol detector and parser disabled for ENIP on UDP.");
@@ -661,13 +659,11 @@ pub unsafe extern "C" fn SCEnipRegisterParsers() {
             let _ = AppLayerRegisterParser(&parser, alproto);
         }
         SCLogDebug!("Rust enip parser registered for TCP.");
-        unsafe {
-            AppLayerParserRegisterParserAcceptableDataDirection(
-                IPPROTO_TCP,
-                ALPROTO_ENIP,
-                STREAM_TOSERVER | STREAM_TOCLIENT,
-            );
-        }
+        AppLayerParserRegisterParserAcceptableDataDirection(
+            IPPROTO_TCP,
+            ALPROTO_ENIP,
+            STREAM_TOSERVER | STREAM_TOCLIENT,
+        );
         AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_ENIP);
     } else {
         SCLogDebug!("Protocol detector and parser disabled for ENIP on TCP.");


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/3958 simple follow up

Describe changes:
- enip: remove unnecessary unsafe to make `cargo update` on MSRV happy

```
error: unnecessary `unsafe` block
   --> src/enip/enip.rs:637:9
    |
585 | pub unsafe extern "C" fn SCEnipRegisterParsers() {
    | ------------------------------------------------ because it's nested under this `unsafe` fn
...
637 |         unsafe {
    |         ^^^^^^ unnecessary `unsafe` block
    |
```