### PR TITLE
rust/clippy/fixups/20240613/v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -41,8 +41,8 @@ hkdf = "~0.12.3"
 aes = "~0.7.5"
 aes-gcm = "~0.9.4"
 
-der-parser = { version = "~9.0.0", default_features = false }
-kerberos-parser = { version = "~0.8.0", default_features = false }
+der-parser = { version = "~9.0.0", default-features = false }
+kerberos-parser = { version = "~0.8.0", default-features = false }
 
 sawp-modbus = "~0.12.1"
 sawp = "~0.12.1"

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -153,7 +153,7 @@ pub(super) fn asn1_parse_rule(input: &str) -> IResult<&str, DetectAsn1Data> {
             tag("relative_offset"),
             multispace1,
             verify(parse_i32_number, |v| {
-                *v >= -i32::from(std::u16::MAX) && *v <= i32::from(std::u16::MAX)
+                *v >= -i32::from(u16::MAX) && *v <= i32::from(u16::MAX)
             }),
         )(i)
     }

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -56,9 +56,9 @@ pub fn ftp_active_port(i: &[u8]) -> IResult<&[u8], u16> {
         digit1,
         tag(","),
     ))(i)?;
-    let (i, part1) = verify(parse_u16, |&v| v <= std::u8::MAX as u16)(i)?;
+    let (i, part1) = verify(parse_u16, |&v| v <= u8::MAX as u16)(i)?;
     let (i, _) = tag(",")(i)?;
-    let (i, part2) = verify(parse_u16, |&v| v <= std::u8::MAX as u16)(i)?;
+    let (i, part2) = verify(parse_u16, |&v| v <= u8::MAX as u16)(i)?;
     Ok((i, part1 * 256 + part2))
 }
 
@@ -77,9 +77,9 @@ pub fn ftp_pasv_response(i: &[u8]) -> IResult<&[u8], u16> {
         digit1,
         tag(","),
     ))(i)?;
-    let (i, part1) = verify(getu16, |&v| v <= std::u8::MAX as u16)(i)?;
+    let (i, part1) = verify(getu16, |&v| v <= u8::MAX as u16)(i)?;
     let (i, _) = tag(",")(i)?;
-    let (i, part2) = verify(getu16, |&v| v <= std::u8::MAX as u16)(i)?;
+    let (i, part2) = verify(getu16, |&v| v <= u8::MAX as u16)(i)?;
     // may also be completed by a final point
     let (i, _) = tag(")")(i)?;
     let (i, _) = opt(complete(tag(".")))(i)?;

--- a/rust/src/ike/parser.rs
+++ b/rust/src/ike/parser.rs
@@ -69,8 +69,8 @@ pub struct IsakmpHeader {
 
 pub struct IsakmpPayloadHeader {
     pub next_payload: u8,
-    pub reserved: u8,
-    pub payload_length: u16,
+    pub _reserved: u8,
+    pub _payload_length: u16,
 }
 
 pub struct IsakmpPayload<'a> {
@@ -83,24 +83,24 @@ pub struct IsakmpPayload<'a> {
 // 1 -> Security Association
 pub struct SecurityAssociationPayload<'a> {
     pub domain_of_interpretation: u32,
-    pub situation: Option<&'a [u8]>,
+    pub _situation: Option<&'a [u8]>,
     pub data: Option<&'a [u8]>,
 }
 
 // 2 -> Proposal
 pub struct ProposalPayload<'a> {
-    pub proposal_number: u8,
-    pub proposal_type: u8,
-    pub spi_size: u8,
-    pub number_transforms: u8,
-    pub spi: &'a [u8],
+    pub _proposal_number: u8,
+    pub _proposal_type: u8,
+    pub _spi_size: u8,
+    pub _number_transforms: u8,
+    pub _spi: &'a [u8],
     pub data: &'a [u8],
 }
 
 // 3 -> Transform
 pub struct TransformPayload<'a> {
-    pub transform_number: u8,
-    pub transform_type: u8,
+    pub _transform_number: u8,
+    pub _transform_type: u8,
     pub sa_attributes: &'a [u8],
 }
 
@@ -286,7 +286,7 @@ pub fn parse_security_association(i: &[u8]) -> IResult<&[u8], SecurityAssociatio
         i,
         SecurityAssociationPayload {
             domain_of_interpretation,
-            situation,
+            _situation: situation,
             data,
         },
     ))
@@ -308,11 +308,11 @@ pub fn parse_proposal(i: &[u8]) -> IResult<&[u8], ProposalPayload> {
         take((start_i.len() - 4) - spi_size as usize)(b)
     })(i)?;
     let payload = ProposalPayload {
-        proposal_number,
-        proposal_type,
-        spi_size,
-        number_transforms,
-        spi,
+        _proposal_number: proposal_number,
+        _proposal_type: proposal_type,
+        _spi_size: spi_size,
+        _number_transforms: number_transforms,
+        _spi: spi,
         data: payload_data.unwrap_or_default(),
     };
     Ok((i, payload))
@@ -326,8 +326,8 @@ pub fn parse_transform(i: &[u8], length: u16) -> IResult<&[u8], TransformPayload
     Ok((
         i,
         TransformPayload {
-            transform_number,
-            transform_type,
+            _transform_number: transform_number,
+            _transform_type: transform_type,
             sa_attributes: payload_data.unwrap_or_default(),
         },
     ))
@@ -495,8 +495,8 @@ pub fn parse_ikev1_payload_list(i: &[u8]) -> IResult<&[u8], Vec<IsakmpPayload>> 
             IsakmpPayload {
                 payload_header: IsakmpPayloadHeader {
                     next_payload,
-                    reserved,
-                    payload_length,
+                    _reserved: reserved,
+                    _payload_length: payload_length,
                 },
                 data: payload_data.unwrap_or_default(),
             },

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -63,9 +63,9 @@ pub struct DetectModbusRust {
 fn check_match_range(sig_range: &Range<u16>, trans_range: RangeInclusive<u16>) -> bool {
     if sig_range.start == sig_range.end {
         sig_range.start >= *trans_range.start() && sig_range.start <= *trans_range.end()
-    } else if sig_range.start == std::u16::MIN {
+    } else if sig_range.start == u16::MIN {
         sig_range.end > *trans_range.start()
-    } else if sig_range.end == std::u16::MAX {
+    } else if sig_range.end == u16::MAX {
         sig_range.start < *trans_range.end()
     } else {
         sig_range.start < *trans_range.end() && *trans_range.start() < sig_range.end
@@ -78,9 +78,9 @@ fn check_match_range(sig_range: &Range<u16>, trans_range: RangeInclusive<u16>) -
 fn check_match(sig_range: &Range<u16>, value: u16) -> bool {
     if sig_range.start == sig_range.end {
         sig_range.start == value
-    } else if sig_range.start == std::u16::MIN {
+    } else if sig_range.start == u16::MIN {
         sig_range.end > value
-    } else if sig_range.end == std::u16::MAX {
+    } else if sig_range.end == u16::MAX {
         sig_range.start < value
     } else {
         sig_range.start < value && value < sig_range.end
@@ -90,8 +90,8 @@ fn check_match(sig_range: &Range<u16>, value: u16) -> bool {
 /// Gets the min/max range of an alert signature from the respective capture groups.
 /// In the case where the max is not given, it is set based on the first char of the min str
 /// which indicates what range we are looking for:
-///     '<' = std::u16::MIN..min
-///     '>' = min..std::u16::MAX
+///     '<' = u16::MIN..min
+///     '>' = min..u16::MAX
 ///     _ = min..min
 /// If the max is given, the range returned is min..max
 fn parse_range(min_str: &str, max_str: &str) -> Result<Range<u16>, ()> {
@@ -100,8 +100,8 @@ fn parse_range(min_str: &str, max_str: &str) -> Result<Range<u16>, ()> {
             debug_validate_bug_on!(!sign.is_ascii_digit() && sign != '<' && sign != '>');
             match min_str[!sign.is_ascii_digit() as usize..].parse::<u16>() {
                 Ok(num) => match sign {
-                    '>' => Ok(num..std::u16::MAX),
-                    '<' => Ok(std::u16::MIN..num),
+                    '>' => Ok(num..u16::MAX),
+                    '<' => Ok(u16::MIN..num),
                     _ => Ok(num..num),
                 },
                 Err(_) => {
@@ -524,7 +524,7 @@ mod test {
             parse_access("access write coils, address <500"),
             Ok(DetectModbusRust {
                 access_type: Some(AccessType::WRITE | AccessType::COILS),
-                address: Some(std::u16::MIN..500),
+                address: Some(u16::MIN..500),
                 ..Default::default()
             })
         );
@@ -532,7 +532,7 @@ mod test {
             parse_access("access write coils, address >500"),
             Ok(DetectModbusRust {
                 access_type: Some(AccessType::WRITE | AccessType::COILS),
-                address: Some(500..std::u16::MAX),
+                address: Some(500..u16::MAX),
                 ..Default::default()
             })
         );
@@ -541,7 +541,7 @@ mod test {
             Ok(DetectModbusRust {
                 access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                 address: Some(100..100),
-                value: Some(std::u16::MIN..1000),
+                value: Some(u16::MIN..1000),
                 ..Default::default()
             })
         );
@@ -583,7 +583,7 @@ mod test {
         assert_eq!(
             parse_unit_id("unit <11"),
             Ok(DetectModbusRust {
-                unit_id: Some(std::u16::MIN..11),
+                unit_id: Some(u16::MIN..11),
                 ..Default::default()
             })
         );
@@ -649,7 +649,7 @@ mod test {
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                     address: Some(15..15),
-                    value: Some(std::u16::MIN..4660),
+                    value: Some(u16::MIN..4660),
                     ..Default::default()
                 }
             ),
@@ -701,7 +701,7 @@ mod test {
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                     address: Some(15..15),
-                    value: Some(4660..std::u16::MAX),
+                    value: Some(4660..u16::MAX),
                     ..Default::default()
                 }
             ),
@@ -714,7 +714,7 @@ mod test {
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                     address: Some(16..16),
-                    value: Some(std::u16::MIN..22137),
+                    value: Some(u16::MIN..22137),
                     ..Default::default()
                 }
             ),
@@ -727,7 +727,7 @@ mod test {
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                     address: Some(16..16),
-                    value: Some(std::u16::MIN..22137),
+                    value: Some(u16::MIN..22137),
                     ..Default::default()
                 }
             ),
@@ -779,7 +779,7 @@ mod test {
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
                     address: Some(17..17),
-                    value: Some(39611..std::u16::MAX),
+                    value: Some(39611..u16::MAX),
                     ..Default::default()
                 }
             ),
@@ -823,7 +823,7 @@ mod test {
             rs_modbus_inspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
-                    unit_id: Some(11..std::u16::MAX),
+                    unit_id: Some(11..u16::MAX),
                     ..Default::default()
                 }
             ),
@@ -834,7 +834,7 @@ mod test {
             rs_modbus_inspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
-                    unit_id: Some(std::u16::MIN..9),
+                    unit_id: Some(u16::MIN..9),
                     ..Default::default()
                 }
             ),
@@ -867,7 +867,7 @@ mod test {
             rs_modbus_inspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
-                    unit_id: Some(9..std::u16::MAX),
+                    unit_id: Some(9..u16::MAX),
                     ..Default::default()
                 }
             ),
@@ -878,7 +878,7 @@ mod test {
             rs_modbus_inspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
-                    unit_id: Some(std::u16::MIN..11),
+                    unit_id: Some(u16::MIN..11),
                     ..Default::default()
                 }
             ),
@@ -1206,7 +1206,7 @@ mod test {
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
-                    address: Some(std::u16::MIN..9),
+                    address: Some(u16::MIN..9),
                     ..Default::default()
                 }
             ),
@@ -1230,7 +1230,7 @@ mod test {
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
-                    address: Some(104..std::u16::MAX),
+                    address: Some(104..u16::MAX),
                     ..Default::default()
                 }
             ),
@@ -1266,7 +1266,7 @@ mod test {
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
-                    address: Some(std::u16::MIN..10),
+                    address: Some(u16::MIN..10),
                     ..Default::default()
                 }
             ),
@@ -1290,7 +1290,7 @@ mod test {
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
-                    address: Some(103..std::u16::MAX),
+                    address: Some(103..u16::MAX),
                     ..Default::default()
                 }
             ),

--- a/rust/src/mqtt/mqtt.rs
+++ b/rust/src/mqtt/mqtt.rs
@@ -33,7 +33,7 @@ use std::ffi::CString;
 // packet in a connection. Note that there is no risk of collision with a
 // parsed packet identifier because in the protocol these are only 16 bit
 // unsigned.
-const MQTT_CONNECT_PKT_ID: u32 = std::u32::MAX;
+const MQTT_CONNECT_PKT_ID: u32 = u32::MAX;
 // Maximum message length in bytes. If the length of a message exceeds
 // this value, it will be truncated. Default: 1MB.
 static mut MAX_MSG_LEN: u32 = 1048576;

--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -455,10 +455,7 @@ pub fn smb_read_dcerpc_record(state: &mut SMBState,
     // msg_id 0 as this data crosses cmd/reply pairs
     let ehdr = SMBHashKeyHdrGuid::new(SMBCommonHdr::new(SMBHDR_TYPE_TRANS_FRAG,
             hdr.ssn_id, hdr.tree_id, 0_u64), guid.to_vec());
-    let mut prevdata = match state.ssnguid2vec_map.remove(&ehdr) {
-        Some(s) => s,
-        None => Vec::new(),
-    };
+    let mut prevdata = state.ssnguid2vec_map.remove(&ehdr).unwrap_or_default();
     SCLogDebug!("indata {} prevdata {}", indata.len(), prevdata.len());
     prevdata.extend_from_slice(indata);
     let data = prevdata;

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -891,11 +891,8 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
             SCLogDebug!("TRANS response {:?}", rd);
 
             // see if we have a stored fid
-            let fid = match state.ssn2vec_map.remove(
-                    &SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID)) {
-                Some(f) => f,
-                None => Vec::new(),
-            };
+            let fid = state.ssn2vec_map.remove(
+                    &SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID)).unwrap_or_default();
             SCLogDebug!("FID {:?}", fid);
 
             let mut frankenfid = fid.to_vec();

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -679,13 +679,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                         /* search key-guid map */
                         let guid_key = SMBCommonHdr::new(SMBHDR_TYPE_GUID,
                                 r.session_id, r.tree_id, r.message_id);
-                        let _guid_vec = match state.ssn2vec_map.remove(&guid_key) {
-                            Some(p) => p,
-                            None => {
-                                SCLogDebug!("SMBv2 response: GUID NOT FOUND");
-                                Vec::new()
-                            },
-                        };
+                        let _guid_vec = state.ssn2vec_map.remove(&guid_key).unwrap_or_default();
                         SCLogDebug!("SMBv2 write response for GUID {:?}", _guid_vec);
                     }
                     _ => {


### PR DESCRIPTION
- **cargo: use default-features instead of default_features**
- **rust: fix clippy lint for legacy_numeric_constants**
- **rust: simply matches with unwrap_or_default**
- **rust/ike: prefix never read field names with _**
