### PR TITLE
fuzz: adapt target to number of keywords being dynamic

### DIFF
--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -49,8 +49,7 @@ static void SigGenerateAware(const uint8_t *data, size_t size, char *r, size_t *
     *len = snprintf(r, 511, "alert ip any any -> any any (");
     for (size_t i = 0; i + 1 < size && *len < 511; i++) {
         if (data[i] & 0x80) {
-            size_t off = (data[i] & 0x7F + ((data[i + 1] & 0xF) << 7)) %
-                         (sizeof(sigmatch_table) / sizeof(SigTableElmt));
+            size_t off = (data[i] & 0x7F + ((data[i + 1] & 0xF) << 7)) % (DETECT_TBLSIZE);
             if (sigmatch_table[off].flags & SIGMATCH_NOOPT ||
                     ((data[i + 1] & 0x80) && sigmatch_table[off].flags & SIGMATCH_OPTIONAL_OPT)) {
                 *len += snprintf(r + *len, 511 - *len, "; %s;", sigmatch_table[off].name);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4683
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69727&q=label%3AProj-suricata
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=69725&q=label%3AProj-suricata

Describe changes:
- fuzz: adapt target to number of keywords being dynamic

Follow up on 4bbe7d92dc858f77484ad9d41327422ff84af655