### PR TITLE
packet: Ensure app_layer_events is not reused as packet is recycled

### DIFF
--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -121,15 +121,6 @@ void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t e
     (*sevents)->events[(*sevents)->cnt++] = event;
 }
 
-void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events)
-{
-    if (events != NULL) {
-        events->cnt = 0;
-        events->event_last_logged = 0;
-    }
-}
-
-
 void AppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events)
 {
     if (events && *events != NULL) {

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -74,7 +74,6 @@ static inline int AppLayerDecoderEventsIsEventSet(
     return 0;
 }
 
-void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events);
 void AppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events);
 int DetectEngineGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type);
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -110,7 +110,6 @@ struct PktPool_;
 /* declare these here as they are called from the
  * PACKET_RECYCLE and PACKET_CLEANUP macro's. */
 typedef struct AppLayerDecoderEvents_ AppLayerDecoderEvents;
-void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events);
 void AppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events);
 
 /* Address */

--- a/src/packet.c
+++ b/src/packet.c
@@ -128,7 +128,7 @@ void PacketReinit(Packet *p)
     p->tunnel_rtv_cnt = 0;
     p->tunnel_tpr_cnt = 0;
     p->events.cnt = 0;
-    AppLayerDecoderEventsResetEvents(p->app_layer_events);
+    AppLayerDecoderEventsFreeEvents(&p->app_layer_events);
     p->next = NULL;
     p->prev = NULL;
     p->tunnel_verdicted = false;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -257,7 +257,6 @@ static int AFPBypassCallback(Packet *p);
 static int AFPXDPBypassCallback(Packet *p);
 #endif
 
-#define MAX_MAPS 32
 /**
  * \brief Structure to hold thread specific variables.
  */


### PR DESCRIPTION
The app_layer_event packet is allocated once and then the memory is re-used. There are a few places where behavior is conditional on whether it's in use (non-NULL). As packets are recycled, the pointer is never reset to NULL. As a result, incorrect behavior can occur if the pointer value is checked.

This PR changes the packet recycle logic to first free the memory (if used) and then clear the pointer to prevent logic issues.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7106

Describe changes:
- Removed unused AF-PACKET cpp value (flagged by compilation warning)
- Free and clear the app_layer_event memory
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
