### PR TITLE
Detect prefilter events 6291 v1

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -536,9 +536,12 @@ static int SignatureCreateMask(Signature *s)
                 }
                 break;
             }
+            case DETECT_DECODE_EVENT:
+                // fallthrough
+            case DETECT_STREAM_EVENT:
+                // fallthrough
             case DETECT_AL_APP_LAYER_EVENT:
-                s->mask |= SIG_MASK_REQUIRE_ENGINE_EVENT;
-                break;
+                // fallthrough
             case DETECT_ENGINE_EVENT:
                 s->mask |= SIG_MASK_REQUIRE_ENGINE_EVENT;
                 break;

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -37,6 +37,7 @@
 #include "detect-flow.h"
 #include "detect-config.h"
 #include "detect-flowbits.h"
+#include "app-layer-events.h"
 
 #include "util-port-interval-tree.h"
 #include "util-profiling.h"
@@ -420,7 +421,8 @@ PacketCreateMask(Packet *p, SignatureMask *mask, AppProto alproto,
         (*mask) |= SIG_MASK_REQUIRE_NO_PAYLOAD;
     }
 
-    if (p->events.cnt > 0 || app_decoder_events != 0 || p->app_layer_events != NULL) {
+    if (p->events.cnt > 0 || app_decoder_events != 0 ||
+            (p->app_layer_events != NULL && p->app_layer_events->cnt)) {
         SCLogDebug("packet/flow has events set");
         (*mask) |= SIG_MASK_REQUIRE_ENGINE_EVENT;
     }

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -80,14 +80,11 @@ static bool PrefilterDecodeEventIsPrefilterable(const Signature *s)
 
 static void PrefilterPacketEventSet(PrefilterPacketHeaderValue *v, void *smctx)
 {
-    const DetectEngineEventData *a = smctx;
-    v->u8[0] = a->event;
 }
 
 static bool PrefilterPacketEventCompare(PrefilterPacketHeaderValue v, void *smctx)
 {
-    const DetectEngineEventData *a = smctx;
-    return (v.u8[0] == a->event);
+    return true;
 }
 
 static void PrefilterPacketEventMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
@@ -96,10 +93,7 @@ static void PrefilterPacketEventMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    DetectEngineEventData de;
-    de.event = ctx->v1.u8[0];
-
-    if (ENGINE_ISSET_EVENT(p, de.event)) {
+    if (p->events.cnt > 0) {
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
 }

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -257,7 +257,6 @@ static int AFPBypassCallback(Packet *p);
 static int AFPXDPBypassCallback(Packet *p);
 #endif
 
-#define MAX_MAPS 32
 /**
  * \brief Structure to hold thread specific variables.
  */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6291
https://redmine.openinfosecfoundation.org/issues/7106

Describe changes:
- fix missed cases in signature mask for decode events and such
- add prefilter for decode-event and such

Tested with a random `TLPW1-ca1fb1ad30189110cc225620dc537368.pcap` with 487089 packets, 

`time ./src/suricata -c suricata.yaml -k none -r TLPW1-ca1fb1ad30189110cc225620dc537368.pcap -S rules/decoder-events.rules --runmode=single` goes down from 12/14 seconds to 8

The second commit is the one with most gains cc @victorjulien 

Draft because of last commit : which version is better for prefilter ? last commit or the one before...

Follows on https://github.com/OISF/suricata/pull/11303 + https://github.com/OISF/suricata/pull/11322