### PR TITLE
output: configurable payload_length field for alerts

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -68,6 +68,7 @@ Metadata::
             #payload: yes             # enable dumping payload in Base64
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
+            #payload-length: yes      # enable dumping payload length
             #packet: yes              # enable dumping of packet (without stream segments)
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -37,6 +37,7 @@ outputs:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
+            # payload-length: yes      # enable dumping payload length
             # packet: yes              # enable dumping of packet (without stream segments)
             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -66,6 +66,9 @@
         "payload": {
             "type": "string"
         },
+        "payload_length": {
+            "type": "integer"
+        },
         "payload_printable": {
             "type": "string"
         },

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,6 +164,7 @@ outputs:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
+            # payload-length: yes      # enable dumping payload length
             # packet: yes              # enable dumping of packet (without stream segments)
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7098

Describe changes:
- output: configurable payload_length field for alerts

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1930
