### PR TITLE
Cherry-pick: profiling: activate when Suricata starts in pcap reader mode

### DIFF
--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1430,6 +1430,7 @@ void SCProfilingInit(void)
     SC_ATOMIC_INIT(profiling_rules_active);
     SC_ATOMIC_INIT(samples);
     intmax_t rate_v = 0;
+    ConfNode *conf;
 
     (void)ConfGetInt("profiling.sample-rate", &rate_v);
     if (rate_v > 0 && rate_v < INT_MAX) {
@@ -1445,6 +1446,11 @@ void SCProfilingInit(void)
             SCLogInfo("profiling runs for every %luth packet", rate + 1);
         else
             SCLogInfo("profiling runs for every packet");
+    }
+
+    conf = ConfGetNode("profiling.rules");
+    if (ConfNodeChildValueIsTrue(conf, "active")) {
+        SC_ATOMIC_SET(profiling_rules_active, 1);
     }
 }
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1470,7 +1470,6 @@ int SCProfileRuleStart(Packet *p)
         p->flags |= PKT_PROFILE;
         return 1;
     }
-
     return 0;
 }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1812,6 +1812,10 @@ profiling:
     enabled: yes
     filename: rule_perf.log
     append: yes
+    # Set active to yes to enable rules profiling at start
+    # if set to no (default), the rules profiling will have to be started
+    # via unix socket commands.
+    #active:no
 
     # Sort options: ticks, avgticks, checks, matches, maxticks
     # If commented out all the sort options will be used.


### PR DESCRIPTION
Cherry-pick of issue 6550

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6557



### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
