### PR TITLE
Cherry-pick: profiling: activate when Suricata starts in pcap reader mode

### DIFF
--- a/rust/src/smb/dcerpc.rs
+++ b/rust/src/smb/dcerpc.rs
@@ -455,10 +455,7 @@ pub fn smb_read_dcerpc_record(state: &mut SMBState,
     // msg_id 0 as this data crosses cmd/reply pairs
     let ehdr = SMBHashKeyHdrGuid::new(SMBCommonHdr::new(SMBHDR_TYPE_TRANS_FRAG,
             hdr.ssn_id, hdr.tree_id, 0_u64), guid.to_vec());
-    let mut prevdata = match state.ssnguid2vec_map.remove(&ehdr) {
-        Some(s) => s,
-        None => Vec::new(),
-    };
+    let mut prevdata = state.ssnguid2vec_map.remove(&ehdr).unwrap_or_default();
     SCLogDebug!("indata {} prevdata {}", indata.len(), prevdata.len());
     prevdata.extend_from_slice(indata);
     let data = prevdata;

--- a/rust/src/smb/smb1.rs
+++ b/rust/src/smb/smb1.rs
@@ -894,11 +894,8 @@ pub fn smb1_trans_response_record(state: &mut SMBState, r: &SmbRecord)
             SCLogDebug!("TRANS response {:?}", rd);
 
             // see if we have a stored fid
-            let fid = match state.ssn2vec_map.remove(
-                    &SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID)) {
-                Some(f) => f,
-                None => Vec::new(),
-            };
+            let fid = state.ssn2vec_map.remove(
+                    &SMBCommonHdr::from1(r, SMBHDR_TYPE_GUID)).unwrap_or_default();
             SCLogDebug!("FID {:?}", fid);
 
             let mut frankenfid = fid.to_vec();

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -679,13 +679,7 @@ pub fn smb2_response_record(state: &mut SMBState, r: &Smb2Record)
                         /* search key-guid map */
                         let guid_key = SMBCommonHdr::new(SMBHDR_TYPE_GUID,
                                 r.session_id, r.tree_id, r.message_id);
-                        let _guid_vec = match state.ssn2vec_map.remove(&guid_key) {
-                            Some(p) => p,
-                            None => {
-                                SCLogDebug!("SMBv2 response: GUID NOT FOUND");
-                                Vec::new()
-                            },
-                        };
+                        let _guid_vec = state.ssn2vec_map.remove(&guid_key).unwrap_or_default();
                         SCLogDebug!("SMBv2 write response for GUID {:?}", _guid_vec);
                     }
                     _ => {

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1430,6 +1430,7 @@ void SCProfilingInit(void)
     SC_ATOMIC_INIT(profiling_rules_active);
     SC_ATOMIC_INIT(samples);
     intmax_t rate_v = 0;
+    ConfNode *conf;
 
     (void)ConfGetInt("profiling.sample-rate", &rate_v);
     if (rate_v > 0 && rate_v < INT_MAX) {
@@ -1445,6 +1446,11 @@ void SCProfilingInit(void)
             SCLogInfo("profiling runs for every %luth packet", rate + 1);
         else
             SCLogInfo("profiling runs for every packet");
+    }
+
+    conf = ConfGetNode("profiling.rules");
+    if (ConfNodeChildValueIsTrue(conf, "active")) {
+        SC_ATOMIC_SET(profiling_rules_active, 1);
     }
 }
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1470,7 +1470,6 @@ int SCProfileRuleStart(Packet *p)
         p->flags |= PKT_PROFILE;
         return 1;
     }
-
     return 0;
 }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1812,6 +1812,10 @@ profiling:
     enabled: yes
     filename: rule_perf.log
     append: yes
+    # Set active to yes to enable rules profiling at start
+    # if set to no (default), the rules profiling will have to be started
+    # via unix socket commands.
+    #active:no
 
     # Sort options: ticks, avgticks, checks, matches, maxticks
     # If commented out all the sort options will be used.


### PR DESCRIPTION
Continuation of #11336 

Cherry-pick of issue 6550

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6557

Updates:
- Cherry pick to address clippy warnings.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
