### PR TITLE
backport-7.0.x: doc: update eBPF/compilation instructions v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1262,6 +1262,56 @@ jobs:
           else
             exit 0
           fi
+  almalinux-9-minimal-recommended-dependecies:
+    name: AlmaLinux 9 (Minimal/Recommended Build)
+    runs-on: ubuntu-latest
+    container: almalinux:9
+    needs: [prepare-deps]
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@v3.3.1
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install git dependencies
+        run: |
+          dnf -y install \
+            sudo \
+            git \
+            libtool \
+            which
+
+      - name: Install Almalinux 9 extra repositories
+        run : |
+          dnf -y update
+          dnf -y install dnf-plugins-core epel-release
+          dnf config-manager --set-enabled crb
+
+      - name: Install minimal dependencies
+        run: ./scripts/docs-almalinux9-minimal-build.sh
+
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: ./autogen.sh
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j ${{ env.CPUS }}
+      - run: ./src/suricata --build-info # check if we can run Suricata
 
   ubuntu-22-04-cov-ut:
     name: Ubuntu 22.04 (unittests coverage)
@@ -1869,6 +1919,45 @@ jobs:
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-netmap
       - run: make -j2
       - run: ./src/suricata --build-info | grep -E "Netmap support:\s+yes"
+
+  ubuntu-22-04-minimal-recommended-build:
+    name: Ubuntu 22.04 (Minimal/Recommended Build)
+    needs: [prepare-deps, prepare-cbindgen]
+    runs-on: ubuntu-22.04
+    steps:
+      # Cache Rust stuff.
+      - name: Cache cargo registry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install git dependencies
+        run: |
+          sudo apt update
+          sudo apt -y install \
+            git \
+            libtool
+
+      - uses: actions/checkout@v3.5.3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      
+      - name: Install minimal dependencies
+        run: ./scripts/docs-ubuntu-debian-minimal-build.sh
+
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
+      - run: make -j ${{ env.CPUS }}
+      - run: ./src/suricata --build-info # check if we can run Suricata
 
   ubuntu-22-04-dpdk-build:
     name: Ubuntu 22.04 (DPDK Build)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2242,7 +2242,6 @@ jobs:
                 ccache \
                 curl \
                 git \
-                gosu \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \
@@ -2317,7 +2316,6 @@ jobs:
                 ccache \
                 curl \
                 git \
-                gosu \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,9 @@ EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              $(SURICATA_UPDATE_DIR) \
 	     lua \
 	     acsite.m4 \
-	     scripts/generate-images.sh
+	     scripts/generate-images.sh \
+	     scripts/docs-almalinux9-minimal-build.sh \
+	     scripts/docs-ubuntu-debian-minimal-build.sh
 SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib etc python ebpf \
           $(SURICATA_UPDATE_DIR)
 

--- a/doc/userguide/capture-hardware/ebpf-xdp.rst
+++ b/doc/userguide/capture-hardware/ebpf-xdp.rst
@@ -80,15 +80,14 @@ Make sure you have ``clang`` (>=3.9) installed on the system  ::
 
  sudo apt install clang
 
-Some i386 headers will also be needed as eBPF is not x86_64 and some included headers
-are architecture specific ::
-
- sudo apt install libc6-dev-i386 --no-install-recommends
-
 libbpf
 ~~~~~~
 
 Suricata uses libbpf to interact with eBPF and XDP ::
+
+  sudo apt install libbpf-dev
+
+If the libbpf package is unavailable, it can be cloned from the repository ::
 
  git clone https://github.com/libbpf/libbpf.git
 
@@ -109,7 +108,7 @@ Compile and install Suricata
 To get Suricata source, you can use the usual ::
 
  git clone https://github.com/OISF/suricata.git
- cd suricata && git clone https://github.com/OISF/libhtp.git -b 0.5.x
+ cd suricata && ./scripts/bundle.sh
 
  ./autogen.sh
 

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -64,62 +64,19 @@ Common configure options
 
     Enables `DPDK <https://www.dpdk.org/>`_ packet capture method.
 
-Dependencies
-^^^^^^^^^^^^
-
-For Suricata's compilation you'll need the following libraries and their development headers installed::
-
-  libjansson, libpcap, libpcre2, libyaml, zlib
-
-The following tools are required::
-
-  make gcc (or clang) pkg-config rustc cargo
-
-Rust support::
-
-  rustc, cargo
-
-  Some distros don't provide or provide outdated Rust packages.
-  Rust can also be installed directly from the Rust project itself::
-
-    1) Install Rust https://www.rust-lang.org/en-US/install.html
-    2) Install cbindgen - if the cbindgen is not found in the repository
-       or the cbindgen version is lower than required, it can be
-       alternatively installed as: cargo install --force cbindgen
-    3) Make sure the cargo path is within your PATH environment
-        e.g. echo 'export PATH=”${PATH}:~/.cargo/bin”' >> ~/.bashrc
-        e.g. export PATH="${PATH}:/root/.cargo/bin"
+Dependencies and compilation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Ubuntu/Debian
 """""""""""""
 
 .. note:: The following instructions require ``sudo`` to be installed.
 
-Minimal::
-
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install build-essential git libjansson-dev libpcap-dev \
-                    libpcre2-dev libtool libyaml-dev make pkg-config zlib1g-dev
-    # On most distros installing cbindgen with package manager should be enough
-    sudo apt-get install cbindgen # alternative: cargo install --force cbindgen
-
-Recommended::
-
-    # Installed Rust and cargo as indicated above
-    sudo apt-get install autoconf automake build-essential ccache clang curl git \
-                    gosu jq libbpf-dev libcap-ng0 libcap-ng-dev libelf-dev \
-                    libevent-dev libgeoip-dev libhiredis-dev libjansson-dev \
-                    liblua5.1-dev libmagic-dev libnet1-dev libpcap-dev \
-                    libpcre2-dev libtool libyaml-0-2 libyaml-dev m4 make \
-                    pkg-config python3 python3-dev python3-yaml sudo zlib1g \
-                    zlib1g-dev
-    cargo install --force cbindgen
-
-Extra for iptables/nftables IPS integration::
-
-    sudo apt-get install libnetfilter-queue-dev libnetfilter-queue1  \
-                    libnetfilter-log-dev libnetfilter-log1      \
-                    libnfnetlink-dev libnfnetlink0
+.. literalinclude:: ../../scripts/docs-ubuntu-debian-minimal-build.sh
+    :caption: Minimal dependencies for Ubuntu/Debian
+    :language: bash
+    :start-after: # install-guide-documentation tag start: Minimal dependencies
+    :end-before: # install-guide-documentation tag end: Minimal dependencies
 
 CentOS, AlmaLinux, RockyLinux, Fedora, etc
 """"""""""""""""""""""""""""""""""""""""""
@@ -131,46 +88,50 @@ repository in most distros. You can enable it possibly by
 one of the following ways::
 
     sudo dnf -y update
-    sudo dnf -y install dnf-plugins-core
-    # AlmaLinux 8
+    sudo dnf -y install epel-release dnf-plugins-core
+    # AlmaLinux 8 / RockyLinux 8
     sudo dnf config-manager --set-enabled powertools
-    # AlmaLinux 9
+    # AlmaLinux 9 / RockyLinux 9
     sudo dnf config-manager --set-enable crb
     # Oracle Linux 8
     sudo dnf config-manager --set-enable ol8_codeready_builder
     # Oracle Linux 9
     sudo dnf config-manager --set-enable ol9_codeready_builder
 
-Minimal::
-
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y gcc gcc-c++ git jansson-devel libpcap-devel libtool \
-                   libyaml-devel make pcre2-devel which zlib-devel
-    cargo install --force cbindgen
-
-Recommended::
-
-    # Installed Rust and cargo as indicated above
-    sudo dnf install -y autoconf automake diffutils file-devel gcc gcc-c++ git \
-                   jansson-devel jq libcap-ng-devel libevent-devel \
-                   libmaxminddb-devel libnet-devel libnetfilter_queue-devel \
-                   libnfnetlink-devel libpcap-devel libtool libyaml-devel \
-                   lua-devel lz4-devel make nss-devel pcre2-devel pkgconfig \
-                   python3-devel python3-sphinx python3-yaml sudo which \
-                   zlib-devel
-    cargo install --force cbindgen
+.. literalinclude:: ../../scripts/docs-almalinux9-minimal-build.sh
+    :caption: Minimal dependencies for RPM-based distributions
+    :language: bash
+    :start-after: # install-guide-documentation tag start: Minimal RPM-based dependencies
+    :end-before: # install-guide-documentation tag end: Minimal RPM-based dependencies
 
 Compilation
-^^^^^^^^^^^
+"""""""""""
 
 Follow these steps from your Suricata directory::
 
-    ./scripts/bundle.sh
-    ./autogen.sh
     ./configure # you may want to add additional parameters here
     # ./configure --help to get all available parameters
-    make -j8 # j is for paralleling, you may de/increase depending on your CPU
+    # j is for adding concurrency to make; the number indicates how much 
+    # concurrency so choose a number that is suitable for your build system
+    make -j8 
     make install # to install your Suricata compiled binary
+    # make install-full - installs configuration and rulesets as well
+
+Rust support
+""""""""""""
+
+  Rust packages can be found in package managers but some distributions
+  don't provide Rust or provide outdated Rust packages.
+  In case of insufficient version you can install Rust directly
+  from the Rust project itself::
+
+    1) Install Rust https://www.rust-lang.org/en-US/install.html
+    2) Install cbindgen - if the cbindgen is not found in the repository
+       or the cbindgen version is lower than required, it can be
+       alternatively installed as: cargo install --force cbindgen
+    3) Make sure the cargo path is within your PATH environment
+       echo 'export PATH="~/.cargo/bin:${PATH}"' >> ~/.bashrc
+       export PATH="~/.cargo/bin:${PATH}"
 
 Auto-Setup
 ^^^^^^^^^^

--- a/scripts/docs-almalinux9-minimal-build.sh
+++ b/scripts/docs-almalinux9-minimal-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Serves for RPM-based docs and is verified by Github Actions
+
+# install-guide-documentation tag start: Minimal RPM-based dependencies
+sudo dnf install -y rustc cargo cbindgen
+sudo dnf install -y gcc gcc-c++ jansson-devel libpcap-devel \
+    libyaml-devel make pcre2-devel zlib-devel
+# install-guide-documentation tag end: Minimal RPM-based dependencies

--- a/scripts/docs-ubuntu-debian-minimal-build.sh
+++ b/scripts/docs-ubuntu-debian-minimal-build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Serves for Ubuntu/Debian docs and is verified by Github Actions
+
+# install-guide-documentation tag start: Minimal dependencies
+sudo apt -y install autoconf automake build-essential cargo \
+    cbindgen libjansson-dev libpcap-dev libpcre2-dev libtool \
+    libyaml-dev make pkg-config rustc zlib1g-dev
+# install-guide-documentation tag end: Minimal dependencies


### PR DESCRIPTION
Follow-up of #11339

Link to Redmine tickets:

https://redmine.openinfosecfoundation.org/issues/6601
https://redmine.openinfosecfoundation.org/issues/6687

Describe changes:
v2
commit updates to fix cherry pick hashes

v1
backport from the master branch
small edit in eBPF instructions to prefer libbpf-dev package to the cloning&compilation
porting changes from the improved version of installation instructions that got merged into master-6.0.x