### PR TITLE
Applayer plugin 5053 v2.1

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1139,7 +1139,6 @@ static void AppLayerSetupExceptionPolicyPerProtoCounters(
     }
 }
 
-#define IPPROTOS_MAX 2
 void AppLayerSetupCounters(void)
 {
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
@@ -1162,7 +1161,7 @@ void AppLayerSetupCounters(void)
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
-    for (uint8_t p = 0; p < IPPROTOS_MAX; p++) {
+    for (uint8_t p = 0; p < FLOW_PROTO_APPLAYER_MAX; p++) {
         const uint8_t ipproto = ipprotos[p];
         const uint8_t ipproto_map = FlowGetProtoMapping(ipproto);
         const char *ipproto_suffix = (ipproto == IPPROTO_TCP) ? "_tcp" : "_udp";
@@ -1257,7 +1256,7 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
         }
     }
 
-    for (uint8_t p = 0; p < IPPROTOS_MAX; p++) {
+    for (uint8_t p = 0; p < FLOW_PROTO_APPLAYER_MAX; p++) {
         const uint8_t ipproto = ipprotos[p];
         const uint8_t ipproto_map = FlowGetProtoMapping(ipproto);
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -355,10 +355,10 @@ typedef struct PktProfiling_ {
 
     PktProfilingTmmData tmm[TMM_SIZE];
     PktProfilingData flowworker[PROFILE_FLOWWORKER_SIZE];
-    PktProfilingAppData app[ALPROTO_MAX];
     PktProfilingDetectData detect[PROF_DETECT_SIZE];
     PktProfilingLoggerData logger[LOGGER_SIZE];
     uint64_t proto_detect;
+    PktProfilingAppData app[];
 } PktProfiling;
 
 #endif /* PROFILING */

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -28,6 +28,7 @@
 #include "detect-engine-mpm.h"
 #include "detect-engine-prefilter.h"
 #include "detect-parse.h"
+#include "detect-engine-content-inspection.h"
 
 int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver)
 {
@@ -104,4 +105,28 @@ int DetectHelperKeywordRegister(const SCSigTableElmt *kw)
     sigmatch_table[DETECT_TBLSIZE_IDX].Free = (void (*)(DetectEngineCtx * de, void *ptr)) kw->Free;
     DETECT_TBLSIZE_IDX++;
     return DETECT_TBLSIZE_IDX - 1;
+}
+
+InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf)
+{
+    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, index);
+    if (buffer == NULL) {
+        return NULL;
+    }
+    if (buffer->initialized) {
+        return buffer;
+    }
+
+    const uint8_t *data = NULL;
+    uint32_t data_len = 0;
+
+    if (!GetBuf(txv, flow_flags, index, &data, &data_len)) {
+        InspectionBufferSetupMultiEmpty(buffer);
+        return NULL;
+    }
+    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    buffer->flags = DETECT_CI_FLAGS_SINGLE;
+    return buffer;
 }

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -32,10 +32,16 @@ int DetectHelperKeywordRegister(const SCSigTableElmt *kw);
 int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
+typedef bool (*MultiGetTxBuffer)(void *, uint8_t, uint32_t, const uint8_t **, uint32_t *);
+
 InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
         const int list_id, SimpleGetTxBuffer GetBuf);
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         bool toclient, bool toserver, InspectionBufferGetDataPtr GetData);
+
+InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf);
 
 #endif /* SURICATA_DETECT_ENGINE_HELPER_H */

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -94,11 +94,14 @@ void DetectFiledataRegister(void)
 }
 
 static void SetupDetectEngineConfig(DetectEngineCtx *de_ctx) {
-    if (de_ctx->filedata_config_initialized)
+    if (de_ctx->filedata_config)
         return;
 
+    de_ctx->filedata_config = SCMalloc(ALPROTO_MAX * sizeof(DetectFileDataCfg));
+    if (unlikely(de_ctx->filedata_config))
+        return;
     /* initialize default */
-    for (int i = 0; i < (int)ALPROTO_MAX; i++) {
+    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
         de_ctx->filedata_config[i].content_limit = FILEDATA_CONTENT_LIMIT;
         de_ctx->filedata_config[i].content_inspect_min_size = FILEDATA_CONTENT_INSPECT_MIN_SIZE;
     }
@@ -109,8 +112,6 @@ static void SetupDetectEngineConfig(DetectEngineCtx *de_ctx) {
     de_ctx->filedata_config[ALPROTO_SMTP].content_limit = smtp_config.content_limit;
     de_ctx->filedata_config[ALPROTO_SMTP].content_inspect_min_size =
             smtp_config.content_inspect_min_size;
-
-    de_ctx->filedata_config_initialized = true;
 }
 
 /**
@@ -220,9 +221,12 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
 
     const uint64_t file_size = FileDataSize(cur_file);
     const DetectEngineCtx *de_ctx = det_ctx->de_ctx;
-    const uint32_t content_limit = de_ctx->filedata_config[f->alproto].content_limit;
-    const uint32_t content_inspect_min_size =
-            de_ctx->filedata_config[f->alproto].content_inspect_min_size;
+    uint32_t content_limit = FILEDATA_CONTENT_LIMIT;
+    uint32_t content_inspect_min_size = FILEDATA_CONTENT_INSPECT_MIN_SIZE;
+    if (de_ctx->filedata_config) {
+        content_limit = de_ctx->filedata_config[f->alproto].content_limit;
+        content_inspect_min_size = de_ctx->filedata_config[f->alproto].content_inspect_min_size;
+    }
 
     SCLogDebug("[list %d] content_limit %u, content_inspect_min_size %u", list_id, content_limit,
             content_inspect_min_size);

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -33,6 +33,7 @@
 #include "detect-engine-mpm.h"
 #include "detect-engine-prefilter.h"
 #include "detect-engine-content-inspection.h"
+#include "detect-engine-helper.h"
 
 #include "detect-http2.h"
 #include "util-byte.h"
@@ -102,30 +103,8 @@ static InspectionBuffer *GetHttp2HNameData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f, const uint8_t flags, void *txv,
         int list_id, uint32_t local_id)
 {
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    uint32_t b_len = 0;
-    const uint8_t *b = NULL;
-
-    if (rs_http2_tx_get_header_name(txv, flags, local_id, &b, &b_len) != 1) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    if (b == NULL || b_len == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(buffer, transforms, b, b_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
+    return DetectHelperGetMultiData(det_ctx, transforms, _f, flags, txv, list_id, local_id,
+            (MultiGetTxBuffer)rs_http2_tx_get_header_name);
 }
 
 void DetectHttp2Register(void)

--- a/src/detect.h
+++ b/src/detect.h
@@ -846,6 +846,11 @@ enum DetectEngineType
  */
 #define FLOW_STATES 2
 
+typedef struct {
+    uint32_t content_limit;
+    uint32_t content_inspect_min_size;
+} DetectFileDataCfg;
+
 /** \brief main detection engine ctx */
 typedef struct DetectEngineCtx_ {
     bool failure_fatal;
@@ -945,8 +950,6 @@ typedef struct DetectEngineCtx_ {
     /** The rule errored out due to missing requirements. */
     bool sigerror_requires;
 
-    bool filedata_config_initialized;
-
     /* specify the configuration for mpm context factory */
     uint8_t sgh_mpm_ctx_cnf;
 
@@ -954,10 +957,7 @@ typedef struct DetectEngineCtx_ {
     /** hash list of keywords that need thread local ctxs */
     HashListTable *keyword_hash;
 
-    struct {
-        uint32_t content_limit;
-        uint32_t content_inspect_min_size;
-    } filedata_config[ALPROTO_MAX];
+    DetectFileDataCfg *filedata_config;
 
 #ifdef PROFILE_RULES
     struct SCProfileDetectCtx_ *profile_ctx;

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -35,12 +35,11 @@
 /** per thread data for this module, contains a list of per thread
  *  data for the packet loggers. */
 typedef struct OutputTxLoggerThreadData_ {
-    OutputLoggerThreadStore *store[ALPROTO_MAX];
-
     /* thread local data from file api */
     OutputFileLoggerThreadData *file;
     /* thread local data from filedata api */
     OutputFiledataLoggerThreadData *filedata;
+    OutputLoggerThreadStore *store[];
 } OutputTxLoggerThreadData;
 
 /* logger instance, a module + a output ctx,
@@ -542,7 +541,8 @@ end:
  *  loggers */
 static TmEcode OutputTxLogThreadInit(ThreadVars *tv, const void *_initdata, void **data)
 {
-    OutputTxLoggerThreadData *td = SCCalloc(1, sizeof(*td));
+    OutputTxLoggerThreadData *td =
+            SCCalloc(1, sizeof(*td) + ALPROTO_MAX * sizeof(OutputLoggerThreadStore *));
     if (td == NULL)
         return TM_ECODE_FAILED;
 

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -1195,9 +1195,8 @@ PktProfiling *SCProfilePacketStart(void)
 {
     uint64_t sample = SC_ATOMIC_ADD(samples, 1);
     if (sample % rate == 0)
-        return SCCalloc(1, sizeof(PktProfiling));
-    else
-        return NULL;
+        return SCCalloc(1, sizeof(PktProfiling) + ALPROTO_MAX * sizeof(PktProfilingAppData));
+    return NULL;
 }
 
 /* see if we want to profile rules for this packet */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
Preliminary work for https://redmine.openinfosecfoundation.org/issues/5053

Describe changes:
- detect: helper function for multibuffer
- get ready to use dynamic number of app-layer protos (also work with static constant) in some places

Small PR good in itself.

Still more work to do : I guess stack allocated arrays are fine, but the global variables cf `git grep '\[ALPROTO_MAX'`  like `src/runmodes.c:static LoggerId logger_bits[ALPROTO_MAX];` need to be allocated and freed, and the app-layer init needs to be taken care of, so that we know `ALPROTO_MAX` final value...