### PR TITLE
Detect prefilter events 6291 v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -68,7 +68,7 @@ Metadata::
             #payload: yes             # enable dumping payload in Base64
             #payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             #payload-printable: yes   # enable dumping payload in printable (lossy) format
-            #payload-length: yes      # enable dumping payload length
+            #payload-length: yes      # enable dumping payload length, including the gaps
             #packet: yes              # enable dumping of packet (without stream segments)
             #http-body: yes           # Requires metadata; enable dumping of http body in Base64
             #http-body-printable: yes # Requires metadata; enable dumping of http body in printable format

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -37,7 +37,7 @@ outputs:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
-            # payload-length: yes      # enable dumping payload length
+            # payload-length: yes      # enable dumping payload length, including the gaps
             # packet: yes              # enable dumping of packet (without stream segments)
             # http-body: yes           # Requires metadata; enable dumping of http body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of http body in printable format

--- a/src/detect-engine-event.c
+++ b/src/detect-engine-event.c
@@ -80,14 +80,11 @@ static bool PrefilterDecodeEventIsPrefilterable(const Signature *s)
 
 static void PrefilterPacketEventSet(PrefilterPacketHeaderValue *v, void *smctx)
 {
-    const DetectEngineEventData *a = smctx;
-    v->u8[0] = a->event;
 }
 
 static bool PrefilterPacketEventCompare(PrefilterPacketHeaderValue v, void *smctx)
 {
-    const DetectEngineEventData *a = smctx;
-    return (v.u8[0] == a->event);
+    return true;
 }
 
 static void PrefilterPacketEventMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
@@ -96,10 +93,7 @@ static void PrefilterPacketEventMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
-    DetectEngineEventData de;
-    de.event = ctx->v1.u8[0];
-
-    if (ENGINE_ISSET_EVENT(p, de.event)) {
+    if (p->events.cnt > 0) {
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -295,8 +295,9 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
     const AppProto proto = FlowGetAppProtocol(p->flow);
     EveJsonSimpleAppLayerLogger *al = SCEveJsonSimpleGetLogger(proto);
     JsonBuilderMark mark = { 0, 0, 0 };
+    void *state;
     if (al && al->LogTx) {
-        void *state = FlowGetAppState(p->flow);
+        state = FlowGetAppState(p->flow);
         if (state) {
             void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
             if (tx) {
@@ -386,11 +387,11 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
             }
             break;
         case ALPROTO_DCERPC:
-            jb_get_mark(jb, &mark);
-            void *state = FlowGetAppState(p->flow);
+            state = FlowGetAppState(p->flow);
             if (state) {
                 void *tx = AppLayerParserGetTx(p->flow->proto, proto, state, tx_id);
                 if (tx) {
+                    jb_get_mark(jb, &mark);
                     jb_open_object(jb, "dcerpc");
                     if (p->proto == IPPROTO_TCP) {
                         if (!rs_dcerpc_log_json_record_tcp(state, tx, jb)) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,7 +164,7 @@ outputs:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
-            # payload-length: yes      # enable dumping payload length
+            # payload-length: yes      # enable dumping payload length, including the gaps
             # packet: yes              # enable dumping of packet (without stream segments)
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6728

Describe changes:
- add prefilter for decode-event and such

Draft because of last commit : which version is better for prefilter ? last commit or the one before...
When this looks ok, I should add app-layer-event in a similar way

Follows on https://github.com/OISF/suricata/pull/11328 with rebase after merge of first commits

cc @coledishington do you still need https://github.com/OISF/suricata/pull/10202 ?