### PR TITLE
detect/snmp: do not bother to free a null pointer

### DIFF
--- a/src/detect-snmp-version.c
+++ b/src/detect-snmp-version.c
@@ -140,7 +140,7 @@ static int DetectSNMPVersionSetup (DetectEngineCtx *de_ctx, Signature *s,
     dd = DetectSNMPVersionParse(rawstr);
     if (dd == NULL) {
         SCLogError("Parsing \'%s\' failed", rawstr);
-        goto error;
+        return -1;
     }
 
     /* okay so far so good, lets get this into a SigMatch


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7134

Describe changes:
- detect/snmp: do not bother to free a null pointer

Not present in master as detect-snmp-version.c was moved to rust

#11400 with ticket