### PR TITLE
detect/analyzer: add policy

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -978,6 +978,32 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     }
     jb_close(ctx.js);
 
+    jb_open_object(ctx.js, "policy");
+    jb_open_array(ctx.js, "actions");
+    if (s->action & ACTION_ALERT) {
+        jb_append_string(ctx.js, "alert");
+    }
+    if (s->action & ACTION_DROP) {
+        jb_append_string(ctx.js, "drop");
+    }
+    if (s->action & ACTION_PASS) {
+        jb_append_string(ctx.js, "pass");
+    }
+    jb_close(ctx.js);
+    enum SignaturePropertyFlowAction flow_action = signature_properties[s->type].flow_action;
+    switch (flow_action) {
+        case SIG_PROP_FLOW_ACTION_PACKET:
+            jb_set_string(ctx.js, "scope", "packet");
+            break;
+        case SIG_PROP_FLOW_ACTION_FLOW:
+            jb_set_string(ctx.js, "scope", "flow");
+            break;
+        case SIG_PROP_FLOW_ACTION_FLOW_IF_STATEFUL:
+            jb_set_string(ctx.js, "scope", "flow_if_stateful");
+            break;
+    }
+    jb_close(ctx.js);
+
     switch (s->type) {
         case SIG_TYPE_NOT_SET:
             jb_set_string(ctx.js, "type", "unset");


### PR DESCRIPTION
Adds a new policy object. In it actions will be listed, as well as the scope. The scope is about where drop/pass are applied.

Example output for a drop + noalert rule that applies the drop to the flow:
```json
    "policy": {
        "actions": [
            "drop"
        ],
        "scope": "flow"
    },
```
Example for a drop rule that only applies to the packet:
```json
  "policy": {
    "actions": [
      "alert",
      "drop"
    ],
    "scope": "packet"
  },
```
Looking for feedback on:
1. naming
2. structure