### PR TITLE
Applayer plugin 5053 v2.5

### DIFF
--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -61,7 +61,7 @@ typedef struct OutputTxLogger_ {
     void (*ThreadExitPrintStats)(ThreadVars *, void *);
 } OutputTxLogger;
 
-static OutputTxLogger *list[ALPROTO_MAX] = { NULL };
+static OutputTxLogger **list = NULL;
 
 int OutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto,
                            TxLogger LogFunc,
@@ -668,6 +668,12 @@ static uint32_t OutputTxLoggerGetActiveCount(void)
 
 void OutputTxLoggerRegister (void)
 {
+    BUG_ON(list);
+    list = SCCalloc(ALPROTO_MAX, sizeof(OutputTxLogger *));
+    if (unlikely(list == NULL)) {
+        FatalError("Failed to allocate OutputTx list");
+    }
+
     OutputRegisterRootLogger(OutputTxLogThreadInit, OutputTxLogThreadDeinit,
         OutputTxLogExitPrintStats, OutputTxLog, OutputTxLoggerGetActiveCount);
 }
@@ -683,4 +689,6 @@ void OutputTxShutdown(void)
         }
         list[alproto] = NULL;
     }
+    SCFree(list);
+    list = NULL;
 }

--- a/src/output.c
+++ b/src/output.c
@@ -669,6 +669,8 @@ OutputModule *OutputGetModuleByConfName(const char *conf_name)
     return NULL;
 }
 
+static EveJsonSimpleAppLayerLogger *simple_json_applayer_loggers;
+
 /**
  * \brief Deregister all modules.  Useful for a memory clean exit.
  */
@@ -680,6 +682,8 @@ void OutputDeregisterAll(void)
         TAILQ_REMOVE(&output_modules, module, entries);
         SCFree(module);
     }
+    SCFree(simple_json_applayer_loggers);
+    simple_json_applayer_loggers = NULL;
 }
 
 static int drop_loggers = 0;
@@ -895,11 +899,73 @@ void TmModuleLoggerRegister(void)
     OutputRegisterLoggers();
 }
 
+EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto)
+{
+    if (alproto < ALPROTO_MAX) {
+        return &simple_json_applayer_loggers[alproto];
+    }
+    return NULL;
+}
+
+static void RegisterSimpleJsonApplayerLogger(
+        AppProto alproto, EveJsonSimpleTxLogFunc LogTx, const char *name)
+{
+    simple_json_applayer_loggers[alproto].LogTx = LogTx;
+    if (name) {
+        simple_json_applayer_loggers[alproto].name = name;
+    } else {
+        simple_json_applayer_loggers[alproto].name = AppProtoToString(alproto);
+    }
+}
+
 /**
  * \brief Register all root loggers.
  */
 void OutputRegisterRootLoggers(void)
 {
+    simple_json_applayer_loggers = SCCalloc(ALPROTO_MAX, sizeof(EveJsonSimpleAppLayerLogger));
+    if (unlikely(simple_json_applayer_loggers == NULL)) {
+        FatalError("Failed to allocate simple_json_applayer_loggers");
+    }
+    // ALPROTO_HTTP1 special: uses some options flags
+    RegisterSimpleJsonApplayerLogger(ALPROTO_FTP, EveFTPLogCommand, NULL);
+    // ALPROTO_SMTP special: uses state
+    RegisterSimpleJsonApplayerLogger(ALPROTO_TLS, JsonTlsLogJSONExtended, NULL);
+    // no cast here but done in rust for SSHTransaction
+    RegisterSimpleJsonApplayerLogger(ALPROTO_SSH, rs_ssh_log_json, NULL);
+    // ALPROTO_SMB special: uses state
+    // ALPROTO_DCERPC special: uses state
+    RegisterSimpleJsonApplayerLogger(ALPROTO_DNS, AlertJsonDns, NULL);
+    // either need a cast here or in rust for ModbusTransaction, done here
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_MODBUS, (EveJsonSimpleTxLogFunc)rs_modbus_to_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_ENIP, SCEnipLoggerLog, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_DNP3, AlertJsonDnp3, NULL);
+    // ALPROTO_NFS special: uses state
+    // underscore instead of dash for ftp_data
+    RegisterSimpleJsonApplayerLogger(ALPROTO_FTPDATA, EveFTPDataAddMetadata, "ftp_data");
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
+    // ALPROTO_IKE special: uses state
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, rs_quic_to_json, NULL);
+    // ALPROTO_DHCP TODO missing
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_SNMP, (EveJsonSimpleTxLogFunc)rs_snmp_log_json_response, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_RFB, rs_rfb_logger_log, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_MQTT, JsonMQTTAddMetadata, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_PGSQL, JsonPgsqlAddMetadata, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_WEBSOCKET, rs_websocket_logger_log, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_TEMPLATE, rs_template_logger_log, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_RDP, (EveJsonSimpleTxLogFunc)rs_rdp_to_json, NULL);
+    // special case : http2 is logged in http object
+    RegisterSimpleJsonApplayerLogger(ALPROTO_HTTP2, rs_http2_log_json, "http");
+    // underscore instead of dash for bittorrent_dht
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_BITTORRENT_DHT, rs_bittorrent_dht_logger_log, "bittorrent_dht");
+
     OutputPacketLoggerRegister();
     OutputFiledataLoggerRegister();
     OutputFileLoggerRegister();
@@ -916,24 +982,7 @@ static int JsonGenericLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return TM_ECODE_FAILED;
     }
 
-    const char *name;
-    switch (al->proto) {
-        case ALPROTO_HTTP2:
-            // special case
-            name = "http";
-            break;
-        case ALPROTO_FTPDATA:
-            // underscore instead of dash
-            name = "ftp_data";
-            break;
-        case ALPROTO_BITTORRENT_DHT:
-            // underscore instead of dash
-            name = "bittorrent_dht";
-            break;
-        default:
-            name = AppProtoToString(al->proto);
-    }
-    JsonBuilder *js = CreateEveHeader(p, dir, name, NULL, thread->ctx);
+    JsonBuilder *js = CreateEveHeader(p, dir, al->name, NULL, thread->ctx);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }
@@ -1114,56 +1163,4 @@ void OutputRegisterLoggers(void)
     }
     /* ARP JSON logger */
     JsonArpLogRegister();
-}
-
-static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {
-    { ALPROTO_UNKNOWN, NULL },
-    { ALPROTO_HTTP1, NULL }, // special: uses some options flags
-    { ALPROTO_FTP, EveFTPLogCommand },
-    { ALPROTO_SMTP, NULL }, // special: uses state
-    { ALPROTO_TLS, JsonTlsLogJSONExtended },
-    { ALPROTO_SSH, rs_ssh_log_json },
-    { ALPROTO_IMAP, NULL },   // protocol detection only
-    { ALPROTO_JABBER, NULL }, // no parser, no logging
-    { ALPROTO_SMB, NULL },    // special: uses state
-    { ALPROTO_DCERPC, NULL }, // special: uses state
-    { ALPROTO_IRC, NULL },    // no parser, no logging
-    { ALPROTO_DNS, AlertJsonDns },
-    { ALPROTO_MODBUS, (EveJsonSimpleTxLogFunc)rs_modbus_to_json },
-    { ALPROTO_ENIP, SCEnipLoggerLog },
-    { ALPROTO_DNP3, AlertJsonDnp3 },
-    { ALPROTO_NFS, NULL }, // special: uses state
-    { ALPROTO_NTP, NULL }, // no logging
-    { ALPROTO_FTPDATA, EveFTPDataAddMetadata },
-    { ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request },
-    { ALPROTO_IKE, NULL }, // special: uses state
-    { ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response },
-    { ALPROTO_QUIC, rs_quic_to_json },
-    { ALPROTO_DHCP, NULL }, // TODO missing
-    { ALPROTO_SNMP, (EveJsonSimpleTxLogFunc)rs_snmp_log_json_response },
-    { ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json },
-    { ALPROTO_RFB, rs_rfb_logger_log },
-    { ALPROTO_MQTT, JsonMQTTAddMetadata },
-    { ALPROTO_PGSQL, JsonPgsqlAddMetadata },
-    { ALPROTO_TELNET, NULL }, // no logging
-    { ALPROTO_WEBSOCKET, rs_websocket_logger_log },
-    { ALPROTO_TEMPLATE, rs_template_logger_log },
-    { ALPROTO_RDP, (EveJsonSimpleTxLogFunc)rs_rdp_to_json },
-    { ALPROTO_HTTP2, rs_http2_log_json },
-    { ALPROTO_BITTORRENT_DHT, rs_bittorrent_dht_logger_log },
-    { ALPROTO_POP3, NULL }, // protocol detection only
-    { ALPROTO_HTTP, NULL }, // signature protocol, not for app-layer logging
-    { ALPROTO_FAILED, NULL },
-#ifdef UNITTESTS
-    { ALPROTO_TEST, NULL },
-#endif /* UNITESTS */
-};
-
-EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto)
-{
-    if (alproto < ALPROTO_MAX) {
-        BUG_ON(simple_json_applayer_loggers[alproto].proto != alproto);
-        return &simple_json_applayer_loggers[alproto];
-    }
-    return NULL;
 }

--- a/src/output.h
+++ b/src/output.h
@@ -192,8 +192,8 @@ void OutputClearActiveLoggers(void);
 typedef bool (*EveJsonSimpleTxLogFunc)(void *, struct JsonBuilder *);
 
 typedef struct EveJsonSimpleAppLayerLogger {
-    AppProto proto;
     EveJsonSimpleTxLogFunc LogTx;
+    const char *name;
 } EveJsonSimpleAppLayerLogger;
 
 EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -540,7 +540,7 @@ static void RunOutputFreeList(void)
 
 static int file_logger_count = 0;
 static int filedata_logger_count = 0;
-static LoggerId logger_bits[ALPROTO_MAX];
+static LoggerId *logger_bits = NULL;
 
 int RunModeOutputFiledataEnabled(void)
 {
@@ -592,6 +592,7 @@ void RunModeShutDown(void)
 
     OutputClearActiveLoggers();
 
+    SCFree(logger_bits);
     /* Reset logger counts. */
     file_logger_count = 0;
     filedata_logger_count = 0;
@@ -790,8 +791,11 @@ void RunModeInitializeOutputs(void)
     char tls_log_enabled = 0;
     char tls_store_present = 0;
 
-    memset(&logger_bits, 0, sizeof(logger_bits));
-
+    // ALPROTO_MAX is set to its final value
+    logger_bits = SCCalloc(ALPROTO_MAX, sizeof(LoggerId));
+    if (unlikely(logger_bits == NULL)) {
+        FatalError("Failed to allocate logger_bits");
+    }
     TAILQ_FOREACH(output, &outputs->head, next) {
 
         output_config = ConfNodeLookupChild(output, output->val);

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -378,8 +378,8 @@ void THashShutdown(THashTableContext *ctx)
         }
         SCFreeAligned(ctx->array);
         ctx->array = NULL;
+        (void)SC_ATOMIC_SUB(ctx->memuse, ctx->config.hash_size * sizeof(THashHashRow));
     }
-    (void) SC_ATOMIC_SUB(ctx->memuse, ctx->config.hash_size * sizeof(THashHashRow));
     THashDataQueueDestroy(&ctx->spare_q);
     DEBUG_VALIDATE_BUG_ON(SC_ATOMIC_GET(ctx->memuse) != 0);
     SCFree(ctx);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
Preliminary work for https://redmine.openinfosecfoundation.org/issues/5053

Describe changes:
- get ready to use dynamic number of app-layer protos for some global arrays : run modes and output

Small PR good in itself.

#11373 next round
Based on #11426 with review taken into account

Still more work to do : I guess stack allocated arrays are fine, but the global variables cf `git grep '\[ALPROTO_MAX'`  in
- app-layer-detect-proto.c
- app-layer-frames.c
- app-layer-parser.c
- app-layer-protos.c
- app-layer.c
need to be allocated and freed, with taking care of the initialization order, so that we know `ALPROTO_MAX` final value...