### PR TITLE
dns: eve dns v3 logging - v12

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -219,7 +219,11 @@ In the ``custom`` option values from both columns can be used. The
 DNS
 ~~~
 
-.. note:: As of Suricata 7.0 the v1 EVE DNS format has been removed.
+.. note:: 
+
+   As of Suricata 7.0 the v1 EVE DNS format has been removed.
+
+   Version 2 EVE DNS will be removed in Suricata 9.
 
 DNS records are logged as one entry for the request, and one entry for
 the response.
@@ -227,7 +231,7 @@ the response.
 YAML::
 
         - dns:
-            #version: 2
+            #version: 3
 
             # Enable/disable this logger. Default: enabled.
             #enabled: yes

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -65,6 +65,9 @@ Major changes
 - Datasets of type String now include the length of the strings to determine if the memcap value is reached.
   This may lead to memcaps being hit for older setups that didn't take that into account.
   For more details, check https://redmine.openinfosecfoundation.org/issues/3910
+- DNS logging has been modified to be more consistent across requests,
+  responses and alerts. See :doc:`DNS Logging Changes for 8.0
+  <upgrade/8.0-dns-logging-changes>`.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/doc/userguide/upgrade/8.0-dns-logging-changes.rst
+++ b/doc/userguide/upgrade/8.0-dns-logging-changes.rst
@@ -1,0 +1,260 @@
+:orphan: Document not referenced in a toctree, so add this.
+
+DNS EVE Logging Changes for 8.0
+===============================
+
+Suricata 8.0 modifies the DNS logging in ``dns`` and ``alert`` records
+to a version ``3`` logging format. These changes address a lack of
+fidelity in alerts for DNS responses, as well as unify the format of
+the ``dns`` object accross ``dns`` and ``alert`` objects.
+
+Ticket: https://redmine.openinfosecfoundation.org/issues/6281
+
+The changes are summarized below:
+
+* DNS requests now have a type of ``request`` instead of ``query``.
+
+* DNS responses now have a type of ``response`` instead of ``answer``.
+
+* DNS requests will now log the queries in an array instead of logging
+  multiple request events in the case where the request contained
+  multiple queries. This was already done for DNS requests logged as
+  part of an ``alert``.
+
+  .. list-table::
+     :widths: 50 50
+     :header-rows: 1
+
+     * - 7.0
+       - 8.0
+     * - .. code-block::
+
+             {
+               "event_type": "dns",
+               "dns": {
+                 "type": "query",
+                 "id": 0,
+                 "rrname": "www.suricata.io",
+                 "rrtype": "A",
+                 "tx_id": 0,
+                 "opcode": 0
+               }
+             }
+
+       - .. code-block::
+
+             {
+               "event_type": "dns",
+               "dns": {
+                 "version": 3,
+                 "type": "request",
+                 "tx_id": 0,
+                 "id": 0,
+                 "flags": "100",
+                 "rd": true,
+                 "opcode": 0,
+                 "rcode": "NOERROR",
+                 "queries": [
+                   {
+                     "rrname": "www.suricata.io",
+                     "rrtype": "A"
+                   }
+                 ]
+               }
+             }
+
+* DNS responses now log the queries in a ``queries`` array instead of
+  logging the first ``rrname`` and ``rrtype`` directly in the ``dns``
+  object.
+
+  .. list-table::
+     :header-rows: 1
+
+     * - 7.0
+       - 8.0
+     * - .. code-block::
+
+           {
+             "event_type": "dns",
+             "dns": {
+               "version": 2,
+               "type": "answer",
+               "id": 0,
+               "flags": "8180",
+               "qr": true,
+               "rd": true,
+               "ra": true,
+               "opcode": 0,
+               "rrname": "www.suricata.io",
+               "rrtype": "A",
+               "rcode": "NOERROR",
+               "answers": [
+                 {
+                   "rrname": "www.suricata.io",
+                   "rrtype": "CNAME",
+                   "ttl": 3597,
+                   "rdata": "suricata.io"
+                 },
+                 {
+                   "rrname": "suricata.io",
+                   "rrtype": "A",
+                   "ttl": 597,
+                   "rdata": "35.212.0.44"
+                 }
+               ]
+             }
+           }
+       - .. code-block::
+
+             {
+               "event_type": "dns",
+               "dns": {
+                 "version": 3,
+                 "type": "response",
+                 "tx_id": 1,
+                 "id": 0,
+                 "flags": "8180",
+                 "qr": true,
+                 "rd": true,
+                 "ra": true,
+                 "opcode": 0,
+                 "rcode": "NOERROR",
+                 "queries": [
+                   {
+                     "rrname": "www.suricata.io",
+                     "rrtype": "A"
+                   }
+                 ],
+                 "answers": [
+                   {
+                     "rrname": "www.suricata.io",
+                     "rrtype": "CNAME",
+                     "ttl": 3597,
+                     "rdata": "suricata.io"
+                   },
+                   {
+                     "rrname": "suricata.io",
+                     "rrtype": "A",
+                     "ttl": 597,
+                     "rdata": "35.212.0.44"
+                   }
+                 ],
+               }
+             }
+
+* DNS requests logged in an alert object will now log the ``answers``
+  as an array. See above 8.0 example for the format. The ``dns``
+  object is now consistent across DNS requests and responses, as well
+  as in ``alerts``.
+
+  * Example of alert on DNS request
+
+    .. list-table::
+       :header-rows: 1
+
+       * - 7.0
+         - 8.0
+       * - .. code-block::
+
+               {
+                 "event_type": "alert",
+                 "dns": {
+                   "query": [
+                     {
+                       "type": "query",
+                       "id": 0,
+                       "rrname": "www.suricata.io",
+                       "rrtype": "A",
+                       "tx_id": 0,
+                       "opcode": 0
+                     }
+                   ]
+                 }
+               }
+
+         - .. code-block::
+
+               {
+                 "event_type": "alert",
+                 "dns": {
+                   "version": 3,
+                   "type": "request",
+                   "tx_id": 0,
+                   "id": 0,
+                   "flags": "100",
+                   "rd": true,
+                   "opcode": 0,
+                   "rcode": "NOERROR",
+                   "queries": [
+                     {
+                       "rrname": "www.suricata.io",
+                       "rrtype": "A"
+                     }
+                   ]
+                 },
+               }
+
+  * Example of alert on DNS response
+  
+    .. list-table::
+      :header-rows: 1
+
+      * - 7.0
+        - 8.0
+      * - .. code-block::
+
+              {
+                "event_type": "alert",
+                "dns": {
+                  "answer": {
+                    "version": 2,
+                    "type": "answer",
+                    "id": 0,
+                    "flags": "8180",
+                    "qr": true,
+                    "rd": true,
+                    "ra": true,
+                    "opcode": 0,
+                    "rrname": "www.suricata.io",
+                    "rrtype": "A",
+                    "rcode": "NOERROR"
+                  }
+                }
+              }
+
+        - .. code-block::
+
+              {
+                "event_type": "alert",
+                "dns": {
+                  "version": 3,
+                  "type": "response",
+                  "tx_id": 1,
+                  "id": 0,
+                  "flags": "8180",
+                  "qr": true,
+                  "rd": true,
+                  "ra": true,
+                  "opcode": 0,
+                  "rcode": "NOERROR",
+                  "queries": [
+                    {
+                      "rrname": "www.suricata.io",
+                      "rrtype": "A"
+                  ],
+                  "answers": [
+                    {
+                      "rrname": "www.suricata.io",
+                      "rrtype": "CNAME",
+                      "ttl": 3597,
+                      "rdata": "suricata.io"
+                    },
+                    {
+                      "rrname": "suricata.io",
+                      "rrtype": "A",
+                      "ttl": 597,
+                      "rdata": "35.212.0.44"
+                    }
+                  ]
+                },
+              }

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1104,6 +1104,9 @@
                 "authorities": {
                     "$ref": "#/$defs/dns.authorities"
                 },
+                "additionals": {
+                    "$ref": "#/$defs/dns.additionals"
+                },
                 "query": {
                     "type": "array",
                     "minItems": 1,
@@ -1175,6 +1178,9 @@
                         },
                         "authorities": {
                             "$ref": "#/$defs/dns.authorities"
+                        },
+                        "additionals": {
+                            "$ref": "#/$defs/dns.additionals"
                         }
                     },
                     "additionalProperties": false
@@ -6340,6 +6346,28 @@
                             }
                         },
                         "additionalProperties": false
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "dns.additionals": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rdata": {
+                        "type": "string"
+                    },
+                    "rrname": {
+                        "type": "string"
+                    },
+                    "rrtype": {
+                        "type": "string"
+                    },
+                    "ttl": {
+                        "type": "integer"
                     }
                 },
                 "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6368,6 +6368,22 @@
                     },
                     "ttl": {
                         "type": "integer"
+                    },
+                    "opt": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
                     }
                 },
                 "additionalProperties": false

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1062,6 +1062,9 @@
                             "ttl": {
                                 "type": "integer"
                             },
+                            "soa": {
+                                "$ref": "#/$defs/dns.soa"
+                            },
                             "srv": {
                                 "type": "object",
                                 "properties": {
@@ -1108,6 +1111,40 @@
                     "$ref": "#/$defs/dns.additionals"
                 },
                 "query": {
+                    "$comment": "EVE DNS v2 style query logging; as of Suricata 8 only used in DNS records when v2 logging is enabled, not used for DNS records logged as part of an event.",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "rrname": {
+                                "type": "string"
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "tx_id": {
+                                "type": "integer"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "z": {
+                                "type": "boolean"
+                            },
+                            "opcode": {
+                                "description": "DNS opcode as an integer",
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "queries": {
+                    "$comment": "EVE DNS v3 style query logging.",
                     "type": "array",
                     "minItems": 1,
                     "items": {
@@ -1235,6 +1272,13 @@
                             "minItems": 1,
                             "items": {
                                 "type": "string"
+                            }
+                        },
+                        "SOA": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/$defs/dns.soa"
                             }
                         },
                         "SRV": {
@@ -6302,6 +6346,33 @@
         }
     },
     "$defs": {
+        "dns.soa": {
+            "type": "object",
+            "properties": {
+                "expire": {
+                    "type": "integer"
+                },
+                "minimum": {
+                    "type": "integer"
+                },
+                "mname": {
+                    "type": "string"
+                },
+                "refresh": {
+                    "type": "integer"
+                },
+                "retry": {
+                    "type": "integer"
+                },
+                "rname": {
+                    "type": "string"
+                },
+                "serial": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
         "dns.authorities": {
             "type": "array",
             "minItems": 1,
@@ -6321,31 +6392,7 @@
                         "type": "integer"
                     },
                     "soa": {
-                        "type": "object",
-                        "properties": {
-                            "expire": {
-                                "type": "integer"
-                            },
-                            "minimum": {
-                                "type": "integer"
-                            },
-                            "mname": {
-                                "type": "string"
-                            },
-                            "refresh": {
-                                "type": "integer"
-                            },
-                            "retry": {
-                                "type": "integer"
-                            },
-                            "rname": {
-                                "type": "string"
-                            },
-                            "serial": {
-                                "type": "integer"
-                            }
-                        },
-                        "additionalProperties": false
+                        "$ref": "#/$defs/dns.soa"
                     }
                 },
                 "additionalProperties": false

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -150,6 +150,14 @@ pub struct DNSQueryEntry {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct DNSRDataOPT {
+    /// Option Code
+    pub code: u16,
+    /// Option Data
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct DNSRDataSOA {
     /// Primary name server for this zone
     pub mname: Vec<u8>,
@@ -207,6 +215,7 @@ pub enum DNSRData {
     SOA(DNSRDataSOA),
     SRV(DNSRDataSRV),
     SSHFP(DNSRDataSSHFP),
+    OPT(Vec<DNSRDataOPT>),
     // RData for remaining types is sometimes ignored
     Unknown(Vec<u8>),
 }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -226,6 +226,7 @@ pub struct DNSMessage {
     pub queries: Vec<DNSQueryEntry>,
     pub answers: Vec<DNSAnswerEntry>,
     pub authorities: Vec<DNSAnswerEntry>,
+    pub additionals: Vec<DNSAnswerEntry>,
 }
 
 #[derive(Debug, Default)]

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -606,6 +606,26 @@ fn dns_log_json_answer(
         js.close()?;
     }
 
+    if !response.additionals.is_empty() {
+        let mut is_js_open = false;
+        for add in &response.additionals {
+            if let DNSRData::Unknown(rdata) = &add.data {
+                if rdata.is_empty() {
+                    continue;
+                }
+            }
+            if !is_js_open {
+                js.open_array("additionals")?;
+                is_js_open = true;
+            }
+            let add_detail = dns_log_json_answer_detail(add)?;
+            js.append_object(&add_detail)?;
+        }
+        if is_js_open {
+            js.close()?;
+        }
+    }
+
     Ok(())
 }
 

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -394,6 +394,17 @@ pub fn dns_print_addr(addr: &[u8]) -> std::string::String {
     }
 }
 
+/// Log OPT section fields
+fn dns_log_opt(opt: &DNSRDataOPT) -> Result<JsonBuilder, JsonError> {
+    let mut js = JsonBuilder::try_new_object()?;
+
+    js.set_uint("code", opt.code as u64)?;
+    js.set_hex("data", &opt.data)?;
+
+    js.close()?;
+    Ok(js)
+} 
+
 /// Log SOA section fields.
 fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
     let mut js = JsonBuilder::try_new_object()?;
@@ -467,6 +478,13 @@ fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, Js
         }
         DNSRData::SRV(srv) => {
             jsa.set_object("srv", &dns_log_srv(srv)?)?;
+        }
+        DNSRData::OPT(opt) => {
+            jsa.open_array("opt")?;
+            for val in opt {
+                jsa.append_object(&dns_log_opt(val)?)?;
+            }
+            jsa.close()?;
         }
         _ => {}
     }
@@ -609,7 +627,7 @@ fn dns_log_json_answer(
     if !response.additionals.is_empty() {
         let mut is_js_open = false;
         for add in &response.additionals {
-            if let DNSRData::Unknown(rdata) = &add.data {
+            if let DNSRData::OPT(rdata) = &add.data {
                 if rdata.is_empty() {
                     continue;
                 }

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017 Open Information Security Foundation
+/* Copyright (C) 2017-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -403,7 +403,7 @@ fn dns_log_opt(opt: &DNSRDataOPT) -> Result<JsonBuilder, JsonError> {
 
     js.close()?;
     Ok(js)
-} 
+}
 
 /// Log SOA section fields.
 fn dns_log_soa(soa: &DNSRDataSOA) -> Result<JsonBuilder, JsonError> {
@@ -647,6 +647,97 @@ fn dns_log_json_answer(
     Ok(())
 }
 
+/// V3 style answer logging.
+fn dns_log_json_answers(
+    jb: &mut JsonBuilder, response: &DNSMessage, flags: u64,
+) -> Result<(), JsonError> {
+    if !response.answers.is_empty() {
+        let mut js_answers = JsonBuilder::try_new_array()?;
+
+        // For grouped answers we use a HashMap keyed by the rrtype.
+        let mut answer_types = HashMap::new();
+
+        for answer in &response.answers {
+            if flags & LOG_FORMAT_GROUPED != 0 {
+                let type_string = dns_rrtype_string(answer.rrtype);
+                match &answer.data {
+                    DNSRData::A(addr) | DNSRData::AAAA(addr) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types
+                                .insert(type_string.to_string(), JsonBuilder::try_new_array()?);
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_string(&dns_print_addr(addr))?;
+                        }
+                    }
+                    DNSRData::CNAME(bytes)
+                    | DNSRData::MX(bytes)
+                    | DNSRData::NS(bytes)
+                    | DNSRData::TXT(bytes)
+                    | DNSRData::NULL(bytes)
+                    | DNSRData::PTR(bytes) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types
+                                .insert(type_string.to_string(), JsonBuilder::try_new_array()?);
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_string_from_bytes(bytes)?;
+                        }
+                    }
+                    DNSRData::SOA(soa) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types
+                                .insert(type_string.to_string(), JsonBuilder::try_new_array()?);
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_object(&dns_log_soa(soa)?)?;
+                        }
+                    }
+                    DNSRData::SSHFP(sshfp) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types
+                                .insert(type_string.to_string(), JsonBuilder::try_new_array()?);
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_object(&dns_log_sshfp(sshfp)?)?;
+                        }
+                    }
+                    DNSRData::SRV(srv) => {
+                        if !answer_types.contains_key(&type_string) {
+                            answer_types
+                                .insert(type_string.to_string(), JsonBuilder::try_new_array()?);
+                        }
+                        if let Some(a) = answer_types.get_mut(&type_string) {
+                            a.append_object(&dns_log_srv(srv)?)?;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if flags & LOG_FORMAT_DETAILED != 0 {
+                js_answers.append_object(&dns_log_json_answer_detail(answer)?)?;
+            }
+        }
+
+        js_answers.close()?;
+
+        if flags & LOG_FORMAT_DETAILED != 0 {
+            jb.set_object("answers", &js_answers)?;
+        }
+
+        if flags & LOG_FORMAT_GROUPED != 0 {
+            jb.open_object("grouped")?;
+            for (k, mut v) in answer_types.drain() {
+                v.close()?;
+                jb.set_object(&k, &v)?;
+            }
+            jb.close()?;
+        }
+    }
+    Ok(())
+}
+
 fn dns_log_query(
     tx: &DNSTransaction, i: u16, flags: u64, jb: &mut JsonBuilder,
 ) -> Result<bool, JsonError> {
@@ -685,6 +776,115 @@ pub extern "C" fn SCDnsLogJsonQuery(
             return true;
         }
     }
+}
+
+/// Common logger for DNS requests and responses.
+///
+/// It is expected that the JsonBuilder is an open object that the DNS
+/// transaction will be logged into. This function will not create the
+/// "dns" object.
+///
+/// This logger implements V3 style DNS logging.
+fn log_json(tx: &mut DNSTransaction, flags: u64, jb: &mut JsonBuilder) -> Result<(), JsonError> {
+    jb.open_object("dns")?;
+    jb.set_int("version", 3)?;
+
+    let message = if let Some(request) = &tx.request {
+        jb.set_string("type", "request")?;
+        request
+    } else if let Some(response) = &tx.response {
+        jb.set_string("type", "response")?;
+        response
+    } else {
+        debug_validate_fail!("unreachable");
+        return Ok(());
+    };
+
+    // The internal Suricata transaction ID.
+    jb.set_uint("tx_id", tx.id - 1)?;
+
+    // The on the wire DNS transaction ID.
+    jb.set_uint("id", tx.tx_id() as u64)?;
+
+    // Log header fields. Should this be a sub-object?
+    let header = &message.header;
+    jb.set_string("flags", format!("{:x}", header.flags).as_str())?;
+    if header.flags & 0x8000 != 0 {
+        jb.set_bool("qr", true)?;
+    }
+    if header.flags & 0x0400 != 0 {
+        jb.set_bool("aa", true)?;
+    }
+    if header.flags & 0x0200 != 0 {
+        jb.set_bool("tc", true)?;
+    }
+    if header.flags & 0x0100 != 0 {
+        jb.set_bool("rd", true)?;
+    }
+    if header.flags & 0x0080 != 0 {
+        jb.set_bool("ra", true)?;
+    }
+    if header.flags & 0x0040 != 0 {
+        jb.set_bool("z", true)?;
+    }
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    jb.set_uint("opcode", opcode as u64)?;
+    jb.set_string("rcode", &dns_rcode_string(header.flags))?;
+
+    if !message.queries.is_empty() {
+        jb.open_array("queries")?;
+        for query in &message.queries {
+            if dns_log_rrtype_enabled(query.rrtype, flags) {
+                jb.start_object()?
+                    .set_string_from_bytes("rrname", &query.name)?
+                    .set_string("rrtype", &dns_rrtype_string(query.rrtype))?
+                    .close()?;
+            }
+        }
+        jb.close()?;
+    }
+
+    if !message.answers.is_empty() {
+        dns_log_json_answers(jb, message, flags)?;
+    }
+
+    if !message.authorities.is_empty() {
+        jb.open_array("authorities")?;
+        for auth in &message.authorities {
+            let auth_detail = dns_log_json_answer_detail(auth)?;
+            jb.append_object(&auth_detail)?;
+        }
+        jb.close()?;
+    }
+
+    if !message.additionals.is_empty() {
+        let mut is_jb_open = false;
+        for add in &message.additionals {
+            if let DNSRData::OPT(rdata) = &add.data {
+                if rdata.is_empty() {
+                    continue;
+                }
+            }
+            if !is_jb_open {
+                jb.open_array("additionals")?;
+                is_jb_open = true;
+            }
+            let add_detail = dns_log_json_answer_detail(add)?;
+            jb.append_object(&add_detail)?;
+        }
+        if is_jb_open {
+            jb.close()?;
+        }
+    }
+
+    jb.close()?;
+    Ok(())
+}
+
+/// FFI wrapper around the common V3 style DNS logger.
+#[no_mangle]
+pub extern "C" fn SCDnsLogJson(tx: &mut DNSTransaction, flags: u64, jb: &mut JsonBuilder) -> bool {
+    log_json(tx, flags, jb).is_ok()
 }
 
 #[no_mangle]

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -180,6 +180,16 @@ pub extern "C" fn SCDnsLuaGetAnswerTable(clua: &mut CLuaState, tx: &mut DNSTrans
                     lua.pushstring(&String::from_utf8_lossy(&srv.target));
                     lua.settable(-3);
                 }
+                DNSRData::OPT(ref opt) => {
+                    if !opt.is_empty() {
+                        lua.pushstring("addr");
+                        for option in opt.iter() {
+                            lua.pushstring(&String::from_utf8_lossy(&option.code.to_be_bytes()));
+                            lua.pushstring(&String::from_utf8_lossy(&option.data));
+                        }
+                        lua.settable(-3);
+                    }
+                }
             }
             lua.settable(-3);
         }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -149,7 +149,7 @@ fn dns_parse_answer<'a>(
                         rrtype: val.rrtype,
                         rrclass: val.rrclass,
                         ttl: val.ttl,
-                        data: DNSRData::Unknown(Vec::new()),
+                        data: DNSRData::OPT(Vec::new()),
                     });
                     input = rem;
                     continue;
@@ -295,6 +295,22 @@ fn dns_parse_rdata_sshfp(input: &[u8]) -> IResult<&[u8], DNSRData> {
     ))
 }
 
+fn dns_parse_rdata_opt(input: &[u8]) -> IResult<&[u8], DNSRData> {
+    let mut dns_rdata_opt_vec = Vec::new();
+    let mut i = input;
+
+    while !i.is_empty() {
+        let (j, code) = be_u16(i)?;
+        let (j, data) = length_data(be_u16)(j)?;
+        i = j;
+        dns_rdata_opt_vec.push(DNSRDataOPT {
+            code,
+            data: data.to_vec(),
+        });
+    }
+    Ok((i, DNSRData::OPT(dns_rdata_opt_vec)))
+}
+
 fn dns_parse_rdata_unknown(input: &[u8]) -> IResult<&[u8], DNSRData> {
     rest(input).map(|(input, data)| (input, DNSRData::Unknown(data.to_vec())))
 }
@@ -314,6 +330,7 @@ fn dns_parse_rdata<'a>(
         DNS_RECORD_TYPE_NULL => dns_parse_rdata_null(input),
         DNS_RECORD_TYPE_SSHFP => dns_parse_rdata_sshfp(input),
         DNS_RECORD_TYPE_SRV => dns_parse_rdata_srv(input, message),
+        DNS_RECORD_TYPE_OPT => dns_parse_rdata_opt(input),
         _ => dns_parse_rdata_unknown(input),
     }
 }
@@ -493,7 +510,7 @@ mod tests {
         let (body, header) = dns_parse_header(pkt).unwrap();
         let res = dns_parse_body(body, pkt, header);
         let (rem, request) = res.unwrap();
-        // The response should be fully parsed.
+        // The request should be fully parsed.
         assert!(rem.is_empty());
 
         assert_eq!(
@@ -517,15 +534,84 @@ mod tests {
 
         // verify additional section
         assert_eq!(request.additionals.len(), 1);
+
         let additional = &request.additionals[0];
         assert_eq!(
             additional,
             &DNSAnswerEntry {
                 name: vec![],
                 rrtype: DNS_RECORD_TYPE_OPT,
-                rrclass: 0x1000, // for OPT this is UDP payload size
+                rrclass: 0x1000,             // for OPT this is UDP payload size
+                ttl: 0,                      // for OPT this is extended RCODE and flags
+                data: DNSRData::OPT(vec![]), // empty rdata
+            }
+        );
+    }
+
+    #[test]
+    fn test_dns_parse_request_multi_opt() {
+        let pkt: &[u8] = &[
+            0x8d, 0x32, 0x01, 0x20, 0x00, 0x01, /* ...2. .. */
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, 0x77, /* .......w */
+            0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, /* ww.suric */
+            0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03, /* ata-ids. */
+            0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01, /* org..... */
+            0x00, 0x00, 0x29, 0x10, 0x00, 0x00, 0x00, 0x00, /* ..)..... */
+            0x00, 0x00, 0x10, /* total rdata len: 16 */
+            /* Option Cookie */
+            0x00, 0x0a, /* Code: 10 */
+            0x00, 0x08, /* Option len: 8 */
+            0x7f, 0x86, 0xcf, 0x8b, 0x81, 0xf6, 0xf9, 0x55, /* Option NSID */
+            0x00, 0x03, /* Code: 3 */
+            0x00, 0x00, /* option len: 0 */
+        ];
+
+        let (body, header) = dns_parse_header(pkt).unwrap();
+        let res = dns_parse_body(body, pkt, header);
+        let (rem, request) = res.unwrap();
+
+        assert!(rem.is_empty());
+        assert_eq!(
+            request.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x0120,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 0,
+                additional_rr: 1,
+            }
+        );
+
+        assert_eq!(request.queries.len(), 1);
+
+        let query = &request.queries[0];
+        assert_eq!(query.name, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(query.rrtype, 1);
+        assert_eq!(query.rrclass, 1);
+
+        // verify additional section
+        assert_eq!(request.additionals.len(), 1);
+
+        let additional = &request.additionals[0];
+        assert_eq!(
+            additional,
+            &DNSAnswerEntry {
+                name: vec![],
+                rrtype: DNS_RECORD_TYPE_OPT,
+                rrclass: 0x1000, // for OPT this is requestor's UDP payload size
                 ttl: 0,          // for OPT this is extended RCODE and flags
-                data: DNSRData::Unknown(vec![]), // empty rdata
+                // verify two options
+                data: DNSRData::OPT(vec![
+                    DNSRDataOPT {
+                        code: 0x000a,
+                        data: vec![0x7f, 0x86, 0xcf, 0x8b, 0x81, 0xf6, 0xf9, 0x55]
+                    },
+                    DNSRDataOPT {
+                        code: 0x0003,
+                        data: vec![]
+                    },
+                ])
             }
         );
     }
@@ -677,9 +763,9 @@ mod tests {
             &DNSAnswerEntry {
                 name: vec![],
                 rrtype: DNS_RECORD_TYPE_OPT,
-                rrclass: 0x0200, // for OPT this is UDP payload size
-                ttl: 0,          // for OPT this is extended RCODE and flags
-                data: DNSRData::Unknown(vec![]), // no rdata
+                rrclass: 0x0200,             // for OPT this is UDP payload size
+                ttl: 0,                      // for OPT this is extended RCODE and flags
+                data: DNSRData::OPT(vec![]), // no rdata
             }
         );
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -246,65 +246,10 @@ typedef struct LogDnsLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogDnsLogThread;
 
-static JsonBuilder *JsonDNSLogQuery(void *txptr)
-{
-    JsonBuilder *queryjb = jb_new_array();
-    if (queryjb == NULL) {
-        return NULL;
-    }
-    bool has_query = false;
-
-    for (uint16_t i = 0; i < UINT16_MAX; i++) {
-        JsonBuilder *js = jb_new_object();
-        if (!SCDnsLogJsonQuery((void *)txptr, i, LOG_ALL_RRTYPES, js)) {
-            jb_free(js);
-            break;
-        }
-        jb_close(js);
-        has_query = true;
-        jb_append_object(queryjb, js);
-        jb_free(js);
-    }
-
-    if (!has_query) {
-        jb_free(queryjb);
-        return NULL;
-    }
-
-    jb_close(queryjb);
-    return queryjb;
-}
-
-static JsonBuilder *JsonDNSLogAnswer(void *txptr)
-{
-    if (!SCDnsLogAnswerEnabled(txptr, LOG_ALL_RRTYPES)) {
-        return NULL;
-    } else {
-        JsonBuilder *js = jb_new_object();
-        SCDnsLogJsonAnswer(txptr, LOG_ALL_RRTYPES, js);
-        jb_close(js);
-        return js;
-    }
-}
-
 bool AlertJsonDns(void *txptr, JsonBuilder *js)
 {
-    bool r = false;
-    jb_open_object(js, "dns");
-    JsonBuilder *qjs = JsonDNSLogQuery(txptr);
-    if (qjs != NULL) {
-        jb_set_object(js, "query", qjs);
-        jb_free(qjs);
-        r = true;
-    }
-    JsonBuilder *ajs = JsonDNSLogAnswer(txptr);
-    if (ajs != NULL) {
-        jb_set_object(js, "answer", ajs);
-        jb_free(ajs);
-        r = true;
-    }
-    jb_close(js);
-    return r;
+    return SCDnsLogJson(
+            txptr, LOG_FORMAT_DETAILED | LOG_QUERIES | LOG_ANSWERS | LOG_ALL_RRTYPES, js);
 }
 
 static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,


### PR DESCRIPTION
Previous PR: #11433 

Tickets:
- https://redmine.openinfosecfoundation.org/issues/7011 (DNS additional)
- https://redmine.openinfosecfoundation.org/issues/7017 (DNS opt)
- https://redmine.openinfosecfoundation.org/issues/6281 (primary)

The main point of this PR is to unify the DNS logging structures across `alert` and `dns` events, and `request` and `response` type where before queries were logged as arrays in alerts but not DNS records.  And answers were logged as arrays in DNS records but not alerts records.

The other DNS tickets were pulled in as well to avoid unnecessary rebasing efforts.

The main difference from the last PRs is this allows users to stick with the v2 format for DNS events until Suricata 9.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1963
