### PR TITLE
userguide: expand documentation for rule profiling - v1

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2621,6 +2621,9 @@ Example:
   Original content: abc
   Final content: bc
 
+
+.. _rule-and-packet-profiling-settings:
+
 Rule and Packet Profiling settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/performance/rule-profiling.rst
+++ b/doc/userguide/performance/rule-profiling.rst
@@ -1,6 +1,14 @@
 Rule Profiling
 ==============
 
+Suricata can generate a rules performance report at the end of each session, if
+built with the ``enable-profiling`` option (see configuring :ref:`Rule profiling<rule-and-packet-profiling-settings>`).
+
+Rule profiling can also be enabled by building the engine with ``enable-profiling-rules``
+and using the unix socket to dumpt the report (see :ref:`rule-management-rules-profiling`).
+
+Once the report is generated, it is stored in the default log directory used by
+Suricata. If not changed, the filename will be ``rule_perf.log``.
 ::
 
   --------------------------------------------------------------------------

--- a/doc/userguide/rule-management/rule-profiling.rst
+++ b/doc/userguide/rule-management/rule-profiling.rst
@@ -1,3 +1,5 @@
+.. _rule-management-rules-profiling:
+
 Rules Profiling
 ===============
 


### PR DESCRIPTION
The page about performance and rule profiling showed the table generated by rules profiling but didn't inform how to achieve nor find it.

Task #4359

Trying to tackle this one as I was reminded of it while exploring running `--engine-analysis`.
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4359

Describe changes:
- Add an explanation on what file has the info that is shown in performance#rule-profiling, as well as links on where to find more info about configuring and enabling that
- add labels in the related documentation secions
