### PR TITLE
doc: update 'bypass' in docs to use new keywords

### DIFF
--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -15,5 +15,6 @@ Bypass a flow on matching http traffic.
 
 Example::
 
-  alert http any any -> any any (content:"suricata.io"; \
-      http_host; bypass; sid:10001; rev:1;)
+  alert http any any -> any any (http.host; 
+      content:"suricata.io"; bypass; \
+      sid:10001; rev:1;)


### PR DESCRIPTION
Documentation for the 'bypass' keyword uses the legacy keyword 
'http_host;' as opposed to the modernised 'http.host;'.

I'm unable to find a version of Suricata that utilises 'bypass;'
while 'http_host;' is the preferred HTTP host keyword.

James Emery-Callcott <james.ec.ozurie@gmail.com>

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7143

Describe changes:
- changed 'http_host;' to 'http.host;' in the example demonstration of the 'bypass;' keyword.