### PR TITLE
util/thash: decrease memuse if array was allocated (backport7)

### DIFF
--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -368,8 +368,8 @@ void THashShutdown(THashTableContext *ctx)
         }
         SCFreeAligned(ctx->array);
         ctx->array = NULL;
+        (void)SC_ATOMIC_SUB(ctx->memuse, ctx->config.hash_size * sizeof(THashHashRow));
     }
-    (void) SC_ATOMIC_SUB(ctx->memuse, ctx->config.hash_size * sizeof(THashHashRow));
     THashDataQueueDestroy(&ctx->spare_q);
     SCFree(ctx);
     return;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7135

Describe changes:
- Backport of #11425 clean cherry-pick
