### PR TITLE
smtp: Prevent error messages on packet path

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -985,7 +985,9 @@ static int SMTPParseCommandBDAT(SMTPState *state, const SMTPLine *line)
     }
     memcpy(strbuf, line->buf + i, len);
     strbuf[len] = '\0';
-    if (StringParseUint32(&state->bdat_chunk_len, 10, 0, strbuf) < 0) {
+    char **endptr = NULL;
+    state->bdat_chunk_len = strtoul((const char *) strbuf, (char **) &endptr, 10);
+    if (((uint8_t *) endptr == line->buf + i) || errno != 0) {
         /* decoder event */
         return -1;
     }


### PR DESCRIPTION
Issue: 7126

This commit abandons the use of StringParseUint32 which generates an error message of there are non-numeric characters.

The SMTP parser had used this function on the packet path; this commit uses strtoul instead.

An example of the content causing the error message to be emitted:

    3460 LAST

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7126

Describe changes:
- Use `strtoul` instead of wrapper function that emits error messages


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
