### PR TITLE
dns: allow triggering raw stream reassembly - 7.0.x backport - v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -555,6 +555,7 @@ impl DNSState {
             );
             if size > 0 && cur_i.len() >= size + 2 {
                 let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                 let _pdu = Frame::new(
                     flow,
                     &stream_slice,
@@ -617,6 +618,7 @@ impl DNSState {
             );
             if size > 0 && cur_i.len() >= size + 2 {
                 let msg = &cur_i[2..(size + 2)];
+                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                 let _pdu = Frame::new(
                     flow,
                     &stream_slice,


### PR DESCRIPTION
For TCP streams, app proto stream reassembly can start earlier, instead of waiting and queueing up data before doing so.

Task #7018
Related to
Bug #7004

(cherry picked from commit bb45ac71ef572acb5591c135eb3c73e901a1cc51)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
(backport) https://redmine.openinfosecfoundation.org/issues/7075
Original: https://redmine.openinfosecfoundation.org/issues/7018

Describe changes:
- Clean cherry-pick of dns/tcp: trigger raw stream reassembly earlier (bb45ac71ef572acb5591c135eb3c73e901a1cc51)

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1967
