### PR TITLE
decode/vxlan: support envelope header stripping

### DIFF
--- a/src/decode-vxlan.c
+++ b/src/decode-vxlan.c
@@ -215,9 +215,12 @@ int DecodeVXLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         PacketClearL3(p);
         PacketClearL4(p);
         // TODO clear things more: tuple, events?
+        p->sp = p->dp = p->proto = 0;
 
-        p->pkt_src = PKT_SRC_DECODER_VXLAN;
+        PKT_SET_SRC(p, PKT_SRC_DECODER_VXLAN);
         p->flags |= PKT_TUNNEL_STRIPPED;
+        p->flags &= ~PKT_WANTS_FLOW;
+        p->flow_hash = 0;
         return DecodeEthernet(tv, dtv, p, encap_pkt, encap_size);
     }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -1330,6 +1330,9 @@ void DecodeUnregisterCounters(void);
 #define PKT_FIRST_ALERTS BIT_U32(29)
 #define PKT_FIRST_TAG    BIT_U32(30)
 
+/** set for packets that have had envelope headers stripped */
+#define PKT_TUNNEL_STRIPPED BIT_U32(31)
+
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) \
     ((p)->flags & (PKT_PSEUDO_STREAM_END|PKT_PSEUDO_DETECTLOG_FLUSH))


### PR DESCRIPTION
By default a VXLAN packet is handled by splitting off the encapsulated packet into it's own Packet, that remains coupled with the original Packet to allow verdicts to be set in IPS mode. For the original "root" packet, payload inspection is disabled, but detection like IP, ports and other non-payload properties can still be inspected.

There cases where all packets will be VXLAN encapsulated, and the headers before the encapsulation matter little. One example is AWS network mirror, where packets are delivered over VXLAN. This is inefficient, as for each real packet there are 2 packets going through the pipeline.

This patch introduces an option to strip the envelope headers, and let the encapsulated packet "take over" the Packet.

The `decoder.vxlan.mode=strip` option will strip the headers.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1972