### PR TITLE
Pcap perf/v7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,7 @@
     AC_CHECK_FUNCS([gethostname inet_ntoa uname])
     AC_CHECK_FUNCS([gettimeofday clock_gettime utime strptime tzset localtime_r])
     AC_CHECK_FUNCS([socket setenv select putenv dup2 endgrent endpwent atexit munmap])
-    AC_CHECK_FUNCS([setrlimit])
+    AC_CHECK_FUNCS([setrlimit setvbuf])
 
     AC_CHECK_FUNCS([fwrite_unlocked])
 

--- a/configure.ac
+++ b/configure.ac
@@ -274,7 +274,7 @@
             ;;
         *-*-linux*)
             # Always compile with -fPIC on Linux for shared library support.
-            CFLAGS="${CFLAGS} -fPIC"
+            CFLAGS="${CFLAGS} -fPIC -DOS_LINUX"
             RUST_LDADD="-ldl -lrt -lm"
             can_build_shared_library="yes"
             AC_DEFINE([SYSTEMD_NOTIFY], [1], [make Suricata notify systemd on startup])

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -59,7 +59,7 @@
 #include "source-af-packet.h"
 #include "util-bpf.h"
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 const char *RunModeAFPGetDefaultMode(void)
 {
@@ -685,7 +685,7 @@ finalize:
     (void) SC_ATOMIC_ADD(aconf->ref, aconf->threads);
 
     if (aconf->ring_size != 0) {
-        if (aconf->ring_size * aconf->threads < max_pending_packets) {
+        if (aconf->ring_size * aconf->threads < (int)max_pending_packets) {
             aconf->ring_size = max_pending_packets / aconf->threads + 1;
             SCLogWarning("%s: inefficient setup: ring-size < max_pending_packets. "
                          "Resetting to decent value %d.",

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -50,7 +50,7 @@
 #include "suricata.h"
 #include "util-bpf.h"
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 const char *RunModeNetmapGetDefaultMode(void)
 {

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -269,7 +269,7 @@ void RunUnittests(int list_unittests, const char *regex_arg)
         UtListTests(regex_arg);
     } else {
         /* global packet pool */
-        extern uint16_t max_pending_packets;
+        extern uint32_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -118,7 +118,7 @@ struct bpf_program {
 
 #endif /* HAVE_AF_PACKET */
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 #ifndef HAVE_AF_PACKET
 

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -89,7 +89,7 @@ NoErfDagSupportExit(ThreadVars *tv, const void *initdata, void **data)
 /* Number of bytes per loop to process before fetching more data. */
 #define BYTES_PER_LOOP (4 * 1024 * 1024) /* 4 MB */
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 typedef struct ErfDagThreadVars_ {
     ThreadVars *tv;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -98,7 +98,7 @@ TmEcode NoIPFWSupportExit(ThreadVars *tv, const void *initdata, void **data)
 
 #define IPFW_SOCKET_POLL_MSEC 300
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 /**
  * \brief Structure to hold thread specific variables.

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -81,7 +81,7 @@ TmEcode NoNapatechSupportExit(ThreadVars *tv, const void *initdata, void **data)
 #include <numa.h>
 #include <nt.h>
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 typedef struct NapatechThreadVars_
 {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -97,7 +97,7 @@ static TmEcode NoNFQSupportExit(ThreadVars *tv, const void *initdata, void **dat
 
 #else /* we do have NFQ support */
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 #define MAX_ALREADY_TREATED 5
 #define NFQ_VERDICT_RETRY_COUNT 3

--- a/src/source-pcap-file-directory-helper.c
+++ b/src/source-pcap-file-directory-helper.c
@@ -45,6 +45,8 @@ static TmEcode PcapDirectoryPopulateBuffer(PcapFileDirectoryVars *ptv,
 static TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
                                                  struct timespec *older_than);
 
+extern PcapFileGlobalVars pcap_g;
+
 void GetTime(struct timespec *tm)
 {
     struct timeval now;
@@ -414,7 +416,8 @@ TmEcode PcapDirectoryDispatchForTimeRange(PcapFileDirectoryVars *pv,
             } else {
                 SCLogDebug("Processing file %s", current_file->filename);
 
-                PcapFileFileVars *pftv = SCCalloc(1, sizeof(PcapFileFileVars));
+                const size_t toalloc = sizeof(PcapFileFileVars) + pcap_g.read_buffer_size;
+                PcapFileFileVars *pftv = SCCalloc(1, toalloc);
                 if (unlikely(pftv == NULL)) {
                     SCLogError("Failed to allocate PcapFileFileVars");
                     SCReturnInt(TM_ECODE_FAILED);

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -208,6 +208,11 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+    errno = 0;
+    if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, sizeof(pfv->buffer)) < 0) {
+        SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+    }
+
     if (pfv->shared != NULL && pfv->shared->bpf_string != NULL) {
         SCLogInfo("using bpf-filter \"%s\"", pfv->shared->bpf_string);
 

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -208,10 +208,15 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    errno = 0;
-    if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, sizeof(pfv->buffer)) < 0) {
-        SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+#if defined(HAVE_SETVBUF) && !defined(OS_WIN32)
+    if (pcap_g.read_buffer_size > 0) {
+        errno = 0;
+        if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, pcap_g.read_buffer_size) <
+                0) {
+            SCLogWarning("Failed to setvbuf on PCAP file handle: %s", strerror(errno));
+        }
     }
+#endif
 
     if (pfv->shared != NULL && pfv->shared->bpf_string != NULL) {
         SCLogInfo("using bpf-filter \"%s\"", pfv->shared->bpf_string);

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -208,7 +208,7 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-#if defined(HAVE_SETVBUF) && !defined(OS_WIN32)
+#if defined(HAVE_SETVBUF) && defined(OS_LINUX)
     if (pcap_g.read_buffer_size > 0) {
         errno = 0;
         if (setvbuf(pcap_file(pfv->pcap_handle), pfv->buffer, _IOFBF, pcap_g.read_buffer_size) <

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -31,7 +31,7 @@
 #include "source-pcap-file.h"
 #include "util-exception-policy.h"
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 extern PcapFileGlobalVars pcap_g;
 
 static void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt);

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -84,7 +84,7 @@ typedef struct PcapFileFileVars_
 
     /** flex array member for the libc io read buffer. Size controlled by
      * PcapFileGlobalVars::read_buffer_size. */
-#if defined(HAVE_SETVBUF) && !defined(OS_WIN32)
+#if defined(HAVE_SETVBUF) && defined(OS_LINUX)
     char buffer[];
 #endif
 } PcapFileFileVars;

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -80,6 +80,8 @@ typedef struct PcapFileFileVars_
     const u_char *first_pkt_data;
     struct pcap_pkthdr *first_pkt_hdr;
     struct timeval first_pkt_ts;
+
+    char buffer[131072];
 } PcapFileFileVars;
 
 /**

--- a/src/source-pcap-file-helper.h
+++ b/src/source-pcap-file-helper.h
@@ -32,6 +32,7 @@ typedef struct PcapFileGlobalVars_ {
     ChecksumValidationMode conf_checksum_mode;
     ChecksumValidationMode checksum_mode;
     SC_ATOMIC_DECLARE(unsigned int, invalid_checksums);
+    int read_buffer_size;
 } PcapFileGlobalVars;
 
 /**
@@ -81,7 +82,11 @@ typedef struct PcapFileFileVars_
     struct pcap_pkthdr *first_pkt_hdr;
     struct timeval first_pkt_ts;
 
-    char buffer[131072];
+    /** flex array member for the libc io read buffer. Size controlled by
+     * PcapFileGlobalVars::read_buffer_size. */
+#if defined(HAVE_SETVBUF) && !defined(OS_WIN32)
+    char buffer[];
+#endif
 } PcapFileFileVars;
 
 /**

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -146,7 +146,7 @@ void PcapFileGlobalInit(void)
     memset(&pcap_g, 0x00, sizeof(pcap_g));
     SC_ATOMIC_INIT(pcap_g.invalid_checksums);
 
-#if defined(HAVE_SETVBUF) && !defined(OS_WIN32)
+#if defined(HAVE_SETVBUF) && defined(OS_LINUX)
     pcap_g.read_buffer_size = PCAP_FILE_BUFFER_SIZE_DEFAULT;
 
     const char *str = NULL;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -33,7 +33,7 @@
 #include "suricata.h"
 #include "conf.h"
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 PcapFileGlobalVars pcap_g;
 
 /**

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -57,7 +57,7 @@ TmEcode DecodePfringThreadInit(ThreadVars *, const void *, void **);
 TmEcode DecodePfring(ThreadVars *, Packet *, void *);
 TmEcode DecodePfringThreadDeinit(ThreadVars *tv, void *data);
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 #ifndef HAVE_PFRING
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -179,7 +179,7 @@ static enum EngineMode g_engine_mode = ENGINE_MODE_UNKNOWN;
 uint8_t host_mode = SURI_HOST_IS_SNIFFER_ONLY;
 
 /** Maximum packets to simultaneously process. */
-uint16_t max_pending_packets;
+uint32_t max_pending_packets;
 
 /** global indicating if detection is enabled */
 int g_detect_disabled = 0;
@@ -2434,16 +2434,16 @@ static int ConfigGetCaptureValue(SCInstance *suri)
     intmax_t tmp_max_pending_packets;
     if (ConfGetInt("max-pending-packets", &tmp_max_pending_packets) != 1)
         tmp_max_pending_packets = DEFAULT_MAX_PENDING_PACKETS;
-    if (tmp_max_pending_packets < 1 || tmp_max_pending_packets >= UINT16_MAX) {
-        SCLogError("Maximum max-pending-packets setting is 65534 and must be greater than 0. "
+    if (tmp_max_pending_packets < 1 || tmp_max_pending_packets > 2147483648) {
+        SCLogError("Maximum max-pending-packets setting is 2147483648 and must be greater than 0. "
                    "Please check %s for errors",
                 suri->conf_filename);
         return TM_ECODE_FAILED;
     } else {
-        max_pending_packets = (uint16_t)tmp_max_pending_packets;
+        max_pending_packets = (uint32_t)tmp_max_pending_packets;
     }
 
-    SCLogDebug("Max pending packets set to %" PRIu16, max_pending_packets);
+    SCLogDebug("Max pending packets set to %" PRIu32, max_pending_packets);
 
     /* Pull the default packet size from the config, if not found fall
      * back on a sane default. */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -631,6 +631,7 @@ static void PrintUsage(const char *progname)
     printf("\t--pcap-file-continuous               : when running in pcap mode with a directory, continue checking directory for pcaps until interrupted\n");
     printf("\t--pcap-file-delete                   : when running in replay mode (-r with directory or file), will delete pcap files that have been processed when done\n");
     printf("\t--pcap-file-recursive                : will descend into subdirectories when running in replay mode (-r)\n");
+    printf("\t--pcap-file-buffer-size              : set read buffer size (setvbuf)\n");
 #ifdef HAVE_PCAP_SET_BUFF
     printf("\t--pcap-buffer-size                   : size of the pcap buffer value from 0 - %i\n",INT_MAX);
 #endif /* HAVE_SET_PCAP_BUFF */
@@ -1356,6 +1357,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
         {"pcap-file-continuous", 0, 0, 0},
         {"pcap-file-delete", 0, 0, 0},
         {"pcap-file-recursive", 0, 0, 0},
+        {"pcap-file-buffer-size", required_argument, 0, 0},
         {"simulate-ips", 0, 0 , 0},
         {"no-random", 0, &g_disable_randomness, 1},
         {"strict-rule-keywords", optional_argument, 0, 0},
@@ -1758,8 +1760,12 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                     SCLogError("failed to set pcap-file.recursive");
                     return TM_ECODE_FAILED;
                 }
-            }
-            else if (strcmp((long_opts[option_index]).name, "data-dir") == 0) {
+            } else if (strcmp((long_opts[option_index]).name, "pcap-file-buffer-size") == 0) {
+                if (ConfSetFinal("pcap-file.buffer-size", optarg) != 1) {
+                    SCLogError("failed to set pcap-file.buffer-size");
+                    return TM_ECODE_FAILED;
+                }
+            } else if (strcmp((long_opts[option_index]).name, "data-dir") == 0) {
                 if (optarg == NULL) {
                     SCLogError("no option argument (optarg) for -d");
                     return TM_ECODE_FAILED;
@@ -1777,7 +1783,7 @@ TmEcode SCParseCommandLine(int argc, char **argv)
                     return TM_ECODE_FAILED;
                 }
                 suri->set_datadir = true;
-            } else if (strcmp((long_opts[option_index]).name , "strict-rule-keywords") == 0){
+            } else if (strcmp((long_opts[option_index]).name, "strict-rule-keywords") == 0) {
                 if (optarg == NULL) {
                     suri->strict_rule_parsing_string = SCStrdup("all");
                 } else {

--- a/src/tests/fuzz/fuzz_decodepcapfile.c
+++ b/src/tests/fuzz/fuzz_decodepcapfile.c
@@ -78,7 +78,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_DECODEPCAPFILE].ThreadInit(tv, NULL, (void **) &dtv);
         (void)SC_ATOMIC_SET(tv->tm_slots->slot_next->slot_data, dtv);
 
-        extern uint16_t max_pending_packets;
+        extern uint32_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -97,7 +97,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern uint16_t max_pending_packets;
+        extern uint32_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         if (DetectEngineReload(&surifuzz) < 0) {

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -90,7 +90,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern uint16_t max_pending_packets;
+        extern uint32_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -115,7 +115,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         tmm_modules[TMM_FLOWWORKER].ThreadInit(&tv, NULL, &fwd);
         StatsSetupPrivate(&tv);
 
-        extern uint16_t max_pending_packets;
+        extern uint32_t max_pending_packets;
         max_pending_packets = 128;
         PacketPoolInit();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -35,7 +35,7 @@
 #include "util-validate.h"
 #include "action-globals.h"
 
-extern uint16_t max_pending_packets;
+extern uint32_t max_pending_packets;
 
 /* Number of freed packet to save for one pool before freeing them. */
 #define MAX_PENDING_RETURN_PACKETS 32
@@ -259,8 +259,7 @@ void PacketPoolInit(void)
     /* pre allocate packets */
     SCLogDebug("preallocating packets... packet size %" PRIuMAX "",
                (uintmax_t)SIZE_OF_PACKET);
-    int i = 0;
-    for (i = 0; i < max_pending_packets; i++) {
+    for (uint32_t i = 0; i < max_pending_packets; i++) {
         Packet *p = PacketGetFromAlloc();
         if (unlikely(p == NULL)) {
             FatalError("Fatal error encountered while allocating a packet. Exiting...");
@@ -459,8 +458,8 @@ void TmqhReleasePacketsToPacketPool(PacketQueue *pq)
  */
 void PacketPoolPostRunmodes(void)
 {
-    extern uint16_t max_pending_packets;
-    uint16_t pending_packets = max_pending_packets;
+    extern uint32_t max_pending_packets;
+    uint32_t pending_packets = max_pending_packets;
     if (pending_packets < RESERVED_PACKETS) {
         FatalError("'max-pending-packets' setting "
                    "must be at least %d",


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/7155

replace #11464: limit to Linux only, as runs fail on FreeBSD and OpenBSD

```
    Info: pcap: Pcap-file will use 4096 buffer size [PcapFileGlobalInit:source-pcap-file.c:159]
    Error: pcap: failed to get first packet timestamp. pcap_next_ex(): -2 [PeekFirstPacketTimestamp:source-pcap-file-helper.c:186]
    Warning: pcap: Failed to init pcap file input.pcap, skipping [ReceivePcapFileThreadInit:source-pcap-file.c:299]
    Error: pcap: pcap file reader thread failed to initialize [ReceivePcapFileLoop:source-pcap-file.c:185]
```
