### PR TITLE
eve/dns: make version required

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -999,6 +999,9 @@
         },
         "dns": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "aa": {
                     "type": "boolean"
@@ -1034,6 +1037,7 @@
                     "type": "string"
                 },
                 "version": {
+                    "description": "The version of this EVE DNS event",
                     "type": "integer"
                 },
                 "opcode": {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -503,7 +503,6 @@ fn dns_log_json_answer(
 ) -> Result<(), JsonError> {
     let header = &response.header;
 
-    js.set_uint("version", 2)?;
     js.set_string("type", "answer")?;
     js.set_uint("id", header.tx_id as u64)?;
     js.set_string("flags", format!("{:x}", header.flags).as_str())?;

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -273,6 +273,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         }
 
         jb_open_object(jb, "dns");
+        jb_set_int(jb, "version", 2);
         if (!SCDnsLogJsonQuery(txptr, i, td->dnslog_ctx->flags, jb)) {
             jb_free(jb);
             break;
@@ -305,6 +306,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
         }
 
         jb_open_object(jb, "dns");
+        jb_set_int(jb, "version", 2);
         SCDnsLogJsonAnswer(txptr, td->dnslog_ctx->flags, jb);
         jb_close(jb);
         OutputJsonBuilderBuffer(jb, td->ctx);


### PR DESCRIPTION
The "eve.version" field is not always logged. Update the schema to
enforce that it is, and fix it for records that don't log it.

Ticket: #7167
