### PR TITLE
backport-7.0.x: dpdk: replace TSC clock with GetTime (gettimeofday) function v1

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -305,7 +305,6 @@ static void InitEal(void)
     if (retval < 0) { // retval bound to the result of rte_eal_init
         FatalError("DPDK EAL initialization error: %s", rte_strerror(-retval));
     }
-    DPDKSetTimevalOfMachineStart();
 }
 
 static void DPDKDerefConfig(void *conf)

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -42,7 +42,6 @@ typedef enum { DPDK_COPY_MODE_NONE, DPDK_COPY_MODE_TAP, DPDK_COPY_MODE_IPS } Dpd
 // Offloads
 #define DPDK_RX_CHECKSUM_OFFLOAD (1 << 4) /**< Enable chsum offload */
 
-void DPDKSetTimevalOfMachineStart(void);
 typedef struct DPDKIfaceConfig_ {
 #ifdef HAVE_DPDK
     char iface[RTE_ETH_NAME_MAX_LEN];


### PR DESCRIPTION
Getting clock through Time Stamp Counter (TSC) can be precise and fast, however only for a short duration of time.
The implementation across CPUs seems to vary. The original idea is to increment the counter with every tick. Then dividing the delta of CPU ticks by the CPU frequency can return the time that passed. However, the CPU clock/frequency can change over time, resulting in uneven incrementation of TSC. On some CPUs this is handled by extra logic. As a result, obtaining time through this method might drift from the real time.

This commit therefore substitues TSC time retrieval by the standard system call wrapped in GetTime function - on Linux it is gettimeofday.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7116

Describe changes:
- backport from 8
- time is now obtained through gettimeofday 