### PR TITLE
Ssh frames 5734 v6

### DIFF
--- a/doc/userguide/rules/ssh-keywords.rst
+++ b/doc/userguide/rules/ssh-keywords.rst
@@ -6,6 +6,26 @@ Suricata has several rule keywords to match on different elements of SSH
 connections.
 
 
+Frames
+------
+
+The SSH parser supports the following frames:
+
+* ssh.record_hdr
+* ssh.record_data
+* ssh.record_pdu
+
+These are header + data = pdu for SSH records, after the banner and before encryption.
+The SSH record header is 6 bytes long : 4 bytes length, 1 byte passing, 1 byte message code.
+
+Example:
+
+.. container:: example-rule
+
+  alert ssh any any -> any any (msg:"hdr frame new keys"; :example-rule-emphasis:`frame:ssh.record.hdr; content: "|15|"; endswith;` bsize: 6; sid:2;)
+
+This rule matches like Wireshark ``ssh.message_code == 0x15``.
+
 ssh.proto
 ---------
 Match on the version of the SSH protocol used. ``ssh.proto`` is a sticky buffer,

--- a/rust/src/enip/enip.rs
+++ b/rust/src/enip/enip.rs
@@ -565,7 +565,6 @@ unsafe extern "C" fn rs_enip_tx_get_alstate_progress(tx: *mut c_void, direction:
     return 0;
 }
 
-// app-layer-frame-documentation tag start: FrameType enum
 #[derive(AppLayerFrameType)]
 pub enum EnipFrameType {
     Hdr,

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -267,15 +267,12 @@ impl SSHState {
                         }
                         Err(Err::Incomplete(_)) => {
                             //we may have consumed data from previous records
-                            if input.len() < SSH_RECORD_HEADER_LEN {
-                                //do not trust nom incomplete value
-                                return AppLayerResult::incomplete(
-                                    (il - input.len()) as u32,
-                                    SSH_RECORD_HEADER_LEN as u32,
-                                );
-                            } else {
-                                panic!("SSH invalid length record header");
-                            }
+                            debug_validate_bug_on!(input.len() >= SSH_RECORD_HEADER_LEN);
+                            //do not trust nom incomplete value
+                            return AppLayerResult::incomplete(
+                                (il - input.len()) as u32,
+                                SSH_RECORD_HEADER_LEN as u32,
+                            );
                         }
                         Err(_e) => {
                             SCLogDebug!("SSH invalid record header {}", _e);

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -36,7 +36,6 @@ pub(super) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
 
 static mut WEBSOCKET_MAX_PAYLOAD_SIZE: u32 = 0xFFFF;
 
-// app-layer-frame-documentation tag start: FrameType enum
 #[derive(AppLayerFrameType)]
 pub enum WebSocketFrameType {
     Header,

--- a/src/detect.c
+++ b/src/detect.c
@@ -150,7 +150,13 @@ static void DetectRun(ThreadVars *th_v,
                 goto end;
             }
             const TcpSession *ssn = p->flow->protoctx;
-            if (ssn && (ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) == 0) {
+            bool setting_nopayload = p->flow->alparser &&
+                                     AppLayerParserStateIssetFlag(
+                                             p->flow->alparser, APP_LAYER_PARSER_NO_INSPECTION) &&
+                                     !(p->flags & PKT_NOPAYLOAD_INSPECTION);
+            // we may be right after disabling app-layer (ssh)
+            if (ssn &&
+                    ((ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED) == 0 || setting_nopayload)) {
                 // PACKET_PROFILING_DETECT_START(p, PROF_DETECT_TX);
                 DetectRunFrames(th_v, de_ctx, det_ctx, p, pflow, &scratch);
                 // PACKET_PROFILING_DETECT_END(p, PROF_DETECT_TX);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5734

Describe changes:
- ssh: add frames support (for clear-text records after banner)
- detect: run frames detection on packet disabling app-layer because next packets are encrypted
- ssh: avoid `panic` in packet path
- rust/frames: remove unneeded or wrong comments

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1932

#11475 with needed rebase