### PR TITLE
git: Add commit template

### DIFF
--- a/doc/userguide/devguide/contributing/code-submission-process.rst
+++ b/doc/userguide/devguide/contributing/code-submission-process.rst
@@ -15,15 +15,19 @@ Commits
 #. If your code changes or adds new behavior, add the related documentation
    updates in their own commit, but make sure to add the same ticket number to
    both commit messages.
-#. Commit messages need to be properly formatted (check the example further
-     below in this section):
+#. Commit messages need to be properly formatted (check the example further below in this section).
       * Meaningful and short (50 chars max) subject line followed by an empty line
       * Naming convention: prefix message with sub-system (**"rule parsing: fixing foobar"**). If
         you're not sure what to use, look at past commits to the file(s) in your PR.
       * Description, wrapped at ~72 characters
 #. Commits should be individually compilable, starting with the oldest commit. Make sure that
-     each commit can be built if it and the preceding commits in the PR are used.
+   each commit can be built if it and the preceding commits in the PR are used.
 #. Commits should be authored with the format: "FirstName LastName <name@example.com>"
+
+We recommend that you use git commit message template with the following command:
+``git config commit.template /path/to/suricata/git-template/commit-template.txt``
+The template lists items that help describe the context and include requisite information in
+the commit message. We reserve the right to strictly enforce the template in the future:
 
 Information that needs to be part of a commit (if applicable):
 

--- a/git-templates/commit-template.txt
+++ b/git-templates/commit-template.txt
@@ -1,0 +1,13 @@
+# Suricata commit template
+# See https://docs.suricata.io/en/latest/devguide/contributing/code-submission-process.html
+# Commit Title
+
+# Description
+# Provide a description of the changes in this commit that
+# gives the "why" for the change(s). Optionally, provide the
+# actual changes (the "what").
+# - List main changes
+# - List the motivation for each change
+# - Optionally, include the specific changes
+
+Ticket: <Redmine ticket number>


### PR DESCRIPTION
Issue: none

This commit adds a template that identifies commit message elements that we find important. The Suricata development team requests that contributions use the template to help improve commit messages. We reserve the right to strictly enforce adherence to the template in the future.

Configure git to use this template with:
    git config commit.template ..github/commit-template.txt


Describe changes:
- Add commit template with instructions on how to configure


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
