### PR TITLE
detect/integers: harmonize parser return handling (backport7)

### DIFF
--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -157,20 +157,6 @@ int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eo
     return 0;
 }
 
-/**
- * \brief This function is used to parse bsize options passed via bsize: keyword
- *
- * \param bsizestr Pointer to the user provided bsize options
- *
- * \retval bsized pointer to DetectU64Data on success
- * \retval NULL on failure
- */
-
-static DetectU64Data *DetectBsizeParse(const char *str)
-{
-    return DetectU64Parse(str);
-}
-
 static int SigParseGetMaxBsize(DetectU64Data *bsz)
 {
     switch (bsz->mode) {
@@ -208,9 +194,9 @@ static int DetectBsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     if (list == DETECT_SM_LIST_NOTSET)
         SCReturnInt(-1);
 
-    DetectU64Data *bsz = DetectBsizeParse(sizestr);
+    DetectU64Data *bsz = DetectU64Parse(sizestr);
     if (bsz == NULL)
-        goto error;
+        SCReturnInt(-1);
 
     sm = SigMatchAlloc();
     if (sm == NULL)

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -124,7 +124,7 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     if (DetectGetLastSMFromLists(s, DETECT_DSIZE, -1)) {
         SCLogError("Can't use 2 or more dsizes in "
                    "the same sig.  Invalidating signature.");
-        goto error;
+        return -1;
     }
 
     SCLogDebug("\'%s\'", rawstr);
@@ -132,7 +132,7 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     dd = DetectU16Parse(rawstr);
     if (dd == NULL) {
         SCLogError("Parsing \'%s\' failed", rawstr);
-        goto error;
+        return -1;
     }
 
     /* Okay so far so good, lets get this into a SigMatch
@@ -141,7 +141,7 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     if (sm == NULL){
         SCLogError("Failed to allocate memory for SigMatch");
         rs_detect_u16_free(dd);
-        goto error;
+        return -1;
     }
 
     sm->type = DETECT_DSIZE;
@@ -160,9 +160,6 @@ static int DetectDsizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *
     }
 
     return 0;
-
-error:
-    return -1;
 }
 
 /**

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -127,7 +127,7 @@ static int DetectFilesizeSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
     fsd = DetectU64Parse(str);
     if (fsd == NULL)
-        goto error;
+        SCReturnInt(-1);
 
     sm = SigMatchAlloc();
     if (sm == NULL)

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -121,7 +121,8 @@ static int DetectICodeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
     SigMatch *sm = NULL;
 
     icd = DetectU8Parse(icodestr);
-    if (icd == NULL) goto error;
+    if (icd == NULL)
+        return -1;
 
     sm = SigMatchAlloc();
     if (sm == NULL) goto error;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -102,20 +102,6 @@ static int DetectITypeMatch (DetectEngineThreadCtx *det_ctx, Packet *p,
 }
 
 /**
- * \brief This function is used to parse itype options passed via itype: keyword
- *
- * \param de_ctx Pointer to the detection engine context
- * \param itypestr Pointer to the user provided itype options
- *
- * \retval itd pointer to DetectU8Data on success
- * \retval NULL on failure
- */
-static DetectU8Data *DetectITypeParse(DetectEngineCtx *de_ctx, const char *itypestr)
-{
-    return DetectU8Parse(itypestr);
-}
-
-/**
  * \brief this function is used to add the parsed itype data into the current signature
  *
  * \param de_ctx pointer to the Detection Engine Context
@@ -131,8 +117,9 @@ static int DetectITypeSetup(DetectEngineCtx *de_ctx, Signature *s, const char *i
     DetectU8Data *itd = NULL;
     SigMatch *sm = NULL;
 
-    itd = DetectITypeParse(de_ctx, itypestr);
-    if (itd == NULL) goto error;
+    itd = DetectU8Parse(itypestr);
+    if (itd == NULL)
+        return -1;
 
     sm = SigMatchAlloc();
     if (sm == NULL) goto error;
@@ -221,7 +208,7 @@ static bool PrefilterITypeIsPrefilterable(const Signature *s)
 static int DetectITypeParseTest01(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "8");
+    itd = DetectU8Parse("8");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->mode == DETECT_UINT_EQ);
@@ -237,7 +224,7 @@ static int DetectITypeParseTest01(void)
 static int DetectITypeParseTest02(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, ">8");
+    itd = DetectU8Parse(">8");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->mode == DETECT_UINT_GT);
@@ -253,7 +240,7 @@ static int DetectITypeParseTest02(void)
 static int DetectITypeParseTest03(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "<8");
+    itd = DetectU8Parse("<8");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->mode == DETECT_UINT_LT);
@@ -269,7 +256,7 @@ static int DetectITypeParseTest03(void)
 static int DetectITypeParseTest04(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "8<>20");
+    itd = DetectU8Parse("8<>20");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->arg2 == 20);
@@ -286,7 +273,7 @@ static int DetectITypeParseTest04(void)
 static int DetectITypeParseTest05(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "   8 ");
+    itd = DetectU8Parse("   8 ");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->mode == DETECT_UINT_EQ);
@@ -302,7 +289,7 @@ static int DetectITypeParseTest05(void)
 static int DetectITypeParseTest06(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "  >  8  ");
+    itd = DetectU8Parse("  >  8  ");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->mode == DETECT_UINT_GT);
@@ -318,7 +305,7 @@ static int DetectITypeParseTest06(void)
 static int DetectITypeParseTest07(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "  8  <> 20  ");
+    itd = DetectU8Parse("  8  <> 20  ");
     FAIL_IF_NULL(itd);
     FAIL_IF_NOT(itd->arg1 == 8);
     FAIL_IF_NOT(itd->arg2 == 20);
@@ -334,7 +321,7 @@ static int DetectITypeParseTest07(void)
 static int DetectITypeParseTest08(void)
 {
     DetectU8Data *itd = NULL;
-    itd = DetectITypeParse(NULL, "> 8 <> 20");
+    itd = DetectU8Parse("> 8 <> 20");
     FAIL_IF_NOT_NULL(itd);
 
     PASS;

--- a/src/detect-rfb-sectype.c
+++ b/src/detect-rfb-sectype.c
@@ -91,20 +91,6 @@ static int DetectRfbSectypeMatch (DetectEngineThreadCtx *det_ctx,
 }
 
 /**
- * \internal
- * \brief Function to parse options passed via rfb.sectype keywords.
- *
- * \param rawstr Pointer to the user provided options.
- *
- * \retval dd pointer to DetectU32Data on success.
- * \retval NULL on failure.
- */
-static DetectU32Data *DetectRfbSectypeParse(const char *rawstr)
-{
-    return DetectU32Parse(rawstr);
-}
-
-/**
  * \brief Function to add the parsed RFB security type field into the current signature.
  *
  * \param de_ctx Pointer to the Detection Engine Context.
@@ -119,10 +105,10 @@ static int DetectRfbSectypeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
     if (DetectSignatureSetAppProto(s, ALPROTO_RFB) != 0)
         return -1;
 
-    DetectU32Data *dd = DetectRfbSectypeParse(rawstr);
+    DetectU32Data *dd = DetectU32Parse(rawstr);
     if (dd == NULL) {
         SCLogError("Parsing \'%s\' failed", rawstr);
-        goto error;
+        return -1;
     }
 
     /* okay so far so good, lets get this into a SigMatch

--- a/src/tests/detect-bsize.c
+++ b/src/tests/detect-bsize.c
@@ -19,7 +19,7 @@
 
 #define TEST_OK(str, m, lo, hi)                                                                    \
     {                                                                                              \
-        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        DetectU64Data *bsz = DetectU64Parse((str));                                                \
         FAIL_IF_NULL(bsz);                                                                         \
         FAIL_IF_NOT(bsz->mode == (m));                                                             \
         DetectBsizeFree(NULL, bsz);                                                                \
@@ -27,7 +27,7 @@
     }
 #define TEST_FAIL(str)                                                                             \
     {                                                                                              \
-        DetectU64Data *bsz = DetectBsizeParse((str));                                              \
+        DetectU64Data *bsz = DetectU64Parse((str));                                                \
         FAIL_IF_NOT_NULL(bsz);                                                                     \
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7173

Describe changes:
- backport of #11496, unclean cherry-pick

```
        both modified:   src/detect-bsize.c
        both modified:   src/detect-filesize.c
        both modified:   src/detect-icode.c
        both modified:   src/detect-itype.c
```

Conflicts easy to fix manually