### PR TITLE
Warnint 64to32 6186 v21.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2302,6 +2302,15 @@ fi
                 AC_MSG_RESULT([yes]),
                 [AC_MSG_RESULT([no])
                 CFLAGS="$OCFLAGS"])
+        # check if our compiler supports -Wimplicit-int-float-conversion
+        AC_MSG_CHECKING(for -Wimplicit-int-float-conversion)
+        OCFLAGS=$CFLAGS
+        CFLAGS="$CFLAGS -Wimplicit-int-float-conversion"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],
+                    [[]])],
+                AC_MSG_RESULT([yes]),
+                [AC_MSG_RESULT([no])
+                CFLAGS="$OCFLAGS"])
     ])
 
     AC_CHECK_LIB(fuzzpcap, FPC_IsFuzzPacketCapture, HAS_FUZZPCAP="yes")

--- a/src/datasets-string.c
+++ b/src/datasets-string.c
@@ -55,7 +55,7 @@ int StringAsBase64(const void *s, char *out, size_t out_size)
 
     strlcpy(out, (const char *)encoded_data, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 int StringSet(void *dst, void *src)

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -522,8 +522,8 @@ static int DatasetLoadString(Dataset *set)
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
-                    strlen(line), &consumed, &num_decoded, Base64ModeStrict);
+            Base64Ecode code = DecodeBase64(decoded, (uint32_t)strlen(line), (const uint8_t *)line,
+                    (uint32_t)strlen(line), &consumed, &num_decoded, Base64ModeStrict);
             if (code == BASE64_ECODE_ERR) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -543,8 +543,8 @@ static int DatasetLoadString(Dataset *set)
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(line)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(line), (const uint8_t *)line,
-                    strlen(line), &consumed, &num_decoded, Base64ModeStrict);
+            Base64Ecode code = DecodeBase64(decoded, (uint32_t)strlen(line), (const uint8_t *)line,
+                    (uint32_t)strlen(line), &consumed, &num_decoded, Base64ModeStrict);
             if (code == BASE64_ECODE_ERR) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -1012,7 +1012,7 @@ static int SaveCallback(void *ctx, const uint8_t *data, const uint32_t data_len)
     FILE *fp = ctx;
     //PrintRawDataFp(fp, data, data_len);
     if (fp) {
-        return fwrite(data, data_len, 1, fp);
+        return (int)fwrite(data, data_len, 1, fp);
     }
     return 0;
 }
@@ -1024,7 +1024,7 @@ static int Md5AsAscii(const void *s, char *out, size_t out_size)
     PrintHexString(str, sizeof(str), (uint8_t *)md5->md5, sizeof(md5->md5));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int Sha256AsAscii(const void *s, char *out, size_t out_size)
@@ -1034,7 +1034,7 @@ static int Sha256AsAscii(const void *s, char *out, size_t out_size)
     PrintHexString(str, sizeof(str), (uint8_t *)sha->sha256, sizeof(sha->sha256));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int IPv4AsAscii(const void *s, char *out, size_t out_size)
@@ -1044,7 +1044,7 @@ static int IPv4AsAscii(const void *s, char *out, size_t out_size)
     PrintInet(AF_INET, ip4->ipv4, str, sizeof(str));
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 static int IPv6AsAscii(const void *s, char *out, size_t out_size)
@@ -1065,7 +1065,7 @@ static int IPv6AsAscii(const void *s, char *out, size_t out_size)
     }
     strlcat(out, str, out_size);
     strlcat(out, "\n", out_size);
-    return strlen(out);
+    return (int)strlen(out);
 }
 
 void DatasetsSave(void)
@@ -1610,8 +1610,9 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[strlen(string)];
             uint32_t consumed = 0, num_decoded = 0;
-            Base64Ecode code = DecodeBase64(decoded, strlen(string), (const uint8_t *)string,
-                    strlen(string), &consumed, &num_decoded, Base64ModeStrict);
+            Base64Ecode code =
+                    DecodeBase64(decoded, (uint32_t)strlen(string), (const uint8_t *)string,
+                            (uint32_t)strlen(string), &consumed, &num_decoded, Base64ModeStrict);
             if (code == BASE64_ECODE_ERR) {
                 return -2;
             }

--- a/src/defrag-config.c
+++ b/src/defrag-config.c
@@ -124,7 +124,7 @@ static void DefragParseParameters(ConfNode *n)
     }
 }
 
-void DefragSetDefaultTimeout(intmax_t timeout)
+void DefragSetDefaultTimeout(int timeout)
 {
     default_timeout = timeout;
     SCLogDebug("default timeout %d", default_timeout);

--- a/src/defrag-config.h
+++ b/src/defrag-config.h
@@ -27,7 +27,7 @@
 
 #include "decode.h"
 
-void DefragSetDefaultTimeout(intmax_t timeout);
+void DefragSetDefaultTimeout(int timeout);
 void DefragPolicyLoadFromConfig(void);
 int DefragPolicyGetHostTimeout(Packet *p);
 void DefragTreeDestroy(void);

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -168,13 +168,13 @@ DefragContextNew(void)
 
     /* Initialize the pool of frags. */
     intmax_t frag_pool_size;
-    if (!ConfGetInt("defrag.max-frags", &frag_pool_size) || frag_pool_size == 0) {
+    if (!ConfGetInt("defrag.max-frags", &frag_pool_size) || frag_pool_size == 0 ||
+            frag_pool_size > UINT32_MAX) {
         frag_pool_size = DEFAULT_DEFRAG_POOL_SIZE;
     }
-    intmax_t frag_pool_prealloc = frag_pool_size / 2;
-    dc->frag_pool = PoolInit(frag_pool_size, frag_pool_prealloc,
-        sizeof(Frag),
-        NULL, DefragFragInit, dc, NULL, NULL);
+    uint32_t frag_pool_prealloc = (uint32_t)frag_pool_size / 2;
+    dc->frag_pool = PoolInit((uint32_t)frag_pool_size, frag_pool_prealloc, sizeof(Frag), NULL,
+            DefragFragInit, dc, NULL, NULL);
     if (dc->frag_pool == NULL) {
         FatalError("Defrag: Failed to initialize fragment pool.");
     }
@@ -194,7 +194,7 @@ DefragContextNew(void)
         else if (timeout > TIMEOUT_MAX) {
             FatalError("defrag: Timeout greater than maximum allowed value.");
         }
-        dc->timeout = timeout;
+        dc->timeout = (uint32_t)timeout;
     }
 
     SCLogDebug("Defrag Initialized:");

--- a/src/defrag.h
+++ b/src/defrag.h
@@ -37,7 +37,7 @@ typedef struct DefragContext_ {
     Pool *frag_pool; /**< Pool of fragments. */
     SCMutex frag_pool_lock;
 
-    time_t timeout; /**< Default timeout. */
+    uint32_t timeout; /**< Default timeout. */
 } DefragContext;
 
 /**

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -89,7 +89,7 @@ static void *ParsePcapConfig(const char *iface)
     if ((ConfGetInt("pcap.buffer-size", &value)) == 1) {
         if (value >= 0 && value <= INT_MAX) {
             SCLogInfo("Pcap will use %d buffer size", (int)value);
-            aconf->buffer_size = value;
+            aconf->buffer_size = (int)value;
         } else {
             SCLogWarning("pcap.buffer-size "
                          "value of %" PRIiMAX " is invalid. Valid range is "
@@ -207,8 +207,10 @@ static void *ParsePcapConfig(const char *iface)
     aconf->snaplen = 0;
     if (ConfGetChildValueIntWithDefault(if_root, if_default, "snaplen", &snaplen) != 1) {
         SCLogDebug("could not get snaplen or none specified");
+    } else if (snaplen < INT_MIN || snaplen > INT_MAX) {
+        SCLogDebug("snaplen value is not in the accepted range");
     } else {
-        aconf->snaplen = snaplen;
+        aconf->snaplen = (int)snaplen;
     }
 
     return aconf;

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -831,6 +831,16 @@ TmEcode UnixSocketDatasetLookup(json_t *cmd, json_t *answer, void *data)
     }
 }
 
+static bool json_u32_value(json_t *jarg, uint32_t *ret)
+{
+    int64_t r = json_integer_value(jarg);
+    if (r < 0 || r > UINT32_MAX) {
+        return false;
+    }
+    *ret = (uint32_t)r;
+    return true;
+}
+
 /**
  * \brief Command to add a tenant handler
  *
@@ -856,7 +866,12 @@ TmEcode UnixSocketRegisterTenantHandler(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id;
+    if (!json_u32_value(jarg, &tenant_id)) {
+        SCLogInfo("tenant_id is not a uint32");
+        json_object_set_new(answer, "message", json_string("tenant_id is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -937,7 +952,12 @@ TmEcode UnixSocketUnregisterTenantHandler(json_t *cmd, json_t* answer, void *dat
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id;
+    if (!json_u32_value(jarg, &tenant_id)) {
+        SCLogInfo("tenant_id is not a uint32");
+        json_object_set_new(answer, "message", json_string("tenant_id is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     /* 2 get tenant handler type */
     jarg = json_object_get(cmd, "htype");
@@ -1018,7 +1038,12 @@ TmEcode UnixSocketRegisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id;
+    if (!json_u32_value(jarg, &tenant_id)) {
+        SCLogInfo("tenant_id is not a uint32");
+        json_object_set_new(answer, "message", json_string("tenant_id is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1086,7 +1111,12 @@ TmEcode UnixSocketReloadTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id;
+    if (!json_u32_value(jarg, &tenant_id)) {
+        SCLogInfo("tenant_id is not a uint32");
+        json_object_set_new(answer, "message", json_string("tenant_id is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     /* 2 get tenant yaml */
     jarg = json_object_get(cmd, "filename");
@@ -1180,7 +1210,12 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data)
         json_object_set_new(answer, "message", json_string("id is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t tenant_id = json_integer_value(jarg);
+    uint32_t tenant_id;
+    if (!json_u32_value(jarg, &tenant_id)) {
+        SCLogInfo("tenant_id is not a uint32");
+        json_object_set_new(answer, "message", json_string("tenant_id is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     SCLogInfo("remove-tenant: removing tenant %d", tenant_id);
 
@@ -1271,14 +1306,24 @@ TmEcode UnixSocketHostbitAdd(json_t *cmd, json_t* answer, void *data_usused)
         json_object_set_new(answer, "message", json_string("expire is not an integer"));
         return TM_ECODE_FAILED;
     }
-    uint32_t expire = json_integer_value(jarg);
+    uint32_t expire;
+    if (!json_u32_value(jarg, &expire)) {
+        SCLogInfo("expire is not a uint32");
+        json_object_set_new(answer, "message", json_string("expire is not a uint32"));
+        return TM_ECODE_FAILED;
+    }
 
     SCLogInfo("add-hostbit: ip %s hostbit %s expire %us", ipaddress, hostbit, expire);
 
     SCTime_t current_time = TimeGet();
     Host *host = HostGetHostFromHash(&a);
     if (host) {
-        HostBitSet(host, idx, SCTIME_SECS(current_time) + expire);
+        if (SCTIME_SECS(current_time) + expire > UINT32_MAX) {
+            json_object_set_new(answer, "message", json_string("couldn't set host expire"));
+            HostRelease(host);
+            return TM_ECODE_FAILED;
+        }
+        HostBitSet(host, idx, (uint32_t)(SCTIME_SECS(current_time) + expire));
         HostRelease(host);
 
         json_object_set_new(answer, "message", json_string("hostbit added"));

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -520,7 +520,11 @@ static void SetBpfStringFromFile(char *filename)
         SCLogError("Failed to stat file %s", filename);
         exit(EXIT_FAILURE);
     }
-    bpf_len = st.st_size + 1;
+    if (st.st_size > UINT32_MAX - 1) {
+        SCLogError("Too big file %s", filename);
+        exit(EXIT_FAILURE);
+    }
+    bpf_len = (uint32_t)(st.st_size + 1);
 
     bpf_filter = SCCalloc(1, bpf_len);
     if (unlikely(bpf_filter == NULL)) {


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix `-Wshorten-64-to-32` warnings for some files : defrag, datasets, suricata.c, runmodes
- adds `-Wimplicit-int-float-conversion` to the set of warning flags used by `./configure  --enable-warnings`

Some commits of #9840
#11453 next batch

Setting first as draft to see if CI is happy for -Wimplicit-int-float-conversion in all builds
