### PR TITLE
smtp: Prevent error messages on packet path

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1004,7 +1004,7 @@ static int SMTPParseCommandBDAT(SMTPState *state, const SMTPLine *line)
         /* decoder event */
         return -1;
     }
-    // copy in temporary null-terminated buffer to call StringParseUint32
+    // copy in temporary null-terminated buffer for conversion
     char strbuf[24];
     int len = 23;
     if (line->len - i < len) {
@@ -1012,7 +1012,7 @@ static int SMTPParseCommandBDAT(SMTPState *state, const SMTPLine *line)
     }
     memcpy(strbuf, line->buf + i, len);
     strbuf[len] = '\0';
-    if (StringParseUint32(&state->bdat_chunk_len, 10, 0, strbuf) < 0) {
+    if (ByteExtractStringUint32(&state->bdat_chunk_len, 10, 0, strbuf) < 0) {
         /* decoder event */
         return -1;
     }

--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -73,8 +73,9 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
 {
     unsigned long gid = 0;
     char *endptr = NULL;
+    errno = 0;
     gid = strtoul(rawstr, &endptr, 10);
-    if (endptr == NULL || *endptr != '\0') {
+    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
         SCLogError("invalid character as arg "
                    "to gid keyword");
         goto error;

--- a/src/detect-rev.c
+++ b/src/detect-rev.c
@@ -43,8 +43,9 @@ static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
 {
     unsigned long rev = 0;
     char *endptr = NULL;
+    errno = 0;
     rev = strtoul(rawstr, &endptr, 10);
-    if (endptr == NULL || *endptr != '\0') {
+    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
         SCLogError("invalid character as arg "
                    "to rev keyword");
         goto error;
@@ -68,4 +69,4 @@ static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
 
  error:
     return -1;
-}
+ }

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -53,8 +53,9 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *si
 {
     unsigned long id = 0;
     char *endptr = NULL;
+    errno = 0;
     id = strtoul(sidstr, &endptr, 10);
-    if (endptr == NULL || *endptr != '\0') {
+    if (errno == ERANGE || endptr == NULL || *endptr != '\0') {
         SCLogError("invalid character as arg "
                    "to sid keyword");
         goto error;


### PR DESCRIPTION
Continuation of #11470 

Issue: 7126

This commit abandons the use of StringParseUint32 which generates an error message of there are non-numeric characters.

The SMTP parser had used this function on the packet path; this commit uses `ByteExtractStringUint32` instead.

An example of the content causing the error message to be emitted:

    3460 LAST

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7126

Describe changes:
- Use `ByteExtractStringUint32` instead of `StringParseUint32` function that emits error messages

Updates:
- Abandoned `strtoul` in favor of `ByteExtractStringUint32`

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
