### PR TITLE
draft: improve CPU cores affinity to NUMA nodes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1413,7 +1413,7 @@
             exit 1
         fi
         CFLAGS="${CFLAGS} `pkg-config --cflags libdpdk`"
-        LIBS="${LIBS} -Wl,-R,`pkg-config --libs-only-L libdpdk | cut -c 3-` -lnuma `pkg-config --libs libdpdk`"
+        LIBS="${LIBS} -Wl,-R,`pkg-config --libs-only-L libdpdk | cut -c 3-` -lnuma `pkg-config --libs libdpdk` -lhwloc"
 
         if test ! -z "$(ldconfig -p | grep librte_net_bond)"; then
             AC_DEFINE([HAVE_DPDK_BOND],[1],(DPDK Bond PMD support enabled))

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -135,6 +135,8 @@ typedef struct ThreadVars_ {
     struct FlowQueue_ *flow_queue;
     bool break_loop;
 
+    char *iface_name; // set if the TV is TVT_PPT
+
 } ThreadVars;
 
 /** Thread setup flags: */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -860,7 +860,7 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {
         ThreadsAffinityType *taf = &thread_affinity[tv->cpu_affinity];
         if (taf->mode_flag == EXCLUSIVE_AFFINITY) {
-            uint16_t cpu = AffinityGetNextCPU(taf);
+            uint16_t cpu = AffinityGetNextCPU(tv, taf);
             SetCPUAffinity(cpu);
             /* If CPU is in a set overwrite the default thread prio */
             if (CPU_ISSET(cpu, &taf->lowprio_cpu)) {

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -26,6 +26,7 @@
 #include "suricata-common.h"
 #include "conf.h"
 #include "threads.h"
+#include "threadvars.h"
 
 #include <hwloc.h>
 
@@ -88,7 +89,7 @@ extern ThreadsAffinityType thread_affinity[MAX_CPU_SET];
 void AffinitySetupLoadFromConfig(void);
 ThreadsAffinityType * GetAffinityTypeFromName(const char *name);
 
-uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf);
+uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf);
 uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
 #ifdef HAVE_DPDK
 uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -27,6 +27,8 @@
 #include "conf.h"
 #include "threads.h"
 
+#include <hwloc.h>
+
 #if defined OS_FREEBSD
 #include <sched.h>
 #include <sys/param.h>

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -310,6 +310,13 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
 
         TmThreadSetCPU(tv, WORKER_CPU_SET);
 
+        if (tv->type == TVT_PPT) {
+            tv->iface_name = strdup(live_dev);
+            SCLogNotice("Duplicated livedev %s to %s", live_dev, tv->iface_name);
+        } else {
+            tv->iface_name = NULL;
+        }
+
         if (TmThreadSpawn(tv) != TM_ECODE_OK) {
             FatalError("TmThreadSpawn failed");
         }


### PR DESCRIPTION
Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7036

This is a draft to discuss the user and implementation details of the ticket. 

Proposal for modes of assignment:
```
    // threading.cpu-assignment:
    //   - legacy - assign as usual
    //   - auto - use hwloc to determine NUMA locality of the NIC and try to assign a core from this NUMA node.
    //            If it fails then use the other NUMA node.
    //            Using this approach e.g. on bonded devices/aliased and any other will not work
    //            Warn/Notify a user when device's NUMA node cannot be determined.
    //            Mention in the docs that NUMA locatity supports PCIe addresses and Kernel interfaces
    //   - manual - in workers CPU set either:
    //              - Specify in one line ([ "eth0@1,2,3,4,7-9", "eth1@10,11" ])
    //              - Specify threading in a list:
    //              - worker-cpu-set:
    //                - interface: eth0
    //                    cpu: [ 1,2,3,4 ]
    //                    mode: "exclusive" 
    //                    prio:
    //                      high: [ 3 ]
    //                      default: "medium" 
```

The current code draft works in somewhat auto mode - it tries to pick CPU core from the NUMA node from where the interface is. 

Added doc update label to not trigger QA.