### PR TITLE
ldap: reset tx_index_completed on tx removal

### DIFF
--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -115,6 +115,7 @@ impl LdapState {
             }
         }
         if found {
+            self.tx_index_completed = 0;
             self.transactions.remove(index);
         }
     }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No redmine ticket, just a quick fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=70539 following ldap introduction

Describe changes:
- ldap: reset tx_index_completed on tx removal

cc @glongo 