### PR TITLE
Draft: Convert FTP parser to Rust

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -82,6 +82,7 @@ include = [
     "QuicState",
     "QuicTransaction",
     "FtpEvent",
+    "FtpCommand",
     "SCSigTableElmt",
 ]
 

--- a/rust/src/ftp/constant.rs
+++ b/rust/src/ftp/constant.rs
@@ -1,0 +1,61 @@
+// FTP state progress values
+pub const FTP_STATE_NONE: u8 = 0;
+pub const FTP_STATE_IN_PROGRESS: u8 = 1;
+pub const FTP_STATE_PORT_DONE: u8 = 2;
+pub const FTP_STATE_FINISHED: u8 = 3;
+
+// FTP Data progress values
+pub const FTPDATA_STATE_IN_PROGRESS: u8 = 1;
+pub const FTPDATA_STATE_FINISHED: u8 = 2;
+
+// FTP request command values
+pub const FTP_COMMAND_UNKNOWN: u8 = 0;
+pub const FTP_COMMAND_ABOR: u8 = 1;
+pub const FTP_COMMAND_ACCT: u8 = 2;
+pub const FTP_COMMAND_ALLO: u8 = 3;
+pub const FTP_COMMAND_APPE: u8 = 4;
+pub const FTP_COMMAND_AUTH_TLS: u8 = 5;
+pub const FTP_COMMAND_CDUP: u8 = 6;
+pub const FTP_COMMAND_CHMOD: u8 = 7;
+pub const FTP_COMMAND_CWD: u8 = 8;
+pub const FTP_COMMAND_DELE: u8 = 9;
+pub const FTP_COMMAND_EPSV: u8 = 10;
+pub const FTP_COMMAND_HELP: u8 = 11;
+pub const FTP_COMMAND_IDLE: u8 = 12;
+pub const FTP_COMMAND_LIST: u8 = 13;
+pub const FTP_COMMAND_MAIL: u8 = 14;
+pub const FTP_COMMAND_MDTM: u8 = 15;
+pub const FTP_COMMAND_MKD: u8 = 16;
+pub const FTP_COMMAND_MLFL: u8 = 17;
+pub const FTP_COMMAND_MODE: u8 = 18;
+pub const FTP_COMMAND_MRCP: u8 = 19;
+pub const FTP_COMMAND_MRSQ: u8 = 20;
+pub const FTP_COMMAND_MSAM: u8 = 21;
+pub const FTP_COMMAND_MSND: u8 = 22;
+pub const FTP_COMMAND_MSOM: u8 = 23;
+pub const FTP_COMMAND_NLST: u8 = 24;
+pub const FTP_COMMAND_NOOP: u8 = 25;
+pub const FTP_COMMAND_PASS: u8 = 26;
+pub const FTP_COMMAND_PASV: u8 = 27;
+pub const FTP_COMMAND_PORT: u8 = 28;
+pub const FTP_COMMAND_PWD: u8 = 29;
+pub const FTP_COMMAND_QUIT: u8 = 30;
+pub const FTP_COMMAND_REIN: u8 = 31;
+pub const FTP_COMMAND_REST: u8 = 32;
+pub const FTP_COMMAND_RETR: u8 = 33;
+pub const FTP_COMMAND_RMD: u8 = 34;
+pub const FTP_COMMAND_RNFR: u8 = 35;
+pub const FTP_COMMAND_RNTO: u8 = 36;
+pub const FTP_COMMAND_SITE: u8 = 37;
+pub const FTP_COMMAND_SIZE: u8 = 38;
+pub const FTP_COMMAND_SMNT: u8 = 39;
+pub const FTP_COMMAND_STAT: u8 = 40;
+pub const FTP_COMMAND_STOR: u8 = 41;
+pub const FTP_COMMAND_STOU: u8 = 42;
+pub const FTP_COMMAND_STRU: u8 = 43;
+pub const FTP_COMMAND_SYST: u8 = 44;
+pub const FTP_COMMAND_TYPE: u8 = 45;
+pub const FTP_COMMAND_UMASK: u8 = 46;
+pub const FTP_COMMAND_USER: u8 = 47;
+pub const FTP_COMMAND_EPRT: u8 = 48;
+pub const FTP_COMMAND_MAX: u8 = 49;

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -18,67 +18,8 @@
 use std;
 use std::os::raw::c_void;
 
-// FTP state progress values
-pub const FTP_STATE_NONE: u8 = 0;
-pub const FTP_STATE_IN_PROGRESS: u8 = 1;
-pub const FTP_STATE_PORT_DONE: u8 = 2;
-pub const FTP_STATE_FINISHED: u8 = 3;
+use crate::ftp::constant::*;
 
-// FTP Data progress values
-pub const FTPDATA_STATE_IN_PROGRESS: u8 = 1;
-pub const FTPDATA_STATE_FINISHED: u8 = 2;
-
-// FTP request command values
-pub const FTP_COMMAND_UNKNOWN: u8 = 0;
-pub const FTP_COMMAND_ABOR: u8 = 1;
-pub const FTP_COMMAND_ACCT: u8 = 2;
-pub const FTP_COMMAND_ALLO: u8 = 3;
-pub const FTP_COMMAND_APPE: u8 = 4;
-pub const FTP_COMMAND_AUTH_TLS: u8 = 5;
-pub const FTP_COMMAND_CDUP: u8 = 6;
-pub const FTP_COMMAND_CHMOD: u8 = 7;
-pub const FTP_COMMAND_CWD: u8 = 8;
-pub const FTP_COMMAND_DELE: u8 = 9;
-pub const FTP_COMMAND_EPSV: u8 = 10;
-pub const FTP_COMMAND_HELP: u8 = 11;
-pub const FTP_COMMAND_IDLE: u8 = 12;
-pub const FTP_COMMAND_LIST: u8 = 13;
-pub const FTP_COMMAND_MAIL: u8 = 14;
-pub const FTP_COMMAND_MDTM: u8 = 15;
-pub const FTP_COMMAND_MKD: u8 = 16;
-pub const FTP_COMMAND_MLFL: u8 = 17;
-pub const FTP_COMMAND_MODE: u8 = 18;
-pub const FTP_COMMAND_MRCP: u8 = 19;
-pub const FTP_COMMAND_MRSQ: u8 = 20;
-pub const FTP_COMMAND_MSAM: u8 = 21;
-pub const FTP_COMMAND_MSND: u8 = 22;
-pub const FTP_COMMAND_MSOM: u8 = 23;
-pub const FTP_COMMAND_NLST: u8 = 24;
-pub const FTP_COMMAND_NOOP: u8 = 25;
-pub const FTP_COMMAND_PASS: u8 = 26;
-pub const FTP_COMMAND_PASV: u8 = 27;
-pub const FTP_COMMAND_PORT: u8 = 28;
-pub const FTP_COMMAND_PWD: u8 = 29;
-pub const FTP_COMMAND_QUIT: u8 = 30;
-pub const FTP_COMMAND_REIN: u8 = 31;
-pub const FTP_COMMAND_REST: u8 = 32;
-pub const FTP_COMMAND_RETR: u8 = 33;
-pub const FTP_COMMAND_RMD: u8 = 34;
-pub const FTP_COMMAND_RNFR: u8 = 35;
-pub const FTP_COMMAND_RNTO: u8 = 36;
-pub const FTP_COMMAND_SITE: u8 = 37;
-pub const FTP_COMMAND_SIZE: u8 = 38;
-pub const FTP_COMMAND_SMNT: u8 = 39;
-pub const FTP_COMMAND_STAT: u8 = 40;
-pub const FTP_COMMAND_STOR: u8 = 41;
-pub const FTP_COMMAND_STOU: u8 = 42;
-pub const FTP_COMMAND_STRU: u8 = 43;
-pub const FTP_COMMAND_SYST: u8 = 44;
-pub const FTP_COMMAND_TYPE: u8 = 45;
-pub const FTP_COMMAND_UMASK: u8 = 46;
-pub const FTP_COMMAND_USER: u8 = 47;
-pub const FTP_COMMAND_EPRT: u8 = 48;
-pub const FTP_COMMAND_MAX: u8 = 49;
 
 #[repr(C)]
 #[allow(dead_code)]

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -16,10 +16,34 @@
  */
 
 use std;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 
 use crate::ftp::constant::*;
 
+#[repr(C)]
+//#[derive(Debug, Copy, Clone)]
+pub struct FtpCommand {
+    pub command_name: *const c_char,
+    pub command: u8,
+    pub command_length: u8,
+}
+
+impl FtpCommand {
+    pub fn new() -> Self {
+        FtpCommand {
+            ..Default::default()
+        }
+    }
+}
+impl Default for FtpCommand {
+    fn default() -> Self {
+        FtpCommand {
+            command_name: std::ptr::null_mut(),
+            command: 0,
+            command_length: 0,
+        }
+    }
+}
 
 #[repr(C)]
 #[allow(dead_code)]

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -16,34 +16,115 @@
  */
 
 use std;
+use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
 
-use crate::ftp::constant::*;
 use crate::conf::{conf_get, get_memval};
+use crate::ftp::constant::*;
+use lazy_static::lazy_static;
 
 #[repr(C)]
-//#[derive(Debug, Copy, Clone)]
-pub struct FtpCommand {
-    pub command_name: *const c_char,
-    pub command: u8,
-    pub command_length: u8,
+
+/// cbindgen:ignore
+struct FtpCommand {
+    command_name: CString,
+    command: u8,
+    command_length: u8,
 }
 
 impl FtpCommand {
-    pub fn new() -> Self {
+    fn new(command_name: &str, command: u8, command_length: u8) -> FtpCommand {
+        let cstring = CString::new(command_name).unwrap();
         FtpCommand {
-            ..Default::default()
+            command_name: cstring,
+            command,
+            command_length,
         }
     }
 }
-impl Default for FtpCommand {
-    fn default() -> Self {
-        FtpCommand {
-            command_name: std::ptr::null_mut(),
-            command: 0,
-            command_length: 0,
+
+lazy_static! {
+    static ref FTP_COMMANDS: Vec<FtpCommand> = vec![
+        FtpCommand::new("PORT", FTP_COMMAND_PORT, 4),
+        FtpCommand::new("EPRT", FTP_COMMAND_EPRT, 4),
+        FtpCommand::new("AUTH_TLS", FTP_COMMAND_AUTH_TLS, 8),
+        FtpCommand::new("PASV", FTP_COMMAND_PASV, 4),
+        FtpCommand::new("EPSV", FTP_COMMAND_EPSV, 4),
+        FtpCommand::new("RETR", FTP_COMMAND_RETR, 4),
+        FtpCommand::new("STOR", FTP_COMMAND_STOR, 4),
+        FtpCommand::new("ABOR", FTP_COMMAND_ABOR, 4),
+        FtpCommand::new("ACCT", FTP_COMMAND_ACCT, 4),
+        FtpCommand::new("ALLO", FTP_COMMAND_ALLO, 4),
+        FtpCommand::new("APPE", FTP_COMMAND_APPE, 4),
+        FtpCommand::new("CDUP", FTP_COMMAND_CDUP, 4),
+        FtpCommand::new("CHMOD", FTP_COMMAND_CHMOD, 5),
+        FtpCommand::new("CWD", FTP_COMMAND_CWD, 3),
+        FtpCommand::new("DELE", FTP_COMMAND_DELE, 4),
+        FtpCommand::new("HELP", FTP_COMMAND_HELP, 4),
+        FtpCommand::new("IDLE", FTP_COMMAND_IDLE, 4),
+        FtpCommand::new("LIST", FTP_COMMAND_LIST, 4),
+        FtpCommand::new("MAIL", FTP_COMMAND_MAIL, 4),
+        FtpCommand::new("MDTM", FTP_COMMAND_MDTM, 4),
+        FtpCommand::new("MKD", FTP_COMMAND_MKD, 3),
+        FtpCommand::new("MLFL", FTP_COMMAND_MLFL, 4),
+        FtpCommand::new("MODE", FTP_COMMAND_MODE, 4),
+        FtpCommand::new("MRCP", FTP_COMMAND_MRCP, 4),
+        FtpCommand::new("MRSQ", FTP_COMMAND_MRSQ, 4),
+        FtpCommand::new("MSAM", FTP_COMMAND_MSAM, 4),
+        FtpCommand::new("MSND", FTP_COMMAND_MSND, 4),
+        FtpCommand::new("MSOM", FTP_COMMAND_MSOM, 4),
+        FtpCommand::new("NLST", FTP_COMMAND_NLST, 4),
+        FtpCommand::new("NOOP", FTP_COMMAND_NOOP, 4),
+        FtpCommand::new("PASS", FTP_COMMAND_PASS, 4),
+        FtpCommand::new("PWD", FTP_COMMAND_PWD, 3),
+        FtpCommand::new("QUIT", FTP_COMMAND_QUIT, 4),
+        FtpCommand::new("REIN", FTP_COMMAND_REIN, 4),
+        FtpCommand::new("REST", FTP_COMMAND_REST, 4),
+        FtpCommand::new("RMD", FTP_COMMAND_RMD, 3),
+        FtpCommand::new("RNFR", FTP_COMMAND_RNFR, 4),
+        FtpCommand::new("RNTO", FTP_COMMAND_RNTO, 4),
+        FtpCommand::new("SITE", FTP_COMMAND_SITE, 4),
+        FtpCommand::new("SIZE", FTP_COMMAND_SIZE, 4),
+        FtpCommand::new("SMNT", FTP_COMMAND_SMNT, 4),
+        FtpCommand::new("STAT", FTP_COMMAND_STAT, 4),
+        FtpCommand::new("STOU", FTP_COMMAND_STOU, 4),
+        FtpCommand::new("STRU", FTP_COMMAND_STRU, 4),
+        FtpCommand::new("SYST", FTP_COMMAND_SYST, 4),
+        FtpCommand::new("TYPE", FTP_COMMAND_TYPE, 4),
+        FtpCommand::new("UMASK", FTP_COMMAND_UMASK, 5),
+        FtpCommand::new("USER", FTP_COMMAND_USER, 4),
+        FtpCommand::new("UNKNOWN", FTP_COMMAND_UNKNOWN, 7),
+        FtpCommand::new("MAX", FTP_COMMAND_MAX, 0),
+    ];
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub unsafe extern "C" fn SCGetFtpCommandInfo(
+    index: usize, name_ptr: *mut *const c_char, code_ptr: *mut u8, len_ptr: *mut u8,
+) -> bool {
+    if index <= FTP_COMMANDS.len() {
+        unsafe {
+            if !name_ptr.is_null() {
+                *name_ptr = FTP_COMMANDS[index].command_name.as_ptr();
+            }
+            if !code_ptr.is_null() {
+                *code_ptr = FTP_COMMANDS[index].command;
+            }
+            if !len_ptr.is_null() {
+                *len_ptr = FTP_COMMANDS[index].command_length;
+            }
         }
+        true
+    } else {
+        false
     }
+}
+
+#[allow(non_snake_case)]
+#[no_mangle]
+pub extern "C" fn SCGetFtpCommandTableSize() -> usize {
+    FTP_COMMANDS.len()
 }
 
 #[repr(C)]
@@ -81,7 +162,9 @@ impl FtpTransferCmd {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCFTPGetConfigValues(memcap: *mut u64, max_tx: *mut u32, max_line_len: *mut u32) {
+pub unsafe extern "C" fn SCFTPGetConfigValues(
+    memcap: *mut u64, max_tx: *mut u32, max_line_len: *mut u32,
+) {
     if let Some(val) = conf_get("app-layer.protocols.ftp.memcap") {
         if let Ok(v) = get_memval(val) {
             *memcap = v;

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -1,0 +1,81 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std;
+use std::os::raw::c_void;
+
+// FTP state progress values
+pub const FTP_STATE_NONE: u8 = 0;
+pub const FTP_STATE_IN_PROGRESS: u8 = 1;
+pub const FTP_STATE_PORT_DONE: u8 = 2;
+pub const FTP_STATE_FINISHED: u8 = 3;
+
+// FTP Data progress values
+pub const FTPDATA_STATE_IN_PROGRESS: u8 = 1;
+pub const FTPDATA_STATE_FINISHED: u8 = 2;
+
+// FTP request command values
+pub const FTP_COMMAND_UNKNOWN: u8 = 0;
+pub const FTP_COMMAND_ABOR: u8 = 1;
+pub const FTP_COMMAND_ACCT: u8 = 2;
+pub const FTP_COMMAND_ALLO: u8 = 3;
+pub const FTP_COMMAND_APPE: u8 = 4;
+pub const FTP_COMMAND_AUTH_TLS: u8 = 5;
+pub const FTP_COMMAND_CDUP: u8 = 6;
+pub const FTP_COMMAND_CHMOD: u8 = 7;
+pub const FTP_COMMAND_CWD: u8 = 8;
+pub const FTP_COMMAND_DELE: u8 = 9;
+pub const FTP_COMMAND_EPSV: u8 = 10;
+pub const FTP_COMMAND_HELP: u8 = 11;
+pub const FTP_COMMAND_IDLE: u8 = 12;
+pub const FTP_COMMAND_LIST: u8 = 13;
+pub const FTP_COMMAND_MAIL: u8 = 14;
+pub const FTP_COMMAND_MDTM: u8 = 15;
+pub const FTP_COMMAND_MKD: u8 = 16;
+pub const FTP_COMMAND_MLFL: u8 = 17;
+pub const FTP_COMMAND_MODE: u8 = 18;
+pub const FTP_COMMAND_MRCP: u8 = 19;
+pub const FTP_COMMAND_MRSQ: u8 = 20;
+pub const FTP_COMMAND_MSAM: u8 = 21;
+pub const FTP_COMMAND_MSND: u8 = 22;
+pub const FTP_COMMAND_MSOM: u8 = 23;
+pub const FTP_COMMAND_NLST: u8 = 24;
+pub const FTP_COMMAND_NOOP: u8 = 25;
+pub const FTP_COMMAND_PASS: u8 = 26;
+pub const FTP_COMMAND_PASV: u8 = 27;
+pub const FTP_COMMAND_PORT: u8 = 28;
+pub const FTP_COMMAND_PWD: u8 = 29;
+pub const FTP_COMMAND_QUIT: u8 = 30;
+pub const FTP_COMMAND_REIN: u8 = 31;
+pub const FTP_COMMAND_REST: u8 = 32;
+pub const FTP_COMMAND_RETR: u8 = 33;
+pub const FTP_COMMAND_RMD: u8 = 34;
+pub const FTP_COMMAND_RNFR: u8 = 35;
+pub const FTP_COMMAND_RNTO: u8 = 36;
+pub const FTP_COMMAND_SITE: u8 = 37;
+pub const FTP_COMMAND_SIZE: u8 = 38;
+pub const FTP_COMMAND_SMNT: u8 = 39;
+pub const FTP_COMMAND_STAT: u8 = 40;
+pub const FTP_COMMAND_STOR: u8 = 41;
+pub const FTP_COMMAND_STOU: u8 = 42;
+pub const FTP_COMMAND_STRU: u8 = 43;
+pub const FTP_COMMAND_SYST: u8 = 44;
+pub const FTP_COMMAND_TYPE: u8 = 45;
+pub const FTP_COMMAND_UMASK: u8 = 46;
+pub const FTP_COMMAND_USER: u8 = 47;
+pub const FTP_COMMAND_EPRT: u8 = 48;
+pub const FTP_COMMAND_MAX: u8 = 49;

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -19,6 +19,7 @@ use std;
 use std::os::raw::{c_char, c_void};
 
 use crate::ftp::constant::*;
+use crate::conf::{conf_get, get_memval};
 
 #[repr(C)]
 //#[derive(Debug, Copy, Clone)]
@@ -53,7 +54,7 @@ pub struct FtpTransferCmd {
     pub flow_id: u64,
     pub file_name: *mut u8,
     pub file_len: u16,
-    pub direction: u16,
+    pub direction: u8,
     pub cmd: u8,
 }
 
@@ -75,6 +76,35 @@ impl FtpTransferCmd {
     pub fn new() -> Self {
         FtpTransferCmd {
             ..Default::default()
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCFTPGetConfigValues(memcap: *mut u64, max_tx: *mut u32, max_line_len: *mut u32) {
+    if let Some(val) = conf_get("app-layer.protocols.ftp.memcap") {
+        if let Ok(v) = get_memval(val) {
+            *memcap = v;
+            SCLogConfig!("FTP memcap: {}", v);
+        } else {
+            SCLogError!("Invalid value {} for ftp.memcap", val);
+        }
+    }
+    if let Some(val) = conf_get("app-layer.protocols.ftp.max-tx") {
+        if let Ok(v) = val.parse::<u32>() {
+            *max_tx = v;
+            SCLogConfig!("FTP max tx: {}", v);
+        } else {
+            SCLogError!("Invalid value {} for ftp.max-tx", val);
+        }
+    }
+    // This value is often expressed with a unit suffix, e.g., 5kb, hence get_memval
+    if let Some(val) = conf_get("app-layer.protocols.ftp.max-line-length") {
+        if let Ok(v) = get_memval(val) {
+            *max_line_len = v as u32;
+            SCLogConfig!("FTP max line length: {}", v);
+        } else {
+            SCLogError!("Invalid value {} for ftp.max-line-length", val);
         }
     }
 }

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -27,6 +27,7 @@ use std::str;
 use std::str::FromStr;
 
 pub mod event;
+pub mod ftp;
 
 // We transform an integer string into a i64, ignoring surrounding whitespaces
 // We look for a digit suite, and try to convert it.

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -89,7 +89,7 @@ pub fn ftp_pasv_response(i: &[u8]) -> IResult<&[u8], u16> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn SCFTPParseActivePort(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_port(buf) {
         Ok((_, dport)) => {
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn rs_ftp_active_port(input: *const u8, len: u32) -> u16 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ftp_pasv_response(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn SCFTPParsePASVResponse(input: *const u8, len: u32) -> u16 {
     let buf = std::slice::from_raw_parts(input, len as usize);
     match ftp_pasv_response(buf) {
         Ok((_, dport)) => {
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn rs_ftp_pasv_response(input: *const u8, len: u32) -> u16
 }
 
 // 229 Entering Extended Passive Mode (|||48758|).
-pub fn ftp_epsv_response(i: &[u8]) -> IResult<&[u8], u16> {
+fn ftp_epsv_response(i: &[u8]) -> IResult<&[u8], u16> {
     let (i, _) = tag("229")(i)?;
     let (i, _) = take_until("|||")(i)?;
     let (i, _) = tag("|||")(i)?;
@@ -134,7 +134,7 @@ pub fn ftp_epsv_response(i: &[u8]) -> IResult<&[u8], u16> {
 }
 
 // EPRT |2|2a01:e34:ee97:b130:8c3e:45ea:5ac6:e301|41813|
-pub fn ftp_active_eprt(i: &[u8]) -> IResult<&[u8], u16> {
+fn ftp_active_eprt(i: &[u8]) -> IResult<&[u8], u16> {
     let (i, _) = tag("EPRT")(i)?;
     let (i, _) = take_until("|")(i)?;
     let (i, _) = tag("|")(i)?;
@@ -148,7 +148,7 @@ pub fn ftp_active_eprt(i: &[u8]) -> IResult<&[u8], u16> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn SCFTPParseActiveEPRT(input: *const u8, len: u32) -> u16 {
     let buf = build_slice!(input, len as usize);
     match ftp_active_eprt(buf) {
         Ok((_, dport)) => {
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn rs_ftp_active_eprt(input: *const u8, len: u32) -> u16 {
     return 0;
 }
 #[no_mangle]
-pub unsafe extern "C" fn rs_ftp_epsv_response(input: *const u8, len: u32) -> u16 {
+pub unsafe extern "C" fn SCFTPParseEPSVResponse(input: *const u8, len: u32) -> u16 {
     let buf = std::slice::from_raw_parts(input, len as usize);
     match ftp_epsv_response(buf) {
         Ok((_, dport)) => {

--- a/rust/src/ftp/mod.rs
+++ b/rust/src/ftp/mod.rs
@@ -26,6 +26,7 @@ use std;
 use std::str;
 use std::str::FromStr;
 
+pub mod constant;
 pub mod event;
 pub mod ftp;
 

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -429,26 +429,16 @@ static int FTPParseRequestCommand(
     SCReturnInt(0);
 }
 
-struct FtpTransferCmd {
-    /** Need to look like a ExpectationData so DFree must
-     *  be first field . */
-    void (*DFree)(void *);
-    uint64_t flow_id;
-    uint8_t *file_name;
-    uint16_t file_len;
-    uint8_t direction; /**< direction in which the data will flow */
-    FtpRequestCommand cmd;
-};
-
 static void FtpTransferCmdFree(void *data)
 {
-    struct FtpTransferCmd *cmd = (struct FtpTransferCmd *) data;
+    FtpTransferCmd *cmd = (FtpTransferCmd *)data;
     if (cmd == NULL)
         return;
     if (cmd->file_name) {
-        FTPFree(cmd->file_name, cmd->file_len + 1);
+        FTPFree((void *)cmd->file_name, cmd->file_len + 1);
     }
-    FTPFree(cmd, sizeof(struct FtpTransferCmd));
+    SCFTPTransferCmdFree(cmd);
+    FTPDecrMemuse((uint64_t)sizeof(FtpTransferCmd));
 }
 
 static uint32_t CopyCommandLine(uint8_t **dest, FtpLineState *line)
@@ -578,10 +568,12 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
                 if (state->dyn_port == 0 || line.len < 6) {
                     SCReturnStruct(APP_LAYER_ERROR);
                 }
-                struct FtpTransferCmd *data = FTPCalloc(1, sizeof(struct FtpTransferCmd));
+                FtpTransferCmd *data = SCFTPTransferCmdNew();
                 if (data == NULL)
                     SCReturnStruct(APP_LAYER_ERROR);
-                data->DFree = FtpTransferCmdFree;
+                FTPIncrMemuse((uint64_t)(sizeof *data));
+                data->data_free = FtpTransferCmdFree;
+
                 /*
                  * Min size has been checked in FTPParseRequestCommand
                  * SC_FILENAME_MAX includes the null
@@ -1056,8 +1048,8 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
 
     SCLogDebug("FTP-DATA flags %04x dir %d", flags, direction);
     if (input_len && ftpdata_state->files == NULL) {
-        struct FtpTransferCmd *data =
-                (struct FtpTransferCmd *)FlowGetStorageById(f, AppLayerExpectationGetFlowId());
+        FtpTransferCmd *data =
+                (FtpTransferCmd *)FlowGetStorageById(f, AppLayerExpectationGetFlowId());
         if (data == NULL) {
             SCReturnStruct(APP_LAYER_ERROR);
         }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -32,7 +32,7 @@
 #include "app-layer-expectation.h"
 #include "app-layer-detect-proto.h"
 
-#include "rust.h"
+#include "rust-bindings.h"
 
 #include "util-misc.h"
 #include "util-mpm.h"

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -544,7 +544,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
 
 static int FTPParsePassiveResponse(FtpState *state, const uint8_t *input, uint32_t input_len)
 {
-    uint16_t dyn_port = rs_ftp_pasv_response(input, input_len);
+    uint16_t dyn_port = SCFTPParsePASVResponse(input, input_len);
     if (dyn_port == 0) {
         return -1;
     }
@@ -559,7 +559,7 @@ static int FTPParsePassiveResponse(FtpState *state, const uint8_t *input, uint32
 
 static int FTPParsePassiveResponseV6(FtpState *state, const uint8_t *input, uint32_t input_len)
 {
-    uint16_t dyn_port = rs_ftp_epsv_response(input, input_len);
+    uint16_t dyn_port = SCFTPParseEPSVResponse(input, input_len);
     if (dyn_port == 0) {
         return -1;
     }
@@ -640,7 +640,7 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
                 break;
 
             case FTP_COMMAND_EPRT:
-                dyn_port = rs_ftp_active_eprt(state->port_line, state->port_line_len);
+                dyn_port = SCFTPParseActiveEPRT(state->port_line, state->port_line_len);
                 if (dyn_port == 0) {
                     goto tx_complete;
                 }
@@ -652,7 +652,7 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
                 break;
 
             case FTP_COMMAND_PORT:
-                dyn_port = rs_ftp_active_port(state->port_line, state->port_line_len);
+                dyn_port = SCFTPParseActivePort(state->port_line, state->port_line_len);
                 if (dyn_port == 0) {
                     goto tx_complete;
                 }

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -47,63 +47,6 @@ typedef struct FTPThreadCtx_ {
 
 static MpmCtx *ftp_mpm_ctx = NULL;
 
-// clang-format off
-const FtpCommand FtpCommands[FTP_COMMAND_MAX + 1] = {
-    /* Parsed and handled */
-    { "PORT",   FTP_COMMAND_PORT,   4 },
-    { "EPRT",   FTP_COMMAND_EPRT,   4 },
-    { "AUTH TLS",   FTP_COMMAND_AUTH_TLS,   8 },
-    { "PASV",   FTP_COMMAND_PASV,   4 },
-    { "RETR",   FTP_COMMAND_RETR,   4 },
-    { "EPSV",   FTP_COMMAND_EPSV,   4 },
-    { "STOR",   FTP_COMMAND_STOR,   4 },
-
-    /* Parsed, but not handled */
-    { "ABOR",   FTP_COMMAND_ABOR,   4 },
-    { "ACCT",   FTP_COMMAND_ACCT,   4 },
-    { "ALLO",   FTP_COMMAND_ALLO,   4 },
-    { "APPE",   FTP_COMMAND_APPE,   4 },
-    { "CDUP",   FTP_COMMAND_CDUP,   4 },
-    { "CHMOD",  FTP_COMMAND_CHMOD,  5 },
-    { "CWD",    FTP_COMMAND_CWD,    3 },
-    { "DELE",   FTP_COMMAND_DELE,   4 },
-    { "HELP",   FTP_COMMAND_HELP,   4 },
-    { "IDLE",   FTP_COMMAND_IDLE,   4 },
-    { "LIST",   FTP_COMMAND_LIST,   4 },
-    { "MAIL",   FTP_COMMAND_MAIL,   4 },
-    { "MDTM",   FTP_COMMAND_MDTM,   4 },
-    { "MKD",    FTP_COMMAND_MKD,    3 },
-    { "MLFL",   FTP_COMMAND_MLFL,   4 },
-    { "MODE",   FTP_COMMAND_MODE,   4 },
-    { "MRCP",   FTP_COMMAND_MRCP,   4 },
-    { "MRSQ",   FTP_COMMAND_MRSQ,   4 },
-    { "MSAM",   FTP_COMMAND_MSAM,   4 },
-    { "MSND",   FTP_COMMAND_MSND,   4 },
-    { "MSOM",   FTP_COMMAND_MSOM,   4 },
-    { "NLST",   FTP_COMMAND_NLST,   4 },
-    { "NOOP",   FTP_COMMAND_NOOP,   4 },
-    { "PASS",   FTP_COMMAND_PASS,   4 },
-    { "PWD",    FTP_COMMAND_PWD,    3 },
-    { "QUIT",   FTP_COMMAND_QUIT,   4 },
-    { "REIN",   FTP_COMMAND_REIN,   4 },
-    { "REST",   FTP_COMMAND_REST,   4 },
-    { "RMD",    FTP_COMMAND_RMD,    3 },
-    { "RNFR",   FTP_COMMAND_RNFR,   4 },
-    { "RNTO",   FTP_COMMAND_RNTO,   4 },
-    { "SITE",   FTP_COMMAND_SITE,   4 },
-    { "SIZE",   FTP_COMMAND_SIZE,   4 },
-    { "SMNT",   FTP_COMMAND_SMNT,   4 },
-    { "STAT",   FTP_COMMAND_STAT,   4 },
-    { "STOU",   FTP_COMMAND_STOU,   4 },
-    { "STRU",   FTP_COMMAND_STRU,   4 },
-    { "SYST",   FTP_COMMAND_SYST,   4 },
-    { "TYPE",   FTP_COMMAND_TYPE,   4 },
-    { "UMASK",  FTP_COMMAND_UMASK,  5 },
-    { "USER",   FTP_COMMAND_USER,   4 },
-    { NULL,     FTP_COMMAND_UNKNOWN,    0 }
-};
-// clang-format on
-
 uint64_t ftp_config_memcap = 0;
 uint32_t ftp_config_maxtx = 1024;
 uint32_t ftp_max_line_len = 4096;
@@ -380,7 +323,7 @@ static AppLayerResult FTPGetLineForDirection(
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static int FTPParseRequestCommand(
-        FTPThreadCtx *td, FtpLineState *line, const FtpCommand **cmd_descriptor)
+        FTPThreadCtx *td, FtpLineState *line, FtpCommandInfo *cmd_descriptor)
 {
     SCEnter();
 
@@ -390,11 +333,19 @@ static int FTPParseRequestCommand(
     int mpm_cnt = mpm_table[FTP_MPM].Search(
             ftp_mpm_ctx, td->ftp_mpm_thread_ctx, td->pmq, line->buf, line->len);
     if (mpm_cnt) {
-        *cmd_descriptor = &FtpCommands[td->pmq->rule_id_array[0]];
-        SCReturnInt(1);
+        uint8_t command_code;
+        const char *command_name;
+        if (SCGetFtpCommandInfo(td->pmq->rule_id_array[0], &command_name, &command_code, NULL)) {
+            SCLogDebug("matching FTP command is %s [code: %d, index %d]", command_name,
+                    command_code, td->pmq->rule_id_array[0]);
+            cmd_descriptor->command_code = command_code;
+            /* FTP command indices are < FTP_COMMAND_MAX and will fit into a u8 */
+            cmd_descriptor->command_index = (uint8_t) td->pmq->rule_id_array[0];
+            SCReturnInt(1);
+        }
     }
 
-    *cmd_descriptor = NULL;
+    cmd_descriptor->command_code = FTP_COMMAND_UNKNOWN;
     SCReturnInt(0);
 }
 
@@ -472,14 +423,14 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
         } else if (res.status == -1) {
             break;
         }
-        const FtpCommand *cmd_descriptor;
 
+        FtpCommandInfo cmd_descriptor;
         if (!FTPParseRequestCommand(thread_data, &line, &cmd_descriptor)) {
             state->command = FTP_COMMAND_UNKNOWN;
             continue;
         }
 
-        state->command = cmd_descriptor->command;
+        state->command = cmd_descriptor.command_code;
         FTPTransaction *tx = FTPTransactionCreate(state);
         if (unlikely(tx == NULL))
             SCReturnStruct(APP_LAYER_ERROR);
@@ -675,9 +626,8 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
             SCReturnStruct(APP_LAYER_ERROR);
         }
         lasttx = tx;
-        if (state->command == FTP_COMMAND_UNKNOWN || tx->command_descriptor == NULL) {
-            /* unknown */
-            tx->command_descriptor = &FtpCommands[FTP_COMMAND_MAX - 1];
+        if (state->command == FTP_COMMAND_UNKNOWN) {
+            tx->command_descriptor.command_code = FTP_COMMAND_UNKNOWN;
         }
 
         state->curr_tx = tx;
@@ -794,9 +744,15 @@ static void FTPStateFree(void *s)
     FTPTransaction *tx = NULL;
     while ((tx = TAILQ_FIRST(&fstate->tx_list))) {
         TAILQ_REMOVE(&fstate->tx_list, tx, next);
-        SCLogDebug("[%s] state %p id %" PRIu64 ", Freeing %d bytes at %p",
-                tx->command_descriptor->command_name, s, tx->tx_id, tx->request_length,
-                tx->request);
+        if (sc_log_global_log_level >= SC_LOG_DEBUG) {
+            const char *command_name = NULL;
+            (void)SCGetFtpCommandInfo(
+                    tx->command_descriptor.command_index, &command_name, NULL, NULL);
+            SCLogDebug("[%s] state %p id %" PRIu64 ", Freeing %d bytes at %p",
+                    command_name != NULL ? command_name : "n/a", s, tx->tx_id, tx->request_length,
+                    tx->request);
+        }
+
         FTPTransactionFree(tx);
     }
 
@@ -907,7 +863,8 @@ static int FTPGetAlstateProgress(void *vtx, uint8_t direction)
     FTPTransaction *tx = vtx;
 
     if (!tx->done) {
-        if (direction == STREAM_TOSERVER && tx->command_descriptor->command == FTP_COMMAND_PORT) {
+        if (direction == STREAM_TOSERVER &&
+                tx->command_descriptor.command_code == FTP_COMMAND_PORT) {
             return FTP_STATE_PORT_DONE;
         }
         return FTP_STATE_IN_PROGRESS;
@@ -1230,16 +1187,23 @@ static void FTPSetMpmState(void)
     MpmInitCtx(ftp_mpm_ctx, FTP_MPM);
 
     uint32_t i = 0;
-    for (i = 0; i < sizeof(FtpCommands)/sizeof(FtpCommand) - 1; i++) {
-        const FtpCommand *cmd = &FtpCommands[i];
-        if (cmd->command_length == 0)
-            continue;
+    const size_t commands_count = SCGetFtpCommandTableSize();
+    for (i = 0; i < commands_count; i++) {
+        const char *command_name;
+        uint8_t command_length;
 
-        MpmAddPatternCI(ftp_mpm_ctx,
-                       (uint8_t *)cmd->command_name,
-                       cmd->command_length,
-                       0 /* defunct */, 0 /* defunct */,
-                       i /*  id */, i /* rule id */ , 0 /* no flags */);
+        if (!SCGetFtpCommandInfo(i, &command_name, NULL, &command_length)) {
+            SCLogError("Failed to obtain info for FTP command index %d", i);
+            continue;
+        }
+
+        SCLogDebug("Adding MPM state for FTP command %s [length %d, index %d]", command_name,
+                command_length, i);
+
+        if (command_length) {
+            MpmAddPatternCI(ftp_mpm_ctx, (uint8_t *)command_name, command_length, 0 /* defunct */,
+                    0 /* defunct */, i /*  id */, i /* rule id */, 0 /* no flags */);
+        }
     }
 
     mpm_table[FTP_MPM].Prepare(ftp_mpm_ctx);

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -115,41 +115,10 @@ static FTPTransaction *FTPGetOldestTx(const FtpState *, FTPTransaction *);
 
 static void FTPParseMemcap(void)
 {
-    const char *conf_val;
-
-    /** set config values for memcap, prealloc and hash_size */
-    if ((ConfGet("app-layer.protocols.ftp.memcap", &conf_val)) == 1)
-    {
-        if (ParseSizeStringU64(conf_val, &ftp_config_memcap) < 0) {
-            SCLogError("Error parsing ftp.memcap "
-                       "from conf file - %s.  Killing engine",
-                    conf_val);
-            exit(EXIT_FAILURE);
-        }
-        SCLogInfo("FTP memcap: %"PRIu64, ftp_config_memcap);
-    } else {
-        /* default to unlimited */
-        ftp_config_memcap = 0;
-    }
+    SCFTPGetConfigValues(&ftp_config_memcap, &ftp_config_maxtx, &ftp_max_line_len);
 
     SC_ATOMIC_INIT(ftp_memuse);
     SC_ATOMIC_INIT(ftp_memcap);
-
-    if ((ConfGet("app-layer.protocols.ftp.max-tx", &conf_val)) == 1) {
-        if (ParseSizeStringU32(conf_val, &ftp_config_maxtx) < 0) {
-            SCLogError("Error parsing ftp.max-tx "
-                       "from conf file - %s.",
-                    conf_val);
-        }
-        SCLogInfo("FTP max tx: %" PRIu32, ftp_config_maxtx);
-    }
-
-    if ((ConfGet("app-layer.protocols.ftp.max-line-length", &conf_val)) == 1) {
-        if (ParseSizeStringU32(conf_val, &ftp_max_line_len) < 0) {
-            SCLogError("Error parsing ftp.max-line-length from conf file - %s.", conf_val);
-        }
-        SCLogConfig("FTP max line length: %" PRIu32, ftp_max_line_len);
-    }
 }
 
 static void FTPIncrMemuse(uint64_t size)

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -27,67 +27,7 @@
 
 #include "rust.h"
 
-enum {
-    FTP_STATE_IN_PROGRESS,
-    FTP_STATE_PORT_DONE,
-    FTP_STATE_FINISHED,
-};
-
-typedef enum {
-    FTP_COMMAND_UNKNOWN = 0,
-    FTP_COMMAND_ABOR,
-    FTP_COMMAND_ACCT,
-    FTP_COMMAND_ALLO,
-    FTP_COMMAND_APPE,
-    FTP_COMMAND_AUTH_TLS,
-    FTP_COMMAND_CDUP,
-    FTP_COMMAND_CHMOD,
-    FTP_COMMAND_CWD,
-    FTP_COMMAND_DELE,
-    FTP_COMMAND_EPSV,
-    FTP_COMMAND_HELP,
-    FTP_COMMAND_IDLE,
-    FTP_COMMAND_LIST,
-    FTP_COMMAND_MAIL,
-    FTP_COMMAND_MDTM,
-    FTP_COMMAND_MKD,
-    FTP_COMMAND_MLFL,
-    FTP_COMMAND_MODE,
-    FTP_COMMAND_MRCP,
-    FTP_COMMAND_MRSQ,
-    FTP_COMMAND_MSAM,
-    FTP_COMMAND_MSND,
-    FTP_COMMAND_MSOM,
-    FTP_COMMAND_NLST,
-    FTP_COMMAND_NOOP,
-    FTP_COMMAND_PASS,
-    FTP_COMMAND_PASV,
-    FTP_COMMAND_PORT,
-    FTP_COMMAND_PWD,
-    FTP_COMMAND_QUIT,
-    FTP_COMMAND_REIN,
-    FTP_COMMAND_REST,
-    FTP_COMMAND_RETR,
-    FTP_COMMAND_RMD,
-    FTP_COMMAND_RNFR,
-    FTP_COMMAND_RNTO,
-    FTP_COMMAND_SITE,
-    FTP_COMMAND_SIZE,
-    FTP_COMMAND_SMNT,
-    FTP_COMMAND_STAT,
-    FTP_COMMAND_STOR,
-    FTP_COMMAND_STOU,
-    FTP_COMMAND_STRU,
-    FTP_COMMAND_SYST,
-    FTP_COMMAND_TYPE,
-    FTP_COMMAND_UMASK,
-    FTP_COMMAND_USER,
-    FTP_COMMAND_EPRT,
-
-    /* must be last */
-    FTP_COMMAND_MAX
-    /** \todo more if missing.. */
-} FtpRequestCommand;
+typedef uint8_t FtpRequestCommand;
 
 typedef struct FtpCommand_ {
     const char *command_name;
@@ -162,11 +102,6 @@ typedef struct FtpState_ {
 
     AppLayerStateData state_data;
 } FtpState;
-
-enum {
-    FTPDATA_STATE_IN_PROGRESS,
-    FTPDATA_STATE_FINISHED,
-};
 
 /** FTP Data State for app layer parser */
 typedef struct FtpDataState_ {

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -50,6 +50,11 @@ typedef struct FTPString_ {
     TAILQ_ENTRY(FTPString_) next;
 } FTPString;
 
+typedef struct FtpCommandInfo_ {
+    uint8_t command_code;
+    uint8_t command_index;
+} FtpCommandInfo;
+
 typedef struct FTPTransaction_  {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
@@ -62,7 +67,7 @@ typedef struct FTPTransaction_  {
     bool request_truncated;
 
     /* for the command description */
-    const FtpCommand *command_descriptor;
+    FtpCommandInfo command_descriptor;
 
     uint16_t dyn_port; /* dynamic port, if applicable */
     bool done; /* transaction complete? */

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -29,12 +29,7 @@
 
 typedef uint8_t FtpRequestCommand;
 
-typedef struct FtpCommand_ {
-    const char *command_name;
-    FtpRequestCommand command;
-    const uint8_t command_length;
-} FtpCommand;
-extern const FtpCommand FtpCommands[FTP_COMMAND_MAX + 1];
+struct FtpCommand;
 
 typedef uint32_t FtpRequestCommandArgOfs;
 

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -58,18 +58,28 @@ bool EveFTPLogCommand(void *vtx, JsonBuilder *jb)
             return false;
         }
     }
+
+    const char *command_name = NULL;
+    uint8_t command_name_length;
+    if (tx->command_descriptor.command_code != FTP_COMMAND_UNKNOWN) {
+        if (!SCGetFtpCommandInfo(tx->command_descriptor.command_index, &command_name, NULL,
+                    &command_name_length)) {
+            SCLogNotice("Unable to fetch info for FTP command code %d [index %d]",
+                    tx->command_descriptor.command_code, tx->command_descriptor.command_index);
+        }
+    }
     jb_open_object(jb, "ftp");
-    jb_set_string(jb, "command", tx->command_descriptor->command_name);
-    uint32_t min_length = tx->command_descriptor->command_length + 1; /* command + space */
-    if (tx->request_length > min_length) {
-        jb_set_string_from_bytes(jb,
-                "command_data",
-                (const uint8_t *)tx->request + min_length,
-                tx->request_length - min_length - 1);
-        if (tx->request_truncated) {
-            JB_SET_TRUE(jb, "command_truncated");
-        } else {
-            JB_SET_FALSE(jb, "command_truncated");
+    if (command_name) {
+        jb_set_string(jb, "command", command_name);
+        uint32_t min_length = command_name_length + 1; /* command + space */
+        if (tx->request_length > min_length) {
+            jb_set_string_from_bytes(jb, "command_data", (const uint8_t *)tx->request + min_length,
+                    tx->request_length - min_length - 1);
+            if (tx->request_truncated) {
+                JB_SET_TRUE(jb, "command_truncated");
+            } else {
+                JB_SET_FALSE(jb, "command_truncated");
+            }
         }
     }
 
@@ -131,8 +141,8 @@ bool EveFTPLogCommand(void *vtx, JsonBuilder *jb)
         jb_set_uint(jb, "dynamic_port", tx->dyn_port);
     }
 
-    if (tx->command_descriptor->command == FTP_COMMAND_PORT ||
-        tx->command_descriptor->command == FTP_COMMAND_EPRT) {
+    if (tx->command_descriptor.command_code == FTP_COMMAND_PORT ||
+            tx->command_descriptor.command_code == FTP_COMMAND_EPRT) {
         if (tx->active) {
             JB_SET_STRING(jb, "mode", "active");
         } else {


### PR DESCRIPTION
WIP: Convert FTP parser to Rust.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/4082

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
