### PR TITLE
pgsql: track 'progress' in tx per direction - v1

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -358,7 +358,6 @@ impl PgsqlState {
             );
             match PgsqlState::state_based_req_parsing(self.state_progress, start) {
                 Ok((rem, request)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     start = rem;
                     let mut temp_state = PgsqlStateProgress::IdleState;
                     if let Some(state) = PgsqlState::request_next_state(&request) {
@@ -374,6 +373,7 @@ impl PgsqlState {
                             } else {
                                 tx.tx_state = PgsqlTransactionState::RequestDone;
                             }
+                            sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                         }
                     } else {
                         // If there isn't a new transaction, we'll consider Suri should move on
@@ -494,7 +494,6 @@ impl PgsqlState {
         while !start.is_empty() {
             match PgsqlState::state_based_resp_parsing(self.state_progress, start) {
                 Ok((rem, response)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     start = rem;
                     SCLogDebug!("Response is {:?}", &response);
                     if let Some(state) = self.response_process_next_state(&response, flow) {
@@ -524,6 +523,7 @@ impl PgsqlState {
                             tx.responses.push(response);
                             if tx_completed {
                                 tx.tx_state = PgsqlTransactionState::ResponseDone;
+                                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                             }
                         }
                     } else {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7113

https://github.com/OISF/suricata/pull/11540 without force-pushes

Describe changes:
- add a tx state for when the pgsql request is done
- add a tx state for when pgsql response is received
- track tx_completion per tx direction
    - add more PgsqlStateProgress states to tx_completion check (especially for to_server direction)
    - reorganize PgsqlStateProgress enum to separate `to_server` and `to_client` states
- bring the trigger raw stream reassembly call to the moment when tx is completed
- proper commit message

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1991
