### PR TITLE
Tx iter 4083 v9

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -657,7 +657,7 @@ pub trait State<Tx: Transaction> {
                 index += 1;
                 continue;
             }
-            *state = index as u64;
+            *state = (index + 1) as u64;
             return AppLayerGetTxIterTuple::with_values(
                 tx as *const _ as *mut _,
                 tx.id() - 1,

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -6347,7 +6347,8 @@ static int HTPParserTest25(void)
             NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOCLIENT, (uint8_t *)str, strlen(str));
     FAIL_IF_NOT(r == 0);
 
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerCleanupTxList app_tx_list = { 0 };
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     uint64_t ret[4];
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
@@ -6359,7 +6360,7 @@ static int HTPParserTest25(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER | STREAM_EOF,
             (uint8_t *)str, strlen(str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 8); // inspect_id[0] not updated by ..Cleanup() until full tx is done
@@ -6370,7 +6371,7 @@ static int HTPParserTest25(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOCLIENT | STREAM_EOF,
             (uint8_t *)str, strlen(str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 9); // inspect_id[0]

--- a/src/app-layer-ike.c
+++ b/src/app-layer-ike.c
@@ -167,7 +167,8 @@ static int IkeParserTest(void)
             sizeof(encrypted));
     FAIL_IF_NOT(r == 0);
 
-    AppLayerParserTransactionsCleanup(&f, STREAM_TOCLIENT);
+    AppLayerCleanupTxList app_tx_list = { 0 };
+    AppLayerParserTransactionsCleanup(&f, STREAM_TOCLIENT, &app_tx_list);
     UTHAppLayerParserStateGetIds(f.alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 5); // inspect_id[0]
     FAIL_IF_NOT(ret[1] == 5); // inspect_id[1]

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -742,8 +742,7 @@ void AppLayerParserSetTransactionInspectId(const Flow *f, AppLayerParserState *p
     const AppProto alproto = f->alproto;
 
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
-    AppLayerGetTxIterState state;
-    memset(&state, 0, sizeof(state));
+    AppLayerGetTxIterState state = { 0 };
 
     SCLogDebug("called: %s, tag_txs_as_inspected %s",direction==0?"toserver":"toclient",
             tag_txs_as_inspected?"true":"false");

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -147,6 +147,12 @@ typedef struct AppLayerGetTxIterState {
     } un;
 } AppLayerGetTxIterState;
 
+typedef struct AppLayerCleanupTxList {
+    uint64_t *tx_id_free_list;
+    // size of tx_id_free_list
+    uint32_t max_tx;
+} AppLayerCleanupTxList;
+
 /** \brief tx iterator prototype */
 typedef AppLayerGetTxIterTuple (*AppLayerGetTxIteratorFunc)
        (const uint8_t ipproto, const AppProto alproto,
@@ -307,7 +313,7 @@ uint16_t AppLayerParserStateIssetFlag(AppLayerParserState *pstate, uint16_t flag
 AppLayerParserState *AppLayerParserStateAlloc(void);
 void AppLayerParserStateFree(AppLayerParserState *pstate);
 
-void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir);
+void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir, AppLayerCleanupTxList *txl);
 
 /***** Unittests *****/
 

--- a/src/app-layer-rfb.c
+++ b/src/app-layer-rfb.c
@@ -132,14 +132,15 @@ static int RFBParserTest(void)
             NULL, alp_tctx, f, ALPROTO_RFB, STREAM_TOCLIENT, (uint8_t *)server_init, sizeof(server_init));
     FAIL_IF_NOT(r == 0);
 
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerCleanupTxList app_tx_list = { 0 };
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 1); // inspect_id[0]
     FAIL_IF_NOT(ret[1] == 1); // inspect_id[1]
     FAIL_IF_NOT(ret[2] == 1); // log_id
     FAIL_IF_NOT(ret[3] == 1); // min_id
 
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     UTHFreeFlow(f);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -115,7 +115,8 @@ static int SMBParserTxCleanupTest(void)
     FAIL_IF_NOT(r == 0);
     req_str[28]++;
 
-    AppLayerParserTransactionsCleanup(f, STREAM_TOSERVER);
+    AppLayerCleanupTxList app_tx_list = { 0 };
+    AppLayerParserTransactionsCleanup(f, STREAM_TOSERVER, &app_tx_list);
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 0); // inspect_id[0]
     FAIL_IF_NOT(ret[1] == 0); // inspect_id[1]
@@ -161,7 +162,7 @@ static int SMBParserTxCleanupTest(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
                                 STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 2); // inspect_id[0]
@@ -173,7 +174,7 @@ static int SMBParserTxCleanupTest(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
                                 STREAM_TOCLIENT, (uint8_t *)resp_str, sizeof(resp_str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 8); // inspect_id[0]
@@ -185,7 +186,7 @@ static int SMBParserTxCleanupTest(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
                                 STREAM_TOSERVER | STREAM_EOF, (uint8_t *)req_str, sizeof(req_str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOSERVER);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOSERVER, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 8); // inspect_id[0] not updated by ..Cleanup() until full tx is done
@@ -197,7 +198,7 @@ static int SMBParserTxCleanupTest(void)
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_SMB,
                                 STREAM_TOCLIENT | STREAM_EOF, (uint8_t *)resp_str, sizeof(resp_str));
     FAIL_IF_NOT(r == 0);
-    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT);
+    AppLayerParserTransactionsCleanup(f, STREAM_TOCLIENT, &app_tx_list);
 
     UTHAppLayerParserStateGetIds(f->alparser, &ret[0], &ret[1], &ret[2], &ret[3]);
     FAIL_IF_NOT(ret[0] == 9); // inspect_id[0]

--- a/src/detect.c
+++ b/src/detect.c
@@ -1424,8 +1424,7 @@ static void DetectRunTx(ThreadVars *tv,
     const int tx_end_state = AppLayerParserGetStateProgressCompletionStatus(alproto, flow_flags);
 
     AppLayerGetTxIteratorFunc IterFunc = AppLayerGetTxIterator(ipproto, alproto);
-    AppLayerGetTxIterState state;
-    memset(&state, 0, sizeof(state));
+    AppLayerGetTxIterState state = { 0 };
 
     while (1) {
         AppLayerGetTxIterTuple ires = IterFunc(ipproto, alproto, alstate, tx_id_min, total_txs, &state);

--- a/src/detect.c
+++ b/src/detect.c
@@ -1632,9 +1632,9 @@ static void DetectRunTx(ThreadVars *tv,
 
             StoreDetectFlags(&tx, flow_flags, ipproto, alproto, new_detect_flags);
         }
-next:
         InspectionBufferClean(det_ctx);
 
+    next:
         if (!ires.has_next)
             break;
     }

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -136,6 +136,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     alsize = size - HEADER_LEN;
     uint8_t flags = STREAM_START;
     int flip = 0;
+    AppLayerCleanupTxList app_tx_list = { 0 };
     alnext = memmem(albuffer, alsize, separator, 4);
     while (alnext) {
         if (flip) {
@@ -173,7 +174,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 break;
             }
 
-            AppLayerParserTransactionsCleanup(f, flags & (STREAM_TOSERVER | STREAM_TOCLIENT));
+            AppLayerParserTransactionsCleanup(
+                    f, flags & (STREAM_TOSERVER | STREAM_TOCLIENT), &app_tx_list);
         }
         alsize -= alnext - albuffer + 4;
         albuffer = alnext + 4;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7089

Describe changes:
- some optimizations for tx iterations

#11526 with comment taken into account
and renaming `total_txs` to `max_id` and fixing its use 