### PR TITLE
 rust/ldap: udp and frames support v3

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4640,8 +4640,12 @@
                                             "Errors encountered parsing Kerberos v5/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
-                                "ldap": {
-                                    "description": "Errors encountered parsing LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Errors encountered parsing LDAP/TCP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "modbus": {
@@ -4811,8 +4815,12 @@
                                     "description": "Number of flows for Kerberos v5/UDP protocol",
                                     "type": "integer"
                                 },
-                                "ldap": {
-                                    "description": "Number of flows for LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Number of flows for LDAP/TCP protocol",
+                                    "type": "integer"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "type": "integer"
                                 },
                                 "modbus": {
@@ -4977,8 +4985,12 @@
                                             "Number of transactions for Kerberos v5/UDP protocol",
                                     "type": "integer"
                                 },
-                                "ldap": {
-                                    "description": "Number of transactions for LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Number of transactions for LDAP/TCP protocol",
+                                    "type": "integer"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "type": "integer"
                                 },
                                 "modbus": {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1724,7 +1724,8 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_sip_register_parser();
     rs_quic_register_parser();
     rs_websocket_register_parser();
-    rs_ldap_register_parser();
+    SCRegisterLdapTcpParser();
+    SCRegisterLdapUdpParser();
     rs_template_register_parser();
     RegisterRFBParsers();
     SCMqttRegisterParser();

--- a/src/output.c
+++ b/src/output.c
@@ -1094,7 +1094,7 @@ void OutputRegisterLoggers(void)
             JsonLogThreadDeinit, NULL);
     /* Ldap JSON logger. */
     OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonLdapLog", "eve-log.ldap",
-            OutputJsonLogInitSub, ALPROTO_LDAP, JsonGenericDirPacketLogger, JsonLogThreadInit,
+            OutputJsonLogInitSub, ALPROTO_LDAP, JsonGenericDirFlowLogger, JsonLogThreadInit,
             JsonLogThreadDeinit, NULL);
     /* DoH2 JSON logger. */
     JsonDoh2LogRegister();

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1189,7 +1189,14 @@ app-layer:
       #enabled: yes
 
     ldap:
-      enabled: yes
+      tcp:
+        enabled: yes
+        detection-ports:
+          dp: 389
+      udp:
+        enabled: yes
+        detection-ports:
+          dp: 389
       # Maximum number of live LDAP transactions per flow
       # max-tx: 1024
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/1199

Describe changes:
- Introduce a new registration function for LDAP/UDP
- Extend the configuration to independently enable/disable a single parser (such as dns)
- Handle GAPs

Note: Can't get CI to go green due to an issue with a Rust dependency and Clippy, see below
```
...
   Compiling thiserror-impl v1.0.58
error[E0282]: type annotations needed for `Box<_>`
  --> /github/home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.20/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

For more information about this error, try `rustc --explain E0282`.
...
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1984
