### PR TITLE
userguide: expand documentation for rule profiling - v3

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2621,6 +2621,9 @@ Example:
   Original content: abc
   Final content: bc
 
+
+.. _rule-and-packet-profiling-settings:
+
 Rule and Packet Profiling settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/performance/rule-profiling.rst
+++ b/doc/userguide/performance/rule-profiling.rst
@@ -1,7 +1,20 @@
 Rule Profiling
 ==============
 
-::
+Suricata can generate a rules performance report at the end of each session, if
+built with the ``enable-profiling`` option (see configuring :ref:`Rule profiling
+<rule-and-packet-profiling-settings>`). With that option, the engine will also
+generate profiling data for other engine modules, such as packet processing.
+
+Rule profiling can also be enabled by building the engine with ``enable-profiling
+-rules`` and using the unix socket to dump the report (see
+:ref:`rule-management-rules-profiling`). This will enable profiling of rules'
+statistics only
+
+Once the report is generated, it is stored in the default log directory used by
+Suricata. If not changed, the filename will be ``rule_perf.log``.
+
+A Rules Profile report looks like this: ::
 
   --------------------------------------------------------------------------
   Date: 9/5/2013 -- 14:59:58
@@ -22,7 +35,7 @@ Rule Profiling
 The meaning of the individual fields:
 
 * Ticks -- total ticks spent on this rule, so a sum of all inspections
-* % -- share of this single sig in the total cost of inspection
+* % -- share of this single signature in the total cost of inspection
 * Checks -- number of times a signature was inspected
 * Matches -- number of times it matched. This may not have resulted in an alert due to suppression and thresholding.
 * Max ticks -- single most expensive inspection

--- a/doc/userguide/rule-management/rule-profiling.rst
+++ b/doc/userguide/rule-management/rule-profiling.rst
@@ -1,3 +1,5 @@
+.. _rule-management-rules-profiling:
+
 Rules Profiling
 ===============
 


### PR DESCRIPTION
The page about performance and rule profiling showed the table generated by rules profiling but didn't inform how to achieve nor find it.

Task [4359](https://redmine.openinfosecfoundation.org/issues/4359)

Previous PR: https://github.com/OISF/suricata/pull/11440

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4359

Describe changes:

- explain the difference between using `enable-profiling` and `enable-profiling-rules`, as suggested by Philippe