### PR TITLE
output/reference: Include reference information in alert (if configured)

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -89,6 +89,9 @@ Metadata::
                 # Log the raw rule text.
                 #raw: false
 
+                # Include the rule reference information
+                # reference: no
+
 Anomaly
 ~~~~~~~
 

--- a/etc/reference.config
+++ b/etc/reference.config
@@ -1,26 +1,44 @@
 # config reference: system URL
 
-config reference: bugtraq   http://www.securityfocus.com/bid/
-config reference: bid	    http://www.securityfocus.com/bid/
-config reference: cve       http://cve.mitre.org/cgi-bin/cvename.cgi?name=
-#config reference: cve       http://cvedetails.com/cve/
-config reference: secunia   http://www.secunia.com/advisories/
+#
+# Note: https// used
+##############################
+# Referenced by ET/Open ET/Pro
+##############################
+
+#  resolves, works as intended
+config reference: cve       https://cve.mitre.org/cgi-bin/cvename.cgi?name=
+config reference: nessus    https://www.tenable.com/plugins/nessus/
+config reference: url       https://
 
 #whitehats is unfortunately gone
-config reference: arachNIDS http://www.whitehats.com/info/IDS
+#
+#  no longer resolves
+config reference: McAfee    https://vil.nai.com/vil/content/v_
+config reference: bid	    https://www.securityfocus.com/bid/
+config reference: bugtraq   https://www.securityfocus.com/bid/
+config reference: md5	    https://www.threatexpert.com/report.aspx?md5=
 
-config reference: McAfee    http://vil.nai.com/vil/content/v_
-config reference: nessus    http://cgi.nessus.org/plugins/dump.php3?id=
-config reference: url       http://
-config reference: et        http://doc.emergingthreats.net/
-config reference: etpro     http://doc.emergingthreatspro.com/
-config reference: telus     http://
+#  resolves, but non-useful page
+config reference: secunia   https://www.secunia.com/advisories/
+config reference: arachNIDS https://www.whitehats.com/info/IDS
+
+###################################################
+# No longer referenced from ET/Open ET/Pro rulesets
+###################################################
+
+#  resolves
+config reference: exploitdb https://www.exploit-db.com/exploits/
+config reference: msft      https://technet.microsoft.com/security/bulletin/
+
+#  resolves, but non-useful page
+config reference: et        https://doc.emergingthreats.net/
+config reference: etpro     https://doc.emergingthreatspro.com/
+config reference: telus     https://
+
+#  no longer resolves
+config reference: xforce    http://xforce.iss.net/xforce/xfdb/
 config reference: osvdb     http://osvdb.org/show/osvdb/
 config reference: threatexpert http://www.threatexpert.com/report.aspx?md5=
-config reference: md5	    http://www.threatexpert.com/report.aspx?md5=
-config reference: exploitdb http://www.exploit-db.com/exploits/
 config reference: openpacket https://www.openpacket.org/capture/grab/
 config reference: securitytracker http://securitytracker.com/id?
-config reference: secunia   http://secunia.com/advisories/
-config reference: xforce    http://xforce.iss.net/xforce/xfdb/
-config reference: msft      http://technet.microsoft.com/security/bulletin/

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -288,6 +288,13 @@
                     },
                     "additionalProperties": true
                 },
+                "references": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "source": {
                     "type": "object",
                     "properties": {

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -132,12 +132,15 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         goto error;
     }
 
-    if (strlen(key) == 0 || strlen(content) == 0)
+    int ref_len = strlen(content);
+    if (strlen(key) == 0 || ref_len == 0)
         goto error;
 
     SCRConfReference *lookup_ref_conf = SCRConfGetReference(key, de_ctx);
     if (lookup_ref_conf != NULL) {
         ref->key = lookup_ref_conf->url;
+        /* already bound checked to be REFERENCE_CONTENT_NAME_MAX or less */
+        ref->key_len = (uint16_t)strlen(ref->key);
     } else {
         if (SigMatchStrictEnabled(DETECT_REFERENCE)) {
             SCLogError("unknown reference key \"%s\"", key);
@@ -162,6 +165,8 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         SCLogError("strdup failed: %s", strerror(errno));
         goto error;
     }
+    /* already bound checked to be REFERENCE_SYSTEM_NAME_MAX or less */
+    ref->reference_len = (uint16_t)ref_len;
 
     pcre2_match_data_free(match);
     /* free the substrings */

--- a/src/detect-reference.h
+++ b/src/detect-reference.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -32,6 +32,13 @@ typedef struct DetectReference_ {
     char *key;
     /* reference data */
     char *reference;
+
+    /*
+     * These have been length checked against REFERENCE_SYSTEM_NAME_MAX,
+     * and REFERENCE_CONTENT_NAME_MAX
+     */
+    uint16_t key_len;
+    uint16_t reference_len;
     /* next reference in the signature */
     struct DetectReference_ *next;
 } DetectReference;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -249,11 +249,11 @@ void AlertJsonHeader(void *ctx, const Packet *p, const PacketAlert *pa, JsonBuil
         AlertJsonSourceTarget(p, pa, js, addr);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_REFERENCE)) {
+    if ((flags & LOG_JSON_REFERENCE)) {
         AlertJsonReference(json_output_ctx, pa, js);
     }
 
-    if ((json_output_ctx != NULL) && (flags & LOG_JSON_RULE_METADATA)) {
+    if (flags & LOG_JSON_RULE_METADATA) {
         AlertJsonMetadata(json_output_ctx, pa, js);
     }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -168,6 +168,19 @@ outputs:
             # payload-length: yes      # enable dumping payload length, including the gaps
             # packet: yes              # enable dumping of packet (without stream segments)
             # metadata: no             # enable inclusion of app layer metadata with alert. Default yes
+            # If you want metadata, use:
+            # metadata:
+              # Include the decoded application layer (ie. http, dns)
+              #app-layer: true
+              # Log the current state of the flow record.
+              #flow: true
+              #rule:
+                # Log the metadata field from the rule in a structured
+                # format.
+                #metadata: true
+                # Log the raw rule text.
+                #raw: false
+                # reference: no        # include reference information from the rule
             # http-body: yes           # Requires metadata; enable dumping of HTTP body in Base64
             # http-body-printable: yes # Requires metadata; enable dumping of HTTP body in printable format
             # websocket-payload: yes   # Requires metadata; enable dumping of WebSocket Payload in Base64


### PR DESCRIPTION
Continuation of #11563      

When configured, include the reference value in the alert. The configuration value is in the `alert` section:  types.alert.reference. The default value is off/no. Set to yes to include the expanded reference from the rule in the alert record.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [4974](https://redmine.openinfosecfoundation.org/issues/4974)

Describe changes:
- Add `reference` value to suricata.yaml.in (default no/off)
- Set flag in output logger if the config setting is on
- Format the reference as a sequence, e.g., `references: [ "ref-1" [, "ref-2" [, ...]]]`

Updates: 
- Address CI issue when assigning to the key and content lens. These values are bounds checked at parse time to be 1024 or less so a `uint16_t` is adequate for storing them.
- Formatting fixup

### Provide values to any of the below to override the defaults.


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1808

