### PR TITLE
Draft: SMB memory and other counters

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -180,17 +180,17 @@ uint64_t FTPMemcapGlobalCounter(void)
  *  \retval 1 if in bounds
  *  \retval 0 if not in bounds
  */
-static int FTPCheckMemcap(uint64_t size)
+static bool FTPCheckMemcap(uint64_t size)
 {
     if (ftp_config_memcap == 0 || size + SC_ATOMIC_GET(ftp_memuse) <= ftp_config_memcap)
-        return 1;
+        return true;
     (void) SC_ATOMIC_ADD(ftp_memcap, 1);
-    return 0;
+    return false;
 }
 
 static void *FTPCalloc(size_t n, size_t size)
 {
-    if (FTPCheckMemcap((uint32_t)(n * size)) == 0) {
+    if (!FTPCheckMemcap((uint32_t)(n * size))) {
         sc_errno = SC_ELIMIT;
         return NULL;
     }
@@ -210,7 +210,7 @@ static void *FTPRealloc(void *ptr, size_t orig_size, size_t size)
 {
     void *rptr = NULL;
 
-    if (FTPCheckMemcap((uint32_t)(size - orig_size)) == 0) {
+    if (!FTPCheckMemcap((uint32_t)(size - orig_size)) == 0) {
         sc_errno = SC_ELIMIT;
         return NULL;
     }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -272,6 +272,7 @@ int AppLayerParserDeSetup(void)
     SCEnter();
 
     FTPParserCleanup();
+    SMBParserCleanup();
     SMTPParserCleanup();
 
     SCReturnInt(0);
@@ -463,6 +464,18 @@ void AppLayerParserRegisterLogger(uint8_t ipproto, AppProto alproto)
 
     SCReturn;
 }
+
+#if 0
+void AppLayerParserRegisterCleanupFunc(uint8_t ipproto, AppProto alproto,
+                                        void (*Cleanup)(void *))
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].Cleanup = Cleanup;
+
+    SCReturn;
+}
+#endif
 
 void AppLayerParserRegisterGetStateProgressFunc(uint8_t ipproto, AppProto alproto,
     int (*StateGetProgress)(void *alstate, uint8_t direction))

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -188,6 +188,12 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->ip_proto, alproto, p->GetFrameIdByName, p->GetFrameNameById);
     }
 
+#if 0
+    if (p->Cleanup) {
+        AppLayerParserRegisterCleanup(p->Cleanup);
+    }
+#endif
+
     return 0;
 }
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -71,6 +71,8 @@ typedef struct AppLayerParser {
 
     uint32_t flags;
 
+    // void (*Cleanup)(void *state);
+
     AppLayerParserGetFrameIdByNameFn GetFrameIdByName;
     AppLayerParserGetFrameNameByIdFn GetFrameNameById;
 

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -52,6 +52,11 @@ void RegisterSMBParsers(void)
 #endif
 }
 
+void SMBParserCleanup(void)
+{
+    rs_smb_memory_stats();
+}
+
 #ifdef UNITTESTS
 #include "stream-tcp.h"
 #include "util-unittest-helper.h"

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -42,6 +42,40 @@ static SuricataFileContext sfc = { &sbcfg };
 static void SMBParserRegisterTests(void);
 #endif
 
+static uint64_t SMBHashMemoryGlobalCounter(void)
+{
+    return SCSMB_hash_memory_get();
+}
+
+static uint64_t SMBTXMemoryGlobalCounter(void)
+{
+    return SCSMB_tx_memory_get();
+}
+
+static uint64_t SMBTXAllocsGlobalCounter(void)
+{
+    return SCSMB_tx_allocs_get();
+}
+
+static uint64_t SMBTXFreesGlobalCounter(void)
+{
+    return SCSMB_tx_frees_get();
+}
+
+static uint64_t SMBStateGlobalCounter(void)
+{
+    return SCSMB_state_get();
+}
+
+void SMBRegisterGlobalCounters(void)
+{
+    StatsRegisterGlobalCounter("smb.hashmemory", SMBHashMemoryGlobalCounter);
+    StatsRegisterGlobalCounter("smb.tx_allocs", SMBTXAllocsGlobalCounter);
+    StatsRegisterGlobalCounter("smb.tx_frees", SMBTXFreesGlobalCounter);
+    StatsRegisterGlobalCounter("smb.tx_memory", SMBTXMemoryGlobalCounter);
+    StatsRegisterGlobalCounter("smb.state", SMBStateGlobalCounter);
+}
+
 void RegisterSMBParsers(void)
 {
     rs_smb_init(&sfc);
@@ -54,7 +88,6 @@ void RegisterSMBParsers(void)
 
 void SMBParserCleanup(void)
 {
-    rs_smb_memory_stats();
 }
 
 #ifdef UNITTESTS

--- a/src/app-layer-smb.h
+++ b/src/app-layer-smb.h
@@ -25,5 +25,6 @@
 #define SURICATA_APP_LAYER_SMB_H
 
 void RegisterSMBParsers(void);
+void SMBParserCleanup(void);
 
 #endif /* !SURICATA_APP_LAYER_SMB_H */

--- a/src/app-layer-smb.h
+++ b/src/app-layer-smb.h
@@ -27,4 +27,5 @@
 void RegisterSMBParsers(void);
 void SMBParserCleanup(void);
 
+void SMBRegisterGlobalCounters(void);
 #endif /* !SURICATA_APP_LAYER_SMB_H */

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -31,6 +31,7 @@
 #include "app-layer-protos.h"
 #include "app-layer-expectation.h"
 #include "app-layer-ftp.h"
+#include "app-layer-smb.h"
 #include "app-layer-detect-proto.h"
 #include "app-layer-frames.h"
 #include "stream-tcp-reassemble.h"
@@ -1112,6 +1113,7 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("http.memcap", HTPMemcapGlobalCounter);
     StatsRegisterGlobalCounter("ftp.memuse", FTPMemuseGlobalCounter);
     StatsRegisterGlobalCounter("ftp.memcap", FTPMemcapGlobalCounter);
+    SMBRegisterGlobalCounters();
     StatsRegisterGlobalCounter("app_layer.expectations", ExpectationGetCounter);
 }
 


### PR DESCRIPTION
WIP: Track SMB activities with global stats

Link to ticket: https://redmine.openinfosecfoundation.org/issues/5672

Describe changes:
- Track SMB-related items - state, tx (memory, frees, allocs), hashmap memory usage -- with Suricata stats.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
