### PR TITLE
Applayer plugin 5053 v2.10

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -192,8 +192,8 @@ void OutputClearActiveLoggers(void);
 typedef bool (*EveJsonSimpleTxLogFunc)(void *, struct JsonBuilder *);
 
 typedef struct EveJsonSimpleAppLayerLogger {
-    AppProto proto;
     EveJsonSimpleTxLogFunc LogTx;
+    const char *name;
 } EveJsonSimpleAppLayerLogger;
 
 EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -386,6 +386,7 @@ void GlobalsDestroy(void)
     AppLayerDeSetup();
     DatasetsSave();
     DatasetsDestroy();
+    OutputTxShutdown();
     TagDestroyCtx();
 
     LiveDeviceListClean();


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
Preliminary work for https://redmine.openinfosecfoundation.org/issues/5053

Describe changes:
- get ready to use dynamic number of app-layer protos for some global arrays : run modes and output

Small PR that should be good in itself.

#11373 next round

Based on #11554 with needed rebase to get green CI

Still more work to do : I guess stack allocated arrays are fine, but the global variables cf `git grep '\[ALPROTO_MAX'`  in
- app-layer-detect-proto.c
- app-layer-frames.c
- app-layer-parser.c
- app-layer-protos.c
- app-layer.c
need to be allocated and freed, with taking care of the initialization order, so that we know `ALPROTO_MAX` final value...

And then take remaining commits out of https://github.com/OISF/suricata/pull/11321
And supply an example of an app-layer plugin