### PR TITLE
fuzz: make confyaml.c an explicit source

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1278,7 +1278,7 @@ if BUILD_FUZZTARGETS
 LDFLAGS_FUZZ = $(all_libraries) $(SECLDFLAGS)
 LDADD_FUZZ = $(LDADD_GENERIC)
 
-fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c
+fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c tests/fuzz/confyaml.c
 fuzz_applayerprotodetectgetproto_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerprotodetectgetproto_LDADD = $(LDADD_FUZZ)
 fuzz_applayerprotodetectgetproto_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
@@ -1290,7 +1290,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_applayerprotodetectgetproto_SOURCES = force-cxx-linking.cxx
 
-fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c
+fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c tests/fuzz/confyaml.c
 fuzz_applayerparserparse_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerparserparse_LDADD = $(LDADD_FUZZ)
 fuzz_applayerparserparse_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
@@ -1338,7 +1338,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_decodepcapfile_SOURCES = force-cxx-linking.cxx
 
-fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c
+fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c tests/fuzz/confyaml.c
 fuzz_sigpcap_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_LDADD = $(LDADD_FUZZ)
 fuzz_sigpcap_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
@@ -1351,7 +1351,7 @@ endif
 nodist_EXTRA_fuzz_sigpcap_SOURCES = force-cxx-linking.cxx
 
 if HAS_FUZZPCAP
-fuzz_sigpcap_aware_SOURCES = tests/fuzz/fuzz_sigpcap_aware.c
+fuzz_sigpcap_aware_SOURCES = tests/fuzz/fuzz_sigpcap_aware.c tests/fuzz/confyaml.c
 fuzz_sigpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
 fuzz_sigpcap_aware_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)
@@ -1363,7 +1363,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_sigpcap_aware_SOURCES = force-cxx-linking.cxx
 
-fuzz_predefpcap_aware_SOURCES = tests/fuzz/fuzz_predefpcap_aware.c
+fuzz_predefpcap_aware_SOURCES = tests/fuzz/fuzz_predefpcap_aware.c tests/fuzz/confyaml.c
 fuzz_predefpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_predefpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
 fuzz_predefpcap_aware_DEPENDENCIES = libsuricata_c.a $(RUST_SURICATA_LIB)

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -1,4 +1,4 @@
-const char configNoChecksum[] = "\
+const char *configNoChecksum = "\
 %YAML 1.1\n\
 ---\n\
 pcap-file:\n\

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -21,7 +21,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv);
 
 AppLayerParserThreadCtx *alp_tctx = NULL;
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 /* input buffer is structured this way :
  * 6 bytes header,

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -18,7 +18,7 @@
 //rule of thumb constant, so as not to timeout target
 #define PROTO_DETECT_MAX_LEN 1024
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 char *filepath = NULL;
 

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 static void SigGenerateAware(const uint8_t *data, size_t size, char *r, size_t *len)
 {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7181

Describe changes:
- fuzz: make confyaml.c an explicit source, so that it gets included in release archive
