### PR TITLE
Warnint 64to32 6186 v22.1

### DIFF
--- a/src/log-cf-common.c
+++ b/src/log-cf-common.c
@@ -123,7 +123,7 @@ int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
                 n = LOG_NODE_STRLEN-2;
                 np = NULL; /* End */
             }else{
-                n = np-p;
+                n = (uint32_t)(np - p);
             }
             strlcpy(node->data,p,n+1);
             p = np;
@@ -151,7 +151,7 @@ int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
                 np = strchr(p, '}');
                 if (np != NULL && np-p > 1 && np-p < LOG_NODE_STRLEN-2) {
                     p++;
-                    n = np-p;
+                    n = (uint32_t)(np - p);
                     strlcpy(node->data, p, n+1);
                     p = np;
                 } else {

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -130,7 +130,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
 {
     LogHttpFileCtx *httplog_ctx = aft->httplog_ctx;
     uint32_t i;
-    uint32_t datalen;
+    size_t datalen;
     char buf[128];
 
     uint8_t *cvalue = NULL;
@@ -251,9 +251,9 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
                 if (tx->request_headers != NULL) {
                     h_request_hdr = htp_table_get_c(tx->request_headers, "Cookie");
                     if (h_request_hdr != NULL) {
-                        cvalue_len = GetCookieValue((uint8_t *) bstr_ptr(h_request_hdr->value),
-                                    bstr_len(h_request_hdr->value), (char *) node->data,
-                                    &cvalue);
+                        cvalue_len = GetCookieValue((uint8_t *)bstr_ptr(h_request_hdr->value),
+                                (uint32_t)bstr_len(h_request_hdr->value), (char *)node->data,
+                                &cvalue);
                     }
                 }
                 if (cvalue_len > 0 && cvalue != NULL) {

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1466,7 +1466,7 @@ static OutputInitResult PcapLogInitCtx(ConfNode *conf)
             } else {
                 lvl = 0;
             }
-            comp->lz4f_prefs.compressionLevel = lvl;
+            comp->lz4f_prefs.compressionLevel = (int)lvl;
 
             /* Allocate resources for lz4. */
 

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -91,9 +91,8 @@ typedef struct LogTlsLogThread_ {
     MemBuffer *buffer;
 } LogTlsLogThread;
 
-int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
-                         Port* sp, char* dstip, size_t dstip_len, Port* dp,
-                         int ipproto)
+int TLSGetIPInformations(const Packet *p, char *srcip, socklen_t srcip_len, Port *sp, char *dstip,
+        socklen_t dstip_len, Port *dp, int ipproto)
 {
     if ((PKT_IS_TOSERVER(p))) {
         switch (ipproto) {

--- a/src/log-tlslog.h
+++ b/src/log-tlslog.h
@@ -27,8 +27,7 @@
 
 void LogTlsLogRegister(void);
 
-int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
-                             Port* sp, char* dstip, size_t dstip_len,
-                             Port* dp, int ipproto);
+int TLSGetIPInformations(const Packet *p, char *srcip, socklen_t srcip_len, Port *sp, char *dstip,
+        socklen_t dstip_len, Port *dp, int ipproto);
 
 #endif /* SURICATA_LOG_TLSLOG_H */

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -158,7 +158,7 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
     ErfFileThreadVars *etv = (ErfFileThreadVars *)data;
     DagRecord dr;
 
-    int r = fread(&dr, sizeof(DagRecord), 1, etv->erf);
+    size_t r = fread(&dr, sizeof(DagRecord), 1, etv->erf);
     if (r < 1) {
         if (feof(etv->erf)) {
             SCLogInfo("End of ERF file reached");

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -166,7 +166,7 @@ void TmModuleDecodePcapRegister (void)
 static inline void UpdatePcapStatsValue64(uint64_t *last, uint32_t current32)
 {
     /* uint64_t -> uint32_t is defined behaviour. It slices lower 32bits. */
-    uint32_t last32 = *last;
+    uint32_t last32 = (uint32_t)*last;
 
     /* Branchless code as wrap-around is defined for unsigned */
     *last += (uint32_t)(current32 - last32);

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -90,10 +90,9 @@ void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
     fprintf(fp, "%s", nbuf);
 }
 
-void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen,
-                    uint8_t *buf, uint32_t buflen)
+void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen, uint8_t *buf, size_t buflen)
 {
-    for (uint32_t u = 0; u < buflen; u++) {
+    for (size_t u = 0; u < buflen; u++) {
         if (isprint(buf[u]) && buf[u] != '\"') {
             if (buf[u] == '\\') {
                 PrintBufferData(retbuf, offset, retbuflen,

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -41,7 +41,7 @@
 
 void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
 void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
-void PrintRawUriBuf(char *, uint32_t *, uint32_t, uint8_t *, uint32_t);
+void PrintRawUriBuf(char *, uint32_t *, uint32_t, uint8_t *, size_t);
 void PrintRawDataFp(FILE *, const uint8_t *, uint32_t);
 void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           const uint8_t *src_buf, uint32_t src_buf_len);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix `-Wshorten-64-to-32` warnings for some files : log, source

Some commits of #9840
#11524 next batch

Still to do afterwards :
- detect
- output
- stream 
- util
