### PR TITLE
userguide: clarify flow:stateless explanation - v1

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -90,7 +90,8 @@ established
 not_established
   Match on packets that are not part of an established connection.
 stateless
-  Match on packets that are and are not part of an established connection.
+  Match on packets that are part of a flow, regarless of connection state.
+  (This means that packets that are not seen as part of a flow won't match).
 only_stream
   Match on packets that have been reassembled by the stream engine.
 no_stream


### PR DESCRIPTION
While not incorrect, the previous wording made the sentence almost paradoxical. While at it, also highlight a side effect that might not be so clear to users.

Related to
Bug #6976

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
(partly https://redmine.openinfosecfoundation.org/issues/6976)

While discussing the issue above, we realized that the keyword description was... Schroedinger's :P

Describe changes:
- change description for `flow:stateless` flow keyword