### PR TITLE
output: Add linktype name

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3465,6 +3465,10 @@
             "properties": {
                 "linktype": {
                     "type": "integer"
+                },
+                "linktype_name": {
+                    "type": "string",
+                    "description": "the descriptive name of the linktype"
                 }
             },
             "additionalProperties": false

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -438,8 +438,15 @@ void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
         return;
     }
     if (!jb_set_uint(js, "linktype", p->datalink)) {
+        jb_close(js);
         return;
     }
+
+    const char *dl_name = pcap_datalink_val_to_name(p->datalink);
+    // Intentionally ignore the return value from jb_set_string and proceed
+    // so the jb object is closed
+    jb_set_string(js, "linktype_name", dl_name == NULL ? "n/a" : dl_name);
+
     jb_close(js);
 }
 


### PR DESCRIPTION
Continuation of #11564

Issue: 6954

This commit adds the linktype name to the output stream. The name is determined from the pcap utility function pcap_datalink_val_to_name

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6954

Describe changes:
- Include the linktype name alongside linktype
- Update the schema with linktype_name

Updates:
- Rebase
- Expanded linktype name validation in s-v tests ensuring that testing on 6 and 7 continues to pass.

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2006
