### PR TITLE
eve/dns: make version required (cherry-pick from master)

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -961,6 +961,9 @@
         },
         "dns": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "aa": {
                     "type": "boolean"
@@ -996,6 +999,7 @@
                     "type": "string"
                 },
                 "version": {
+                    "description": "The version of this EVE DNS event",
                     "type": "integer"
                 },
                 "opcode": {

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -480,7 +480,6 @@ fn dns_log_json_answer(
 ) -> Result<(), JsonError> {
     let header = &response.header;
 
-    js.set_uint("version", 2)?;
     js.set_string("type", "answer")?;
     js.set_uint("id", header.tx_id as u64)?;
     js.set_string("flags", format!("{:x}", header.flags).as_str())?;

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -323,6 +323,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         }
 
         jb_open_object(jb, "dns");
+        jb_set_int(jb, "version", 2);
         if (!rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags, jb)) {
             jb_free(jb);
             break;
@@ -355,6 +356,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
         }
 
         jb_open_object(jb, "dns");
+        jb_set_int(jb, "version", 2);
         rs_dns_log_json_answer(txptr, td->dnslog_ctx->flags, jb);
         jb_close(jb);
         OutputJsonBuilderBuffer(jb, td->ctx);


### PR DESCRIPTION
The "eve.version" field is not always logged. Update the schema to enforce that it is, and fix it for records that don't log it.

Ticket: #7167
(cherry picked from commit fcc1b1067b5e4c3b9b063ab90fa073de57577968)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7168

Describe changes:
- Cherry pick fcc1b1067b5e4c3b9b063ab90fa073de57577968 from master
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
