### PR TITLE
pgsql: track 'progress' in tx per direction - v2

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -368,7 +368,6 @@ impl PgsqlState {
             );
             match PgsqlState::state_based_req_parsing(self.state_progress, start) {
                 Ok((rem, request)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     start = rem;
                     let mut temp_state = PgsqlStateProgress::IdleState;
                     if let Some(state) = PgsqlState::request_next_state(&request) {
@@ -385,6 +384,7 @@ impl PgsqlState {
                             } else {
                                 tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
                             }
+                            sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                         }
                     } else {
                         // If there isn't a new transaction, we'll consider Suri should move on
@@ -505,7 +505,6 @@ impl PgsqlState {
         while !start.is_empty() {
             match PgsqlState::state_based_resp_parsing(self.state_progress, start) {
                 Ok((rem, response)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     start = rem;
                     SCLogDebug!("Response is {:?}", &response);
                     if let Some(state) = self.response_process_next_state(&response, flow) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7113

Previous PR: #11547 

##### Describe changes:
- track tx_completion per tx direction
- add more PgsqlStateProgress states to tx_completion check (especially for `to_server` direction)
   - reorganize PgsqlStateProgress enum to separate `to_server` and `to_client` states
- bring the trigger raw stream reassembly call to the moment when tx is completed

##### Update:
- split `PgsqlTransactionState` per direction ([as seen with htp](https://github.com/OISF/libhtp/blob/0.5.x/htp/htp_transaction.h#L75-L91))
- truly track transaction progress per direction (again following the [htp model](https://github.com/OISF/libhtp/blob/0.5.x/htp/htp.h#L532))
- add a function to get the tx state per direction, and then actually use the direction in the function that decides what is the parser state progress

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1991