### PR TITLE
Rust fix clippy nightly 1.82 warnings

### DIFF
--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -434,11 +434,11 @@ pub fn http2_frames_get_header_value_vec(
                         vec.extend_from_slice(&block.value);
                         found = 1;
                     } else if found == 1 && Rc::strong_count(&block.name) <= 2 {
-                        vec.extend_from_slice(&[b',', b' ']);
+                        vec.extend_from_slice(b", ");
                         vec.extend_from_slice(&block.value);
                         found = 2;
                     } else if Rc::strong_count(&block.name) <= 2 {
-                        vec.extend_from_slice(&[b',', b' ']);
+                        vec.extend_from_slice(b", ");
                         vec.extend_from_slice(&block.value);
                     }
                 }
@@ -474,11 +474,11 @@ fn http2_frames_get_header_value<'a>(
                         if let Ok(s) = single {
                             vec.extend_from_slice(s);
                         }
-                        vec.extend_from_slice(&[b',', b' ']);
+                        vec.extend_from_slice(b", ");
                         vec.extend_from_slice(&block.value);
                         found = 2;
                     } else if Rc::strong_count(&block.name) <= 2 {
-                        vec.extend_from_slice(&[b',', b' ']);
+                        vec.extend_from_slice(b", ");
                         vec.extend_from_slice(&block.value);
                     }
                 }
@@ -730,7 +730,7 @@ fn http2_escape_header(blocks: &[parser::HTTP2FrameHeaderBlock], i: u32) -> Vec<
     let normalsize = blocks[i as usize].value.len() + 2 + blocks[i as usize].name.len();
     let mut vec = Vec::with_capacity(normalsize);
     vec.extend_from_slice(&blocks[i as usize].name);
-    vec.extend_from_slice(&[b':', b' ']);
+    vec.extend_from_slice(b": ");
     vec.extend_from_slice(&blocks[i as usize].value);
     return vec;
 }
@@ -750,12 +750,12 @@ pub unsafe extern "C" fn rs_http2_tx_get_header_names(
             for block in blocks.iter() {
                 // we do not escape linefeeds in headers names
                 vec.extend_from_slice(&block.name);
-                vec.extend_from_slice(&[b'\r', b'\n']);
+                vec.extend_from_slice(b"\r\n");
             }
         }
     }
     if vec.len() > 2 {
-        vec.extend_from_slice(&[b'\r', b'\n']);
+        vec.extend_from_slice(b"\r\n");
         tx.escaped.push(vec);
         let idx = tx.escaped.len() - 1;
         let value = &tx.escaped[idx];
@@ -815,9 +815,9 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers(
                 if !http2_header_iscookie(direction.into(), &block.name) {
                     // we do not escape linefeeds nor : in headers names
                     vec.extend_from_slice(&block.name);
-                    vec.extend_from_slice(&[b':', b' ']);
+                    vec.extend_from_slice(b": ");
                     vec.extend_from_slice(http2_header_trimspaces(&block.value));
-                    vec.extend_from_slice(&[b'\r', b'\n']);
+                    vec.extend_from_slice(b"\r\n");
                 }
             }
         }
@@ -848,9 +848,9 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers_raw(
             for block in blocks.iter() {
                 // we do not escape linefeeds nor : in headers names
                 vec.extend_from_slice(&block.name);
-                vec.extend_from_slice(&[b':', b' ']);
+                vec.extend_from_slice(b": ");
                 vec.extend_from_slice(&block.value);
-                vec.extend_from_slice(&[b'\r', b'\n']);
+                vec.extend_from_slice(b"\r\n");
             }
         }
     }

--- a/rust/src/ike/ikev2.rs
+++ b/rust/src/ike/ikev2.rs
@@ -186,24 +186,20 @@ fn add_proposals(
         // Rule 1: warn on weak or unknown transforms
         for xform in &transforms {
             match *xform {
-                IkeV2Transform::Encryption(ref enc) => {
-                    match *enc {
-                        IkeTransformEncType::ENCR_DES_IV64
-                        | IkeTransformEncType::ENCR_DES
-                        | IkeTransformEncType::ENCR_3DES
-                        | IkeTransformEncType::ENCR_RC5
-                        | IkeTransformEncType::ENCR_IDEA
-                        | IkeTransformEncType::ENCR_CAST
-                        | IkeTransformEncType::ENCR_BLOWFISH
-                        | IkeTransformEncType::ENCR_3IDEA
-                        | IkeTransformEncType::ENCR_DES_IV32
-                        | IkeTransformEncType::ENCR_NULL => {
-                            SCLogDebug!("Weak Encryption: {:?}", enc);
-                            // XXX send event only if direction == Direction::ToClient ?
-                            tx.set_event(IkeEvent::WeakCryptoEnc);
-                        }
-                        _ => (),
-                    }
+                IkeV2Transform::Encryption(
+                    IkeTransformEncType::ENCR_DES_IV64
+                    | IkeTransformEncType::ENCR_DES
+                    | IkeTransformEncType::ENCR_3DES
+                    | IkeTransformEncType::ENCR_RC5
+                    | IkeTransformEncType::ENCR_IDEA
+                    | IkeTransformEncType::ENCR_CAST
+                    | IkeTransformEncType::ENCR_BLOWFISH
+                    | IkeTransformEncType::ENCR_3IDEA
+                    | IkeTransformEncType::ENCR_DES_IV32
+                    | IkeTransformEncType::ENCR_NULL,
+                ) => {
+                    // XXX send event only if direction == Direction::ToClient ?
+                    tx.set_event(IkeEvent::WeakCryptoEnc);
                 }
                 IkeV2Transform::PRF(ref prf) => match *prf {
                     IkeTransformPRFType::PRF_NULL => {
@@ -276,9 +272,9 @@ fn add_proposals(
             IkeV2Transform::Auth(_) => true,
             _ => false,
         }) && !transforms.iter().any(|x| match *x {
-                IkeV2Transform::Encryption(ref enc) => enc.is_aead(),
-                _ => false,
-            }) {
+            IkeV2Transform::Encryption(ref enc) => enc.is_aead(),
+            _ => false,
+        }) {
             SCLogDebug!("No integrity transform found");
             tx.set_event(IkeEvent::WeakCryptoNoAuth);
         }

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -759,7 +759,7 @@ fn mime_smtp_complete(ctx: &mut MimeStateSMTP) {
         ctx.md5_result = ctx.md5.finalize_reset();
     }
     // look for url in the last unfinished line
-    mime_smtp_find_url_strings(ctx, &[b'\n']);
+    mime_smtp_find_url_strings(ctx, b"\n");
 }
 
 #[no_mangle]


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just clippy warnings fix

Describe changes:
- rust: fix nightly clippy 1.82 warnings (clippy 0.1.82 (2cbbe8b 2024-07-28))

To better anticipate a0bf28296376422ffa1a7803b3563065c536b315