### PR TITLE
LLMNR parser and logger

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -718,7 +718,7 @@ impl DNSState {
 
 const DNS_HEADER_SIZE: usize = 12;
 
-fn probe_header_validity(header: &DNSHeader, rlen: usize) -> (bool, bool, bool) {
+pub fn probe_header_validity(header: &DNSHeader, rlen: usize) -> (bool, bool, bool) {
     let min_msg_size = 2
         * (header.additional_rr as usize
             + header.answer_rr as usize

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -90,7 +90,7 @@ pub const DNS_LOG_VERSION_2: u8 = 2;
 pub const DNS_LOG_VERSION_3: u8 = 3;
 pub const DNS_LOG_VERSION_DEFAULT: u8 = DNS_LOG_VERSION_3;
 
-fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool {
+pub fn dns_log_rrtype_enabled(rtype: u16, flags: u64) -> bool {
     if flags == !0 {
         return true;
     }
@@ -456,7 +456,7 @@ fn dns_log_srv(srv: &DNSRDataSRV) -> Result<JsonBuilder, JsonError> {
     return Ok(js);
 }
 
-fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
+pub fn dns_log_json_answer_detail(answer: &DNSAnswerEntry) -> Result<JsonBuilder, JsonError> {
     let mut jsa = JsonBuilder::try_new_object()?;
 
     jsa.set_string_from_bytes("rrname", &answer.name)?;
@@ -652,7 +652,7 @@ fn dns_log_json_answer(
 }
 
 /// V3 style answer logging.
-fn dns_log_json_answers(
+pub fn dns_log_json_answers(
     jb: &mut JsonBuilder, response: &DNSMessage, flags: u64,
 ) -> Result<(), JsonError> {
     if !response.answers.is_empty() {
@@ -742,7 +742,7 @@ fn dns_log_json_answers(
     Ok(())
 }
 
-fn dns_log_query(
+pub fn dns_log_query(
     tx: &DNSTransaction, i: u16, flags: u64, jb: &mut JsonBuilder,
 ) -> Result<bool, JsonError> {
     let index = i as usize;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -126,6 +126,7 @@ pub mod ffi;
 pub mod feature;
 pub mod sdp;
 pub mod ldap;
+pub mod llmnr;
 
 #[allow(unused_imports)]
 pub use suricata_lua_sys;

--- a/rust/src/llmnr/llmnr.rs
+++ b/rust/src/llmnr/llmnr.rs
@@ -1,0 +1,461 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std;
+use std::collections::VecDeque;
+use std::ffi::CString;
+
+use crate::applayer::*;
+use crate::core::{self, *};
+use crate::dns::dns::{DNSHeader, DNSMessage};
+use crate::dns::*;
+use crate::frames::Frame;
+
+use nom7::Err;
+
+static mut ALPROTO_LLMNR: AppProto = ALPROTO_UNKNOWN;
+
+#[derive(AppLayerFrameType)]
+enum LLMNRFrameType {
+    Pdu,
+}
+
+#[derive(Debug, PartialEq, Eq, AppLayerEvent)]
+pub enum LLMNREvent {
+    MalformedData,
+    NotRequest,
+    NotResponse,
+    ZFlagSet,
+    InvalidOpcode,
+}
+
+#[derive(Debug, Default)]
+pub struct LLMNRTransaction {
+    pub id: u64,
+    pub request: Option<DNSMessage>,
+    pub response: Option<DNSMessage>,
+    pub tx_data: AppLayerTxData,
+}
+
+impl Transaction for LLMNRTransaction {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
+impl LLMNRTransaction {
+    fn new(direction: Direction) -> Self {
+        Self {
+            tx_data: AppLayerTxData::for_direction(direction),
+            ..Default::default()
+        }
+    }
+
+    /// Get the LLMNR transactions ID (not the internal tracking ID).
+    pub fn tx_id(&self) -> u16 {
+        if let Some(request) = &self.request {
+            return request.header.tx_id;
+        }
+        if let Some(response) = &self.response {
+            return response.header.tx_id;
+        }
+
+        // Shouldn't happen.
+        return 0;
+    }
+}
+
+#[derive(Default)]
+pub struct LLMNRState {
+    state_data: AppLayerStateData,
+
+    // Internal transaction ID.
+    tx_id: u64,
+
+    // Transactions.
+    transactions: VecDeque<LLMNRTransaction>,
+}
+
+impl State<LLMNRTransaction> for LLMNRState {
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&LLMNRTransaction> {
+        self.transactions.get(index)
+    }
+}
+
+impl LLMNRState {
+    fn new() -> Self {
+        Default::default()
+    }
+
+    fn new_tx(&mut self, direction: Direction) -> LLMNRTransaction {
+        let mut tx = LLMNRTransaction::new(direction);
+        self.tx_id += 1;
+        tx.id = self.tx_id;
+        return tx;
+    }
+
+    fn free_tx(&mut self, tx_id: u64) {
+        let len = self.transactions.len();
+        let mut found = false;
+        let mut index = 0;
+        for i in 0..len {
+            let tx = &self.transactions[i];
+            if tx.id == tx_id + 1 {
+                found = true;
+                index = i;
+                break;
+            }
+        }
+        if found {
+            self.transactions.remove(index);
+        }
+    }
+
+    fn get_tx(&mut self, tx_id: u64) -> Option<&LLMNRTransaction> {
+        return self.transactions.iter().find(|&tx| tx.id == tx_id + 1);
+    }
+
+    /// Set an event. The event is set on the most recent transaction.
+    fn set_event(&mut self, event: LLMNREvent) {
+        let len = self.transactions.len();
+        if len == 0 {
+            return;
+        }
+
+        let tx = &mut self.transactions[len - 1];
+        tx.tx_data.set_event(event as u8);
+    }
+
+    fn validate_header<'a>(&self, input: &'a [u8]) -> Option<(&'a [u8], DNSHeader)> {
+        if let Ok((body, header)) = crate::dns::parser::dns_parse_header(input) {
+            if crate::dns::dns::probe_header_validity(&header, input.len()).0 {
+                return Some((body, header));
+            }
+        }
+        None
+    }
+
+    fn parse_request(
+        &mut self, input: &[u8], is_tcp: bool, frame: Option<Frame>, flow: *const core::Flow,
+    ) -> bool {
+        let (body, header) = if let Some((body, header)) = self.validate_header(input) {
+            (body, header)
+        } else {
+            return !is_tcp;
+        };
+
+        match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, request)) => {
+                if request.header.flags & 0x8000 != 0 {
+                    SCLogDebug!("LLMNR message is not a request");
+                    self.set_event(LLMNREvent::NotRequest);
+                    return false;
+                }
+
+                let opcode = ((request.header.flags >> 11) & 0xf) as u8;
+
+                let mut tx = self.new_tx(Direction::ToServer);
+                if let Some(frame) = frame {
+                    frame.set_tx(flow, tx.id);
+                }
+                tx.request = Some(request);
+                self.transactions.push_back(tx);
+
+                if opcode >= 7 {
+                    self.set_event(LLMNREvent::InvalidOpcode);
+                }
+
+                return true;
+            }
+            Err(Err::Incomplete(_)) => {
+                // Insufficient data.
+                SCLogDebug!("Insufficient data while parsing LLMNR request");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+            Err(_) => {
+                // Error, probably malformed data.
+                SCLogDebug!("An error occurred while parsing LLMNR request");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+        }
+    }
+
+    fn parse_request_udp(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
+        let input = stream_slice.as_slice();
+        let frame = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            LLMNRFrameType::Pdu as u8,
+            None,
+        );
+        self.parse_request(input, false, frame, flow)
+    }
+
+    fn parse_response_udp(&mut self, flow: *const core::Flow, stream_slice: StreamSlice) -> bool {
+        let input = stream_slice.as_slice();
+        let frame = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            LLMNRFrameType::Pdu as u8,
+            None,
+        );
+        self.parse_response(input, false, frame, flow)
+    }
+
+    fn parse_response(
+        &mut self, input: &[u8], is_tcp: bool, frame: Option<Frame>, flow: *const core::Flow,
+    ) -> bool {
+        let (body, header) = if let Some((body, header)) = self.validate_header(input) {
+            (body, header)
+        } else {
+            return !is_tcp;
+        };
+
+        match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, response)) => {
+                SCLogDebug!("Response header flags: {}", response.header.flags);
+
+                if response.header.flags & 0x8000 == 0 {
+                    SCLogDebug!("DNS message is not a response");
+                    self.set_event(LLMNREvent::NotResponse);
+                }
+
+                let opcode = ((response.header.flags >> 11) & 0xf) as u8;
+
+                let mut tx = self.new_tx(Direction::ToClient);
+                if let Some(frame) = frame {
+                    frame.set_tx(flow, tx.id);
+                }
+
+                tx.response = Some(response);
+                self.transactions.push_back(tx);
+
+                if opcode >= 7 {
+                    self.set_event(LLMNREvent::InvalidOpcode);
+                }
+
+                return true;
+            }
+            Err(Err::Incomplete(_)) => {
+                // Insufficient data.
+                SCLogDebug!("Insufficient data while parsing LLMNR response");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+            Err(_) => {
+                // Error, probably malformed data.
+                SCLogDebug!("An error occurred while parsing LLMNR response");
+                self.set_event(LLMNREvent::MalformedData);
+                return false;
+            }
+        }
+    }
+}
+
+/// Probe input to see if it looks like DNS.
+///
+/// Returns a tuple of booleans: (is_dns, is_request, incomplete)
+fn probe(input: &[u8], dlen: usize) -> (bool, bool, bool) {
+    // Trim input to dlen if larger.
+    let input = if input.len() <= dlen {
+        input
+    } else {
+        &input[..dlen]
+    };
+
+    // If input is less than dlen then we know we don't have enough data to
+    // parse a complete message, so perform header validation only.
+    if input.len() < dlen {
+        if let Ok((_, header)) = crate::dns::parser::dns_parse_header(input) {
+            return crate::dns::dns::probe_header_validity(&header, dlen);
+        } else {
+            return (false, false, false);
+        }
+    }
+
+    match parser::dns_parse_header(input) {
+        Ok((body, header)) => match crate::dns::parser::dns_parse_body(body, input, header) {
+            Ok((_, request)) => crate::dns::dns::probe_header_validity(&request.header, dlen),
+            Err(Err::Incomplete(_)) => (false, false, true),
+            Err(_) => (false, false, false),
+        },
+        Err(_) => (false, false, false),
+    }
+}
+
+unsafe extern "C" fn probe_udp(
+    _flow: *const core::Flow, _dir: u8, input: *const u8, len: u32, rdir: *mut u8,
+) -> AppProto {
+    if input.is_null() || len < std::mem::size_of::<DNSHeader>() as u32 {
+        return core::ALPROTO_UNKNOWN;
+    }
+    let slice: &[u8] = std::slice::from_raw_parts(input as *mut u8, len as usize);
+    let (is_dns, is_request, _) = probe(slice, slice.len());
+    if is_dns {
+        let dir = if is_request {
+            Direction::ToServer
+        } else {
+            Direction::ToClient
+        };
+        *rdir = dir as u8;
+        return ALPROTO_LLMNR;
+    }
+    return 0;
+}
+
+/// Returns *mut LLMNRState
+extern "C" fn state_new(
+    _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
+) -> *mut std::os::raw::c_void {
+    let state = LLMNRState::new();
+    let boxed = Box::new(state);
+    return Box::into_raw(boxed) as *mut _;
+}
+
+/// Params:
+/// - state: *mut DNSState as void pointer
+extern "C" fn state_free(state: *mut std::os::raw::c_void) {
+    // Just unbox...
+    std::mem::drop(unsafe { Box::from_raw(state as *mut LLMNRState) });
+}
+
+unsafe extern "C" fn state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+    let state = cast_pointer!(state, LLMNRState);
+    state.free_tx(tx_id);
+}
+
+extern "C" fn tx_get_alstate_progress(
+    _tx: *mut std::os::raw::c_void, _direction: u8,
+) -> std::os::raw::c_int {
+    // This is a stateless parser, just the existence of a transaction
+    // means its complete.
+    SCLogDebug!("rs_llmnr_tx_get_alstate_progress");
+    return 1;
+}
+
+unsafe extern "C" fn state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+    let state = cast_pointer!(state, LLMNRState);
+    SCLogDebug!("rs_llmnr_state_get_tx_count: returning {}", state.tx_id);
+    return state.tx_id;
+}
+
+unsafe extern "C" fn state_get_tx(
+    state: *mut std::os::raw::c_void, tx_id: u64,
+) -> *mut std::os::raw::c_void {
+    let state = cast_pointer!(state, LLMNRState);
+    match state.get_tx(tx_id) {
+        Some(tx) => {
+            return tx as *const _ as *mut _;
+        }
+        None => {
+            return std::ptr::null_mut();
+        }
+    }
+}
+
+/// C binding parse a LLMNR request. Returns 1 on success, -1 on failure.
+unsafe extern "C" fn parse_request(
+    flow: *const core::Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    state.parse_request_udp(flow, stream_slice);
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn parse_response(
+    flow: *const core::Flow, state: *mut std::os::raw::c_void, _pstate: *mut std::os::raw::c_void,
+    stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LLMNRState);
+    state.parse_response_udp(flow, stream_slice);
+    AppLayerResult::ok()
+}
+
+unsafe extern "C" fn state_get_tx_data(tx: *mut std::os::raw::c_void) -> *mut AppLayerTxData {
+    let tx = cast_pointer!(tx, LLMNRTransaction);
+    return &mut tx.tx_data;
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRTxIsRequest(tx: &mut LLMNRTransaction) -> bool {
+    tx.request.is_some()
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRTxIsResponse(tx: &mut LLMNRTransaction) -> bool {
+    tx.response.is_some()
+}
+
+export_state_data_get!(rs_llmnr_get_state_data, LLMNRState);
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLLMNRParser() {
+    let default_port = std::ffi::CString::new("5355").unwrap();
+    let parser = RustParser {
+        name: b"llmnr\0".as_ptr() as *const std::os::raw::c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_UDP,
+        probe_ts: Some(probe_udp),
+        probe_tc: Some(probe_udp),
+        min_depth: 0,
+        max_depth: std::mem::size_of::<DNSHeader>() as u16,
+        state_new,
+        state_free,
+        tx_free: state_tx_free,
+        parse_ts: parse_request,
+        parse_tc: parse_response,
+        get_tx_count: state_get_tx_count,
+        get_tx: state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: tx_get_alstate_progress,
+        get_eventinfo: Some(LLMNREvent::get_event_info),
+        get_eventinfo_byid: Some(LLMNREvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(
+            crate::applayer::state_get_tx_iterator::<LLMNRState, LLMNRTransaction>,
+        ),
+        get_tx_data: state_get_tx_data,
+        get_state_data: rs_llmnr_get_state_data,
+        apply_tx_config: None,
+        flags: 0,
+        get_frame_id_by_name: Some(LLMNRFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(LLMNRFrameType::ffi_name_from_id),
+    };
+
+    let ip_proto_str = CString::new("udp").unwrap();
+    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
+        ALPROTO_LLMNR = alproto;
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+    }
+}

--- a/rust/src/llmnr/logger.rs
+++ b/rust/src/llmnr/logger.rs
@@ -1,0 +1,130 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use crate::jsonbuilder::{JsonBuilder, JsonError};
+use crate::llmnr::llmnr::LLMNRTransaction;
+
+fn log_json(tx: &LLMNRTransaction, flags: u64, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("dns")?;
+
+    let message = if let Some(request) = &tx.request {
+        js.set_string("type", "request")?;
+        request
+    } else if let Some(response) = &tx.response {
+        js.set_string("type", "response")?;
+        response
+    } else {
+        debug_validate_fail!("unreachable");
+        return Ok(());
+    };
+
+    // The internal Suricata transaction ID.
+    js.set_uint("tx_id", tx.id - 1)?;
+
+    // The on the wire LOGGER transaction ID.
+    js.set_uint("id", tx.tx_id() as u64)?;
+
+    let header = &message.header;
+    js.set_string("flags", format!("{:x}", header.flags).as_str())?;
+    if header.flags & 0x0400 != 0 {
+        js.set_bool("c", true)?;
+    }
+    if header.flags & 0x0200 != 0 {
+        js.set_bool("tc", true)?;
+    }
+    if header.flags & 0x0100 != 0 {
+        js.set_bool("t", true)?;
+    }
+    let opcode = ((header.flags >> 11) & 0xf) as u8;
+    js.set_uint("opcode", opcode as u64)?;
+
+    if !message.queries.is_empty() {
+        js.open_array("queries")?;
+        for query in &message.queries {
+            if crate::dns::log::dns_log_rrtype_enabled(query.rrtype, flags) {
+                js.start_object()?
+                    .set_string_from_bytes("rrname", &query.name)?
+                    .set_string("rrtype", &crate::dns::log::dns_rrtype_string(query.rrtype))?
+                    .close()?;
+            }
+        }
+        js.close()?;
+    }
+
+    if !message.answers.is_empty() {
+        crate::dns::log::dns_log_json_answers(js, message, flags)?;
+    }
+
+    if !message.authorities.is_empty() {
+        js.open_array("authorities")?;
+        for auth in &message.authorities {
+            let auth_detail = crate::dns::log::dns_log_json_answer_detail(auth)?;
+            js.append_object(&auth_detail)?;
+        }
+        js.close()?;
+    }
+
+    if !message.additionals.is_empty() {
+        let mut is_js_open = false;
+        for add in &message.additionals {
+            if let crate::dns::dns::DNSRData::OPT(rdata) = &add.data {
+                if rdata.is_empty() {
+                    continue;
+                }
+            }
+            if !is_js_open {
+                js.open_array("additionals")?;
+                is_js_open = true;
+            }
+            let add_detail = crate::dns::log::dns_log_json_answer_detail(add)?;
+            js.append_object(&add_detail)?;
+        }
+        if is_js_open {
+            js.close()?;
+        }
+    }
+
+    js.close()?;
+    Ok(())
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRLogEnabled(tx: &LLMNRTransaction, flags: u64) -> bool {
+    let message = if let Some(request) = &tx.request {
+        request
+    } else if let Some(response) = &tx.response {
+        response
+    } else {
+        return false;
+    };
+
+    for query in &message.queries {
+        if crate::dns::log::dns_log_rrtype_enabled(query.rrtype, flags) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#[no_mangle]
+pub extern "C" fn SCLLMNRLogJson(
+    tx: &mut LLMNRTransaction, flags: u64, jb: &mut JsonBuilder,
+) -> bool {
+    log_json(tx, flags, jb).is_ok()
+}

--- a/rust/src/llmnr/mod.rs
+++ b/rust/src/llmnr/mod.rs
@@ -1,0 +1,22 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! LLMNR protocol parser, detection and logger module.
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+pub mod llmnr;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -391,6 +391,7 @@ noinst_HEADERS = \
 	output-json.h \
 	output-json-http.h \
 	output-json-ike.h \
+	output-json-llmnr.h \
 	output-json-metadata.h \
 	output-json-mqtt.h \
 	output-json-netflow.h \
@@ -972,6 +973,7 @@ libsuricata_c_a_SOURCES = \
 	output-json-ftp.c \
 	output-json-http.c \
 	output-json-ike.c \
+	output-json-llmnr.c \
 	output-json-metadata.c \
 	output-json-mqtt.c \
 	output-json-netflow.c \

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1732,6 +1732,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_rdp_register_parser();
     RegisterHTTP2Parsers();
     rs_telnet_register_parser();
+    SCRegisterLLMNRParser();
     RegisterIMAPParsers();
 
     /** POP3 */

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -68,6 +68,7 @@ const AppProtoStringTuple AppProtoStrings[ALPROTO_MAX] = {
     { ALPROTO_HTTP2, "http2" },
     { ALPROTO_BITTORRENT_DHT, "bittorrent-dht" },
     { ALPROTO_POP3, "pop3" },
+    { ALPROTO_LLMNR, "llmnr" },
     { ALPROTO_HTTP, "http" },
     { ALPROTO_FAILED, "failed" },
 #ifdef UNITTESTS

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -64,6 +64,7 @@ enum AppProtoEnum {
     ALPROTO_HTTP2,
     ALPROTO_BITTORRENT_DHT,
     ALPROTO_POP3,
+    ALPROTO_LLMNR,
 
     // signature-only (ie not seen in flow)
     // HTTP for any version (ALPROTO_HTTP1 (version 1) or ALPROTO_HTTP2)

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -24,10 +24,26 @@
 #ifndef SURICATA_OUTPUT_JSON_DNS_H
 #define SURICATA_OUTPUT_JSON_DNS_H
 
+#define LOG_QUERIES BIT_U64(0)
+#define LOG_ANSWERS BIT_U64(1)
+
+#define LOG_FORMAT_GROUPED  BIT_U64(60)
+#define LOG_FORMAT_DETAILED BIT_U64(61)
+#define LOG_HTTPS           BIT_U64(62)
+
+#define LOG_FORMAT_ALL (LOG_FORMAT_GROUPED | LOG_FORMAT_DETAILED)
+#define LOG_ALL_RRTYPES                                                                            \
+    (~(uint64_t)(LOG_QUERIES | LOG_ANSWERS | LOG_FORMAT_DETAILED | LOG_FORMAT_GROUPED))
+
 void JsonDnsLogRegister(void);
 void JsonDoh2LogRegister(void);
 
 bool AlertJsonDns(void *vtx, JsonBuilder *js);
 bool AlertJsonDoh2(void *vtx, JsonBuilder *js);
+
+void JsonDnsLogParseConfig(uint64_t *logger_flags, ConfNode *conf, const char *query_key,
+        const char *answer_key, const char *answer_types_key);
+
+void JsonDnsLogInitFilters(uint64_t *logger_flags, ConfNode *conf);
 
 #endif /* SURICATA_OUTPUT_JSON_DNS_H */

--- a/src/output-json-llmnr.c
+++ b/src/output-json-llmnr.c
@@ -1,0 +1,178 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+#include "suricata-common.h"
+#include "conf.h"
+
+#include "threadvars.h"
+
+#include "util-byte.h"
+#include "util-debug.h"
+#include "util-mem.h"
+#include "app-layer-parser.h"
+#include "output.h"
+
+#include "output-json.h"
+#include "output-json-dns.h"
+#include "output-json-llmnr.h"
+#include "rust.h"
+
+typedef struct LogLLMNRFileCtx_ {
+    uint64_t flags; /** Store mode */
+    OutputJsonCtx *eve_ctx;
+} LogLLMNRFileCtx;
+
+typedef struct LogLLMNRLogThread_ {
+    LogLLMNRFileCtx *llmnrlog_ctx;
+    OutputJsonThreadCtx *ctx;
+} LogLLMNRLogThread;
+
+bool AlertJsonLLMNR(void *txptr, JsonBuilder *js)
+{
+    return SCLLMNRLogJson(
+            txptr, LOG_FORMAT_DETAILED | LOG_QUERIES | LOG_ANSWERS | LOG_ALL_RRTYPES, js);
+}
+
+static int JsonLLMNRLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
+        void *alstate, void *txptr, uint64_t tx_id)
+{
+    LogLLMNRLogThread *td = (LogLLMNRLogThread *)thread_data;
+    LogLLMNRFileCtx *llmnrlog_ctx = td->llmnrlog_ctx;
+
+    if (SCDnsTxIsRequest(txptr)) {
+        if (unlikely(llmnrlog_ctx->flags & LOG_QUERIES) == 0) {
+            return TM_ECODE_OK;
+        }
+    } else if (SCDnsTxIsResponse(txptr)) {
+        if (unlikely(llmnrlog_ctx->flags & LOG_ANSWERS) == 0) {
+            return TM_ECODE_OK;
+        }
+    }
+
+    if (!SCDnsLogEnabled(txptr, td->llmnrlog_ctx->flags)) {
+        return TM_ECODE_OK;
+    }
+
+    JsonBuilder *jb = CreateEveHeader(p, LOG_DIR_FLOW, "llmnr", NULL, llmnrlog_ctx->eve_ctx);
+    if (unlikely(jb == NULL)) {
+        return TM_ECODE_OK;
+    }
+
+    if (SCDnsLogJson(txptr, td->llmnrlog_ctx->flags, jb)) {
+        OutputJsonBuilderBuffer(jb, td->ctx);
+    }
+    jb_free(jb);
+
+    return TM_ECODE_OK;
+}
+
+static TmEcode LogLLMNRLogThreadInit(ThreadVars *t, const void *initdata, void **data)
+{
+    LogLLMNRLogThread *aft = SCCalloc(1, sizeof(LogLLMNRLogThread));
+    if (unlikely(aft == NULL))
+        return TM_ECODE_FAILED;
+
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for EveLogLLMNR.  \"initdata\" argument NULL");
+        goto error_exit;
+    }
+
+    /* Use the Output Context (file pointer and mutex) */
+    aft->llmnrlog_ctx = ((OutputCtx *)initdata)->data;
+    aft->ctx = CreateEveThreadCtx(t, aft->llmnrlog_ctx->eve_ctx);
+    if (!aft->ctx) {
+        goto error_exit;
+    }
+
+    *data = (void *)aft;
+    return TM_ECODE_OK;
+
+error_exit:
+    SCFree(aft);
+    return TM_ECODE_FAILED;
+}
+
+static TmEcode LogLLMNRLogThreadDeinit(ThreadVars *t, void *data)
+{
+    LogLLMNRLogThread *aft = (LogLLMNRLogThread *)data;
+    if (aft == NULL) {
+        return TM_ECODE_OK;
+    }
+    FreeEveThreadCtx(aft->ctx);
+
+    /* clear memory */
+    memset(aft, 0, sizeof(LogLLMNRLogThread));
+
+    SCFree(aft);
+    return TM_ECODE_OK;
+}
+
+static void LogLLMNRLogDeInitCtxSub(OutputCtx *output_ctx)
+{
+    SCLogDebug("cleaning up sub output_ctx %p", output_ctx);
+    LogLLMNRFileCtx *llmnrlog_ctx = (LogLLMNRFileCtx *)output_ctx->data;
+    SCFree(llmnrlog_ctx);
+    SCFree(output_ctx);
+}
+
+static OutputInitResult JsonLLMNRLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
+{
+    OutputInitResult result = { NULL, false };
+    const char *enabled = ConfNodeLookupChildValue(conf, "enabled");
+    if (enabled != NULL && !ConfValIsTrue(enabled)) {
+        result.ok = true;
+        return result;
+    }
+
+    OutputJsonCtx *ojc = parent_ctx->data;
+
+    LogLLMNRFileCtx *llmnrlog_ctx = SCCalloc(1, sizeof(LogLLMNRFileCtx));
+    if (unlikely(llmnrlog_ctx == NULL)) {
+        return result;
+    }
+
+    llmnrlog_ctx->eve_ctx = ojc;
+    llmnrlog_ctx->flags = ~0ULL;
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(llmnrlog_ctx);
+        return result;
+    }
+
+    output_ctx->data = llmnrlog_ctx;
+    output_ctx->DeInit = LogLLMNRLogDeInitCtxSub;
+
+    JsonDnsLogInitFilters(&llmnrlog_ctx->flags, conf);
+
+    SCLogDebug("LLMNR log sub-module initialized");
+
+    AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_LLMNR);
+
+    result.ctx = output_ctx;
+    result.ok = true;
+    return result;
+}
+
+void JsonLLMNRLogRegister(void)
+{
+    OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonLLMNRLog", "eve-log.llmnr",
+            JsonLLMNRLogInitCtxSub, ALPROTO_LLMNR, JsonLLMNRLogger, LogLLMNRLogThreadInit,
+            LogLLMNRLogThreadDeinit, NULL);
+}

--- a/src/output-json-llmnr.h
+++ b/src/output-json-llmnr.h
@@ -15,9 +15,13 @@
  * 02110-1301, USA.
  */
 
-//! LLMNR protocol parser, detection and logger module.
-
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-pub mod llmnr;
-pub mod logger;
+#ifndef SURICATA_OUTPUT_JSON_LLMNR_H
+#define SURICATA_OUTPUT_JSON_LLMNR_H
+
+void JsonLLMNRLogRegister(void);
+
+bool AlertJsonLLMNR(void *txptr, JsonBuilder *js);
+
+#endif /* SURICATA_OUTPUT_JSON_LLMNR_H */

--- a/src/output.c
+++ b/src/output.c
@@ -82,6 +82,7 @@
 #include "app-layer-parser.h"
 #include "output-filestore.h"
 #include "output-json-arp.h"
+#include "output-json-llmnr.h"
 
 typedef struct RootLogger_ {
     OutputLogFunc LogFunc;
@@ -1120,6 +1121,8 @@ void OutputRegisterLoggers(void)
     }
     /* ARP JSON logger */
     JsonArpLogRegister();
+    /* LLMNR JSON logger. */
+    JsonLLMNRLogRegister();
 }
 
 static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {
@@ -1160,6 +1163,7 @@ static EveJsonSimpleAppLayerLogger simple_json_applayer_loggers[ALPROTO_MAX] = {
     { ALPROTO_HTTP2, rs_http2_log_json },
     { ALPROTO_BITTORRENT_DHT, rs_bittorrent_dht_logger_log },
     { ALPROTO_POP3, NULL }, // protocol detection only
+    { ALPROTO_LLMNR, AlertJsonLLMNR },
     { ALPROTO_HTTP, NULL }, // signature protocol, not for app-layer logging
     { ALPROTO_FAILED, NULL },
 #ifdef UNITTESTS


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:

This PR is a proposal for implementing a parser and logger for the LLMNR protocol.
Considering that it is based on the DNS packet format (as specified in RFC4795), most of the DNS code can be reused. However, separate parser registration and logging functions have been implemented.
The logging schema for LLMNR is the same as DNS v3.

I guess the proposed approach is valid, but feedback is welcome.

TBD:
- add SV tests
- update schema.json
- add sticky buffers