### PR TITLE
output/json: Close jb object on error

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -445,7 +445,13 @@ void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
     if (!jb_open_object(js, "packet_info")) {
         return;
     }
+    /*
+     * ensure the object is closed on error. This is done defensively
+     * in case additional logic is added before the final jb_close()
+     * invocation
+     */
     if (!jb_set_uint(js, "linktype", p->datalink)) {
+        jb_close(js);
         return;
     }
     jb_close(js);


### PR DESCRIPTION
Issue: 7194

Ensure that the jb object is closed on errors.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7194

Describe changes:
- Close jb object on error paths in EveHeader.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
