### PR TITLE
rust/ldap: udp and frames support v5

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4640,8 +4640,12 @@
                                             "Errors encountered parsing Kerberos v5/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
-                                "ldap": {
-                                    "description": "Errors encountered parsing LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Errors encountered parsing LDAP/TCP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "modbus": {
@@ -4811,8 +4815,12 @@
                                     "description": "Number of flows for Kerberos v5/UDP protocol",
                                     "type": "integer"
                                 },
-                                "ldap": {
-                                    "description": "Number of flows for LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Number of flows for LDAP/TCP protocol",
+                                    "type": "integer"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "type": "integer"
                                 },
                                 "modbus": {
@@ -4977,8 +4985,12 @@
                                             "Number of transactions for Kerberos v5/UDP protocol",
                                     "type": "integer"
                                 },
-                                "ldap": {
-                                    "description": "Number of transactions for LDAP protocol",
+                                "ldap_tcp": {
+                                    "description": "Number of transactions for LDAP/TCP protocol",
+                                    "type": "integer"
+                                },
+                                "ldap_udp": {
+                                    "description": "Errors encountered parsing LDAP/UDP protocol",
                                     "type": "integer"
                                 },
                                 "modbus": {

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -19,7 +19,8 @@
 
 use crate::applayer::{self, *};
 use crate::conf::conf_get;
-use crate::core::*;
+use crate::core::{Flow, *};
+use crate::frames::*;
 use nom7 as nom;
 use std;
 use std::collections::VecDeque;
@@ -33,6 +34,11 @@ static LDAP_MAX_TX_DEFAULT: usize = 256;
 static mut LDAP_MAX_TX: usize = LDAP_MAX_TX_DEFAULT;
 
 static mut ALPROTO_LDAP: AppProto = ALPROTO_UNKNOWN;
+
+#[derive(AppLayerFrameType)]
+pub enum LdapFrameType {
+    Pdu,
+}
 
 #[derive(AppLayerEvent)]
 enum LdapEvent {
@@ -82,6 +88,8 @@ pub struct LdapState {
     tx_id: u64,
     transactions: VecDeque<LdapTransaction>,
     tx_index_completed: usize,
+    request_frame: Option<Frame>,
+    response_frame: Option<Frame>,
 }
 
 impl State<LdapTransaction> for LdapState {
@@ -101,6 +109,8 @@ impl LdapState {
             tx_id: 0,
             transactions: VecDeque::new(),
             tx_index_completed: 0,
+            request_frame: None,
+            response_frame: None,
         }
     }
 
@@ -162,17 +172,29 @@ impl LdapState {
         })
     }
 
-    fn parse_request(&mut self, input: &[u8]) -> AppLayerResult {
+    fn parse_request(&mut self, flow: *const Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
         if input.is_empty() {
             return AppLayerResult::ok();
         }
 
         let mut start = input;
         while !start.is_empty() {
+            if self.request_frame.is_none() {
+                self.request_frame = Frame::new(
+                    flow,
+                    &stream_slice,
+                    start,
+                    -1_i64,
+                    LdapFrameType::Pdu as u8,
+                    None,
+                );
+                SCLogDebug!("ts: pdu {:?}", self.request_frame);
+            }
             match ldap_parse_msg(start) {
                 Ok((rem, msg)) => {
-                    start = rem;
                     let mut tx = self.new_tx();
+                    let tx_id = tx.id();
                     let request = LdapMessage::from(msg);
                     tx.complete = match request.protocol_op {
                         ProtocolOp::UnbindRequest => true,
@@ -180,6 +202,14 @@ impl LdapState {
                     };
                     tx.request = Some(request);
                     self.transactions.push_back(tx);
+
+                    let consumed = start.len() - rem.len();
+                    start = rem;
+                    if let Some(frame) = &self.request_frame {
+                        frame.set_len(flow, consumed as i64);
+                        frame.set_tx(flow, tx_id);
+                        self.request_frame = None;
+                    }
                 }
                 Err(nom::Err::Incomplete(_)) => {
                     let consumed = input.len() - start.len();
@@ -195,16 +225,27 @@ impl LdapState {
         return AppLayerResult::ok();
     }
 
-    fn parse_response(&mut self, input: &[u8]) -> AppLayerResult {
+    fn parse_response(&mut self, flow: *const Flow, stream_slice: StreamSlice) -> AppLayerResult {
+        let input = stream_slice.as_slice();
         if input.is_empty() {
             return AppLayerResult::ok();
         }
+
         let mut start = input;
         while !start.is_empty() {
+            if self.response_frame.is_none() {
+                self.response_frame = Frame::new(
+                    flow,
+                    &stream_slice,
+                    start,
+                    -1_i64,
+                    LdapFrameType::Pdu as u8,
+                    None,
+                );
+                SCLogDebug!("tc: pdu {:?}", self.response_frame);
+            }
             match ldap_parse_msg(start) {
                 Ok((rem, msg)) => {
-                    start = rem;
-
                     let response = LdapMessage::from(msg);
                     if let Some(tx) = self.find_request(response.message_id) {
                         tx.complete = match response.protocol_op {
@@ -218,21 +259,43 @@ impl LdapState {
                             | ProtocolOp::ExtendedResponse(_) => true,
                             _ => false,
                         };
+                        let tx_id = tx.id();
                         tx.responses.push_back(response);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     } else if let ProtocolOp::ExtendedResponse(_) = response.protocol_op {
                         // this is an unsolicited notification, which means
                         // there is no request
                         let mut tx = self.new_tx();
+                        let tx_id = tx.id();
                         tx.complete = true;
                         tx.responses.push_back(response);
                         self.transactions.push_back(tx);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     } else {
                         let mut tx = self.new_tx();
                         tx.complete = true;
+                        let tx_id = tx.id();
                         tx.responses.push_back(response);
                         self.transactions.push_back(tx);
                         self.set_event(LdapEvent::RequestNotFound);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     };
+                    start = rem;
                 }
                 Err(nom::Err::Incomplete(_)) => {
                     let consumed = input.len() - start.len();
@@ -250,9 +313,18 @@ impl LdapState {
     }
 
     fn parse_request_udp(
-        &mut self, _flow: *const Flow, stream_slice: StreamSlice,
+        &mut self, flow: *const Flow, stream_slice: StreamSlice,
     ) -> AppLayerResult {
         let input = stream_slice.as_slice();
+        let _pdu = Frame::new(
+            flow,
+            &stream_slice,
+            input,
+            input.len() as i64,
+            LdapFrameType::Pdu as u8,
+            None,
+        );
+        SCLogDebug!("ts: pdu {:?}", self.request_frame);
 
         match ldap_parse_msg(input) {
             Ok((_, msg)) => {
@@ -279,7 +351,7 @@ impl LdapState {
     }
 
     fn parse_response_udp(
-        &mut self, _flow: *const Flow, stream_slice: StreamSlice,
+        &mut self, flow: *const Flow, stream_slice: StreamSlice,
     ) -> AppLayerResult {
         let input = stream_slice.as_slice();
         if input.is_empty() {
@@ -288,6 +360,17 @@ impl LdapState {
 
         let mut start = input;
         while !start.is_empty() {
+            if self.response_frame.is_none() {
+                self.response_frame = Frame::new(
+                    flow,
+                    &stream_slice,
+                    start,
+                    -1_i64,
+                    LdapFrameType::Pdu as u8,
+                    None,
+                );
+                SCLogDebug!("tc: pdu {:?}", self.response_frame);
+            }
             match ldap_parse_msg(start) {
                 Ok((rem, msg)) => {
                     let response = LdapMessage::from(msg);
@@ -303,20 +386,41 @@ impl LdapState {
                             | ProtocolOp::ExtendedResponse(_) => true,
                             _ => false,
                         };
+                        let tx_id = tx.id();
                         tx.responses.push_back(response);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     } else if let ProtocolOp::ExtendedResponse(_) = response.protocol_op {
                         // this is an unsolicited notification, which means
                         // there is no request
                         let mut tx = self.new_tx();
                         tx.complete = true;
+                        let tx_id = tx.id();
                         tx.responses.push_back(response);
                         self.transactions.push_back(tx);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     } else {
                         let mut tx = self.new_tx();
                         tx.complete = true;
+                        let tx_id = tx.id();
                         tx.responses.push_back(response);
                         self.transactions.push_back(tx);
                         self.set_event(LdapEvent::RequestNotFound);
+                        let consumed = start.len() - rem.len();
+                        if let Some(frame) = &self.response_frame {
+                            frame.set_len(flow, consumed as i64);
+                            frame.set_tx(flow, tx_id);
+                            self.response_frame = None;
+                        }
                     };
                     start = rem;
                 }
@@ -394,7 +498,7 @@ unsafe extern "C" fn SCLdapStateTxFree(state: *mut c_void, tx_id: u64) {
 
 #[no_mangle]
 unsafe extern "C" fn SCLdapParseRequest(
-    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
     _data: *const c_void,
 ) -> AppLayerResult {
     if stream_slice.is_empty() {
@@ -405,14 +509,12 @@ unsafe extern "C" fn SCLdapParseRequest(
         }
     }
     let state = cast_pointer!(state, LdapState);
-    state.parse_request(stream_slice.as_slice());
-
-    AppLayerResult::ok()
+    state.parse_request(flow, stream_slice)
 }
 
 #[no_mangle]
 unsafe extern "C" fn SCLdapParseResponse(
-    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
     _data: *const c_void,
 ) -> AppLayerResult {
     if stream_slice.is_empty() {
@@ -423,9 +525,7 @@ unsafe extern "C" fn SCLdapParseResponse(
         }
     }
     let state = cast_pointer!(state, LdapState);
-    state.parse_response(stream_slice.as_slice());
-
-    AppLayerResult::ok()
+    state.parse_response(flow, stream_slice)
 }
 
 #[no_mangle]
@@ -510,8 +610,8 @@ pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
         get_state_data: SCLdapGetStateData,
         apply_tx_config: None,
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
-        get_frame_id_by_name: None,
-        get_frame_name_by_id: None,
+        get_frame_id_by_name: Some(LdapFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(LdapFrameType::ffi_name_from_id),
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
@@ -567,8 +667,8 @@ pub unsafe extern "C" fn SCRegisterLdapUdpParser() {
         get_state_data: SCLdapGetStateData,
         apply_tx_config: None,
         flags: 0,
-        get_frame_id_by_name: None,
-        get_frame_name_by_id: None,
+        get_frame_id_by_name: Some(LdapFrameType::ffi_id_from_name),
+        get_frame_name_by_id: Some(LdapFrameType::ffi_name_from_id),
     };
 
     let ip_proto_str = CString::new("udp").unwrap();

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -90,6 +90,8 @@ pub struct LdapState {
     tx_index_completed: usize,
     request_frame: Option<Frame>,
     response_frame: Option<Frame>,
+    request_gap: bool,
+    response_gap: bool,
 }
 
 impl State<LdapTransaction> for LdapState {
@@ -111,6 +113,8 @@ impl LdapState {
             tx_index_completed: 0,
             request_frame: None,
             response_frame: None,
+            request_gap: false,
+            response_gap: false,
         }
     }
 
@@ -178,6 +182,22 @@ impl LdapState {
             return AppLayerResult::ok();
         }
 
+        if self.request_gap {
+            match ldap_parse_msg(input) {
+                Ok((_, msg)) => {
+                    let ldap_msg = LdapMessage::from(msg);
+                    if ldap_msg.is_unknown() {
+                        return AppLayerResult::err();
+                    }
+                    AppLayerResult::ok();
+                }
+                Err(_e) => {
+                    return AppLayerResult::err();
+                }
+            }
+            self.request_gap = false;
+        }
+
         let mut start = input;
         while !start.is_empty() {
             if self.request_frame.is_none() {
@@ -229,6 +249,22 @@ impl LdapState {
         let input = stream_slice.as_slice();
         if input.is_empty() {
             return AppLayerResult::ok();
+        }
+
+        if self.response_gap {
+            match ldap_parse_msg(input) {
+                Ok((_, msg)) => {
+                    let ldap_msg = LdapMessage::from(msg);
+                    if ldap_msg.is_unknown() {
+                        return AppLayerResult::err();
+                    }
+                    AppLayerResult::ok();
+                }
+                Err(_e) => {
+                    return AppLayerResult::err();
+                }
+            }
+            self.response_gap = false;
         }
 
         let mut start = input;
@@ -437,6 +473,14 @@ impl LdapState {
 
         return AppLayerResult::ok();
     }
+
+    fn on_request_gap(&mut self, _size: u32) {
+        self.request_gap = true;
+    }
+
+    fn on_response_gap(&mut self, _size: u32) {
+        self.response_gap = true;
+    }
 }
 
 fn probe(input: &[u8], direction: Direction, rdir: *mut u8) -> AppProto {
@@ -509,7 +553,13 @@ unsafe extern "C" fn SCLdapParseRequest(
         }
     }
     let state = cast_pointer!(state, LdapState);
-    state.parse_request(flow, stream_slice)
+
+    if stream_slice.is_gap() {
+        state.on_request_gap(stream_slice.gap_size());
+    } else {
+        return state.parse_request(flow, stream_slice);
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]
@@ -525,7 +575,12 @@ unsafe extern "C" fn SCLdapParseResponse(
         }
     }
     let state = cast_pointer!(state, LdapState);
-    state.parse_response(flow, stream_slice)
+    if stream_slice.is_gap() {
+        state.on_response_gap(stream_slice.gap_size());
+    } else {
+        return state.parse_response(flow, stream_slice);
+    }
+    AppLayerResult::ok()
 }
 
 #[no_mangle]

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -28,7 +28,9 @@ use std::os::raw::{c_char, c_int, c_void};
 
 use crate::ldap::types::*;
 
-static mut LDAP_MAX_TX: usize = 256;
+static LDAP_MAX_TX_DEFAULT: usize = 256;
+
+static mut LDAP_MAX_TX: usize = LDAP_MAX_TX_DEFAULT;
 
 static mut ALPROTO_LDAP: AppProto = ALPROTO_UNKNOWN;
 
@@ -37,6 +39,7 @@ enum LdapEvent {
     TooManyTransactions,
     InvalidData,
     RequestNotFound,
+    IncompleteData,
 }
 
 #[derive(Debug)]
@@ -245,6 +248,91 @@ impl LdapState {
 
         return AppLayerResult::ok();
     }
+
+    fn parse_request_udp(
+        &mut self, _flow: *const Flow, stream_slice: StreamSlice,
+    ) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+
+        match ldap_parse_msg(input) {
+            Ok((_, msg)) => {
+                let mut tx = self.new_tx();
+                let request = LdapMessage::from(msg);
+                tx.complete = match request.protocol_op {
+                    ProtocolOp::UnbindRequest => true,
+                    _ => false,
+                };
+                tx.request = Some(request);
+                self.transactions.push_back(tx);
+            }
+            Err(nom::Err::Incomplete(_)) => {
+                self.set_event(LdapEvent::IncompleteData);
+                return AppLayerResult::err();
+            }
+            Err(_) => {
+                self.set_event(LdapEvent::InvalidData);
+                return AppLayerResult::err();
+            }
+        }
+
+        return AppLayerResult::ok();
+    }
+
+    fn parse_response_udp(
+        &mut self, _flow: *const Flow, stream_slice: StreamSlice,
+    ) -> AppLayerResult {
+        let input = stream_slice.as_slice();
+        if input.is_empty() {
+            return AppLayerResult::ok();
+        }
+
+        let mut start = input;
+        while !start.is_empty() {
+            match ldap_parse_msg(start) {
+                Ok((rem, msg)) => {
+                    let response = LdapMessage::from(msg);
+                    if let Some(tx) = self.find_request(response.message_id) {
+                        tx.complete = match response.protocol_op {
+                            ProtocolOp::SearchResultDone(_)
+                            | ProtocolOp::BindResponse(_)
+                            | ProtocolOp::ModifyResponse(_)
+                            | ProtocolOp::AddResponse(_)
+                            | ProtocolOp::DelResponse(_)
+                            | ProtocolOp::ModDnResponse(_)
+                            | ProtocolOp::CompareResponse(_)
+                            | ProtocolOp::ExtendedResponse(_) => true,
+                            _ => false,
+                        };
+                        tx.responses.push_back(response);
+                    } else if let ProtocolOp::ExtendedResponse(_) = response.protocol_op {
+                        // this is an unsolicited notification, which means
+                        // there is no request
+                        let mut tx = self.new_tx();
+                        tx.complete = true;
+                        tx.responses.push_back(response);
+                        self.transactions.push_back(tx);
+                    } else {
+                        let mut tx = self.new_tx();
+                        tx.complete = true;
+                        tx.responses.push_back(response);
+                        self.transactions.push_back(tx);
+                        self.set_event(LdapEvent::RequestNotFound);
+                    };
+                    start = rem;
+                }
+                Err(nom::Err::Incomplete(_)) => {
+                    self.set_event(LdapEvent::IncompleteData);
+                    return AppLayerResult::err();
+                }
+                Err(_) => {
+                    self.set_event(LdapEvent::InvalidData);
+                    return AppLayerResult::err();
+                }
+            }
+        }
+
+        return AppLayerResult::ok();
+    }
 }
 
 fn probe(input: &[u8], direction: Direction, rdir: *mut u8) -> AppProto {
@@ -341,6 +429,24 @@ unsafe extern "C" fn SCLdapParseResponse(
 }
 
 #[no_mangle]
+unsafe extern "C" fn SCLdapParseRequestUDP(
+    flow: *const Flow, state: *mut c_void, _pstate: *mut c_void, stream_slice: StreamSlice,
+    _data: *const c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LdapState);
+    state.parse_request_udp(flow, stream_slice)
+}
+
+#[no_mangle]
+unsafe extern "C" fn SCLdapParseResponseUDP(
+    flow: *const Flow, state: *mut c_void, _pstate: *mut c_void, stream_slice: StreamSlice,
+    _data: *const c_void,
+) -> AppLayerResult {
+    let state = cast_pointer!(state, LdapState);
+    state.parse_response_udp(flow, stream_slice)
+}
+
+#[no_mangle]
 unsafe extern "C" fn SCLdapStateGetTx(state: *mut c_void, tx_id: u64) -> *mut c_void {
     let state = cast_pointer!(state, LdapState);
     match state.get_tx(tx_id) {
@@ -374,7 +480,7 @@ export_state_data_get!(SCLdapGetStateData, LdapState);
 const PARSER_NAME: &[u8] = b"ldap\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ldap_register_parser() {
+pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
     let default_port = CString::new("389").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const c_char,
@@ -409,7 +515,6 @@ pub unsafe extern "C" fn rs_ldap_register_parser() {
     };
 
     let ip_proto_str = CString::new("tcp").unwrap();
-
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
         ALPROTO_LDAP = alproto;
@@ -418,13 +523,72 @@ pub unsafe extern "C" fn rs_ldap_register_parser() {
         }
         if let Some(val) = conf_get("app-layer.protocols.ldap.max-tx") {
             if let Ok(v) = val.parse::<usize>() {
-                LDAP_MAX_TX = v;
+                if LDAP_MAX_TX == LDAP_MAX_TX_DEFAULT {
+                    LDAP_MAX_TX = v;
+                }
             } else {
                 SCLogError!("Invalid value for ldap.max-tx");
             }
         }
         AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_LDAP);
     } else {
-        SCLogDebug!("Protocol detection and parser disabled for LDAP.");
+        SCLogDebug!("Protocol detection and parser disabled for LDAP/TCP.");
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCRegisterLdapUdpParser() {
+    let default_port = CString::new("389").unwrap();
+    let parser = RustParser {
+        name: PARSER_NAME.as_ptr() as *const c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_UDP,
+        probe_ts: Some(SCLdapProbingParser),
+        probe_tc: Some(SCLdapProbingParser),
+        min_depth: 0,
+        max_depth: 16,
+        state_new: SCLdapStateNew,
+        state_free: SCLdapStateFree,
+        tx_free: SCLdapStateTxFree,
+        parse_ts: SCLdapParseRequestUDP,
+        parse_tc: SCLdapParseResponseUDP,
+        get_tx_count: SCLdapStateGetTxCount,
+        get_tx: SCLdapStateGetTx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: SCLdapTxGetAlstateProgress,
+        get_eventinfo: Some(LdapEvent::get_event_info),
+        get_eventinfo_byid: Some(LdapEvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(applayer::state_get_tx_iterator::<LdapState, LdapTransaction>),
+        get_tx_data: SCLdapGetTxData,
+        get_state_data: SCLdapGetStateData,
+        apply_tx_config: None,
+        flags: 0,
+        get_frame_id_by_name: None,
+        get_frame_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("udp").unwrap();
+    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
+        ALPROTO_LDAP = alproto;
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+        if let Some(val) = conf_get("app-layer.protocols.ldap.max-tx") {
+            if let Ok(v) = val.parse::<usize>() {
+                if LDAP_MAX_TX == LDAP_MAX_TX_DEFAULT {
+                    LDAP_MAX_TX = v;
+                }
+            } else {
+                SCLogError!("Invalid value for ldap.max-tx");
+            }
+        }
+        AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_LDAP);
+    } else {
+        SCLogDebug!("Protocol detection and parser disabled for LDAP/UDP.");
     }
 }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1724,7 +1724,8 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_sip_register_parser();
     rs_quic_register_parser();
     rs_websocket_register_parser();
-    rs_ldap_register_parser();
+    SCRegisterLdapTcpParser();
+    SCRegisterLdapUdpParser();
     rs_template_register_parser();
     RegisterRFBParsers();
     SCMqttRegisterParser();

--- a/src/output.c
+++ b/src/output.c
@@ -1094,7 +1094,7 @@ void OutputRegisterLoggers(void)
             JsonLogThreadDeinit, NULL);
     /* Ldap JSON logger. */
     OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonLdapLog", "eve-log.ldap",
-            OutputJsonLogInitSub, ALPROTO_LDAP, JsonGenericDirPacketLogger, JsonLogThreadInit,
+            OutputJsonLogInitSub, ALPROTO_LDAP, JsonGenericDirFlowLogger, JsonLogThreadInit,
             JsonLogThreadDeinit, NULL);
     /* DoH2 JSON logger. */
     JsonDoh2LogRegister();

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1189,7 +1189,14 @@ app-layer:
       #enabled: yes
 
     ldap:
-      enabled: yes
+      tcp:
+        enabled: yes
+        detection-ports:
+          dp: 389
+      udp:
+        enabled: yes
+        detection-ports:
+          dp: 389
       # Maximum number of live LDAP transactions per flow
       # max-tx: 1024
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/1199

Describe changes:
The LDAP/UDP parser now has its own request and response parsing functions.
Previously, it used the same parsing logic as LDAP/TCP for handling LDAP traffic over UDP, but in some cases, it incorrectly returned 'AppLayerResult::incomplete()', which is only used for TCP, when it should return 'AppLayerResult::err()'.
This likely explains why line 1373 in app-layer-parser.c was executed.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/1984
