### PR TITLE
detect/dataset: delay set operation after signature full match

### DIFF
--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -99,6 +99,7 @@ int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,
             // No need to allocate and copy as this data lives
             // as long as detection runs one iteration
             dmd->data_len = data_len;
+            // TODO this will not work for multi buffers as it will take only the last one
             dmd->data = data;
             return 1;
         }
@@ -117,8 +118,13 @@ int DetectDatasetMatch(
     DetectDatasetMatchData *dmd = (DetectDatasetMatchData *)DetectThreadCtxGetKeywordThreadCtx(
             det_ctx, sd->thread_ctx_id);
 
-    if (dmd == NULL) {
+    if (dmd == NULL || dmd->data == NULL) {
         return 0;
+    }
+    if (s == NULL) {
+        // hack : we are called with s == NULL when there is no match
+        // so we reset, to avoid reusing a dangling pointer
+        dmd->data = NULL;
     }
     return DatasetAdd(sd->set, dmd->data, dmd->data_len);
 }

--- a/src/detect-dataset.h
+++ b/src/detect-dataset.h
@@ -34,6 +34,7 @@
 typedef struct DetectDatasetData_ {
     Dataset *set;
     uint8_t cmd;
+    int thread_ctx_id;
 } DetectDatasetData;
 
 int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,

--- a/src/detect.c
+++ b/src/detect.c
@@ -1222,6 +1222,16 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         inspect_flags |= DE_STATE_FLAG_FULL_INSPECT;
         TRACE_SID_TXS(s->id, tx, "MATCH");
         retval = true;
+    } else {
+        const SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_POSTMATCH];
+        if (smd != NULL) {
+            while (1) {
+                (void)sigmatch_table[smd->type].Match(det_ctx, p, NULL, smd->ctx);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
     }
 
     if (stored_flags) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5576

Describe changes:
- detect/dataset: delay set operation after signature full match

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2000

Side note: the limitation described for flowvar in https://redmine.openinfosecfoundation.org/issues/7197 likely also applies here to dataset
