### PR TITLE
fuzz: make confyaml.c an explicit source (backport7)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1343,7 +1343,7 @@ if BUILD_FUZZTARGETS
 LDFLAGS_FUZZ = $(all_libraries) $(SECLDFLAGS)
 LDADD_FUZZ = libsuricata_c.a $(RUST_SURICATA_LIB) $(HTP_LDADD) $(RUST_LDADD)
 
-fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c
+fuzz_applayerprotodetectgetproto_SOURCES = tests/fuzz/fuzz_applayerprotodetectgetproto.c tests/fuzz/confyaml.c
 fuzz_applayerprotodetectgetproto_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerprotodetectgetproto_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
@@ -1354,7 +1354,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_applayerprotodetectgetproto_SOURCES = force-cxx-linking.cxx
 
-fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c
+fuzz_applayerparserparse_SOURCES = tests/fuzz/fuzz_applayerparserparse.c tests/fuzz/confyaml.c
 fuzz_applayerparserparse_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_applayerparserparse_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
@@ -1398,7 +1398,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_decodepcapfile_SOURCES = force-cxx-linking.cxx
 
-fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c
+fuzz_sigpcap_SOURCES = tests/fuzz/fuzz_sigpcap.c tests/fuzz/confyaml.c
 fuzz_sigpcap_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_LDADD = $(LDADD_FUZZ)
 if HAS_FUZZLDFLAGS
@@ -1410,7 +1410,7 @@ endif
 nodist_EXTRA_fuzz_sigpcap_SOURCES = force-cxx-linking.cxx
 
 if HAS_FUZZPCAP
-fuzz_sigpcap_aware_SOURCES = tests/fuzz/fuzz_sigpcap_aware.c
+fuzz_sigpcap_aware_SOURCES = tests/fuzz/fuzz_sigpcap_aware.c tests/fuzz/confyaml.c
 fuzz_sigpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_sigpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
 if HAS_FUZZLDFLAGS
@@ -1421,7 +1421,7 @@ endif
 # force usage of CXX for linker
 nodist_EXTRA_fuzz_sigpcap_aware_SOURCES = force-cxx-linking.cxx
 
-fuzz_predefpcap_aware_SOURCES = tests/fuzz/fuzz_predefpcap_aware.c
+fuzz_predefpcap_aware_SOURCES = tests/fuzz/fuzz_predefpcap_aware.c tests/fuzz/confyaml.c
 fuzz_predefpcap_aware_LDFLAGS = $(LDFLAGS_FUZZ)
 fuzz_predefpcap_aware_LDADD = $(LDADD_FUZZ) -lfuzzpcap
 if HAS_FUZZLDFLAGS

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -1,4 +1,4 @@
-const char configNoChecksum[] = "\
+const char *configNoChecksum = "\
 %YAML 1.1\n\
 ---\n\
 pcap-file:\n\

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -21,7 +21,7 @@ int LLVMFuzzerInitialize(int *argc, char ***argv);
 
 AppLayerParserThreadCtx *alp_tctx = NULL;
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 /* input buffer is structured this way :
  * 6 bytes header,

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -18,7 +18,7 @@
 //rule of thumb constant, so as not to timeout target
 #define PROTO_DETECT_MAX_LEN 1024
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 

--- a/src/tests/fuzz/fuzz_predefpcap_aware.c
+++ b/src/tests/fuzz/fuzz_predefpcap_aware.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 char *filepath = NULL;
 

--- a/src/tests/fuzz/fuzz_sigpcap.c
+++ b/src/tests/fuzz/fuzz_sigpcap.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/src/tests/fuzz/fuzz_sigpcap_aware.c
+++ b/src/tests/fuzz/fuzz_sigpcap_aware.c
@@ -42,7 +42,7 @@ void *fwd;
 SCInstance surifuzz;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
-#include "confyaml.c"
+extern const char *configNoChecksum;
 
 static void SigGenerateAware(const uint8_t *data, size_t size, char *r, size_t *len)
 {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7182

Describe changes:
- Backport of #11583 clean cherry-pick
