### PR TITLE
ssh/frames: avoid unsigned integer overflow

### DIFF
--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -233,7 +233,8 @@ impl SSHState {
                                 flow,
                                 stream_slice,
                                 input,
-                                (head.pkt_len + 4) as i64,
+                                // cast first to avoid unsigned integer overflow
+                                (head.pkt_len as u64 + 4) as i64,
                                 SshFrameType::RecordPdu as u8,
                                 Some(0),
                             );


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5734

Describe changes:
- ssh/frames: fix unsigned integer overflow

as found by CIFuzz in https://github.com/OISF/suricata/pull/11601

#11603 clean (and typo in commit fixed)