### PR TITLE
New spm "mm"; Simd optimizations v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -194,6 +194,12 @@ jobs:
         working-directory: examples/plugins/c-json-filetype
         run: make clean all
 
+      - name: Test library bench content inspect tool
+        working-directory: tools/benches/bench-content-inspect
+        run: |
+          make clean all
+          ./bench_content_inspect ci-run
+
       - name: Install Suricata and library
         run: make install install-headers install-library
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
 	     examples/plugins
 SUBDIRS = $(HTP_DIR) rust src plugins qa rules doc contrib etc python ebpf \
           $(SURICATA_UPDATE_DIR)
-DIST_SUBDIRS = $(SUBDIRS) examples/lib/simple
+DIST_SUBDIRS = $(SUBDIRS) examples/lib/simple tools/benches/bench-content-inspect
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -2507,6 +2507,7 @@ AC_CONFIG_FILES(libsuricata-config)
 AC_CONFIG_FILES(examples/plugins/c-json-filetype/Makefile)
 AC_CONFIG_FILES(examples/plugins/ci-capture/Makefile)
 AC_CONFIG_FILES(examples/lib/simple/Makefile examples/lib/simple/Makefile.example)
+AC_CONFIG_FILES(tools/benches/bench-content-inspect/Makefile)
 AC_CONFIG_FILES(plugins/Makefile)
 AC_CONFIG_FILES(plugins/pfring/Makefile)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -576,6 +576,7 @@ noinst_HEADERS = \
 	util-spm-bs.h \
 	util-spm.h \
 	util-spm-hs.h \
+	util-spm-mm.h \
 	util-storage.h \
 	util-streaming-buffer.h \
 	util-syslog.h \
@@ -1145,6 +1146,7 @@ libsuricata_c_a_SOURCES = \
 	util-spm-bs.c \
 	util-spm.c \
 	util-spm-hs.c \
+	util-spm-mm.c \
 	util-storage.c \
 	util-streaming-buffer.c \
 	util-strlcatu.c \

--- a/src/detect-transform-casechange.c
+++ b/src/detect-transform-casechange.c
@@ -28,6 +28,7 @@
 #include "detect-engine.h"
 #include "detect-parse.h"
 #include "detect-transform-casechange.h"
+#include "util-memcpy.h"
 
 /**
  *  \internal
@@ -63,9 +64,7 @@ static void DetectTransformToLower(InspectionBuffer *buffer, void *options)
     }
 
     uint8_t output[input_len];
-    for (uint32_t i = 0; i < input_len; i++) {
-        output[i] = u8_tolower(input[i]);
-    }
+    MemcpyToLower(output, input, input_len);
 
     InspectionBufferCopy(buffer, output, input_len);
 }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -783,6 +783,15 @@ static void PrintBuildInfo(void)
 
     /* SIMD stuff */
     memset(features, 0x00, sizeof(features));
+#if defined(__AVX512VL__)
+    strlcat(features, "AVX512VL ", sizeof(features));
+#endif
+#if defined(__AVX512BW__)
+    strlcat(features, "AVX512BW ", sizeof(features));
+#endif
+#if defined(__AVX2__)
+    strlcat(features, "AVX2 ", sizeof(features));
+#endif
 #if defined(__SSE4_2__)
     strlcat(features, "SSE_4_2 ", sizeof(features));
 #endif

--- a/src/util-memcmp.c
+++ b/src/util-memcmp.c
@@ -156,154 +156,427 @@ static int MemcmpTest13 (void)
 
 #define TEST_RUNS 1000000
 
-static int MemcmpTest14 (void)
+#ifdef PROFILING
+/* patterns used with SCMemcmpLowercase throughout the engine */
+const char *used[] = {
+    "content-type:", // HTTP parsing
+    "content-disposition:",
+    "filename=",
+    "boundary=",
+    "cookie", // HTTP cookie keyword
+    "set-cookie",
+    ".tar.gz", // fileext likely patterns
+    ".exe",
+    ".doc",
+    ".html",
+    ".pdf.exe",
+    ".pdf",
+    "pipelining", // SMTP command parsing
+    "starttls",
+    "rset",
+    "quit",
+    "data",
+    "bdat",
+    "mail from",
+    "rcpt to",
+    "234 ", // FTP response codes
+    "227 ",
+    "229 ",
+    NULL,
+};
+
+const char *syn[] = {
+    "1",
+    "2a",
+    "4aaa",
+    "8aaaaaaa",
+    "16aaaaaaaaaaaaaa",
+    "32aaaaaaaaaaaaaa32aaaaaaaaaaaaaa",
+    "64aaaaaaaaaaaaaa64aaaaaaaaaaaaaa64aaaaaaaaaaaaaa64aaaaaaaaaaaaaa",
+    "128aaaaaaaaaaaaaaaaaaaaaaaaaaaaa128aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "128aaaaaaaaaaaaaaaaaaaaaaaaaaaaa128aaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa256aaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa512aaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa1024aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa2048aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa4096aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    NULL,
+};
+
+static inline int TestWrapMemcmp(const void *s1, const void *s2, size_t len)
+{
+    return (memcmp(s1, s2, len) == 0) ? 0 : 1;
+}
+
+#define BIGSZ 1024 * 1024
+#define DRIVER(f)                                                                                  \
+    uint8_t *big = SCCalloc(1, BIGSZ);                                                             \
+    memset(big, 'a', BIGSZ);                                                                       \
+    int res = 0;                                                                                   \
+    uint64_t cnt = 0;                                                                              \
+    uint64_t ticks_start = UtilCpuGetTicks();                                                      \
+    for (int t = 0; t < TEST_RUNS; t++) {                                                          \
+        for (int i = 0; used[i] != NULL; i++) {                                                    \
+            size_t alen = strlen(used[i]) - 1;                                                     \
+            for (int j = 0; used[j] != NULL; j++) {                                                \
+                size_t blen = strlen(used[j]) - 1;                                                 \
+                cnt++;                                                                             \
+                res += (f)((uint8_t *)used[i], (uint8_t *)used[j], (alen < blen) ? alen : blen);   \
+            }                                                                                      \
+        }                                                                                          \
+    }                                                                                              \
+    uint64_t ticks_end = UtilCpuGetTicks();                                                        \
+    printf("real: %3" PRIu64 " - ", ((uint64_t)(ticks_end - ticks_start)) / cnt);                  \
+    if (res != (504 * TEST_RUNS)) {                                                                \
+        SCLogNotice("%d %" PRIu64 "\n", res, ((uint64_t)(ticks_end - ticks_start)) / cnt);         \
+        return 0;                                                                                  \
+    }                                                                                              \
+    res = 0;                                                                                       \
+    cnt = 0;                                                                                       \
+    ticks_start = UtilCpuGetTicks();                                                               \
+    for (int t = 0; t < TEST_RUNS; t++) {                                                          \
+        for (int i = 0; syn[i] != NULL; i++) {                                                     \
+            size_t alen = strlen(syn[i]) - 1;                                                      \
+            for (int j = 0; syn[j] != NULL; j++) {                                                 \
+                size_t blen = strlen(syn[j]) - 1;                                                  \
+                cnt++;                                                                             \
+                res += (f)((uint8_t *)syn[i], (uint8_t *)syn[j], (alen < blen) ? alen : blen);     \
+            }                                                                                      \
+        }                                                                                          \
+    }                                                                                              \
+    ticks_end = UtilCpuGetTicks();                                                                 \
+    printf("syn: %3" PRIu64 " - ", ((uint64_t)(ticks_end - ticks_start)) / cnt);                   \
+    if (res != (128 * TEST_RUNS)) {                                                                \
+        SCLogNotice("%d %" PRIu64 "\n", res, ((uint64_t)(ticks_end - ticks_start)) / cnt);         \
+        return 0;                                                                                  \
+    }                                                                                              \
+    res = 0;                                                                                       \
+    cnt = 0;                                                                                       \
+    ticks_start = UtilCpuGetTicks();                                                               \
+    for (int t = 0; t < 10; t++) {                                                                 \
+        for (int i = 0; used[i] != NULL; i++) {                                                    \
+            size_t alen = strlen(used[i]) - 1;                                                     \
+            for (size_t j = 0; j < BIGSZ; j++) {                                                   \
+                if (BIGSZ - j < alen)                                                              \
+                    continue;                                                                      \
+                uint8_t *b = big + j;                                                              \
+                cnt++;                                                                             \
+                res += (f)((uint8_t *)used[i], b, alen);                                           \
+            }                                                                                      \
+        }                                                                                          \
+    }                                                                                              \
+    ticks_end = UtilCpuGetTicks();                                                                 \
+    printf("stream1: %3" PRIu64 " - ", ((uint64_t)(ticks_end - ticks_start)) / cnt);               \
+    if (res != 241171330) {                                                                        \
+        SCLogNotice("%d %" PRIu64 "\n", res, ((uint64_t)(ticks_end - ticks_start)) / cnt);         \
+        return 0;                                                                                  \
+    }                                                                                              \
+    res = 0;                                                                                       \
+    cnt = 0;                                                                                       \
+    ticks_start = UtilCpuGetTicks();                                                               \
+    for (int t = 0; t < 10; t++) {                                                                 \
+        for (int i = 0; syn[i] != NULL; i++) {                                                     \
+            size_t alen = strlen(syn[i]) - 1;                                                      \
+                                                                                                   \
+            for (size_t j = 0; j < BIGSZ; j++) {                                                   \
+                if (BIGSZ - j < alen)                                                              \
+                    continue;                                                                      \
+                uint8_t *b = big + j;                                                              \
+                cnt++;                                                                             \
+                res += (f)((uint8_t *)syn[i], b, alen);                                            \
+            }                                                                                      \
+        }                                                                                          \
+    }                                                                                              \
+    ticks_end = UtilCpuGetTicks();                                                                 \
+    printf("stream2: %3" PRIu64 " - ", ((uint64_t)(ticks_end - ticks_start)) / cnt);               \
+    if (res != 125747460) {                                                                        \
+        SCLogNotice("%d %" PRIu64 "\n", res, ((uint64_t)(ticks_end - ticks_start)) / cnt);         \
+        return 0;                                                                                  \
+    }                                                                                              \
+    SCFree(big);
+#endif
+
+static int MemcmpTestExactLibcMemcmp(void)
 {
 #ifdef PROFILING
-    uint64_t ticks_start = 0;
-    uint64_t ticks_end = 0;
-    const char *a[] = { "0123456789012345", "abc", "abcdefghij", "suricata", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-    const char *b[] = { "1234567890123456", "abc", "abcdefghik", "suricatb", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-
-    int t = 0;
-    int i, j;
-    int r1 = 0;
-
-    printf("\n");
-
-    ticks_start = UtilCpuGetTicks();
-    for (t = 0; t < TEST_RUNS; t++) {
-        for (i = 0; a[i] != NULL; i++) {
-            // printf("a[%d] = %s\n", i, a[i]);
-            size_t alen = strlen(a[i]) - 1;
-
-            for (j = 0; b[j] != NULL; j++) {
-                // printf("b[%d] = %s\n", j, b[j]);
-                size_t blen = strlen(b[j]) - 1;
-
-                r1 += (memcmp((uint8_t *)a[i], (uint8_t *)b[j], (alen < blen) ? alen : blen) ? 1 : 0);
-            }
-        }
-    }
-    ticks_end = UtilCpuGetTicks();
-    printf("memcmp(%d) \t\t\t%"PRIu64"\n", TEST_RUNS, ((uint64_t)(ticks_end - ticks_start))/TEST_RUNS);
-    SCLogInfo("ticks passed %"PRIu64, ticks_end - ticks_start);
-
-    printf("r1 %d\n", r1);
-    FAIL_IF(r1 != (51 * TEST_RUNS));
+    DRIVER(TestWrapMemcmp);
 #endif
     PASS;
 }
 
-static int MemcmpTest15 (void)
+static int MemcmpTestExactSCMemcmp(void)
 {
 #ifdef PROFILING
-    uint64_t ticks_start = 0;
-    uint64_t ticks_end = 0;
-    const char *a[] = { "0123456789012345", "abc", "abcdefghij", "suricata", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-    const char *b[] = { "1234567890123456", "abc", "abcdefghik", "suricatb", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-
-    int t = 0;
-    int i, j;
-    int r2 = 0;
-
-    printf("\n");
-
-    ticks_start = UtilCpuGetTicks();
-    for (t = 0; t < TEST_RUNS; t++) {
-        for (i = 0; a[i] != NULL; i++) {
-            // printf("a[%d] = %s\n", i, a[i]);
-            size_t alen = strlen(a[i]) - 1;
-
-            for (j = 0; b[j] != NULL; j++) {
-                // printf("b[%d] = %s\n", j, b[j]);
-                size_t blen = strlen(b[j]) - 1;
-
-                r2 += MemcmpLowercase((uint8_t *)a[i], (uint8_t *)b[j], (alen < blen) ? alen : blen);
-            }
-        }
-    }
-    ticks_end = UtilCpuGetTicks();
-    printf("MemcmpLowercase(%d) \t\t%"PRIu64"\n", TEST_RUNS, ((uint64_t)(ticks_end - ticks_start))/TEST_RUNS);
-    SCLogInfo("ticks passed %"PRIu64, ticks_end - ticks_start);
-
-    printf("r2 %d\n", r2);
-    FAIL_IF(r2 != (51 * TEST_RUNS));
+    DRIVER(SCMemcmp);
 #endif
     PASS;
 }
 
-static int MemcmpTest16 (void)
+static int MemcmpTestExactSCMemcmpSSE3(void)
 {
 #ifdef PROFILING
-    uint64_t ticks_start = 0;
-    uint64_t ticks_end = 0;
-    const char *a[] = { "0123456789012345", "abc", "abcdefghij", "suricata", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-    const char *b[] = { "1234567890123456", "abc", "abcdefghik", "suricatb", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-
-    int t = 0;
-    int i, j;
-    int r3 = 0;
-
-    printf("\n");
-
-    ticks_start = UtilCpuGetTicks();
-    for (t = 0; t < TEST_RUNS; t++) {
-        for (i = 0; a[i] != NULL; i++) {
-            // printf("a[%d] = %s\n", i, a[i]);
-            size_t alen = strlen(a[i]) - 1;
-
-            for (j = 0; b[j] != NULL; j++) {
-                // printf("b[%d] = %s\n", j, b[j]);
-                size_t blen = strlen(b[j]) - 1;
-
-                r3 += SCMemcmp((uint8_t *)a[i], (uint8_t *)b[j], (alen < blen) ? alen : blen);
-            }
-        }
-    }
-    ticks_end = UtilCpuGetTicks();
-    printf("SCMemcmp(%d) \t\t\t%"PRIu64"\n", TEST_RUNS, ((uint64_t)(ticks_end - ticks_start))/TEST_RUNS);
-    SCLogInfo("ticks passed %"PRIu64, ticks_end - ticks_start);
-
-    printf("r3 %d\n", r3);
-    FAIL_IF(r3 != (51 * TEST_RUNS));
+    DRIVER(SCMemcmpSSE3);
 #endif
     PASS;
 }
 
-static int MemcmpTest17 (void)
+static int MemcmpTestExactSCMemcmpSSE41(void)
 {
 #ifdef PROFILING
-    uint64_t ticks_start = 0;
-    uint64_t ticks_end = 0;
-    const char *a[] = { "0123456789012345", "abc", "abcdefghij", "suricata", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
-    const char *b[] = { "1234567890123456", "abc", "abcdefghik", "suricatb", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };
+    DRIVER(SCMemcmpSSE41);
+#endif
+    return 1;
+}
 
-    int t = 0;
-    int i, j;
-    int r4 = 0;
+static int MemcmpTestExactSCMemcmpSSE42(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpSSE42);
+#endif
+    return 1;
+}
 
-    printf("\n");
+static int MemcmpTestExactSCMemcmpAVX2(void)
+{
+#ifdef PROFILING
+#ifdef __AVX2__
+    DRIVER(SCMemcmpAVX2);
+#endif
+#endif
+    return 1;
+}
 
-    ticks_start = UtilCpuGetTicks();
-    for (t = 0; t < TEST_RUNS; t++) {
-        for (i = 0; a[i] != NULL; i++) {
-            // printf("a[%d] = %s\n", i, a[i]);
-            size_t alen = strlen(a[i]) - 1;
+static int MemcmpTestExactSCMemcmpAVX512_128(void)
+{
+#ifdef PROFILING
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    DRIVER(SCMemcmpAVX512_128);
+#endif
+#endif
+    return 1;
+}
 
-            for (j = 0; b[j] != NULL; j++) {
-                // printf("b[%d] = %s\n", j, b[j]);
-                size_t blen = strlen(b[j]) - 1;
+static int MemcmpTestExactSCMemcmpAVX512_256(void)
+{
+#ifdef PROFILING
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    DRIVER(SCMemcmpAVX512_256);
+#endif
+#endif
+    return 1;
+}
 
-                r4 += SCMemcmpLowercase((uint8_t *)a[i], (uint8_t *)b[j], (alen < blen) ? alen : blen);
-            }
-        }
-    }
-    ticks_end = UtilCpuGetTicks();
-    printf("SCMemcmpLowercase(%d) \t\t%"PRIu64"\n", TEST_RUNS, ((uint64_t)(ticks_end - ticks_start))/TEST_RUNS);
-    SCLogInfo("ticks passed %"PRIu64, ticks_end - ticks_start);
+static int MemcmpTestExactSCMemcmpAVX512_512(void)
+{
+#ifdef PROFILING
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    DRIVER(SCMemcmpAVX512_512);
+#endif
+#endif
+    return 1;
+}
 
-    printf("r4 %d\n", r4);
-    FAIL_IF(r4 != (51 * TEST_RUNS));
+static int MemcmpTestLowercaseDefault(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercase);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseNoSIMD(void)
+{
+#ifdef PROFILING
+    DRIVER(MemcmpLowercase);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseSSE3(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercaseSSE3);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseSSE3and(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercaseSSE3and);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseSSE3andload(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercaseSSE3andload);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseSSE41(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercaseSSE41);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseSSE42(void)
+{
+#ifdef PROFILING
+    DRIVER(SCMemcmpLowercaseSSE42);
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseAVX2(void)
+{
+#ifdef PROFILING
+#ifdef __AVX2__
+    DRIVER(SCMemcmpLowercaseAVX2);
+#endif
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseAVX512_256(void)
+{
+#ifdef PROFILING
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    DRIVER(SCMemcmpLowercaseAVX512_256);
+#endif
+#endif
+    return 1;
+}
+
+static int MemcmpTestLowercaseAVX512_512(void)
+{
+#ifdef PROFILING
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    DRIVER(SCMemcmpLowercaseAVX512_512);
+#endif
 #endif
     PASS;
 }
@@ -313,25 +586,101 @@ struct MemcmpTest18Tests {
     const char *b;
     int result;
 } memcmp_tests18_tests[] = {
-        { "abcdefgh", "!bcdefgh", 1, },
-        { "?bcdefgh", "!bcdefgh", 1, },
-        { "!bcdefgh", "abcdefgh", 1, },
-        { "!bcdefgh", "?bcdefgh", 1, },
-        { "zbcdefgh", "bbcdefgh", 1, },
+    {
+            "abcdefgh",
+            "!bcdefgh",
+            1,
+    },
+    {
+            "?bcdefgh",
+            "!bcdefgh",
+            1,
+    },
+    {
+            "!bcdefgh",
+            "abcdefgh",
+            1,
+    },
+    {
+            "!bcdefgh",
+            "?bcdefgh",
+            1,
+    },
+    {
+            "zbcdefgh",
+            "bbcdefgh",
+            1,
+    },
 
-        { "abcdefgh12345678", "!bcdefgh12345678", 1, },
-        { "?bcdefgh12345678", "!bcdefgh12345678", 1, },
-        { "!bcdefgh12345678", "abcdefgh12345678", 1, },
-        { "!bcdefgh12345678", "?bcdefgh12345678", 1, },
-        { "bbcdefgh12345678", "zbcdefgh12345678", 1, },
+    {
+            "abcdefgh12345678",
+            "!bcdefgh12345678",
+            1,
+    },
+    {
+            "?bcdefgh12345678",
+            "!bcdefgh12345678",
+            1,
+    },
+    {
+            "!bcdefgh12345678",
+            "abcdefgh12345678",
+            1,
+    },
+    {
+            "!bcdefgh12345678",
+            "?bcdefgh12345678",
+            1,
+    },
+    {
+            "bbcdefgh12345678",
+            "zbcdefgh12345678",
+            1,
+    },
 
-        { "abcdefgh", "abcdefgh", 0, },
-        { "abcdefgh", "Abcdefgh", 0, },
-        { "abcdefgh12345678", "Abcdefgh12345678", 0, },
+    {
+            "abcdefgh",
+            "abcdefgh",
+            0,
+    },
+    {
+            "abcdefgh",
+            "Abcdefgh",
+            0,
+    },
+    {
+            "abcdefgh12345678",
+            "Abcdefgh12345678",
+            0,
+    },
+    {
+            "abcdefghijklmnopqrstuvwxyz12345678",
+            "AbcdefghijKLMnopqrstuvwXYZ12345678",
+            0,
+    },
+    {
+            "abcdefghijklmnopqrstuvwxyz12345678",
+            "AbcdefghijKLMnopqrstXvwXYZ12345678",
+            1,
+    },
+    {
+            "abcdefghijklmnopqrstuvwxyz1234567890",
+            "AbcdefghijKLMnopqrstuvwXYZ1234567890",
+            0,
+    },
+    {
+            "abcdefghijklmnopqrstuvwxyz1234567890",
+            "AbcdefghijKLMnopqrstXvwXYZ1234567890",
+            1,
+    },
+    { "abcdefghijklmnopqrstuvwxyz12345678abcdefghijklmnopqrstuvwxyz12345678",
+            "AbcdefghijklmnopqrstUvwxyz12345678abcdefghijklmnopqrstuvwxyZ12345678", 0 },
+    { "abcdefghijklmnopqrstuvwxyz12345678abcdefghijklmnopqrstuvwxyz12345678",
+            "abcdefghijklmnopqrstUvwxyz12345678abcdefXhijklmnopqrstuvwxyz12345678", 1 },
 
-        { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
 
-    };
+};
 
 static int MemcmpTest18 (void)
 {
@@ -346,11 +695,8 @@ static int MemcmpTest18 (void)
     PASS;
 }
 
-#endif /* UNITTESTS */
-
 void MemcmpRegisterTests(void)
 {
-#ifdef UNITTESTS
     UtRegisterTest("MemcmpTest01", MemcmpTest01);
     UtRegisterTest("MemcmpTest02", MemcmpTest02);
     UtRegisterTest("MemcmpTest03", MemcmpTest03);
@@ -364,11 +710,25 @@ void MemcmpRegisterTests(void)
     UtRegisterTest("MemcmpTest11", MemcmpTest11);
     UtRegisterTest("MemcmpTest12", MemcmpTest12);
     UtRegisterTest("MemcmpTest13", MemcmpTest13);
-    UtRegisterTest("MemcmpTest14", MemcmpTest14);
-    UtRegisterTest("MemcmpTest15", MemcmpTest15);
-    UtRegisterTest("MemcmpTest16", MemcmpTest16);
-    UtRegisterTest("MemcmpTest17", MemcmpTest17);
+    UtRegisterTest("MemcmpTestExactLibcMemcmp", MemcmpTestExactLibcMemcmp);
+    UtRegisterTest("MemcmpTestExactSCMemcmpDefault", MemcmpTestExactSCMemcmp);
+    UtRegisterTest("MemcmpTestExactSCMemcmpSSE3", MemcmpTestExactSCMemcmpSSE3);
+    UtRegisterTest("MemcmpTestExactSCMemcmpSSE41", MemcmpTestExactSCMemcmpSSE41);
+    UtRegisterTest("MemcmpTestExactSCMemcmpSSE42", MemcmpTestExactSCMemcmpSSE42);
+    UtRegisterTest("MemcmpTestExactSCMemcmpAVX2", MemcmpTestExactSCMemcmpAVX2);
+    UtRegisterTest("MemcmpTestExactSCMemcmpAVX512_128", MemcmpTestExactSCMemcmpAVX512_128);
+    UtRegisterTest("MemcmpTestExactSCMemcmpAVX512_256", MemcmpTestExactSCMemcmpAVX512_256);
+    UtRegisterTest("MemcmpTestExactSCMemcmpAVX512_512", MemcmpTestExactSCMemcmpAVX512_512);
+    UtRegisterTest("MemcmpTestLowercaseDefault", MemcmpTestLowercaseDefault);
+    UtRegisterTest("MemcmpTestLowercaseNoSIMD", MemcmpTestLowercaseNoSIMD);
+    UtRegisterTest("MemcmpTestLowercaseSSE3", MemcmpTestLowercaseSSE3);
+    UtRegisterTest("MemcmpTestLowercaseSSE3and", MemcmpTestLowercaseSSE3and);
+    UtRegisterTest("MemcmpTestLowercaseSSE3andload", MemcmpTestLowercaseSSE3andload);
+    UtRegisterTest("MemcmpTestLowercaseSSE41", MemcmpTestLowercaseSSE41);
+    UtRegisterTest("MemcmpTestLowercaseSSE42", MemcmpTestLowercaseSSE42);
+    UtRegisterTest("MemcmpTestLowercaseAVX2", MemcmpTestLowercaseAVX2);
+    UtRegisterTest("MemcmpTestLowercaseAVX512_256", MemcmpTestLowercaseAVX512_256);
+    UtRegisterTest("MemcmpTestLowercaseAVX512_512", MemcmpTestLowercaseAVX512_512);
     UtRegisterTest("MemcmpTest18", MemcmpTest18);
-#endif /* UNITTESTS */
 }
-
+#endif /* UNITTESTS */

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2022 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -20,7 +20,7 @@
  *
  * \author Victor Julien <victor@inliniac.net>
  *
- * Memcmp implementations for SSE3, SSE4.1, SSE4.2.
+ * Memcmp implementations for SSE3, SSE4.1, SSE4.2 and AVX2.
  *
  * Both SCMemcmp and SCMemcmpLowercase return 0 on a exact match,
  * 1 on a failed match.
@@ -35,9 +35,9 @@
 /** \brief compare two patterns, converting the 2nd to lowercase
  *  \warning *ONLY* the 2nd pattern is converted to lowercase
  */
-static inline int SCMemcmpLowercase(const void *, const void *, size_t);
 
-void MemcmpRegisterTests(void);
+static inline int SCMemcmpLT32(const void *s1, const void *s2, size_t len);
+static inline int SCMemcmpLowercaseLT32(const void *s1, const void *s2, size_t len);
 
 static inline int
 MemcmpLowercase(const void *s1, const void *s2, size_t n)
@@ -50,11 +50,328 @@ MemcmpLowercase(const void *s1, const void *s2, size_t n)
     return 0;
 }
 
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+#include <immintrin.h>
+#define SCMEMCMP_BYTES 16
+static inline int SCMemcmpAVX512_128(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return memcmp(s1, s2, len - offset) ? 1 : 0;
+        }
+
+        /* unaligned loads */
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
+        if (_mm_cmpeq_epi8_mask(b1, b2) != 0x0000FFFF) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#define SCMEMCMP_BYTES 32
+static inline int SCMemcmpAVX512_256(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpAVX512_128(s1, s2, len - offset);
+        }
+
+        /* unaligned loads */
+        __m256i b1 = _mm256_lddqu_si256((const __m256i *)s1);
+        __m256i b2 = _mm256_lddqu_si256((const __m256i *)s2);
+        if (_mm256_cmpeq_epi8_mask(b1, b2) != UINT32_MAX) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#define SCMEMCMP_BYTES 64
+static inline int SCMemcmpAVX512_512(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpAVX512_256(s1, s2, len - offset);
+        }
+
+        /* unaligned loads */
+        __m512i b1 = _mm512_loadu_si512((const __m512i *)s1);
+        __m512i b2 = _mm512_loadu_si512((const __m512i *)s2);
+        if (_mm512_cmpeq_epi8_mask(b1, b2) != UINT64_MAX) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#endif
+
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+#include <immintrin.h>
+#define SCMEMCMP_BYTES 32
+// clang-format off
+static char scmemcmp_avx512_space32[32] __attribute__((aligned(32))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+static char scmemcmp_avx512_upper_low32[32] __attribute__((aligned(32))) = {
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+};
+static char scmemcmp_avx512_upper_hi32[32] __attribute__((aligned(32))) = {
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+};
+// clang-format on
+
+static inline int SCMemcmpLowercaseAVX512_256(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    __m256i b1, b2, mask1, mask2, upper1, upper2, uplow;
+
+    upper1 = _mm256_load_si256((const __m256i *)scmemcmp_avx512_upper_low32);
+    upper2 = _mm256_load_si256((const __m256i *)scmemcmp_avx512_upper_hi32);
+    uplow = _mm256_load_si256((const __m256i *)scmemcmp_avx512_space32);
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpLowercaseLT32(s1, s2, len - offset);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        b1 = _mm256_lddqu_si256((const __m256i *)s1);
+        b2 = _mm256_lddqu_si256((const __m256i *)s2);
+
+        /* mark all chars bigger than upper1 */
+        mask1 = _mm256_cmpgt_epi8(b2, upper1);
+        /* mark all chars lower than upper2 */
+        mask2 = _mm256_cmpgt_epi8(upper2, b2);
+        /* merge the two, leaving only those that are true in both */
+        mask1 = _mm256_cmpeq_epi8(mask1, mask2);
+        /* Next we use that mask to create a new: this one has 0x20 for
+         * the uppercase chars, 00 for all other. */
+        mask1 = _mm256_and_si256(uplow, mask1);
+
+        /* add to b2, converting uppercase to lowercase */
+        b2 = _mm256_add_epi8(b2, mask1);
+
+        /* now all is lowercase, let's do the actual compare */
+        int32_t r = _mm256_cmpeq_epi8_mask(b1, b2);
+        if (r != -1) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#define SCMEMCMP_BYTES 64
+// clang-format off
+static char scmemcmp_space64[64] __attribute__((aligned(64))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+static char scmemcmp_upper_low64[64] __attribute__((aligned(64))) = {
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+};
+static char scmemcmp_upper_hi64[64] __attribute__((aligned(64))) = {
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+};
+// clang-format on
+
+static inline int SCMemcmpLowercaseAVX512_512(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    __m512i upper1 = _mm512_load_si512((const __m512i *)scmemcmp_upper_low64);
+    __m512i upper2 = _mm512_load_si512((const __m512i *)scmemcmp_upper_hi64);
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpLowercaseAVX512_256(s1, s2, len - offset);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        __m512i b1 = _mm512_loadu_si512((const __m512i *)s1);
+        __m512i b2 = _mm512_loadu_si512((const __m512i *)s2);
+
+        /* mark all chars bigger than upper1 */
+        uint64_t m1 = _mm512_cmp_epi8_mask(upper1, b2, _MM_CMPINT_LT);
+        /* mark all chars lower than upper2 */
+        uint64_t m2 = _mm512_cmp_epi8_mask(b2, upper2, _MM_CMPINT_LT);
+        /* merge the two, leaving only those that are true in both */
+        uint64_t m3 = m1 & m2;
+        /* use mask to create array of 0x20 and 0x00's */
+        __m512i uplow = _mm512_mask_loadu_epi8(
+                _mm512_setzero_si512(), m3, (const __m512i *)scmemcmp_space64);
+        /* use it to create the lowercase'd buffer */
+        b2 = _mm512_add_epi8(b2, uplow);
+        /* now all is lowercase, let's do the actual compare */
+        uint64_t r = _mm512_cmpeq_epi8_mask(b1, b2);
+        if (r != UINT64_MAX) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#endif
+#if defined(__AVX2__)
+#include <immintrin.h>
+#define SCMEMCMP_BYTES 32
+
+static inline int SCMemcmpAVX2(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpLT32(s1, s2, len - offset);
+        }
+
+        __m256i b1 = _mm256_lddqu_si256((const __m256i *)((const uint8_t *)s1 + offset));
+        __m256i b2 = _mm256_lddqu_si256((const __m256i *)((const uint8_t *)s2 + offset));
+        __m256i c = _mm256_cmpeq_epi8(b1, b2);
+
+        int r = _mm256_movemask_epi8(c);
+        if (r != -1) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#endif
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#define SCMEMCMP_BYTES 32
+// clang-format off
+static char scmemcmp_space32[32] __attribute__((aligned(32))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+static char scmemcmp_upper_low32[32] __attribute__((aligned(32))) = {
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+};
+static char scmemcmp_upper_hi32[32] __attribute__((aligned(32))) = {
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+};
+// clang-format on
+
+static inline int SCMemcmpLowercaseAVX2(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    __m256i upper1 = _mm256_load_si256((const __m256i *)scmemcmp_upper_low32);
+    __m256i upper2 = _mm256_load_si256((const __m256i *)scmemcmp_upper_hi32);
+    __m256i uplow = _mm256_load_si256((const __m256i *)scmemcmp_space32);
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return SCMemcmpLowercaseLT32(s1, s2, len - offset);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        __m256i b1 = _mm256_lddqu_si256((const __m256i *)((const uint8_t *)s1 + offset));
+        __m256i b2 = _mm256_lddqu_si256((const __m256i *)((const uint8_t *)s2 + offset));
+
+        /* mark all chars bigger than upper1 */
+        __m256i mask1 = _mm256_cmpgt_epi8(b2, upper1);
+        /* mark all chars lower than upper2 */
+        __m256i mask2 = _mm256_cmpgt_epi8(upper2, b2);
+        /* merge the two, leaving only those that are true in both */
+        mask1 = _mm256_cmpeq_epi8(mask1, mask2);
+        /* Next we use that mask to create a new: this one has 0x20 for
+         * the uppercase chars, 00 for all other. */
+        mask1 = _mm256_and_si256(uplow, mask1);
+        /* add to b2, converting uppercase to lowercase */
+        b2 = _mm256_add_epi8(b2, mask1);
+        /* now all is lowercase, let's do the actual compare (reuse mask1 reg) */
+        mask1 = _mm256_cmpeq_epi8(b1, b2);
+
+        int r = _mm256_movemask_epi8(mask1);
+        if (r != -1) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#endif
+
 #if defined(__SSE4_2__)
 #include <nmmintrin.h>
 #define SCMEMCMP_BYTES 16
 
-static inline int SCMemcmp(const void *s1, const void *s2, size_t n)
+static inline int SCMemcmpSSE42(const void *s1, const void *s2, size_t n)
 {
     int r = 0;
     /* counter for how far we already matched in the buffer */
@@ -65,8 +382,8 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t n)
         }
 
         /* load the buffers into the 128bit vars */
-        __m128i b1 = _mm_loadu_si128((const __m128i *)s1);
-        __m128i b2 = _mm_loadu_si128((const __m128i *)s2);
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
 
         /* do the actual compare: _mm_cmpestri() returns the number of matching bytes */
         r = _mm_cmpestri(b1, SCMEMCMP_BYTES, b2, SCMEMCMP_BYTES,
@@ -78,22 +395,33 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t n)
 
     return ((m == n) ? 0 : 1);
 }
+#undef SCMEMCMP_BYTES
+#endif
 
+#if defined(__SSE4_2__)
+#include <nmmintrin.h>
+#define SCMEMCMP_BYTES 16
 /* Range of values of uppercase characters. We only use the first 2 bytes. */
+// clang-format off
 static char scmemcmp_uppercase[16] __attribute__((aligned(16))) = {
     'A', 'Z', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, };
+static char scmemcmp_space[16] __attribute__((aligned(16))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+// clang-format on
 
 /** \brief compare two buffers in a case insensitive way
  *  \param s1 buffer already in lowercase
  *  \param s2 buffer with mixed upper and lowercase
  */
-static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n)
+static inline int SCMemcmpLowercaseSSE42(const void *s1, const void *s2, size_t n)
 {
     /* counter for how far we already matched in the buffer */
     size_t m = 0;
     int r = 0;
     __m128i ucase = _mm_load_si128((const __m128i *) scmemcmp_uppercase);
-    __m128i uplow = _mm_set1_epi8(0x20);
+    __m128i uplow = _mm_load_si128((const __m128i *)scmemcmp_space);
 
     do {
         const size_t len = n - m;
@@ -101,8 +429,8 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n)
             return MemcmpLowercase(s1, s2, len);
         }
 
-        __m128i b1 = _mm_loadu_si128((const __m128i *)s1);
-        __m128i b2 = _mm_loadu_si128((const __m128i *)s2);
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
         /* The first step is creating a mask that is FF for all uppercase
          * characters, 00 for all others */
         __m128i mask = _mm_cmpestrm(ucase, 2, b2, len, _SIDD_CMP_RANGES | _SIDD_UNIT_MASK);
@@ -112,7 +440,6 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n)
         /* finally, merge the mask and the buffer converting the
          * uppercase to lowercase */
         b2 = _mm_add_epi8(b2, mask);
-
         /* search using our converted buffer, return number of matching bytes */
         r = _mm_cmpestri(b1, SCMEMCMP_BYTES, b2, SCMEMCMP_BYTES,
                 _SIDD_CMP_EQUAL_EACH | _SIDD_MASKED_NEGATIVE_POLARITY);
@@ -123,12 +450,14 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n)
 
     return ((m == n) ? 0 : 1);
 }
+#undef SCMEMCMP_BYTES
+#endif
 
-#elif defined(__SSE4_1__)
+#if defined(__SSE4_1__)
 #include <smmintrin.h>
 #define SCMEMCMP_BYTES  16
 
-static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
+static inline int SCMemcmpSSE41(const void *s1, const void *s2, size_t len)
 {
     size_t offset = 0;
     do {
@@ -137,8 +466,8 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
         }
 
         /* unaligned loads */
-        __m128i b1 = _mm_loadu_si128((const __m128i *)s1);
-        __m128i b2 = _mm_loadu_si128((const __m128i *)s2);
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
         __m128i c = _mm_cmpeq_epi8(b1, b2);
 
         if (_mm_movemask_epi8(c) != 0x0000FFFF) {
@@ -152,19 +481,38 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
 
     return 0;
 }
+#undef SCMEMCMP_BYTES
+#endif
 
+#if defined(__SSE4_1__)
+#include <smmintrin.h>
+#define SCMEMCMP_BYTES 16
 #define UPPER_LOW   0x40 /* "A" - 1 */
 #define UPPER_HIGH  0x5B /* "Z" + 1 */
 
-static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
+// clang-format off
+static char scmemcmp_sse41_ul[16] __attribute__((aligned(16))) = {
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+};
+static char scmemcmp_sse41_uh[16] __attribute__((aligned(16))) = {
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+};
+static char scmemcmp_sse41_sp[16] __attribute__((aligned(16))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+// clang-format on
+
+static inline int SCMemcmpLowercaseSSE41(const void *s1, const void *s2, size_t len)
 {
     size_t offset = 0;
-    __m128i b1, b2, mask1, mask2, upper1, upper2, uplow;
 
     /* setup registers for upper to lower conversion */
-    upper1 = _mm_set1_epi8(UPPER_LOW);
-    upper2 = _mm_set1_epi8(UPPER_HIGH);
-    uplow = _mm_set1_epi8(0x20);
+    __m128i upper1 = _mm_load_si128((const __m128i *)scmemcmp_sse41_ul);
+    __m128i upper2 = _mm_load_si128((const __m128i *)scmemcmp_sse41_uh);
+    __m128i uplow = _mm_load_si128((const __m128i *)scmemcmp_sse41_sp);
 
     do {
         if (likely(len - offset < SCMEMCMP_BYTES)) {
@@ -172,13 +520,12 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
         }
 
         /* unaligned loading of the bytes to compare */
-        b1 = _mm_loadu_si128((const __m128i *) s1);
-        b2 = _mm_loadu_si128((const __m128i *) s2);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
 
         /* mark all chars bigger than upper1 */
-        mask1 = _mm_cmpgt_epi8(b2, upper1);
+        __m128i mask1 = _mm_cmpgt_epi8(b2, upper1);
         /* mark all chars lower than upper2 */
-        mask2 = _mm_cmplt_epi8(b2, upper2);
+        __m128i mask2 = _mm_cmplt_epi8(b2, upper2);
         /* merge the two, leaving only those that are true in both */
         mask1 = _mm_cmpeq_epi8(mask1, mask2);
         /* Next we use that mask to create a new: this one has 0x20 for
@@ -187,6 +534,7 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
         /* add to b2, converting uppercase to lowercase */
         b2 = _mm_add_epi8(b2, mask1);
         /* now all is lowercase, let's do the actual compare (reuse mask1 reg) */
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
         mask1 = _mm_cmpeq_epi8(b1, b2);
 
         if (_mm_movemask_epi8(mask1) != 0x0000FFFF) {
@@ -200,12 +548,14 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
 
     return 0;
 }
+#undef SCMEMCMP_BYTES
+#endif
 
-#elif defined(__SSE3__)
+#if defined(__SSE3__)
 #include <pmmintrin.h> /* for SSE3 */
 #define SCMEMCMP_BYTES  16
 
-static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
+static inline int SCMemcmpSSE3(const void *s1, const void *s2, size_t len)
 {
     size_t offset = 0;
     __m128i b1, b2, c;
@@ -236,15 +586,33 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
 #define UPPER_HIGH  0x5B /* "Z" + 1 */
 #define UPPER_DELTA 0xDF /* 0xFF - 0x20 */
 
-static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
+// clang-format off
+static char scmemcmp_sse3_ul[16] __attribute__((aligned(16))) = {
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+    0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40, 0x40,
+};
+static char scmemcmp_sse3_uh[16] __attribute__((aligned(16))) = {
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+    0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b, 0x5b,
+};
+static char scmemcmp_sse3_dt[16] __attribute__((aligned(16))) = {
+    0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf,
+    0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf, 0xdf,
+};
+static char scmemcmp_sse3_sp[16] __attribute__((aligned(16))) = {
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+    0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+};
+// clang-format on
+
+/* use subs delta */
+static inline int SCMemcmpLowercaseSSE3(const void *s1, const void *s2, size_t len)
 {
     size_t offset = 0;
-    __m128i b1, b2, mask1, mask2, upper1, upper2, delta;
-
     /* setup registers for upper to lower conversion */
-    upper1 = _mm_set1_epi8(UPPER_LOW);
-    upper2 = _mm_set1_epi8(UPPER_HIGH);
-    delta  = _mm_set1_epi8(UPPER_DELTA);
+    __m128i upper1 = _mm_load_si128((const __m128i *)scmemcmp_sse3_ul);
+    __m128i upper2 = _mm_load_si128((const __m128i *)scmemcmp_sse3_uh);
+    __m128i delta = _mm_load_si128((const __m128i *)scmemcmp_sse3_dt);
 
     do {
         if (likely(len - offset < SCMEMCMP_BYTES)) {
@@ -252,13 +620,12 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
         }
 
         /* unaligned loading of the bytes to compare */
-        b1 = _mm_loadu_si128((const __m128i *) s1);
-        b2 = _mm_loadu_si128((const __m128i *) s2);
+        __m128i b2 = _mm_lddqu_si128((const __m128i *)s2);
 
         /* mark all chars bigger than upper1 */
-        mask1 = _mm_cmpgt_epi8(b2, upper1);
+        __m128i mask1 = _mm_cmpgt_epi8(b2, upper1);
         /* mark all chars lower than upper2 */
-        mask2 = _mm_cmplt_epi8(b2, upper2);
+        __m128i mask2 = _mm_cmplt_epi8(b2, upper2);
         /* merge the two, leaving only those that are true in both */
         mask1 = _mm_cmpeq_epi8(mask1, mask2);
         /* sub delta leaves 0x20 only for uppercase positions, the
@@ -268,6 +635,7 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
         b2 = _mm_add_epi8(b2, mask1);
 
         /* now all is lowercase, let's do the actual compare (reuse mask1 reg) */
+        __m128i b1 = _mm_lddqu_si128((const __m128i *)s1);
         mask1 = _mm_cmpeq_epi8(b1, b2);
 
         if (_mm_movemask_epi8(mask1) != 0x0000FFFF) {
@@ -282,21 +650,223 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
     return 0;
 }
 
-#else
+/* use sp and */
+static inline int SCMemcmpLowercaseSSE3and(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    __m128i b1, b2, mask1, mask2, upper1, upper2, zero20;
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return MemcmpLowercase(s1, s2, len - offset);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        b2 = _mm_lddqu_si128((const __m128i *)s2);
+        /* setup registers for upper to lower conversion */
+        upper1 = _mm_load_si128((const __m128i *)scmemcmp_sse3_ul);
+        upper2 = _mm_load_si128((const __m128i *)scmemcmp_sse3_uh);
+        zero20 = _mm_load_si128((const __m128i *)scmemcmp_sse3_sp);
+
+        /* mark all chars bigger than upper1 */
+        mask1 = _mm_cmpgt_epi8(b2, upper1);
+        /* mark all chars lower than upper2 */
+        mask2 = _mm_cmplt_epi8(b2, upper2);
+        /* merge the two, leaving only those that are true in both */
+        mask1 = _mm_cmpeq_epi8(mask1, mask2);
+        /* sub delta leaves 0x20 only for uppercase positions, the
+           rest is 0x00 due to the saturation (reuse mask1 reg)*/
+        mask1 = _mm_and_si128(zero20, mask1);
+        /* add to b2, converting uppercase to lowercase */
+        b2 = _mm_add_epi8(b2, mask1);
+
+        /* now all is lowercase, let's do the actual compare (reuse mask1 reg) */
+        b1 = _mm_lddqu_si128((const __m128i *)s1);
+        mask1 = _mm_cmpeq_epi8(b1, b2);
+
+        if (_mm_movemask_epi8(mask1) != 0x0000FFFF) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+
+/* sp and + loadu */
+static inline int SCMemcmpLowercaseSSE3andload(const void *s1, const void *s2, size_t len)
+{
+    size_t offset = 0;
+    __m128i b1, b2, mask1, mask2, upper1, upper2, zero20;
+
+    do {
+        if (likely(len - offset < SCMEMCMP_BYTES)) {
+            return MemcmpLowercase(s1, s2, len - offset);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        b2 = _mm_loadu_si128((const __m128i *)s2);
+        /* setup registers for upper to lower conversion */
+        upper1 = _mm_load_si128((const __m128i *)scmemcmp_sse3_ul);
+        upper2 = _mm_load_si128((const __m128i *)scmemcmp_sse3_uh);
+        zero20 = _mm_load_si128((const __m128i *)scmemcmp_sse3_sp);
+
+        /* mark all chars bigger than upper1 */
+        mask1 = _mm_cmpgt_epi8(b2, upper1);
+        /* mark all chars lower than upper2 */
+        mask2 = _mm_cmplt_epi8(b2, upper2);
+        /* merge the two, leaving only those that are true in both */
+        mask1 = _mm_cmpeq_epi8(mask1, mask2);
+        /* sub delta leaves 0x20 only for uppercase positions, the
+           rest is 0x00 due to the saturation (reuse mask1 reg)*/
+        mask1 = _mm_and_si128(zero20, mask1);
+        /* add to b2, converting uppercase to lowercase */
+        b2 = _mm_add_epi8(b2, mask1);
+
+        /* now all is lowercase, let's do the actual compare (reuse mask1 reg) */
+        b1 = _mm_loadu_si128((const __m128i *)s1);
+        mask1 = _mm_cmpeq_epi8(b1, b2);
+
+        if (_mm_movemask_epi8(mask1) != 0x0000FFFF) {
+            return 1;
+        }
+
+        offset += SCMEMCMP_BYTES;
+        s1 += SCMEMCMP_BYTES;
+        s2 += SCMEMCMP_BYTES;
+    } while (len > offset);
+
+    return 0;
+}
+#undef SCMEMCMP_BYTES
+#endif
 
 /* No SIMD support, fall back to plain memcmp and a home grown lowercase one */
 
+static inline int SCMemcmpLT32(const void *s1, const void *s2, size_t len)
+{
+    if (len < 16) {
+        return memcmp(s1, s2, len) == 0 ? 0 : 1;
+    }
+
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    return SCMemcmpAVX512_128(s1, s2, len);
+#elif defined(__SSE4_2__)
+    return SCMemcmpSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpSSE3(s1, s2, len);
+#else
+    return memcmp(s1, s2, len) == 0 ? 0 : 1;
+#endif
+}
+
+static inline int SCMemcmpLT64(const void *s1, const void *s2, size_t len)
+{
+    if (len < 32) {
+        return SCMemcmpLT32(s1, s2, len);
+    }
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    return SCMemcmpAVX512_256(s1, s2, len);
+#elif defined(__AVX2__)
+    return SCMemcmpAVX2(s1, s2, len);
+#elif defined(__SSE4_2__)
+    return SCMemcmpSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpSSE3(s1, s2, len);
+#else
+    return memcmp(s1, s2, len) == 0 ? 0 : 1;
+#endif
+}
+
 /* wrapper around memcmp to match the retvals of the SIMD implementations */
-#define SCMemcmp(a,b,c) ({ \
-    memcmp((a), (b), (c)) ? 1 : 0; \
-})
+static inline int SCMemcmp(const void *s1, const void *s2, size_t len)
+{
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    if (len < 64) {
+        return SCMemcmpLT64(s1, s2, len);
+    }
+    return SCMemcmpAVX512_256(s1, s2, len);
+#elif defined(__AVX2__)
+    if (len < 32) {
+        return SCMemcmpLT32(s1, s2, len);
+    }
+    return SCMemcmpAVX2(s1, s2, len);
+#elif defined(__SSE4_2__)
+    return SCMemcmpSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpSSE3(s1, s2, len);
+#else
+    return memcmp(s1, s2, len) == 0 ? 0 : 1;
+#endif
+}
+
+static inline int SCMemcmpLowercaseLT32(const void *s1, const void *s2, size_t len)
+{
+    if (len < 16) {
+        return MemcmpLowercase(s1, s2, len);
+    }
+#if defined(__SSE4_2__)
+    return SCMemcmpLowercaseSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpLowercaseSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpLowercaseSSE3(s1, s2, len);
+#else
+    return MemcmpLowercase(s1, s2, len);
+#endif
+}
+
+static inline int SCMemcmpLowercaseLT64(const void *s1, const void *s2, size_t len)
+{
+    if (len < 32) {
+        return SCMemcmpLowercaseLT32(s1, s2, len);
+    }
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    return SCMemcmpLowercaseAVX512_256(s1, s2, len);
+#elif defined(__AVX2__)
+    return SCMemcmpLowercaseAVX2(s1, s2, len);
+#elif defined(__SSE4_2__)
+    return SCMemcmpLowercaseSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpLowercaseSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpLowercaseSSE3(s1, s2, len);
+#else
+    return MemcmpLowercase(s1, s2, len);
+#endif
+}
 
 static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t len)
 {
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    if (len < 64) {
+        return SCMemcmpLowercaseLT64(s1, s2, len);
+    }
+    return SCMemcmpLowercaseAVX512_512(s1, s2, len);
+#elif defined(__AVX2__)
+    if (len < 32) {
+        return SCMemcmpLowercaseLT32(s1, s2, len);
+    }
+    return SCMemcmpLowercaseAVX2(s1, s2, len);
+#elif defined(__SSE4_2__)
+    return SCMemcmpLowercaseSSE42(s1, s2, len);
+#elif defined(__SSE4_1__)
+    return SCMemcmpLowercaseSSE41(s1, s2, len);
+#elif defined(__SSE3__)
+    return SCMemcmpLowercaseSSE3(s1, s2, len);
+#else
     return MemcmpLowercase(s1, s2, len);
+#endif
 }
-
-#endif /* SIMD */
 
 static inline int SCBufferCmp(const void *s1, size_t len1, const void *s2, size_t len2)
 {
@@ -308,4 +878,7 @@ static inline int SCBufferCmp(const void *s1, size_t len1, const void *s2, size_
     return 1;
 }
 
+#ifdef UNITTESTS
+void MemcmpRegisterTests(void);
+#endif
 #endif /* SURICATA_UTIL_MEMCMP_H */

--- a/src/util-memcpy.h
+++ b/src/util-memcpy.h
@@ -37,10 +37,10 @@
  * \param s   Pointer to the src string for memcpy.
  * \param len len of the string sent in s.
  */
-static inline void memcpy_tolower(uint8_t *d, const uint8_t *s, uint16_t len)
+static inline void MemcpyToLower(uint8_t *d, const uint8_t *s, size_t n)
 {
     uint16_t i;
-    for (i = 0; i < len; i++)
+    for (i = 0; i < n; i++)
         d[i] = u8_tolower(s[i]);
 
     return;

--- a/src/util-memcpy.h
+++ b/src/util-memcpy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Open Information Security Foundation
+/* Copyright (C) 2014-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,19 +15,148 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Ken Steele <suricata@tilera.com>
- *
- * Memcpy_tolower()
- *
- */
-
 #ifndef SURICATA_UTIL_MEMCPY_H
 #define SURICATA_UTIL_MEMCPY_H
 
 #include "suricata-common.h"
+static inline void MemcpyToLower(uint8_t *d, const uint8_t *s, size_t len);
+
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+#include <immintrin.h>
+#define TOLOWER_BYTES 64
+static inline void MemcpyToLowerLT64(uint8_t *d, const uint8_t *s, size_t n);
+
+static inline void MemcpyToLowerAVX512(uint8_t *dst, const uint8_t *src, size_t n)
+{
+    size_t offset = 0;
+    __m512i upper1 = _mm512_load_si512((const __m512i *)scmemcmp_upper_low64);
+    __m512i upper2 = _mm512_load_si512((const __m512i *)scmemcmp_upper_hi64);
+
+    do {
+        const size_t len = n - offset;
+        if (likely(len < TOLOWER_BYTES)) {
+            return MemcpyToLowerLT64(dst + offset, src + offset, len);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        __m512i b = _mm512_loadu_si512((const __m512i *)(src + offset));
+
+        /* mark all chars bigger than upper1 */
+        uint64_t m1 = _mm512_cmp_epi8_mask(upper1, b, _MM_CMPINT_LT);
+        /* mark all chars lower than upper2 */
+        uint64_t m2 = _mm512_cmp_epi8_mask(b, upper2, _MM_CMPINT_LT);
+        /* merge the two, leaving only those that are true in both */
+        uint64_t m3 = m1 & m2;
+        __m512i uplow = _mm512_mask_loadu_epi8(
+                _mm512_setzero_si512(), m3, (const __m512i *)scmemcmp_space64);
+        /* add to b2, converting uppercase to lowercase */
+        b = _mm512_add_epi8(b, uplow);
+        /* store back into the buffer */
+        _mm512_storeu_si512((__m512i *)(dst + offset), b);
+
+        offset += TOLOWER_BYTES;
+    } while (offset < n);
+}
+
+#if defined(__AVX2__)
+static inline void MemcmpyToLowerAVX2(uint8_t *dst, const uint8_t *src, size_t n);
+#endif
+#if defined(__SSE4_2__)
+static inline void MemcpyToLowerSSE42(uint8_t *dst, const uint8_t *src, size_t n);
+#endif
+
+static inline void MemcpyToLowerLT64(uint8_t *d, const uint8_t *s, size_t n)
+{
+#if defined(__AVX2__)
+    if (n >= 32) {
+        return MemcmpyToLowerAVX2(d, s, n);
+    }
+#endif
+#if defined(__SSE4_2__)
+    if (n >= 16) {
+        return MemcpyToLowerSSE42(d, s, n);
+    }
+#endif
+    for (size_t i = 0; i < n; i++)
+        d[i] = u8_tolower(s[i]);
+}
+#undef TOLOWER_BYTES
+#endif
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#define TOLOWER_BYTES 32
+
+static inline void MemcmpyToLowerAVX2(uint8_t *dst, const uint8_t *src, size_t n)
+{
+    size_t offset = 0;
+    __m256i upper1 = _mm256_load_si256((const __m256i *)scmemcmp_upper_low32);
+    __m256i upper2 = _mm256_load_si256((const __m256i *)scmemcmp_upper_hi32);
+    __m256i uplow = _mm256_load_si256((const __m256i *)scmemcmp_space32);
+
+    do {
+        const size_t len = n - offset;
+        if (likely(len < TOLOWER_BYTES)) {
+            return MemcpyToLower(dst + offset, src + offset, len);
+        }
+
+        /* unaligned loading of the bytes to compare */
+        __m256i b = _mm256_lddqu_si256((const __m256i *)(src + offset));
+
+        /* mark all chars bigger than upper1 */
+        __m256i mask1 = _mm256_cmpgt_epi8(b, upper1);
+        /* mark all chars lower than upper2 */
+        __m256i mask2 = _mm256_cmpgt_epi8(upper2, b);
+        /* merge the two, leaving only those that are true in both */
+        mask1 = _mm256_cmpeq_epi8(mask1, mask2);
+        /* Next we use that mask to create a new: this one has 0x20 for
+         * the uppercase chars, 00 for all other. */
+        mask1 = _mm256_and_si256(uplow, mask1);
+
+        /* add to b2, converting uppercase to lowercase */
+        b = _mm256_add_epi8(b, mask1);
+
+        _mm256_storeu_si256((__m256i *)(dst + offset), b);
+
+        offset += TOLOWER_BYTES;
+    } while (offset < n);
+}
+#undef TOLOWER_BYTES
+#endif
+
+#if defined(__SSE4_2__)
+#include <nmmintrin.h>
+#define TOLOWER_BYTES 16
+
+static inline void MemcpyToLowerSSE42(uint8_t *dst, const uint8_t *src, size_t n)
+{
+    size_t offset = 0;
+    __m128i ucase = _mm_load_si128((const __m128i *)scmemcmp_uppercase);
+    __m128i uplow = _mm_set1_epi8(0x20);
+
+    do {
+        const size_t len = n - offset;
+        if (likely(len < TOLOWER_BYTES)) {
+            return MemcpyToLower(dst + offset, src + offset, len);
+        }
+
+        __m128i b = _mm_loadu_si128((const __m128i *)(src + offset));
+        /* The first step is creating a mask that is FF for all uppercase
+         * characters, 00 for all others */
+        __m128i mask = _mm_cmpestrm(ucase, 2, b, len, _SIDD_CMP_RANGES | _SIDD_UNIT_MASK);
+        /* Next we use that mask to create a new: this one has 0x20 for
+         * the uppercase chars, 00 for all other. */
+        mask = _mm_and_si128(uplow, mask);
+        /* merge the mask and the buffer converting the
+         * uppercase to lowercase */
+        b = _mm_add_epi8(b, mask);
+        /* store the result back in the buffer */
+        _mm_storeu_si128((__m128i *)(dst + offset), b);
+
+        offset += TOLOWER_BYTES;
+    } while (offset < n);
+}
+#endif /* SSE 4.2 */
 
 /**
  * \internal
@@ -39,11 +168,23 @@
  */
 static inline void MemcpyToLower(uint8_t *d, const uint8_t *s, size_t n)
 {
-    uint16_t i;
-    for (i = 0; i < n; i++)
+#if defined(__AVX512VL__) && defined(__AVX512BW__)
+    if (n >= 64) {
+        return MemcpyToLowerAVX512(d, s, n);
+    }
+#endif
+#if defined(__AVX2__)
+    if (n >= 32) {
+        return MemcmpyToLowerAVX2(d, s, n);
+    }
+#endif
+#if defined(__SSE4_2__)
+    if (n >= 16) {
+        return MemcpyToLowerSSE42(d, s, n);
+    }
+#endif
+    for (size_t i = 0; i < n; i++)
         d[i] = u8_tolower(s[i]);
-
-    return;
 }
 
 #endif /* SURICATA_UTIL_MEMCPY_H */

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -481,7 +481,7 @@ int MpmAddPattern(MpmCtx *mpm_ctx, uint8_t *pat, uint16_t patlen,
             goto error;
         mpm_ctx->memory_cnt++;
         mpm_ctx->memory_size += patlen;
-        memcpy_tolower(p->ci, pat, patlen);
+        MemcpyToLower(p->ci, pat, patlen);
 
         /* setup the case sensitive part of the pattern */
         if (p->flags & MPM_PATTERN_FLAG_NOCASE) {

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -58,7 +58,7 @@ static void PreBmGsNocase(const uint8_t *x, uint16_t m, uint16_t *bmGs);
 void BoyerMooreCtxToNocase(BmCtx *bm_ctx, uint8_t *needle, uint16_t needle_len)
 {
     /* Store the content as lower case to make searching faster */
-    memcpy_tolower(needle, needle, needle_len);
+    MemcpyToLower(needle, needle, needle_len);
 
     /* Prepare bad chars with nocase chars */
     PreBmBcNocase(needle, needle_len, bm_ctx->bmBc);

--- a/src/util-spm-mm.c
+++ b/src/util-spm-mm.c
@@ -1,0 +1,164 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "util-spm.h"
+#include "util-spm-mm.h"
+
+#ifdef HAVE_MEMMEM
+#include "util-debug.h"
+#include "util-error.h"
+#include "util-memcpy.h"
+#include "util-validate.h"
+
+/** \param needle lowercase version of the pattern to look for
+ *
+ *  Convert haystack data to lowercase before inspecting it with
+ *  `memmem`. Do this in a sliding window manner. */
+const uint8_t *SCMemimem(const uint8_t *haystack, uint32_t haystack_len, const uint8_t *needle,
+        const uint32_t needle_len)
+{
+    if (needle_len > haystack_len)
+        return NULL;
+    uint32_t slice_size = MAX(MIN(haystack_len, 128), needle_len * 3);
+    uint8_t slice[slice_size];
+    uint32_t o = 0;
+    do {
+        const uint32_t size = MIN(haystack_len - o, slice_size);
+        MemcpyToLower(slice, haystack + o, size);
+        uint8_t *found = memmem(slice, size, needle, needle_len);
+        if (found) {
+            size_t slice_offset = found - slice;
+            return haystack + (o + slice_offset);
+        }
+        o += (size - (needle_len - 1));
+    } while (o + needle_len <= haystack_len);
+    return NULL;
+}
+
+uint8_t *MMScan(const SpmCtx *ctx, SpmThreadCtx *_thread_ctx, const uint8_t *haystack,
+        uint32_t haystack_len)
+{
+    const SpmMmCtx *sctx = ctx->ctx;
+
+    if (sctx->nocase) {
+        return (uint8_t *)SCMemimem(haystack, haystack_len, sctx->needle, sctx->needle_len);
+    } else {
+        return memmem(haystack, haystack_len, sctx->needle, sctx->needle_len);
+    }
+}
+
+static SpmCtx *MMInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+        SpmGlobalThreadCtx *global_thread_ctx)
+{
+    SpmCtx *ctx = SCCalloc(1, sizeof(SpmCtx));
+    if (ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmCtx.");
+        return NULL;
+    }
+
+    SpmMmCtx *sctx = SCCalloc(1, sizeof(SpmMmCtx) + needle_len);
+    if (sctx == NULL) {
+        SCFree(ctx);
+        return NULL;
+    }
+
+    sctx->nocase = nocase;
+    sctx->needle_len = needle_len;
+    if (nocase)
+        MemcpyToLower(sctx->needle, needle, needle_len);
+    else
+        memcpy(sctx->needle, needle, needle_len);
+
+    ctx->ctx = sctx;
+    ctx->matcher = SPM_MM;
+    return ctx;
+}
+
+static void MMDestroyCtx(SpmCtx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    SpmMmCtx *sctx = ctx->ctx;
+    if (sctx != NULL) {
+        SCFree(sctx);
+    }
+
+    SCFree(ctx);
+}
+
+static SpmGlobalThreadCtx *MMInitGlobalThreadCtx(void)
+{
+    SpmGlobalThreadCtx *global_thread_ctx = SCCalloc(1, sizeof(SpmGlobalThreadCtx));
+    if (global_thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmThreadCtx.");
+        return NULL;
+    }
+    global_thread_ctx->matcher = SPM_MM;
+    return global_thread_ctx;
+}
+
+static void MMDestroyGlobalThreadCtx(SpmGlobalThreadCtx *global_thread_ctx)
+{
+    if (global_thread_ctx == NULL) {
+        return;
+    }
+    SCFree(global_thread_ctx);
+}
+
+static void MMDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    if (thread_ctx == NULL) {
+        return;
+    }
+    SCFree(thread_ctx);
+}
+
+static SpmThreadCtx *MMMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx)
+{
+    SpmThreadCtx *thread_ctx = SCCalloc(1, sizeof(SpmThreadCtx));
+    if (thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmThreadCtx.");
+        return NULL;
+    }
+    thread_ctx->matcher = SPM_MM;
+    return thread_ctx;
+}
+#endif /* HAVE_MEMMEM */
+
+void SpmMMRegister(void)
+{
+#ifdef HAVE_MEMMEM
+    spm_table[SPM_MM].name = "mm";
+    spm_table[SPM_MM].Scan = MMScan;
+    spm_table[SPM_MM].InitCtx = MMInitCtx;
+    spm_table[SPM_MM].DestroyCtx = MMDestroyCtx;
+    spm_table[SPM_MM].InitGlobalThreadCtx = MMInitGlobalThreadCtx;
+    spm_table[SPM_MM].DestroyGlobalThreadCtx = MMDestroyGlobalThreadCtx;
+    spm_table[SPM_MM].MakeThreadCtx = MMMakeThreadCtx;
+    spm_table[SPM_MM].DestroyThreadCtx = MMDestroyThreadCtx;
+#endif /* HAVE_MEMMEM */
+}

--- a/src/util-spm-mm.h
+++ b/src/util-spm-mm.h
@@ -1,0 +1,41 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ */
+
+#ifndef SURICATA_UTIL_SPM_MM
+#define SURICATA_UTIL_SPM_MM
+
+#ifdef HAVE_MEMMEM
+
+typedef struct SpmMmCtx_ {
+    uint32_t needle_len;
+    int nocase;
+    uint8_t needle[];
+} SpmMmCtx;
+
+uint8_t *MMScan(const SpmCtx *ctx, SpmThreadCtx *_thread_ctx, const uint8_t *haystack,
+        uint32_t haystack_len);
+
+#endif /* HAVE_MEMMEM */
+
+void SpmMMRegister(void);
+
+#endif /* SURICATA_UTIL_SPM_MM */

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -2563,28 +2563,18 @@ static int SpmSearchTest01(void) {
         {"foo", 3, "Foo FOo fOo foO FOO foo", 23, 0, 20},
     };
 
-    int ret = 1;
-
-    uint8_t matcher;
-    for (matcher = 0; matcher < SPM_TABLE_SIZE; matcher++) {
+    for (uint8_t matcher = 0; matcher < SPM_TABLE_SIZE; matcher++) {
         const SpmTableElmt *m = &spm_table[matcher];
         if (m->name == NULL) {
             continue;
         }
-        printf("matcher: %s\n", m->name);
-
-        uint32_t i;
-        for (i = 0; i < sizeof(data)/sizeof(data[0]); i++) {
+        for (uint32_t i = 0; i < sizeof(data) / sizeof(data[0]); i++) {
             const SpmTestData *d = &data[i];
-            if (SpmTestSearch(d, matcher) == 0) {
-                printf("  test %" PRIu32 ": fail\n", i);
-                ret = 0;
-            }
+            FAIL_IF(SpmTestSearch(d, matcher) == 0);
         }
-        printf("  %" PRIu32 " tests passed\n", i);
     }
 
-    return ret;
+    PASS;
 }
 
 static int SpmSearchTest02(void) {

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -53,6 +53,7 @@
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
 #include "util-spm-hs.h"
+#include "util-spm-mm.h"
 #include "util-clock.h"
 #ifdef BUILD_HYPERSCAN
 #include "hs.h"
@@ -89,6 +90,12 @@ uint8_t SinglePatternMatchDefaultMatcher(void)
                        "not compiled into Suricata.");
         }
 #endif
+#ifndef HAVE_MEMMEM
+        if ((spm_algo != NULL) && (strcmp(spm_algo, "mm") == 0)) {
+            FatalError("Memmem (mm) support for spm-algo is "
+                       "not compiled into Suricata.");
+        }
+#endif
         SCLogError("Invalid spm algo supplied "
                    "in the yaml conf file: \"%s\"",
                 spm_algo);
@@ -98,8 +105,8 @@ uint8_t SinglePatternMatchDefaultMatcher(void)
 default_matcher:
     /* When Suricata is built with Hyperscan support, default to using it for
      * SPM. */
-#ifdef BUILD_HYPERSCAN
-    #ifdef HAVE_HS_VALID_PLATFORM
+#if defined(BUILD_HYPERSCAN)
+#ifdef HAVE_HS_VALID_PLATFORM
     /* Enable runtime check for SSSE3. Do not use Hyperscan SPM matcher if
      * check is not successful. */
         if (hs_valid_platform() != HS_SUCCESS) {
@@ -111,8 +118,10 @@ default_matcher:
             return SPM_HS;
         }
     #else
-        return SPM_HS;
-    #endif
+    return SPM_HS;
+#endif
+#elif defined(HAVE_MEMMEM)
+    return SPM_MM;
 #else
     /* Otherwise, default to Boyer-Moore */
     return SPM_BM;
@@ -124,6 +133,7 @@ void SpmTableSetup(void)
     memset(spm_table, 0, sizeof(spm_table));
 
     SpmBMRegister();
+    SpmMMRegister();
 #ifdef BUILD_HYPERSCAN
     #ifdef HAVE_HS_VALID_PLATFORM
         if (hs_valid_platform() == HS_SUCCESS) {

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -29,6 +29,7 @@
 enum {
     SPM_BM, /* Boyer-Moore */
     SPM_HS, /* Hyperscan */
+    SPM_MM, /* Memmem */
     /* Other SPM matchers will go here. */
     SPM_TABLE_SIZE
 };
@@ -94,6 +95,9 @@ uint8_t *Bs2bmSearch(
         const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *BoyerMooreSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *BoyerMooreNocaseSearch(const uint8_t *text, uint32_t textlen, uint8_t *needle, uint16_t needlelen);
+
+const uint8_t *SCMemimem(const uint8_t *haystack, uint32_t haystack_len, const uint8_t *needle,
+        const uint32_t needle_len);
 
 /* Macros for automatic algorithm selection (use them only when you can't store the context) */
 #define SpmSearch(text, textlen, needle, needlelen) ({\

--- a/tools/benches/bench-content-inspect/Makefile.am
+++ b/tools/benches/bench-content-inspect/Makefile.am
@@ -1,0 +1,12 @@
+bin_PROGRAMS = bench_content_inspect
+
+bench_content_inspect_SOURCES = main.c
+
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/rust/gen
+
+bench_content_inspect_LDFLAGS = $(all_libraries) $(SECLDFLAGS)
+bench_content_inspect_LDADD = $(top_builddir)/src/libsuricata_c.a ../../$(RUST_SURICATA_LIB) $(RUST_LDADD)
+if HTP_LDADD
+bench_content_inspect_LDADD += ../../$(HTP_LDADD)
+endif
+bench_content_inspect_DEPENDENCIES = $(top_builddir)/src/libsuricata_c.a ../../$(RUST_SURICATA_LIB)

--- a/tools/benches/bench-content-inspect/main.c
+++ b/tools/benches/bench-content-inspect/main.c
@@ -1,0 +1,635 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * Benchmark Suricata's content inspection code and the closely related
+ * SPM (single pattern matcher) code.
+ */
+
+#include "suricata.h"
+#include "detect.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "detect-engine-build.h"
+#include "detect-engine-content-inspection.h"
+#include "util-conf.h"
+#include "util-spm.h"
+
+char csv[8192] = "";
+char csvh[8192] = "";
+
+/* Signatures should have a short message w/o comma's as they are used as header in the csv output.
+ */
+const char *sigs1[] = {
+    "alert ip any any -> any any (content:\"abcdef\"; sid:1; msg:\"floating pattern start\";)",
+    "alert ip any any -> any any (content:\"uvwxyz\"; sid:2; msg:\"floating pattern end\";)",
+    "alert ip any any -> any any (content:\"lmnopqrstuvwxyz\"; sid:3; msg:\"floating pattern end "
+    "long\";)",
+    "alert ip any any -> any any (content:\"xxxxxxxxxxxxxxxxxxxxxxxxxlmnopqrstuvwxyz\"; sid:4; "
+    "msg:\"floating pattern end longer\";)",
+    "alert ip any any -> any any (content:\"abc\"; depth:3; sid:5; msg:\"anchor depth == "
+    "pattern\";)",
+    "alert ip any any -> any any (content:\"abc\"; startswith; sid:6; msg:\"startswith\";)",
+    "alert ip any any -> any any (content:\"xyz\"; endswith; sid:7; msg:\"endswith\";)",
+    "alert ip any any -> any any (content:\"abc\"; content:\"def\"; distance:0; within:3; sid:8; "
+    "msg:\"split floating pattern\";)",
+    "alert ip any any -> any any (content:\"abc\"; content:\"xyz\"; distance:0; sid:9; "
+    "msg:\"pattern1 followed by pattern2\";)",
+    "alert ip any any -> any any (content:\"abcdef\"; content:\"xyz\"; distance:0; sid:10; "
+    "msg:\"longer pattern1 followed by pattern2\";)",
+    "alert ip any any -> any any (content:\"abc\"; content:\"def\"; distance:0; within:3; "
+    "content:\"xyz\"; distance:0; sid:11; msg:\"split pattern followed by pattern3\";)",
+    "alert ip any any -> any any (content:\"def\"; offset:3; depth:3; sid:12; msg:\"single "
+    "anchored pattern\";)",
+    "alert ip any any -> any any (pcre:\"/^abc/\"; sid:13; msg:\"pcre anchored\";)",
+    "alert ip any any -> any any (content:\"abc\"; depth:3; pcre:\"/^abc/\"; sid:14; msg:\"pattern "
+    "anchored pcre anchored\";)",
+    "alert ip any any -> any any (pcre:\"/^abc.*xyz/\"; sid:15; msg:\"pcre anchored pat1 -> "
+    "pat2\";)",
+    "alert ip any any -> any any (pcre:\"/^abc.*xyz$/\"; sid:16; msg:\"pcre anchored pat1 -> "
+    "anchored pat2\";)",
+    "alert ip any any -> any any (pcre:\"/^abc/\"; pcre:\"/xyz$/R\"; sid:17; msg:\"anchored pat1 "
+    "-> pcre anchored pat2\";)",
+    "alert ip any any -> any any (content:\"abc\"; depth:3; content:\"xyz\"; endswith; sid:18; "
+    "msg:\"anchored pat1 -> anchored pat2\";)",
+    "alert ip any any -> any any (content:\"abc\"; depth:3; content:\"xyz\"; endswith; "
+    "pcre:\"/^abc.*xyz/\"; sid:19; msg:\"anchored pat1 -> anchored pat2 repeat for pcre\";)",
+    "alert ip any any -> any any (content:\"abc\"; depth:3; content:\"xyz\"; endswith; "
+    "pcre:\"/^abc.*xyz$/\"; sid:20; msg:\"anchored pat1 -> anchored pat2 repeat for pcre "
+    "anchored\";)",
+    "alert ip any any -> any any (content:\"abc\"; isdataat:!1000,relative; sid:21; msg:\"floating "
+    "pattern followed by !isdataat\";)",
+    "alert ip any any -> any any (content:!\"xyz\"; startswith; sid:22; msg:\"negated "
+    "startswith\";)",
+    "alert ip any any -> any any (content:!\"abc\"; endswith; sid:23; msg:\"negated endswith\";)",
+    "alert ip any any -> any any (content:!\"abcdefxyz\"; sid:24; msg:\"negated floating "
+    "pattern\";)",
+    "alert ip any any -> any any (byte_test:1,=,97,0; byte_jump:1,1; byte_test:1,!=,97,0,relative; "
+    "sid:25; msg:\"byte: test>jump>test\";)",
+    "alert ip any any -> any any (content:\"abc\"; content:\"xxl\"; distance:0; content:\"xyz\"; "
+    "distance:0; sid:26; msg:\"pat1>pat2>pat3\";)",
+    "alert ip any any -> any any (pcre:\"/abc.*xxl.*xyz/\"; sid:27; msg:\"pat1>pat2>pat3(pcre)\";)",
+    "alert ip any any -> any any (content:\"abc\"; nocase; content:\"xxl\"; distance:0; nocase; "
+    "content:\"xyz\"; distance:0; nocase; sid:28; msg:\"pat1>pat2>pat3 nocase\";)",
+    "alert ip any any -> any any (pcre:\"/abc.*xxl.*xyz/i\"; sid:29; "
+    "msg:\"pat1>pat2>pat3(pcre/i)\";)",
+    "alert ip any any -> any any (content:\"XXLMNOPQRSTUVWXYZ\"; nocase; sid:30; msg:\"pat1 "
+    "nocase\";)",
+    "alert ip any any -> any any (content:\"ABC\"; nocase; startswith; content:\"GHI\"; nocase; "
+    "distance:3; within:3; sid:31; msg:\"anchored implicit nocase\";)",
+    NULL,
+};
+
+const char *sigs2[] = {
+    "alert ip any any -> any any (content:\"a\"; content:\"b\"; within:1; distance:0; "
+    "content:\"l\"; within:1; distance:0; sid:10001;)",
+    "alert ip any any -> any any (content:\"a\"; depth:1; content:\"b\"; within:1; distance:0; "
+    "content:\"l\"; within:1; distance:0; sid:10002;)",
+    "alert ip any any -> any any (content:\"ab\"; content:\"l\"; within:1; distance:0; sid:1;)",
+    "alert ip any any -> any any (content:\"abl\"; sid:10003;)",
+    "alert ip any any -> any any (content:\"A\"; nocase; content:\"B\"; nocase; within:1; "
+    "distance:0; "
+    "content:\"L\"; nocase; within:1; distance:0; sid:10004;)",
+    NULL,
+};
+
+const char *bufs[] = { "a",
+    "abcdefghijkxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxlmnopqrstuvwxyz",
+    "abcdefghijkabababababababababababababababababababababababababababababababababababababababx"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababababababababababababababababab"
+    "ababababababababababababababababababababababababababababababxlmnopqrstuvwxyz",
+    "abcdefghijkxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxlmnopqrstuvwxyz",
+    "ABCDEFGHIJKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXLMNOPQRSTUVWXYZ",
+    NULL };
+
+// based on: https://www.gnu.org/software/libc/manual/html_node/Calculating-Elapsed-Time.html
+int timespec_subtract(struct timespec *result, struct timespec *x, struct timespec *y)
+{
+    /* Perform the carry for the later subtraction by updating y. */
+    if (x->tv_nsec < y->tv_nsec) {
+        int64_t nsec = (y->tv_nsec - x->tv_nsec) / 1000000000LL + 1;
+        y->tv_nsec -= 1000000000LL * nsec;
+        y->tv_sec += nsec;
+    }
+    if (x->tv_nsec - y->tv_nsec > 1000000000LL) {
+        int64_t nsec = (x->tv_nsec - y->tv_nsec) / 1000000000LL;
+        y->tv_nsec += 1000000000LL * nsec;
+        y->tv_sec -= nsec;
+    }
+
+    /* Compute the time remaining to wait.
+       tv_usec is certainly positive. */
+    result->tv_sec = x->tv_sec - y->tv_sec;
+    result->tv_nsec = x->tv_nsec - y->tv_nsec;
+
+    /* Return 1 if result is negative. */
+    return x->tv_sec < y->tv_sec;
+}
+
+/* strstr is not usable as spm, since it is for strings, not byte arrays. Test it anyway to get a
+ * sense for what is possible wrt optimizations. */
+static void StrstrBaselinePattern(const char *needles[])
+{
+    const char *buf = bufs[1];
+    char csv_line[8192] = "";
+    uint64_t total_nsecs = 0;
+    uint64_t total_evals = 0;
+    snprintf(csv_line, sizeof(csv_line), "%s,", "strstr");
+
+    int i = 0;
+    do {
+        const char *needle = needles[i];
+        struct timespec tps, tpe;
+        clock_gettime(CLOCK_REALTIME, &tps);
+
+        uint64_t cnt = 0;
+        uint64_t matches = 0;
+
+        uint32_t volatile x = 0;
+        for (; x < 1000000; x++) {
+            cc_barrier();
+            cnt++;
+            char *found = strstr((const char *)buf, needle);
+            matches = (found != NULL);
+        }
+
+        clock_gettime(CLOCK_REALTIME, &tpe);
+        struct timespec diff;
+        int r = timespec_subtract(&diff, &tpe, &tps);
+        BUG_ON(r != 0);
+
+        BUG_ON(matches != 0 && matches != 1000000 && x != 1000000);
+
+        uint64_t nsecs = diff.tv_sec * 1000000000ULL + diff.tv_nsec;
+        uint64_t nsecs_avg = nsecs / cnt;
+        total_nsecs += nsecs_avg;
+        total_evals++;
+
+        char value[32] = "";
+        snprintf(value, sizeof(value), "%" PRIu64 ",", nsecs_avg);
+        strlcat(csv_line, value, sizeof(csv_line));
+
+        i++;
+    } while (needles[i] != NULL);
+
+    char value[32] = "";
+    snprintf(value, sizeof(value), "%" PRIu64 "\n", total_nsecs / total_evals);
+    strlcat(csv_line, value, sizeof(csv_line));
+    printf("%s", csv_line);
+}
+
+static void MemmemBaselinePattern(const char *needles[])
+{
+    const char *buf = bufs[1];
+    const size_t buf_size = strlen(buf);
+    char csv_line[8192] = "";
+    uint64_t total_nsecs = 0;
+    uint64_t total_evals = 0;
+    snprintf(csv_line, sizeof(csv_line), "%s,", "memmem");
+
+    int i = 0;
+    do {
+        const char *needle = needles[i];
+        const size_t needle_len = strlen(needle);
+        struct timespec tps, tpe;
+        clock_gettime(CLOCK_REALTIME, &tps);
+
+        uint64_t cnt = 0;
+        uint64_t matches = 0;
+
+        uint32_t volatile x = 0;
+        for (; x < 1000000; x++) {
+            cc_barrier();
+            cnt++;
+            void *found = memmem(buf, buf_size, needle, needle_len);
+            matches = (found != NULL);
+        }
+
+        clock_gettime(CLOCK_REALTIME, &tpe);
+        struct timespec diff;
+        int r = timespec_subtract(&diff, &tpe, &tps);
+        BUG_ON(r != 0);
+
+        BUG_ON(matches != 0 && matches != 1000000 && x != 1000000);
+
+        uint64_t nsecs = diff.tv_sec * 1000000000ULL + diff.tv_nsec;
+        uint64_t nsecs_avg = nsecs / cnt;
+        total_nsecs += nsecs_avg;
+        total_evals++;
+
+        char value[32] = "";
+        snprintf(value, sizeof(value), "%" PRIu64 ",", nsecs_avg);
+        strlcat(csv_line, value, sizeof(csv_line));
+
+        i++;
+    } while (needles[i] != NULL);
+
+    char value[32] = "";
+    snprintf(value, sizeof(value), "%" PRIu64 "\n", total_nsecs / total_evals);
+    strlcat(csv_line, value, sizeof(csv_line));
+    printf("%s", csv_line);
+}
+
+static void BasicSearchBaselinePattern(const char *needles[])
+{
+    const char *buf = bufs[1];
+    const size_t buf_size = strlen(buf);
+    char csv_line[8192] = "";
+    uint64_t total_nsecs = 0;
+    uint64_t total_evals = 0;
+    snprintf(csv_line, sizeof(csv_line), "%s,", "bs");
+
+    int i = 0;
+    do {
+        const char *needle = needles[i];
+        const size_t needle_len = strlen(needle);
+        struct timespec tps, tpe;
+        clock_gettime(CLOCK_REALTIME, &tps);
+
+        uint64_t cnt = 0;
+        uint64_t matches = 0;
+
+        uint32_t volatile x = 0;
+        for (; x < 100000; x++) {
+            cc_barrier();
+            cnt++;
+            uint8_t *found = BasicSearch(
+                    (const uint8_t *)buf, buf_size, (const uint8_t *)needle, needle_len);
+            matches = (found != NULL);
+        }
+
+        clock_gettime(CLOCK_REALTIME, &tpe);
+        struct timespec diff;
+        int r = timespec_subtract(&diff, &tpe, &tps);
+        BUG_ON(r != 0);
+
+        BUG_ON(matches != 0 && matches != 100000 && x != 100000);
+
+        uint64_t nsecs = diff.tv_sec * 1000000000ULL + diff.tv_nsec;
+        uint64_t nsecs_avg = nsecs / cnt;
+        total_nsecs += nsecs_avg;
+        total_evals++;
+
+        char value[32] = "";
+        snprintf(value, sizeof(value), "%" PRIu64 ",", nsecs_avg);
+        strlcat(csv_line, value, sizeof(csv_line));
+
+        i++;
+    } while (needles[i] != NULL);
+
+    char value[32] = "";
+    snprintf(value, sizeof(value), "%" PRIu64 "\n", total_nsecs / total_evals);
+    strlcat(csv_line, value, sizeof(csv_line));
+    printf("%s", csv_line);
+}
+
+static void SpmBaselinePatterns(const char *needles[], const uint8_t matcher)
+{
+    const char *buf = bufs[1];
+    size_t buf_size = strlen(buf);
+    char csv_line[8192] = "";
+    uint64_t total_nsecs = 0;
+    uint64_t total_evals = 0;
+    int i = 0;
+    snprintf(csv_line, sizeof(csv_line), "%s,", spm_table[matcher].name);
+    do {
+        const char *needle = needles[i];
+
+        SpmGlobalThreadCtx *g_thread_ctx = SpmInitGlobalThreadCtx(matcher);
+        BUG_ON(g_thread_ctx == NULL);
+
+        SpmCtx *spm_ctx = SpmInitCtx((const uint8_t *)needle, strlen(needle), 0, g_thread_ctx);
+        BUG_ON(!spm_ctx);
+        SpmThreadCtx *thread_ctx = SpmMakeThreadCtx(g_thread_ctx);
+        BUG_ON(thread_ctx == NULL);
+
+        struct timespec tps, tpe;
+        clock_gettime(CLOCK_REALTIME, &tps);
+
+        uint64_t cnt = 0;
+        uint64_t matches = 0;
+
+        uint32_t volatile x = 0;
+        for (; x < 1000000; x++) {
+            cc_barrier();
+            cnt++;
+            SpmScan(spm_ctx, thread_ctx, (const uint8_t *)buf, buf_size);
+        }
+
+        clock_gettime(CLOCK_REALTIME, &tpe);
+        struct timespec diff;
+        int r = timespec_subtract(&diff, &tpe, &tps);
+        BUG_ON(r != 0);
+        uint64_t nsecs = diff.tv_sec * 1000000000ULL + diff.tv_nsec;
+        uint64_t nsecs_avg = nsecs / cnt;
+        total_nsecs += nsecs_avg;
+        total_evals++;
+
+        BUG_ON(matches != 0 && matches != 1000000 && x != 1000000);
+
+        SpmDestroyThreadCtx(thread_ctx);
+        SpmDestroyGlobalThreadCtx(g_thread_ctx);
+        SpmDestroyCtx(spm_ctx);
+
+        char value[32] = "";
+        snprintf(value, sizeof(value), "%" PRIu64 ",", nsecs_avg);
+        strlcat(csv_line, value, sizeof(csv_line));
+
+        i++;
+    } while (needles[i] != NULL);
+
+    char value[32] = "";
+    snprintf(value, sizeof(value), "%" PRIu64 "\n", total_nsecs / total_evals);
+    strlcat(csv_line, value, sizeof(csv_line));
+    printf("%s", csv_line);
+}
+
+const char *patterns[] = {
+    "a",
+    "z",
+    "abc",
+    "abcdef",
+    "xyz",
+    "uvwxyz",
+    "abcdefxyz",
+    "xxxxxxxxxxxxxxxx",
+    NULL,
+};
+
+static void SpmBaseline(void)
+{
+    printf("spm,");
+    int i = 0;
+    do {
+        const char *needle = patterns[i];
+        printf("%s,", needle);
+        i++;
+    } while (patterns[i] != NULL);
+    printf("avg,\n");
+
+    MemmemBaselinePattern(patterns);
+    StrstrBaselinePattern(patterns);
+    BasicSearchBaselinePattern(patterns);
+
+    for (i = 0; i < SPM_TABLE_SIZE; i++) {
+        if (spm_table[i].name == NULL)
+            continue;
+        SpmBaselinePatterns(patterns, i);
+    }
+}
+
+static void Run(ThreadVars *tv, const char *sigs[], const uint32_t loops, const char *test,
+        const char *prefix)
+{
+    char filename[PATH_MAX];
+    snprintf(filename, sizeof(filename), "%s-%s.csv", prefix, test);
+    FILE *fp = fopen(filename, "w");
+    BUG_ON(fp == NULL);
+    bool once = false;
+
+    for (uint8_t m = 0; m < SPM_TABLE_SIZE; m++) {
+        if (spm_table[m].name == NULL)
+            continue;
+        const char *spm = spm_table[m].name;
+        ConfSet("spm-algo", spm_table[m].name);
+        printf("SPM matcher %s\tTest %s:\t", spm_table[m].name, test);
+
+        snprintf(csvh, sizeof(csvh), "spm,");
+        snprintf(csv, sizeof(csv), "%s,", spm);
+
+        uint64_t total_nsecs = 0;
+        uint64_t total_evals = 0;
+
+        int i = 0;
+        do {
+            char sidstr[64];
+            const char *sig = sigs[i];
+            DetectEngineThreadCtx *det_ctx = NULL;
+            DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+            if (de_ctx == NULL) {
+                exit(EXIT_FAILURE);
+            }
+            de_ctx->flags |= DE_QUIET;
+            DetectEngineAddToMaster(de_ctx);
+
+            Signature *s = DetectEngineAppendSig(de_ctx, sig);
+            if (s == NULL)
+                goto error;
+            SigGroupBuild(de_ctx);
+
+            if (s->msg) {
+                snprintf(sidstr, sizeof(sidstr), "sid:%u-%s", s->id, s->msg);
+            } else {
+                snprintf(sidstr, sizeof(sidstr), "sid:%u", s->id);
+            }
+
+            SigMatchData *smd = s->sm_arrays[1];
+            BUG_ON(smd == NULL);
+
+            BUG_ON(DetectEngineThreadCtxInit(tv, (void *)de_ctx, (void *)&det_ctx) != TM_ECODE_OK);
+
+            uint64_t sig_nsecs = 0;
+
+            int b = 0;
+            do {
+                const size_t buf_size = strlen(bufs[b]);
+                struct timespec tps, tpe;
+                clock_gettime(CLOCK_REALTIME, &tps);
+
+                uint64_t cnt = 0;
+                for (uint32_t x = 0; x < loops; x++) {
+                    cnt++;
+
+                    (void)DetectEngineContentInspection(de_ctx, det_ctx, s, smd, NULL, NULL,
+                            (const uint8_t *)bufs[b], buf_size, 0, DETECT_CI_FLAGS_SINGLE,
+                            DETECT_ENGINE_CONTENT_INSPECTION_MODE_PAYLOAD);
+                }
+                clock_gettime(CLOCK_REALTIME, &tpe);
+                struct timespec diff;
+                int r = timespec_subtract(&diff, &tpe, &tps);
+                BUG_ON(r != 0);
+                uint64_t nsecs = diff.tv_sec * 1000000000ULL + diff.tv_nsec;
+                sig_nsecs += (nsecs / cnt);
+                total_nsecs += sig_nsecs;
+                total_evals++;
+
+                b++;
+            } while (bufs[b] != NULL);
+
+            char csve[128] = "";
+            snprintf(csve, sizeof(csve), "%s,", sidstr);
+            strlcat(csvh, csve, sizeof(csvh));
+            char csvv[64] = "";
+            snprintf(csvv, sizeof(csvv), "%" PRIu64 ",", sig_nsecs / b);
+            strlcat(csv, csvv, sizeof(csv));
+
+            DetectEngineThreadCtxDeinit(tv, (void *)det_ctx);
+            DetectEngineMoveToFreeList(de_ctx);
+            DetectEnginePruneFreeList();
+            DetectEngineBumpVersion();
+
+            i++;
+        } while (sigs[i] != NULL);
+
+        /* print csv header once */
+        if (!once) {
+            fprintf(fp, "%s\n", csvh);
+            once = true;
+        }
+        fprintf(fp, "%s\n", csv);
+        printf("%" PRIu64 "\n", total_nsecs / total_evals);
+    }
+
+    fclose(fp);
+    return;
+error:
+    fclose(fp);
+    exit(EXIT_FAILURE);
+}
+
+int main(int argc, char **argv)
+{
+    SCInstance instance;
+    ThreadVars th_v;
+    SuricataPreInit(argv[0]);
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&instance, 0, sizeof(instance));
+
+    if (argc <= 1) {
+        SCLogError("call with '%s <filename prefix>'. E.g. '%s master'", argv[0], argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    setenv("SC_LOG_LEVEL", "Error", 1);
+    InitGlobal();
+    GlobalsInitPreConfig();
+    ConfigSetLogDirectory("/tmp/");
+    PostConfLoadedSetup(&instance);
+    PostConfLoadedDetectSetup(&instance);
+
+    SpmBaseline();
+
+    Run(&th_v, sigs1, 10000, "common", argv[1]);
+    Run(&th_v, sigs2, 10000, "edge", argv[1]);
+
+    GlobalsDestroy();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
General SIMD work and introduce a new SPM "mm" - a memmem wrapper.

Results from the CI bench tool #11614
![image](https://github.com/user-attachments/assets/2bc0fa54-440b-4099-9d83-0bb04e44b7de)

Make `mm` the default when hyperscan/vector scan are not available.