### PR TITLE
pgsql: track 'progress' in tx per direction - v3

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -356,7 +356,6 @@ impl PgsqlState {
             );
             match PgsqlState::state_based_req_parsing(self.state_progress, start) {
                 Ok((rem, request)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     start = rem;
                     let temp_state: PgsqlStateProgress;
                     let tx_completed = if let Some(state) = PgsqlState::request_next_state(&request) {
@@ -377,6 +376,7 @@ impl PgsqlState {
                             } else {
                                 tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
                             }
+                            sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                         }
                     } else {
                         // If there isn't a new transaction, we'll consider Suri should move on
@@ -516,7 +516,6 @@ impl PgsqlState {
         while !start.is_empty() {
             match PgsqlState::state_based_resp_parsing(self.state_progress, start) {
                 Ok((rem, response)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     start = rem;
                     SCLogDebug!("Response is {:?}", &response);
                     let (curr_state, tx_completed) = if let Some(state) = self.response_process_next_state(&response, flow) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7113

Previous PR: https://github.com/OISF/suricata/pull/11587

Describe changes:
- track `tx_completion` per tx direction
- add more `PgsqlStateProgress` states to `tx_completion` check (especially for `to_server` direction)
- reorganize `PgsqlStateProgress` enum to separate `to_server` and `to_client` states
- bring the trigger raw stream reassembly call to the moment when tx is completed

Update:
- split the function that checks for tx_completion to per-direction functions, too, and decouple checking for transaction completion from the global state
- mark request or response as completed as soon as we have that info
- add a comment to explain why we're marking a response as done when parsing a request
- reword commit message, previous version was weird.


Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2004