### PR TITLE
lua: use lua from crates.io rather than github

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -67,7 +67,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { git = "https://github.com/jasonish/suricata-lua-sys", version = "0.1.0-alpha.1" }
+suricata-lua-sys = { version = "0.1.0-alpha.1" }
 
 [dev-dependencies]
 test-case = "~3.3.1"


### PR DESCRIPTION
This allows offline builds to work when this crate is vendored.

Ticket: https://redmine.openinfosecfoundation.org/issues/7226