### PR TITLE
rust: compatibility with cbindgen 0.27 (7.0.x backport)

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -464,6 +464,7 @@ pub type GetFrameNameById = unsafe extern "C" fn(u8) -> *const c_char;
 
 
 // Defined in app-layer-register.h
+/// cbindgen:ignore
 extern {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
     pub fn AppLayerRegisterParserAlias(parser_name: *const c_char, alias_name: *const c_char);
@@ -475,6 +476,7 @@ pub unsafe fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProt
 }
 
 // Defined in app-layer-detect-proto.h
+/// cbindgen:ignore
 extern {
     pub fn AppLayerProtoDetectPPRegister(ipproto: u8, portstr: *const c_char, alproto: AppProto,
                                          min_depth: u16, max_depth: u16, dir: u8,
@@ -509,6 +511,7 @@ pub const APP_LAYER_PARSER_OPT_ACCEPT_GAPS: u32 = BIT_U32!(0);
 
 pub const APP_LAYER_TX_SKIP_INSPECT_FLAG: u64 = BIT_U64!(62);
 
+/// cbindgen:ignore
 extern {
     pub fn AppLayerParserStateSetFlag(state: *mut c_void, flag: u16);
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u16) -> u16;

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -31,6 +31,7 @@ use nom7::{
     IResult,
 };
 
+/// cbindgen:ignore
 extern {
     fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;
     fn ConfGetChildValue(conf: *const c_void, key: *const c_char,

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -128,6 +128,7 @@ macro_rules!BIT_U64 {
 pub const FLOW_DIR_REVERSED: u32 = BIT_U32!(26);
 
 // Defined in app-layer-protos.h
+/// cbindgen:ignore
 extern {
     pub fn StringToAppProto(proto_name: *const u8) -> AppProto;
 }
@@ -232,6 +233,7 @@ pub struct SuricataFileContext {
     pub files_sbcfg: &'static StreamingBufferConfig,
 }
 
+/// cbindgen:ignore
 extern {
     pub fn SCGetContext() -> &'static mut SuricataContext;
     pub fn SCLogGetLogLevel() -> i32;
@@ -298,6 +300,7 @@ pub fn sc_app_layer_decoder_events_free_events(
 pub enum Flow {}
 
 // Extern functions operating on Flow.
+/// cbindgen:ignore
 extern {
     pub fn FlowGetLastTimeAsParts(flow: &Flow, secs: *mut u64, usecs: *mut u64);
     pub fn FlowGetFlags(flow: &Flow) -> u32;

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -23,6 +23,7 @@ use std::os::raw::{c_void};
 use crate::core::*;
 
 // Defined in util-file.h
+/// cbindgen:ignore
 extern {
     pub fn FileFlowFlagsToFlags(flow_file_flags: u16, flags: u8) -> u16;
 }

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -30,6 +30,7 @@ struct CFrame {
 }
 
 // Defined in app-layer-register.h
+/// cbindgen:ignore
 extern {
     #[cfg(not(test))]
     fn AppLayerFrameNewByRelativeOffset(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -49,6 +49,10 @@
 // just due to FFI.
 #![allow(clippy::missing_safety_doc)]
 
+// Allow /// cbindgen:ignore comments on extern blocks
+// cf https://github.com/mozilla/cbindgen/issues/709
+#![allow(unused_doc_comments)]
+
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -30,6 +30,7 @@ type LuaInteger = i32;
 /// The Rust place holder for lua_State.
 pub enum CLuaState {}
 
+/// cbindgen:ignore
 extern {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);


### PR DESCRIPTION
Backport of #11622 