### PR TITLE
pgsql: track 'progress' in tx per direction - v4

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -291,7 +291,7 @@ fn log_pgsql_param(param: &PgsqlParameter) -> Result<JsonBuilder, JsonError> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_logger(
+pub unsafe extern "C" fn SCPgsqlLogger(
     tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
 ) -> bool {
     let tx_pgsql = cast_pointer!(tx, PgsqlTransaction);

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -36,17 +36,27 @@ static mut PGSQL_MAX_TX: usize = 1024;
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
-pub enum PgsqlTransactionState {
-    Init = 0,
-    RequestReceived,
-    ResponseDone,
-    FlushedOut,
+pub enum PgsqlTxReqProgress {
+    TxReqInit = 0,
+    TxReqReceived,
+    TxReqDone,
+    TxReqFlushedOut,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialOrd, PartialEq, Eq, Debug)]
+pub enum PgsqlTxResProgress {
+    TxResInit = 0,
+    TxResReceived,
+    TxResDone,
+    TxResFlushedOut,
 }
 
 #[derive(Debug)]
 pub struct PgsqlTransaction {
     pub tx_id: u64,
-    pub tx_state: PgsqlTransactionState,
+    pub tx_req_state: PgsqlTxReqProgress,
+    pub tx_res_state: PgsqlTxResProgress,
     pub request: Option<PgsqlFEMessage>,
     pub responses: Vec<PgsqlBEMessage>,
 
@@ -72,7 +82,8 @@ impl PgsqlTransaction {
     pub fn new() -> Self {
         Self {
             tx_id: 0,
-            tx_state: PgsqlTransactionState::Init,
+            tx_req_state: PgsqlTxReqProgress::TxReqInit,
+            tx_res_state: PgsqlTxResProgress::TxResInit,
             request: None,
             responses: Vec::<PgsqlBEMessage>::new(),
             data_row_cnt: 0,
@@ -97,28 +108,30 @@ impl PgsqlTransaction {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PgsqlStateProgress {
     IdleState,
+// Related to Frontend-received messages //
     SSLRequestReceived,
-    SSLRejectedReceived,
     StartupMessageReceived,
-    SASLAuthenticationReceived,
     SASLInitialResponseReceived,
-    // SSPIAuthenticationReceived, // TODO implement
     SASLResponseReceived,
+    PasswordMessageReceived,
+    SimpleQueryReceived,
+    CancelRequestReceived,
+    ConnectionTerminated,
+// Related to Backend-received messages //
+    SSLRejectedReceived,
+    // SSPIAuthenticationReceived, // TODO implement
+    SASLAuthenticationReceived,
     SASLAuthenticationContinueReceived,
     SASLAuthenticationFinalReceived,
     SimpleAuthenticationReceived,
-    PasswordMessageReceived,
     AuthenticationOkReceived,
     ParameterSetup,
     BackendKeyReceived,
     ReadyForQueryReceived,
-    SimpleQueryReceived,
     RowDescriptionReceived,
     DataRowReceived,
     CommandCompletedReceived,
     ErrorMessageReceived,
-    CancelRequestReceived,
-    ConnectionTerminated,
     #[cfg(test)]
     UnknownState,
     Finished,
@@ -203,8 +216,11 @@ impl PgsqlState {
             let mut index = self.tx_index_completed;
             for tx_old in &mut self.transactions.range_mut(self.tx_index_completed..) {
                 index += 1;
-                if tx_old.tx_state < PgsqlTransactionState::ResponseDone {
-                    tx_old.tx_state = PgsqlTransactionState::FlushedOut;
+                if tx_old.tx_res_state < PgsqlTxResProgress::TxResDone {
+                    // we don't check for TxReqDone for the majority of requests are basically completed
+                    // when they're parsed, as of now
+                    tx_old.tx_req_state = PgsqlTxReqProgress::TxReqFlushedOut;
+                    tx_old.tx_res_state = PgsqlTxResProgress::TxResFlushedOut;
                     //TODO set event
                     break;
                 }
@@ -238,26 +254,6 @@ impl PgsqlState {
         // If we don't need a new transaction, just return the current one
         SCLogDebug!("find_or_create state is {:?}", &self.state_progress);
         return self.transactions.back_mut();
-    }
-
-    /// Process State progress to decide if PgsqlTransaction is finished
-    ///
-    /// As Pgsql transactions are bidirectional and may be comprised of several
-    /// responses, we must track State progress to decide on tx completion
-    fn is_tx_completed(&self) -> bool {
-        if let PgsqlStateProgress::ReadyForQueryReceived
-        | PgsqlStateProgress::SSLRejectedReceived
-        | PgsqlStateProgress::SimpleAuthenticationReceived
-        | PgsqlStateProgress::SASLAuthenticationReceived
-        | PgsqlStateProgress::SASLAuthenticationContinueReceived
-        | PgsqlStateProgress::SASLAuthenticationFinalReceived
-        | PgsqlStateProgress::ConnectionTerminated
-        | PgsqlStateProgress::Finished = self.state_progress
-        {
-            true
-        } else {
-            false
-        }
     }
 
     /// Define PgsqlState progression, based on the request received
@@ -313,6 +309,27 @@ impl PgsqlState {
         }
     }
 
+
+    /// Process State progress to decide if request is finished
+    ///
+    fn request_is_complete(state: PgsqlStateProgress) -> bool {
+        match state {
+            PgsqlStateProgress::SSLRequestReceived
+            | PgsqlStateProgress::StartupMessageReceived
+            | PgsqlStateProgress::SimpleQueryReceived
+            | PgsqlStateProgress::PasswordMessageReceived
+            | PgsqlStateProgress::SASLInitialResponseReceived
+            | PgsqlStateProgress::SASLResponseReceived
+            | PgsqlStateProgress::CancelRequestReceived
+            | PgsqlStateProgress::ConnectionTerminated => {
+                true
+            }
+            _ => {
+                false
+            }
+        }
+    }
+
     fn parse_request(&mut self, flow: *const Flow, input: &[u8]) -> AppLayerResult {
         // We're not interested in empty requests.
         if input.is_empty() {
@@ -343,14 +360,28 @@ impl PgsqlState {
                 Ok((rem, request)) => {
                     sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     start = rem;
-                    if let Some(state) = PgsqlState::request_next_state(&request) {
+                    let (temp_state, tx_completed) = if let Some(state) = PgsqlState::request_next_state(&request) {
                         self.state_progress = state;
+                        // PostreSQL progress states can be represented as a finite state machine
+                        // After the connection phase, the backend/ server will be mostly waiting in a state of `ReadyForQuery`, unless it's processing some request.
+                        // When the frontend wants to cancel a request, it will send a CancelRequest message over a new connection - to which there won't be any responses.
+                        // If the frontend wants to terminate the connection, the backend won't send any confirmation after receiving a Terminate request.
+                        // A simplified finite state machine for PostgreSQL v3 can be found at:
+                        // https://samadhiweb.com/blog/2013.04.28.graphviz.postgresv3.html
+                        (state, Self::request_is_complete(state))
+                    } else {
+                        (self.state_progress, false)
                     };
-                    let tx_completed = self.is_tx_completed();
                     if let Some(tx) = self.find_or_create_tx() {
                         tx.request = Some(request);
                         if tx_completed {
-                            tx.tx_state = PgsqlTransactionState::ResponseDone;
+                            if temp_state == PgsqlStateProgress::ConnectionTerminated || temp_state == PgsqlStateProgress::CancelRequestReceived { 
+                                tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
+                                /* The server won't send any responses to such requests, so transaction should be over */
+                                tx.tx_res_state = PgsqlTxResProgress::TxResDone;
+                            } else {
+                                tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
+                            }
                         }
                     } else {
                         // If there isn't a new transaction, we'll consider Suri should move on
@@ -450,6 +481,25 @@ impl PgsqlState {
         }
     }
 
+    /// Process State progress to decide if response is finished
+    ///
+    fn response_is_complete(state: PgsqlStateProgress) -> bool {
+        match state {
+            PgsqlStateProgress::ReadyForQueryReceived
+            | PgsqlStateProgress::SSLRejectedReceived
+            | PgsqlStateProgress::SimpleAuthenticationReceived
+            | PgsqlStateProgress::SASLAuthenticationReceived
+            | PgsqlStateProgress::SASLAuthenticationContinueReceived
+            | PgsqlStateProgress::SASLAuthenticationFinalReceived
+            | PgsqlStateProgress::Finished => {
+                true
+            }
+            _ => {
+                false
+            }
+        }
+    }
+
     fn parse_response(&mut self, flow: *const Flow, input: &[u8]) -> AppLayerResult {
         // We're not interested in empty responses.
         if input.is_empty() {
@@ -474,12 +524,16 @@ impl PgsqlState {
                     sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     start = rem;
                     SCLogDebug!("Response is {:?}", &response);
-                    if let Some(state) = self.response_process_next_state(&response, flow) {
+                    let (curr_state, tx_completed) = if let Some(state) = self.response_process_next_state(&response, flow) {
                         self.state_progress = state;
+                        (state, Self::response_is_complete(state))
+                    } else {
+                        (self.state_progress, false)
                     };
-                    let tx_completed = self.is_tx_completed();
-                    let curr_state = self.state_progress;
                     if let Some(tx) = self.find_or_create_tx() {
+                        if tx.tx_res_state == PgsqlTxResProgress::TxResInit {
+                            tx.tx_res_state = PgsqlTxResProgress::TxResReceived;
+                        }
                         if curr_state == PgsqlStateProgress::DataRowReceived {
                             tx.incr_row_cnt();
                         } else if curr_state == PgsqlStateProgress::CommandCompletedReceived
@@ -497,7 +551,9 @@ impl PgsqlState {
                         } else {
                             tx.responses.push(response);
                             if tx_completed {
-                                tx.tx_state = PgsqlTransactionState::ResponseDone;
+                                tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
+                                tx.tx_res_state = PgsqlTxResProgress::TxResDone;
+                                sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                             }
                         }
                     } else {
@@ -706,19 +762,33 @@ pub extern "C" fn rs_pgsql_state_get_tx_count(state: *mut std::os::raw::c_void) 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_tx_get_state(tx: *mut std::os::raw::c_void) -> PgsqlTransactionState {
+pub extern "C" fn rs_pgsql_tx_get_req_state(tx: *mut std::os::raw::c_void) -> PgsqlTxReqProgress {
     let tx_safe: &mut PgsqlTransaction;
     unsafe {
         tx_safe = cast_pointer!(tx, PgsqlTransaction);
     }
-    return tx_safe.tx_state;
+    return tx_safe.tx_req_state;
+}
+
+#[no_mangle]
+pub extern "C" fn rs_pgsql_tx_get_res_state(tx: *mut std::os::raw::c_void) -> PgsqlTxResProgress {
+    let tx_safe: &mut PgsqlTransaction;
+    unsafe {
+        tx_safe = cast_pointer!(tx, PgsqlTransaction);
+    }
+    return tx_safe.tx_res_state;
 }
 
 #[no_mangle]
 pub extern "C" fn rs_pgsql_tx_get_alstate_progress(
-    tx: *mut std::os::raw::c_void, _direction: u8,
+    tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
-    return rs_pgsql_tx_get_state(tx) as i32;
+    if direction == Direction::ToServer as u8 {
+        return rs_pgsql_tx_get_req_state(tx) as i32;
+    }
+
+    // Direction has only two possible values, so we don't need to check for the other one
+    return rs_pgsql_tx_get_res_state(tx) as i32;
 }
 
 export_tx_data_get!(rs_pgsql_get_tx_data, PgsqlTransaction);
@@ -746,8 +816,8 @@ pub unsafe extern "C" fn rs_pgsql_register_parser() {
         parse_tc: rs_pgsql_parse_response,
         get_tx_count: rs_pgsql_state_get_tx_count,
         get_tx: rs_pgsql_state_get_tx,
-        tx_comp_st_ts: PgsqlTransactionState::RequestReceived as i32,
-        tx_comp_st_tc: PgsqlTransactionState::ResponseDone as i32,
+        tx_comp_st_ts: PgsqlTxReqProgress::TxReqDone as i32,
+        tx_comp_st_tc: PgsqlTxResProgress::TxResDone as i32,
         tx_get_progress: rs_pgsql_tx_get_alstate_progress,
         get_eventinfo: None,
         get_eventinfo_byid: None,

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -608,7 +608,7 @@ fn probe_tc(input: &[u8]) -> bool {
 
 /// C entry point for a probing parser.
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
+pub unsafe extern "C" fn SCPgsqlProbingParserTS(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     if input_len >= 1 && !input.is_null() {
@@ -635,7 +635,7 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_ts(
 
 /// C entry point for a probing parser.
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
+pub unsafe extern "C" fn SCPgsqlProbingParserTC(
     _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
 ) -> AppProto {
     if input_len >= 1 && !input.is_null() {
@@ -665,7 +665,7 @@ pub unsafe extern "C" fn rs_pgsql_probing_parser_tc(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_state_new(
+pub extern "C" fn SCPgsqlStateNew(
     _orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto,
 ) -> *mut std::os::raw::c_void {
     let state = PgsqlState::new();
@@ -674,13 +674,13 @@ pub extern "C" fn rs_pgsql_state_new(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_state_free(state: *mut std::os::raw::c_void) {
+pub extern "C" fn SCPgsqlStateFree(state: *mut std::os::raw::c_void) {
     // Just unbox...
     std::mem::drop(unsafe { Box::from_raw(state as *mut PgsqlState) });
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_state_tx_free(state: *mut std::os::raw::c_void, tx_id: u64) {
+pub extern "C" fn SCPgsqlStateTxFree(state: *mut std::os::raw::c_void, tx_id: u64) {
     let state_safe: &mut PgsqlState;
     unsafe {
         state_safe = cast_pointer!(state, PgsqlState);
@@ -689,7 +689,7 @@ pub extern "C" fn rs_pgsql_state_tx_free(state: *mut std::os::raw::c_void, tx_id
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_parse_request(
+pub unsafe extern "C" fn SCPgsqlParseRequest(
     flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
@@ -714,7 +714,7 @@ pub unsafe extern "C" fn rs_pgsql_parse_request(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_parse_response(
+pub unsafe extern "C" fn SCPgsqlParseResponse(
     flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
@@ -737,7 +737,7 @@ pub unsafe extern "C" fn rs_pgsql_parse_response(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_state_get_tx(
+pub unsafe extern "C" fn SCPgsqlStateGetTx(
     state: *mut std::os::raw::c_void, tx_id: u64,
 ) -> *mut std::os::raw::c_void {
     let state_safe: &mut PgsqlState = cast_pointer!(state, PgsqlState);
@@ -752,7 +752,7 @@ pub unsafe extern "C" fn rs_pgsql_state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
+pub extern "C" fn SCPgsqlStateGetTxCount(state: *mut std::os::raw::c_void) -> u64 {
     let state_safe: &mut PgsqlState;
     unsafe {
         state_safe = cast_pointer!(state, PgsqlState);
@@ -761,7 +761,7 @@ pub extern "C" fn rs_pgsql_state_get_tx_count(state: *mut std::os::raw::c_void) 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_tx_get_req_state(tx: *mut std::os::raw::c_void) -> PgsqlTxReqProgress {
+pub extern "C" fn SCPgsqlTxGetReqState(tx: *mut std::os::raw::c_void) -> PgsqlTxReqProgress {
     let tx_safe: &mut PgsqlTransaction;
     unsafe {
         tx_safe = cast_pointer!(tx, PgsqlTransaction);
@@ -770,7 +770,7 @@ pub extern "C" fn rs_pgsql_tx_get_req_state(tx: *mut std::os::raw::c_void) -> Pg
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_tx_get_res_state(tx: *mut std::os::raw::c_void) -> PgsqlTxResProgress {
+pub extern "C" fn SCPgsqlTxGetResState(tx: *mut std::os::raw::c_void) -> PgsqlTxResProgress {
     let tx_safe: &mut PgsqlTransaction;
     unsafe {
         tx_safe = cast_pointer!(tx, PgsqlTransaction);
@@ -779,15 +779,15 @@ pub extern "C" fn rs_pgsql_tx_get_res_state(tx: *mut std::os::raw::c_void) -> Pg
 }
 
 #[no_mangle]
-pub extern "C" fn rs_pgsql_tx_get_alstate_progress(
+pub extern "C" fn SCPgsqlTxGetALStateProgress(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     if direction == Direction::ToServer as u8 {
-        return rs_pgsql_tx_get_req_state(tx) as i32;
+        return SCPgsqlTxGetReqState(tx) as i32;
     }
 
     // Direction has only two possible values, so we don't need to check for the other one
-    return rs_pgsql_tx_get_res_state(tx) as i32;
+    return SCPgsqlTxGetResState(tx) as i32;
 }
 
 export_tx_data_get!(rs_pgsql_get_tx_data, PgsqlTransaction);
@@ -797,27 +797,27 @@ export_state_data_get!(rs_pgsql_get_state_data, PgsqlState);
 const PARSER_NAME: &[u8] = b"pgsql\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_pgsql_register_parser() {
+pub unsafe extern "C" fn SCRegisterPgsqlParser() {
     let default_port = CString::new("[5432]").unwrap();
     let mut stream_depth = PGSQL_CONFIG_DEFAULT_STREAM_DEPTH;
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),
         ipproto: IPPROTO_TCP,
-        probe_ts: Some(rs_pgsql_probing_parser_ts),
-        probe_tc: Some(rs_pgsql_probing_parser_tc),
+        probe_ts: Some(SCPgsqlProbingParserTS),
+        probe_tc: Some(SCPgsqlProbingParserTC),
         min_depth: 0,
         max_depth: 16,
-        state_new: rs_pgsql_state_new,
-        state_free: rs_pgsql_state_free,
-        tx_free: rs_pgsql_state_tx_free,
-        parse_ts: rs_pgsql_parse_request,
-        parse_tc: rs_pgsql_parse_response,
-        get_tx_count: rs_pgsql_state_get_tx_count,
-        get_tx: rs_pgsql_state_get_tx,
+        state_new: SCPgsqlStateNew,
+        state_free: SCPgsqlStateFree,
+        tx_free: SCPgsqlStateTxFree,
+        parse_ts: SCPgsqlParseRequest,
+        parse_tc: SCPgsqlParseResponse,
+        get_tx_count: SCPgsqlStateGetTxCount,
+        get_tx: SCPgsqlStateGetTx,
         tx_comp_st_ts: PgsqlTxReqProgress::TxReqDone as i32,
         tx_comp_st_tc: PgsqlTxResProgress::TxResDone as i32,
-        tx_get_progress: rs_pgsql_tx_get_alstate_progress,
+        tx_get_progress: SCPgsqlTxGetALStateProgress,
         get_eventinfo: None,
         get_eventinfo_byid: None,
         localstorage_new: None,

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -358,7 +358,6 @@ impl PgsqlState {
             );
             match PgsqlState::state_based_req_parsing(self.state_progress, start) {
                 Ok((rem, request)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                     start = rem;
                     let (temp_state, tx_completed) = if let Some(state) = PgsqlState::request_next_state(&request) {
                         self.state_progress = state;
@@ -382,6 +381,7 @@ impl PgsqlState {
                             } else {
                                 tx.tx_req_state = PgsqlTxReqProgress::TxReqDone;
                             }
+                            sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToServer as i32);
                         }
                     } else {
                         // If there isn't a new transaction, we'll consider Suri should move on
@@ -521,7 +521,6 @@ impl PgsqlState {
         while !start.is_empty() {
             match PgsqlState::state_based_resp_parsing(self.state_progress, start) {
                 Ok((rem, response)) => {
-                    sc_app_layer_parser_trigger_raw_stream_reassembly(flow, Direction::ToClient as i32);
                     start = rem;
                     SCLogDebug!("Response is {:?}", &response);
                     let (curr_state, tx_completed) = if let Some(state) = self.response_process_next_state(&response, flow) {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1727,7 +1727,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_template_register_parser();
     SCRfbRegisterParser();
     SCMqttRegisterParser();
-    rs_pgsql_register_parser();
+    SCRegisterPgsqlParser();
     rs_rdp_register_parser();
     RegisterHTTP2Parsers();
     rs_telnet_register_parser();

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -61,7 +61,7 @@ typedef struct LogPgsqlLogThread_ {
 
 bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb)
 {
-    return rs_pgsql_logger(vtx, PGSQL_DEFAULTS, jb);
+    return SCPgsqlLogger(vtx, PGSQL_DEFAULTS, jb);
 }
 
 static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state,
@@ -76,7 +76,7 @@ static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, F
         return TM_ECODE_FAILED;
     }
 
-    if (!rs_pgsql_logger(txptr, thread->pgsqllog_ctx->flags, jb)) {
+    if (!SCPgsqlLogger(txptr, thread->pgsqllog_ctx->flags, jb)) {
         goto error;
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7113

Previous PR: https://github.com/OISF/suricata/pull/11618

Describe changes:
- track `tx_completion` per tx direction
- add more `PgsqlStateProgress` states to tx completion check (especially for `to_server` direction)
- reorganize `PgsqlStateProgress` enum to separate `to_server` and `to_client` states
- bring the trigger raw stream reassembly call to the moment when tx is completed

Update:
- add comment explaining and referencing Pgsql state machine
- make code a bit more compact when checking for temporary progress state in `parse_request`
- try to address https://github.com/OISF/suricata/pull/11618#discussion_r1708653138 by not checking for `TxReqDone` before flushing out tx
- update all pgsql function exposed to C to the new API style

Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2014