### PR TITLE
Backport of 6553 to main-7.0.x

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -619,7 +619,8 @@ static void AlertAddFiles(const Packet *p, JsonBuilder *jb, const uint64_t tx_id
     }
 }
 
-static void AlertAddFrame(const Packet *p, JsonBuilder *jb, const int64_t frame_id)
+static void AlertAddFrame(
+        const Packet *p, const int64_t frame_id, JsonBuilder *jb, MemBuffer *buffer)
 {
     if (p->flow == NULL || (p->proto == IPPROTO_TCP && p->flow->protoctx == NULL))
         return;
@@ -641,7 +642,7 @@ static void AlertAddFrame(const Packet *p, JsonBuilder *jb, const int64_t frame_
         }
         Frame *frame = FrameGetById(frames, frame_id);
         if (frame != NULL) {
-            FrameJsonLogOneFrame(IPPROTO_TCP, frame, p->flow, stream, p, jb);
+            FrameJsonLogOneFrame(IPPROTO_TCP, frame, p->flow, stream, p, jb, buffer);
         }
     } else if (p->proto == IPPROTO_UDP) {
         if (PKT_IS_TOSERVER(p)) {
@@ -651,7 +652,7 @@ static void AlertAddFrame(const Packet *p, JsonBuilder *jb, const int64_t frame_
         }
         Frame *frame = FrameGetById(frames, frame_id);
         if (frame != NULL) {
-            FrameJsonLogOneFrame(IPPROTO_UDP, frame, p->flow, NULL, p, jb);
+            FrameJsonLogOneFrame(IPPROTO_UDP, frame, p->flow, NULL, p, jb, buffer);
         }
     }
 }
@@ -889,7 +890,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         }
 
         if (pa->flags & PACKET_ALERT_FLAG_FRAME) {
-            AlertAddFrame(p, jb, pa->frame_id);
+            AlertAddFrame(p, pa->frame_id, jb, aft->payload_buffer);
         }
 
         /* base64-encoded full packet */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -35,6 +35,7 @@
 #include "tm-threads.h"
 #include "threadvars.h"
 #include "util-debug.h"
+#include "stream-tcp.h"
 
 #include "util-logopenfile.h"
 #include "util-misc.h"
@@ -125,17 +126,6 @@ typedef struct JsonAlertLogThread_ {
     AlertJsonOutputCtx* json_output_ctx;
     OutputJsonThreadCtx *ctx;
 } JsonAlertLogThread;
-
-/* Callback function to pack payload contents from a stream into a buffer
- * so we can report them in JSON output. */
-static int AlertJsonDumpStreamSegmentCallback(
-        const Packet *p, TcpSegment *seg, void *data, const uint8_t *buf, uint32_t buflen)
-{
-    MemBuffer *payload = (MemBuffer *)data;
-    MemBufferWriteRaw(payload, buf, buflen);
-
-    return 1;
-}
 
 static void AlertJsonTls(const Flow *f, const uint32_t sig_flags, JsonBuilder *js)
 {
@@ -717,9 +707,61 @@ void EveAddVerdict(JsonBuilder *jb, const Packet *p)
     jb_close(jb);
 }
 
+struct AlertJsonStreamDataCallbackData {
+    MemBuffer *payload;
+    uint64_t last_re;
+};
+
+static int AlertJsonStreamDataCallback(
+        void *cb_data, const uint8_t *input, const uint32_t input_len, const uint64_t input_offset)
+{
+    struct AlertJsonStreamDataCallbackData *cbd = cb_data;
+    if (input_offset > cbd->last_re) {
+        MemBufferWriteString(
+                cbd->payload, "[%" PRIu64 " bytes missing]", input_offset - cbd->last_re);
+    }
+
+    MemBufferWriteRaw(cbd->payload, input, input_len);
+    cbd->last_re = input_offset + input_len;
+    return 0;
+}
+
+/** \internal
+ *  \brief try to log stream data into payload/payload_printable
+ *  \retval true stream data logged
+ *  \retval false stream data not logged
+ */
+static bool AlertJsonStreamData(const AlertJsonOutputCtx *json_output_ctx, JsonAlertLogThread *aft,
+        Flow *f, const Packet *p, JsonBuilder *jb)
+{
+    TcpSession *ssn = f->protoctx;
+    TcpStream *stream = (PKT_IS_TOSERVER(p)) ? &ssn->client : &ssn->server;
+
+    MemBufferReset(aft->payload_buffer);
+    struct AlertJsonStreamDataCallbackData cbd = { .payload = aft->payload_buffer,
+        .last_re = STREAM_BASE_OFFSET(stream) };
+    uint64_t unused = 0;
+    StreamReassembleLog(ssn, stream, AlertJsonStreamDataCallback, &cbd, STREAM_BASE_OFFSET(stream),
+            &unused, false);
+    if (cbd.payload->offset) {
+        if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
+            jb_set_base64(jb, "payload", cbd.payload->buffer, cbd.payload->offset);
+        }
+
+        if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
+            uint8_t printable_buf[cbd.payload->offset + 1];
+            uint32_t offset = 0;
+            PrintStringsToBuffer(printable_buf, &offset, sizeof(printable_buf), cbd.payload->buffer,
+                    cbd.payload->offset);
+            jb_set_string(jb, "payload_printable", (char *)printable_buf);
+        }
+        return true;
+    }
+    return false;
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
-    MemBuffer *payload = aft->payload_buffer;
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
 
     if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
@@ -827,36 +869,14 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             int stream = (p->proto == IPPROTO_TCP) ?
                          (pa->flags & (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_STREAM_MATCH) ?
                          1 : 0) : 0;
+            DEBUG_VALIDATE_BUG_ON(
+                    p->flow == NULL); // should be impossible, but scan-build got confused
 
             /* Is this a stream?  If so, pack part of it into the payload field */
-            if (stream) {
-                uint8_t flag;
-
-                MemBufferReset(payload);
-
-                if (p->flowflags & FLOW_PKT_TOSERVER) {
-                    flag = STREAM_DUMP_TOCLIENT;
-                } else {
-                    flag = STREAM_DUMP_TOSERVER;
-                }
-
-                StreamSegmentForEach((const Packet *)p, flag,
-                                    AlertJsonDumpStreamSegmentCallback,
-                                    (void *)payload);
-                if (payload->offset) {
-                    if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
-                        jb_set_base64(jb, "payload", payload->buffer, payload->offset);
-                    }
-
-                    if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
-                        uint8_t printable_buf[payload->offset + 1];
-                        uint32_t offset = 0;
-                        PrintStringsToBuffer(printable_buf, &offset,
-                                sizeof(printable_buf),
-                                payload->buffer, payload->offset);
-                        jb_set_string(jb, "payload_printable", (char *)printable_buf);
-                    }
-                } else if (p->payload_len) {
+            if (stream && p->flow != NULL) {
+                const bool stream_data_logged =
+                        AlertJsonStreamData(json_output_ctx, aft, p->flow, p, jb);
+                if (!stream_data_logged && p->payload_len) {
                     /* Fallback on packet payload */
                     AlertAddPayload(json_output_ctx, jb, p);
                 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -722,9 +722,12 @@ static int AlertJsonStreamDataCallback(
                 cbd->payload, "[%" PRIu64 " bytes missing]", input_offset - cbd->last_re);
     }
 
-    MemBufferWriteRaw(cbd->payload, input, input_len);
+    int done = 0;
+    uint32_t written = MemBufferWriteRaw(cbd->payload, input, input_len);
+    if (written < input_len)
+        done = 1;
     cbd->last_re = input_offset + input_len;
-    return 0;
+    return done;
 }
 
 /** \internal

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1129,14 +1129,13 @@ static void JsonAlertLogSetupMetadata(AlertJsonOutputCtx *json_output_ctx,
                 warn_no_meta = true;
             }
         }
-
-        json_output_ctx->payload_buffer_size = payload_buffer_size;
     }
 
     if (flags & LOG_JSON_RULE_METADATA) {
         DetectEngineSetParseMetadata();
     }
 
+    json_output_ctx->payload_buffer_size = payload_buffer_size;
     json_output_ctx->flags |= flags;
 }
 

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -163,7 +163,9 @@ static int FrameJsonStreamDataCallback(
     }
 
     if (write_size > 0) {
-        MemBufferWriteRaw(cbd->payload, input, write_size);
+        uint32_t written = MemBufferWriteRaw(cbd->payload, input, write_size);
+        if (written < write_size)
+            done = 1;
     }
     cbd->last_re = input_offset + write_size;
     return done;

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -224,7 +224,7 @@ static void FrameAddPayloadUDP(JsonBuilder *js, const Packet *p, const Frame *fr
  *  \note ipproto argument is passed to assist static code analyzers
  */
 void FrameJsonLogOneFrame(const uint8_t ipproto, const Frame *frame, const Flow *f,
-        const TcpStream *stream, const Packet *p, JsonBuilder *jb)
+        const TcpStream *stream, const Packet *p, JsonBuilder *jb, MemBuffer *buffer)
 {
     DEBUG_VALIDATE_BUG_ON(ipproto != p->proto);
     DEBUG_VALIDATE_BUG_ON(ipproto != f->proto);
@@ -287,7 +287,7 @@ static int FrameJsonUdp(
             return TM_ECODE_OK;
 
         jb_set_string(jb, "app_proto", AppProtoToString(f->alproto));
-        FrameJsonLogOneFrame(IPPROTO_UDP, frame, p->flow, NULL, p, jb);
+        FrameJsonLogOneFrame(IPPROTO_UDP, frame, p->flow, NULL, p, jb, aft->payload_buffer);
         OutputJsonBuilderBuffer(jb, aft->ctx);
         jb_free(jb);
         frame->flags |= FRAME_FLAG_LOGGED;
@@ -359,7 +359,7 @@ static int FrameJson(ThreadVars *tv, JsonFrameLogThread *aft, const Packet *p)
                 return TM_ECODE_OK;
 
             jb_set_string(jb, "app_proto", AppProtoToString(p->flow->alproto));
-            FrameJsonLogOneFrame(IPPROTO_TCP, frame, p->flow, stream, p, jb);
+            FrameJsonLogOneFrame(IPPROTO_TCP, frame, p->flow, stream, p, jb, aft->payload_buffer);
             OutputJsonBuilderBuffer(jb, aft->ctx);
             jb_free(jb);
             frame->flags |= FRAME_FLAG_LOGGED;

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -483,8 +483,22 @@ static OutputInitResult JsonFrameLogInitCtxSub(ConfNode *conf, OutputCtx *parent
     }
     memset(json_output_ctx, 0, sizeof(FrameJsonOutputCtx));
 
+    uint32_t payload_buffer_size = 4096;
+    if (conf != NULL) {
+        const char *payload_buffer_value = ConfNodeLookupChildValue(conf, "payload-buffer-size");
+        if (payload_buffer_value != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(payload_buffer_value, &value) < 0) {
+                SCLogError("Error parsing payload-buffer-size \"%s\"", payload_buffer_value);
+                goto error;
+            }
+            payload_buffer_size = value;
+        }
+    }
+
     json_output_ctx->file_ctx = ajt->file_ctx;
     json_output_ctx->eve_ctx = ajt;
+    json_output_ctx->payload_buffer_size = payload_buffer_size;
 
     output_ctx->data = json_output_ctx;
     output_ctx->DeInit = JsonFrameLogDeInitCtxSub;

--- a/src/output-json-frame.h
+++ b/src/output-json-frame.h
@@ -30,7 +30,7 @@
 #include "app-layer-frames.h"
 #include "stream-tcp-private.h"
 
-void FrameJsonLogOneFrame(const uint8_t ipproto, const Frame *frame, const Flow *f,
+void FrameJsonLogOneFrame(const uint8_t ipproto, const Frame *frame, Flow *f,
         const TcpStream *stream, const Packet *p, JsonBuilder *jb, MemBuffer *);
 void JsonFrameLogRegister(void);
 

--- a/src/output-json-frame.h
+++ b/src/output-json-frame.h
@@ -31,7 +31,7 @@
 #include "stream-tcp-private.h"
 
 void FrameJsonLogOneFrame(const uint8_t ipproto, const Frame *frame, const Flow *f,
-        const TcpStream *stream, const Packet *p, JsonBuilder *jb);
+        const TcpStream *stream, const Packet *p, JsonBuilder *jb, MemBuffer *);
 void JsonFrameLogRegister(void);
 
 #endif /* __OUTPUT_JSON_FRAME_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -933,7 +933,7 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data)
         MemBufferExpand(memb, wrapper->expand_by);
     }
 
-    MemBufferWriteRaw((*memb), str, size);
+    MemBufferWriteRaw((*memb), (const uint8_t *)str, size);
     return 0;
 }
 
@@ -949,7 +949,7 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     }
 
     if (file_ctx->prefix) {
-        MemBufferWriteRaw((*buffer), file_ctx->prefix, file_ctx->prefix_len);
+        MemBufferWriteRaw((*buffer), (const uint8_t *)file_ctx->prefix, file_ctx->prefix_len);
     }
 
     OutputJSONMemBufferWrapper wrapper = {
@@ -983,7 +983,7 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
     MemBufferReset(*buffer);
 
     if (file_ctx->prefix) {
-        MemBufferWriteRaw((*buffer), file_ctx->prefix, file_ctx->prefix_len);
+        MemBufferWriteRaw((*buffer), (const uint8_t *)file_ctx->prefix, file_ctx->prefix_len);
     }
 
     size_t jslen = jb_len(js);

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1394,7 +1394,7 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 /** \internal
  *  \brief get stream data from offset
  *  \param offset stream offset */
-static int GetRawBuffer(TcpStream *stream, const uint8_t **data, uint32_t *data_len,
+static int GetRawBuffer(const TcpStream *stream, const uint8_t **data, uint32_t *data_len,
         StreamingBufferBlock **iter, uint64_t offset, uint64_t *data_offset)
 {
     const uint8_t *mydata;
@@ -1417,7 +1417,7 @@ static int GetRawBuffer(TcpStream *stream, const uint8_t **data, uint32_t *data_
                 *iter == NULL ? "starting" : "continuing", offset);
         if (*iter == NULL) {
             StreamingBufferBlock key = { .offset = offset, .len = 0 };
-            *iter = SBB_RB_FIND_INCLUSIVE(&stream->sb.sbb_tree, &key);
+            *iter = SBB_RB_FIND_INCLUSIVE((struct SBB *)&stream->sb.sbb_tree, &key);
             SCLogDebug("*iter %p", *iter);
         }
         if (*iter == NULL) {
@@ -1758,7 +1758,7 @@ static int StreamReassembleRawInline(TcpSession *ssn, const Packet *p,
  *  `respect_inspect_depth` is used to avoid useless inspection of too
  *  much data.
  */
-static int StreamReassembleRawDo(TcpSession *ssn, TcpStream *stream,
+static int StreamReassembleRawDo(const TcpSession *ssn, const TcpStream *stream,
         StreamReassembleRawFunc Callback, void *cb_data, const uint64_t progress_in,
         const uint64_t re, uint64_t *progress_out, bool eof, bool respect_inspect_depth)
 {
@@ -1920,10 +1920,9 @@ int StreamReassembleRaw(TcpSession *ssn, const Packet *p,
             progress_out, (p->flags & PKT_PSEUDO_STREAM_END), respect_inspect_depth);
 }
 
-int StreamReassembleLog(TcpSession *ssn, TcpStream *stream,
-                        StreamReassembleRawFunc Callback, void *cb_data,
-                        uint64_t progress_in,
-                        uint64_t *progress_out, bool eof)
+int StreamReassembleLog(const TcpSession *ssn, const TcpStream *stream,
+        StreamReassembleRawFunc Callback, void *cb_data, const uint64_t progress_in,
+        uint64_t *progress_out, const bool eof)
 {
     if (stream->flags & (STREAMTCP_STREAM_FLAG_NOREASSEMBLY))
         return 0;

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -131,10 +131,9 @@ typedef int (*StreamReassembleRawFunc)(
 
 int StreamReassembleForFrame(TcpSession *ssn, TcpStream *stream, StreamReassembleRawFunc Callback,
         void *cb_data, const uint64_t offset, const bool eof);
-int StreamReassembleLog(TcpSession *ssn, TcpStream *stream,
-        StreamReassembleRawFunc Callback, void *cb_data,
-        uint64_t progress_in,
-        uint64_t *progress_out, bool eof);
+int StreamReassembleLog(const TcpSession *ssn, const TcpStream *stream,
+        StreamReassembleRawFunc Callback, void *cb_data, const uint64_t progress_in,
+        uint64_t *progress_out, const bool eof);
 int StreamReassembleRaw(TcpSession *ssn, const Packet *p,
         StreamReassembleRawFunc Callback, void *cb_data,
         uint64_t *progress_out, bool respect_inspect_depth);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -300,7 +300,7 @@ static int UnixCommandSendJSONToClient(UnixClient *client, json_t *js)
         if (MEMBUFFER_OFFSET(client->mbuf) + 1 >= MEMBUFFER_SIZE(client->mbuf)) {
             MemBufferExpand(&client->mbuf, 1);
         }
-        MemBufferWriteRaw(client->mbuf, "\n", 1);
+        MemBufferWriteString(client->mbuf, "\n");
     }
 
     if (send(client->fd, (const char *)MEMBUFFER_BUFFER(client->mbuf),

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -110,7 +110,7 @@ void MemBufferPrintToFPAsHex(MemBuffer *b, FILE *fp)
     }
 }
 
-void MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len)
+uint32_t MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len)
 {
     uint32_t write_len;
     if (raw_len >= dst->size - dst->offset) {
@@ -122,6 +122,7 @@ void MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_le
     memcpy(dst->buffer + dst->offset, raw, write_len);
     dst->offset += write_len;
     dst->buffer[dst->offset] = '\0';
+    return write_len;
 }
 
 void MemBufferWriteString(MemBuffer *dst, const char *fmt, ...)

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -48,8 +48,7 @@ MemBuffer *MemBufferCreateNew(uint32_t size)
         return NULL;
     }
     buffer->size = size;
-    buffer->buffer = (uint8_t *)buffer + sizeof(MemBuffer);
-
+    MemBufferReset(buffer);
     return buffer;
 }
 
@@ -75,7 +74,6 @@ int MemBufferExpand(MemBuffer **buffer, uint32_t expand_by) {
     }
     *buffer = tbuffer;
     (*buffer)->size += expand_by;
-    (*buffer)->buffer = (uint8_t *)tbuffer + sizeof(MemBuffer);
 
     SCLogDebug("expanded buffer by %u, size is now %u", expand_by, (*buffer)->size);
     return 0;

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -40,15 +40,13 @@ MemBuffer *MemBufferCreateNew(uint32_t size)
         return NULL;
     }
 
-    uint32_t total_size = size + sizeof(MemBuffer);
+    size_t total_size = size + sizeof(MemBuffer);
 
     MemBuffer *buffer = SCMalloc(total_size);
     if (unlikely(buffer == NULL)) {
         sc_errno = SC_ENOMEM;
         return NULL;
     }
-    memset(buffer, 0, total_size);
-
     buffer->size = size;
     buffer->buffer = (uint8_t *)buffer + sizeof(MemBuffer);
 
@@ -69,13 +67,12 @@ int MemBufferExpand(MemBuffer **buffer, uint32_t expand_by) {
         return -1;
     }
 
-    uint32_t total_size = (*buffer)->size + sizeof(MemBuffer) + expand_by;
+    size_t total_size = (*buffer)->size + sizeof(MemBuffer) + expand_by;
 
     MemBuffer *tbuffer = SCRealloc(*buffer, total_size);
     if (unlikely(tbuffer == NULL)) {
         return -1;
     }
-
     *buffer = tbuffer;
     (*buffer)->size += expand_by;
     (*buffer)->buffer = (uint8_t *)tbuffer + sizeof(MemBuffer);
@@ -89,4 +86,64 @@ void MemBufferFree(MemBuffer *buffer)
     SCFree(buffer);
 
     return;
+}
+
+void MemBufferPrintToFP(MemBuffer *buffer, FILE *fp)
+{
+    for (uint32_t i = 0; i < buffer->offset; i++) {
+        if (isprint(buffer->buffer[i]))
+            fprintf(fp, "%c", buffer->buffer[i]);
+        else
+            fprintf(fp, "|%02X|", buffer->buffer[i]);
+    }
+}
+
+size_t MemBufferPrintToFPAsString(MemBuffer *b, FILE *fp)
+{
+    return fwrite(MEMBUFFER_BUFFER(b), sizeof(uint8_t), MEMBUFFER_OFFSET(b), fp);
+}
+
+void MemBufferPrintToFPAsHex(MemBuffer *b, FILE *fp)
+{
+    for (uint32_t i = 0; i < MEMBUFFER_OFFSET(b); i++) {
+        if (MEMBUFFER_OFFSET(b) % 8 == 0)
+            fprintf(fp, "\n");
+        fprintf(fp, " %02X", b->buffer[i]);
+    }
+}
+
+void MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len)
+{
+    uint32_t write_len;
+    if (raw_len >= dst->size - dst->offset) {
+        SCLogDebug("Truncating data write since it exceeded buffer limit of %" PRIu32, dst->size);
+        write_len = dst->size - dst->offset - 1;
+    } else {
+        write_len = raw_len;
+    }
+    memcpy(dst->buffer + dst->offset, raw, write_len);
+    dst->offset += write_len;
+    dst->buffer[dst->offset] = '\0';
+}
+
+void MemBufferWriteString(MemBuffer *dst, const char *fmt, ...)
+{
+    uint32_t available = dst->size - dst->offset;
+    uint32_t max_string_size = MIN(available, 2048);
+    va_list ap;
+    char string[max_string_size];
+    va_start(ap, fmt);
+    int written = vsnprintf(string, sizeof(string), fmt, ap);
+    va_end(ap);
+    if (written < 0) {
+        return;
+    } else if ((uint32_t)written > max_string_size) {
+        SCLogDebug("Truncating data write since it exceeded buffer "
+                   "limit of %" PRIu32,
+                dst->size);
+    }
+    size_t string_size = strlen(string);
+    memcpy(dst->buffer + dst->offset, string, string_size);
+    dst->offset += string_size;
+    dst->buffer[dst->offset] = '\0';
 }

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -111,8 +111,9 @@ void MemBufferPrintToFPAsHex(MemBuffer *b, FILE *fp);
  *
  * \param raw_buffer     The buffer to write.
  * \param raw_buffer_len Length of the above buffer.
+ * \retval write_len Bytes written. If less than raw_len, the buffer is full.
  */
-void MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len);
+uint32_t MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len);
 
 /**
  * \brief Write a string buffer to the Membuffer dst.

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -25,9 +25,9 @@
 #define __UTIL_BUFFER_H__
 
 typedef struct MemBuffer_ {
-   uint8_t *buffer;
-   uint32_t size;
-   uint32_t offset;
+    uint32_t size;
+    uint32_t offset;
+    uint8_t buffer[];
 } MemBuffer;
 
 MemBuffer *MemBufferCreateNew(uint32_t size);

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -128,6 +128,6 @@ uint32_t MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t ra
  * \param format The format string.
  * \param ...    Variable arguments.
  */
-void MemBufferWriteString(MemBuffer *dst, const char *fmt, ...);
+void MemBufferWriteString(MemBuffer *dst, const char *fmt, ...) ATTR_FMT_PRINTF(2, 3);
 
 #endif /* __UTIL_BUFFER_H__ */

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2023 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -39,10 +39,11 @@ void MemBufferFree(MemBuffer *buffer);
  *
  * \param mem_buffer Pointer to the mem buffer instance.
  */
-#define MemBufferReset(mem_buffer) do {                     \
-        (mem_buffer)->buffer[0] = 0;                        \
-        (mem_buffer)->offset = 0;                           \
-    } while (0)
+static inline void MemBufferReset(MemBuffer *b)
+{
+    b->buffer[0] = 0;
+    b->offset = 0;
+}
 
 /**
  * \brief Get the MemBuffers underlying buffer.
@@ -73,43 +74,24 @@ void MemBufferFree(MemBuffer *buffer);
  * \param buffer Pointer to the src MemBuffer instance to write.
  * \param fp     Pointer to the file instance to write to.
  */
-#define MemBufferPrintToFP(buffer, fp) do {             \
-        uint32_t i;                                     \
-                                                        \
-        for (i = 0; i < (buffer)->offset; i++) {            \
-            if (isprint(buffer->buffer[i]))                 \
-                fprintf(fp, "%c", (buffer)->buffer[i]);     \
-            else                                            \
-                fprintf(fp, "|%02X|", (buffer)->buffer[i]); \
-        }                                                   \
-    } while (0)
+void MemBufferPrintToFP(MemBuffer *buffer, FILE *fp);
 
 /**
  * \brief Write a buffer to the file pointer as a printable char string.
  *
- * \param buffer Pointer to the src MemBuffer instance to write.
- * \param fp     Pointer to the file instance to write to.
+ * \param b     Pointer to the src MemBuffer instance to write.
+ * \param fp    Pointer to the file instance to write to.
+ * \retval size_t bytes written by fwrite()
  */
-#define MemBufferPrintToFPAsString(mem_buffer, fp) ({                           \
-    fwrite((mem_buffer)->buffer, sizeof(uint8_t), (mem_buffer)->offset, fp);    \
-})
+size_t MemBufferPrintToFPAsString(MemBuffer *b, FILE *fp);
 
 /**
  * \brief Write a buffer in hex format.
  *
- * \param buffer Pointer to the src MemBuffer instance to write.
+ * \param b      Pointer to the src MemBuffer instance to write.
  * \param fp     Pointer to the file instance to write to.
  */
-#define MemBufferPrintToFPAsHex(mem_buffer, fp) do {        \
-        uint32_t i;                                     \
-                                                        \
-        for (i = 0; i < (mem_buffer)->offset; i++) {        \
-            if (((mem_buffer)->offset % 8) == 0)            \
-                fprintf(fp, "\n");                      \
-            fprintf(fp, " %02X", (mem_buffer)->buffer[i]);  \
-        }                                               \
-    } while (0)
-
+void MemBufferPrintToFPAsHex(MemBuffer *b, FILE *fp);
 
 /**
  * \brief Write a raw buffer to the MemBuffer dst.
@@ -130,21 +112,7 @@ void MemBufferFree(MemBuffer *buffer);
  * \param raw_buffer     The buffer to write.
  * \param raw_buffer_len Length of the above buffer.
  */
-#define MemBufferWriteRaw(dst, raw_buffer, raw_buffer_len) do { \
-        uint32_t write_len;                                     \
-                                                                \
-        if (((raw_buffer_len) >= (dst)->size - (dst)->offset)) {        \
-            SCLogDebug("Truncating data write since it exceeded buffer limit of " \
-                       "- %"PRIu32, (dst)->size);                       \
-            write_len = ((dst)->size - (dst)->offset) - 1;              \
-        } else {                                                        \
-            write_len = (raw_buffer_len);                               \
-        }                                                               \
-                                                                        \
-        memcpy((dst)->buffer + (dst)->offset, (raw_buffer), write_len); \
-        (dst)->offset += write_len;                                     \
-        dst->buffer[dst->offset] = '\0';                                \
-    } while (0)
+void MemBufferWriteRaw(MemBuffer *dst, const uint8_t *raw, const uint32_t raw_len);
 
 /**
  * \brief Write a string buffer to the Membuffer dst.
@@ -159,19 +127,6 @@ void MemBufferFree(MemBuffer *buffer);
  * \param format The format string.
  * \param ...    Variable arguments.
  */
-#define MemBufferWriteString(dst, ...) do {                             \
-        int cw = snprintf((char *)(dst)->buffer + (dst)->offset,        \
-                          (dst)->size - (dst)->offset,                  \
-                          __VA_ARGS__);                                 \
-        if (cw >= 0) {                                                  \
-            if ( ((dst)->offset + cw) >= (dst)->size) {                 \
-                SCLogDebug("Truncating data write since it exceeded buffer " \
-                           "limit of - %"PRIu32"\n", (dst)->size); \
-                (dst)->offset = (dst)->size - 1;                        \
-            } else {                                                    \
-                (dst->offset) += cw;                                    \
-            }                                                           \
-        }                                                               \
-    } while (0)
+void MemBufferWriteString(MemBuffer *dst, const char *fmt, ...);
 
 #endif /* __UTIL_BUFFER_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -176,6 +176,7 @@ outputs:
         - frame:
             # disabled by default as this is very verbose.
             enabled: no
+            # payload-buffer-size: 4kb # max size of frame payload buffer to output in eve-log
         - anomaly:
             # Anomaly log records describe unexpected conditions such
             # as truncated packets, packets with invalid IP/UDP/TCP


### PR DESCRIPTION
Continuation of #11634 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6555

Describe changes:
- Cherry-pick commits from https://github.com/OISF/suricata/pull/10654 for issue 6555
- s-v updates for 7.0.7+
Updates:
- Initialize membuffer values (detected via asan)

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2012
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
