### PR TITLE
Cherry-pick: tcp: fix 'broken ack' on flow timeout

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -223,7 +223,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
         p->tcph->th_dport = htons(f->dp);
 
         p->tcph->th_seq = htonl(ssn->client.next_seq);
-        p->tcph->th_ack = htonl(ssn->server.last_ack);
+        p->tcph->th_ack = 0;
 
         /* to client */
     } else {
@@ -231,7 +231,7 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
         p->tcph->th_dport = htons(f->sp);
 
         p->tcph->th_seq = htonl(ssn->server.next_seq);
-        p->tcph->th_ack = htonl(ssn->client.last_ack);
+        p->tcph->th_ack = 0;
     }
 
     if (FLOW_IS_IPV4(f)) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5369,10 +5369,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
          * we care about reassembly here. */
         if (p->flags & PKT_PSEUDO_STREAM_END) {
             if (PKT_IS_TOCLIENT(p)) {
-                ssn->client.last_ack = TCP_GET_ACK(p);
                 StreamTcpReassembleHandleSegment(tv, stt->ra_ctx, ssn, &ssn->server, p);
             } else {
-                ssn->server.last_ack = TCP_GET_ACK(p);
                 StreamTcpReassembleHandleSegment(tv, stt->ra_ctx, ssn, &ssn->client, p);
             }
             /* straight to 'skip' as we already handled reassembly */


### PR DESCRIPTION
Cherry-pick of 6490

Don't set an ACK value if ACK flag is no longer set. This avoids a bogus `pkt_broken_ack` event set.

Fixes: ebf465a11bff ("tcp: do not assign TCP flags to pseudopackets")

Ticket: #7158.
(cherry picked from commit a404fd26af64f60e8eaa86419a11393d7c4bfdda)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7166

Describe changes:
-Cherry-pick of fixes from 6490

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
