### PR TITLE
Backport of 6490: profiling: allow absolute paths

### DIFF
--- a/src/util-profiling-keywords.c
+++ b/src/util-profiling-keywords.c
@@ -32,6 +32,7 @@
 #include "detect-engine.h"
 #include "tm-threads.h"
 #include "util-conf.h"
+#include "util-path.h"
 #include "util-time.h"
 
 /**
@@ -67,11 +68,13 @@ void SCProfilingKeywordsGlobalInit(void)
             profiling_keyword_enabled = 1;
             const char *filename = ConfNodeLookupChildValue(conf, "filename");
             if (filename != NULL) {
-                const char *log_dir;
-                log_dir = ConfigGetLogDirectory();
-
-                snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s",
-                        log_dir, filename);
+                if (PathIsAbsolute(filename)) {
+                    strlcpy(profiling_file_name, filename, sizeof(profiling_file_name));
+                } else {
+                    const char *log_dir = ConfigGetLogDirectory();
+                    snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s", log_dir,
+                            filename);
+                }
 
                 const char *v = ConfNodeLookupChildValue(conf, "append");
                 if (v == NULL || ConfValIsTrue(v)) {

--- a/src/util-profiling-prefilter.c
+++ b/src/util-profiling-prefilter.c
@@ -30,6 +30,7 @@
 #ifdef PROFILING
 #include "detect-engine-prefilter.h"
 #include "util-conf.h"
+#include "util-path.h"
 #include "util-time.h"
 
 typedef struct SCProfilePrefilterData_ {
@@ -67,11 +68,13 @@ void SCProfilingPrefilterGlobalInit(void)
             profiling_prefilter_enabled = 1;
             const char *filename = ConfNodeLookupChildValue(conf, "filename");
             if (filename != NULL) {
-                const char *log_dir;
-                log_dir = ConfigGetLogDirectory();
-
-                snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s",
-                        log_dir, filename);
+                if (PathIsAbsolute(filename)) {
+                    strlcpy(profiling_file_name, filename, sizeof(profiling_file_name));
+                } else {
+                    const char *log_dir = ConfigGetLogDirectory();
+                    snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s", log_dir,
+                            filename);
+                }
 
                 const char *v = ConfNodeLookupChildValue(conf, "append");
                 if (v == NULL || ConfValIsTrue(v)) {

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -29,6 +29,7 @@
 
 #ifdef PROFILING
 #include "util-conf.h"
+#include "util-path.h"
 #include "util-time.h"
 
 /**
@@ -70,11 +71,13 @@ void SCProfilingSghsGlobalInit(void)
             profiling_sghs_enabled = 1;
             const char *filename = ConfNodeLookupChildValue(conf, "filename");
             if (filename != NULL) {
-                const char *log_dir;
-                log_dir = ConfigGetLogDirectory();
-
-                snprintf(profiling_file_name, sizeof(profiling_file_name),
-                        "%s/%s", log_dir, filename);
+                if (PathIsAbsolute(filename)) {
+                    strlcpy(profiling_file_name, filename, sizeof(profiling_file_name));
+                } else {
+                    const char *log_dir = ConfigGetLogDirectory();
+                    snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s", log_dir,
+                            filename);
+                }
 
                 const char *v = ConfNodeLookupChildValue(conf, "append");
                 if (v == NULL || ConfValIsTrue(v)) {

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -29,6 +29,7 @@
 
 #include "util-byte.h"
 #include "util-conf.h"
+#include "util-path.h"
 #include "util-time.h"
 
 #ifdef PROFILE_RULES
@@ -139,12 +140,13 @@ void SCProfilingRulesGlobalInit(void)
             }
             const char *filename = ConfNodeLookupChildValue(conf, "filename");
             if (filename != NULL) {
-
-                const char *log_dir;
-                log_dir = ConfigGetLogDirectory();
-
-                snprintf(profiling_file_name, sizeof(profiling_file_name),
-                        "%s/%s", log_dir, filename);
+                if (PathIsAbsolute(filename)) {
+                    strlcpy(profiling_file_name, filename, sizeof(profiling_file_name));
+                } else {
+                    const char *log_dir = ConfigGetLogDirectory();
+                    snprintf(profiling_file_name, sizeof(profiling_file_name), "%s/%s", log_dir,
+                            filename);
+                }
 
                 const char *v = ConfNodeLookupChildValue(conf, "append");
                 if (v == NULL || ConfValIsTrue(v)) {


### PR DESCRIPTION
Continuation of #11640 

Backport of ticket #6490 into main-7.0.x

(cherry picked from commit 855cc8963612387ff0440b707ce3145523f1a9ac)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7166

Describe changes:
- Backport of fix for 6490

Updates:
- Updated to use actual merge commit.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
