### PR TITLE
profiling: use correct conditional on packet profiling data dump v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2297,7 +2297,7 @@ void PostRunDeinit(const int runmode, struct timeval *start_time)
 
     TmqResetQueues();
 #ifdef PROFILING
-    if (profiling_rules_enabled)
+    if (profiling_packets_enabled)
         SCProfilingDump();
     SCProfilingDestroy();
 #endif


### PR DESCRIPTION
Minor fix to run SCProfilingDump when packet profiling is enabled and not when rule profiling is enabled.
SCProfilingDump is a function that dumps information related to packet profiling.

https://redmine.openinfosecfoundation.org/issues/7218
