### PR TITLE
flow: add support to define elephant flows

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6073,6 +6073,10 @@
                                     "Number of times retrieval of flow from hash was attempted but was unsuccessful",
                             "type": "integer"
                         },
+                        "elephant_flows": {
+                            "description": "Total number of elephant flows seen",
+                            "type": "integer"
+                        },
                         "icmpv4": {
                             "description": "Number of ICMPv4 flows",
                             "type": "integer"

--- a/src/decode.c
+++ b/src/decode.c
@@ -663,6 +663,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_flow_get_used_eval_reject = StatsRegisterCounter("flow.get_used_eval_reject", tv);
     dtv->counter_flow_get_used_eval_busy = StatsRegisterCounter("flow.get_used_eval_busy", tv);
     dtv->counter_flow_get_used_failed = StatsRegisterCounter("flow.get_used_failed", tv);
+    dtv->counter_flow_elephant = StatsRegisterCounter("flow.elephant_flows", tv);
 
     dtv->counter_flow_spare_sync_avg = StatsRegisterAvgCounter("flow.wrk.spare_sync_avg", tv);
     dtv->counter_flow_spare_sync = StatsRegisterCounter("flow.wrk.spare_sync", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -1013,6 +1013,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_flow_get_used_eval_reject;
     uint16_t counter_flow_get_used_eval_busy;
     uint16_t counter_flow_get_used_failed;
+    uint16_t counter_flow_elephant;
 
     uint16_t counter_flow_spare_sync;
     uint16_t counter_flow_spare_sync_empty;

--- a/src/flow.c
+++ b/src/flow.c
@@ -209,6 +209,23 @@ int FlowChangeProto(Flow *f)
     return 0;
 }
 
+static void FlowIsElephant(Flow *f, ThreadVars *tv, DecodeThreadVars *dtv)
+{
+    if (f->elephant)
+        return; /* Flow is a known elephant flow, no need to calculate again */
+    uint32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    if (age == 0)
+        return;
+    uint64_t rate_byte_influx = (f->tosrcbytecnt + f->todstbytecnt) / age;
+    if (rate_byte_influx >= flow_config.elephant_flow_rate) {
+        f->elephant = true;
+        StatsIncr(tv, dtv->counter_flow_elephant);
+        /* Let Flow Manager take care of this elephant flow */
+    }
+
+    /* Nothing should be reset as an elephant flow should not be considered a normal flow */
+}
+
 static inline void FlowSwapFlags(Flow *f)
 {
     SWAP_FLAGS(f->flags, FLOW_TO_SRC_SEEN, FLOW_TO_DST_SEEN);
@@ -421,6 +438,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     if (pkt_dir == TOSERVER) {
         f->todstpktcnt++;
         f->todstbytecnt += GET_PKT_LEN(p);
+        FlowIsElephant(f, tv, dtv);
         p->flowflags = FLOW_PKT_TOSERVER;
         if (!(f->flags & FLOW_TO_DST_SEEN)) {
             if (FlowUpdateSeenFlag(p)) {
@@ -445,6 +463,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
     } else {
         f->tosrcpktcnt++;
         f->tosrcbytecnt += GET_PKT_LEN(p);
+        FlowIsElephant(f, tv, dtv);
         p->flowflags = FLOW_PKT_TOCLIENT;
         if (!(f->flags & FLOW_TO_SRC_SEEN)) {
             if (FlowUpdateSeenFlag(p)) {
@@ -543,6 +562,7 @@ void FlowInitConfig(bool quiet)
     flow_config.hash_size   = FLOW_DEFAULT_HASHSIZE;
     flow_config.prealloc    = FLOW_DEFAULT_PREALLOC;
     SC_ATOMIC_SET(flow_config.memcap, FLOW_DEFAULT_MEMCAP);
+    flow_config.elephant_flow_rate = UINT32_MAX;
 
     /* If we have specific config, overwrite the defaults with them,
      * otherwise, leave the default values */
@@ -603,6 +623,16 @@ void FlowInitConfig(bool quiet)
         if (StringParseUint32(&configval, 10, strlen(conf_val),
                                     conf_val) > 0) {
             flow_config.prealloc = configval;
+        }
+    }
+
+    if ((ConfGet("elephant-flow.rate", &conf_val)) == 1) {
+        if (conf_val == NULL) {
+            FatalError("Invalid value for elephant_flow: NULL");
+        }
+
+        if (StringParseUint32(&configval, 10, strlen(conf_val), conf_val) > 0) {
+            flow_config.elephant_flow_rate = configval;
         }
     }
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -301,6 +301,8 @@ typedef struct FlowCnf_
     uint32_t timeout_new;
     uint32_t timeout_est;
 
+    uint32_t elephant_flow_rate;
+
     uint32_t emergency_recovery;
 
     enum ExceptionPolicy memcap_policy;
@@ -503,6 +505,7 @@ typedef struct Flow_
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
 
+    bool elephant;
     Storage storage[];
 } Flow;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1474,6 +1474,13 @@ flow:
   #managers: 1 # default to one flow manager
   #recyclers: 1 # default to one flow recycler thread
 
+# Mark a flow as an elephant flow if the rate of influx of bytes is equal to
+# or exceeds the given number. The rate is calculated by dividing the total
+# number of bytes a flow has seen in either direction divided by the time a
+# flow has been alive.
+elephant-flow:
+  rate: 1000000
+
 # This option controls the use of VLAN ids in the flow (and defrag)
 # hashing. Normally this should be enabled, but in some (broken)
 # setups where both sides of a flow are not tagged with the same VLAN


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/5647

Known TODOs:
1. Define and implement what marking an elephant flow from a rule would look like.
2. Steps that come after a flow has been marked. Should it be deferred to FM? What shall be done? Should it be a generic solution or configurable, etc.

Looking for feedback on:
1. Generic flags seemed to be full so added this as a separate boolean in `Flow` struct. Is this a good decision?
2. Is a default of u32_max ok?
3. Should the setting be off by default in `suricata.yaml`?