### PR TITLE
userguide: update Security Onion docs reference - v1

### DIFF
--- a/doc/userguide/public-data-sets.rst
+++ b/doc/userguide/public-data-sets.rst
@@ -13,6 +13,6 @@ Netresec: http://www.netresec.com/?page=PcapFiles
 
 Wireshark: https://gitlab.com/wireshark/wireshark/-/wikis/SampleCaptures
 
-Security Onion collection: https://securityonion.net/docs/Pcaps
+Security Onion collection: https://docs.securityonion.net/en/2.4/pcaps.html
 
 Stratosphere IPS. Malware Capture Facility Project: https://stratosphereips.org/category/dataset.html


### PR DESCRIPTION
Minor update, as in our Public Datasets section, the link to the Security Onion docs was returning 404.

Also checked the other links. Although some seem to only contain old traffic, they all still work.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- update link to Security Onion docs in our Public Data Sets section

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
