### PR TITLE
doc/rfb: mention accidental fix for security_result log

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -76,6 +76,11 @@ Removals
 ~~~~~~~~
 - The ssh keywords ``ssh.protoversion`` and ``ssh.softwareversion`` have been removed.
 
+Logging changes
+~~~~~~~~~~~~~~~
+- RFB security result is now consistently logged as ``security_result`` when it was
+  sometimes logged with a dash instead of an underscore.
+
 Upgrading 6.0 to 7.0
 --------------------
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7198

Describe changes:
- doc/rfb: mention accidental fix for security_result log

As requested in https://github.com/OISF/suricata/pull/11629#discussion_r1718466414

#11636 with typo fixed