### PR TITLE
7.0.x backport: eve/dns: make version required - v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -961,6 +961,9 @@
         },
         "dns": {
             "type": "object",
+            "required": [
+                "version"
+            ],
             "properties": {
                 "aa": {
                     "type": "boolean"
@@ -996,6 +999,7 @@
                     "type": "string"
                 },
                 "version": {
+                    "description": "The version of this EVE DNS event",
                     "type": "integer"
                 },
                 "opcode": {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -230,6 +230,7 @@ static void AlertJsonDns(const Flow *f, const uint64_t tx_id, JsonBuilder *js)
                                           dns_state, tx_id);
         if (txptr) {
             jb_open_object(js, "dns");
+            jb_set_int(js, "version", 2);
             JsonBuilder *qjs = JsonDNSLogQuery(txptr);
             if (qjs != NULL) {
                 jb_set_object(js, "query", qjs);

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -323,6 +323,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
         }
 
         jb_open_object(jb, "dns");
+        jb_set_int(jb, "version", 2);
         if (!rs_dns_log_json_query(txptr, i, td->dnslog_ctx->flags, jb)) {
             jb_free(jb);
             break;


### PR DESCRIPTION
Fixup of https://github.com/OISF/suricata/pull/11586 to make sure the `dns.version` is created in all code paths without duplicates.

Ticket: https://redmine.openinfosecfoundation.org/issues/7168
