### PR TITLE
detect/dataset: delay set operation after signature full match

### DIFF
--- a/src/detect-dataset.h
+++ b/src/detect-dataset.h
@@ -34,6 +34,7 @@
 typedef struct DetectDatasetData_ {
     Dataset *set;
     uint8_t cmd;
+    int thread_ctx_id;
 } DetectDatasetData;
 
 int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,

--- a/src/detect.c
+++ b/src/detect.c
@@ -1222,6 +1222,16 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         inspect_flags |= DE_STATE_FLAG_FULL_INSPECT;
         TRACE_SID_TXS(s->id, tx, "MATCH");
         retval = true;
+    } else {
+        const SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_POSTMATCH];
+        if (smd != NULL) {
+            while (1) {
+                (void)sigmatch_table[smd->type].Match(det_ctx, p, NULL, smd->ctx);
+                if (smd->is_last)
+                    break;
+                smd++;
+            }
+        }
     }
 
     if (stored_flags) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5576

Describe changes:
- detect/dataset: delay set operation after signature full match

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2000

https://github.com/OISF/suricata/pull/11623 with rebase to get greener CI

Side note: the limitation described for flowvar in https://redmine.openinfosecfoundation.org/issues/7197 also applies here to dataset, and needs a bigger design...

Draft : is it okay to get this in with this limitation ? As it already improves some cases ?
And could we run postmatch clean stuff if there is no complete match...
