### PR TITLE
Regit/dataset lookup fix v3

### DIFF
--- a/.github/workflows/live/icmp.rules
+++ b/.github/workflows/live/icmp.rules
@@ -1,2 +1,3 @@
 alert icmp any any -> any any (itype:8; sid:1;)
 alert icmp any any -> any any (itype:8; ip.dst; dataset:set,ipv4-list,type ipv4; sid:222;)
+alert icmp any any -> any any (itype:8; ip.dst; dataset:set,ipv6-list,type ipv6; sid:226;)

--- a/.github/workflows/live/pcap.sh
+++ b/.github/workflows/live/pcap.sh
@@ -75,6 +75,29 @@ if [ $CHECK -ne 2 ]; then
     RES=1
 fi
 
+JSON=$(python3 python/bin/suricatasc -c "dataset-add ipv6-list ip 192.168.1.1" /var/run/suricata/suricata-command.socket)
+echo $JSON
+if [ "$(echo $JSON | jq -r .message)" != "data added" ]; then
+    echo "ERROR unix socket dataset add failed"
+    RES=1
+fi
+
+# look it up in IPv4 in IPv6 notation
+JSON=$(python3 python/bin/suricatasc -c "dataset-lookup ipv6-list ip ::ffff:c0a8:0101" /var/run/suricata/suricata-command.socket)
+echo $JSON
+if [ "$(echo $JSON | jq -r .message)" != "item found in set" ]; then
+    echo "ERROR unix socket dataset lookup failed"
+    RES=1
+fi
+
+# fail to add junk
+JSON=$(python3 python/bin/suricatasc -c "dataset-add ipv6-list ip ::ffff:c0a8:0z0z" /var/run/suricata/suricata-command.socket)
+echo $JSON
+if [ "$(echo $JSON | jq -r .message)" != "failed to add data" ]; then
+    echo "ERROR unix socket dataset added junk"
+    RES=1
+fi
+
 echo "SURIPID $SURIPID PINGPID $PINGPID"
 
 # set second rule file for the reload

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -240,7 +240,7 @@ static int DatasetLoadIPv4(Dataset *set)
     return 0;
 }
 
-static int ParseIpv6String(Dataset *set, char *line, struct in6_addr *in6)
+static int ParseIpv6String(Dataset *set, const char *line, struct in6_addr *in6)
 {
     /* Checking IPv6 case */
     char *got_colon = strchr(line, ':');
@@ -1642,10 +1642,12 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
             return DatasetOpIPv4(set, (uint8_t *)&in.s_addr, 4);
         }
         case DATASET_TYPE_IPV6: {
-            struct in6_addr in;
-            if (inet_pton(AF_INET6, string, &in) != 1)
+            struct in6_addr in6;
+            if (ParseIpv6String(set, string, &in6) != 0) {
+                SCLogError("Dataset failed to import %s as IPv6", string);
                 return -2;
-            return DatasetOpIPv6(set, (uint8_t *)&in.s6_addr, 16);
+            }
+            return DatasetOpIPv6(set, (uint8_t *)&in6.s6_addr, 16);
         }
     }
     return -1;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6969

Describe changes:
- datasets: fix ipv6 operations when done with socket (for cases such as ipv4 in ipv6 notation)

https://github.com/OISF/suricata/pull/11663 with clean CI and git history

> Error: datasets: Dataset failed to import ::ffff:c0a8:0z0z as IPv6 [DatasetOpSerialized:datasets.c:1649]
