### PR TITLE
alert/metadata: no pgsql object encapsulation (7.0.x backport) - v1

### DIFF
--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -27,6 +27,7 @@ use std;
 pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("pgsql")?;
     js.set_uint("tx_id", tx.tx_id)?;
     if let Some(request) = &tx.request {
         js.set_object("request", &log_request(request, flags)?)?;
@@ -35,12 +36,14 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
         // TODO Log anomaly event instead?
         js.set_bool("request", false)?;
         js.set_bool("response", false)?;
+        js.close()?;
         return Ok(());
     }
 
     if !tx.responses.is_empty() {
         js.set_object("response", &log_response_object(tx)?)?;
     }
+    js.close()?;
 
     Ok(())
 }

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -661,7 +661,13 @@ pub unsafe extern "C" fn rs_pgsql_parse_response(
     flow: *const Flow, state: *mut std::os::raw::c_void, pstate: *mut std::os::raw::c_void,
     stream_slice: StreamSlice, _data: *const std::os::raw::c_void,
 ) -> AppLayerResult {
-    let _eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0;
+    if stream_slice.is_empty() {
+        if AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0 {
+            return AppLayerResult::ok();
+        } else {
+            return AppLayerResult::err();
+        }
+    }
 
     let state_safe: &mut PgsqlState = cast_pointer!(state, PgsqlState);
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013-2023 Open Information Security Foundation
+/* Copyright (C) 2013-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -78,6 +78,7 @@
 #include "output-json-modbus.h"
 #include "output-json-frame.h"
 #include "output-json-quic.h"
+#include "output-json-pgsql.h"
 
 #include "util-byte.h"
 #include "util-privs.h"
@@ -591,6 +592,12 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb, const uint64_t tx
             break;
         case ALPROTO_BITTORRENT_DHT:
             AlertJsonBitTorrentDHT(p->flow, tx_id, jb);
+            break;
+        case ALPROTO_PGSQL:
+            jb_get_mark(jb, &mark);
+            if (!JsonPgsqlAddMetadata(p->flow, tx_id, jb)) {
+                jb_restore_mark(jb, &mark);
+            }
             break;
         default:
             break;

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -70,11 +70,9 @@ static int JsonPgsqlLogger(ThreadVars *tv, void *thread_data, const Packet *p, F
         return TM_ECODE_FAILED;
     }
 
-    jb_open_object(jb, "pgsql");
     if (!rs_pgsql_logger(txptr, thread->pgsqllog_ctx->flags, jb)) {
         goto error;
     }
-    jb_close(jb);
 
     OutputJsonBuilderBuffer(jb, thread->ctx);
     jb_free(jb);

--- a/src/output-json-pgsql.h
+++ b/src/output-json-pgsql.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,5 +25,6 @@
 #define __OUTPUT_JSON_PGSQL_H__
 
 void JsonPgsqlLogRegister(void);
+bool JsonPgsqlAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *jb);
 
 #endif /* __OUTPUT_JSON_PGSQL_H__ */


### PR DESCRIPTION
Trying to decouple this backport from progress (or delays) of https://github.com/OISF/suricata/pull/11635

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7066

Describe changes:
- clean cherry-pick of https://github.com/OISF/suricata/pull/11253/commits/69e26de197c48e7f3e351229ee34b96388673b72
- add alert metadata logging for pgsql (from what I could see, the way this is seen in 7 is different from master, so couldn't simply backport what we have for that
- [extra] clean cherry-pick of ce1556cefd79ff53e3eb2 as this seemed like something that should be backported, too

### Provide values to any of the below to override the defaults.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2020