### PR TITLE
flow: Add cfg for optional flow reuse during low memory

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1071,6 +1071,14 @@ percent of the 10000 flows is completed).
   emergency_recovery: 30                  #Percentage of 1000 prealloc'd flows.
   prune_flows: 5                          #Amount of flows being terminated during the emergency mode.
 
+If aggressive flow pruning in emergency-mode is not desired, it can be disabled by
+configuring flow.force_reuse.
+
+::
+
+  flow:
+    force_reuse: false
+
 Flow Time-Outs
 ~~~~~~~~~~~~~~
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1180,9 +1180,14 @@ static inline bool StillAlive(const Flow *f, const SCTime_t ts)
  */
 static Flow *FlowGetUsedFlow(ThreadVars *tv, DecodeThreadVars *dtv, const SCTime_t ts)
 {
-    uint32_t idx = GetUsedAtomicUpdate(FLOW_GET_NEW_TRIES) % flow_config.hash_size;
     uint32_t tried = 0;
+    uint32_t idx;
 
+    if (!flow_config.force_reuse) {
+        return NULL;
+    }
+
+    idx = GetUsedAtomicUpdate(FLOW_GET_NEW_TRIES) % flow_config.hash_size;
     while (1) {
         if (tried++ > FLOW_GET_NEW_TRIES) {
             STATSADDUI64(counter_flow_get_used_eval, tried);

--- a/src/flow.c
+++ b/src/flow.c
@@ -606,11 +606,19 @@ void FlowInitConfig(bool quiet)
         }
     }
 
+    int confint_val;
+    if (ConfGetBool("flow.force-reuse", &confint_val) != 1) {
+        flow_config.force_reuse = true;
+    } else {
+        flow_config.force_reuse = !!confint_val;
+    }
+
     flow_config.memcap_policy = ExceptionPolicyParse("flow.memcap-policy", false);
 
-    SCLogDebug("Flow config from suricata.yaml: memcap: %"PRIu64", hash-size: "
-               "%"PRIu32", prealloc: %"PRIu32, SC_ATOMIC_GET(flow_config.memcap),
-               flow_config.hash_size, flow_config.prealloc);
+    SCLogDebug("Flow config from suricata.yaml: memcap: %" PRIu64 ", hash-size: "
+               "%" PRIu32 ", prealloc: %" PRIu32 ", reuse: %s",
+            SC_ATOMIC_GET(flow_config.memcap), flow_config.hash_size, flow_config.prealloc,
+            flow_config.force_reuse ? "force" : "disabled");
 
     /* alloc hash memory */
     uint64_t hash_size = flow_config.hash_size * sizeof(FlowBucket);

--- a/src/flow.h
+++ b/src/flow.h
@@ -298,6 +298,9 @@ typedef struct FlowCnf_
     uint32_t hash_size;
     uint32_t prealloc;
 
+    /* Controls if non-expired flows are re-used in low memory conditions. */
+    bool force_reuse;
+
     uint32_t timeout_new;
     uint32_t timeout_est;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1473,6 +1473,7 @@ flow:
   emergency-recovery: 30
   #managers: 1 # default to one flow manager
   #recyclers: 1 # default to one flow recycler thread
+  #force-reuse: true # Default to forcing flow reuse in low memory conditions
 
 # This option controls the use of VLAN ids in the flow (and defrag)
 # hashing. Normally this should be enabled, but in some (broken)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6293

Describe changes:
- Add a configuration option flow.force-reuse, enabled by default, that can turn off flow reuse in low memory situations.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2021

https://github.com/OISF/suricata/pull/10585 rebased with new SV test
