### PR TITLE
arp: profiling logger id must come before LOGGER_SIZE

### DIFF
--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -491,8 +491,10 @@ typedef enum {
     LOGGER_JSON_METADATA,
     LOGGER_JSON_FRAME,
     LOGGER_JSON_STREAM,
-    LOGGER_SIZE,
     LOGGER_JSON_ARP,
+
+    /* Must come last. */
+    LOGGER_SIZE,
 } LoggerId;
 
 /* If we don't have Lua, create a typedef for lua_State so the


### PR DESCRIPTION
Also added comment to make this more clear.
