### PR TITLE
doc/userguide: update guidance on 5 to 6 upgrading (7.0.x backport)

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -183,6 +183,12 @@ Removals
   if this behavior is still required. See :ref:`multiple-eve-instances`.
 - Unified2 has been removed. See :ref:`unified2-removed`.
 
+Performance
+~~~~~~~~~~~
+- In YAML files w/o a `flow-timeouts.tcp.closed` setting, the default went from 0 to 10 seconds.
+  This may lead to higher than expected TCP memory use:
+  https://redmine.openinfosecfoundation.org/issues/6552
+
 Upgrading 4.1 to 5.0
 --------------------
 


### PR DESCRIPTION
TCP memory use can be higher than expected in certain configs.

Ticket: #6552.
(cherry picked from commit 3456dea276c209b5bf0f95259a42f89d121ada32)

Ticket: https://redmine.openinfosecfoundation.org/issues/6641
