### PR TITLE
github/pr-template: update contribution checks - v1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,19 @@
-Make sure these boxes are signed before submitting your Pull Request -- thank you.
+Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.
 
+## Contribution style:
 - [ ] I have read the contributing guide lines at
    https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
+
+## Our Contribution agreements:
 - [ ] I have signed the Open Information Security Foundation contribution agreement at
    https://suricata.io/about/contribution-agreement/ (note: this is only required once)
-- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
+
+## Changes (if applicable):
+- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
+- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
+      (including schema descriptions)
 - [ ] I have created a ticket at
       https://redmine.openinfosecfoundation.org/projects/suricata/issues
-      (if applicable)
 
 Link to ticket: https://redmine.openinfosecfoundation.org/issues/
 


### PR DESCRIPTION
We have different types of checks, all in a single list. Adding a title of sorts to each group in the hopes of highlighting their purposes.

When we add new items to the json schema, many times we don't add their descriptions, while this would be the perfect time to also do that.

--

The balance between having too much info or not having what we want is always difficult, to me.

Didn't add anything related to that intentional mention of which ticket the PR fixes because I don't know if we already want to do that.