### PR TITLE
tls: bypass options of 'detectlog flush' pseudo packet from the parent packet

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6715,10 +6715,10 @@ static void StreamTcpPseudoPacketCreateDetectLogFlush(ThreadVars *tv,
     np->vlan_idx = f->vlan_idx;
     np->livedev = (struct LiveDevice_ *)f->livedev;
 
-    if (f->flags & FLOW_NOPACKET_INSPECTION) {
+    if (parent->flags & PKT_NOPACKET_INSPECTION) {
         DecodeSetNoPacketInspectionFlag(np);
     }
-    if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
+    if (parent->flags & PKT_NOPAYLOAD_INSPECTION) {
         DecodeSetNoPayloadInspectionFlag(np);
     }
 


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues
      (if applicable)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7235

Describe changes:

Flow flags may already have 'no inspection' flags set by the application layer. As a result, detection is not applied to the unencrypted part of the stream buffer. The condition is reachable e.g. when encrypted data follows the plane one in the same packet. To avoid this, the original packet bypass options are inherited by 'detectlog flush' pseudo packet instead of flow options.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2026
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
