### PR TITLE
[detect] Harmonize code for validate callbacks 5634 v2

### DIFF
--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -90,29 +90,6 @@
 
 #include "util-spm.h"
 
-typedef struct DetectContentData_ {
-    uint8_t *content;
-    uint16_t content_len;
-    uint16_t replace_len;
-    /* for chopped fast pattern, the length */
-    uint16_t fp_chop_len;
-    /* for chopped fast pattern, the offset */
-    uint16_t fp_chop_offset;
-    /* would want to move PatIntId here and flags down to remove the padding
-     * gap, but I think the first four members was used as a template for
-     * casting.  \todo check this and fix it if possible */
-    uint32_t flags;
-    PatIntId id;
-    uint16_t depth;
-    uint16_t offset;
-    int32_t distance;
-    int32_t within;
-    /* SPM search context. */
-    SpmCtx *spm_ctx;
-    /* pointer to replacement data */
-    uint8_t *replace;
-} DetectContentData;
-
 /* prototypes */
 void DetectContentRegister(void);
 DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1300,8 +1300,9 @@ void DetectEngineBufferRunSetupCallback(const DetectEngineCtx *de_ctx, const int
     }
 }
 
-void DetectBufferTypeRegisterValidateCallback(const char *name,
-        bool (*ValidateCallback)(const Signature *, const char **sigerror))
+void DetectBufferTypeRegisterValidateCallback(
+        const char *name, bool (*ValidateCallback)(const Signature *, const DetectContentData *,
+                                  const char **sigerror))
 {
     BUG_ON(g_buffer_type_reg_closed);
     DetectBufferTypeRegister(name);
@@ -1315,7 +1316,20 @@ bool DetectEngineBufferRunValidateCallback(
 {
     const DetectBufferType *map = DetectEngineBufferTypeGetById(de_ctx, id);
     if (map && map->ValidateCallback) {
-        return map->ValidateCallback(s, sigerror);
+        for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
+            if (s->init_data->buffers[x].id != (uint32_t)map->id)
+                continue;
+            const SigMatch *sm = s->init_data->buffers[x].head;
+            for (; sm != NULL; sm = sm->next) {
+                if (sm->type != DETECT_CONTENT)
+                    continue;
+
+                const DetectContentData *cd = (DetectContentData *)sm->ctx;
+                if (!map->ValidateCallback(s, cd, sigerror)) {
+                    return false;
+                }
+            }
+        }
     }
     return true;
 }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4952,6 +4952,35 @@ void DetectEngineSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e)
     det_ctx->events++;
 }
 
+bool DetectMd5ValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
+{
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = "md5-like keyword should not be used together with "
+                    "nocase, since the rule is automatically "
+                    "lowercased anyway which makes nocase redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+    }
+
+    if (cd->content_len != SC_MD5_HEX_LEN) {
+        *sigerror = "Invalid length for md5-like keyword (should "
+                    "be 32 characters long). This rule will therefore "
+                    "never match.";
+        SCLogError("rule %u: %s", s->id, *sigerror);
+        return false;
+    }
+
+    for (size_t i = 0; i < cd->content_len; ++i) {
+        if (!isxdigit(cd->content[i])) {
+            *sigerror = "Invalid md5-like string (should be string of hexadecimal characters)."
+                        "This rule will therefore never match.";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
+        }
+    }
+    return true;
+}
+
 /*************************************Unittest*********************************/
 
 #ifdef UNITTESTS

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -58,8 +58,9 @@ void DetectBufferTypeSetDescriptionByName(const char *name, const char *desc);
 const char *DetectBufferTypeGetDescriptionByName(const char *name);
 void DetectBufferTypeRegisterSetupCallback(const char *name,
         void (*Callback)(const DetectEngineCtx *, Signature *));
-void DetectBufferTypeRegisterValidateCallback(const char *name,
-        bool (*ValidateCallback)(const Signature *, const char **sigerror));
+void DetectBufferTypeRegisterValidateCallback(
+        const char *name, bool (*ValidateCallback)(const Signature *s, const DetectContentData *cd,
+                                  const char **sigerror));
 
 /* detect engine related buffer funcs */
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -210,6 +210,9 @@ void DetectRunStoreStateTx(const SigGroupHead *sgh, Flow *f, void *tx, uint64_t 
 
 void DetectEngineStateResetTxs(Flow *f);
 
+bool DetectMd5ValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror);
+
 void DeStateRegisterTests(void);
 
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -62,7 +62,8 @@ static int DetectHttpHHSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectHttpHHRegisterTests(void);
 #endif
-static bool DetectHttpHostValidateCallback(const Signature *s, const char **sigerror);
+static bool DetectHttpHostValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror);
 static int DetectHttpHostSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
@@ -177,42 +178,32 @@ static int DetectHttpHHSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
             de_ctx, s, arg, DETECT_AL_HTTP_HOST, g_http_host_buffer_id, ALPROTO_HTTP1);
 }
 
-static bool DetectHttpHostValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpHostValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_http_host_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type == DETECT_CONTENT) {
-                DetectContentData *cd = (DetectContentData *)sm->ctx;
-                if (cd->flags & DETECT_CONTENT_NOCASE) {
-                    *sigerror = "http.host keyword "
-                                "specified along with \"nocase\". "
-                                "The hostname buffer is normalized "
-                                "to lowercase, specifying "
-                                "nocase is redundant.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                } else {
-                    uint32_t u;
-                    for (u = 0; u < cd->content_len; u++) {
-                        if (isupper(cd->content[u]))
-                            break;
-                    }
-                    if (u != cd->content_len) {
-                        *sigerror = "A pattern with "
-                                    "uppercase characters detected for http.host. "
-                                    "The hostname buffer is normalized to lowercase, "
-                                    "please specify a lowercase pattern.";
-                        SCLogWarning("rule %u: %s", s->id, *sigerror);
-                        return false;
-                    }
-                }
-            }
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = "http.host keyword "
+                    "specified along with \"nocase\". "
+                    "The hostname buffer is normalized "
+                    "to lowercase, specifying "
+                    "nocase is redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+        return false;
+    } else {
+        uint32_t u;
+        for (u = 0; u < cd->content_len; u++) {
+            if (isupper(cd->content[u]))
+                break;
+        }
+        if (u != cd->content_len) {
+            *sigerror = "A pattern with "
+                        "uppercase characters detected for http.host. "
+                        "The hostname buffer is normalized to lowercase, "
+                        "please specify a lowercase pattern.";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
         }
     }
-
     return true;
 }
 

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -128,24 +128,15 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectHttpProtocolValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpProtocolValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
 #ifdef HAVE_HTP_CONFIG_SET_ALLOW_SPACE_URI
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (cd->content[i] == ' ') {
-                    *sigerror = "Invalid http.protocol string containing a space";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
+    for (size_t i = 0; i < cd->content_len; ++i) {
+        if (cd->content[i] == ' ') {
+            *sigerror = "Invalid http.protocol string containing a space";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
         }
     }
 #endif

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -58,7 +58,8 @@ static int DetectHttpRawHeaderSetupSticky(DetectEngineCtx *de_ctx, Signature *s,
 #ifdef UNITTESTS
 static void DetectHttpRawHeaderRegisterTests(void);
 #endif
-static bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror);
+static bool DetectHttpRawHeaderValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror);
 static int g_http_raw_header_buffer_id = 0;
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
@@ -163,7 +164,8 @@ static int DetectHttpRawHeaderSetupSticky(DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 }
 
-static bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpRawHeaderValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
     if ((s->flags & (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) == (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) {
         *sigerror = "http_raw_header signature "

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -61,7 +61,6 @@ static void DetectHttpUriRegisterTests(void);
 #endif
 static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
                                        Signature *s);
-static bool DetectHttpUriValidateCallback(const Signature *s, const char **sigerror);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
@@ -73,7 +72,6 @@ static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
                                           Signature *s);
-static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **);
 static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
@@ -125,8 +123,7 @@ void DetectHttpUriRegister (void)
     DetectBufferTypeRegisterSetupCallback("http_uri",
             DetectHttpUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("http_uri",
-            DetectHttpUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("http_uri", DetectUrilenValidateContent);
 
     g_http_uri_buffer_id = DetectBufferTypeGetByName("http_uri");
 
@@ -164,8 +161,7 @@ void DetectHttpUriRegister (void)
     DetectBufferTypeRegisterSetupCallback("http_raw_uri",
             DetectHttpRawUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("http_raw_uri",
-            DetectHttpRawUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("http_raw_uri", DetectUrilenValidateContent);
 
     g_http_raw_uri_buffer_id = DetectBufferTypeGetByName("http_raw_uri");
 }
@@ -185,11 +181,6 @@ int DetectHttpUriSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     return DetectEngineContentModifierBufferSetup(
             de_ctx, s, str, DETECT_AL_HTTP_URI, g_http_uri_buffer_id, ALPROTO_HTTP1);
-}
-
-static bool DetectHttpUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_http_uri_buffer_id, sigerror);
 }
 
 static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
@@ -280,11 +271,6 @@ static int DetectHttpRawUriSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 {
     return DetectEngineContentModifierBufferSetup(
             de_ctx, s, arg, DETECT_AL_HTTP_RAW_URI, g_http_raw_uri_buffer_id, ALPROTO_HTTP1);
-}
-
-static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_http_raw_uri_buffer_id, sigerror);
 }
 
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -59,8 +59,7 @@
 #ifdef UNITTESTS
 static void DetectHttpUriRegisterTests(void);
 #endif
-static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
-                                       Signature *s);
+static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
@@ -70,8 +69,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         const int list_id);
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
-                                          Signature *s);
+static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -82,35 +82,6 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static bool DetectQuicHashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror)
-{
-    if (cd->flags & DETECT_CONTENT_NOCASE) {
-        *sigerror = BUFFER_NAME " should not be used together with "
-                                "nocase, since the rule is automatically "
-                                "lowercased anyway which makes nocase redundant.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-    }
-
-    if (cd->content_len != 32) {
-        *sigerror = "Invalid length of the specified" BUFFER_NAME " (should "
-                    "be 32 characters long). This rule will therefore "
-                    "never match.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-        return false;
-    }
-    for (size_t i = 0; i < cd->content_len; ++i) {
-        if (!isxdigit(cd->content[i])) {
-            *sigerror =
-                    "Invalid " BUFFER_NAME " string (should be string of hexadecimal characters)."
-                    "This rule will therefore never match.";
-            SCLogWarning("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
-    }
-    return true;
-}
-
 void DetectQuicCyuHashRegister(void)
 {
     /* quic.cyu.hash sticky buffer */
@@ -130,7 +101,7 @@ void DetectQuicCyuHashRegister(void)
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectQuicHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 
     DetectBufferTypeSupportsMultiInstance(BUFFER_NAME);
 }

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -82,41 +82,30 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static bool DetectQuicHashValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectQuicHashValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = BUFFER_NAME " should not be used together with "
+                                "nocase, since the rule is automatically "
+                                "lowercased anyway which makes nocase redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+    }
 
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = BUFFER_NAME " should not be used together with "
-                                        "nocase, since the rule is automatically "
-                                        "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified" BUFFER_NAME " (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror = "Invalid " BUFFER_NAME
-                                " string (should be string of hexadecimal characters)."
-                                "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
+    if (cd->content_len != 32) {
+        *sigerror = "Invalid length of the specified" BUFFER_NAME " (should "
+                    "be 32 characters long). This rule will therefore "
+                    "never match.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+        return false;
+    }
+    for (size_t i = 0; i < cd->content_len; ++i) {
+        if (!isxdigit(cd->content[i])) {
+            *sigerror =
+                    "Invalid " BUFFER_NAME " string (should be string of hexadecimal characters)."
+                    "This rule will therefore never match.";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
         }
     }
     return true;

--- a/src/detect-sip-method.c
+++ b/src/detect-sip-method.c
@@ -69,35 +69,26 @@ static int DetectSipMethodSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 }
 
-static bool DetectSipMethodValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectSipMethodValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-            const DetectContentData *cd = (const DetectContentData *)sm->ctx;
-            if (cd->content && cd->content_len) {
-                if (cd->content[cd->content_len - 1] == 0x20) {
-                    *sigerror = "sip.method pattern with trailing space";
-                    SCLogError("%s", *sigerror);
-                    return true;
-                } else if (cd->content[0] == 0x20) {
-                    *sigerror = "sip.method pattern with leading space";
-                    SCLogError("%s", *sigerror);
-                    return true;
-                } else if (cd->content[cd->content_len - 1] == 0x09) {
-                    *sigerror = "sip.method pattern with trailing tab";
-                    SCLogError("%s", *sigerror);
-                    return true;
-                } else if (cd->content[0] == 0x09) {
-                    *sigerror = "sip.method pattern with leading tab";
-                    SCLogError("%s", *sigerror);
-                    return true;
-                }
-            }
+    if (cd->content && cd->content_len) {
+        if (cd->content[cd->content_len - 1] == 0x20) {
+            *sigerror = "sip.method pattern with trailing space";
+            SCLogError("%s", *sigerror);
+            return true;
+        } else if (cd->content[0] == 0x20) {
+            *sigerror = "sip.method pattern with leading space";
+            SCLogError("%s", *sigerror);
+            return true;
+        } else if (cd->content[cd->content_len - 1] == 0x09) {
+            *sigerror = "sip.method pattern with trailing tab";
+            SCLogError("%s", *sigerror);
+            return true;
+        } else if (cd->content[0] == 0x09) {
+            *sigerror = "sip.method pattern with leading tab";
+            SCLogError("%s", *sigerror);
+            return true;
         }
     }
     return true;

--- a/src/detect-sip-uri.c
+++ b/src/detect-sip-uri.c
@@ -59,11 +59,6 @@
 #define BUFFER_DESC  "sip request uri"
 static int g_buffer_id = 0;
 
-static bool DetectSipUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_buffer_id, sigerror);
-}
-
 static void DetectSipUriSetupCallback(const DetectEngineCtx *de_ctx,
                                        Signature *s)
 {
@@ -122,8 +117,7 @@ void DetectSipUriRegister(void)
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME,
             DetectSipUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME,
-            DetectSipUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectUrilenValidateContent);
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -118,41 +118,30 @@ static int DetectSshHasshServerSetup(DetectEngineCtx *de_ctx, Signature *s, cons
 
 }
 
-static bool DetectSshHasshServerHashValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectSshHasshServerHashValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_ssh_hassh_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = "ssh.hassh.server should not be used together with "
+                    "nocase, since the rule is automatically "
+                    "lowercased anyway which makes nocase redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+    }
 
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ssh.hassh.server should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified ssh.hassh.server (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror = "Invalid ssh.hassh.server string (should be string of hexadecimal "
-                                "characters)."
-                                "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
+    if (cd->content_len != 32) {
+        *sigerror = "Invalid length of the specified ssh.hassh.server (should "
+                    "be 32 characters long). This rule will therefore "
+                    "never match.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+        return false;
+    }
+    for (size_t i = 0; i < cd->content_len; ++i) {
+        if (!isxdigit(cd->content[i])) {
+            *sigerror = "Invalid ssh.hassh.server string (should be string of hexadecimal "
+                        "characters)."
+                        "This rule will therefore never match.";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
         }
     }
     return true;

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -118,35 +118,6 @@ static int DetectSshHasshServerSetup(DetectEngineCtx *de_ctx, Signature *s, cons
 
 }
 
-static bool DetectSshHasshServerHashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror)
-{
-    if (cd->flags & DETECT_CONTENT_NOCASE) {
-        *sigerror = "ssh.hassh.server should not be used together with "
-                    "nocase, since the rule is automatically "
-                    "lowercased anyway which makes nocase redundant.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-    }
-
-    if (cd->content_len != 32) {
-        *sigerror = "Invalid length of the specified ssh.hassh.server (should "
-                    "be 32 characters long). This rule will therefore "
-                    "never match.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-        return false;
-    }
-    for (size_t i = 0; i < cd->content_len; ++i) {
-        if (!isxdigit(cd->content[i])) {
-            *sigerror = "Invalid ssh.hassh.server string (should be string of hexadecimal "
-                        "characters)."
-                        "This rule will therefore never match.";
-            SCLogWarning("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
-    }
-    return true;
-}
-
 static void DetectSshHasshServerHashSetupCallback(const DetectEngineCtx *de_ctx,
                                           Signature *s)
 {
@@ -195,5 +166,5 @@ void DetectSshHasshServerRegister(void)
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME, DetectSshHasshServerHashSetupCallback);
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectSshHasshServerHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 }

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -118,43 +118,29 @@ static int DetectSshHasshSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 }
 
-
-static bool DetectSshHasshHashValidateCallback(const Signature *s,
-                                              const char **sigerror)
+static bool DetectSshHasshHashValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_ssh_hassh_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = "ssh.hassh should not be used together with "
+                    "nocase, since the rule is automatically "
+                    "lowercased anyway which makes nocase redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+    }
 
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ssh.hassh should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified ssh.hassh (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror =
-                            "Invalid ssh.hassh string (should be string of hexadecimal characters)."
-                            "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
+    if (cd->content_len != 32) {
+        *sigerror = "Invalid length of the specified ssh.hassh (should "
+                    "be 32 characters long). This rule will therefore "
+                    "never match.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
+        return false;
+    }
+    for (size_t i = 0; i < cd->content_len; ++i) {
+        if (!isxdigit(cd->content[i])) {
+            *sigerror = "Invalid ssh.hassh string (should be string of hexadecimal characters)."
+                        "This rule will therefore never match.";
+            SCLogWarning("rule %u: %s", s->id, *sigerror);
+            return false;
         }
     }
     return true;

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -118,34 +118,6 @@ static int DetectSshHasshSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 }
 
-static bool DetectSshHasshHashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror)
-{
-    if (cd->flags & DETECT_CONTENT_NOCASE) {
-        *sigerror = "ssh.hassh should not be used together with "
-                    "nocase, since the rule is automatically "
-                    "lowercased anyway which makes nocase redundant.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-    }
-
-    if (cd->content_len != 32) {
-        *sigerror = "Invalid length of the specified ssh.hassh (should "
-                    "be 32 characters long). This rule will therefore "
-                    "never match.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-        return false;
-    }
-    for (size_t i = 0; i < cd->content_len; ++i) {
-        if (!isxdigit(cd->content[i])) {
-            *sigerror = "Invalid ssh.hassh string (should be string of hexadecimal characters)."
-                        "This rule will therefore never match.";
-            SCLogWarning("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
-    }
-    return true;
-}
-
 static void DetectSshHasshHashSetupCallback(const DetectEngineCtx *de_ctx,
                                           Signature *s)
 {
@@ -194,6 +166,6 @@ void DetectSshHasshRegister(void)
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME, DetectSshHasshHashSetupCallback);
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectSshHasshHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 }
 

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -70,10 +70,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
-static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
-       Signature *s);
-static bool DetectTlsJa3HashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror);
+static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static int g_tls_ja3_hash_buffer_id = 0;
 #endif
 
@@ -112,8 +109,7 @@ void DetectTlsJa3HashRegister(void)
     DetectBufferTypeRegisterSetupCallback("ja3.hash",
             DetectTlsJa3HashSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("ja3.hash",
-            DetectTlsJa3HashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("ja3.hash", DetectMd5ValidateCallback);
 
     g_tls_ja3_hash_buffer_id = DetectBufferTypeGetByName("ja3.hash");
 #endif /* HAVE_JA3 */
@@ -176,26 +172,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     }
 
     return buffer;
-}
-
-static bool DetectTlsJa3HashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror)
-{
-    if (cd->flags & DETECT_CONTENT_NOCASE) {
-        *sigerror = "ja3.hash should not be used together with "
-                    "nocase, since the rule is automatically "
-                    "lowercased anyway which makes nocase redundant.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-    }
-
-    if (cd->content_len == SC_MD5_HEX_LEN)
-        return true;
-
-    *sigerror = "Invalid length of the specified JA3 hash (should "
-                "be 32 characters long). This rule will therefore "
-                "never match.";
-    SCLogWarning("rule %u: %s", s->id, *sigerror);
-    return false;
 }
 
 static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -72,8 +72,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        void *txv, const int list_id);
 static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
        Signature *s);
-static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
-       const char **sigerror);
+static bool DetectTlsJa3SHashValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror);
 static int g_tls_ja3s_hash_buffer_id = 0;
 #endif
 
@@ -176,37 +176,24 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
-                                               const char **sigerror)
+static bool DetectTlsJa3SHashValidateCallback(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_tls_ja3s_hash_buffer_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ja3s.hash should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len == SC_MD5_HEX_LEN)
-                return true;
-
-            *sigerror = "Invalid length of the specified JA3S hash (should "
-                        "be 32 characters long). This rule will therefore "
-                        "never match.";
-            SCLogError("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
+    if (cd->flags & DETECT_CONTENT_NOCASE) {
+        *sigerror = "ja3s.hash should not be used together with "
+                    "nocase, since the rule is automatically "
+                    "lowercased anyway which makes nocase redundant.";
+        SCLogWarning("rule %u: %s", s->id, *sigerror);
     }
-    return true;
+
+    if (cd->content_len == SC_MD5_HEX_LEN)
+        return true;
+
+    *sigerror = "Invalid length of the specified JA3S hash (should "
+                "be 32 characters long). This rule will therefore "
+                "never match.";
+    SCLogError("rule %u: %s", s->id, *sigerror);
+    return false;
 }
 
 static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -70,10 +70,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
-static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
-       Signature *s);
-static bool DetectTlsJa3SHashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror);
+static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static int g_tls_ja3s_hash_buffer_id = 0;
 #endif
 
@@ -111,8 +108,7 @@ void DetectTlsJa3SHashRegister(void)
     DetectBufferTypeRegisterSetupCallback("ja3s.hash",
             DetectTlsJa3SHashSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("ja3s.hash",
-            DetectTlsJa3SHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("ja3s.hash", DetectMd5ValidateCallback);
 
     g_tls_ja3s_hash_buffer_id = DetectBufferTypeGetByName("ja3s.hash");
 #endif /* HAVE_JA3 */
@@ -174,26 +170,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     }
 
     return buffer;
-}
-
-static bool DetectTlsJa3SHashValidateCallback(
-        const Signature *s, const DetectContentData *cd, const char **sigerror)
-{
-    if (cd->flags & DETECT_CONTENT_NOCASE) {
-        *sigerror = "ja3s.hash should not be used together with "
-                    "nocase, since the rule is automatically "
-                    "lowercased anyway which makes nocase redundant.";
-        SCLogWarning("rule %u: %s", s->id, *sigerror);
-    }
-
-    if (cd->content_len == SC_MD5_HEX_LEN)
-        return true;
-
-    *sigerror = "Invalid length of the specified JA3S hash (should "
-                "be 32 characters long). This rule will therefore "
-                "never match.";
-    SCLogError("rule %u: %s", s->id, *sigerror);
-    return false;
 }
 
 static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -217,13 +217,13 @@ void DetectUrilenApplyToContent(Signature *s, int list)
 bool DetectUrilenValidateContent(
         const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-            if (cd->depth && cd->depth < cd->content_len) {
-                *sigerror = "depth or urilen smaller than content len";
-                SCLogError("depth or urilen %u smaller "
-                           "than content len %u",
-                        cd->depth, cd->content_len);
-                return false;
-            }
+    if (cd->depth && cd->depth < cd->content_len) {
+        *sigerror = "depth or urilen smaller than content len";
+        SCLogError("depth or urilen %u smaller "
+                   "than content len %u",
+                cd->depth, cd->content_len);
+        return false;
+    }
     return true;
 }
 

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -214,20 +214,9 @@ void DetectUrilenApplyToContent(Signature *s, int list)
     }
 }
 
-bool DetectUrilenValidateContent(const Signature *s, int list, const char **sigerror)
+bool DetectUrilenValidateContent(
+        const Signature *s, const DetectContentData *cd, const char **sigerror)
 {
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)list)
-            continue;
-        for (const SigMatch *sm = s->init_data->buffers[x].head; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT) {
-                continue;
-            }
-            DetectContentData *cd = (DetectContentData *)sm->ctx;
-            if (cd == NULL) {
-                continue;
-            }
-
             if (cd->depth && cd->depth < cd->content_len) {
                 *sigerror = "depth or urilen smaller than content len";
                 SCLogError("depth or urilen %u smaller "
@@ -235,8 +224,6 @@ bool DetectUrilenValidateContent(const Signature *s, int list, const char **sige
                         cd->depth, cd->content_len);
                 return false;
             }
-        }
-    }
     return true;
 }
 

--- a/src/detect-urilen.h
+++ b/src/detect-urilen.h
@@ -24,7 +24,7 @@
 #ifndef _DETECT_URILEN_H
 #define	_DETECT_URILEN_H
 
-bool DetectUrilenValidateContent(const Signature *s, int list, const char **);
+bool DetectUrilenValidateContent(const Signature *s, const DetectContentData *cd, const char **);
 void DetectUrilenApplyToContent(Signature *s, int list);
 void DetectUrilenRegister(void);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -451,6 +451,29 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct DetectEngineAppInspectionEngine_ *next;
 } DetectEngineAppInspectionEngine;
 
+typedef struct DetectContentData_ {
+    uint8_t *content;
+    uint16_t content_len;
+    uint16_t replace_len;
+    /* for chopped fast pattern, the length */
+    uint16_t fp_chop_len;
+    /* for chopped fast pattern, the offset */
+    uint16_t fp_chop_offset;
+    /* would want to move PatIntId here and flags down to remove the padding
+     * gap, but I think the first four members was used as a template for
+     * casting.  \todo check this and fix it if possible */
+    uint32_t flags;
+    PatIntId id;
+    uint16_t depth;
+    uint16_t offset;
+    int32_t distance;
+    int32_t within;
+    /* SPM search context. */
+    SpmCtx *spm_ctx;
+    /* pointer to replacement data */
+    uint8_t *replace;
+} DetectContentData;
+
 typedef struct DetectBufferType_ {
     char name[32];
     char description[128];
@@ -462,7 +485,8 @@ typedef struct DetectBufferType_ {
     bool supports_transforms;
     bool multi_instance; /**< buffer supports multiple buffer instances per tx */
     void (*SetupCallback)(const struct DetectEngineCtx_ *, struct Signature_ *);
-    bool (*ValidateCallback)(const struct Signature_ *, const char **sigerror);
+    bool (*ValidateCallback)(
+            const struct Signature_ *s, const struct DetectContentData_ *cd, const char **sigerror);
     DetectEngineTransforms transforms;
 } DetectBufferType;
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5634

Describe changes:
- detect: change the ValidateCallback prototype to deduplicate code
- detect: use one function for md5-like keywords (quic-cyu-hash, ssh-hassh, tls-ja3-hash...)

#11697 with clean git history

This was done on the way to convert quic keywords to rust like https://github.com/OISF/suricata/pull/11575

With this PR, it should be easy to add a wrapper for rust for this ValidateCallback stuff