### PR TITLE
Dcerpc header 7230/v2

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020-2022 Open Information Security Foundation
+/* Copyright (C) 2020-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -606,6 +606,7 @@ impl DCERPCState {
     /// * Success: Number of bytes successfully parsed.
     /// * Failure: -1 in case of Incomplete data or Eof.
     ///            -2 in case of Error while parsing.
+    ///            -3 in case of invalid DCERPC header.
     pub fn process_header(&mut self, input: &[u8]) -> i32 {
         match parser::parse_dcerpc_header(input) {
             Ok((leftover_bytes, header)) => {
@@ -617,7 +618,7 @@ impl DCERPCState {
                         header.rpc_vers,
                         header.rpc_vers_minor
                     );
-                    return -1;
+                    return -3;
                 }
                 self.header = Some(header);
                 (input.len() - leftover_bytes.len()) as i32
@@ -980,7 +981,7 @@ impl DCERPCState {
                 self.extend_buffer(buffer, direction);
                 return AppLayerResult::ok();
             }
-            if parsed == -2 {
+            if parsed < 0 {
                 return AppLayerResult::err();
             }
             self.bytes_consumed += parsed;

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -690,6 +690,7 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 parser_error:
     ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
     AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
+    AppLayerIncFlowCounter(tv, f);
     SCReturnInt(-1);
 detect_error:
     DisableAppLayer(tv, f, p);
@@ -845,6 +846,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx, Packet
                     ExceptionPolicyApply(
                             p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
                     AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
+                    AppLayerIncFlowCounter(tv, f);
                     SCReturnInt(-1);
                 }
             }
@@ -986,6 +988,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     if (r < 0) {
         ExceptionPolicyApply(p, g_applayerparser_error_policy, PKT_DROP_REASON_APPLAYER_ERROR);
         AppLayerIncrErrorExcPolicyCounter(tv, f, g_applayerparser_error_policy);
+        AppLayerIncFlowCounter(tv, f);
         SCReturnInt(-1);
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7230

Previous PR: https://github.com/OISF/suricata/pull/11676

Changes since v1:
- commit 7e868889ef5810f3ae7cd8825dbe8e1276cdf954 to count even the flows that errored out in applayer parser
- rebased on top of latest master