### PR TITLE
rust/rfb: use consistent key name for security_result (7.0.x backport) - v3

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1895,7 +1895,7 @@ Fields
 * "client_protocol_version.major", "client_protocol_version.minor": The RFB protocol version agreed by the client.
 * "authentication.security_type": Security type agreed upon in the logged transaction, e.g. ``2`` is VNC auth.
 * "authentication.vnc.challenge", "authentication.vnc.response": Only available when security type 2 is used. Contains the challenge and response byte buffers exchanged by the server and client as hex strings.
-* "authentication.security-result": Result of the authentication process (``OK``, ``FAIL`` or ``TOOMANY``).
+* "authentication.security_result": Result of the authentication process (``OK``, ``FAIL`` or ``TOOMANY``).
 * "screen_shared": Boolean value describing whether the client requested screen sharing.
 * "framebuffer": Contains metadata about the initial screen setup process. Only available when the handshake completed this far.
 * "framebuffer.width", "framebuffer.height": Screen size as offered by the server.
@@ -1925,7 +1925,7 @@ Example of RFB logging, with full VNC style authentication parameters:
         "challenge": "0805b790b58e967f2b350a0c99de3881",
         "response": "aecb26faeaaa62179636a5934bac1078"
       },
-      "security-result": "OK"
+      "security_result": "OK"
     },
     "screen_shared": false,
     "framebuffer": {

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -67,12 +67,13 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         _ => (),
     }
     if let Some(security_result) = &tx.tc_security_result {
+        let result_key = "security_result";
         let _ = match security_result.status {
-            0 => js.set_string("security_result", "OK")?,
-            1 => js.set_string("security-result", "FAIL")?,
-            2 => js.set_string("security_result", "TOOMANY")?,
+            0 => js.set_string(result_key, "OK")?,
+            1 => js.set_string(result_key, "FAIL")?,
+            2 => js.set_string(result_key, "TOOMANY")?,
             _ => js.set_string(
-                "security_result",
+                result_key,
                 &format!("UNKNOWN ({})", security_result.status),
             )?,
         };


### PR DESCRIPTION
Previous PR: #11629

Link to ticket:  https://redmine.openinfosecfoundation.org/issues/7198

Changes to previous PR:
- Cherry-pick merged commit from master with comment line.
