### PR TITLE
draft: improve CPU cores affinity to NUMA nodes v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -102,6 +102,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libtool \
@@ -258,6 +260,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libtool \
@@ -351,6 +355,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libtool \
@@ -425,6 +431,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libtool \
@@ -529,6 +537,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libtool \
@@ -621,6 +631,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 hiredis-devel \
                 jansson-devel \
                 jq \
@@ -718,6 +730,8 @@ jobs:
                 gcc-c++ \
                 git \
                 hiredis-devel \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libasan \
@@ -815,6 +829,8 @@ jobs:
                 gcc-c++ \
                 git \
                 hiredis-devel \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libasan \
@@ -912,6 +928,8 @@ jobs:
                 gcc-c++ \
                 git \
                 hiredis-devel \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libasan \
@@ -1004,6 +1022,8 @@ jobs:
                 gcc-c++ \
                 git \
                 hiredis-devel \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libasan \
@@ -1088,6 +1108,8 @@ jobs:
                 gcc-c++ \
                 git \
                 hiredis-devel \
+                hwloc \
+                hwloc-devel \
                 jansson-devel \
                 jq \
                 libasan \
@@ -1183,6 +1205,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-devel \
                 libasan \
                 libtool \
                 libyaml-devel \
@@ -1302,6 +1326,8 @@ jobs:
                 coccinelle \
                 dpdk-dev \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libcap-ng-dev \
                 libevent-dev \
@@ -1373,6 +1399,8 @@ jobs:
                 clang-14 \
                 curl \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libtool \
                 libpcap-dev \
@@ -1498,6 +1526,8 @@ jobs:
                 llvm-14-dev \
                 clang-14 \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 inetutils-ping \
                 libc++-dev \
@@ -1612,6 +1642,8 @@ jobs:
                 llvm-14-dev \
                 clang-14 \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 inetutils-ping \
                 libc++-dev \
@@ -1760,6 +1792,8 @@ jobs:
                 cbindgen \
                 clang-18 \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libc++-dev \
                 libc++abi-dev \
@@ -1847,6 +1881,8 @@ jobs:
                 cbindgen \
                 clang-18 \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 inetutils-ping \
                 libc++-dev \
@@ -1948,6 +1984,8 @@ jobs:
                 llvm-14-dev \
                 clang-14 \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libc++-dev \
                 libc++abi-dev \
@@ -2056,6 +2094,8 @@ jobs:
                 automake \
                 cargo \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libtool \
                 libpcap-dev \
@@ -2148,6 +2188,8 @@ jobs:
           apt -y install \
                 build-essential \
                 curl \
+                hwloc \
+                hwloc-dev \
                 libtool \
                 libpcap-dev \
                 libnet1-dev \
@@ -2217,6 +2259,8 @@ jobs:
                 automake \
                 cargo \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libtool \
                 libpcap-dev \
@@ -2310,6 +2354,8 @@ jobs:
                 automake \
                 cargo \
                 git \
+                hwloc \
+                hwloc-dev \
                 libtool \
                 libpcap-dev \
                 libnet1-dev \
@@ -2377,6 +2423,8 @@ jobs:
                   automake \
                   cargo \
                   git \
+                  hwloc \
+                  hwloc-dev \
                   jq \
                   libtool \
                   libpcap-dev \
@@ -2517,6 +2565,8 @@ jobs:
                 automake \
                 cargo \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libtool \
                 libpcap-dev \
@@ -2624,6 +2674,8 @@ jobs:
               curl \
               dpdk-dev \
               git \
+              hwloc \
+              hwloc-dev \
               jq \
               make \
               libpcre3 \
@@ -2722,6 +2774,8 @@ jobs:
               cmake \
               curl \
               git \
+              hwloc \
+              hwloc-dev \
               jq \
               make \
               libpcre3 \
@@ -2812,6 +2866,8 @@ jobs:
               curl \
               dpdk-dev \
               git \
+              hwloc \
+              hwloc-dev \
               jq \
               make \
               libpcre3 \
@@ -2904,6 +2960,8 @@ jobs:
                 ccache \
                 curl \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \
@@ -2985,6 +3043,8 @@ jobs:
                 ccache \
                 curl \
                 git \
+                hwloc \
+                hwloc-dev \
                 jq \
                 libpcre2-dev \
                 libpcap-dev   \
@@ -3056,6 +3116,8 @@ jobs:
           automake \
           curl \
           hiredis \
+          hwloc \
+          hwloc-dev \
           jansson \
           jq \
           libmagic \
@@ -3276,6 +3338,8 @@ jobs:
                 gcc \
                 gcc-c++ \
                 git \
+                hwloc \
+                hwloc-dev \
                 jansson-devel \
                 libtool \
                 libyaml-devel \

--- a/configure.ac
+++ b/configure.ac
@@ -740,6 +740,28 @@
         exit 1
     fi
 
+    LIBHWLOC=""
+    PKG_CHECK_MODULES([HWLOC], [hwloc >= 2.0.0],
+        [AC_DEFINE([HAVE_HWLOC], [1], [Define if hwloc library is present and meets version requirements])],
+        LIBHWLOC="no")
+
+    if test "$LIBHWLOC" = "no"; then
+        echo
+        echo "   ERROR!  hwloc library version > 2.0.0 not found, go get it"
+        echo "   from https://www.open-mpi.org/projects/hwloc/ "
+        echo "   or your distribution:"
+        echo
+        echo "   Ubuntu: apt-get install hwloc libhwloc-dev"
+        echo "   Fedora: dnf install  hwloc hwloc-devel"
+        echo "   CentOS/RHEL: yum install hwloc hwloc-devel"
+        echo
+        exit 1
+    else
+        CFLAGS="${CFLAGS} ${HWLOC_CFLAGS}"
+        LDFLAGS="${LDFLAGS} ${HWLOC_LIBS}"
+        enable_hwloc="yes"
+    fi
+
   # libpthread
     AC_ARG_WITH(libpthread_includes,
             [  --with-libpthread-includes=DIR  libpthread include directory],
@@ -2541,6 +2563,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   JA4 support:                             ${enable_ja4}
   Non-bundled htp:                         ${enable_non_bundled_htp}
   Hyperscan support:                       ${enable_hyperscan}
+  Hwloc support:                           ${enable_hwloc}
   Libnet support:                          ${enable_libnet}
   liblz4 support:                          ${enable_liblz4}
   Landlock support:                        ${enable_landlock}

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -366,12 +366,17 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(-EINVAL);
     }
 
-    ThreadsAffinityType *wtaf = GetAffinityTypeFromName("worker-cpu-set");
+    bool wtaf_periface = true;
+    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iconf->iface);
     if (wtaf == NULL) {
-        SCLogError("Specify worker-cpu-set list in the threading section");
-        SCReturnInt(-EINVAL);
+        wtaf_periface = false;
+        wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL); // mandatory
+        if (wtaf == NULL) {
+            SCLogError("Specify worker-cpu-set list in the threading section");
+            SCReturnInt(-EINVAL);
+        }
     }
-    ThreadsAffinityType *mtaf = GetAffinityTypeFromName("management-cpu-set");
+    ThreadsAffinityType *mtaf = GetAffinityTypeForNameAndIface("management-cpu-set", NULL);
     if (mtaf == NULL) {
         SCLogError("Specify management-cpu-set list in the threading section");
         SCReturnInt(-EINVAL);
@@ -404,7 +409,12 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
     }
 
     if (strcmp(entry_str, "auto") == 0) {
-        iconf->threads = (uint16_t)sched_cpus / LiveGetDeviceCount();
+        if (wtaf_periface) {
+            iconf->threads = (uint16_t)sched_cpus;
+            SCLogConfig("%s: auto-assigned %u threads", iconf->iface, iconf->threads);
+            SCReturnInt(0);
+        }
+        iconf->threads = (uint16_t)sched_cpus / LiveGetDeviceCountWithoutAssignedThreading();
         if (iconf->threads == 0) {
             SCLogError("Not enough worker CPU cores with affinity were configured");
             SCReturnInt(-ERANGE);
@@ -414,7 +424,8 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
             iconf->threads++;
             remaining_auto_cpus--;
         } else if (remaining_auto_cpus == -1) {
-            remaining_auto_cpus = (int32_t)sched_cpus % LiveGetDeviceCount();
+            remaining_auto_cpus =
+                    (int32_t)sched_cpus % LiveGetDeviceCountWithoutAssignedThreading();
             if (remaining_auto_cpus > 0) {
                 iconf->threads++;
                 remaining_auto_cpus--;
@@ -827,20 +838,35 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
     SCReturnInt(0);
 }
 
-static int32_t ConfigValidateThreads(uint16_t iface_threads)
+static int32_t ConfigValidateThreads(uint16_t iface_threads, const char *iface)
 {
     static uint32_t total_cpus = 0;
-    total_cpus += iface_threads;
-    ThreadsAffinityType *wtaf = GetAffinityTypeFromName("worker-cpu-set");
+    bool per_iface_set = true;
+    ThreadsAffinityType *wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", iface);
     if (wtaf == NULL) {
-        SCLogError("Specify worker-cpu-set list in the threading section");
-        return -1;
+        per_iface_set = false;
+        wtaf = GetAffinityTypeForNameAndIface("worker-cpu-set", NULL);
+        if (wtaf == NULL) {
+            SCLogError("Specify worker-cpu-set list in the threading section");
+            return -1;
+        }
     }
-    if (total_cpus > UtilAffinityGetAffinedCPUNum(wtaf)) {
-        SCLogError("Interfaces requested more cores than configured in the threading section "
-                   "(requested %d configured %d",
-                total_cpus, UtilAffinityGetAffinedCPUNum(wtaf));
-        return -1;
+
+    if (!per_iface_set) {
+        total_cpus += iface_threads;
+        if (total_cpus > UtilAffinityGetAffinedCPUNum(wtaf)) {
+            SCLogError("Interfaces requested more cores than configured in the threading section "
+                       "(requested %d configured %d",
+                    total_cpus, UtilAffinityGetAffinedCPUNum(wtaf));
+            return -1;
+        }
+    } else {
+        if (iface_threads > UtilAffinityGetAffinedCPUNum(wtaf)) {
+            SCLogError("Interface %s requested more cores than configured in the threading section "
+                       "(requested %d configured %d",
+                    iface, iface_threads, UtilAffinityGetAffinedCPUNum(wtaf));
+            return -1;
+        }
     }
 
     return 0;
@@ -856,7 +882,7 @@ static DPDKIfaceConfig *ConfigParse(const char *iface)
 
     ConfigInit(&iconf);
     retval = ConfigLoad(iconf, iface);
-    if (retval < 0 || ConfigValidateThreads(iconf->threads) != 0) {
+    if (retval < 0 || ConfigValidateThreads(iconf->threads, iface) != 0) {
         iconf->DerefFunc(iconf);
         SCReturnPtr(NULL, "void *");
     }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -112,6 +112,7 @@
 #include "tmqh-packetpool.h"
 #include "tm-queuehandlers.h"
 
+#include "util-affinity.h"
 #include "util-byte.h"
 #include "util-conf.h"
 #include "util-coredump-config.h"
@@ -2300,6 +2301,7 @@ void PostRunDeinit(const int runmode, struct timeval *start_time)
     StreamTcpFreeConfig(STREAM_VERBOSE);
     DefragDestroy();
     HttpRangeContainersDestroy();
+    TopologyDestroy();
 
     TmqResetQueues();
 #ifdef PROFILING

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -135,6 +135,8 @@ typedef struct ThreadVars_ {
     struct FlowQueue_ *flow_queue;
     bool break_loop;
 
+    char *iface_name; // set if the TV is TVT_PPT
+
 } ThreadVars;
 
 /** Thread setup flags: */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -856,8 +856,11 @@ TmEcode TmThreadSetupOptions(ThreadVars *tv)
         TmThreadSetPrio(tv);
     if (tv->thread_setup_flags & THREAD_SET_AFFTYPE) {
         ThreadsAffinityType *taf = &thread_affinity[tv->cpu_affinity];
+        if (tv->cpu_affinity == WORKER_CPU_SET &&
+                FindAffinityByInterface(taf, tv->iface_name) != NULL)
+            taf = FindAffinityByInterface(taf, tv->iface_name);
         if (taf->mode_flag == EXCLUSIVE_AFFINITY) {
-            uint16_t cpu = AffinityGetNextCPU(taf);
+            uint16_t cpu = AffinityGetNextCPU(tv, taf);
             SetCPUAffinity(cpu);
             /* If CPU is in a set overwrite the default thread prio */
             if (CPU_ISSET(cpu, &taf->lowprio_cpu)) {

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -33,33 +33,37 @@
 
 ThreadsAffinityType thread_affinity[MAX_CPU_SET] = {
     {
-        .name = "receive-cpu-set",
-        .mode_flag = EXCLUSIVE_AFFINITY,
-        .prio = PRIO_MEDIUM,
-        .lcpu = 0,
+            .name = "receive-cpu-set",
+            .mode_flag = EXCLUSIVE_AFFINITY,
+            .prio = PRIO_MEDIUM,
+            .lcpu = { 0 },
     },
     {
-        .name = "worker-cpu-set",
-        .mode_flag = EXCLUSIVE_AFFINITY,
-        .prio = PRIO_MEDIUM,
-        .lcpu = 0,
+            .name = "worker-cpu-set",
+            .mode_flag = EXCLUSIVE_AFFINITY,
+            .prio = PRIO_MEDIUM,
+            .lcpu = { 0 },
     },
     {
-        .name = "verdict-cpu-set",
-        .mode_flag = BALANCED_AFFINITY,
-        .prio = PRIO_MEDIUM,
-        .lcpu = 0,
+            .name = "verdict-cpu-set",
+            .mode_flag = BALANCED_AFFINITY,
+            .prio = PRIO_MEDIUM,
+            .lcpu = { 0 },
     },
     {
-        .name = "management-cpu-set",
-        .mode_flag = BALANCED_AFFINITY,
-        .prio = PRIO_MEDIUM,
-        .lcpu = 0,
+            .name = "management-cpu-set",
+            .mode_flag = BALANCED_AFFINITY,
+            .prio = PRIO_MEDIUM,
+            .lcpu = { 0 },
     },
 
 };
 
 int thread_affinity_init_done = 0;
+
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+static hwloc_topology_t topology = NULL;
+#endif /* OS_WIN32 and __OpenBSD__ */
 
 /**
  * \brief find affinity by its name
@@ -74,6 +78,115 @@ ThreadsAffinityType * GetAffinityTypeFromName(const char *name)
         }
     }
     return NULL;
+}
+
+static ThreadsAffinityType *AllocAndInitAffinityType(
+        const char *name, const char *interface_name, ThreadsAffinityType *parent)
+{
+    ThreadsAffinityType *new_affinity = SCCalloc(1, sizeof(ThreadsAffinityType));
+    if (new_affinity == NULL) {
+        FatalError("Unable to allocate memory for new affinity type");
+    }
+
+    new_affinity->name = strdup(interface_name);
+    new_affinity->parent = parent;
+    new_affinity->mode_flag = EXCLUSIVE_AFFINITY;
+    new_affinity->prio = PRIO_MEDIUM;
+    for (int i = 0; i < MAX_NUMA_NODES; i++) {
+        new_affinity->lcpu[i] = 0;
+    }
+
+    if (parent != NULL) {
+        if (parent->nb_children == parent->nb_children_capacity) {
+            parent->nb_children_capacity *= 2;
+            parent->children = SCRealloc(
+                    parent->children, parent->nb_children_capacity * sizeof(ThreadsAffinityType *));
+            if (parent->children == NULL) {
+                FatalError("Unable to reallocate memory for children affinity types");
+            }
+        }
+        parent->children[parent->nb_children++] = new_affinity;
+    }
+
+    return new_affinity;
+}
+
+ThreadsAffinityType *FindAffinityByInterface(
+        ThreadsAffinityType *parent, const char *interface_name)
+{
+    for (uint32_t i = 0; i < parent->nb_children; i++) {
+        if (strcmp(parent->children[i]->name, interface_name) == 0) {
+            return parent->children[i];
+        }
+    }
+    return NULL;
+}
+
+/**
+ * \brief find affinity by its name and interface name, if children are not allowed, then those are
+ * alloced and initialized. \retval a pointer to the affinity or NULL if not found
+ */
+ThreadsAffinityType *GetAffinityTypeForNameAndIface(const char *name, const char *interface_name)
+{
+    int i;
+    ThreadsAffinityType *parent_affinity = NULL;
+
+    for (i = 0; i < MAX_CPU_SET; i++) {
+        if (strcmp(thread_affinity[i].name, name) == 0) {
+            parent_affinity = &thread_affinity[i];
+            break;
+        }
+    }
+
+    if (parent_affinity == NULL) {
+        SCLogError("Affinity with name \"%s\" not found", name);
+        return NULL;
+    }
+
+    if (interface_name != NULL) {
+        ThreadsAffinityType *child_affinity =
+                FindAffinityByInterface(parent_affinity, interface_name);
+        // found or not found, it is returned
+        return child_affinity;
+    }
+
+    return parent_affinity;
+}
+
+/**
+ * \brief find affinity by its name and interface name, if children are not allowed, then those are
+ * alloced and initialized. \retval a pointer to the affinity or NULL if not found
+ */
+ThreadsAffinityType *GetOrAllocAffinityTypeForIfaceOfName(
+        const char *name, const char *interface_name)
+{
+    int i;
+    ThreadsAffinityType *parent_affinity = NULL;
+
+    for (i = 0; i < MAX_CPU_SET; i++) {
+        if (strcmp(thread_affinity[i].name, name) == 0) {
+            parent_affinity = &thread_affinity[i];
+            break;
+        }
+    }
+
+    if (parent_affinity == NULL) {
+        SCLogError("Affinity with name \"%s\" not found", name);
+        return NULL;
+    }
+
+    if (interface_name != NULL) {
+        ThreadsAffinityType *child_affinity =
+                FindAffinityByInterface(parent_affinity, interface_name);
+        if (child_affinity != NULL) {
+            return child_affinity;
+        }
+
+        // If not found, allocate and initialize a new child affinity
+        return AllocAndInitAffinityType(name, interface_name, parent_affinity);
+    }
+
+    return parent_affinity;
 }
 
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
@@ -158,154 +271,551 @@ static void BuildCpuset(const char *name, ConfNode *node, cpu_set_t *cpu)
 #endif /* OS_WIN32 and __OpenBSD__ */
 
 /**
- * \brief Extract cpu affinity configuration from current config file
+ * \brief Get the appropriate set name for a given affinity value.
  */
+static const char *GetAffinitySetName(const char *val)
+{
+    if (strcmp(val, "decode-cpu-set") == 0 || strcmp(val, "stream-cpu-set") == 0 ||
+            strcmp(val, "reject-cpu-set") == 0 || strcmp(val, "output-cpu-set") == 0) {
+        return NULL;
+    }
 
+    return (strcmp(val, "detect-cpu-set") == 0) ? "worker-cpu-set" : val;
+}
+
+/**
+ * \brief Set up CPU sets for the given affinity type.
+ */
+static void SetupCpuSets(ThreadsAffinityType *taf, ConfNode *affinity, const char *setname)
+{
+    CPU_ZERO(&taf->cpu_set);
+
+    ConfNode *cpu_node = ConfNodeLookupChild(affinity->head.tqh_first, "cpu");
+    if (cpu_node != NULL) {
+        BuildCpuset(setname, cpu_node, &taf->cpu_set);
+    } else {
+        SCLogInfo("Unable to find 'cpu' node for set %s", setname);
+    }
+}
+
+/**
+ * \brief Build a priority CPU set for the given priority level.
+ */
+static void BuildPriorityCpuset(ThreadsAffinityType *taf, ConfNode *prio_node, const char *priority,
+        cpu_set_t *cpuset, const char *setname)
+{
+    ConfNode *node = ConfNodeLookupChild(prio_node, priority);
+    if (node != NULL) {
+        BuildCpuset(setname, node, cpuset);
+    } else {
+        SCLogDebug("Unable to find '%s' priority for set %s", priority, setname);
+    }
+}
+
+/**
+ * \brief Set up the default priority for the given affinity type.
+ */
+static void SetupDefaultPriority(ThreadsAffinityType *taf, ConfNode *prio_node, const char *setname)
+{
+    ConfNode *default_node = ConfNodeLookupChild(prio_node, "default");
+    if (default_node == NULL)
+        return;
+
+    if (strcmp(default_node->val, "low") == 0) {
+        taf->prio = PRIO_LOW;
+    } else if (strcmp(default_node->val, "medium") == 0) {
+        taf->prio = PRIO_MEDIUM;
+    } else if (strcmp(default_node->val, "high") == 0) {
+        taf->prio = PRIO_HIGH;
+    } else {
+        FatalError("Unknown default CPU affinity priority: %s", default_node->val);
+    }
+
+    SCLogConfig("Using default priority '%s' for set %s", default_node->val, setname);
+}
+
+/**
+ * \brief Set up priority CPU sets for the given affinity type.
+ */
+static void SetupAffinityPriority(ThreadsAffinityType *taf, ConfNode *affinity, const char *setname)
+{
+    CPU_ZERO(&taf->lowprio_cpu);
+    CPU_ZERO(&taf->medprio_cpu);
+    CPU_ZERO(&taf->hiprio_cpu);
+
+    ConfNode *prio_node = ConfNodeLookupChild(affinity->head.tqh_first, "prio");
+    if (prio_node == NULL)
+        return;
+
+    BuildPriorityCpuset(taf, prio_node, "low", &taf->lowprio_cpu, setname);
+    BuildPriorityCpuset(taf, prio_node, "medium", &taf->medprio_cpu, setname);
+    BuildPriorityCpuset(taf, prio_node, "high", &taf->hiprio_cpu, setname);
+
+    SetupDefaultPriority(taf, prio_node, setname);
+}
+
+/**
+ * \brief Set up CPU affinity mode for the given affinity type.
+ */
+static void SetupAffinityMode(ThreadsAffinityType *taf, ConfNode *affinity)
+{
+    ConfNode *mode_node = ConfNodeLookupChild(affinity->head.tqh_first, "mode");
+    if (mode_node == NULL)
+        return;
+
+    if (strcmp(mode_node->val, "exclusive") == 0) {
+        taf->mode_flag = EXCLUSIVE_AFFINITY;
+    } else if (strcmp(mode_node->val, "balanced") == 0) {
+        taf->mode_flag = BALANCED_AFFINITY;
+    } else {
+        FatalError("Unknown CPU affinity mode: %s", mode_node->val);
+    }
+}
+
+/**
+ * \brief Set up the number of threads for the given affinity type.
+ */
+static void SetupAffinityThreads(ThreadsAffinityType *taf, ConfNode *affinity)
+{
+    ConfNode *threads_node = ConfNodeLookupChild(affinity->head.tqh_first, "threads");
+    if (threads_node == NULL)
+        return;
+
+    if (StringParseUint32(&taf->nb_threads, 10, 0, threads_node->val) < 0 || taf->nb_threads == 0) {
+        FatalError("Invalid thread count: %s", threads_node->val);
+    }
+}
+
+/**
+ * \brief Check if the set name corresponds to a worker CPU set.
+ */
+static bool IsWorkerCpuSet(const char *setname)
+{
+    return (strcmp(setname, "worker-cpu-set") == 0);
+}
+
+/**
+ * \brief Set up affinity configuration for a single interface.
+ */
+static void SetupSingleIfaceAffinity(ThreadsAffinityType *taf, ConfNode *iface_node)
+{
+    const char *interface_name = NULL;
+    ConfNode *cpu_node = NULL, *mode_node = NULL, *prio_node = NULL, *threads_node = NULL;
+    ConfNode *child;
+    TAILQ_FOREACH (child, &iface_node->head, next) {
+        if (strcmp(child->name, "interface") == 0) {
+            interface_name = child->val;
+        } else if (strcmp(child->name, "cpu") == 0) {
+            cpu_node = child;
+        } else if (strcmp(child->name, "mode") == 0) {
+            mode_node = child;
+        } else if (strcmp(child->name, "prio") == 0) {
+            prio_node = child;
+        } else if (strcmp(child->name, "threads") == 0) {
+            threads_node = child;
+        }
+    }
+
+    if (interface_name == NULL) {
+        return;
+    }
+
+    ThreadsAffinityType *iface_taf =
+            GetOrAllocAffinityTypeForIfaceOfName(taf->name, interface_name);
+    if (iface_taf == NULL) {
+        FatalError("Unknown CPU affinity type for interface: %s", interface_name);
+    }
+
+    SetupCpuSets(iface_taf, cpu_node, interface_name);
+    SetupAffinityPriority(iface_taf, prio_node, interface_name);
+    SetupAffinityMode(iface_taf, mode_node);
+    SetupAffinityThreads(iface_taf, threads_node);
+}
+
+/**
+ * \brief Set up per-interface affinity configurations.
+ */
+static void SetupPerIfaceAffinity(ThreadsAffinityType *taf, ConfNode *affinity)
+{
+    ConfNode *per_iface_node = ConfNodeLookupChild(affinity->head.tqh_first, "per-iface");
+    if (per_iface_node == NULL)
+        return;
+
+    ConfNode *iface_node;
+    TAILQ_FOREACH (iface_node, &per_iface_node->head, next) {
+        SetupSingleIfaceAffinity(taf, iface_node);
+    }
+}
+
+/**
+ * \brief Extract CPU affinity configuration from current config file
+ */
 void AffinitySetupLoadFromConfig(void)
 {
 #if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
-    ConfNode *root = ConfGetNode("threading.cpu-affinity");
-    ConfNode *affinity;
-
     if (thread_affinity_init_done == 0) {
         AffinitySetupInit();
         thread_affinity_init_done = 1;
     }
 
-    SCLogDebug("Load affinity from config\n");
+    SCLogDebug("Loading CPU affinity from config...\n");
+
+    ConfNode *root = ConfGetNode("threading.cpu-affinity");
     if (root == NULL) {
-        SCLogInfo("can't get cpu-affinity node");
+        SCLogInfo("Cannot find cpu-affinity node in config");
         return;
     }
 
+    ConfNode *affinity;
     TAILQ_FOREACH(affinity, &root->head, next) {
-        if (strcmp(affinity->val, "decode-cpu-set") == 0 ||
-            strcmp(affinity->val, "stream-cpu-set") == 0 ||
-            strcmp(affinity->val, "reject-cpu-set") == 0 ||
-            strcmp(affinity->val, "output-cpu-set") == 0) {
+        const char *setname = GetAffinitySetName(affinity->val);
+        if (setname == NULL)
             continue;
-        }
 
-        const char *setname = affinity->val;
-        if (strcmp(affinity->val, "detect-cpu-set") == 0)
-            setname = "worker-cpu-set";
-
-        ThreadsAffinityType *taf = GetAffinityTypeFromName(setname);
-        ConfNode *node = NULL;
-        ConfNode *nprio = NULL;
-
+        ThreadsAffinityType *taf = GetOrAllocAffinityTypeForIfaceOfName(setname, NULL);
         if (taf == NULL) {
-            FatalError("unknown cpu-affinity type");
-        } else {
-            SCLogConfig("Found affinity definition for \"%s\"", setname);
+            FatalError("Unknown CPU affinity type: %s", setname);
         }
 
-        CPU_ZERO(&taf->cpu_set);
-        node = ConfNodeLookupChild(affinity->head.tqh_first, "cpu");
-        if (node == NULL) {
-            SCLogInfo("unable to find 'cpu'");
-        } else {
-            BuildCpuset(setname, node, &taf->cpu_set);
-        }
+        SCLogConfig("Found affinity definition for \"%s\"", setname);
 
-        CPU_ZERO(&taf->lowprio_cpu);
-        CPU_ZERO(&taf->medprio_cpu);
-        CPU_ZERO(&taf->hiprio_cpu);
-        nprio = ConfNodeLookupChild(affinity->head.tqh_first, "prio");
-        if (nprio != NULL) {
-            node = ConfNodeLookupChild(nprio, "low");
-            if (node == NULL) {
-                SCLogDebug("unable to find 'low' prio using default value");
-            } else {
-                BuildCpuset(setname, node, &taf->lowprio_cpu);
-            }
+        SetupCpuSets(taf, affinity, setname);
+        SetupAffinityPriority(taf, affinity, setname);
+        SetupAffinityMode(taf, affinity);
+        SetupAffinityThreads(taf, affinity);
 
-            node = ConfNodeLookupChild(nprio, "medium");
-            if (node == NULL) {
-                SCLogDebug("unable to find 'medium' prio using default value");
-            } else {
-                BuildCpuset(setname, node, &taf->medprio_cpu);
-            }
-
-            node = ConfNodeLookupChild(nprio, "high");
-            if (node == NULL) {
-                SCLogDebug("unable to find 'high' prio using default value");
-            } else {
-                BuildCpuset(setname, node, &taf->hiprio_cpu);
-            }
-            node = ConfNodeLookupChild(nprio, "default");
-            if (node != NULL) {
-                if (!strcmp(node->val, "low")) {
-                    taf->prio = PRIO_LOW;
-                } else if (!strcmp(node->val, "medium")) {
-                    taf->prio = PRIO_MEDIUM;
-                } else if (!strcmp(node->val, "high")) {
-                    taf->prio = PRIO_HIGH;
-                } else {
-                    FatalError("unknown cpu_affinity prio");
-                }
-                SCLogConfig("Using default prio '%s' for set '%s'",
-                        node->val, setname);
-            }
-        }
-
-        node = ConfNodeLookupChild(affinity->head.tqh_first, "mode");
-        if (node != NULL) {
-            if (!strcmp(node->val, "exclusive")) {
-                taf->mode_flag = EXCLUSIVE_AFFINITY;
-            } else if (!strcmp(node->val, "balanced")) {
-                taf->mode_flag = BALANCED_AFFINITY;
-            } else {
-                FatalError("unknown cpu_affinity node");
-            }
-        }
-
-        node = ConfNodeLookupChild(affinity->head.tqh_first, "threads");
-        if (node != NULL) {
-            if (StringParseUint32(&taf->nb_threads, 10, 0, (const char *)node->val) < 0) {
-                FatalError("invalid value for threads "
-                           "count: '%s'",
-                        node->val);
-            }
-            if (! taf->nb_threads) {
-                FatalError("bad value for threads count");
-            }
+        if (IsWorkerCpuSet(setname)) {
+            SetupPerIfaceAffinity(taf, affinity);
         }
     }
 #endif /* OS_WIN32 and __OpenBSD__ */
+}
+
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+
+static int HwLocDeviceNumaGet(hwloc_topology_t topology, hwloc_obj_t obj)
+{
+#if HWLOC_VERSION_MAJOR >= 2 && HWLOC_VERSION_MINOR >= 5
+    // TODO: test this block of code or remove it
+    hwloc_obj_t nodes[MAX_NUMA_NODES]; // Assuming a maximum of 16 NUMA nodes
+    unsigned num_nodes = MAX_NUMA_NODES;
+    struct hwloc_location location;
+
+    location.type = HWLOC_LOCATION_TYPE_OBJECT;
+    location.location.object = obj;
+
+    int result = hwloc_get_local_numanode_objs(topology, &location, &num_nodes, nodes, 0);
+    if (result == 0 && num_nodes > 0 && num_nodes <= MAX_NUMA_NODES) {
+        return nodes[0]->logical_index;
+        // printf("NUMA nodes for PCIe device:\n");
+        // for (unsigned i = 0; i < num_nodes; i++) {
+        //     printf("NUMA node %d\n", nodes[i]->logical_index);
+        // }
+    }
+    return -1;
+#endif /* HWLOC_VERSION_MAJOR >= 2 && HWLOC_VERSION_MINOR >= 5 */
+
+    hwloc_obj_t non_io_ancestor = hwloc_get_non_io_ancestor_obj(topology, obj);
+    if (non_io_ancestor == NULL) {
+        fprintf(stderr, "Failed to find non-IO ancestor object.\n");
+        return -1;
+    }
+
+    // Iterate over NUMA nodes and check their nodeset
+    hwloc_obj_t numa_node = NULL;
+    while ((numa_node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, numa_node)) !=
+            NULL) {
+        if (hwloc_bitmap_isset(non_io_ancestor->nodeset, numa_node->os_index)) {
+            return numa_node->logical_index;
+        }
+    }
+
+    return -1;
+}
+
+static hwloc_obj_t HwLocDeviceGetByKernelName(hwloc_topology_t topology, const char *interface_name)
+{
+    hwloc_obj_t obj = NULL;
+
+    while ((obj = hwloc_get_next_osdev(topology, obj)) != NULL) {
+        if (obj->attr->osdev.type == HWLOC_OBJ_OSDEV_NETWORK &&
+                strcmp(obj->name, interface_name) == 0) {
+            hwloc_obj_t parent = obj->parent;
+            while (parent) {
+                if (parent->type == HWLOC_OBJ_PCI_DEVICE) {
+                    return parent;
+                }
+                parent = parent->parent;
+            }
+        }
+    }
+    return NULL;
+}
+
+// Static function to deparse PCIe interface string name to individual components
+/**
+ * \brief Parse PCIe address string to individual components
+ * \param[in] pcie_address PCIe address string
+ * \param[out] domain Domain component
+ * \param[out] bus Bus component
+ * \param[out] device Device component
+ * \param[out] function Function component
+ */
+static void PcieAddressToComponents(const char *pcie_address, unsigned int *domain,
+        unsigned int *bus, unsigned int *device, unsigned int *function)
+{
+    // Handle both full and short PCIe address formats
+    if (sscanf(pcie_address, "%x:%x:%x.%x", domain, bus, device, function) != 4) {
+        if (sscanf(pcie_address, "%x:%x.%x", bus, device, function) != 3) {
+            FatalError("Error parsing PCIe address: %s", pcie_address);
+        }
+        *domain = 0; // Default domain to 0 if not provided
+    }
+}
+
+// Function to convert PCIe address to hwloc object
+static hwloc_obj_t HwLocDeviceGetByPcie(hwloc_topology_t topology, const char *pcie_address)
+{
+    hwloc_obj_t obj = NULL;
+    unsigned int domain, bus, device, function;
+    PcieAddressToComponents(pcie_address, &domain, &bus, &device, &function);
+    while ((obj = hwloc_get_next_pcidev(topology, obj)) != NULL) {
+        if (obj->attr->pcidev.domain == domain && obj->attr->pcidev.bus == bus &&
+                obj->attr->pcidev.dev == device && obj->attr->pcidev.func == function) {
+            return obj;
+        }
+    }
+    return NULL;
+}
+
+static void HwlocObjectDump(hwloc_obj_t obj, const char *iface_name)
+{
+    if (!obj) {
+        SCLogDebug("No object found for the given PCIe address.\n");
+        return;
+    }
+
+    static char pcie_address[32];
+    snprintf(pcie_address, sizeof(pcie_address), "%04x:%02x:%02x.%x", obj->attr->pcidev.domain,
+            obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
+    SCLogDebug("Interface (%s / %s) has NUMA ID %d", iface_name, pcie_address,
+            HwLocDeviceNumaGet(topology, obj));
+
+    SCLogDebug("Object type: %s\n", hwloc_obj_type_string(obj->type));
+    SCLogDebug("Logical index: %u\n", obj->logical_index);
+    SCLogDebug("Depth: %u\n", obj->depth);
+    SCLogDebug("Attributes:\n");
+    if (obj->type == HWLOC_OBJ_PCI_DEVICE) {
+        SCLogDebug("  Domain: %04x\n", obj->attr->pcidev.domain);
+        SCLogDebug("  Bus: %02x\n", obj->attr->pcidev.bus);
+        SCLogDebug("  Device: %02x\n", obj->attr->pcidev.dev);
+        SCLogDebug("  Function: %01x\n", obj->attr->pcidev.func);
+        SCLogDebug("  Class ID: %04x\n", obj->attr->pcidev.class_id);
+        SCLogDebug("  Vendor ID: %04x\n", obj->attr->pcidev.vendor_id);
+        SCLogDebug("  Device ID: %04x\n", obj->attr->pcidev.device_id);
+        SCLogDebug("  Subvendor ID: %04x\n", obj->attr->pcidev.subvendor_id);
+        SCLogDebug("  Subdevice ID: %04x\n", obj->attr->pcidev.subdevice_id);
+        SCLogDebug("  Revision: %02x\n", obj->attr->pcidev.revision);
+        SCLogDebug("  Link speed: %f GB/s\n", obj->attr->pcidev.linkspeed);
+    } else {
+        SCLogDebug("  No PCI device attributes available.\n");
+    }
+}
+
+static bool CPUIsFromNuma(uint16_t ncpu, uint16_t numa)
+{
+    int core_id = ncpu;
+    int depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
+    hwloc_obj_t numa_node = NULL;
+
+    while ((numa_node = hwloc_get_next_obj_by_depth(topology, depth, numa_node)) != NULL) {
+        hwloc_cpuset_t cpuset = hwloc_bitmap_alloc();
+        hwloc_bitmap_copy(cpuset, numa_node->cpuset);
+
+        if (hwloc_bitmap_isset(cpuset, core_id)) {
+            SCLogDebug("Core %d - NUMA %d", core_id, numa_node->logical_index);
+            hwloc_bitmap_free(cpuset);
+            break;
+        }
+        hwloc_bitmap_free(cpuset);
+    }
+
+    if (numa == numa_node->logical_index)
+        return true;
+
+    return false;
+}
+
+static bool TopologyShouldAutooptimize(ThreadVars *tv, ThreadsAffinityType *taf)
+{
+    bool cond;
+    SCMutexLock(&taf->taf_mutex);
+    cond = tv->type == TVT_PPT && tv->iface_name &&
+           (strcmp(tv->iface_name, taf->name) == 0 || strcmp("worker-cpu-set", taf->name) == 0);
+    SCMutexUnlock(&taf->taf_mutex);
+    return cond;
+}
+
+static void TopologyInitialize(void)
+{
+    if (topology == NULL) {
+        if (hwloc_topology_init(&topology) == -1) {
+            FatalError("Failed to initialize topology");
+        }
+
+        if (hwloc_topology_set_flags(topology, HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM) == -1 ||
+                hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_ALL) == -1 ||
+                hwloc_topology_load(topology) == -1) {
+            FatalError("Failed to set/load topology");
+        }
+    }
+}
+
+void TopologyDestroy()
+{
+    if (topology != NULL) {
+        hwloc_topology_destroy(topology);
+        topology = NULL;
+    }
+}
+
+static int InterfaceGetNumaNode(ThreadVars *tv)
+{
+    hwloc_obj_t if_obj = HwLocDeviceGetByKernelName(topology, tv->iface_name);
+    if (if_obj == NULL) {
+        if_obj = HwLocDeviceGetByPcie(topology, tv->iface_name);
+    }
+
+    if (if_obj != NULL) {
+        HwlocObjectDump(if_obj, tv->iface_name);
+    }
+
+    return HwLocDeviceNumaGet(topology, if_obj);
+}
+
+static int16_t FindCPUInNumaNode(int numa_node, ThreadsAffinityType *taf)
+{
+    if (taf->lcpu[numa_node] >= UtilCpuGetNumProcessorsOnline()) {
+        return -1;
+    }
+
+    uint16_t cpu = taf->lcpu[numa_node];
+    while (cpu < UtilCpuGetNumProcessorsOnline() &&
+            (!CPU_ISSET(cpu, &taf->cpu_set) || !CPUIsFromNuma(cpu, numa_node))) {
+        cpu++;
+    }
+
+    taf->lcpu[numa_node] = (CPU_ISSET(cpu, &taf->cpu_set) && CPUIsFromNuma(cpu, numa_node))
+                                   ? cpu + 1
+                                   : UtilCpuGetNumProcessorsOnline();
+    return (CPU_ISSET(cpu, &taf->cpu_set) && CPUIsFromNuma(cpu, numa_node)) ? cpu : -1;
+}
+
+static bool AllCPUsUsed(ThreadsAffinityType *taf)
+{
+    for (int i = 0; i < MAX_NUMA_NODES; i++) {
+        if (taf->lcpu[i] < UtilCpuGetNumProcessorsOnline()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void ResetCPUs(ThreadsAffinityType *taf)
+{
+    for (int i = 0; i < MAX_NUMA_NODES; i++) {
+        taf->lcpu[i] = 0;
+    }
+}
+
+static int16_t CPUSelectFromNuma(int iface_numa, ThreadsAffinityType *taf)
+{
+    if (iface_numa != -1) {
+        return FindCPUInNumaNode(iface_numa, taf);
+    }
+    return -1;
+}
+
+static int16_t CPUSelectAlternative(ThreadsAffinityType *taf)
+{
+    for (int nid = 0; nid < MAX_NUMA_NODES; nid++) {
+        int cpu = FindCPUInNumaNode(nid, taf);
+        if (cpu != -1) {
+            return cpu;
+        }
+    }
+    return -1;
+}
+
+static uint16_t CPUSelectDefault(ThreadsAffinityType *taf)
+{
+    uint16_t cpu = taf->lcpu[0];
+    int attempts = 0;
+
+    while (!CPU_ISSET(cpu, &taf->cpu_set) && attempts < 2) {
+        cpu = (cpu + 1) % UtilCpuGetNumProcessorsOnline();
+        if (cpu == 0)
+            attempts++;
+    }
+
+    taf->lcpu[0] = cpu + 1;
+
+    if (attempts == 2) {
+        SCLogError(
+                "cpu_set does not contain available CPUs, CPU affinity configuration is invalid");
+    }
+
+    return cpu;
+}
+
+static uint16_t GetNextAvailableCPU(int iface_numa, ThreadsAffinityType *taf)
+{
+    int16_t cpu = CPUSelectFromNuma(iface_numa, taf);
+    if (iface_numa == -1 || cpu == -1) {
+        cpu = CPUSelectAlternative(taf);
+        if (cpu == -1) {
+            ResetCPUs(taf);
+        }
+    }
+
+    if (cpu != -1)
+        return cpu;
+
+    cpu = CPUSelectDefault(taf);
+
+    return cpu;
+}
+
+#endif /* OS_WIN32 and __OpenBSD__ */
+
+uint16_t AffinityGetNextCPU(ThreadVars *tv, ThreadsAffinityType *taf)
+{
+    uint16_t next_cpu = 0;
+#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
+    int iface_numa = -1;
+    if (TopologyShouldAutooptimize(tv, taf)) {
+        TopologyInitialize();
+        iface_numa = InterfaceGetNumaNode(tv);
+    }
+
+    SCMutexLock(&taf->taf_mutex);
+    next_cpu = GetNextAvailableCPU(iface_numa, taf);
+
+    if (AllCPUsUsed(taf)) {
+        ResetCPUs(taf);
+    }
+
+    SCLogDebug("Setting affinity on CPU %d", cpu);
+    SCMutexUnlock(&taf->taf_mutex);
+#endif /* OS_WIN32 and __OpenBSD__ */
+
+    return next_cpu;
 }
 
 /**
- * \brief Return next cpu to use for a given thread family
- * \retval the cpu to used given by its id
+ * \brief Return the total number of CPUs in a given affinity
+ * \retval the number of affined CPUs
  */
-uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf)
-{
-    uint16_t ncpu = 0;
-#if !defined __CYGWIN__ && !defined OS_WIN32 && !defined __OpenBSD__ && !defined sun
-    int iter = 0;
-    SCMutexLock(&taf->taf_mutex);
-    ncpu = taf->lcpu;
-    while (!CPU_ISSET(ncpu, &taf->cpu_set) && iter < 2) {
-        ncpu++;
-        if (ncpu >= UtilCpuGetNumProcessorsOnline()) {
-            ncpu = 0;
-            iter++;
-        }
-    }
-    if (iter == 2) {
-        SCLogError("cpu_set does not contain "
-                   "available cpus, cpu affinity conf is invalid");
-    }
-    taf->lcpu = ncpu + 1;
-    if (taf->lcpu >= UtilCpuGetNumProcessorsOnline())
-        taf->lcpu = 0;
-    SCMutexUnlock(&taf->taf_mutex);
-    SCLogDebug("Setting affinity on CPU %d", ncpu);
-#endif /* OS_WIN32 and __OpenBSD__ */
-    return ncpu;
-}
-
 uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
 {
     uint16_t ncpu = 0;

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -24,6 +24,7 @@
 
 #include "device-storage.h"
 #include "util-debug.h"
+#include "util-affinity.h"
 
 #define MAX_DEVNAME 10
 
@@ -168,6 +169,20 @@ int LiveGetDeviceCount(void)
 
     TAILQ_FOREACH(pd, &live_devices, next) {
         i++;
+    }
+
+    return i;
+}
+
+int LiveGetDeviceCountWithoutAssignedThreading(void)
+{
+    int i = 0;
+    LiveDevice *pd;
+
+    TAILQ_FOREACH (pd, &live_devices, next) {
+        if (GetAffinityTypeForNameAndIface("worker-cpu-set", pd->dev) == NULL) {
+            i++;
+        }
     }
 
     return i;

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -85,6 +85,7 @@ void LiveDevAddBypassStats(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevSubBypassStats(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevAddBypassFail(LiveDevice *dev, uint64_t cnt, int family);
 void LiveDevAddBypassSuccess(LiveDevice *dev, uint64_t cnt, int family);
+int LiveGetDeviceCountWithoutAssignedThreading(void);
 int LiveGetDeviceCount(void);
 const char *LiveGetDeviceName(int number);
 LiveDevice *LiveGetDevice(const char *dev);

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -310,6 +310,12 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
 
         TmThreadSetCPU(tv, WORKER_CPU_SET);
 
+        if (tv->type == TVT_PPT) {
+            tv->iface_name = strdup(live_dev);
+        } else {
+            tv->iface_name = NULL;
+        }
+
         if (TmThreadSpawn(tv) != TM_ECODE_OK) {
             FatalError("TmThreadSpawn failed");
         }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1767,6 +1767,19 @@ threading:
           medium: [ "1-2" ]
           high: [ 3 ]
           default: "medium"
+        # per-iface:
+        #   - interface: ens1f0 # 0000:3b:00.0 # ens1f0
+        #     cpu: [ 1,3,5,7,9 ]
+        #     mode: "exclusive"
+        #     prio:
+        #       high: [ "all" ]
+        #       default: "medium"
+        #   - interface: ens1f1 # 0000:3b:00.1 # ens1f1
+        #     cpu: [ 2,4,6,8,10 ]
+        #     mode: "exclusive"
+        #     prio:
+        #       high: [ 2,4 ]
+        #       default: "medium"
     #- verdict-cpu-set:
     #    cpu: [ 0 ]
     #    prio:


### PR DESCRIPTION
Followup of https://github.com/OISF/suricata/pull/11521

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7036

This work allows more precise thread assignment and it is done either
- automatically - by picking assigned cores of the same NUMA locality as the interface from the worker-cpu-list 
- manually - you can specify per-iface settings in the threading section

This works with AF-PACKET and DPDK (and should with other capture modes as well). Primary target is workers runmode.

Dependency - hwloc - for the automatic core assignment.

At this point I am not sure why pkg-config doesn't find hwloc in github ci - it works on my machines - in case it fails on yours add LIBS="$LIBS -lhwloc" to your configure.ac