### PR TITLE
tls/ja3: do not append to ja3 str one ja3 hash is computed

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -896,10 +896,14 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
             processed_len += 2;
         }
 
-        if (enable_ja3 && ssl_state->curr_connp->ja3_hash == NULL) {
-            int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_cipher_suites);
-            if (rc == -1) {
-                return -1;
+        if (enable_ja3) {
+            if (ssl_state->curr_connp->ja3_hash == NULL) {
+                int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_cipher_suites);
+                if (rc == -1) {
+                    return -1;
+                }
+            } else {
+                Ja3BufferFree(&ja3_cipher_suites);
             }
         }
 
@@ -1515,22 +1519,31 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
     }
 
 end:
-    if (ja3 && ssl_state->curr_connp->ja3_hash == NULL) {
-        rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                   &ja3_extensions);
-        if (rc == -1)
-            goto error;
-
-        if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+    if (ja3) {
+        if (ssl_state->curr_connp->ja3_hash == NULL) {
             rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                       &ja3_elliptic_curves);
+                                       &ja3_extensions);
             if (rc == -1)
                 goto error;
 
-            rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                       &ja3_elliptic_curves_pf);
-            if (rc == -1)
-                goto error;
+            if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+                rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
+                                           &ja3_elliptic_curves);
+                if (rc == -1)
+                    goto error;
+
+                rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
+                                           &ja3_elliptic_curves_pf);
+                if (rc == -1)
+                    goto error;
+            }
+        } else {
+            if (ja3_extensions != NULL)
+                Ja3BufferFree(&ja3_extensions);
+            if (ja3_elliptic_curves != NULL)
+                Ja3BufferFree(&ja3_elliptic_curves);
+            if (ja3_elliptic_curves_pf != NULL)
+                Ja3BufferFree(&ja3_elliptic_curves_pf);
         }
     }
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1521,19 +1521,17 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
 end:
     if (ja3) {
         if (ssl_state->curr_connp->ja3_hash == NULL) {
-            rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                       &ja3_extensions);
+            rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_extensions);
             if (rc == -1)
                 goto error;
 
             if (ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
-                rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                           &ja3_elliptic_curves);
+                rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_elliptic_curves);
                 if (rc == -1)
                     goto error;
 
-                rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
-                                           &ja3_elliptic_curves_pf);
+                rc = Ja3BufferAppendBuffer(
+                        &ssl_state->curr_connp->ja3_str, &ja3_elliptic_curves_pf);
                 if (rc == -1)
                     goto error;
             }

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -896,7 +896,7 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
             processed_len += 2;
         }
 
-        if (enable_ja3) {
+        if (enable_ja3 && ssl_state->curr_connp->ja3_hash == NULL) {
             int rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str, &ja3_cipher_suites);
             if (rc == -1) {
                 return -1;
@@ -1515,7 +1515,7 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
     }
 
 end:
-    if (ja3) {
+    if (ja3 && ssl_state->curr_connp->ja3_hash == NULL) {
         rc = Ja3BufferAppendBuffer(&ssl_state->curr_connp->ja3_str,
                                    &ja3_extensions);
         if (rc == -1)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6634

Describe changes:
- ja3/tls: do not have a ja3 string with 9 commas

https://github.com/OISF/suricata/pull/10059 simpler solution
And no event as https://redmine.openinfosecfoundation.org/issues/7016 already shows that we do not want these events because of TLS Hello Retry Request

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2028
