### PR TITLE
detect/dataset: delay set operation after signature full match

### DIFF
--- a/.github/workflows/live/afp-ids.sh
+++ b/.github/workflows/live/afp-ids.sh
@@ -65,7 +65,7 @@ if [ $STATSCHECK = false ]; then
     echo "ERROR no packets captured"
     RES=1
 fi
-SID1CHECK=$(jq -c 'select(.event_type == "alert")' ./eve.json | tail -n1 | jq '.alert.signature_id == 1')
+SID1CHECK=$(jq -c 'select(.alert.signature_id == 1)' ./eve.json | wc -l)
 if [ $SID1CHECK = false ]; then
     echo "ERROR no alerts for sid 1"
     RES=1

--- a/.github/workflows/live/pcap.sh
+++ b/.github/workflows/live/pcap.sh
@@ -55,7 +55,7 @@ if [ $STATSCHECK = false ]; then
     echo "ERROR no packets captured"
     RES=1
 fi
-SID1CHECK=$(jq -c 'select(.event_type == "alert")' ./eve.json | tail -n1 | jq '.alert.signature_id == 1')
+SID1CHECK=$(jq -c 'select(.alert.signature_id == 1)' ./eve.json | wc -l)
 if [ $SID1CHECK = false ]; then
     echo "ERROR no alerts for sid 1"
     RES=1

--- a/src/detect-dataset.h
+++ b/src/detect-dataset.h
@@ -34,6 +34,8 @@
 typedef struct DetectDatasetData_ {
     Dataset *set;
     uint8_t cmd;
+    // for postmatch to retrieve the buffer
+    int list;
 } DetectDatasetData;
 
 int DetectDatasetBufferMatch(DetectEngineThreadCtx *det_ctx,

--- a/src/detect.c
+++ b/src/detect.c
@@ -188,9 +188,8 @@ end:
     SCReturn;
 }
 
-static void DetectRunPostMatch(ThreadVars *tv,
-                               DetectEngineThreadCtx *det_ctx, Packet *p,
-                               const Signature *s)
+static void DetectRunPostMatch(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, Packet *p,
+        const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv)
 {
     /* run the packet match functions */
     const SigMatchData *smd = s->sm_arrays[DETECT_SM_LIST_POSTMATCH];
@@ -201,6 +200,10 @@ static void DetectRunPostMatch(ThreadVars *tv,
 
         while (1) {
             KEYWORD_PROFILING_START;
+            if (sigmatch_table[smd->type].AppLayerTxMatch != NULL) {
+                sigmatch_table[smd->type].AppLayerTxMatch(
+                        det_ctx, f, flags, alstate, txv, s, smd->ctx);
+            }
             (void)sigmatch_table[smd->type].Match(det_ctx, p, s, smd->ctx);
             KEYWORD_PROFILING_END(det_ctx, smd->type, 1);
             if (smd->is_last)
@@ -811,7 +814,7 @@ static inline void DetectRulePacketRules(
 #ifdef PROFILE_RULES
         smatch = true;
 #endif
-        DetectRunPostMatch(tv, det_ctx, p, s);
+        DetectRunPostMatch(tv, det_ctx, p, s, NULL, 0, NULL, NULL);
 
         uint64_t txid = PACKET_ALERT_NOTX;
         if ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
@@ -1594,7 +1597,7 @@ static void DetectRunTx(ThreadVars *tv,
                     alstate, &tx, s, inspect_flags, can, scratch);
             if (r == 1) {
                 /* match */
-                DetectRunPostMatch(tv, det_ctx, p, s);
+                DetectRunPostMatch(tv, det_ctx, p, s, f, flow_flags, alstate, tx.tx_ptr);
 
                 const uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_TX);
                 SCLogDebug("%p/%"PRIu64" sig %u (%u) matched", tx.tx_ptr, tx.tx_id, s->id, s->num);
@@ -1753,7 +1756,7 @@ static void DetectRunFrames(ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngin
                 r = DetectRunFrameInspectRule(tv, det_ctx, s, f, p, frames, frame);
                 if (r == true) {
                     /* match */
-                    DetectRunPostMatch(tv, det_ctx, p, s);
+                    DetectRunPostMatch(tv, det_ctx, p, s, NULL, 0, NULL, NULL);
 
                     uint8_t alert_flags = (PACKET_ALERT_FLAG_STATE_MATCH | PACKET_ALERT_FLAG_FRAME);
                     det_ctx->frame_id = frame->id;

--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -47,10 +47,19 @@ extern thread_local int profiling_keyword_entered;
     (ctx)->keyword_perf_list = (list); \
 }
 
+#define KEYWORD_PROFILING_PAUSE                                                                    \
+    if (profiling_keyword_enabled == 1) {                                                          \
+        profiling_keyword_enabled = 2;                                                             \
+    }
+#define KEYWORD_PROFILING_UNPAUSE                                                                  \
+    if (profiling_keyword_enabled == 2) {                                                          \
+        profiling_keyword_enabled = 1;                                                             \
+    }
+
 #define KEYWORD_PROFILING_START                                                                    \
     uint64_t profile_keyword_start_ = 0;                                                           \
     uint64_t profile_keyword_end_ = 0;                                                             \
-    if (profiling_keyword_enabled) {                                                               \
+    if (profiling_keyword_enabled == 1) {                                                          \
         if (profiling_keyword_entered > 0) {                                                       \
             SCLogError("Re-entered profiling, exiting.");                                          \
             abort();                                                                               \
@@ -61,11 +70,12 @@ extern thread_local int profiling_keyword_entered;
 
 /* we allow this macro to be called if profiling_keyword_entered == 0,
  * so that we don't have to refactor some of the detection code. */
-#define KEYWORD_PROFILING_END(ctx, type, m) \
-    if (profiling_keyword_enabled && profiling_keyword_entered) { \
-        profile_keyword_end_ = UtilCpuGetTicks(); \
-        SCProfilingKeywordUpdateCounter((ctx),(type),(profile_keyword_end_ - profile_keyword_start_),(m)); \
-        profiling_keyword_entered--; \
+#define KEYWORD_PROFILING_END(ctx, type, m)                                                        \
+    if (profiling_keyword_enabled == 1 && profiling_keyword_entered) {                             \
+        profile_keyword_end_ = UtilCpuGetTicks();                                                  \
+        SCProfilingKeywordUpdateCounter(                                                           \
+                (ctx), (type), (profile_keyword_end_ - profile_keyword_start_), (m));              \
+        profiling_keyword_entered--;                                                               \
     }
 
 PktProfiling *SCProfilePacketStart(void);
@@ -327,6 +337,8 @@ void SCProfilingDump(void);
 
 #define KEYWORD_PROFILING_SET_LIST(a,b)
 #define KEYWORD_PROFILING_START
+#define KEYWORD_PROFILING_PAUSE
+#define KEYWORD_PROFILING_UNPAUSE
 #define KEYWORD_PROFILING_END(a,b,c)
 
 #define PACKET_PROFILING_START(p)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5576

Describe changes:
- detect/dataset: delay set operation after signature full match

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2000

https://github.com/OISF/suricata/pull/11704 with clean CI

No longer the limitation described for flowvar in https://redmine.openinfosecfoundation.org/issues/7197
