### PR TITLE
Http2 frames 5743 v3

### DIFF
--- a/doc/userguide/rules/http2-keywords.rst
+++ b/doc/userguide/rules/http2-keywords.rst
@@ -4,6 +4,14 @@ HTTP2 Keywords
 HTTP2 frames are grouped into transactions based on the stream identifier it it is not 0.
 For frames with stream identifier 0, whose effects are global for the connection, a transaction is created for each frame.
 
+Frames
+------
+
+The HTTP2 parser supports the following frames (as defined by Suricata) which are created for each HTTP2 frame (as defined by the HTTP2 RFC) :
+
+* http2.hdr
+* http2.data
+* http2.pdu
 
 http2.frametype
 ---------------

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -28,8 +28,6 @@
 
 /** max 63 to fit the 64 bit per protocol space */
 #define FRAME_STREAM_TYPE 63
-/** always the first frame to be created. TODO but what about protocol upgrades? */
-#define FRAME_STREAM_ID 1
 
 typedef int64_t FrameId;
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1210,7 +1210,7 @@ static void HandleStreamFrames(Flow *f, StreamSlice stream_slice, const uint8_t 
     if (((direction == 0 && (pstate->flags & APP_LAYER_PARSER_SFRAME_TS) == 0) ||
                 (direction == 1 && (pstate->flags & APP_LAYER_PARSER_SFRAME_TC) == 0)) &&
             input != NULL && f->proto == IPPROTO_TCP) {
-        Frame *frame = AppLayerFrameGetById(f, direction, FRAME_STREAM_ID);
+        Frame *frame = AppLayerFrameGetLastOpenByType(f, direction, FRAME_STREAM_TYPE);
         if (frame == NULL) {
             int64_t frame_len = -1;
             if (flags & STREAM_EOF)
@@ -1231,7 +1231,7 @@ static void HandleStreamFrames(Flow *f, StreamSlice stream_slice, const uint8_t 
             }
         }
     } else if (flags & STREAM_EOF) {
-        Frame *frame = AppLayerFrameGetById(f, direction, FRAME_STREAM_ID);
+        Frame *frame = AppLayerFrameGetLastOpenByType(f, direction, FRAME_STREAM_TYPE);
         SCLogDebug("EOF closing: frame %p", frame);
         if (frame) {
             /* calculate final frame length */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5743
https://redmine.openinfosecfoundation.org/issues/7213

Describe changes:
- http2: support frames
- frames: fix use of stream frame (only when enabled)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2011

#11707 with better commit message and earlier frames creation followed by set_tx