### PR TITLE
WIP app-layer-protocol

### DIFF
--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -86,6 +86,7 @@ static int DetectAppLayerProtocolPacketMatch(
             p->pcap_cnt,
             p->flowflags & (FLOW_PKT_TOCLIENT|FLOW_PKT_TOSERVER),
             f->alproto, f->alproto_ts, f->alproto_tc);
+        SCReturnInt(0);
     }
     r = r ^ data->negated;
     if (r) {


### PR DESCRIPTION
Don't return true for negated protocol check if no protocol has been evaluated due to ALPROTO_UNKNOWN in the packet direction.

Fixes: bf9bbdd61285 ("detect: fix app-layer-protocol keyword for HTTP")
