### PR TITLE
Implement Memcmp SIMD for arm64 NEON and SVE

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -796,6 +796,12 @@ static void PrintBuildInfo(void)
 #if defined(__SSE2__)
     strlcat(features, "SSE_2 ", sizeof(features));
 #endif
+#if defined(__ARM_FEATURE_SVE)
+    strlcat(features, "SVE ", sizeof(features));
+#endif
+#if defined(__ARM_NEON)
+    strlcat(features, "NEON ", sizeof(features));
+#endif
     if (strlen(features) == 0) {
         strlcat(features, "none", sizeof(features));
     }

--- a/src/util-cpu.c
+++ b/src/util-cpu.c
@@ -192,6 +192,10 @@ uint64_t UtilCpuGetTicks(void)
     ::: "%eax", "%ecx", "%edx");
 #endif
 
+#elif defined(__GNUC__) && defined(__aarch64__)
+    __asm__ __volatile__("isb\n\t"
+                         "mrs %0,  cntvct_el0\n\t"
+                         : "=r"(val));
 #else /* #if defined(__GNU__) */
 //#warning Using inferior version of UtilCpuGetTicks
     struct timeval now;

--- a/src/util-memcmp.c
+++ b/src/util-memcmp.c
@@ -35,102 +35,134 @@
 
 static int MemcmpTest01 (void)
 {
-    uint8_t a[] = "abcd";
-    uint8_t b[] = "abcd";
+    uint8_t a[] = "abcd            abcd";
+    uint8_t b[] = "abcd            abcd";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest02 (void)
 {
-    uint8_t a[] = "abcdabcdabcdabcd";
-    uint8_t b[] = "abcdabcdabcdabcd";
+    uint8_t a[] = "abcdabcdabcdabcd    ";
+    uint8_t b[] = "abcdabcdabcdabcd    ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest03 (void)
 {
-    uint8_t a[] = "abcdabcd";
-    uint8_t b[] = "abcdabcd";
+    uint8_t a[] = "abcdabcd         ";
+    uint8_t b[] = "abcdabcd         ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest04 (void)
 {
-    uint8_t a[] = "abcd";
-    uint8_t b[] = "abcD";
+    uint8_t a[] = "abcd             ";
+    uint8_t b[] = "abcD             ";
 
-    int r = SCMemcmp(a, b, sizeof(a)-1);
-    FAIL_IF(r != 1);
+    for (size_t x = 4; x < sizeof(a); x++) {
+        int r = SCMemcmp(a, b, x);
+        FAIL_IF(r != 1);
+    }
 
     PASS;
 }
 
 static int MemcmpTest05 (void)
 {
-    uint8_t a[] = "abcdabcdabcdabcd";
-    uint8_t b[] = "abcDabcdabcdabcd";
+    uint8_t a[] = "abcdabcdabcdabcd       ";
+    uint8_t b[] = "abcDabcdabcdabcd       ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    for (size_t x = 4; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    }
+
     PASS;
 }
 
 static int MemcmpTest06 (void)
 {
-    uint8_t a[] = "abcdabcd";
-    uint8_t b[] = "abcDabcd";
+    uint8_t a[] = "abcdabcd              ";
+    uint8_t b[] = "abcDabcd              ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    for (size_t x = 4; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    }
+
     PASS;
 }
 
 static int MemcmpTest07 (void)
 {
-    uint8_t a[] = "abcd";
-    uint8_t b[] = "abcde";
+    uint8_t a[] = "            abcd";
+    uint8_t b[] = "            abcde";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest08 (void)
 {
-    uint8_t a[] = "abcdabcdabcdabcd";
-    uint8_t b[] = "abcdabcdabcdabcde";
+    uint8_t a[] = "  zyxvabcdabcdabcdabcd";
+    uint8_t b[] = "  zyxvabcdabcdabcdabcde";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest09 (void)
 {
-    uint8_t a[] = "abcdabcd";
-    uint8_t b[] = "abcdabcde";
+    uint8_t a[] = "         abcdabcd";
+    uint8_t b[] = "         abcdabcde";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
 static int MemcmpTest10 (void)
 {
-    uint8_t a[] = "abcd";
-    uint8_t b[] = "Zbcde";
+    uint8_t a[] = "abcd                 ";
+    uint8_t b[] = "Zbcde                ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    }
+
     PASS;
 }
 
 static int MemcmpTest11 (void)
 {
-    uint8_t a[] = "abcdabcdabcdabcd";
-    uint8_t b[] = "Zbcdabcdabcdabcde";
+    uint8_t a[] = "abcdabcdabcdabcd     ";
+    uint8_t b[] = "Zbcdabcdabcdabcde    ";
 
-    FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmp(a, b, sizeof(a) - 1) != 1);
+    }
+
     PASS;
 }
 
@@ -145,10 +177,13 @@ static int MemcmpTest12 (void)
 
 static int MemcmpTest13 (void)
 {
-    uint8_t a[] = "abcdefgh";
-    uint8_t b[] = "AbCdEfGhIjK";
+    uint8_t a[] = "        abcdefgh";
+    uint8_t b[] = "        AbCdEfGhIjK";
 
-    FAIL_IF(SCMemcmpLowercase(a, b, sizeof(a) - 1) != 0);
+    for (size_t x = 1; x < sizeof(a); x++) {
+        FAIL_IF(SCMemcmpLowercase(a, b, sizeof(a) - 1) != 0);
+    }
+
     PASS;
 }
 
@@ -313,25 +348,142 @@ struct MemcmpTest18Tests {
     const char *b;
     int result;
 } memcmp_tests18_tests[] = {
-        { "abcdefgh", "!bcdefgh", 1, },
-        { "?bcdefgh", "!bcdefgh", 1, },
-        { "!bcdefgh", "abcdefgh", 1, },
-        { "!bcdefgh", "?bcdefgh", 1, },
-        { "zbcdefgh", "bbcdefgh", 1, },
+    {
+            "abcdefgh",
+            "!bcdefgh",
+            1,
+    },
+    {
+            "?bcdefgh",
+            "!bcdefgh",
+            1,
+    },
+    {
+            "!bcdefgh",
+            "abcdefgh",
+            1,
+    },
+    {
+            "!bcdefgh",
+            "?bcdefgh",
+            1,
+    },
+    {
+            "zbcdefgh",
+            "bbcdefgh",
+            1,
+    },
+    {
+            "abcdefgh       ",
+            "!bcdefgh       ",
+            1,
+    },
+    {
+            "?bcdefgh       ",
+            "!bcdefgh       ",
+            1,
+    },
+    {
+            "!bcdefgh       ",
+            "abcdefgh       ",
+            1,
+    },
+    {
+            "!bcdefgh       ",
+            "?bcdefgh       ",
+            1,
+    },
+    {
+            "zbcdefgh       ",
+            "bbcdefgh       ",
+            1,
+    },
 
-        { "abcdefgh12345678", "!bcdefgh12345678", 1, },
-        { "?bcdefgh12345678", "!bcdefgh12345678", 1, },
-        { "!bcdefgh12345678", "abcdefgh12345678", 1, },
-        { "!bcdefgh12345678", "?bcdefgh12345678", 1, },
-        { "bbcdefgh12345678", "zbcdefgh12345678", 1, },
+    {
+            "abcdefgh12345678",
+            "!bcdefgh12345678",
+            1,
+    },
+    {
+            "?bcdefgh12345678",
+            "!bcdefgh12345678",
+            1,
+    },
+    {
+            "!bcdefgh12345678",
+            "abcdefgh12345678",
+            1,
+    },
+    {
+            "!bcdefgh12345678",
+            "?bcdefgh12345678",
+            1,
+    },
+    {
+            "bbcdefgh12345678",
+            "zbcdefgh12345678",
+            1,
+    },
 
-        { "abcdefgh", "abcdefgh", 0, },
-        { "abcdefgh", "Abcdefgh", 0, },
-        { "abcdefgh12345678", "Abcdefgh12345678", 0, },
+    {
+            "abcdefgh",
+            "abcdefgh",
+            0,
+    },
+    {
+            "abcdefgh",
+            "Abcdefgh",
+            0,
+    },
+    {
+            "abcdefgh        ",
+            "abcdefgh        ",
+            0,
+    },
+    {
+            "abcdefgh        ",
+            "Abcdefgh        ",
+            0,
+    },
+    {
+            "abcdefgh12345678",
+            "Abcdefgh12345678",
+            0,
+    },
+    {
+            "abcdefgz12345678",
+            "AbcdefgZ12345678",
+            0,
+    },
+    {
+            "abcdefgz[@@45678aa",
+            "AbcdefgZ[@@45678AA",
+            0,
+    },
+    {
+            "abcdefgz12345678",
+            "abcdefgz12345678",
+            0,
+    },
+    {
+            "abcdefgz12345678",
+            "Xbcdefgz12345678",
+            1,
+    },
+    {
+            "abcdefgz12345678",
+            "abcdefgzX2345678",
+            1,
+    },
+    {
+            "abcdefgz12345678",
+            "abcdXfgz1234X678",
+            1,
+    },
 
-        { NULL, NULL, 0 },
+    { NULL, NULL, 0 },
 
-    };
+};
 
 static int MemcmpTest18 (void)
 {


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
-  [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [X] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7245

Describe changes:
- Increase testing to have values wide enough to use SIMD
- Add a arm64 instruction for timing
- Add both a NEON and SVE implementation for of SCMemcmp (for SVE, the libc version already uses NEON) and SCMemcmpLowercase (for both NEON and SVE)
-  Resubmission of https://github.com/OISF/suricata/pull/8764 which has been closed after rebasing

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
