### PR TITLE
Clippy 182 fixes v1

### DIFF
--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -33,22 +33,19 @@ fn log_dcerpc_header_tcp(
                 jsb.set_uint("stub_data_size", tx.stub_data_buffer_ts.len() as u64)?;
                 jsb.close()?;
             }
-            DCERPC_TYPE_BIND => match &state.bind {
-                Some(bind) => {
-                    jsb.open_array("interfaces")?;
-                    for uuid in &bind.uuid_list {
-                        jsb.start_object()?;
-                        let ifstr = Uuid::from_slice(uuid.uuid.as_slice());
-                        let ifstr = ifstr.map(|uuid| uuid.to_hyphenated().to_string()).unwrap();
-                        jsb.set_string("uuid", &ifstr)?;
-                        let vstr = format!("{}.{}", uuid.version, uuid.versionminor);
-                        jsb.set_string("version", &vstr)?;
-                        jsb.set_uint("ack_result", uuid.result as u64)?;
-                        jsb.close()?;
-                    }
+            DCERPC_TYPE_BIND => if let Some(bind) = &state.bind {
+                jsb.open_array("interfaces")?;
+                for uuid in &bind.uuid_list {
+                    jsb.start_object()?;
+                    let ifstr = Uuid::from_slice(uuid.uuid.as_slice());
+                    let ifstr = ifstr.map(|uuid| uuid.to_hyphenated().to_string()).unwrap();
+                    jsb.set_string("uuid", &ifstr)?;
+                    let vstr = format!("{}.{}", uuid.version, uuid.versionminor);
+                    jsb.set_string("version", &vstr)?;
+                    jsb.set_uint("ack_result", uuid.result as u64)?;
                     jsb.close()?;
                 }
-                None => {}
+                jsb.close()?;
             },
             _ => {}
         }

--- a/rust/src/detect/iprep.rs
+++ b/rust/src/detect/iprep.rs
@@ -55,6 +55,7 @@ impl std::str::FromStr for DetectIPRepDataCmd {
 }
 
 /// value matching is done use `DetectUintData` logic.
+///
 /// isset matching is done using special `DetectUintData` value ">= 0"
 /// isnotset matching bypasses `DetectUintData` and is handled directly
 /// in the match function (in C).


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket, just new clippy warnings

Describe changes:
- rust/dcerpc: fix single_match clippy warning
- rust/detect: fix too_long_first_doc_paragraph clippy warning

cc @jasonish 
do we want this kind of `too_long_first_doc_paragraph` warnings ?