### PR TITLE
detect/app-layer-proto: don't run detection on ALPROTO_UNKNOWN

### DIFF
--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -86,6 +86,7 @@ static int DetectAppLayerProtocolPacketMatch(
             p->pcap_cnt,
             p->flowflags & (FLOW_PKT_TOCLIENT|FLOW_PKT_TOSERVER),
             f->alproto, f->alproto_ts, f->alproto_tc);
+        SCReturnInt(0);
     }
     r = r ^ data->negated;
     if (r) {


### PR DESCRIPTION
Don't return true for negated protocol check if no protocol has been evaluated due to ALPROTO_UNKNOWN in the packet direction.

This leads to false positives for negated matching, as an expression like "!tls" will match if checked against ALPROTO_UNKNOWN.

This patch readds missing check. The keyword returns no match as long as the alproto is ALPROTO_UNKNOWN.

Fixes: bf9bbdd61285 ("detect: fix app-layer-protocol keyword for HTTP")

Ticket: #7242.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2034