### PR TITLE
lua: use lua from crates.io rather than github - v2

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1009,8 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/jasonish/suricata-lua-sys#b04cf66fa70e0e2ec66dc09aae5fd5ee96637493"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27aba92b2bc53955440218aed3fa6e6f4cf6cba443deb8fed7e216e6b1d96af2"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -67,7 +67,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { git = "https://github.com/jasonish/suricata-lua-sys", version = "0.1.0-alpha.1" }
+suricata-lua-sys = { version = "0.1.0-alpha.1" }
 
 [dev-dependencies]
 test-case = "~3.3.1"


### PR DESCRIPTION
This allows the source override in .cargo/config.toml to apply to the suricata-lua-sys crate as well fixing offline builds.

Ticket: #7226

Previous PR: https://github.com/OISF/suricata/pull/11624

Changes from last PR:
- Update the lock file as well