### PR TITLE
frames: do not only rely on FRAME_STREAM_ID

### DIFF
--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -28,8 +28,6 @@
 
 /** max 63 to fit the 64 bit per protocol space */
 #define FRAME_STREAM_TYPE 63
-/** always the first frame to be created. TODO but what about protocol upgrades? */
-#define FRAME_STREAM_ID 1
 
 typedef int64_t FrameId;
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1238,6 +1238,9 @@ static inline void SetEOFFlags(AppLayerParserState *pstate, const uint8_t flags)
     }
 }
 
+// if there is a stream frame, it should always be the first
+#define FRAME_STREAM_ID 1
+
 /** \internal
  *  \brief create/close stream frames
  *  On first invocation of TCP parser in a direction, create a <alproto>.stream frame.
@@ -1253,7 +1256,7 @@ static void HandleStreamFrames(Flow *f, StreamSlice stream_slice, const uint8_t 
                 (direction == 1 && (pstate->flags & APP_LAYER_PARSER_SFRAME_TC) == 0)) &&
             input != NULL && f->proto == IPPROTO_TCP) {
         Frame *frame = AppLayerFrameGetById(f, direction, FRAME_STREAM_ID);
-        if (frame == NULL) {
+        if (frame == NULL || frame->type != FRAME_STREAM_TYPE) {
             int64_t frame_len = -1;
             if (flags & STREAM_EOF)
                 frame_len = input_len;
@@ -1275,7 +1278,7 @@ static void HandleStreamFrames(Flow *f, StreamSlice stream_slice, const uint8_t 
     } else if (flags & STREAM_EOF) {
         Frame *frame = AppLayerFrameGetById(f, direction, FRAME_STREAM_ID);
         SCLogDebug("EOF closing: frame %p", frame);
-        if (frame) {
+        if (frame && frame->type == FRAME_STREAM_TYPE) {
             /* calculate final frame length */
             int64_t slice_o = (int64_t)stream_slice.offset - (int64_t)frame->offset;
             int64_t frame_len = slice_o + (int64_t)input_len;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7214

Describe changes:
- backport of commit in https://github.com/OISF/suricata/pull/11717 clean cherry-pick

https://github.com/OISF/suricata/pull/11760 with clean history and CI