### PR TITLE
rust: pin serde version

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -886,18 +886,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -984,6 +984,8 @@ dependencies = [
  "regex",
  "sawp",
  "sawp-modbus",
+ "serde",
+ "serde_derive",
  "sha1",
  "sha2",
  "snmp-parser",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -65,6 +65,10 @@ ldap-parser = { version = "~0.4.0" }
 
 time = "~0.3.36"
 
+# pinned until oss-fuzz supports newer rust nightly cf https://github.com/google/oss-fuzz/pull/12365
+serde = { version = "=1.0.197" }
+serde_derive = { version = "1.0.197" }
+
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { git = "https://github.com/jasonish/suricata-lua-sys", version = "0.1.0-alpha.1" }


### PR DESCRIPTION
https://github.com/OISF/suricata/pull/11763 but squashed to keep the lock file
in sync with the changes, and to make autoconf/automake happy with the
timestamps.
