### PR TITLE
stream/reassembly: optimize GetBlock

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1039,14 +1039,8 @@ static StreamingBufferBlock *GetBlock(const StreamingBuffer *sb, const uint64_t 
     if (blk == NULL)
         return NULL;
 
-    for ( ; blk != NULL; blk = SBB_RB_NEXT(blk)) {
-        if (blk->offset >= offset)
-            return blk;
-        else if ((blk->offset + blk->len) > offset) {
-            return blk;
-        }
-    }
-    return NULL;
+    StreamingBufferBlock key = {.offset = offset, .len = 0};
+    return SBB_RB_FIND_INCLUSIVE(&sb->sbb_tree, &key);
 }
 
 static inline bool GapAhead(const TcpStream *stream, StreamingBufferBlock *cur_blk)


### PR DESCRIPTION
Current GetBlock degrees the sbb search from rb tree to line, which costs much cpu time, and could be replaced by SBB_RB_FIND_EXCLUSIVE It reduces time complexity from O(nlogn) to O(logn).

Bug: #7208.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7208
