### PR TITLE
detect: safety for app-layer logging of stream-only rules

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -659,6 +659,7 @@ The detection-engine builds internal groups of signatures. Suricata loads signat
       toserver-groups: 25
     sgh-mpm-context: auto
     inspection-recursion-limit: 3000
+    stream-tx-log-limit: 4
 
 At all of these options, you can add (or change) a value. Most
 signatures have the adjustment to focus on one direction, meaning
@@ -692,6 +693,11 @@ bugs in Suricata cause big problems. Often Suricata has to deal with
 complicated issues. It could end up in an 'endless loop' due to a bug,
 meaning it will repeat its actions over and over again. With the
 option inspection-recursion-limit you can limit this action.
+
+The stream-tx-log-limit defines the maximum number of times a
+transaction will get logged for a stream-only rule match.
+This is meant to avoid logging the same data an arbitrary number
+of times.
 
 *Example 4	Detection-engine grouping tree*
 

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -114,6 +114,8 @@ pub struct AppLayerTxData {
     /// STREAM_TOCLIENT: file tx , files only in toclient dir
     /// STREAM_TOSERVER|STREAM_TOCLIENT: files possible in both dirs
     pub file_tx: u8,
+    /// Number of times this tx data has already been logged for one stream match
+    pub stream_logged: u8,
 
     /// detection engine flags for use by detection engine
     detect_flags_ts: u64,
@@ -152,6 +154,7 @@ impl AppLayerTxData {
             files_stored: 0,
             file_flags: 0,
             file_tx: 0,
+            stream_logged: 0,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
             de_state: std::ptr::null_mut(),
@@ -174,6 +177,7 @@ impl AppLayerTxData {
             files_stored: 0,
             file_flags: 0,
             file_tx: 0,
+            stream_logged: 0,
             detect_flags_ts,
             detect_flags_tc,
             de_state: std::ptr::null_mut(),

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2904,6 +2904,17 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
     SCLogDebug("de_ctx->inspection_recursion_limit: %d",
                de_ctx->inspection_recursion_limit);
 
+    // default value is 4
+    de_ctx->stream_tx_log_limit = 4;
+    if (ConfGetInt("detect.stream-tx-log-limit", &value) == 1) {
+        if (value >= 0 && value <= UINT8_MAX) {
+            de_ctx->stream_tx_log_limit = (uint8_t)value;
+        } else {
+            SCLogWarning("Invalid value for detect-engine.stream-tx-log-limit: must be between 0 "
+                         "and 255, will default to 4");
+        }
+    }
+
     /* parse port grouping whitelisting settings */
 
     const char *ports = NULL;

--- a/src/detect.h
+++ b/src/detect.h
@@ -884,6 +884,9 @@ typedef struct DetectEngineCtx_ {
     /* maximum recursion depth for content inspection */
     int inspection_recursion_limit;
 
+    /* maximum number of times a tx will get logged for a stream-only rule match */
+    uint8_t stream_tx_log_limit;
+
     /* registration id for per thread ctx for the filemagic/file.magic keywords */
     int filemagic_thread_ctx_id;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1673,6 +1673,8 @@ detect:
     toserver-groups: 25
   sgh-mpm-context: auto
   inspection-recursion-limit: 3000
+  # maximum number of times a tx will get logged for a stream-only rule match
+  # stream-tx-log-limit: 4
   # If set to yes, the loading of signatures will be made after the capture
   # is started. This will limit the downtime in IPS mode.
   #delayed-detect: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7085

Describe changes:
- detect: limit the number of times for app-layer logging of stream-only rules

#11738 rebased to get green CI