### PR TITLE
Dns invalid additionals 7228 v4

### DIFF
--- a/rules/dns-events.rules
+++ b/rules/dns-events.rules
@@ -8,3 +8,5 @@ alert dns any any -> any any (msg:"SURICATA DNS Not a response"; flow:to_client;
 # Z flag (reserved) not 0
 alert dns any any -> any any (msg:"SURICATA DNS Z flag set"; app-layer-event:dns.z_flag_set; classtype:protocol-command-decode; sid:2240006; rev:2;)
 alert dns any any -> any any (msg:"SURICATA DNS Invalid opcode"; app-layer-event:dns.invalid_opcode; classtype:protocol-command-decode; sid:2240007; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS invalid additionals"; app-layer-event:dns.invalid_additionals; classtype:protocol-command-decode; sid:2240008; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS invalid authorities"; app-layer-event:dns.invalid_authorities; classtype:protocol-command-decode; sid:2240009; rev:1;)

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -361,16 +361,39 @@ pub fn dns_parse_body<'a>(
 ) -> IResult<&'a [u8], DNSMessage> {
     let (i, queries) = count(|b| dns_parse_query(b, message), header.questions as usize)(i)?;
     let (i, answers) = dns_parse_answer(i, message, header.answer_rr as usize)?;
-    let (i, authorities) = dns_parse_answer(i, message, header.authority_rr as usize)?;
-    let (i, additionals) = dns_parse_answer(i, message, header.additional_rr as usize)?;
+
+    let mut invalid_authorities = false;
+    let mut authorities = Vec::new();
+    let mut i_next = i;
+    let authorities_parsed = dns_parse_answer(i, message, header.authority_rr as usize);
+    if let Ok((i, authorities_ok)) = authorities_parsed {
+        authorities = authorities_ok;
+        i_next = i;
+    } else {
+        invalid_authorities = true;
+    }
+
+    let mut invalid_additionals = false;
+    let mut additionals = Vec::new();
+    if !invalid_authorities {
+        let additionals_parsed = dns_parse_answer(i_next, message, header.additional_rr as usize);
+        if let Ok((i, additionals_ok)) = additionals_parsed {
+                additionals = additionals_ok;
+                i_next = i;
+            } else {
+                invalid_additionals = true;
+            }
+    }
     Ok((
-        i,
+        i_next,
         DNSMessage {
             header,
             queries,
             answers,
             authorities,
+            invalid_authorities,
             additionals,
+            invalid_additionals,
         },
     ))
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7228

Describe changes:
- dns: improved handling of corrupt additionals
- dns: improve probing parser by making it more strict to have better ground truth on QA

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2032

https://github.com/OISF/suricata/pull/11785 with newer commit for the DNS probing parser improvement

@jasonish what do you think about it ?
Should we have a separate ticket and PR to handle first the probing parser ?