### PR TITLE
ssl/ja3: better check for ja3 being enabled - 7.0.x backport - v1

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1109,8 +1109,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurves(SSLState *ssl_state,
     if (!(HAS_SPACE(elliptic_curves_len)))
         goto invalid_length;
 
-    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
-            SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) && ja3_elliptic_curves) {
         uint16_t ec_processed_len = 0;
         /* coverity[tainted_data] */
         while (ec_processed_len < elliptic_curves_len)
@@ -1166,8 +1165,7 @@ static inline int TLSDecodeHSHelloExtensionEllipticCurvePF(SSLState *ssl_state,
     if (!(HAS_SPACE(ec_pf_len)))
         goto invalid_length;
 
-    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
-            SC_ATOMIC_GET(ssl_config.enable_ja3)) {
+    if ((ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) && ja3_elliptic_curves_pf) {
         uint8_t ec_pf_processed_len = 0;
         /* coverity[tainted_data] */
         while (ec_pf_processed_len < ec_pf_len)


### PR DESCRIPTION
Ticket: 6634

Completes commit 84735251b577a284af3795708786974fd30720b0

Avoids error log in Ja3BufferAddValue about NULL buffer

(cherry picked from commit 1d32f117456bb6d220ca3f7e99b4680ec7fbd549)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7276
Original ticket (found initial merge) https://redmine.openinfosecfoundation.org/issues/7276

Describe changes:
- clean cherry-pick of https://github.com/OISF/suricata/pull/11813