### PR TITLE
threads: don't drop capabilities for packet threads

### DIFF
--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -240,8 +240,6 @@ static void *TmThreadsSlotPktAcqLoop(void *td)
     if (tv->thread_setup_flags != 0)
         TmThreadSetupOptions(tv);
 
-    /* Drop the capabilities for this thread */
-    SCDropCaps(tv);
     CaptureStatsSetup(tv);
     PacketPoolInit();
 


### PR DESCRIPTION
Remove the call to SCDropCaps for packet processing threads. This
logic in this function is required to setup packet processing even
when the thread is provided by a library user, in which case Suricata
should not be touching is capabilities.

As SCDropCaps is currently a no-op its clear this feature needs to
be (re)designed properly, taking into consideration library users as
well.

Related ticket: https://redmine.openinfosecfoundation.org/issues/2375
