### PR TITLE
WIP detect: add option to reenable flow actions

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1708,6 +1708,9 @@ void SignatureSetType(DetectEngineCtx *de_ctx, Signature *s)
             } else {
                 s->type = SIG_TYPE_PKT_STREAM;
             }
+        } else if (de_ctx->pass_applayer_flow_action && (s->flags & SIG_FLAG_APPLAYER) &&
+                   (s->flags & SIG_FLAG_REQUIRE_PACKET) == 0) {
+            s->type = SIG_TYPE_APPLAYER;
         } else if (has_match) {
             s->type = SIG_TYPE_PKT;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2468,6 +2468,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(
     de_ctx->type = type;
     de_ctx->filemagic_thread_ctx_id = -1;
     de_ctx->tenant_id = tenant_id;
+    de_ctx->pass_applayer_flow_action = false;
 
     if (type == DETECT_ENGINE_TYPE_DD_STUB || type == DETECT_ENGINE_TYPE_MT_STUB) {
         de_ctx->version = DetectEngineGetVersion();
@@ -2484,6 +2485,12 @@ static DetectEngineCtx *DetectEngineCtxInitReal(
         SCLogDebug("ConfGetBool could not load the value.");
     }
     de_ctx->failure_fatal = (failure_fatal == 1);
+
+    int pass_applayer_flow_action = 0;
+    if (ConfGetBool("detect.pass-applayer-flow-action", (int *)&pass_applayer_flow_action) != 1) {
+        SCLogDebug("ConfGetBool could not load the value.");
+    }
+    de_ctx->pass_applayer_flow_action = (pass_applayer_flow_action == 1);
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
     de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();

--- a/src/detect.h
+++ b/src/detect.h
@@ -1045,6 +1045,8 @@ typedef struct DetectEngineCtx_ {
 
     /* number of signatures using filestore, limited as u16 */
     uint16_t filestore_cnt;
+
+    bool pass_applayer_flow_action;
 } DetectEngineCtx;
 
 /* Engine groups profiles (low, medium, high, custom) */


### PR DESCRIPTION
Add an option to allow rules like `pass tls ...` to be considered `app-layer` instead of `pkt`. This will turn the actions into flow actions.

Ticket: #7284.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2066