### PR TITLE
tls: do not break custom fields when enabling JA4 (7.x)

### DIFF
--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -592,7 +592,7 @@ static OutputTlsCtx *OutputTlsInitCtx(ConfNode *conf)
     /* In 7.0.x, ja4 hash is only logged when requested */
     const char *ja4 = ConfNodeLookupChildValue(conf, "ja4");
     if (ja4 && ConfValIsTrue(ja4)) {
-        tls_ctx->fields = LOG_TLS_FIELD_JA4;
+        tls_ctx->fields |= LOG_TLS_FIELD_JA4;
     }
 
     const char *session_resumption = ConfNodeLookupChildValue(conf, "session-resumption");


### PR DESCRIPTION
## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [X] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7286

Describe changes:
- Ensure `tls_ctx->fields` is not overwritten when selecting JA4 log output.
