### PR TITLE
schema/tls: add missing custom fields chain/cert - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6586,6 +6586,16 @@
         "tls": {
             "type": "object",
             "properties": {
+                "certificate": {
+                    "type": "string"
+                },
+                "chain": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "client": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Task [#7287](https://redmine.openinfosecfoundation.org/issues/7287)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7287

Describe changes:
- add fields `certificate` and `chain` to the `tls` json schema. This issue was exposed while crafting SV tests for https://github.com/OISF/suricata/pull/11843

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2068
