### PR TITLE
Fixed the typo of the buffer name for sip.stat_code

### DIFF
--- a/src/detect-sip-stat-code.c
+++ b/src/detect-sip-stat-code.c
@@ -56,7 +56,7 @@
 
 #define KEYWORD_NAME "sip.stat_code"
 #define KEYWORD_DOC  "sip-keywords.html#sip-stat-code"
-#define BUFFER_NAME  "sip.method"
+#define BUFFER_NAME  "sip.stat_code"
 #define BUFFER_DESC  "sip response status code"
 static int g_buffer_id = 0;
 


### PR DESCRIPTION
Fixed the typo of the buffer name for sip.stat_code, The correct name is sip.stat_code, not sip.method.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2072