### PR TITLE
yaml: Add check of allocation for node object

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -330,6 +330,9 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
                             node = existing;
                         } else {
                             node = ConfNodeNew();
+                            if (unlikely(node == NULL)) {
+                                goto fail;
+                            }
                             node->name = SCStrdup(value);
                             node->parent = parent;
                             if (node->name && strchr(node->name, '_')) {


### PR DESCRIPTION
Fix potential dereference of nullptr in case
of unsuccessful allocation of memory for
list node

Bug: #7270

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7270
Describe changes:
- Add check of node pointers after allocation of memory;
- If memory allocated successfully, behavior do not change;
- If allocation fail, goto fail marker;

Follows https://github.com/OISF/suricata/pull/11822 with transforming commit message to proper state