### PR TITLE
github-ci: build rpms - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2709,6 +2709,19 @@ jobs:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
 
+      # Setup apt package caching.
+      - name: Setup apt package caching
+        run: |
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >> /etc/apt/apt.conf.d/99cache
+          echo 'APT::Keep-Downloaded-Packages "false";' >> /etc/apt/apt.conf.d/99cache
+          rm -f /etc/apt/apt.conf.d/docker-clean
+
+      - name: Cache apt downloads
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ github.job }}-apt
+
       - name: Determine number of CPUs
         run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -387,6 +387,83 @@ jobs:
 
       - run: PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --enable-non-bundled-htp --with-libhtp-includes=/usr/local/include --with-libhtp-libraries=/usr/local/lib
 
+  rpms:
+    name: Build RPMs
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    needs: [ubuntu-22-04-dist]
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - almalinux:9
+          - fedora:40
+    steps:
+      - name: Cache cargo registry
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: ~/.cargo
+          key: ${{ github.job }}-cargo
+
+      - name: Cache RPMs
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: /var/cache/dnf
+          key: ${{ github.job }}-dnf
+      - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Install packages
+        run: |
+          if test -e /etc/almalinux-release; then
+              dnf -y install \
+                epel-release \
+                git \
+                make \
+                rpm-build \
+                rpmdevtools \
+                dnf-plugins-core
+              dnf config-manager --set-enabled crb
+           elif test -e /etc/fedora-release; then
+              dnf -y install \
+                git \
+                make \
+                rpm-build \
+                rpmdevtools
+           else
+              echo "ERROR: Unsupported distribution for RPM building"
+              exit 1
+           fi
+      - name: Download Suricata distribution archive
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: dist
+      - run: git clone https://github.com/jasonish/suricata-rpms
+      - run: make update-release update-sources
+        working-directory: suricata-rpms/devel
+      - run: dnf -y install $(rpmspec -q --buildrequires ./suricata.spec)
+        working-directory: suricata-rpms/devel
+      - run: mv suricata-*.tar.gz suricata-rpms/devel
+      - run: make srpm
+        working-directory: suricata-rpms/devel
+      - run: make local
+        working-directory: suricata-rpms/devel
+
+      # We need a step for each RPM upload as we can't use the
+      # container name directly in an artifact, as artifacts can't
+      # have ':' in the name.
+      - if: matrix.container == 'fedora:40'
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        name: Uploading RPMs
+        with:
+          name: rpms-fedora-40
+          path: suricata-rpms/devel/rpms
+      - if: matrix.container == 'almalinux:9'
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        name: Uploading RPMs
+        with:
+          name: rpms-epel-9
+          path: suricata-rpms/devel/rpms
+
   almalinux-8:
     name: AlmaLinux 8
     runs-on: ubuntu-latest

--- a/ebpf/Makefile.am
+++ b/ebpf/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST= include bypass_filter.c filter.c lb.c vlan_filter.c xdp_filter.c \
-	    xdp_lb.c hash_func01.h
+	    xdp_lb.c hash_func01.h llvm_bpfload.h
 
 if BUILD_EBPF
 


### PR DESCRIPTION
With my recent update to the RPM repo, its easy to build RPMs from development release archives (ie: suricata-8.0.0-dev.tar.gz), so add 2 RPM builds to GitHub-ci. This already caught the fact that epbf failed to build from a release archive (master only). The RPMs are saved as artifacts.

Also:
- adding apt caching to the dist builder to speed it up a little, as other jobs depend on this one any speed up is useful
- move the dist builder job earlier in the file, this does appear to make it start sooner
