### PR TITLE
sip/detect: fix stat code buffer name.

### DIFF
--- a/src/detect-sip-stat-code.c
+++ b/src/detect-sip-stat-code.c
@@ -56,7 +56,7 @@
 
 #define KEYWORD_NAME "sip.stat_code"
 #define KEYWORD_DOC  "sip-keywords.html#sip-stat-code"
-#define BUFFER_NAME  "sip.method"
+#define BUFFER_NAME  "sip.stat_code"
 #define BUFFER_DESC  "sip response status code"
 static int g_buffer_id = 0;
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7295

Describe changes:
- sip/detect: fix stat code buffer name.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2072

https://github.com/OISF/suricata/pull/11846 with commit reworded