### PR TITLE
[draft] flow/detect: skip packet rules if only tx needs to be inspected

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -137,10 +137,24 @@ static void DetectRun(ThreadVars *th_v,
     /* run the prefilters for packets */
     DetectRunPrefilterPkt(th_v, de_ctx, det_ctx, p, &scratch);
 
-    PACKET_PROFILING_DETECT_START(p, PROF_DETECT_RULES);
-    /* inspect the rules against the packet */
-    DetectRulePacketRules(th_v, de_ctx, det_ctx, p, pflow, &scratch);
-    PACKET_PROFILING_DETECT_END(p, PROF_DETECT_RULES);
+    bool skip_packet_rules = false;
+    if (pflow) {
+        if (FlowGetPacketDirection(pflow, p) == TOSERVER) {
+            if (pflow->ffr_ts == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_TX_DETECTION) {
+                skip_packet_rules = true;
+            }
+        } else {
+            if (pflow->ffr_tc == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_TX_DETECTION) {
+                skip_packet_rules = true;
+            }
+        }
+    }
+
+    if (!skip_packet_rules) {
+        PACKET_PROFILING_DETECT_START(p, PROF_DETECT_RULES);
+        DetectRulePacketRules(th_v, de_ctx, det_ctx, p, pflow, &scratch);
+        PACKET_PROFILING_DETECT_END(p, PROF_DETECT_RULES);
+    }
 
     /* run tx/state inspection. Don't call for ICMP error msgs. */
     if (pflow && pflow->alstate && likely(pflow->proto == p->proto)) {

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -305,16 +305,16 @@ bool FlowNeedsReassembly(Flow *f)
     }
 
     /* if app layer still needs some love, push through */
-    if (f->alproto != ALPROTO_UNKNOWN && f->alstate != NULL) {
+    else if (f->alproto != ALPROTO_UNKNOWN && f->alstate != NULL) {
         const uint64_t total_txs = AppLayerParserGetTxCnt(f, f->alstate);
 
         if (AppLayerParserGetTransactionActive(f, f->alparser, STREAM_TOCLIENT) < total_txs)
         {
-            server = STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION;
+            server = STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_TX_DETECTION;
         }
         if (AppLayerParserGetTransactionActive(f, f->alparser, STREAM_TOSERVER) < total_txs)
         {
-            client = STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION;
+            client = STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_TX_DETECTION;
         }
     }
 

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -119,7 +119,7 @@ static int FlowFinish(ThreadVars *tv, Flow *f, FlowWorkerThreadData *fw, void *d
     const TcpSession *ssn = (TcpSession *)f->protoctx;
 
     /* insert a pseudo packet in the toserver direction */
-    if (client == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
+    if (client >= STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
         Packet *p = FlowPseudoPacketGet(0, f, ssn);
         if (p != NULL) {
             PKT_SET_SRC(p, PKT_SRC_FFR);
@@ -133,7 +133,7 @@ static int FlowFinish(ThreadVars *tv, Flow *f, FlowWorkerThreadData *fw, void *d
     }
 
     /* handle toclient */
-    if (server == STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
+    if (server >= STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION) {
         Packet *p = FlowPseudoPacketGet(1, f, ssn);
         if (p != NULL) {
             PKT_SET_SRC(p, PKT_SRC_FFR);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -178,6 +178,7 @@ enum {
     /* stream has no segments for forced reassembly, but only segments that
      * have been sent for detection, but are stuck in the detection queues */
     STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_DETECTION = 1,
+    STREAM_HAS_UNPROCESSED_SEGMENTS_NEED_ONLY_TX_DETECTION = 2,
 };
 
 TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueueNoLock *);


### PR DESCRIPTION
For discussion only. It appears a pseudo packet that exists only to flush out transaction handling on flow finish is also subject to packet rules, which lead to an alert that doesn't really make sense, matching the details of the first packet in the flow.

Instead, if a flush packet only exists to give the app-layer some love, flag it as such, and skip packet rules.

Only one S-V test fails, but on a quick look, it appears the missing alert after this change is probably correct.

Flags: needs confirmation that this alert shouldn't exist.

Ticket: https://redmine.openinfosecfoundation.org/issues/7318
