### PR TITLE
7302 init parser after check with stat()

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -558,11 +558,6 @@ ConfYamlLoadFileWithPrefix(const char *filename, const char *prefix)
     int ret;
     ConfNode *root = ConfGetNode(prefix);
 
-    if (yaml_parser_initialize(&parser) != 1) {
-        SCLogError("failed to initialize yaml parser.");
-        return -1;
-    }
-
     struct stat stat_buf;
     /* coverity[toctou] */
     if (stat(filename, &stat_buf) == 0) {
@@ -572,6 +567,11 @@ ConfYamlLoadFileWithPrefix(const char *filename, const char *prefix)
                     filename);
             return -1;
         }
+    }
+
+    if (yaml_parser_initialize(&parser) != 1) {
+        SCLogError("failed to initialize yaml parser.");
+        return -1;
     }
 
     /* coverity[toctou] */


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [+ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [- ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [- ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [- ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [+ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7302

Describe changes:
- move parser initializing code below checking file with stat() function (to prevent possible memory leak)
