### PR TITLE
transform/base64: check for 0-sized buffer

### DIFF
--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -141,6 +141,9 @@ static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options)
         }
         decode_length = nbytes;
     }
+    if (decode_length == 0) {
+        return;
+    }
 
     uint32_t decoded_size = Base64DecodeBufferSize(decode_length);
     uint8_t decoded[decoded_size];


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7296

Describe changes:
- transform/base64: check for 0-sized buffer

As done already by other transforms

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2075

https://github.com/OISF/suricata/pull/11866 with SV test and better check : wait after computation of offset...