### PR TITLE
detect-engine-address-ipv4: convert unittests to FAIL/PASS APIs

### DIFF
--- a/src/detect-engine-address-ipv4.c
+++ b/src/detect-engine-address-ipv4.c
@@ -412,13 +412,12 @@ static int DetectAddressIPv4TestAddressCmp01(void)
     int result = 1;
 
     DetectAddress *a = DetectAddressInit();
-    if (a == NULL)
-        return 0;
+    FAIL_IF_NULL(a);
 
     DetectAddress *b = DetectAddressInit();
     if (b == NULL) {
         DetectAddressFree(a);
-        return 0;
+        FAIL;
     }
 
     if (inet_pton(AF_INET, "1.2.3.4", &in) < 0)
@@ -845,12 +844,13 @@ static int DetectAddressIPv4TestAddressCmp01(void)
 
     DetectAddressFree(a);
     DetectAddressFree(b);
-    return result;
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
     DetectAddressFree(b);
-    return 0;
+    FAIL;
 }
 
 static int DetectAddressIPv4IsCompleteIPSpace02(void)
@@ -859,8 +859,8 @@ static int DetectAddressIPv4IsCompleteIPSpace02(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        goto error;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
         goto error;
@@ -880,8 +880,8 @@ static int DetectAddressIPv4IsCompleteIPSpace02(void)
 
     DetectAddressFree(a);
 
-    if ( (a = DetectAddressInit()) == NULL)
-        goto error;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
         goto error;
@@ -893,12 +893,12 @@ static int DetectAddressIPv4IsCompleteIPSpace02(void)
 
     DetectAddressFree(a);
 
-    return result;
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
-    if (a != NULL)
-        DetectAddressFree(a);
-    return 0;
+     DetectAddressFree(a);
+     FAIL;
 }
 
 static int DetectAddressIPv4IsCompleteIPSpace03(void)
@@ -908,8 +908,8 @@ static int DetectAddressIPv4IsCompleteIPSpace03(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        goto error;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
     temp = a;
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
@@ -970,12 +970,12 @@ static int DetectAddressIPv4IsCompleteIPSpace03(void)
 
     DetectAddressFree(a);
 
-    return result;
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
-    if (a != NULL)
-        DetectAddressFree(a);
-    return 0;
+     DetectAddressFree(a);
+     FAIL;
 }
 
 static int DetectAddressIPv4IsCompleteIPSpace04(void)
@@ -985,8 +985,8 @@ static int DetectAddressIPv4IsCompleteIPSpace04(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        goto error;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
     temp = a;
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
@@ -1047,12 +1047,12 @@ static int DetectAddressIPv4IsCompleteIPSpace04(void)
 
     DetectAddressFree(a);
 
-    return result;
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
-    if (a != NULL)
-        DetectAddressFree(a);
-    return 0;
+     DetectAddressFree(a);
+     FAIL;
 }
 
 static int DetectAddressIPv4CutNot05(void)
@@ -1062,8 +1062,8 @@ static int DetectAddressIPv4CutNot05(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        return 0;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
         goto error;
@@ -1074,15 +1074,14 @@ static int DetectAddressIPv4CutNot05(void)
     result &= (DetectAddressCutNotIPv4(a, &b) == -1);
 
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return result;
+    DetectAddressFree(b);
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return 0;
+    DetectAddressFree(b);
+    FAIL;
 }
 
 static int DetectAddressIPv4CutNot06(void)
@@ -1092,8 +1091,8 @@ static int DetectAddressIPv4CutNot06(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        return 0;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "0.0.0.0", &in) < 0)
         goto error;
@@ -1111,15 +1110,14 @@ static int DetectAddressIPv4CutNot06(void)
     result &= (a->ip2.addr_data32[0] = in.s_addr);
 
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return result;
+    DetectAddressFree(b);
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return 0;
+    DetectAddressFree(b);
+    FAIL;
 }
 
 static int DetectAddressIPv4CutNot07(void)
@@ -1129,8 +1127,8 @@ static int DetectAddressIPv4CutNot07(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        return 0;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "1.2.3.4", &in) < 0)
         goto error;
@@ -1148,15 +1146,14 @@ static int DetectAddressIPv4CutNot07(void)
     result &= (a->ip2.addr_data32[0] = in.s_addr);
 
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return result;
+    DetectAddressFree(b);
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return 0;
+    DetectAddressFree(b);
+    FAIL;
 }
 
 static int DetectAddressIPv4CutNot08(void)
@@ -1166,8 +1163,8 @@ static int DetectAddressIPv4CutNot08(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        return 0;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "1.2.3.4", &in) < 0)
         goto error;
@@ -1185,7 +1182,6 @@ static int DetectAddressIPv4CutNot08(void)
     result &= (a->ip2.addr_data32[0] = in.s_addr);
 
     if (b == NULL) {
-        result = 0;
         goto error;
     } else {
         result &= 1;
@@ -1198,15 +1194,14 @@ static int DetectAddressIPv4CutNot08(void)
     result &= (b->ip2.addr_data32[0] = in.s_addr);
 
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return result;
+    DetectAddressFree(b);
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return 0;
+    DetectAddressFree(b);
+    FAIL;
 }
 
 static int DetectAddressIPv4CutNot09(void)
@@ -1216,8 +1211,8 @@ static int DetectAddressIPv4CutNot09(void)
     struct in_addr in;
     int result = 1;
 
-    if ( (a = DetectAddressInit()) == NULL)
-        return 0;
+    a = DetectAddressInit();
+    FAIL_IF_NULL(a);
 
     if (inet_pton(AF_INET, "1.2.3.4", &in) < 0)
         goto error;
@@ -1235,7 +1230,6 @@ static int DetectAddressIPv4CutNot09(void)
     result &= (a->ip2.addr_data32[0] = in.s_addr);
 
     if (b == NULL) {
-        result = 0;
         goto error;
     } else {
         result &= 1;
@@ -1248,15 +1242,14 @@ static int DetectAddressIPv4CutNot09(void)
     result &= (b->ip2.addr_data32[0] = in.s_addr);
 
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return result;
+    DetectAddressFree(b);
+    FAIL_IF_NOT(result);
+    PASS;
 
  error:
     DetectAddressFree(a);
-    if (b != NULL)
-        DetectAddressFree(b);
-    return 0;
+    DetectAddressFree(b);
+    FAIL;
 }
 
 #endif


### PR DESCRIPTION
Ticket OISF#6318

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6318

Describe changes:
- Update detect-engine-address-ipv4.c unittests  to use FAIL/PASS API


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
