### PR TITLE
SDP: implements sticky buffers

### DIFF
--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -29,6 +29,7 @@ Suricata Rules
    snmp-keywords
    base64-keywords
    sip-keywords
+   sdp-keywords
    rfb-keywords
    mqtt-keywords
    ike-keywords

--- a/doc/userguide/rules/sdp-keywords.rst
+++ b/doc/userguide/rules/sdp-keywords.rst
@@ -1,0 +1,382 @@
+SDP Keywords
+============
+
+The SDP keywords are implemented as sticky buffers and can be used to match on fields in SDP messages.
+
+======================================== ==================
+Keyword                                  Direction
+======================================== ==================
+sdp.origin                               Both
+sdp.session_name                         Both
+sdp.session_info                         Both
+sdp.uri                                  Both
+sdp.email                                Both
+sdp.connection_data                      Both
+sdp.bandwidth                            Both
+sdp.time                                 Both
+sdp.repeat_time                          Both
+sdp.timezone                             Both
+sdp.encryption_key                       Both
+sdp.attribute                            Both
+sdp.media_description.media              Both
+sdp.media_description.session_info       Both
+sdp.media_description.connection_data    Both
+sdp.media_description.encryption_key     Both
+======================================== ==================
+
+sdp.origin
+----------
+
+This keyword matches on the originator found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.origin; content:<origin>;
+
+Where <origin> is an originator that follows the SDP Origin (o=) scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.origin; content:"SIPPS 105015165 105015162 IN IP4 192.168.1.2";
+
+sdp.session_name
+----------------
+
+This keyword matches on the session name found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.session_name; content:<session_name>;
+
+Where <session_name> is a name that follows the SDP Session name (s=) scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.session_name; content:"SIP call";
+
+sdp.session_info
+----------------
+
+This keyword matches on the session information found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.session_info; content:<session_info>;
+
+Where <session_info> is a description that follows the SDP Session information (i=) scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.session_info; content:"Session Description Protocol";
+
+sdp.uri
+-------
+
+This keyword matches on the URI found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.uri; content:<uri>;
+
+Where <uri> is a URI (u=) that the follows the SDP scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.uri; content:"https://www.sdp.proto"
+
+sdp.email
+---------
+
+This keyword matches on the email found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.email; content:<email>
+
+Where <email> is an email address (e=) that follows the SDP scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.email; content:"j.doe@example.com (Jane Doe)";
+
+sdp.phone_number
+----------------
+
+This keyword matches on the phone number found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.phone_number; content:<phone_number>
+
+Where <phone_number> is a phone number (p=) that follows the SDP scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.phone_number; content:"+1 617 555-6011 (Jane Doe)";
+
+sdp.connection_data
+-------------------
+
+This keyword matches on the connection found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.connection_data; content:<connection_data>;
+
+Where <connection_data> is a connection (c=) that follows the SDP scheme.
+
+Examples
+~~~~~~~~
+
+::
+
+  sdp.connection_data; content:"IN IP4 192.168.1.2"
+
+sdp.bandwidth
+-------------
+
+This keyword matches on the bandwidths found in an SDP request or response. 
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.bandwidth; content:<bandwidth>
+
+Where <bandwidth> is a bandwidth (b=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.bandwidth; content:"AS:64"
+
+sdp.time
+--------
+
+This keyword matches on the time found in an SDP request or response. 
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.time; content:<time>
+
+Where <time> is a time (t=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.time; content:"3034423619 3042462419"
+
+sdp.repeat_time
+---------------
+
+This keyword matches on the repeat time found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.repeat_time; content:<repeat_time>
+
+Where <repeat_time> is a repeat time (r=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.repeat_time; content:"604800 3600 0 90000"
+
+sdp.timezone
+------------
+
+This keyword matches on the timezone found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.timezone; content:<timezone>
+
+Where <timezone> is a timezone (z=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.timezone; content:"2882844526 -1h 2898848070 0"
+
+sdp.encryption_key
+------------------
+
+This keyword matches on the encryption key found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.encryption_key; content:<encryption_key>
+
+Where <encryption_key> is a key (k=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.encryption_key; content:"prompt"
+
+sdp.attribute
+----------------
+
+This keyword matches on the attributes found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.attribute; content:<attribute>
+
+Where <attribute> is an attribute (a=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.attribute; content:"sendrecv"
+
+sdp.media_description.media
+---------------------------
+
+This keyword matches on the Media subfield of a Media description field found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.media_description.media; content:<media>
+
+Where <media> is a media (m=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.media_description.media; content:"audio 30000 RTP/AVP 0 8 97 2 3"
+
+sdp.media_description.session_info
+----------------------------------
+
+This keyword matches on the Session information subfield of a Media description field found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.media_description.session_info; content:<session_info>
+
+Where <session_info> is a description (i=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.media_description.session_info; content:"Session Description Protocol"
+
+sdp.media_description.connection_data
+-------------------------------------
+
+This keyword matches on the Connection data subfield of a Media description field found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.media_description.connection_data; content:<connection_data>
+
+Where <connection_data> is a connection (c=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.media_description.connection_data; content:"IN IP4 192.168.1.2"
+
+sdp.media_description.encryption_key
+------------------------------------
+
+This keyword matches on the Encryption key subfield of a Media description field found in an SDP request or response.
+
+Syntax
+~~~~~~
+
+::
+
+  sdp.media_description.encryption_key; content:<encryption_key>
+
+Where <encryption_key> is a key (k=) that follows the SDP scheme.
+
+Example
+~~~~~~~
+
+::
+
+  sdp.media_description.encryption_key; content:"prompt"

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -77,6 +77,7 @@ Major changes
     - sip.to
     - sip.content_type
     - sip.content_length
+- SDP sticky buffers have been introduced.
 
 Removals
 ~~~~~~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4112,6 +4112,12 @@
                                         "optional": true,
                                         "description": "Connection data per media description"
                                     },
+                                    "encryption_key": {
+                                        "type": "string",
+                                        "optional": true,
+                                        "description":
+                                                "Field used to convey encryption keys if SDP is used over a secure channel"
+                                    },
                                     "attributes": {
                                         "type": "array",
                                         "description":

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -37,6 +37,7 @@ static mut G_SDP_CONNECTION_DATA_BUFFER_ID: c_int = 0;
 static mut G_SDP_BANDWIDTH_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_REPEAT_TIME_BUFFER_ID: c_int = 0;
+static mut G_SDP_TIMEZONE_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -528,6 +529,55 @@ unsafe extern "C" fn sdp_repeat_time_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_timezone_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_TIMEZONE_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_timezone_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_timezone_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_timezone_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(z) = &sdp.time_zone {
+            if !z.is_empty() {
+                *buffer = z.as_ptr();
+                *buffer_len = z.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -715,5 +765,23 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_repeat_time_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.timezone\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP timezone field\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#timezone\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_timezone_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_TIMEZONE_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.timezone\0".as_ptr() as *const libc::c_char,
+        b"sdp.timezone\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_timezone_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -38,6 +38,7 @@ static mut G_SDP_BANDWIDTH_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_REPEAT_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIMEZONE_BUFFER_ID: c_int = 0;
+static mut G_SDP_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -578,6 +579,55 @@ unsafe extern "C" fn sdp_timezone_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_encryption_key_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_ENCRYPTION_KEY_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_encryption_key_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_encryption_key_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_encryption_key_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(k) = &sdp.encryption_key {
+            if !k.is_empty() {
+                *buffer = k.as_ptr();
+                *buffer_len = k.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -783,5 +833,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_timezone_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.encryption_key\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP encryption key field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#encryption-key\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_encryption_key_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_ENCRYPTION_KEY_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.encryption_key\0".as_ptr() as *const libc::c_char,
+        b"sdp.encription_key\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_encryption_key_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -29,6 +29,7 @@ use std::ptr;
 static mut G_SDP_ORIGIN_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
+static mut G_SDP_URI_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -175,6 +176,55 @@ unsafe extern "C" fn sdp_origin_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_uri_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_URI_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_uri_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_uri_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_uri_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref u) = sdp.uri {
+            if !u.is_empty() {
+                *buffer = u.as_ptr();
+                *buffer_len = u.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -232,5 +282,23 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_origin_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.uri\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP uri field\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-uri\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_uri_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_URI_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.uri\0".as_ptr() as *const libc::c_char,
+        b"sdp.uri\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_uri_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -1,0 +1,100 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+use crate::core::Direction;
+use crate::detect::{
+    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt, SIGMATCH_NOOPT,
+};
+use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
+use std::os::raw::{c_int, c_void};
+use std::ptr;
+
+static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
+
+unsafe extern "C" fn sdp_session_name_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_SESSION_NAME_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_session_name_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_session_name_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_session_name_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_message = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_message {
+        let session_name = &sdp.session_name;
+        if !session_name.is_empty() {
+            *buffer = session_name.as_ptr();
+            *buffer_len = session_name.len() as u32;
+            return true;
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ScDetectSdpRegister() {
+    let kw = SCSigTableElmt {
+        name: b"sdp.session_name\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP session name field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-session-name\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_session_name_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_SESSION_NAME_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.session_name\0".as_ptr() as *const libc::c_char,
+        b"sdp.session_name\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_session_name_get,
+    );
+}

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -26,6 +26,7 @@ use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 
+static mut G_SDP_ORIGIN_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
 
@@ -126,6 +127,54 @@ unsafe extern "C" fn sdp_session_info_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_origin_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_ORIGIN_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_origin_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_origin_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_origin_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        let origin = &sdp.origin;
+        if !origin.is_empty() {
+            *buffer = origin.as_ptr();
+            *buffer_len = origin.len() as u32;
+            return true;
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -165,5 +214,23 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_session_info_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.origin\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP origin field\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-origin\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_origin_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_ORIGIN_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.origin\0".as_ptr() as *const libc::c_char,
+        b"sdp.origin\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_origin_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -36,6 +36,7 @@ static mut G_SDP_PHONE_NUMBER_BUFFER_ID: c_int = 0;
 static mut G_SDP_CONNECTION_DATA_BUFFER_ID: c_int = 0;
 static mut G_SDP_BANDWIDTH_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIME_BUFFER_ID: c_int = 0;
+static mut G_SDP_REPEAT_TIME_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -478,6 +479,55 @@ unsafe extern "C" fn sdp_time_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_repeat_time_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_REPEAT_TIME_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_repeat_time_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_repeat_time_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_repeat_time_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(r) = &sdp.repeat_time {
+            if !r.is_empty() {
+                *buffer = r.as_ptr();
+                *buffer_len = r.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -646,5 +696,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_time_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP repeat time field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#repeat-time\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_repeat_time_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_REPEAT_TIME_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
+        b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_repeat_time_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -32,6 +32,7 @@ static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
 static mut G_SDP_URI_BUFFER_ID: c_int = 0;
 static mut G_SDP_EMAIL_BUFFER_ID: c_int = 0;
 static mut G_SDP_PHONE_NUMBER_BUFFER_ID: c_int = 0;
+static mut G_SDP_CONNECTION_DATA_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -325,6 +326,55 @@ unsafe extern "C" fn sdp_phone_number_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_conn_data_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_CONNECTION_DATA_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_conn_data_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_conn_data_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_conn_data_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref c) = sdp.connection_data {
+            if !c.is_empty() {
+                *buffer = c.as_ptr();
+                *buffer_len = c.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -437,5 +487,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_phone_number_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP connection data field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-connection-data\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_conn_data_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_CONNECTION_DATA_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
+        b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_conn_data_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -35,6 +35,7 @@ static mut G_SDP_EMAIL_BUFFER_ID: c_int = 0;
 static mut G_SDP_PHONE_NUMBER_BUFFER_ID: c_int = 0;
 static mut G_SDP_CONNECTION_DATA_BUFFER_ID: c_int = 0;
 static mut G_SDP_BANDWIDTH_BUFFER_ID: c_int = 0;
+static mut G_SDP_TIME_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -429,6 +430,54 @@ unsafe extern "C" fn sip_bandwidth_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_time_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_TIME_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_time_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_time_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_time_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        let time = &sdp.time;
+        if !time.is_empty() {
+            *buffer = time.as_ptr();
+            *buffer_len = time.len() as u32;
+            return true;
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -579,5 +628,23 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_bandwidth_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.time\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP time field\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#time\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_time_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_TIME_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.time\0".as_ptr() as *const libc::c_char,
+        b"sdp.time\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_time_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -27,6 +27,7 @@ use std::os::raw::{c_int, c_void};
 use std::ptr;
 
 static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
+static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -76,6 +77,55 @@ unsafe extern "C" fn sdp_session_name_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_session_info_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_SESSION_INFO_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_session_info_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_session_info_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_session_info_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_message = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_message {
+        if let Some(ref s) = sdp.session_info {
+            if !s.is_empty() {
+                *buffer = s.as_ptr();
+                *buffer_len = s.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -96,5 +146,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_session_name_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.session_info\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP session info field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-session-info\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_session_info_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_SESSION_INFO_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.session_info\0".as_ptr() as *const libc::c_char,
+        b"sdp.session_info\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_session_info_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -39,6 +39,7 @@ static mut G_SDP_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_REPEAT_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIMEZONE_BUFFER_ID: c_int = 0;
 static mut G_SDP_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
+static mut G_SDP_ATTRIBUTE_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -628,6 +629,58 @@ unsafe extern "C" fn sdp_encryption_key_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_attribute_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_ATTRIBUTE_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_attribute_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_attribute_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_attribute_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref a) = sdp.attributes {
+            if (local_id as usize) < a.len() {
+                let val = &a[local_id as usize];
+                *buffer = val.as_ptr();
+                *buffer_len = val.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -852,5 +905,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_encryption_key_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.attribute\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP attribute field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-attribute\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_attribute_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_ATTRIBUTE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.attribute\0".as_ptr() as *const libc::c_char,
+        b"sdp.attribute\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_attribute_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -31,6 +31,7 @@ static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
 static mut G_SDP_URI_BUFFER_ID: c_int = 0;
 static mut G_SDP_EMAIL_BUFFER_ID: c_int = 0;
+static mut G_SDP_PHONE_NUMBER_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -275,6 +276,55 @@ unsafe extern "C" fn sdp_email_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_phone_number_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_PHONE_NUMBER_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_phone_number_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_phone_number_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_phone_number_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref p) = sdp.phone_number {
+            if !p.is_empty() {
+                *buffer = p.as_ptr();
+                *buffer_len = p.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -368,5 +418,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_email_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP phone number field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-phone-number\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_phone_number_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_PHONE_NUMBER_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
+        b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_phone_number_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -20,7 +20,8 @@
 use crate::core::Direction;
 use crate::detect::{
     DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt, SIGMATCH_NOOPT,
+    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SCSigTableElmt, SIGMATCH_NOOPT,
 };
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
 use std::os::raw::{c_int, c_void};
@@ -33,6 +34,7 @@ static mut G_SDP_URI_BUFFER_ID: c_int = 0;
 static mut G_SDP_EMAIL_BUFFER_ID: c_int = 0;
 static mut G_SDP_PHONE_NUMBER_BUFFER_ID: c_int = 0;
 static mut G_SDP_CONNECTION_DATA_BUFFER_ID: c_int = 0;
+static mut G_SDP_BANDWIDTH_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -375,6 +377,58 @@ unsafe extern "C" fn sdp_conn_data_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_bandwidth_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_BANDWIDTH_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_bandwidth_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_bandwidth_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_bandwidth_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref b) = sdp.bandwidths {
+            if (local_id as usize) < b.len() {
+                let val = &b[local_id as usize];
+                *buffer = val.as_ptr();
+                *buffer_len = val.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -506,5 +560,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_conn_data_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP bandwidth field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-bandwidth\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_bandwidth_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_BANDWIDTH_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
+        b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_bandwidth_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -30,6 +30,7 @@ static mut G_SDP_ORIGIN_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_INFO_BUFFER_ID: c_int = 0;
 static mut G_SDP_URI_BUFFER_ID: c_int = 0;
+static mut G_SDP_EMAIL_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -225,6 +226,55 @@ unsafe extern "C" fn sdp_uri_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_email_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_EMAIL_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_email_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        sdp_email_get_data,
+    );
+}
+
+unsafe extern "C" fn sdp_email_get_data(
+    tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let sdp_option = match direction.into() {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref e) = sdp.email {
+            if !e.is_empty() {
+                *buffer = e.as_ptr();
+                *buffer_len = e.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -300,5 +350,23 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_uri_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.email\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP email field\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-email\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_email_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_EMAIL_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"sdp.email\0".as_ptr() as *const libc::c_char,
+        b"sdp.email\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_email_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -42,6 +42,7 @@ static mut G_SDP_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
 static mut G_SDP_ATTRIBUTE_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID: c_int = 0;
+static mut G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -788,6 +789,59 @@ unsafe extern "C" fn sip_media_desc_session_info_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_media_desc_connection_data_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_media_desc_connection_data_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_media_desc_connection_data_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_media_desc_connection_data_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref m) = sdp.media_description {
+            if (local_id as usize) < m.len() {
+                if let Some(c) = &m[local_id as usize].connection_data {
+                    *buffer = c.as_ptr();
+                    *buffer_len = c.len() as u32;
+                    return true;
+                }
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -1069,5 +1123,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_media_desc_session_info_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP connection data subfield of the media_description field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-media-description-connection-data\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_media_desc_connection_data_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
+        b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_media_desc_connection_data_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -40,6 +40,7 @@ static mut G_SDP_REPEAT_TIME_BUFFER_ID: c_int = 0;
 static mut G_SDP_TIMEZONE_BUFFER_ID: c_int = 0;
 static mut G_SDP_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
 static mut G_SDP_ATTRIBUTE_BUFFER_ID: c_int = 0;
+static mut G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -681,6 +682,58 @@ unsafe extern "C" fn sip_attribute_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_media_desc_media_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_media_desc_media_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_media_desc_media_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_media_desc_media_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref m) = sdp.media_description {
+            if (local_id as usize) < m.len() {
+                let val = &m[local_id as usize].media;
+                *buffer = val.as_ptr();
+                *buffer_len = val.len() as u32;
+                return true;
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -924,5 +977,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_attribute_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.media.media\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP media subfield of the media_description field\0"
+            .as_ptr() as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#media-description-media\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_media_desc_media_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.media.media\0".as_ptr() as *const libc::c_char,
+        b"sdp.media.media\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_media_desc_media_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -41,6 +41,7 @@ static mut G_SDP_TIMEZONE_BUFFER_ID: c_int = 0;
 static mut G_SDP_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
 static mut G_SDP_ATTRIBUTE_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID: c_int = 0;
+static mut G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -734,6 +735,59 @@ unsafe extern "C" fn sip_media_desc_media_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_media_desc_session_info_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_media_desc_session_info_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_media_desc_session_info_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_media_desc_session_info_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref m) = sdp.media_description {
+            if (local_id as usize) < m.len() {
+                if let Some(i) = &m[local_id as usize].session_info {
+                    *buffer = i.as_ptr();
+                    *buffer_len = i.len() as u32;
+                    return true;
+                }
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -996,5 +1050,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_media_desc_media_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP session info subfield of the media_description field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-media-description-session-info\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_media_desc_session_info_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
+        b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_media_desc_session_info_get,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -43,6 +43,7 @@ static mut G_SDP_ATTRIBUTE_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID: c_int = 0;
 static mut G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID: c_int = 0;
+static mut G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn sdp_session_name_setup(
     de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
@@ -842,6 +843,59 @@ unsafe extern "C" fn sip_media_desc_connection_data_get_data(
     false
 }
 
+unsafe extern "C" fn sdp_media_desc_encryption_key_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SIP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn sdp_media_desc_encryption_key_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        sip_media_desc_encryption_key_get_data,
+    );
+}
+
+unsafe extern "C" fn sip_media_desc_encryption_key_get_data(
+    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, SIPTransaction);
+    let direction = flow_flags.into();
+    let sdp_option = match direction {
+        Direction::ToServer => tx.request.as_ref().and_then(|req| req.body.as_ref()),
+        Direction::ToClient => tx.response.as_ref().and_then(|resp| resp.body.as_ref()),
+    };
+    if let Some(sdp) = sdp_option {
+        if let Some(ref m) = sdp.media_description {
+            if (local_id as usize) < m.len() {
+                if let Some(k) = &m[local_id as usize].encryption_key {
+                    *buffer = k.as_ptr();
+                    *buffer_len = k.len() as u32;
+                    return true;
+                }
+            }
+        }
+    }
+    *buffer = ptr::null();
+    *buffer_len = 0;
+    false
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn ScDetectSdpRegister() {
     let kw = SCSigTableElmt {
@@ -1142,5 +1196,24 @@ pub unsafe extern "C" fn ScDetectSdpRegister() {
         true,
         true,
         sdp_media_desc_connection_data_get,
+    );
+    let kw = SCSigTableElmt {
+        name: b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
+        desc: b"sticky buffer to match on the SDP encryption key subfield of the media_description field\0".as_ptr()
+            as *const libc::c_char,
+        url: b"/rules/sdp-keywords.html#sdp-media-description-encryption-key\0".as_ptr() as *const libc::c_char,
+        Setup: sdp_media_desc_encryption_key_setup,
+        flags: SIGMATCH_NOOPT,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _ = DetectHelperKeywordRegister(&kw);
+    G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
+        b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SIP,
+        true,
+        true,
+        sdp_media_desc_encryption_key_get,
     );
 }

--- a/rust/src/sdp/logger.rs
+++ b/rust/src/sdp/logger.rs
@@ -102,6 +102,9 @@ fn log_media_description(
             if let Some(conn_data) = &m.connection_data {
                 log_connection_data(conn_data, js)?;
             }
+            if let Some(enc_key) = &m.encryption_key {
+                js.set_string("encryption_key", enc_key)?;
+            }
             if let Some(attrs) = &m.attributes {
                 log_attributes(attrs, js)?;
             }

--- a/rust/src/sdp/mod.rs
+++ b/rust/src/sdp/mod.rs
@@ -1,2 +1,22 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// written by Giuseppe Longo <giuseppe@glongo.it>
+
+pub mod detect;
 pub mod logger;
 pub mod parser;

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -695,6 +695,7 @@ void SigTableSetup(void)
     ScDetectMqttRegister();
     ScDetectRfbRegister();
     ScDetectSipRegister();
+    ScDetectSdpRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
- https://redmine.openinfosecfoundation.org/issues/7291
- https://redmine.openinfosecfoundation.org/issues/7305

Describe changes:
- Sticky buffers for SDP have been implemented.
- `sdp.media.bandwidth` and `sdp.media.attribute` sticky buffers have not been implemented yet because the media field is a vector of `MediaDescription`, and both the `bandwidth` and `attribute` fields are vectors as well.
I believe the multi-buffer API cannot handle such a situation.
If I'm not mistaken, a simple solution could be to "stringify" these fields like this:
```
"media_description": {
    "bandwidth": "AS:64,AS:65,AS:66",
    "attribute": "sendonly,recvonly"
}
```
- Media's encryption key is logged now.

Personal considerations:
- The `sdp.media.*` sticky buffers were initially meant to be named `sdp.media_descriptions.*`, but I realized the names were too long. I wonder if I should rename the `media_description` field to `media` for consistency.
- I don't like the name `sdp.media.media`; I would prefer to rename it to `sdp.media.name`, or just `sdp.media`, and adjust the logged field name if necessary.
 
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2076