### PR TITLE
hyperscan: add caching mechanism for hyperscan contexts v8

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,7 @@ install-conf:
 	install -d "$(DESTDIR)$(e_rundir)"
 	install -m 770 -d "$(DESTDIR)$(e_localstatedir)"
 	install -m 770 -d "$(DESTDIR)$(e_datadir)"
+	install -m 660 -d "$(DESTDIR)$(e_hscachedir)"
 
 install-rules:
 if INSTALL_SURICATA_UPDATE

--- a/configure.ac
+++ b/configure.ac
@@ -2439,6 +2439,7 @@ if test "$WINDOWS_PATH" = "yes"; then
 
     e_sysconfdir="${e_winbase}\\\\"
     e_defaultruledir="$e_winbase\\\\rules\\\\"
+    e_hscachedir="$e_winbase\\\\cache\\\\hs\\\\"
     e_magic_file="$e_winbase\\\\magic.mgc"
     e_logdir="$e_winbase\\\\log"
     e_logfilesdir="$e_logdir\\\\files"
@@ -2460,6 +2461,7 @@ else
     EXPAND_VARIABLE(sysconfdir, e_sysconfdir, "/suricata/")
     EXPAND_VARIABLE(localstatedir, e_localstatedir, "/run/suricata")
     EXPAND_VARIABLE(datadir, e_datarulesdir, "/suricata/rules")
+    EXPAND_VARIABLE(localstatedir, e_hscachedir, "/lib/suricata/cache/hs")
     EXPAND_VARIABLE(localstatedir, e_datadir, "/lib/suricata/data")
     EXPAND_VARIABLE(localstatedir, e_defaultruledir, "/lib/suricata/rules")
 
@@ -2473,6 +2475,7 @@ AC_SUBST(e_logcertsdir)
 AC_SUBST(e_sysconfdir)
 AC_DEFINE_UNQUOTED([CONFIG_DIR],["$e_sysconfdir"],[Our CONFIG_DIR])
 AC_SUBST(e_localstatedir)
+AC_SUBST(e_hscachedir)
 AC_SUBST(e_datadir)
 AC_DEFINE_UNQUOTED([DATA_DIR],["$e_datadir"],[Our DATA_DIR])
 AC_SUBST(e_magic_file)

--- a/doc/userguide/performance/hyperscan.rst
+++ b/doc/userguide/performance/hyperscan.rst
@@ -82,3 +82,27 @@ if it is present on the system in case of the "auto" setting.
 
 If the current suricata installation does not have hyperscan
 support, refer to :ref:`installation`
+
+Hyperscan caching
+~~~~~~~~~~~~~~~~~
+
+Upon startup, Hyperscan compiles and optimizes the ruleset into its own 
+internal structure. Suricata optimizes the startup process by saving 
+the Hyperscan internal structures to disk and loading them on the next start. 
+This prevents the recompilation of the ruleset and results in faster 
+initialization. If the ruleset is changed, new necessary cache files are 
+automatically created. 
+
+To enable this function, in `suricata.yaml` configure:
+
+::
+
+  # Cache MPM contexts to the disk to avoid rule compilation at the startup.
+  # Cache files are created in the default logging directory.
+  sgh-mpm-caching: yes
+  sgh-mpm-caching-path: /var/lib/suricata/cache/hs
+
+
+**Note**: 
+You might need to create and adjust permissions to the default caching folder 
+path, especially if you are running Suricata as a non-root user.

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -33,6 +33,7 @@
 #include "tm-threads.h"
 #include "queue.h"
 
+#include "detect-engine.h"
 #include "detect-engine-loader.h"
 #include "detect-engine-build.h"
 #include "detect-engine-analyzer.h"
@@ -401,6 +402,10 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, bool sig_file_exc
         goto end;
 
     ret = 0;
+
+    if (DetectEngineMpmCachingEnabled() && mpm_table[de_ctx->mpm_matcher].CacheRuleset != NULL) {
+        mpm_table[de_ctx->mpm_matcher].CacheRuleset();
+    }
 
  end:
     gettimeofday(&de_ctx->last_reload, NULL);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3000,14 +3000,6 @@ bool DetectEngineMpmCachingEnabled(void)
     return (bool)sgh_mpm_caching;
 }
 
-/*
- * getting & (re)setting the internal sig i
- */
-
-//inline uint32_t DetectEngineGetMaxSigId(DetectEngineCtx *de_ctx)
-//{
-//    return de_ctx->signum;
-//}
 const char *DetectEngineMpmCachingGetPath(void)
 {
     const char *strval = NULL;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2989,6 +2989,17 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
     return 0;
 }
 
+bool DetectEngineMpmCachingEnabled(void)
+{
+    const char *strval = NULL;
+    if (ConfGet("detect.sgh-mpm-caching", &strval) != 1)
+        return false;
+
+    int sgh_mpm_caching = 0;
+    (void)ConfGetBool("detect.sgh-mpm-caching", &sgh_mpm_caching);
+    return (bool)sgh_mpm_caching;
+}
+
 /*
  * getting & (re)setting the internal sig i
  */
@@ -2997,6 +3008,12 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
 //{
 //    return de_ctx->signum;
 //}
+const char *DetectEngineMpmCachingGetPath(void)
+{
+    const char *strval = NULL;
+    ConfGet("detect.sgh-mpm-caching-path", &strval);
+    return strval;
+}
 
 void DetectEngineResetMaxSigId(DetectEngineCtx *de_ctx)
 {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -100,7 +100,9 @@ void *DetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, i
 
 TmEcode DetectEngineThreadCtxInit(ThreadVars *, void *, void **);
 TmEcode DetectEngineThreadCtxDeinit(ThreadVars *, void *);
+bool DetectEngineMpmCachingEnabled(void);
 //inline uint32_t DetectEngineGetMaxSigId(DetectEngineCtx *);
+const char *DetectEngineMpmCachingGetPath(void);
 /* faster as a macro than a inline function on my box -- VJ */
 #define DetectEngineGetMaxSigId(de_ctx) ((de_ctx)->signum)
 void DetectEngineResetMaxSigId(DetectEngineCtx *);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -101,7 +101,6 @@ void *DetectThreadCtxGetGlobalKeywordThreadCtx(DetectEngineThreadCtx *det_ctx, i
 TmEcode DetectEngineThreadCtxInit(ThreadVars *, void *, void **);
 TmEcode DetectEngineThreadCtxDeinit(ThreadVars *, void *);
 bool DetectEngineMpmCachingEnabled(void);
-//inline uint32_t DetectEngineGetMaxSigId(DetectEngineCtx *);
 const char *DetectEngineMpmCachingGetPath(void);
 /* faster as a macro than a inline function on my box -- VJ */
 #define DetectEngineGetMaxSigId(de_ctx) ((de_ctx)->signum)

--- a/src/util-hash-lookup3.c
+++ b/src/util-hash-lookup3.c
@@ -805,7 +805,211 @@ void hashlittle2(
   *pc=c; *pb=b;
 }
 
+/*
+ * hashlittle2: return 2 32-bit hash values
+ *
+ * This is identical to hashlittle(), except it returns two 32-bit hash
+ * values instead of just one.  This is good enough for hash table
+ * lookup with 2^^64 buckets, or if you want a second hash if you're not
+ * happy with the first, or if you want a probably-unique 64-bit ID for
+ * the key.  *pc is better mixed than *pb, so use *pc first.  If you want
+ * a 64-bit value do something like "*pc + (((uint64_t)*pb)<<32)".
+ */
+void hashlittle2_safe(const void *key, /* the key to hash */
+        size_t length,                 /* length of the key */
+        uint32_t *pc,                  /* IN: primary initval, OUT: primary hash */
+        uint32_t *pb)                  /* IN: secondary initval, OUT: secondary hash */
+{
+    uint32_t a, b, c; /* internal state */
+    union {
+        const void *ptr;
+        size_t i;
+    } u; /* needed for Mac Powerbook G4 */
 
+    /* Set up the internal state */
+    a = b = c = 0xdeadbeef + ((uint32_t)length) + *pc;
+    c += *pb;
+
+    u.ptr = key;
+    if (HASH_LITTLE_ENDIAN && ((u.i & 0x3) == 0)) {
+        const uint32_t *k = (const uint32_t *)key; /* read 32-bit chunks */
+
+        /*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+        while (length > 12) {
+            a += k[0];
+            b += k[1];
+            c += k[2];
+            mix(a, b, c);
+            length -= 12;
+            k += 3;
+        }
+
+        /*----------------------------- handle the last (probably partial) block */
+        /*
+         * Note that unlike hashlittle() above, we use the "safe" version of this
+         * block that is #ifdef VALGRIND above, in order to avoid warnings from
+         * Valgrind or Address Sanitizer.
+         */
+        const uint8_t *k8 = (const uint8_t *)k;
+        switch (length) {
+            case 12:
+                c += k[2];
+                b += k[1];
+                a += k[0];
+                break;
+            case 11:
+                c += ((uint32_t)k8[10]) << 16; /* fall through */
+            case 10:
+                c += ((uint32_t)k8[9]) << 8; /* fall through */
+            case 9:
+                c += k8[8]; /* fall through */
+            case 8:
+                b += k[1];
+                a += k[0];
+                break;
+            case 7:
+                b += ((uint32_t)k8[6]) << 16; /* fall through */
+            case 6:
+                b += ((uint32_t)k8[5]) << 8; /* fall through */
+            case 5:
+                b += k8[4]; /* fall through */
+            case 4:
+                a += k[0];
+                break;
+            case 3:
+                a += ((uint32_t)k8[2]) << 16; /* fall through */
+            case 2:
+                a += ((uint32_t)k8[1]) << 8; /* fall through */
+            case 1:
+                a += k8[0];
+                break;
+            case 0:
+                *pc = c;
+                *pb = b;
+                return; /* zero length strings require no mixing */
+        }
+
+    } else if (HASH_LITTLE_ENDIAN && ((u.i & 0x1) == 0)) {
+        const uint16_t *k = (const uint16_t *)key; /* read 16-bit chunks */
+        const uint8_t *k8;
+
+        /*--------------- all but last block: aligned reads and different mixing */
+        while (length > 12) {
+            a += k[0] + (((uint32_t)k[1]) << 16);
+            b += k[2] + (((uint32_t)k[3]) << 16);
+            c += k[4] + (((uint32_t)k[5]) << 16);
+            mix(a, b, c);
+            length -= 12;
+            k += 6;
+        }
+
+        /*----------------------------- handle the last (probably partial) block */
+        k8 = (const uint8_t *)k;
+        switch (length) {
+            case 12:
+                c += k[4] + (((uint32_t)k[5]) << 16);
+                b += k[2] + (((uint32_t)k[3]) << 16);
+                a += k[0] + (((uint32_t)k[1]) << 16);
+                break;
+            case 11:
+                c += ((uint32_t)k8[10]) << 16; /* fall through */
+            case 10:
+                c += k[4];
+                b += k[2] + (((uint32_t)k[3]) << 16);
+                a += k[0] + (((uint32_t)k[1]) << 16);
+                break;
+            case 9:
+                c += k8[8]; /* fall through */
+            case 8:
+                b += k[2] + (((uint32_t)k[3]) << 16);
+                a += k[0] + (((uint32_t)k[1]) << 16);
+                break;
+            case 7:
+                b += ((uint32_t)k8[6]) << 16; /* fall through */
+            case 6:
+                b += k[2];
+                a += k[0] + (((uint32_t)k[1]) << 16);
+                break;
+            case 5:
+                b += k8[4]; /* fall through */
+            case 4:
+                a += k[0] + (((uint32_t)k[1]) << 16);
+                break;
+            case 3:
+                a += ((uint32_t)k8[2]) << 16; /* fall through */
+            case 2:
+                a += k[0];
+                break;
+            case 1:
+                a += k8[0];
+                break;
+            case 0:
+                *pc = c;
+                *pb = b;
+                return; /* zero length strings require no mixing */
+        }
+
+    } else { /* need to read the key one byte at a time */
+        const uint8_t *k = (const uint8_t *)key;
+
+        /*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+        while (length > 12) {
+            a += k[0];
+            a += ((uint32_t)k[1]) << 8;
+            a += ((uint32_t)k[2]) << 16;
+            a += ((uint32_t)k[3]) << 24;
+            b += k[4];
+            b += ((uint32_t)k[5]) << 8;
+            b += ((uint32_t)k[6]) << 16;
+            b += ((uint32_t)k[7]) << 24;
+            c += k[8];
+            c += ((uint32_t)k[9]) << 8;
+            c += ((uint32_t)k[10]) << 16;
+            c += ((uint32_t)k[11]) << 24;
+            mix(a, b, c);
+            length -= 12;
+            k += 12;
+        }
+
+        /*-------------------------------- last block: affect all 32 bits of (c) */
+        switch (length) /* all the case statements fall through */
+        {
+            case 12:
+                c += ((uint32_t)k[11]) << 24; /* fall through */
+            case 11:
+                c += ((uint32_t)k[10]) << 16; /* fall through */
+            case 10:
+                c += ((uint32_t)k[9]) << 8; /* fall through */
+            case 9:
+                c += k[8]; /* fall through */
+            case 8:
+                b += ((uint32_t)k[7]) << 24; /* fall through */
+            case 7:
+                b += ((uint32_t)k[6]) << 16; /* fall through */
+            case 6:
+                b += ((uint32_t)k[5]) << 8; /* fall through */
+            case 5:
+                b += k[4]; /* fall through */
+            case 4:
+                a += ((uint32_t)k[3]) << 24; /* fall through */
+            case 3:
+                a += ((uint32_t)k[2]) << 16; /* fall through */
+            case 2:
+                a += ((uint32_t)k[1]) << 8; /* fall through */
+            case 1:
+                a += k[0];
+                break;
+            case 0:
+                *pc = c;
+                *pb = b;
+                return; /* zero length strings require no mixing */
+        }
+    }
+
+    final(a, b, c);
+    *pc = c;
+    *pb = b;
+}
 
 /*
  * hashbig():

--- a/src/util-hash-lookup3.h
+++ b/src/util-hash-lookup3.h
@@ -62,6 +62,11 @@ void hashlittle2(const void *key,       /* the key to hash */
                  uint32_t   *pc,        /* IN: primary initval, OUT: primary hash */
                  uint32_t   *pb);       /* IN: secondary initval, OUT: secondary hash */
 
+/* A variant of hashlittle2() that ensures avoids accesses beyond the last byte
+ * of the string, which will cause warnings from tools like Valgrind or Address
+ * Sanitizer. */
+void hashlittle2_safe(const void *key, size_t length, uint32_t *pc, uint32_t *pb);
+
 uint32_t hashbig( const void *key, size_t length, uint32_t initval);
 
 #endif /* SURICATA_UTIL_HASH_LOOKUP3_H */

--- a/src/util-hash.c
+++ b/src/util-hash.c
@@ -208,6 +208,20 @@ void *HashTableLookup(HashTable *ht, void *data, uint16_t datalen)
     return NULL;
 }
 
+void HashTableIterate(HashTable *ht, void (*callback)(void *))
+{
+    if (ht == NULL || callback == NULL)
+        return;
+
+    for (uint32_t i = 0; i < ht->array_size; i++) {
+        HashTableBucket *hashbucket = ht->array[i];
+        while (hashbucket != NULL) {
+            callback(hashbucket->data);
+            hashbucket = hashbucket->next;
+        }
+    }
+}
+
 uint32_t HashTableGenericHash(HashTable *ht, void *data, uint16_t datalen)
 {
      uint8_t *d = (uint8_t *)data;

--- a/src/util-hash.h
+++ b/src/util-hash.h
@@ -51,6 +51,7 @@ void HashTableFree(HashTable *);
 int HashTableAdd(HashTable *, void *, uint16_t);
 int HashTableRemove(HashTable *, void *, uint16_t);
 void *HashTableLookup(HashTable *, void *, uint16_t);
+void HashTableIterate(HashTable *ht, void (*callback)(void *));
 uint32_t HashTableGenericHash(HashTable *, void *, uint16_t);
 char HashTableDefaultCompare(void *, uint16_t, void *, uint16_t);
 

--- a/src/util-mpm-ac-ks.c
+++ b/src/util-mpm-ac-ks.c
@@ -1403,6 +1403,7 @@ void MpmACTileRegister(void)
     mpm_table[MPM_AC_KS].AddPattern = SCACTileAddPatternCS;
     mpm_table[MPM_AC_KS].AddPatternNocase = SCACTileAddPatternCI;
     mpm_table[MPM_AC_KS].Prepare = SCACTilePreparePatterns;
+    mpm_table[MPM_AC_KS].CacheRuleset = NULL;
     mpm_table[MPM_AC_KS].Search = SCACTileSearch;
     mpm_table[MPM_AC_KS].PrintCtx = SCACTilePrintInfo;
 #ifdef UNITTESTS

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1102,6 +1102,7 @@ void MpmACRegister(void)
     mpm_table[MPM_AC].AddPattern = SCACAddPatternCS;
     mpm_table[MPM_AC].AddPatternNocase = SCACAddPatternCI;
     mpm_table[MPM_AC].Prepare = SCACPreparePatterns;
+    mpm_table[MPM_AC].CacheRuleset = NULL;
     mpm_table[MPM_AC].Search = SCACSearch;
     mpm_table[MPM_AC].PrintCtx = SCACPrintInfo;
 #ifdef UNITTESTS

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -428,7 +428,7 @@ typedef struct SCHSCompileData_ {
     unsigned int pattern_cnt;
 } SCHSCompileData;
 
-static SCHSCompileData *SCHSAllocCompileData(unsigned int pattern_cnt)
+static SCHSCompileData *CompileDataAlloc(unsigned int pattern_cnt)
 {
     SCHSCompileData *cd = SCCalloc(pattern_cnt, sizeof(SCHSCompileData));
     if (cd == NULL) {
@@ -471,7 +471,7 @@ error:
     return NULL;
 }
 
-static void SCHSFreeCompileData(SCHSCompileData *cd)
+static void CompileDataFree(SCHSCompileData *cd)
 {
     if (cd == NULL) {
         return;
@@ -695,8 +695,6 @@ static void SCHSCachePatternHash(const SCHSPattern *p, uint32_t *h1, uint32_t *h
 
 static int HSLoadCache(hs_database_t **hs_db, uint64_t hs_db_hash)
 {
-    if (SCCreateDirectoryTree(DetectEngineMpmCachingGetPath(), true) != 0)
-        return -1;
     const char *hash_file_static = HSCacheConstructFPath(hs_db_hash);
     if (hash_file_static == NULL)
         return -1;
@@ -762,6 +760,9 @@ static int HSSaveCache(hs_database_t *hs_db, uint64_t hs_db_hash)
                 hash_file_static);
     }
 
+    if (SCCreateDirectoryTree(DetectEngineMpmCachingGetPath(), true) != 0)
+        return -1;
+
     FILE *db_cache_out = fopen(hash_file_static, "w");
     if (!db_cache_out) {
         if (!notified) {
@@ -819,6 +820,194 @@ static void HSSaveCacheIterator(void *data)
     }
 }
 
+static int HSCheckPatterns(MpmCtx *mpm_ctx, SCHSCtx *ctx)
+{
+    if (mpm_ctx->pattern_cnt == 0 || ctx->init_hash == NULL) {
+        SCLogDebug("no patterns supplied to this mpm_ctx");
+        return 0;
+    }
+    return 1;
+}
+
+static void HSPatternArrayPopulate(SCHSCtx *ctx, PatternDatabase *pd)
+{
+    for (uint32_t i = 0, p = 0; i < INIT_HASH_SIZE; i++) {
+        SCHSPattern *node = ctx->init_hash[i];
+        SCHSPattern *nnode = NULL;
+        while (node != NULL) {
+            nnode = node->next;
+            node->next = NULL;
+            pd->parray[p++] = node;
+            node = nnode;
+        }
+    }
+}
+
+static void HSPatternArrayInit(SCHSCtx *ctx, PatternDatabase *pd)
+{
+    HSPatternArrayPopulate(ctx, pd);
+    /* we no longer need the hash, so free its memory */
+    SCFree(ctx->init_hash);
+    ctx->init_hash = NULL;
+}
+
+static int HSGlobalPatternDatabaseInit(void)
+{
+    if (g_db_table == NULL) {
+        g_db_table = HashTableInit(INIT_DB_HASH_SIZE, PatternDatabaseHash,
+                                   PatternDatabaseCompare,
+                                   PatternDatabaseTableFree);
+        if (g_db_table == NULL) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void HSLogCompileError(hs_compile_error_t *compile_err)
+{
+    SCLogError("failed to compile hyperscan database");
+    if (compile_err) {
+        SCLogError("compile error: %s", compile_err->message);
+        hs_free_compile_error(compile_err);
+    }
+}
+
+static int HSScratchAlloc(const hs_database_t *db)
+{
+    SCMutexLock(&g_scratch_proto_mutex);
+    hs_error_t err = hs_alloc_scratch(db, &g_scratch_proto);
+    SCMutexUnlock(&g_scratch_proto_mutex);
+    if (err != HS_SUCCESS) {
+        SCLogError("failed to allocate scratch");
+        return -1;
+    }
+    return 0;
+}
+
+static int PatternDatabaseGetSize(PatternDatabase *pd, size_t *db_size)
+{
+    hs_error_t err = hs_database_size(pd->hs_db, db_size);
+    if (err != HS_SUCCESS) {
+        SCLogError("failed to query database size: %s", HSErrorToStr(err));
+        return -1;
+    }
+    return 0;
+}
+
+static void SCHSCleanupOnError(PatternDatabase *pd, SCHSCompileData *cd)
+{
+    if (pd) {
+        PatternDatabaseFree(pd);
+    }
+    if (cd) {
+        CompileDataFree(cd);
+    }
+}
+
+static int CompileDataExtensionsInit(hs_expr_ext_t **ext, const SCHSPattern *p)
+{
+    if (p->flags & (MPM_PATTERN_FLAG_OFFSET | MPM_PATTERN_FLAG_DEPTH)) {
+        *ext = SCCalloc(1, sizeof(hs_expr_ext_t));
+        if ((*ext) == NULL) {
+            return -1;
+        }
+        if (p->flags & MPM_PATTERN_FLAG_OFFSET) {
+            (*ext)->flags |= HS_EXT_FLAG_MIN_OFFSET;
+            (*ext)->min_offset = p->offset + p->len;
+        }
+        if (p->flags & MPM_PATTERN_FLAG_DEPTH) {
+            (*ext)->flags |= HS_EXT_FLAG_MAX_OFFSET;
+            (*ext)->max_offset = p->offset + p->depth;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * \brief Initialize the pattern database - try to get existing pd
+ * from the global hash table, or load it from disk if caching is enabled.
+ *
+ * \param PatternDatabase* [in/out] Pointer to the pattern database to use.
+ * \param SCHSCompileData* [in] Pointer to the compile data.
+ * \retval 0 On success, negative value on failure.
+ */
+static int PatternDatabaseGetCached(PatternDatabase **pd, SCHSCompileData *cd)
+{
+    /* Check global hash table to see if we've seen this pattern database
+     * before, and reuse the Hyperscan database if so. */
+    PatternDatabase *pd_cached = HashTableLookup(g_db_table, *pd, 1);
+    if (pd_cached != NULL) {
+        SCLogDebug("Reusing cached database %p with %" PRIu32
+                   " patterns (ref_cnt=%" PRIu32 ")",
+                   pd_cached->hs_db, pd_cached->pattern_cnt,
+                   pd_cached->ref_cnt);
+        pd_cached->ref_cnt++;
+        PatternDatabaseFree(*pd);
+        CompileDataFree(cd);
+        *pd = pd_cached;
+        return 0;
+    } else if (DetectEngineMpmCachingEnabled()) {
+        pd_cached = *pd;
+        uint64_t db_lookup_hash = HSHashDb(pd_cached);
+        if (HSLoadCache(&pd_cached->hs_db, db_lookup_hash) == 0) {
+            pd_cached->ref_cnt = 1;
+            pd_cached->cached = true;
+            if (HSScratchAlloc(pd_cached->hs_db) != 0) {
+                goto recover;
+            }
+            if (HashTableAdd(g_db_table, pd_cached, 1) < 0) {
+                goto recover;
+            }
+            CompileDataFree(cd);
+            return 0;
+
+        recover:
+            pd_cached->ref_cnt = 0;
+            pd_cached->cached = false;
+            return -1;
+        }
+    }
+
+    return -1; // not cached
+}
+
+static int PatternDatabaseCompile(PatternDatabase *pd, SCHSCompileData *cd)
+{
+    for (uint32_t i = 0; i < pd->pattern_cnt; i++) {
+        const SCHSPattern *p = pd->parray[i];
+        cd->ids[i] = i;
+        cd->flags[i] = HS_FLAG_SINGLEMATCH;
+        if (p->flags & MPM_PATTERN_FLAG_NOCASE) {
+            cd->flags[i] |= HS_FLAG_CASELESS;
+        }
+        cd->expressions[i] = HSRenderPattern(p->original_pat, p->len);
+        if (CompileDataExtensionsInit(&cd->ext[i], p) != 0) {
+            return -1;
+        }
+    }
+
+    hs_compile_error_t *compile_err = NULL;
+    hs_error_t err = hs_compile_ext_multi((const char *const *)cd->expressions, cd->flags, cd->ids,
+            (const hs_expr_ext_t *const *)cd->ext, cd->pattern_cnt, HS_MODE_BLOCK, NULL, &pd->hs_db,
+            &compile_err);
+    if (err != HS_SUCCESS) {
+        HSLogCompileError(compile_err);
+        return -1;
+    }
+
+    if (HSScratchAlloc(pd->hs_db) != 0) {
+        return -1;
+    }
+
+    if (HashTableAdd(g_db_table, pd, 1) < 0) {
+        return -1;
+    }
+    pd->ref_cnt = 1;
+    return 0;
+}
+
 /**
  * \brief Process the patterns added to the mpm, and create the internal tables.
  *
@@ -828,168 +1017,51 @@ int SCHSPreparePatterns(MpmCtx *mpm_ctx)
 {
     SCHSCtx *ctx = (SCHSCtx *)mpm_ctx->ctx;
 
-    if (mpm_ctx->pattern_cnt == 0 || ctx->init_hash == NULL) {
-        SCLogDebug("no patterns supplied to this mpm_ctx");
+    if (HSCheckPatterns(mpm_ctx, ctx) == 0) {
         return 0;
     }
 
-    hs_error_t err;
-    hs_compile_error_t *compile_err = NULL;
-    SCHSCompileData *cd = NULL;
-    PatternDatabase *pd = NULL;
-
-    cd = SCHSAllocCompileData(mpm_ctx->pattern_cnt);
-    if (cd == NULL) {
+    SCHSCompileData *cd = CompileDataAlloc(mpm_ctx->pattern_cnt);
+    PatternDatabase *pd = PatternDatabaseAlloc(mpm_ctx->pattern_cnt);
+    if (cd == NULL || pd == NULL) {
         goto error;
     }
 
-    pd = PatternDatabaseAlloc(mpm_ctx->pattern_cnt);
-    if (pd == NULL) {
-        goto error;
-    }
-
-    /* populate the pattern array with the patterns in the hash */
-    for (uint32_t i = 0, p = 0; i < INIT_HASH_SIZE; i++) {
-        SCHSPattern *node = ctx->init_hash[i], *nnode = NULL;
-        while (node != NULL) {
-            nnode = node->next;
-            node->next = NULL;
-            pd->parray[p++] = node;
-            node = nnode;
-        }
-    }
-
-    /* we no longer need the hash, so free its memory */
-    SCFree(ctx->init_hash);
-    ctx->init_hash = NULL;
-
+    HSPatternArrayInit(ctx, pd);
     /* Serialise whole database compilation as a relatively easy way to ensure
      * dedupe is safe. */
     SCMutexLock(&g_db_table_mutex);
+    if (HSGlobalPatternDatabaseInit() == -1) {
+        SCMutexUnlock(&g_db_table_mutex);
+        goto error;
+    }
 
-    /* Init global pattern database hash if necessary. */
-    if (g_db_table == NULL) {
-        g_db_table = HashTableInit(INIT_DB_HASH_SIZE, PatternDatabaseHash,
-                                   PatternDatabaseCompare,
-                                   PatternDatabaseTableFree);
-        if (g_db_table == NULL) {
+    if (PatternDatabaseGetCached(&pd, cd) == 0 && pd != NULL) {
+        ctx->pattern_db = pd;
+        if (PatternDatabaseGetSize(pd, &ctx->hs_db_size) != 0) {
             SCMutexUnlock(&g_db_table_mutex);
             goto error;
         }
-    }
 
-    /* Check global hash table to see if we've seen this pattern database
-     * before, and reuse the Hyperscan database if so. */
-    PatternDatabase *pd_cached = HashTableLookup(g_db_table, pd, 1);
-    if (pd_cached != NULL) {
-        SCLogDebug("Reusing cached database %p with %" PRIu32
-                   " patterns (ref_cnt=%" PRIu32 ")",
-                   pd_cached->hs_db, pd_cached->pattern_cnt,
-                   pd_cached->ref_cnt);
-        pd_cached->ref_cnt++;
-        ctx->pattern_db = pd_cached;
-        SCMutexUnlock(&g_db_table_mutex);
-        PatternDatabaseFree(pd);
-        SCHSFreeCompileData(cd);
-        return 0;
-    } else if (DetectEngineMpmCachingEnabled()) {
-        if (HSLoadCache(&pd->hs_db, SCHSHashDb(pd)) == 0) {
-            pd->ref_cnt = 1;
-            pd->cache_loaded = true;
-            ctx->pattern_db = pd;
-
-            SCMutexLock(&g_scratch_proto_mutex);
-            err = hs_alloc_scratch(pd->hs_db, &g_scratch_proto);
-            SCMutexUnlock(&g_scratch_proto_mutex);
-            if (err != HS_SUCCESS) {
-                SCLogError("failed to allocate scratch: %s", HSErrorToStr(err));
-                SCMutexUnlock(&g_db_table_mutex);
-                goto error;
-            }
-
-            err = hs_database_size(pd->hs_db, &ctx->hs_db_size);
-            if (err != HS_SUCCESS) {
-                SCLogError("failed to query database size: %s", HSErrorToStr(err));
-                SCMutexUnlock(&g_db_table_mutex);
-                goto error;
-            }
-
+        if (pd->ref_cnt == 1) {
+            // freshly allocated
             mpm_ctx->memory_cnt++;
             mpm_ctx->memory_size += ctx->hs_db_size;
-
-            int r = HashTableAdd(g_db_table, pd, 1);
-            SCMutexUnlock(&g_db_table_mutex);
-            if (r < 0)
-                goto error;
-
-            SCMutexUnlock(&g_db_table_mutex);
-            SCHSFreeCompileData(cd);
-            return 0;
         }
+        SCMutexUnlock(&g_db_table_mutex);
+        return 0;
     }
 
     BUG_ON(ctx->pattern_db != NULL); /* already built? */
-
-    for (uint32_t i = 0; i < pd->pattern_cnt; i++) {
-        const SCHSPattern *p = pd->parray[i];
-
-        cd->ids[i] = i;
-        cd->flags[i] = HS_FLAG_SINGLEMATCH;
-        if (p->flags & MPM_PATTERN_FLAG_NOCASE) {
-            cd->flags[i] |= HS_FLAG_CASELESS;
-        }
-
-        cd->expressions[i] = HSRenderPattern(p->original_pat, p->len);
-
-        if (p->flags & (MPM_PATTERN_FLAG_OFFSET | MPM_PATTERN_FLAG_DEPTH)) {
-            cd->ext[i] = SCCalloc(1, sizeof(hs_expr_ext_t));
-            if (cd->ext[i] == NULL) {
-                SCMutexUnlock(&g_db_table_mutex);
-                goto error;
-            }
-
-            if (p->flags & MPM_PATTERN_FLAG_OFFSET) {
-                cd->ext[i]->flags |= HS_EXT_FLAG_MIN_OFFSET;
-                cd->ext[i]->min_offset = p->offset + p->len;
-            }
-            if (p->flags & MPM_PATTERN_FLAG_DEPTH) {
-                cd->ext[i]->flags |= HS_EXT_FLAG_MAX_OFFSET;
-                cd->ext[i]->max_offset = p->offset + p->depth;
-            }
-        }
-    }
-
     BUG_ON(mpm_ctx->pattern_cnt == 0);
 
-    err = hs_compile_ext_multi((const char *const *)cd->expressions, cd->flags,
-                               cd->ids, (const hs_expr_ext_t *const *)cd->ext,
-                               cd->pattern_cnt, HS_MODE_BLOCK, NULL, &pd->hs_db,
-                               &compile_err);
-
-    if (err != HS_SUCCESS) {
-        SCLogError("failed to compile hyperscan database");
-        if (compile_err) {
-            SCLogError("compile error: %s", compile_err->message);
-        }
-        hs_free_compile_error(compile_err);
+    if (PatternDatabaseCompile(pd, cd) != 0) {
         SCMutexUnlock(&g_db_table_mutex);
         goto error;
     }
 
     ctx->pattern_db = pd;
-
-    SCMutexLock(&g_scratch_proto_mutex);
-    err = hs_alloc_scratch(pd->hs_db, &g_scratch_proto);
-    SCMutexUnlock(&g_scratch_proto_mutex);
-    if (err != HS_SUCCESS) {
-        SCLogError("failed to allocate scratch");
-        SCMutexUnlock(&g_db_table_mutex);
-        goto error;
-    }
-
-    err = hs_database_size(pd->hs_db, &ctx->hs_db_size);
-    if (err != HS_SUCCESS) {
-        SCLogError("failed to query database size");
+    if (PatternDatabaseGetSize(pd, &ctx->hs_db_size) != 0) {
         SCMutexUnlock(&g_db_table_mutex);
         goto error;
     }
@@ -997,26 +1069,12 @@ int SCHSPreparePatterns(MpmCtx *mpm_ctx)
     mpm_ctx->memory_cnt++;
     mpm_ctx->memory_size += ctx->hs_db_size;
 
-    SCLogDebug("Built %" PRIu32 " patterns into a database of size %" PRIuMAX
-               " bytes", mpm_ctx->pattern_cnt, (uintmax_t)ctx->hs_db_size);
-
-    /* Cache this database globally for later. */
-    pd->ref_cnt = 1;
-    int r = HashTableAdd(g_db_table, pd, 1);
     SCMutexUnlock(&g_db_table_mutex);
-    if (r < 0)
-        goto error;
-
-    SCHSFreeCompileData(cd);
+    CompileDataFree(cd);
     return 0;
 
 error:
-    if (pd) {
-        PatternDatabaseFree(pd);
-    }
-    if (cd) {
-        SCHSFreeCompileData(cd);
-    }
+    SCHSCleanupOnError(pd, cd);
     return -1;
 }
 
@@ -1026,7 +1084,7 @@ error:
  */
 static int SCHSCacheRuleset(void)
 {
-    SCLogDebug("Caching the loaded ruleset");
+    SCLogDebug("Caching the loaded ruleset ");
     SCMutexLock(&g_db_table_mutex);
     HashTableIterate(g_db_table, HSSaveCacheIterator);
     SCMutexUnlock(&g_db_table_mutex);

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -33,6 +33,7 @@
 #include "detect-engine-build.h"
 
 #include "conf.h"
+#include "util-conf.h"
 #include "util-debug.h"
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
@@ -42,6 +43,7 @@
 #include "util-hash.h"
 #include "util-hash-lookup3.h"
 #include "util-hyperscan.h"
+#include "util-path.h"
 
 #ifdef BUILD_HYPERSCAN
 
@@ -80,6 +82,53 @@ static SCMutex g_scratch_proto_mutex = SCMUTEX_INITIALIZER;
  * serialised via g_db_table_mutex. */
 static HashTable *g_db_table = NULL;
 static SCMutex g_db_table_mutex = SCMUTEX_INITIALIZER;
+
+/**
+ * Translates Hyperscan error codes to human-readable messages.
+ *
+ * \param error_code
+ *      The error code returned by a Hyperscan function.
+ * \return
+ *      A string describing the error.
+ */
+static const char *HSErrorToStr(hs_error_t error_code)
+{
+    switch (error_code) {
+        case HS_SUCCESS:
+            return "HS_SUCCESS: The engine completed normally";
+        case HS_INVALID:
+            return "HS_INVALID: A parameter passed to this function was invalid";
+        case HS_NOMEM:
+            return "HS_NOMEM: A memory allocation failed";
+        case HS_SCAN_TERMINATED:
+            return "HS_SCAN_TERMINATED: The engine was terminated by callback";
+        case HS_COMPILER_ERROR:
+            return "HS_COMPILER_ERROR: The pattern compiler failed";
+        case HS_DB_VERSION_ERROR:
+            return "HS_DB_VERSION_ERROR: The given database was built for a different version of "
+                   "Hyperscan";
+        case HS_DB_PLATFORM_ERROR:
+            return "HS_DB_PLATFORM_ERROR: The given database was built for a different platform "
+                   "(i.e., CPU type)";
+        case HS_DB_MODE_ERROR:
+            return "HS_DB_MODE_ERROR: The given database was built for a different mode of "
+                   "operation";
+        case HS_BAD_ALIGN:
+            return "HS_BAD_ALIGN: A parameter passed to this function was not correctly aligned";
+        case HS_BAD_ALLOC:
+            return "HS_BAD_ALLOC: The memory allocator did not return correctly aligned memory";
+        case HS_SCRATCH_IN_USE:
+            return "HS_SCRATCH_IN_USE: The scratch region was already in use";
+        case HS_ARCH_ERROR:
+            return "HS_ARCH_ERROR: Unsupported CPU architecture";
+        case HS_INSUFFICIENT_SPACE:
+            return "HS_INSUFFICIENT_SPACE: Provided buffer was too small";
+        case HS_UNKNOWN_ERROR:
+            return "HS_UNKNOWN_ERROR: Unexpected internal error";
+        default:
+            return "Unknown error code";
+    }
+}
 
 /**
  * \internal
@@ -452,6 +501,8 @@ typedef struct PatternDatabase_ {
 
     /* Reference count: number of MPM contexts using this pattern database. */
     uint32_t ref_cnt;
+    /* Signals if the matcher has loaded/saved the pattern database to disk */
+    bool cached;
 } PatternDatabase;
 
 static uint32_t SCHSPatternHash(const SCHSPattern *p, uint32_t hash)
@@ -559,6 +610,7 @@ static PatternDatabase *PatternDatabaseAlloc(uint32_t pattern_cnt)
     pd->pattern_cnt = pattern_cnt;
     pd->ref_cnt = 0;
     pd->hs_db = NULL;
+    pd->cached = false;
 
     /* alloc the pattern array */
     pd->parray = (SCHSPattern **)SCCalloc(pd->pattern_cnt, sizeof(SCHSPattern *));
@@ -568,6 +620,203 @@ static PatternDatabase *PatternDatabaseAlloc(uint32_t pattern_cnt)
     }
 
     return pd;
+}
+
+static const char *HSCacheConstructFPath(uint64_t hs_db_hash)
+{
+    static char hash_file_path[PATH_MAX];
+
+    char hash_file_path_suffix[] = "_v1.hs";
+    char filename[PATH_MAX];
+    int r = snprintf(filename, sizeof(filename), "%020lu%s", hs_db_hash, hash_file_path_suffix);
+    if (r != (int)(20 + strlen(hash_file_path_suffix)))
+        return NULL;
+
+    r = PathMerge(
+            hash_file_path, sizeof(hash_file_path), DetectEngineMpmCachingGetPath(), filename);
+    if (r)
+        return NULL;
+
+    return hash_file_path;
+}
+
+static char *HSReadStream(const char *file_path, size_t *buffer_sz)
+{
+    FILE *file = fopen(file_path, "rb");
+    if (!file) {
+        SCLogConfig("Failed to open file %s: %s", file_path, strerror(errno));
+        return NULL;
+    }
+
+    // Seek to the end of the file to determine its size
+    fseek(file, 0, SEEK_END);
+    long file_sz = ftell(file);
+    if (file_sz < 0) {
+        SCLogConfig("Failed to determine file size of %s: %s", file_path, strerror(errno));
+        fclose(file);
+        return NULL;
+    }
+
+    char *buffer = (char *)SCCalloc(file_sz, sizeof(char));
+    if (!buffer) {
+        SCLogWarning("Failed to allocate memory");
+        fclose(file);
+        return NULL;
+    }
+
+    // Rewind file pointer and read the file into the buffer
+    rewind(file);
+    size_t bytes_read = fread(buffer, 1, file_sz, file);
+    if (bytes_read != (size_t)file_sz) {
+        SCLogConfig("Failed to read the entire file %s: %s", file_path, strerror(errno));
+        SCFree(buffer);
+        fclose(file);
+        return NULL;
+    }
+
+    *buffer_sz = file_sz;
+    fclose(file);
+    return buffer;
+}
+
+/**
+ * Function to hash the searched pattern, only things relevant to Hyperscan
+ * compilation are hashed.
+ */
+static void SCHSCachePatternHash(const SCHSPattern *p, uint32_t *h1, uint32_t *h2)
+{
+    BUG_ON(p->original_pat == NULL);
+    hashlittle2_safe(&p->len, sizeof(p->len), h1, h2);
+    hashlittle2_safe(&p->flags, sizeof(p->flags), h1, h2);
+    hashlittle2_safe(p->original_pat, p->len, h1, h2);
+    hashlittle2_safe(&p->offset, sizeof(p->offset), h1, h2);
+    hashlittle2_safe(&p->depth, sizeof(p->depth), h1, h2);
+}
+
+static int HSLoadCache(hs_database_t **hs_db, uint64_t hs_db_hash)
+{
+    if (SCCreateDirectoryTree(DetectEngineMpmCachingGetPath(), true) != 0)
+        return -1;
+    const char *hash_file_static = HSCacheConstructFPath(hs_db_hash);
+    if (hash_file_static == NULL)
+        return -1;
+
+    SCLogDebug("Loading the cached HS DB from %s", hash_file_static);
+    if (!SCPathExists(hash_file_static))
+        return -1;
+
+    FILE *db_cache = fopen(hash_file_static, "r");
+    char *buffer = NULL;
+    int ret = 0;
+    if (db_cache) {
+        size_t buffer_size;
+        buffer = HSReadStream(hash_file_static, &buffer_size);
+        if (!buffer) {
+            SCLogWarning("Hyperscan cached DB file %s cannot be read", hash_file_static);
+            ret = -1;
+            goto freeup;
+        }
+
+        hs_error_t error = hs_deserialize_database(buffer, buffer_size, hs_db);
+        if (error != HS_SUCCESS) {
+            SCLogWarning("Failed to deserialize Hyperscan database of %s: %s", hash_file_static,
+                    HSErrorToStr(error));
+            ret = -1;
+            goto freeup;
+        }
+
+        ret = 0;
+        goto freeup;
+    }
+
+freeup:
+    if (db_cache)
+        fclose(db_cache);
+    if (buffer)
+        SCFree(buffer);
+    return ret;
+}
+
+static int HSSaveCache(hs_database_t *hs_db, uint64_t hs_db_hash)
+{
+    static bool notified = false;
+    char *db_stream = NULL;
+    size_t db_size;
+    int ret = -1;
+
+    hs_error_t err = hs_serialize_database(hs_db, &db_stream, &db_size);
+    if (err != HS_SUCCESS) {
+        SCLogWarning("Failed to serialize Hyperscan database: %s", HSErrorToStr(err));
+        goto cleanup;
+    }
+
+    const char *hash_file_static = HSCacheConstructFPath(hs_db_hash);
+    SCLogDebug("Caching the compiled HS at %s", hash_file_static);
+    if (SCPathExists(hash_file_static)) {
+        // potentially signs that it might not work as expected as we got into
+        // hash collision. If this happens with older and not used caches it is
+        // fine.
+        // It is problematic when one ruleset yields two colliding MPM groups.
+        SCLogWarning("Overwriting cache file %s. If the problem persists consider switching off "
+                     "the caching",
+                hash_file_static);
+    }
+
+    FILE *db_cache_out = fopen(hash_file_static, "w");
+    if (!db_cache_out) {
+        if (!notified) {
+            SCLogWarning("Failed to create Hyperscan cache file, make sure the folder exist and is "
+                         "writable or adjust sgh-mpm-caching-path setting (%s)",
+                    hash_file_static);
+            notified = true;
+        }
+        goto cleanup;
+    }
+    size_t r = fwrite(db_stream, sizeof(db_stream[0]), db_size, db_cache_out);
+    if (r > 0 && (size_t)r != db_size) {
+        SCLogWarning("Failed to write to file: %s", hash_file_static);
+        if (r != db_size) {
+            // possibly a corrupted DB cache was created
+            r = remove(hash_file_static);
+            if (r != 0) {
+                SCLogWarning("Failed to remove corrupted cache file: %s", hash_file_static);
+            }
+        }
+    }
+    ret = fclose(db_cache_out);
+    if (ret != 0) {
+        SCLogWarning("Failed to close file: %s", hash_file_static);
+        goto cleanup;
+    }
+
+    ret = 0;
+cleanup:
+    if (db_stream)
+        SCFree(db_stream);
+    return ret;
+}
+
+static uint64_t HSHashDb(const PatternDatabase *pd)
+{
+    uint64_t cached_hash = 0;
+    uint32_t *hash = (uint32_t *)(&cached_hash);
+    hashword2(&pd->pattern_cnt, 1, &hash[0], &hash[1]);
+    for (uint32_t i = 0; i < pd->pattern_cnt; i++) {
+        SCHSCachePatternHash(pd->parray[i], &hash[0], &hash[1]);
+    }
+
+    return cached_hash;
+}
+
+static void HSSaveCacheIterator(void *data)
+{
+    PatternDatabase *pd = (PatternDatabase *)data;
+    if (pd->cached)
+        return;
+
+    if (HSSaveCache(pd->hs_db, HSHashDb(pd)) == 0) {
+        pd->cached = true; // for rule reloads
+    }
 }
 
 /**
@@ -632,7 +881,6 @@ int SCHSPreparePatterns(MpmCtx *mpm_ctx)
     /* Check global hash table to see if we've seen this pattern database
      * before, and reuse the Hyperscan database if so. */
     PatternDatabase *pd_cached = HashTableLookup(g_db_table, pd, 1);
-
     if (pd_cached != NULL) {
         SCLogDebug("Reusing cached database %p with %" PRIu32
                    " patterns (ref_cnt=%" PRIu32 ")",
@@ -644,6 +892,40 @@ int SCHSPreparePatterns(MpmCtx *mpm_ctx)
         PatternDatabaseFree(pd);
         SCHSFreeCompileData(cd);
         return 0;
+    } else if (DetectEngineMpmCachingEnabled()) {
+        if (HSLoadCache(&pd->hs_db, SCHSHashDb(pd)) == 0) {
+            pd->ref_cnt = 1;
+            pd->cache_loaded = true;
+            ctx->pattern_db = pd;
+
+            SCMutexLock(&g_scratch_proto_mutex);
+            err = hs_alloc_scratch(pd->hs_db, &g_scratch_proto);
+            SCMutexUnlock(&g_scratch_proto_mutex);
+            if (err != HS_SUCCESS) {
+                SCLogError("failed to allocate scratch: %s", HSErrorToStr(err));
+                SCMutexUnlock(&g_db_table_mutex);
+                goto error;
+            }
+
+            err = hs_database_size(pd->hs_db, &ctx->hs_db_size);
+            if (err != HS_SUCCESS) {
+                SCLogError("failed to query database size: %s", HSErrorToStr(err));
+                SCMutexUnlock(&g_db_table_mutex);
+                goto error;
+            }
+
+            mpm_ctx->memory_cnt++;
+            mpm_ctx->memory_size += ctx->hs_db_size;
+
+            int r = HashTableAdd(g_db_table, pd, 1);
+            SCMutexUnlock(&g_db_table_mutex);
+            if (r < 0)
+                goto error;
+
+            SCMutexUnlock(&g_db_table_mutex);
+            SCHSFreeCompileData(cd);
+            return 0;
+        }
     }
 
     BUG_ON(ctx->pattern_db != NULL); /* already built? */
@@ -736,6 +1018,19 @@ error:
         SCHSFreeCompileData(cd);
     }
     return -1;
+}
+
+/**
+ * \brief Cache the loaded ruleset
+ *
+ */
+static int SCHSCacheRuleset(void)
+{
+    SCLogDebug("Caching the loaded ruleset");
+    SCMutexLock(&g_db_table_mutex);
+    HashTableIterate(g_db_table, HSSaveCacheIterator);
+    SCMutexUnlock(&g_db_table_mutex);
+    return 0;
 }
 
 /**
@@ -1048,6 +1343,7 @@ void MpmHSRegister(void)
     mpm_table[MPM_HS].AddPattern = SCHSAddPatternCS;
     mpm_table[MPM_HS].AddPatternNocase = SCHSAddPatternCI;
     mpm_table[MPM_HS].Prepare = SCHSPreparePatterns;
+    mpm_table[MPM_HS].CacheRuleset = SCHSCacheRuleset;
     mpm_table[MPM_HS].Search = SCHSSearch;
     mpm_table[MPM_HS].PrintCtx = SCHSPrintInfo;
     mpm_table[MPM_HS].PrintThreadCtx = SCHSPrintSearchStats;

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -164,6 +164,7 @@ typedef struct MpmTableElmt_ {
     int  (*AddPattern)(struct MpmCtx_ *, uint8_t *, uint16_t, uint16_t, uint16_t, uint32_t, SigIntId, uint8_t);
     int  (*AddPatternNocase)(struct MpmCtx_ *, uint8_t *, uint16_t, uint16_t, uint16_t, uint32_t, SigIntId, uint8_t);
     int  (*Prepare)(struct MpmCtx_ *);
+    int (*CacheRuleset)(void);
     /** \retval cnt number of patterns that matches: once per pattern max. */
     uint32_t (*Search)(const struct MpmCtx_ *, struct MpmThreadCtx_ *, PrefilterRuleStore *, const uint8_t *, uint32_t);
     void (*PrintCtx)(struct MpmCtx_ *);

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -118,42 +118,6 @@ char *PathMergeAlloc(const char *const dir, const char *const fname)
 }
 
 /**
- * \brief Wrapper to join a directory and filename and resolve using realpath
- *   _fullpath is used for WIN32
- *
- * \param out_buf output buffer.  Up to PATH_MAX will be written.  Unchanged on exit failure.
- * \param buf_size length of output buffer, must be PATH_MAX
- * \param dir the directory
- * \param fname the filename
- *
- * \retval 0 on success
- * \retval -1 on failure
- */
-int PathJoin(char *out_buf, size_t buf_size, const char *const dir, const char *const fname)
-{
-    SCEnter();
-    if (buf_size != PATH_MAX) {
-        return -1;
-    }
-    if (PathMerge(out_buf, buf_size, dir, fname) != 0) {
-        SCLogError("Could not join filename to path");
-        return -1;
-    }
-    char *tmp_buf = SCRealPath(out_buf, NULL);
-    if (tmp_buf == NULL) {
-        SCLogError("Error resolving path: %s", strerror(errno));
-        return -1;
-    }
-    memset(out_buf, 0, buf_size);
-    size_t ret = strlcpy(out_buf, tmp_buf, buf_size);
-    free(tmp_buf);
-    if (ret >= buf_size) {
-        return -1;
-    }
-    return 0;
-}
-
-/**
  * \brief Wrapper around SCMkDir with default mode arguments.
  */
 int SCDefaultMkDir(const char *path)

--- a/src/util-path.h
+++ b/src/util-path.h
@@ -51,7 +51,6 @@ int PathIsAbsolute(const char *);
 int PathIsRelative(const char *);
 int PathMerge(char *out_buf, size_t buf_size, const char *const dir, const char *const fname);
 char *PathMergeAlloc(const char *const dir, const char *const fname);
-int PathJoin(char *out_buf, size_t buf_len, const char *const dir, const char *const fname);
 int SCDefaultMkDir(const char *path);
 int SCCreateDirectoryTree(const char *path, const bool final);
 bool SCPathExists(const char *path);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1687,6 +1687,10 @@ detect:
     toclient-groups: 3
     toserver-groups: 25
   sgh-mpm-context: auto
+  # Cache MPM contexts to the disk to avoid rule compilation at the startup.
+  # Cache files are created in the default logging directory.
+  sgh-mpm-caching: yes
+  sgh-mpm-caching-path: @e_hscachedir@
   inspection-recursion-limit: 3000
   # maximum number of times a tx will get logged for a stream-only rule match
   # stream-tx-log-limit: 4


### PR DESCRIPTION
Followup of https://github.com/OISF/suricata/pull/11887

Cache Hyperscan serialized databases to disk to prevent compilation of the same databases when Suricata is run again with the same ruleset.
The current work operates in the logging folder and caches individual Hyperscan databases - potentially the ruleset might be even slightly changed and it still can reuse part of the unchanged signature groups.
Loading **fresh** ET Open ruleset:  19 seconds
Loading **cached** ET Open ruleset: 07 seconds

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7170

Describe changes:
v7: (v6 was private)
- fix docs and add ticket number to the commit
- fix privilege drop issue, files are created after privilege drop, tested also rule reload - it worked fine 
- refactor the util-mpm-hs code, primarily prepare function 
- rebase

v5:
- rebased
- commit message update
- docs update

v4:
- rebased
- changed the default caching directory to somewhere /var/lib/suricata/cache/hs
- custom cache directory path option added
- docs added
- the default settings changed - enabled on the config generation, **disabled** when the option is not present in the config

v3
- rebased
- MPM caching is still left on by default.

v2
- improved styling to follow Suricata code styleguide
- increased cache file name length from 10 to 20 characters
- cache file name is a hash of the patterns - now only HS relevant fields are hashed - as long as the group of patterns itself is not changed then it is reused
- minor refactors
- added a safe variant of littlehash2 function
- added suricata.yaml option to enable/disable caching
- changed the storage location to the configured logging directory

v1
- initial work to cache and load Hyperscan databases from the disk