### PR TITLE
detect/engine: remove unneeded flag

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -957,8 +957,7 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
     jb_open_array(ctx.js, "requirements");
     if (s->mask & SIG_MASK_REQUIRE_PAYLOAD) {
         jb_append_string(ctx.js, "payload");
-    }
-    if (s->mask & SIG_MASK_REQUIRE_NO_PAYLOAD) {
+    } else {
         jb_append_string(ctx.js, "no_payload");
     }
     if (s->mask & SIG_MASK_REQUIRE_FLOW) {

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -416,9 +416,6 @@ PacketCreateMask(Packet *p, SignatureMask *mask, AppProto alproto,
     } else if (p->flags & PKT_DETECT_HAS_STREAMDATA) {
         SCLogDebug("stream data available");
         (*mask) |= SIG_MASK_REQUIRE_PAYLOAD;
-    } else {
-        SCLogDebug("packet has no payload");
-        (*mask) |= SIG_MASK_REQUIRE_NO_PAYLOAD;
     }
 
     if (p->events.cnt > 0 || app_decoder_events != 0 ||
@@ -529,9 +526,6 @@ static int SignatureCreateMask(Signature *s)
                     if (ds->arg1 > 0) {
                         s->mask |= SIG_MASK_REQUIRE_PAYLOAD;
                         SCLogDebug("sig requires payload");
-                    } else {
-                        s->mask |= SIG_MASK_REQUIRE_NO_PAYLOAD;
-                        SCLogDebug("sig requires no payload");
                     }
                 }
                 break;

--- a/src/detect.h
+++ b/src/detect.h
@@ -302,7 +302,7 @@ typedef struct DetectPort_ {
 #define SIG_MASK_REQUIRE_FLOW               BIT_U8(1)
 #define SIG_MASK_REQUIRE_FLAGS_INITDEINIT   BIT_U8(2)    /* SYN, FIN, RST */
 #define SIG_MASK_REQUIRE_FLAGS_UNUSUAL      BIT_U8(3)    /* URG, ECN, CWR */
-#define SIG_MASK_REQUIRE_NO_PAYLOAD         BIT_U8(4)
+// vacancy 1x
 #define SIG_MASK_REQUIRE_REAL_PKT           BIT_U8(5)
 // vacancy 1x
 #define SIG_MASK_REQUIRE_ENGINE_EVENT       BIT_U8(7)


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2084

I think this also ends up fixing some scenarios where `SIG_MASK_REQUIRE_NO_PAYLOAD` is not set even though there is no payload.
Thoughts?