### PR TITLE
misc: Eliminate compiler warnings

### DIFF
--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -120,12 +120,6 @@ char *MagicThreadLookup(magic_t *ctx, const uint8_t *buf, uint32_t buflen)
 
 #ifdef UNITTESTS
 
-#if defined OS_FREEBSD || defined OS_DARWIN
-#define MICROSOFT_OFFICE_DOC "OLE 2 Compound Document"
-#else
-#define MICROSOFT_OFFICE_DOC "Microsoft Office Document"
-#endif
-
 /** \test magic lib calls -- init */
 static int MagicInitTest01(void)
 {

--- a/src/util-memcmp.c
+++ b/src/util-memcmp.c
@@ -154,11 +154,10 @@ static int MemcmpTest13 (void)
 
 #include "util-cpu.h"
 
-#define TEST_RUNS 1000000
-
 static int MemcmpTest14 (void)
 {
 #ifdef PROFILING
+#define TEST_RUNS 1000000
     uint64_t ticks_start = 0;
     uint64_t ticks_end = 0;
     const char *a[] = { "0123456789012345", "abc", "abcdefghij", "suricata", "test", "xyz", "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "abcdefghijklmnopqrstuvwxyz", NULL };

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -42,9 +42,6 @@
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
-#define DEFAULT_LOG_FILENAME "profile.log"
-#define DEFAULT_LOG_MODE_APPEND "yes"
-
 static pthread_mutex_t packet_profile_lock;
 static FILE *packet_profile_csv_fp = NULL;
 

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -267,9 +267,6 @@ uint8_t *BoyerMooreNocaseSearch(const uint8_t *text, uint32_t textlen,
  *  #define ENABLE_SEARCH_STATS 1
  */
 
-/* Number of times to repeat the search (for stats) */
-#define STATS_TIMES 1000000
-
 /**
  * \brief Unittest helper function wrappers for the search algorithms
  * \param text pointer to the buffer to search in
@@ -403,6 +400,9 @@ static uint8_t *BoyerMooreNocaseWrapper(uint8_t *text, uint8_t *in_needle, int t
 }
 
 #ifdef ENABLE_SEARCH_STATS
+/* Number of times to repeat the search (for stats) */
+#define STATS_TIMES 1000000
+
 /**
  * \brief Unittest helper function wrappers for the search algorithms
  * \param text pointer to the buffer to search in


### PR DESCRIPTION
Issue: 7314

Fixup macro usage to eliminate compiler warnings.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7314

Describe changes:
- Eliminate unused macros, reposition others to avoid warnings.


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
