### PR TITLE
template: remove -rust references

### DIFF
--- a/src/detect-template-rust-buffer.c
+++ b/src/detect-template-rust-buffer.c
@@ -78,11 +78,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 void DetectTemplateRustBufferRegister(void)
 {
     /* TEMPLATE_START_REMOVE */
-    if (ConfGetNode("app-layer.protocols.template-rust") == NULL) {
+    if (ConfGetNode("app-layer.protocols.template") == NULL) {
         return;
     }
     /* TEMPLATE_END_REMOVE */
-    sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_rust_buffer";
+    sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template.buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =
             "Template content modifier to match on the template buffers";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].Setup = DetectTemplateRustBufferSetup;
@@ -144,14 +144,14 @@ static int DetectTemplateRustBufferTest(void)
     /* This rule should match. */
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any ("
                                       "msg:\"TEMPLATE Test Rule\"; "
-                                      "template_rust_buffer; content:\"World!\"; "
+                                      "template.buffer; content:\"World!\"; "
                                       "sid:1; rev:1;)");
     FAIL_IF_NULL(s);
 
     /* This rule should not match. */
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any ("
                                       "msg:\"TEMPLATE Test Rule\"; "
-                                      "template_rust_buffer; content:\"W0rld!\"; "
+                                      "template.buffer; content:\"W0rld!\"; "
                                       "sid:2; rev:1;)");
     FAIL_IF_NULL(s);
 

--- a/src/tests/fuzz/confyaml.c
+++ b/src/tests/fuzz/confyaml.c
@@ -85,8 +85,6 @@ app-layer:\n\
       enabled: yes\n\
     template:\n\
       enabled: yes\n\
-    template-rust:\n\
-      enabled: yes\n\
     modbus:\n\
       enabled: yes\n\
       detection-ports:\n\


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7315

Describe changes:
- template: remove -rust references

Completes commit 4a7567b3f04075f02543762717dbff9dd5b5c1f3

#11916 with SV passing with right buffer name

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2087

Should go before https://github.com/OISF/suricata/pull/11911 (to have the backport and SV test passing for 7 with template keyword)