### PR TITLE
[draft] flow callbacks for ndpi - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2293,6 +2293,19 @@ fi
     ])
     AC_SUBST(RUST_FEATURES)
 
+# nDPI support (no library checks for this stub)
+    AC_ARG_ENABLE(ndpi,
+           AS_HELP_STRING([--enable-ndpi], [Enable nDPI support]),
+           [enable_ndpi=$enableval],[enable_ndpi=no])
+    if test "x$enable_ndpi" = "xyes"; then
+        AM_CONDITIONAL([BUILD_NDPI], [true])
+        ndpi_comment=""
+    else
+        AM_CONDITIONAL([BUILD_NDPI], [false])
+        ndpi_comment="#"
+    fi
+    AC_SUBST([ndpi_comment])
+
     AC_ARG_ENABLE(warnings,
            AS_HELP_STRING([--enable-warnings], [Enable supported C compiler warnings]),[enable_warnings=$enableval],[enable_warnings=no])
     AS_IF([test "x$enable_warnings" = "xyes"], [
@@ -2513,6 +2526,7 @@ AC_CONFIG_FILES(examples/plugins/ci-capture/Makefile)
 AC_CONFIG_FILES(examples/lib/simple/Makefile examples/lib/simple/Makefile.example)
 AC_CONFIG_FILES(plugins/Makefile)
 AC_CONFIG_FILES(plugins/pfring/Makefile)
+AC_CONFIG_FILES(plugins/ndpi-dummy/Makefile)
 
 AC_OUTPUT
 

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -3,3 +3,7 @@ SUBDIRS =
 if BUILD_PFRING
 SUBDIRS += pfring
 endif
+
+if BUILD_NDPI
+SUBDIRS += ndpi-dummy
+endif

--- a/plugins/ndpi-dummy/Makefile.am
+++ b/plugins/ndpi-dummy/Makefile.am
@@ -1,0 +1,8 @@
+pkglib_LTLIBRARIES = ndpi.la
+
+ndpi_la_LDFLAGS = -module -avoid-version -shared
+
+ndpi_la_SOURCES = ndpi.c
+
+install-exec-hook:
+	cd $(DESTDIR)$(pkglibdir) && $(RM) $(pkglib_LTLIBRARIES)

--- a/plugins/ndpi-dummy/ndpi.c
+++ b/plugins/ndpi-dummy/ndpi.c
@@ -1,0 +1,84 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/* License note: While this "glue" code to the nDPI library is GPLv2,
+ * nDPI is itself LGPLv3 which is known to be incompatible with the
+ * GPLv2. */
+
+#include "suricata-common.h"
+#include "suricata-plugin.h"
+#include "util-debug.h"
+
+#include "flow-callbacks.h"
+#include "flow-storage.h"
+
+static FlowStorageId flow_storage_id = { .id = -1 };
+
+static void *FlowStorageAlloc(unsigned int size)
+{
+    SCLogNotice("Allocating nDPI flow storage, size=%d", size);
+    return NULL;
+}
+
+static void FlowStorageFree(void *ptr)
+{
+    SCLogNotice("De-allocating nDPI flow storage");
+    int *dummy_storage = ptr;
+    SCLogNotice("%d", *dummy_storage);
+    SCFree(ptr);
+}
+
+static void OnFlowInit(Flow *f, const Packet *p)
+{
+    SCLogNotice("...");
+    static int counter = 0;
+    int *dummy_storage = SCCalloc(1, sizeof(int));
+    *dummy_storage = counter++;
+    FlowSetStorageById(f, flow_storage_id, dummy_storage);
+}
+
+static void OnFlowUpdate(Flow *f, Packet *p, ThreadVars *tv)
+{
+    SCLogNotice("...");
+    int *dummy_storage = FlowGetStorageById(f, flow_storage_id);
+    SCLogNotice("dummy_storage=%d", *dummy_storage);
+}
+
+static void NdpiInit(void)
+{
+    SCLogNotice("Initializing nDPI plugin");
+
+    flow_storage_id = FlowStorageRegister("ndpi", sizeof(void *), NULL, FlowStorageFree);
+    if (flow_storage_id.id < 0) {
+        FatalError("Failed to register nDPI flow storage");
+    }
+
+    SCFlowRegisterInitCallback(OnFlowInit);
+    SCFlowRegisterUpdateCallback(OnFlowUpdate);
+}
+
+const SCPlugin PluginRegistration = {
+    .name = "ndpi-dummy",
+    .author = "FirstName LastName",
+    .license = "GPLv2",
+    .Init = NdpiInit,
+};
+
+const SCPlugin *SCPluginRegister()
+{
+    return &PluginRegistration;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -329,6 +329,7 @@ noinst_HEADERS = \
 	feature.h \
 	flow-bit.h \
 	flow-bypass.h \
+	flow-callbacks.h \
 	flow.h \
 	flow-hash.h \
 	flow-manager.h \
@@ -902,6 +903,7 @@ libsuricata_c_a_SOURCES = \
 	feature.c \
 	flow-bit.c \
 	flow-bypass.c \
+	flow-callbacks.c \
 	flow.c \
 	flow-hash.c \
 	flow-manager.c \

--- a/src/flow-callbacks.c
+++ b/src/flow-callbacks.c
@@ -1,0 +1,88 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "flow-callbacks.h"
+
+typedef struct FlowInitCallback_ {
+    SCFlowInitCallbackFn fn;
+    struct FlowInitCallback_ *next;
+} FlowInitCallback;
+
+static FlowInitCallback *init_callbacks = NULL;
+
+typedef struct FlowUpdateCallback_ {
+    SCFlowUpdateCallbackFn fn;
+    struct FlowUpdateCallback_ *next;
+} FlowUpdateCallback;
+
+static FlowUpdateCallback *update_callbacks = NULL;
+
+bool SCFlowRegisterInitCallback(SCFlowInitCallbackFn fn)
+{
+    FlowInitCallback *cb = SCCalloc(1, sizeof(*cb));
+    if (cb == NULL) {
+        return false;
+    }
+    cb->fn = fn;
+    if (init_callbacks == NULL) {
+        init_callbacks = cb;
+    } else {
+        FlowInitCallback *current = init_callbacks;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = cb;
+    }
+    return true;
+}
+
+void SCFlowRunInitCallbacks(Flow *f, const Packet *p)
+{
+    FlowInitCallback *cb = init_callbacks;
+    while (cb != NULL) {
+        cb->fn(f, p);
+        cb = cb->next;
+    }
+}
+
+bool SCFlowRegisterUpdateCallback(SCFlowUpdateCallbackFn fn)
+{
+    FlowUpdateCallback *cb = SCCalloc(1, sizeof(*cb));
+    if (cb == NULL) {
+        return false;
+    }
+    cb->fn = fn;
+    if (update_callbacks == NULL) {
+        update_callbacks = cb;
+    } else {
+        FlowUpdateCallback *current = update_callbacks;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = cb;
+    }
+    return true;
+}
+
+void SCFlowRunUpdateCallbacks(Flow *f, Packet *p, ThreadVars *tv)
+{
+    FlowUpdateCallback *cb = update_callbacks;
+    while (cb != NULL) {
+        cb->fn(f, p, tv);
+        cb = cb->next;
+    }
+}

--- a/src/flow-callbacks.h
+++ b/src/flow-callbacks.h
@@ -1,0 +1,60 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_FLOW_CALLBACKS_H
+#define SURICATA_FLOW_CALLBACKS_H
+
+#include "suricata-common.h"
+#include "flow.h"
+
+typedef void (*SCFlowInitCallbackFn)(Flow *f, const Packet *p);
+
+/** \brief Register a flow init callback.
+ *
+ * Register a user provided function to be called every time a flow is
+ * initialized for use.
+ *
+ * \returns true if callback was registered, otherwise false if the
+ *     callback could not be registered due to memory allocation error.
+ */
+bool SCFlowRegisterInitCallback(SCFlowInitCallbackFn fn);
+
+/** \internal
+ *
+ * Run all registered flow init callbacks.
+ */
+void SCFlowRunInitCallbacks(Flow *f, const Packet *p);
+
+typedef void (*SCFlowUpdateCallbackFn)(Flow *f, Packet *p, ThreadVars *tv);
+
+/** \brief Register a flow update callback.
+ *
+ * Register a user provided function to be called everytime a flow is
+ * updated.
+ *
+ * \returns true if callback was registered, otherwise false if the
+ *     callback could not be registered due to memory allocation error.
+ */
+bool SCFlowRegisterUpdateCallback(SCFlowUpdateCallbackFn fn);
+
+/** \internal
+ *
+ * Run all registered flow update callbacks.
+ */
+void SCFlowRunUpdateCallbacks(Flow *f, Packet *p, ThreadVars *tv);
+
+#endif /* SURICATA_FLOW_CALLBACKS_H */

--- a/src/flow-util.c
+++ b/src/flow-util.c
@@ -29,6 +29,7 @@
 #include "flow.h"
 #include "flow-private.h"
 #include "flow-util.h"
+#include "flow-callbacks.h"
 #include "flow-var.h"
 #include "app-layer.h"
 
@@ -202,6 +203,8 @@ void FlowInit(Flow *f, const Packet *p)
         MacSet *ms = MacSetInit(10);
         FlowSetStorageById(f, MacSetGetFlowStorageID(), ms);
     }
+
+    SCFlowRunInitCallbacks(f, p);
 
     SCReturn;
 }

--- a/src/flow.c
+++ b/src/flow.c
@@ -44,6 +44,7 @@
 #include "flow-storage.h"
 #include "flow-bypass.h"
 #include "flow-spare-pool.h"
+#include "flow-callbacks.h"
 
 #include "stream-tcp-private.h"
 
@@ -503,6 +504,8 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p, ThreadVars *tv, DecodeThreadVars
         SCLogDebug("setting FLOW_NOPAYLOAD_INSPECTION flag on flow %p", f);
         DecodeSetNoPayloadInspectionFlag(p);
     }
+
+    SCFlowRunUpdateCallbacks(f, p, tv);
 }
 
 /** \brief Entry point for packet flow handling

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -81,6 +81,7 @@ stats:
 # Plugins -- Experimental -- specify the filename for each plugin shared object
 plugins:
   @pfring_comment@- @prefix@/lib/@PACKAGE_NAME@/pfring.so
+  @ndpi_comment@- @prefix@/lib/@PACKAGE_NAME@/ndpi.so
 # - /path/to/plugin.so
 
 # Configure the type of alert (and other) logging you would like.


### PR DESCRIPTION
In order for nDPI to become a plugin it needs to hook into flow initialization and flow updates. This PR provides user registerable flow callbacks for these events.

It also includes a "dummy" ndpi plugin using these callbacks, and also shows how to use the flow storage API to avoid modifying the Flow structure directly.

Original nDPI PR: #11671 

Tickets:
- https://redmine.openinfosecfoundation.org/issues/7319
- https://redmine.openinfosecfoundation.org/issues/7320