### PR TITLE
Convert unittests to new fail pass api v 2

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -3057,7 +3057,6 @@ static int HTPParserTest01c(void)
  *        response of the parser from HTP library. */
 static int HTPParserTest01a(void)
 {
-    int result = 0;
     Flow *f = NULL;
     uint8_t httpbuf1[] = " POST  /  HTTP/1.0\r\nUser-Agent: Victor/1.0\r\n\r\nPost"
                          " Data is c0oL!";
@@ -3070,8 +3069,7 @@ static int HTPParserTest01a(void)
     memset(&ssn, 0, sizeof(ssn));
 
     f = UTHBuildFlow(AF_INET, "1.2.3.4", "1.2.3.5", 1024, 80);
-    if (f == NULL)
-        goto end;
+    FAIL_IF_NULL(f);
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_HTTP1;
@@ -3090,39 +3088,26 @@ static int HTPParserTest01a(void)
             flags = STREAM_TOSERVER;
 
         r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, flags, &httpbuf1[u], 1);
-        if (r != 0) {
-            printf("toserver chunk %" PRIu32 " returned %" PRId32 ", expected"
-                    " 0: ", u, r);
-            goto end;
-        }
+        FAIL_IF(r != 0);
     }
 
     htp_state = f->alstate;
-    if (htp_state == NULL) {
-        printf("no http state: ");
-        goto end;
-    }
+    FAIL_IF_NULL(htp_state);
 
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
+    FAIL_IF_NULL(tx);
+
     htp_header_t *h =  htp_table_get_index(tx->request_headers, 0, NULL);
-    if (strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0")
-        || tx->request_method_number != HTP_M_POST ||
-        tx->request_protocol_number != HTP_PROTOCOL_1_0)
-    {
-        printf("expected header value: Victor/1.0 and got %s: and expected"
-                " method: POST and got %s, expected protocol number HTTP/1.0"
-                "  and got: %s \n", bstr_util_strdup_to_c(h->value),
-                bstr_util_strdup_to_c(tx->request_method),
-                bstr_util_strdup_to_c(tx->request_protocol));
-        goto end;
-    }
-    result = 1;
-end:
-    if (alp_tctx != NULL)
-        AppLayerParserThreadCtxFree(alp_tctx);
+    FAIL_IF_NULL(h);
+
+    FAIL_IF(strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0"));
+    FAIL_IF(tx->request_method_number != HTP_M_POST);
+    FAIL_IF(tx->request_protocol_number != HTP_PROTOCOL_1_0);
+
+    AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     UTHFreeFlow(f);
-    return result;
+    PASS;
 }
 
 /** \test See how it deals with an incomplete request. */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -3134,7 +3134,6 @@ static int HTPParserTest02(void)
             STREAM_TOSERVER | STREAM_START | STREAM_EOF, httpbuf1, httplen1);
     FAIL_IF(r != 0);
 
-
     http_state = f->alstate;
     FAIL_IF_NULL(http_state);
 
@@ -3155,8 +3154,6 @@ static int HTPParserTest02(void)
     UTHFreeFlow(f);
     PASS;
 }
-    
-
 
 /** \test Test case where method is invalid and data is sent in smaller chunks
  *        and check the response of the parser from HTP library. */
@@ -3194,13 +3191,12 @@ static int HTPParserTest03(void)
     htp_state = f->alstate;
     FAIL_IF_NULL(htp_state);
 
-
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
     htp_header_t *h =  htp_table_get_index(tx->request_headers, 0, NULL);
-   
-    FAIL_IF(h!=NULL);
+
+    FAIL_IF(h != NULL);
     FAIL_IF(tx->request_method_number != HTP_M_UNKNOWN);
     FAIL_IF(tx->request_protocol_number != HTP_PROTOCOL_1_0);
 
@@ -3242,8 +3238,8 @@ static int HTPParserTest04(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
     htp_header_t *h = htp_table_get_index(tx->request_headers, 0, NULL);
-   
-    FAIL_IF(h!=NULL);
+
+    FAIL_IF(h != NULL);
     FAIL_IF(tx->request_method_number != HTP_M_UNKNOWN);
     FAIL_IF(tx->request_protocol_number != HTP_PROTOCOL_0_9);
 
@@ -3468,7 +3464,6 @@ static int HTPParserTest07(void)
     FAIL_IF(memcmp(bstr_ptr(tx_ud->request_uri_normalized), ref,
                     bstr_len(tx_ud->request_uri_normalized)) != 0);
 
-    
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     UTHFreeFlow(f);
@@ -3531,7 +3526,7 @@ libhtp:\n\
         PrintRawDataFp(stdout, bstr_ptr(tx_ud->request_uri_normalized),
                        bstr_len(tx_ud->request_uri_normalized));
     }
-    
+
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     HTPFreeConfig();
@@ -3586,7 +3581,6 @@ libhtp:\n\
 
     r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, flags, httpbuf1, httplen1);
     FAIL_IF(r != 0);
-    
 
     htp_state = f->alstate;
     FAIL_IF_NULL(htp_state);
@@ -3599,7 +3593,7 @@ libhtp:\n\
         PrintRawDataFp(stdout, bstr_ptr(tx_ud->request_uri_normalized),
                        bstr_len(tx_ud->request_uri_normalized));
     }
-    
+
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
     HTPFreeConfig();
@@ -3646,7 +3640,6 @@ static int HTPParserTest10(void)
 
         r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, flags, &httpbuf1[u], 1);
         FAIL_IF(r != 0);
-            
     }
 
     htp_state = f->alstate;
@@ -3673,7 +3666,6 @@ static int HTPParserTest10(void)
     UTHFreeFlow(f);
     PASS;
 }
-   
 
 /** \test double encoding in path
  */
@@ -3783,7 +3775,6 @@ static int HTPParserTest12(void)
 
         r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, flags, &httpbuf1[u], 1);
         FAIL_IF(r != 0);
-           
     }
 
     htp_state = f->alstate;
@@ -3859,7 +3850,6 @@ static int HTPParserTest13(void)
         r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, flags, &httpbuf1[u], 1);
         FAIL_IF(r != 0);
     }
-    
 
     htp_state = f->alstate;
     FAIL_IF_NULL(htp_state);
@@ -3889,7 +3879,7 @@ static int HTPParserTest13(void)
 /** \test Test basic config */
 static int HTPParserConfigTest01(void)
 {
-    int ret =0;
+    int ret = 0;
     char input[] = "\
 %YAML 1.1\n\
 ---\n\
@@ -3928,9 +3918,8 @@ libhtp:\n\
     FAIL_IF(strcmp(node->name, "0") != 0);
     node = TAILQ_FIRST(&node->head);
     FAIL_IF_NULL(node);
-    
+
     FAIL_IF(strcmp(node->name, "apache-tomcat") != 0);
-    
 
     int i = 0;
     ConfNode *n;
@@ -3942,7 +3931,7 @@ libhtp:\n\
     node = ConfNodeLookupChild(node, "address");
     FAIL_IF_NULL(node);
 
-    TAILQ_FOREACH(n, &node->head, next) {
+    TAILQ_FOREACH (n, &node->head, next) {
         FAIL_IF_NULL(n);
         switch(i) {
             case 0:


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6935

Describe changes:
-
-converted applayer/htp to new FAIL/PASS API
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
