### PR TITLE
threads: wait for pause cleanup - v3

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -406,9 +406,8 @@ static void *StatsMgmtThread(void *arg)
     SCLogDebug("stats_thread_data %p", &stats_thread_data);
 
     TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
-    while (1) {
-        TmThreadsWaitForUnpause(tv_local);
-
+    bool run = TmThreadsWaitForUnpause(tv_local);
+    while (run) {
         struct timeval cur_timev;
         gettimeofday(&cur_timev, NULL);
         struct timespec cond_time = FROM_TIMEVAL(cur_timev);
@@ -483,10 +482,9 @@ static void *StatsWakeupThread(void *arg)
     }
 
     TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
+    bool run = TmThreadsWaitForUnpause(tv_local);
 
-    while (1) {
-        TmThreadsWaitForUnpause(tv_local);
-
+    while (run) {
         struct timeval cur_timev;
         gettimeofday(&cur_timev, NULL);
         struct timespec cond_time = FROM_TIMEVAL(cur_timev);

--- a/src/counters.c
+++ b/src/counters.c
@@ -407,11 +407,7 @@ static void *StatsMgmtThread(void *arg)
 
     TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
     while (1) {
-        if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
-            TmThreadsSetFlag(tv_local, THV_PAUSED);
-            TmThreadTestThreadUnPaused(tv_local);
-            TmThreadsUnsetFlag(tv_local, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(tv_local);
 
         struct timeval cur_timev;
         gettimeofday(&cur_timev, NULL);
@@ -489,11 +485,7 @@ static void *StatsWakeupThread(void *arg)
     TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
 
     while (1) {
-        if (TmThreadsCheckFlag(tv_local, THV_PAUSE)) {
-            TmThreadsSetFlag(tv_local, THV_PAUSED);
-            TmThreadTestThreadUnPaused(tv_local);
-            TmThreadsUnsetFlag(tv_local, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(tv_local);
 
         struct timeval cur_timev;
         gettimeofday(&cur_timev, NULL);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -595,10 +595,8 @@ static TmEcode DetectLoader(ThreadVars *th_v, void *thread_data)
 
     TmThreadsSetFlag(th_v, THV_INIT_DONE | THV_RUNNING);
     SCLogDebug("loader thread started");
-    while (1)
-    {
-        TmThreadsWaitForUnpause(th_v);
-
+    bool run = TmThreadsWaitForUnpause(th_v);
+    while (run) {
         /* see if we have tasks */
 
         DetectLoaderControl *loader = &loaders[ftd->instance];

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -597,11 +597,7 @@ static TmEcode DetectLoader(ThreadVars *th_v, void *thread_data)
     SCLogDebug("loader thread started");
     while (1)
     {
-        if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
-            TmThreadsSetFlag(th_v, THV_PAUSED);
-            TmThreadTestThreadUnPaused(th_v);
-            TmThreadsUnsetFlag(th_v, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(th_v);
 
         /* see if we have tasks */
 

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -94,9 +94,9 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
         return TM_ECODE_OK;
 
     TmThreadsSetFlag(th_v, THV_RUNNING);
+    bool run = TmThreadsWaitForUnpause(th_v);
 
-    while (1) {
-        TmThreadsWaitForUnpause(th_v);
+    while (run) {
         SCLogDebug("Dumping the table");
         gettimeofday(&tv, NULL);
         TIMEVAL_TO_TIMESPEC(&tv, &curtime);

--- a/src/flow-bypass.c
+++ b/src/flow-bypass.c
@@ -96,11 +96,7 @@ static TmEcode BypassedFlowManager(ThreadVars *th_v, void *thread_data)
     TmThreadsSetFlag(th_v, THV_RUNNING);
 
     while (1) {
-        if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
-            TmThreadsSetFlag(th_v, THV_PAUSED);
-            TmThreadTestThreadUnPaused(th_v);
-            TmThreadsUnsetFlag(th_v, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(th_v);
         SCLogDebug("Dumping the table");
         gettimeofday(&tv, NULL);
         TIMEVAL_TO_TIMESPEC(&tv, &curtime);

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -820,11 +820,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 
     while (1)
     {
-        if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
-            TmThreadsSetFlag(th_v, THV_PAUSED);
-            TmThreadTestThreadUnPaused(th_v);
-            TmThreadsUnsetFlag(th_v, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(th_v);
 
         bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 
@@ -1085,11 +1081,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
 
     while (1)
     {
-        if (TmThreadsCheckFlag(th_v, THV_PAUSE)) {
-            TmThreadsSetFlag(th_v, THV_PAUSED);
-            TmThreadTestThreadUnPaused(th_v);
-            TmThreadsUnsetFlag(th_v, THV_PAUSED);
-        }
+        TmThreadsWaitForUnpause(th_v);
         SC_ATOMIC_ADD(flowrec_busy,1);
         FlowQueuePrivate list = FlowQueueExtractPrivate(&flow_recycle_q);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -817,11 +817,9 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
     StatsSetUI64(th_v, ftd->cnt.flow_mgr_rows_sec, rows_sec);
 
     TmThreadsSetFlag(th_v, THV_RUNNING);
+    bool run = TmThreadsWaitForUnpause(th_v);
 
-    while (1)
-    {
-        TmThreadsWaitForUnpause(th_v);
-
+    while (run) {
         bool emerg = ((SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) != 0);
 
         /* Get the time */
@@ -1078,10 +1076,9 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
     FlowQueuePrivate ret_queue = { NULL, NULL, 0 };
 
     TmThreadsSetFlag(th_v, THV_RUNNING);
+    bool run = TmThreadsWaitForUnpause(th_v);
 
-    while (1)
-    {
-        TmThreadsWaitForUnpause(th_v);
+    while (run) {
         SC_ATOMIC_ADD(flowrec_busy,1);
         FlowQueuePrivate list = FlowQueueExtractPrivate(&flow_recycle_q);
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -358,11 +358,21 @@ error:
     return NULL;
 }
 
+/**
+ * Also returns if the kill flag is set.
+ */
 void TmThreadsWaitForUnpause(ThreadVars *tv)
 {
     if (TmThreadsCheckFlag(tv, THV_PAUSE)) {
         TmThreadsSetFlag(tv, THV_PAUSED);
-        TmThreadTestThreadUnPaused(tv);
+
+        while (TmThreadsCheckFlag(tv, THV_PAUSE)) {
+            SleepUsec(100);
+
+            if (TmThreadsCheckFlag(tv, THV_KILL))
+                break;
+        }
+
         TmThreadsUnsetFlag(tv, THV_PAUSED);
     }
 }
@@ -1734,24 +1744,6 @@ static void TmThreadDeinitMC(ThreadVars *tv)
     if (tv->ctrl_cond) {
         SCCtrlCondDestroy(tv->ctrl_cond);
         SCFree(tv->ctrl_cond);
-    }
-}
-
-/**
- * \brief Tests if the thread represented in the arg has been unpaused or not.
- *
- *        The function would return if the thread tv has been unpaused or if the
- *        kill flag for the thread has been set.
- *
- * \param tv Pointer to the TV instance.
- */
-void TmThreadTestThreadUnPaused(ThreadVars *tv)
-{
-    while (TmThreadsCheckFlag(tv, THV_PAUSE)) {
-        SleepUsec(100);
-
-        if (TmThreadsCheckFlag(tv, THV_KILL))
-            break;
     }
 }
 

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -288,4 +288,7 @@ void TmThreadsGetMinimalTimestamp(struct timeval *ts);
 uint16_t TmThreadsGetWorkerThreadMax(void);
 bool TmThreadsTimeSubsysIsReady(void);
 
+/** \brief Wait for a thread to become unpaused. */
+void TmThreadsWaitForUnpause(ThreadVars *tv);
+
 #endif /* SURICATA_TM_THREADS_H */

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -291,7 +291,9 @@ bool TmThreadsTimeSubsysIsReady(void);
  *
  * Check if a thread should wait to be unpaused and wait if so, or
  * until the thread kill flag is set.
+ *
+ * \returns true if the thread was unpaused, false if killed.
  */
-void TmThreadsWaitForUnpause(ThreadVars *tv);
+bool TmThreadsWaitForUnpause(ThreadVars *tv);
 
 #endif /* SURICATA_TM_THREADS_H */

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -108,7 +108,6 @@ void TmThreadSetPrio(ThreadVars *);
 int TmThreadGetNbThreads(uint8_t type);
 
 void TmThreadInitMC(ThreadVars *);
-void TmThreadTestThreadUnPaused(ThreadVars *);
 void TmThreadContinue(ThreadVars *);
 void TmThreadContinueThreads(void);
 void TmThreadCheckThreadState(void);
@@ -288,7 +287,11 @@ void TmThreadsGetMinimalTimestamp(struct timeval *ts);
 uint16_t TmThreadsGetWorkerThreadMax(void);
 bool TmThreadsTimeSubsysIsReady(void);
 
-/** \brief Wait for a thread to become unpaused. */
+/** \brief Wait for a thread to become unpaused.
+ *
+ * Check if a thread should wait to be unpaused and wait if so, or
+ * until the thread kill flag is set.
+ */
 void TmThreadsWaitForUnpause(ThreadVars *tv);
 
 #endif /* SURICATA_TM_THREADS_H */


### PR DESCRIPTION
- move common pattern into function, merging 2 functions together where we check if we should pause, pause, then wait for unpause
- as we're only paused on startup, move the check for pause before any loop where this check/wait is done
- if killed before unpause, don't enter loop.

Previous PR: https://github.com/OISF/suricata/pull/11936
