### PR TITLE
Warnint 64to32 6186 v23.4

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -601,8 +601,8 @@ static bool AlertJsonStreamData(const AlertJsonOutputCtx *json_output_ctx, JsonA
         if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
             uint8_t printable_buf[cbd.payload->offset + 1];
             uint32_t offset = 0;
-            PrintStringsToBuffer(printable_buf, &offset, sizeof(printable_buf), cbd.payload->buffer,
-                    cbd.payload->offset);
+            PrintStringsToBuffer(printable_buf, &offset, cbd.payload->offset + 1,
+                    cbd.payload->buffer, cbd.payload->offset);
             jb_set_string(jb, "payload_printable", (char *)printable_buf);
         }
         return true;

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -188,7 +188,7 @@ TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *
     SCReturnInt(TM_ECODE_OK);
 }
 
-bool EveEmailAddMetadata(const Flow *f, uint32_t tx_id, JsonBuilder *js)
+bool EveEmailAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js)
 {
     SMTPState *smtp_state = (SMTPState *)FlowGetAppState(f);
     if (smtp_state) {

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -36,7 +36,7 @@ typedef struct JsonEmailLogThread_ {
 } JsonEmailLogThread;
 
 TmEcode EveEmailLogJson(JsonEmailLogThread *aft, JsonBuilder *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
-bool EveEmailAddMetadata(const Flow *f, uint32_t tx_id, JsonBuilder *js);
+bool EveEmailAddMetadata(const Flow *f, uint64_t tx_id, JsonBuilder *js);
 
 void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx);
 

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -225,7 +225,7 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
     CreateIsoTimeString(f->lastts, timebuf2, sizeof(timebuf2));
     jb_set_string(jb, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(jb, "age", age);
 
     if (f->flow_end_flags & FLOW_END_FLAG_EMERGENCY)

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -202,7 +202,7 @@ static void FrameAddPayloadTCP(Flow *f, const TcpSession *ssn, const TcpStream *
         jb_set_base64(jb, "payload", cbd.payload->buffer, cbd.payload->offset);
         uint8_t printable_buf[cbd.payload->offset + 1];
         uint32_t offset = 0;
-        PrintStringsToBuffer(printable_buf, &offset, sizeof(printable_buf), cbd.payload->buffer,
+        PrintStringsToBuffer(printable_buf, &offset, cbd.payload->offset + 1, cbd.payload->buffer,
                 cbd.payload->offset);
         jb_set_string(jb, "payload_printable", (char *)printable_buf);
         jb_set_bool(jb, "complete", complete);
@@ -217,12 +217,12 @@ static void FrameAddPayloadUDP(JsonBuilder *js, const Packet *p, const Frame *fr
 
     uint32_t frame_len;
     if (frame->len == -1) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = (uint32_t)(p->payload_len - frame->offset);
     } else {
         frame_len = (uint32_t)frame->len;
     }
     if (frame->offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = (uint32_t)(p->payload_len - frame->offset);
         JB_SET_FALSE(js, "complete");
     } else {
         JB_SET_TRUE(js, "complete");

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -198,8 +198,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 {
     /* hostname */
     if (tx->request_hostname != NULL) {
-        jb_set_string_from_bytes(
-                js, "hostname", bstr_ptr(tx->request_hostname), bstr_len(tx->request_hostname));
+        jb_set_string_from_bytes(js, "hostname", bstr_ptr(tx->request_hostname),
+                (uint32_t)bstr_len(tx->request_hostname));
     }
 
     /* port */
@@ -214,7 +214,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 
     /* uri */
     if (tx->request_uri != NULL) {
-        jb_set_string_from_bytes(js, "url", bstr_ptr(tx->request_uri), bstr_len(tx->request_uri));
+        jb_set_string_from_bytes(
+                js, "url", bstr_ptr(tx->request_uri), (uint32_t)bstr_len(tx->request_uri));
     }
 
     if (tx->request_headers != NULL) {
@@ -222,14 +223,14 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
         htp_header_t *h_user_agent = htp_table_get_c(tx->request_headers, "user-agent");
         if (h_user_agent != NULL) {
             jb_set_string_from_bytes(js, "http_user_agent", bstr_ptr(h_user_agent->value),
-                    bstr_len(h_user_agent->value));
+                    (uint32_t)bstr_len(h_user_agent->value));
         }
 
         /* x-forwarded-for */
         htp_header_t *h_x_forwarded_for = htp_table_get_c(tx->request_headers, "x-forwarded-for");
         if (h_x_forwarded_for != NULL) {
             jb_set_string_from_bytes(js, "xff", bstr_ptr(h_x_forwarded_for->value),
-                    bstr_len(h_x_forwarded_for->value));
+                    (uint32_t)bstr_len(h_x_forwarded_for->value));
         }
     }
 
@@ -248,8 +249,8 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
         htp_header_t *h_content_range = htp_table_get_c(tx->response_headers, "content-range");
         if (h_content_range != NULL) {
             jb_open_object(js, "content_range");
-            jb_set_string_from_bytes(
-                    js, "raw", bstr_ptr(h_content_range->value), bstr_len(h_content_range->value));
+            jb_set_string_from_bytes(js, "raw", bstr_ptr(h_content_range->value),
+                    (uint32_t)bstr_len(h_content_range->value));
             HTTPContentRange crparsed;
             if (HTPParseContentRange(h_content_range->value, &crparsed) == 0) {
                 if (crparsed.start >= 0)
@@ -273,19 +274,19 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
     }
     if (h_referer != NULL) {
         jb_set_string_from_bytes(
-                js, "http_refer", bstr_ptr(h_referer->value), bstr_len(h_referer->value));
+                js, "http_refer", bstr_ptr(h_referer->value), (uint32_t)bstr_len(h_referer->value));
     }
 
     /* method */
     if (tx->request_method != NULL) {
-        jb_set_string_from_bytes(
-                js, "http_method", bstr_ptr(tx->request_method), bstr_len(tx->request_method));
+        jb_set_string_from_bytes(js, "http_method", bstr_ptr(tx->request_method),
+                (uint32_t)bstr_len(tx->request_method));
     }
 
     /* protocol */
     if (tx->request_protocol != NULL) {
-        jb_set_string_from_bytes(
-                js, "protocol", bstr_ptr(tx->request_protocol), bstr_len(tx->request_protocol));
+        jb_set_string_from_bytes(js, "protocol", bstr_ptr(tx->request_protocol),
+                (uint32_t)bstr_len(tx->request_protocol));
     }
 
     /* response status: from libhtp:
@@ -306,7 +307,7 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
     htp_header_t *h_location = htp_table_get_c(tx->response_headers, "location");
     if (h_location != NULL) {
         jb_set_string_from_bytes(
-                js, "redirect", bstr_ptr(h_location->value), bstr_len(h_location->value));
+                js, "redirect", bstr_ptr(h_location->value), (uint32_t)bstr_len(h_location->value));
     }
 
     /* length */
@@ -383,9 +384,7 @@ static void BodyPrintableBuffer(JsonBuilder *js, HtpBody *body, const char *key)
         }
 
         uint8_t printable_buf[body_data_len + 1];
-        PrintStringsToBuffer(printable_buf, &offset,
-                             sizeof(printable_buf),
-                             body_data, body_data_len);
+        PrintStringsToBuffer(printable_buf, &offset, body_data_len + 1, body_data, body_data_len);
         if (offset > 0) {
             jb_set_string(js, key, (char *)printable_buf);
         }

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -193,7 +193,7 @@ static void NetFlowLogEveToServer(JsonBuilder *js, Flow *f)
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(js, "age", age);
 
     jb_set_uint(js, "min_ttl", f->min_ttl_toserver);
@@ -237,7 +237,7 @@ static void NetFlowLogEveToClient(JsonBuilder *js, Flow *f)
     jb_set_string(js, "start", timebuf1);
     jb_set_string(js, "end", timebuf2);
 
-    int32_t age = SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts);
+    uint64_t age = (SCTIME_SECS(f->lastts) - SCTIME_SECS(f->startts));
     jb_set_uint(js, "age", age);
 
     /* To client is zero if we did not see any packet */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -199,24 +199,18 @@ static void EveAddPacketVars(const Packet *p, JsonBuilder *js_vars)
             if (pv->key != NULL) {
                 uint32_t offset = 0;
                 uint8_t keybuf[pv->key_len + 1];
-                PrintStringsToBuffer(keybuf, &offset,
-                        sizeof(keybuf),
-                        pv->key, pv->key_len);
+                PrintStringsToBuffer(keybuf, &offset, pv->key_len + 1, pv->key, pv->key_len);
                 uint32_t len = pv->value_len;
                 uint8_t printable_buf[len + 1];
                 offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        pv->value, pv->value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, pv->value, pv->value_len);
                 jb_set_string(js_vars, (char *)keybuf, (char *)printable_buf);
             } else {
                 const char *varname = VarNameStoreLookupById(pv->id, VAR_TYPE_PKT_VAR);
                 uint32_t len = pv->value_len;
                 uint8_t printable_buf[len + 1];
                 uint32_t offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        pv->value, pv->value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, pv->value, pv->value_len);
                 jb_set_string(js_vars, varname, (char *)printable_buf);
             }
             jb_close(js_vars);
@@ -271,9 +265,8 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
                     uint32_t len = fv->data.fv_str.value_len;
                     uint8_t printable_buf[len + 1];
                     uint32_t offset = 0;
-                    PrintStringsToBuffer(printable_buf, &offset,
-                            sizeof(printable_buf),
-                            fv->data.fv_str.value, fv->data.fv_str.value_len);
+                    PrintStringsToBuffer(printable_buf, &offset, len + 1, fv->data.fv_str.value,
+                            fv->data.fv_str.value_len);
 
                     jb_start_object(js_flowvars);
                     jb_set_string(js_flowvars, varname, (char *)printable_buf);
@@ -288,16 +281,13 @@ static void EveAddFlowVars(const Flow *f, JsonBuilder *js_root, JsonBuilder **js
 
                 uint8_t keybuf[fv->keylen + 1];
                 uint32_t offset = 0;
-                PrintStringsToBuffer(keybuf, &offset,
-                        sizeof(keybuf),
-                        fv->key, fv->keylen);
+                PrintStringsToBuffer(keybuf, &offset, fv->keylen + 1, fv->key, fv->keylen);
 
                 uint32_t len = fv->data.fv_str.value_len;
                 uint8_t printable_buf[len + 1];
                 offset = 0;
-                PrintStringsToBuffer(printable_buf, &offset,
-                        sizeof(printable_buf),
-                        fv->data.fv_str.value, fv->data.fv_str.value_len);
+                PrintStringsToBuffer(printable_buf, &offset, len + 1, fv->data.fv_str.value,
+                        fv->data.fv_str.value_len);
 
                 jb_start_object(js_flowvars);
                 jb_set_string(js_flowvars, (const char *)keybuf, (char *)printable_buf);
@@ -429,9 +419,9 @@ void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, c
  * \param js JSON object
  * \param max_length If non-zero, restricts the number of packet data bytes handled.
  */
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length)
+void EvePacket(const Packet *p, JsonBuilder *js, uint32_t max_length)
 {
-    unsigned long max_len = max_length == 0 ? GET_PKT_LEN(p) : max_length;
+    uint32_t max_len = max_length == 0 ? GET_PKT_LEN(p) : max_length;
     jb_set_base64(js, "packet", GET_PKT_DATA(p), max_len);
 
     if (!jb_open_object(js, "packet_info")) {
@@ -931,7 +921,8 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data)
         MemBufferExpand(memb, wrapper->expand_by);
     }
 
-    MemBufferWriteRaw((*memb), (const uint8_t *)str, size);
+    DEBUG_VALIDATE_BUG_ON(size > UINT32_MAX);
+    MemBufferWriteRaw((*memb), (const uint8_t *)str, (uint32_t)size);
     return 0;
 }
 
@@ -985,11 +976,12 @@ int OutputJsonBuilderBuffer(JsonBuilder *js, OutputJsonThreadCtx *ctx)
     }
 
     size_t jslen = jb_len(js);
+    DEBUG_VALIDATE_BUG_ON(jb_len(js) > UINT32_MAX);
     if (MEMBUFFER_OFFSET(*buffer) + jslen >= MEMBUFFER_SIZE(*buffer)) {
-        MemBufferExpand(buffer, jslen);
+        MemBufferExpand(buffer, (uint32_t)jslen);
     }
 
-    MemBufferWriteRaw((*buffer), jb_ptr(js), jslen);
+    MemBufferWriteRaw((*buffer), jb_ptr(js), (uint32_t)jslen);
     LogFileWrite(file_ctx, *buffer);
 
     return 0;
@@ -1144,7 +1136,7 @@ OutputInitResult OutputJsonInitCtx(ConfNode *conf)
             {
                 FatalError("Failed to allocate memory for eve-log.prefix setting.");
             }
-            json_ctx->file_ctx->prefix_len = strlen(prefix);
+            json_ctx->file_ctx->prefix_len = (uint32_t)strlen(prefix);
         }
 
         /* Threaded file output */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -65,7 +65,7 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir,
 /* helper struct for OutputJSONMemBufferCallback */
 typedef struct OutputJSONMemBufferWrapper_ {
     MemBuffer **buffer; /**< buffer to use & expand as needed */
-    size_t expand_by;   /**< expand by this size */
+    uint32_t expand_by; /**< expand by this size */
 } OutputJSONMemBufferWrapper;
 
 typedef struct OutputJsonCommonSettings_ {
@@ -97,7 +97,7 @@ json_t *SCJsonString(const char *val);
 void CreateEveFlowId(JsonBuilder *js, const Flow *f);
 void EveFileInfo(JsonBuilder *js, const File *file, const uint64_t tx_id, const uint16_t flags);
 void EveTcpFlags(uint8_t flags, JsonBuilder *js);
-void EvePacket(const Packet *p, JsonBuilder *js, unsigned long max_length);
+void EvePacket(const Packet *p, JsonBuilder *js, uint32_t max_length);
 JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, OutputJsonCtx *eve_ctx);
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -275,7 +275,8 @@ static int TcpDataLogger (Flow *f, TcpSession *ssn, TcpStream *stream,
             progress, &progress, eof);
 
     if (progress > STREAM_LOG_PROGRESS(stream)) {
-        uint32_t slide = progress - STREAM_LOG_PROGRESS(stream);
+        DEBUG_VALIDATE_BUG_ON(progress - STREAM_LOG_PROGRESS(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(progress - STREAM_LOG_PROGRESS(stream));
         stream->log_progress_rel += slide;
     }
 

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -931,7 +931,8 @@ void StreamTcpPruneSession(Flow *f, uint8_t flags)
     const uint64_t left_edge = GetLeftEdge(f, ssn, stream);
     SCLogDebug("buffer left_edge %" PRIu64, left_edge);
     if (left_edge && left_edge > STREAM_BASE_OFFSET(stream)) {
-        uint32_t slide = left_edge - STREAM_BASE_OFFSET(stream);
+        DEBUG_VALIDATE_BUG_ON(left_edge - STREAM_BASE_OFFSET(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(left_edge - STREAM_BASE_OFFSET(stream));
         SCLogDebug("buffer sliding %u to offset %"PRIu64, slide, left_edge);
 
         if (!(ssn->flags & STREAMTCP_FLAG_APP_LAYER_DISABLED)) {

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1092,9 +1092,9 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
                     "got data at %"PRIu64". GAP of size %"PRIu64,
                     offset, blk->offset, blk->offset - offset);
             *data = NULL;
-            *data_len = blk->offset - offset;
+            *data_len = (uint32_t)(blk->offset - offset);
 
-        /* block starts before offset, but ends after */
+            /* block starts before offset, but ends after */
         } else if (offset > blk->offset && offset <= (blk->offset + blk->len)) {
             SCLogDebug("get data from offset %"PRIu64". SBB %"PRIu64"/%u",
                     offset, blk->offset, blk->len);
@@ -1184,7 +1184,7 @@ static inline uint32_t AdjustToAcked(const Packet *p,
             /* see if the buffer contains unack'd data as well */
             if (app_progress <= last_ack_abs && app_progress + data_len > last_ack_abs) {
                 uint32_t check = data_len;
-                adjusted = last_ack_abs - app_progress;
+                adjusted = (uint32_t)(last_ack_abs - app_progress);
                 BUG_ON(adjusted > check);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", adjusted);
@@ -1414,7 +1414,7 @@ static int GetRawBuffer(const TcpStream *stream, const uint8_t **data, uint32_t 
             uint64_t delta = offset - (*iter)->offset;
             if (delta < mydata_len) {
                 *data = mydata + delta;
-                *data_len = mydata_len - delta;
+                *data_len = (uint32_t)(mydata_len - delta);
                 *data_offset = offset;
             } else {
                 SCLogDebug("no data (yet)");
@@ -1498,7 +1498,8 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
     }
 
     if (progress > STREAM_RAW_PROGRESS(stream)) {
-        uint32_t slide = progress - STREAM_RAW_PROGRESS(stream);
+        DEBUG_VALIDATE_BUG_ON(progress - STREAM_RAW_PROGRESS(stream) > UINT32_MAX);
+        uint32_t slide = (uint32_t)(progress - STREAM_RAW_PROGRESS(stream));
         stream->raw_progress_rel += slide;
         stream->flags &= ~STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
 
@@ -1510,7 +1511,8 @@ void StreamReassembleRawUpdateProgress(TcpSession *ssn, Packet *p, const uint64_
             target = GetAbsLastAck(stream);
         }
         if (target > STREAM_RAW_PROGRESS(stream)) {
-            uint32_t slide = target - STREAM_RAW_PROGRESS(stream);
+            DEBUG_VALIDATE_BUG_ON(target - STREAM_RAW_PROGRESS(stream) > UINT32_MAX);
+            uint32_t slide = (uint32_t)(target - STREAM_RAW_PROGRESS(stream));
             stream->raw_progress_rel += slide;
         }
         stream->flags &= ~STREAMTCP_STREAM_FLAG_TRIGGER_RAW;
@@ -1781,7 +1783,7 @@ static int StreamReassembleRawDo(const TcpSession *ssn, const TcpStream *stream,
             /* see if the buffer contains unack'd data as well */
             if (progress + mydata_len > re) {
                 uint32_t check = mydata_len;
-                mydata_len = re - progress;
+                mydata_len = (uint32_t)(re - progress);
                 BUG_ON(check < mydata_len);
                 SCLogDebug("data len adjusted to %u to make sure only ACK'd "
                         "data is considered", mydata_len);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1187,7 +1187,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1294,7 +1294,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->server.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->server.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1347,7 +1347,7 @@ static int StreamTcpPacketStateNone(
             if (ssn->client.last_ts == 0)
                 ssn->client.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             ssn->client.flags |= STREAMTCP_STREAM_FLAG_TIMESTAMP;
         }
 
@@ -1455,7 +1455,7 @@ static int StreamTcpPacketStateNone(
 
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
 
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->server.last_ts == 0)
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
             if (ssn->client.last_ts == 0)
@@ -1490,7 +1490,7 @@ static inline void StreamTcp3whsSynAckToStateQueue(Packet *p, TcpStateQueue *q)
     q->win = TCP_GET_RAW_WINDOW(tcph);
     q->seq = TCP_GET_RAW_SEQ(tcph);
     q->ack = TCP_GET_RAW_ACK(tcph);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p))
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -1753,7 +1753,7 @@ static void TcpStateQueueInitFromPktSyn(const Packet *p, TcpStateQueue *q)
     const TCPHdr *tcph = PacketGetTCP(p);
 
     q->win = TCP_GET_RAW_WINDOW(tcph);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p)) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -1786,7 +1786,7 @@ static void TcpStateQueueInitFromPktSynAck(const Packet *p, TcpStateQueue *q)
 
     const TCPHdr *tcph = PacketGetTCP(p);
     q->win = TCP_GET_RAW_WINDOW(tcph);
-    q->pkt_ts = SCTIME_SECS(p->ts);
+    q->pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
     if (TCP_GET_SACKOK(p)) {
         q->flags |= STREAMTCP_QUEUE_FLAG_SACK;
@@ -2025,7 +2025,7 @@ static int StreamTcpPacketStateSynSent(
                        "ssn->server.last_ts %" PRIu32 "",
                     ssn, ssn->client.last_ts, ssn->server.last_ts);
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             if (ssn->client.last_ts == 0)
                 ssn->client.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
         } else {
@@ -2131,7 +2131,7 @@ static int StreamTcpPacketStateSynSent(
 
                 if (ssn->server.last_ts == 0)
                     ssn->server.flags |= STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
-                ssn->server.last_pkt_ts = SCTIME_SECS(p->ts);
+                ssn->server.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
                 ssn->server.flags |= STREAMTCP_STREAM_FLAG_TIMESTAMP;
             }
 
@@ -2233,7 +2233,7 @@ static int StreamTcpPacketStateSynSent(
         {
             ssn->flags |= STREAMTCP_FLAG_TIMESTAMP;
             ssn->client.flags &= ~STREAMTCP_STREAM_FLAG_TIMESTAMP;
-            ssn->client.last_pkt_ts = SCTIME_SECS(p->ts);
+            ssn->client.last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
         } else {
             ssn->client.last_ts = 0;
             ssn->client.flags &= ~STREAMTCP_STREAM_FLAG_ZERO_TIMESTAMP;
@@ -6350,7 +6350,7 @@ static int StreamTcpValidateTimestamp (TcpSession *ssn, Packet *p)
             if (last_pkt_ts == 0 &&
                     (ssn->flags & STREAMTCP_FLAG_MIDSTREAM))
             {
-                last_pkt_ts = SCTIME_SECS(p->ts);
+                last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             }
 
             if (result < 0) {
@@ -6494,7 +6494,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
             if (sender_stream->last_pkt_ts == 0 &&
                     (ssn->flags & STREAMTCP_FLAG_MIDSTREAM))
             {
-                sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
             }
 
             if (result < 0) {
@@ -6519,7 +6519,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
                 if (SEQ_EQ(sender_stream->next_seq, seq))
                     sender_stream->last_ts = ts;
 
-                sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
             } else if (ret == 0) {
                 /* if the timestamp of packet is not valid then, check if the
@@ -6529,7 +6529,7 @@ static int StreamTcpHandleTimestamp (TcpSession *ssn, Packet *p)
                         (((uint32_t)SCTIME_SECS(p->ts) >
                                 (sender_stream->last_pkt_ts + PAWS_24DAYS)))) {
                     sender_stream->last_ts = ts;
-                    sender_stream->last_pkt_ts = SCTIME_SECS(p->ts);
+                    sender_stream->last_pkt_ts = (uint32_t)SCTIME_SECS(p->ts);
 
                     SCLogDebug("timestamp considered valid anyway");
                 } else {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -125,7 +125,7 @@ typedef struct LogFileCtx_ {
     /**< Used by some alert loggers like the unified ones that append
      * the date onto the end of files. */
     char *prefix;
-    size_t prefix_len;
+    uint32_t prefix_len;
 
     /** Generic size_limit and size_current
      * They must be common to the threads accessing the same file */


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix `-Wshorten-64-to-32` warnings for some files : output, stream

Some commits of #9840
#11580 next batch
#11904 without commit about https://redmine.openinfosecfoundation.org/issues/7311 (and so still some warning)

Still to do afterwards :
- detect
- util
