### PR TITLE
Detect validate callbacks 5634 v4

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -92,6 +92,11 @@ Deprecations
   Suricata 9.0. Note that this is the standalone ``syslog`` output and
   does affect the ``eve`` outputs ability to send to syslog.
 
+Keyword changes
+~~~~~~~~~~~~~~~
+- ``ja3.hash`` and ``ja3s.hash`` no longer accept contents with non hexadecimal
+  characters, as they will never match.
+
 Logging changes
 ~~~~~~~~~~~~~~~
 - RFB security result is now consistently logged as ``security_result`` when it was

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1301,7 +1301,7 @@ void DetectEngineBufferRunSetupCallback(const DetectEngineCtx *de_ctx, const int
 }
 
 void DetectBufferTypeRegisterValidateCallback(const char *name,
-        bool (*ValidateCallback)(const Signature *, const char **sigerror))
+        bool (*ValidateCallback)(const Signature *, const char **sigerror, uint32_t))
 {
     BUG_ON(g_buffer_type_reg_closed);
     DetectBufferTypeRegister(name);
@@ -1315,7 +1315,7 @@ bool DetectEngineBufferRunValidateCallback(
 {
     const DetectBufferType *map = DetectEngineBufferTypeGetById(de_ctx, id);
     if (map && map->ValidateCallback) {
-        return map->ValidateCallback(s, sigerror);
+        return map->ValidateCallback(s, sigerror, map->id);
     }
     return true;
 }

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -59,7 +59,7 @@ const char *DetectBufferTypeGetDescriptionByName(const char *name);
 void DetectBufferTypeRegisterSetupCallback(const char *name,
         void (*Callback)(const DetectEngineCtx *, Signature *));
 void DetectBufferTypeRegisterValidateCallback(const char *name,
-        bool (*ValidateCallback)(const Signature *, const char **sigerror));
+        bool (*ValidateCallback)(const Signature *, const char **sigerror, uint32_t));
 
 /* detect engine related buffer funcs */
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -207,6 +207,8 @@ void DetectRunStoreStateTx(const SigGroupHead *sgh, Flow *f, void *tx, uint64_t 
 
 void DetectEngineStateResetTxs(Flow *f);
 
+bool DetectMd5ValidateCallback(const Signature *s, const char **sigerror, uint32_t buf_id);
+
 void DeStateRegisterTests(void);
 
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -62,7 +62,8 @@ static int DetectHttpHHSetup(DetectEngineCtx *, Signature *, const char *);
 #ifdef UNITTESTS
 static void DetectHttpHHRegisterTests(void);
 #endif
-static bool DetectHttpHostValidateCallback(const Signature *s, const char **sigerror);
+static bool DetectHttpHostValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int DetectHttpHostSetup(DetectEngineCtx *, Signature *, const char *);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
@@ -177,10 +178,11 @@ static int DetectHttpHHSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
             de_ctx, s, arg, DETECT_AL_HTTP_HOST, g_http_host_buffer_id, ALPROTO_HTTP1);
 }
 
-static bool DetectHttpHostValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpHostValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_http_host_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -65,7 +65,8 @@ static int DetectHttpMethodSetupSticky(DetectEngineCtx *de_ctx, Signature *s, co
 void DetectHttpMethodRegisterTests(void);
 #endif
 void DetectHttpMethodFree(void *);
-static bool DetectHttpMethodValidateCallback(const Signature *s, const char **sigerror);
+static bool DetectHttpMethodValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
         const uint8_t _flow_flags, void *txv, const int list_id);
@@ -161,10 +162,11 @@ static int DetectHttpMethodSetupSticky(DetectEngineCtx *de_ctx, Signature *s, co
  *  \retval 1 valid
  *  \retval 0 invalid
  */
-static bool DetectHttpMethodValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpMethodValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_http_method_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -128,11 +128,12 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectHttpProtocolValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpProtocolValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
 #ifdef HAVE_HTP_CONFIG_SET_ALLOW_SPACE_URI
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -58,7 +58,8 @@ static int DetectHttpRawHeaderSetupSticky(DetectEngineCtx *de_ctx, Signature *s,
 #ifdef UNITTESTS
 static void DetectHttpRawHeaderRegisterTests(void);
 #endif
-static bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror);
+static bool DetectHttpRawHeaderValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int g_http_raw_header_buffer_id = 0;
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
@@ -163,7 +164,8 @@ static int DetectHttpRawHeaderSetupSticky(DetectEngineCtx *de_ctx, Signature *s,
     return 0;
 }
 
-static bool DetectHttpRawHeaderValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectHttpRawHeaderValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     if ((s->flags & (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) == (SIG_FLAG_TOCLIENT|SIG_FLAG_TOSERVER)) {
         *sigerror = "http_raw_header signature "

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -59,9 +59,7 @@
 #ifdef UNITTESTS
 static void DetectHttpUriRegisterTests(void);
 #endif
-static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
-                                       Signature *s);
-static bool DetectHttpUriValidateCallback(const Signature *s, const char **sigerror);
+static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
@@ -71,9 +69,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         const int list_id);
 static int DetectHttpUriSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str);
 static int DetectHttpRawUriSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,
-                                          Signature *s);
-static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **);
+static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms,
         Flow *_f, const uint8_t _flow_flags,
@@ -125,8 +121,7 @@ void DetectHttpUriRegister (void)
     DetectBufferTypeRegisterSetupCallback("http_uri",
             DetectHttpUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("http_uri",
-            DetectHttpUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("http_uri", DetectUrilenValidateContent);
 
     g_http_uri_buffer_id = DetectBufferTypeGetByName("http_uri");
 
@@ -164,8 +159,7 @@ void DetectHttpUriRegister (void)
     DetectBufferTypeRegisterSetupCallback("http_raw_uri",
             DetectHttpRawUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("http_raw_uri",
-            DetectHttpRawUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("http_raw_uri", DetectUrilenValidateContent);
 
     g_http_raw_uri_buffer_id = DetectBufferTypeGetByName("http_raw_uri");
 }
@@ -185,11 +179,6 @@ int DetectHttpUriSetup(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
     return DetectEngineContentModifierBufferSetup(
             de_ctx, s, str, DETECT_AL_HTTP_URI, g_http_uri_buffer_id, ALPROTO_HTTP1);
-}
-
-static bool DetectHttpUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_http_uri_buffer_id, sigerror);
 }
 
 static void DetectHttpUriSetupCallback(const DetectEngineCtx *de_ctx,
@@ -280,11 +269,6 @@ static int DetectHttpRawUriSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
 {
     return DetectEngineContentModifierBufferSetup(
             de_ctx, s, arg, DETECT_AL_HTTP_RAW_URI, g_http_raw_uri_buffer_id, ALPROTO_HTTP1);
-}
-
-static bool DetectHttpRawUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_http_raw_uri_buffer_id, sigerror);
 }
 
 static void DetectHttpRawUriSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -82,10 +82,11 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static bool DetectQuicHashValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectQuicHashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -82,47 +82,6 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
     SCReturnPtr(buffer, "InspectionBuffer");
 }
 
-static bool DetectQuicHashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id)
-{
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != buf_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = BUFFER_NAME " should not be used together with "
-                                        "nocase, since the rule is automatically "
-                                        "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified" BUFFER_NAME " (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror = "Invalid " BUFFER_NAME
-                                " string (should be string of hexadecimal characters)."
-                                "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
-}
-
 void DetectQuicCyuHashRegister(void)
 {
     /* quic.cyu.hash sticky buffer */
@@ -142,7 +101,7 @@ void DetectQuicCyuHashRegister(void)
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectQuicHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 
     DetectBufferTypeSupportsMultiInstance(BUFFER_NAME);
 }

--- a/src/detect-sip-method.c
+++ b/src/detect-sip-method.c
@@ -69,10 +69,11 @@ static int DetectSipMethodSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 }
 
-static bool DetectSipMethodValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectSipMethodValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-sip-uri.c
+++ b/src/detect-sip-uri.c
@@ -59,11 +59,6 @@
 #define BUFFER_DESC  "sip request uri"
 static int g_buffer_id = 0;
 
-static bool DetectSipUriValidateCallback(const Signature *s, const char **sigerror)
-{
-    return DetectUrilenValidateContent(s, g_buffer_id, sigerror);
-}
-
 static void DetectSipUriSetupCallback(const DetectEngineCtx *de_ctx,
                                        Signature *s)
 {
@@ -122,8 +117,7 @@ void DetectSipUriRegister(void)
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME,
             DetectSipUriSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME,
-            DetectSipUriValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectUrilenValidateContent);
 
     g_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -118,10 +118,11 @@ static int DetectSshHasshServerSetup(DetectEngineCtx *de_ctx, Signature *s, cons
 
 }
 
-static bool DetectSshHasshServerHashValidateCallback(const Signature *s, const char **sigerror)
+static bool DetectSshHasshServerHashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_ssh_hassh_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -118,49 +118,7 @@ static int DetectSshHasshServerSetup(DetectEngineCtx *de_ctx, Signature *s, cons
 
 }
 
-static bool DetectSshHasshServerHashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id)
-{
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != buf_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ssh.hassh.server should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified ssh.hassh.server (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror = "Invalid ssh.hassh.server string (should be string of hexadecimal "
-                                "characters)."
-                                "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
-}
-
-static void DetectSshHasshServerHashSetupCallback(const DetectEngineCtx *de_ctx,
-                                          Signature *s)
+static void DetectSshHasshServerHashSetupCallback(const DetectEngineCtx *de_ctx, Signature *s)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         if (s->init_data->buffers[x].id != (uint32_t)g_ssh_hassh_buffer_id)
@@ -207,5 +165,5 @@ void DetectSshHasshServerRegister(void)
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME, DetectSshHasshServerHashSetupCallback);
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectSshHasshServerHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 }

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -118,47 +118,6 @@ static int DetectSshHasshSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 }
 
-static bool DetectSshHasshHashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id)
-{
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != buf_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ssh.hassh should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len != 32) {
-                *sigerror = "Invalid length of the specified ssh.hassh (should "
-                            "be 32 characters long). This rule will therefore "
-                            "never match.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-                return false;
-            }
-            for (size_t i = 0; i < cd->content_len; ++i) {
-                if (!isxdigit(cd->content[i])) {
-                    *sigerror =
-                            "Invalid ssh.hassh string (should be string of hexadecimal characters)."
-                            "This rule will therefore never match.";
-                    SCLogWarning("rule %u: %s", s->id, *sigerror);
-                    return false;
-                }
-            }
-        }
-    }
-    return true;
-}
-
 static void DetectSshHasshHashSetupCallback(const DetectEngineCtx *de_ctx,
                                           Signature *s)
 {
@@ -207,6 +166,6 @@ void DetectSshHasshRegister(void)
     g_ssh_hassh_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 
     DetectBufferTypeRegisterSetupCallback(BUFFER_NAME, DetectSshHasshHashSetupCallback);
-    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectSshHasshHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback(BUFFER_NAME, DetectMd5ValidateCallback);
 }
 

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -118,12 +118,11 @@ static int DetectSshHasshSetup(DetectEngineCtx *de_ctx, Signature *s, const char
 
 }
 
-
-static bool DetectSshHasshHashValidateCallback(const Signature *s,
-                                              const char **sigerror)
+static bool DetectSshHasshHashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_ssh_hassh_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -62,8 +62,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         void *txv, const int list_id);
 static void DetectTlsFingerprintSetupCallback(const DetectEngineCtx *de_ctx,
         Signature *s);
-static bool DetectTlsFingerprintValidateCallback(const Signature *s,
-        const char **sigerror);
+static bool DetectTlsFingerprintValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int g_tls_cert_fingerprint_buffer_id = 0;
 
 /**
@@ -158,11 +158,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectTlsFingerprintValidateCallback(const Signature *s,
-                                                  const char **sigerror)
+static bool DetectTlsFingerprintValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_tls_cert_fingerprint_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -62,8 +62,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         void *txv, const int list_id);
 static void DetectTlsSerialSetupCallback(const DetectEngineCtx *de_ctx,
         Signature *s);
-static bool DetectTlsSerialValidateCallback(const Signature *s,
-        const char **sigerror);
+static bool DetectTlsSerialValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int g_tls_cert_serial_buffer_id = 0;
 
 /**
@@ -157,11 +157,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectTlsSerialValidateCallback(const Signature *s,
-                                             const char **sigerror)
+static bool DetectTlsSerialValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_tls_cert_serial_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -72,8 +72,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        void *txv, const int list_id);
 static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
        Signature *s);
-static bool DetectTlsJa3HashValidateCallback(const Signature *s,
-       const char **sigerror);
+static bool DetectTlsJa3HashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int g_tls_ja3_hash_buffer_id = 0;
 #endif
 
@@ -178,11 +178,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectTlsJa3HashValidateCallback(const Signature *s,
-                                              const char **sigerror)
+static bool DetectTlsJa3HashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_tls_ja3_hash_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -70,10 +70,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
-static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,
-       Signature *s);
-static bool DetectTlsJa3HashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id);
+static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static int g_tls_ja3_hash_buffer_id = 0;
 #endif
 
@@ -112,8 +109,7 @@ void DetectTlsJa3HashRegister(void)
     DetectBufferTypeRegisterSetupCallback("ja3.hash",
             DetectTlsJa3HashSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("ja3.hash",
-            DetectTlsJa3HashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("ja3.hash", DetectMd5ValidateCallback);
 
     g_tls_ja3_hash_buffer_id = DetectBufferTypeGetByName("ja3.hash");
 #endif /* HAVE_JA3 */
@@ -176,39 +172,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     }
 
     return buffer;
-}
-
-static bool DetectTlsJa3HashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id)
-{
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != buf_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ja3.hash should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len == SC_MD5_HEX_LEN)
-                return true;
-
-            *sigerror = "Invalid length of the specified JA3 hash (should "
-                        "be 32 characters long). This rule will therefore "
-                        "never match.";
-            SCLogWarning("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
-    }
-    return true;
 }
 
 static void DetectTlsJa3HashSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -72,8 +72,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        void *txv, const int list_id);
 static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
        Signature *s);
-static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
-       const char **sigerror);
+static bool DetectTlsJa3SHashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id);
 static int g_tls_ja3s_hash_buffer_id = 0;
 #endif
 
@@ -176,11 +176,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
-static bool DetectTlsJa3SHashValidateCallback(const Signature *s,
-                                               const char **sigerror)
+static bool DetectTlsJa3SHashValidateCallback(
+        const Signature *s, const char **sigerror, uint32_t buf_id)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)g_tls_ja3s_hash_buffer_id)
+        if (s->init_data->buffers[x].id != buf_id)
             continue;
         const SigMatch *sm = s->init_data->buffers[x].head;
         for (; sm != NULL; sm = sm->next) {

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -70,10 +70,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
        const DetectEngineTransforms *transforms,
        Flow *f, const uint8_t flow_flags,
        void *txv, const int list_id);
-static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,
-       Signature *s);
-static bool DetectTlsJa3SHashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id);
+static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx, Signature *s);
 static int g_tls_ja3s_hash_buffer_id = 0;
 #endif
 
@@ -111,8 +108,7 @@ void DetectTlsJa3SHashRegister(void)
     DetectBufferTypeRegisterSetupCallback("ja3s.hash",
             DetectTlsJa3SHashSetupCallback);
 
-    DetectBufferTypeRegisterValidateCallback("ja3s.hash",
-            DetectTlsJa3SHashValidateCallback);
+    DetectBufferTypeRegisterValidateCallback("ja3s.hash", DetectMd5ValidateCallback);
 
     g_tls_ja3s_hash_buffer_id = DetectBufferTypeGetByName("ja3s.hash");
 #endif /* HAVE_JA3 */
@@ -174,39 +170,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     }
 
     return buffer;
-}
-
-static bool DetectTlsJa3SHashValidateCallback(
-        const Signature *s, const char **sigerror, uint32_t buf_id)
-{
-    for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != buf_id)
-            continue;
-        const SigMatch *sm = s->init_data->buffers[x].head;
-        for (; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_CONTENT)
-                continue;
-
-            const DetectContentData *cd = (DetectContentData *)sm->ctx;
-
-            if (cd->flags & DETECT_CONTENT_NOCASE) {
-                *sigerror = "ja3s.hash should not be used together with "
-                            "nocase, since the rule is automatically "
-                            "lowercased anyway which makes nocase redundant.";
-                SCLogWarning("rule %u: %s", s->id, *sigerror);
-            }
-
-            if (cd->content_len == SC_MD5_HEX_LEN)
-                return true;
-
-            *sigerror = "Invalid length of the specified JA3S hash (should "
-                        "be 32 characters long). This rule will therefore "
-                        "never match.";
-            SCLogError("rule %u: %s", s->id, *sigerror);
-            return false;
-        }
-    }
-    return true;
 }
 
 static void DetectTlsJa3SHashSetupCallback(const DetectEngineCtx *de_ctx,

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -214,10 +214,10 @@ void DetectUrilenApplyToContent(Signature *s, int list)
     }
 }
 
-bool DetectUrilenValidateContent(const Signature *s, int list, const char **sigerror)
+bool DetectUrilenValidateContent(const Signature *s, const char **sigerror, uint32_t list)
 {
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
-        if (s->init_data->buffers[x].id != (uint32_t)list)
+        if (s->init_data->buffers[x].id != list)
             continue;
         for (const SigMatch *sm = s->init_data->buffers[x].head; sm != NULL; sm = sm->next) {
             if (sm->type != DETECT_CONTENT) {

--- a/src/detect-urilen.h
+++ b/src/detect-urilen.h
@@ -24,7 +24,7 @@
 #ifndef _DETECT_URILEN_H
 #define	_DETECT_URILEN_H
 
-bool DetectUrilenValidateContent(const Signature *s, int list, const char **);
+bool DetectUrilenValidateContent(const Signature *s, const char **, uint32_t buf_id);
 void DetectUrilenApplyToContent(Signature *s, int list);
 void DetectUrilenRegister(void);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -462,7 +462,7 @@ typedef struct DetectBufferType_ {
     bool supports_transforms;
     bool multi_instance; /**< buffer supports multiple buffer instances per tx */
     void (*SetupCallback)(const struct DetectEngineCtx_ *, struct Signature_ *);
-    bool (*ValidateCallback)(const struct Signature_ *, const char **sigerror);
+    bool (*ValidateCallback)(const struct Signature_ *, const char **sigerror, uint32_t);
     DetectEngineTransforms transforms;
 } DetectBufferType;
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5634

Describe changes:
- detect: change the ValidateCallback prototype to deduplicate code
- detect: use one function for md5-like keywords (quic-cyu-hash, ssh-hassh, tls-ja3-hash...)

#11902 with review taken into account : `ValidateCallback` is not specialized, but extended to have the buffer id, so that keywords can share the same validator code when this buffer id is the only thing changing

This was done on the way to convert quic keywords to rust like https://github.com/OISF/suricata/pull/11575

With this PR, it should be easy to add a wrapper for rust for this ValidateCallback stuff