### PR TITLE
yaml: Add check of allocation for node object - (70x backport) - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -332,6 +332,9 @@ static int ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq, int
                             node = existing;
                         } else {
                             node = ConfNodeNew();
+                            if (unlikely(node == NULL)) {
+                                goto fail;
+                            }
                             node->name = SCStrdup(value);
                             node->parent = parent;
                             if (node->name && strchr(node->name, '_')) {


### PR DESCRIPTION
Fix potential dereference of nullptr in case
of unsuccessful allocation of memory for
list node

Bug: #7270
(cherry picked from commit c72404e5546635a6239bdd7302fe945f47ce1927)

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [ ] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [ ] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
- original: https://redmine.openinfosecfoundation.org/issues/7270
- backport: https://redmine.openinfosecfoundation.org/issues/7294

Describe changes:
- clean cherry pick from work present in https://github.com/OISF/suricata/pull/11847 

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
