### PR TITLE
7.0.x ghci fixes/v4

### DIFF
--- a/.github/actions/install-cbindgen/action.yml
+++ b/.github/actions/install-cbindgen/action.yml
@@ -1,0 +1,15 @@
+name: Install cbindgen
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with:
+        name: cbindgen
+        path: prep
+    - name: Setup cbindgen
+      shell: bash
+      run: |
+        mkdir -p $HOME/.cargo/bin
+        cp prep/cbindgen $HOME/.cargo/bin
+        chmod 755 $HOME/.cargo/bin/cbindgen
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/.github/workflows/authors-done.yml
+++ b/.github/workflows/authors-done.yml
@@ -12,7 +12,7 @@ jobs:
       - run: echo "Author check is complete"
 
       - name: Download artifact new authors
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -38,14 +38,13 @@ jobs:
           fi
       - name: Comment on PR
         if: ${{ env.new_authors == 'yes' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             let fs = require('fs');
             let issue_number = Number(fs.readFileSync('./pr-number.txt'));
-            let new_authors = String(fs.readFileSync('./new-authors.txt'));
-            let msg = 'NOTE: This PR may contain new authors:\n\n```\n' + new_authors + '```';
+            let msg = 'NOTE: This PR may contain new authors.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -3,13 +3,19 @@ name: New Authors Check
 on:
   pull_request:
 
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-id:
     name: New Author Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -17,13 +23,13 @@ jobs:
       - name: Export known authors from master branch
         run: git log --format="%an <%ae>" origin/master | sort | uniq > authors.txt
       - name: Export authors from new commits
-        run: git log --format="%an <%ae>" origin/${GITHUB_BASE_REF}... | sort | uniq > commit-authors.txt
+        run: git log --format="%an <%ae>" ${{ github.event.pull_request.base.sha }}... | sort | uniq > commit-authors.txt
       - name: Check new authors
         run: |
           touch new-authors.txt
           while read -r author; do
              echo "Checking author: ${author}"
-             if ! grep -q "^${author}\$" authors.txt; then
+             if ! grep -qFx "${author}" authors.txt; then
                  echo "ERROR: ${author} NOT FOUND"
                  echo "::warning ::New author found: ${author}"
                  echo "${author}" >> new-authors.txt
@@ -35,7 +41,7 @@ jobs:
       - run: echo ${{ github.event.number }} > new-authors/pr-number.txt
       - run: ls -l
       - name: Upload new authors
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: new-authors
           path: new-authors

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2411,8 +2411,7 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
-          key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.5.3
+          key: windows-msys2-mingw64-cargo
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2467,8 +2466,7 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
-          key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.5.3
+          key: windows-msys2-mingw64-cargo
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2511,8 +2509,7 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.cargo
-          key: ${{ github.job }}-cargo
-      - uses: actions/checkout@v3.5.3
+          key: windows-msys2-mingw64-cargo
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -194,17 +194,9 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      # Download and extract dependency archives created during prep
-      # job.
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: prep
-          path: prep
-      - run: tar xvf prep/libhtp.tar.gz
-      - run: tar xvf prep/suricata-update.tar.gz
-      - run: tar xvf prep/suricata-verify.tar.gz
       - name: Install system packages
         run: |
           dnf -y install dnf-plugins-core epel-release
@@ -259,19 +251,27 @@ jobs:
                 texlive-upquote \
                 texlive-capt-of \
                 texlive-needspace
-      #- name: Setup cppclean
-      #  run: |
-      #    git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
-      #    cd cppclean
-      #    python3 setup.py install
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: ./.github/actions/install-cbindgen
+      # Download and extract dependency archives created during prep
+      # job.
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: prep
+          path: prep
+      - run: tar xvf prep/libhtp.tar.gz
+      - run: tar xvf prep/suricata-update.tar.gz
+      - run: tar xvf prep/suricata-verify.tar.gz
       - name: Configuring
         run: |
           ./autogen.sh
           CFLAGS="${DEFAULT_CFLAGS}" ./configure
-      - run: make -j2 distcheck
+      - run: make -j ${{ env.CPUS }} distcheck
         env:
           DISTCHECK_CONFIGURE_FLAGS: "--enable-unittests --enable-debug --enable-lua --enable-geoip --enable-profiling --enable-profiling-locks --enable-dpdk"
+          MAKEFLAGS: "-j ${{ env.CPUS }}"
       - run: test -e doc/userguide/suricata.1
       - name: Checking includes
         run: |
@@ -279,7 +279,7 @@ jobs:
       - name: Building Rust documentation
         run: make doc
         working-directory: rust
-      - run: make install
+      - run: make install install-conf
       - run: suricatasc -h
       - run: suricata-update -V
       - name: Check if Suricata-Update example configuration files are installed
@@ -312,17 +312,9 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry
 
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      # Download and extract dependency archives created during prep
-      # job.
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: prep
-          path: prep
-      - run: tar xvf prep/libhtp.tar.gz
-      - run: tar xvf prep/suricata-update.tar.gz
-      - run: tar xvf prep/suricata-verify.tar.gz
       - name: Install system packages
         run: |
           dnf -y install dnf-plugins-core epel-release
@@ -366,14 +358,28 @@ jobs:
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: rustup component add rustfmt
       - run: rustup component add clippy
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+
       - uses: ./.github/actions/install-cbindgen
+
+      # Download and extract dependency archives created during prep
+      # job.
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: prep
+          path: prep
+      - run: tar xvf prep/libhtp.tar.gz
+      - run: tar xvf prep/suricata-update.tar.gz
+      - run: tar xvf prep/suricata-verify.tar.gz
       - name: Build
         run: |
           ./autogen.sh
           CFLAGS="${DEFAULT_CFLAGS}" ./configure
-          make -j2
+          make -j ${{ env.CPUS }}
       - run: ./scripts/setup-app-layer.py --parser --logger --detect FooBar payload
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --list-app-layer-protos | grep foobar
       - name: Verify rustfmt
         run: rustfmt -v --check src/applayerfoobar/*.rs
@@ -402,26 +408,9 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
-      # Prebuild check for duplicate SIDs
-      - name: Check for duplicate SIDs
-        run: |
-          dups=$(sed -n 's/^alert.*sid:\([[:digit:]]*\);.*/\1/p' ./rules/*.rules|sort|uniq -d|tr '\n' ' ')
-          if [[ "${dups}" != "" ]]; then
-            echo "::error::Duplicate SIDs found:${dups}"
-            exit 1
-          fi
-
-      # Download and extract dependency archives created during prep
-      # job.
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: prep
-          path: prep
-      - run: tar xvf prep/libhtp.tar.gz
-      - run: tar xvf prep/suricata-update.tar.gz
-      - run: tar xvf prep/suricata-verify.tar.gz
       - name: Install system packages
         run: |
           yum -y install dnf-plugins-core
@@ -461,12 +450,36 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+
+      - uses: ./.github/actions/install-cbindgen
+
+      # Prebuild check for duplicate SIDs
+      - name: Check for duplicate SIDs
+        run: |
+          dups=$(sed -n 's/^alert.*sid:\([[:digit:]]*\);.*/\1/p' ./rules/*.rules|sort|uniq -d|tr '\n' ' ')
+          if [[ "${dups}" != "" ]]; then
+            echo "::error::Duplicate SIDs found:${dups}"
+            exit 1
+          fi
+
+      # Download and extract dependency archives created during prep
+      # job.
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: prep
+          path: prep
+      - run: tar xvf prep/libhtp.tar.gz
+      - run: tar xvf prep/suricata-update.tar.gz
+      - run: tar xvf prep/suricata-verify.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - name: Configuring
         run: |
           ./autogen.sh
           CFLAGS="${DEFAULT_CFLAGS}" ./configure
-      - run: make -j2 check
+      - run: make -j ${{ env.CPUS }} check
       - name: Checking includes
         run: |
           cppclean src/*.h | grep "does not need to be #included" | python3 scripts/cppclean_check.py
@@ -493,6 +506,9 @@ jobs:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - name: Install system packages
         run: |
@@ -542,7 +558,7 @@ jobs:
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
       - name: ./configure
         run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: make install
       - run: make install-conf
       - run: suricatasc -h
@@ -563,6 +579,9 @@ jobs:
       - run: python3 ./suricata-verify/run.py -q --debug-failed
       - run: suricata-update -V
       - run: suricatasc -h
+      # Test build after clean.
+      - run: make clean
+      - run: make -j ${{ env.CPUS }}
 
   fedora-39-sv-codecov:
     name: Fedora 39 (Suricata Verify codecov)

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1274,6 +1274,80 @@ jobs:
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info # check if we can run Suricata
 
+  ubuntu-24-04:
+    name: Ubuntu 24.04 (cocci)
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    needs: [prepare-deps]
+    steps:
+      - name: Cache ~/.cargo
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          apt update
+          apt -y install \
+                autoconf \
+                automake \
+                build-essential \
+                cargo \
+                cbindgen \
+                clang-14 \
+                coccinelle \
+                dpdk-dev \
+                git \
+                jq \
+                libcap-ng-dev \
+                libevent-dev \
+                libevent-pthreads-2.1-7 \
+                libhiredis-dev \
+                libhyperscan-dev \
+                libjansson-dev \
+                libmagic-dev \
+                libnet1-dev \
+                libnetfilter-queue-dev \
+                libnetfilter-queue1 \
+                libnfnetlink-dev \
+                libnfnetlink0 \
+                libnuma-dev \
+                libpcap-dev \
+                libpcre2-dev \
+                libpython3.12 \
+                libtool \
+                libyaml-dev \
+                llvm-14-dev \
+                make \
+                parallel \
+                python-is-python3 \
+                python3-yaml \
+                rustc \
+                software-properties-common \
+                zlib1g \
+                zlib1g-dev
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: prep
+          path: prep
+      - run: tar xf prep/libhtp.tar.gz
+      - run: tar xf prep/suricata-update.tar.gz
+      - run: tar xf prep/suricata-verify.tar.gz
+      - run: ./autogen.sh
+      - run: ./configure --enable-unittests --enable-coccinelle
+      - run: make -j ${{ env.CPUS }}
+      - run: CONCURRENCY_LEVEL=${{ env.CPUS }} make check
+      - run: python3 ./suricata-verify/run.py -q --debug-failed
+      - run: make install
+      - run: make install-headers
+      - run: make install-library
+
   ubuntu-22-04-cov-ut:
     name: Ubuntu 22.04 (unittests coverage)
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1470,7 +1470,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -518,7 +518,6 @@ jobs:
                 autoconf \
                 automake \
                 cargo-vendor \
-                cbindgen \
                 diffutils \
                 numactl-devel \
                 dpdk-devel \

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -564,10 +564,10 @@ jobs:
       - run: suricata-update -V
       - run: suricatasc -h
 
-  fedora-38-sv-codecov:
-    name: Fedora 38 (Suricata Verify codecov)
+  fedora-39-sv-codecov:
+    name: Fedora 39 (Suricata Verify codecov)
     runs-on: ubuntu-latest
-    container: fedora:38
+    container: fedora:39
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -584,6 +584,9 @@ jobs:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - run: |
           dnf -y install \
@@ -642,7 +645,7 @@ jobs:
           CC: "clang"
           RUSTFLAGS: "-C instrument-coverage"
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0"
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
         env:
           CC: "clang"
           RUSTFLAGS: "-C instrument-coverage"
@@ -659,11 +662,11 @@ jobs:
           fail_ci_if_error: false
           flags: suricata-verify
 
-  # Fedora 38 build using Clang.
-  fedora-38-clang:
-    name: Fedora 38 (clang, debug, asan, wshadow, rust-strict, systemd)
+  # Fedora 39 build using Clang.
+  fedora-39-clang:
+    name: Fedora 39 (clang, debug, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
-    container: fedora:38
+    container: fedora:39
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -681,6 +684,9 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
       - run: |
           dnf -y install \
                 autoconf \
@@ -689,7 +695,6 @@ jobs:
                 cbindgen \
                 ccache \
                 clang \
-                coccinelle \
                 diffutils \
                 file-devel \
                 gcc \
@@ -733,17 +738,15 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared  --enable-coccinelle
-      - name: Running unit tests and cocci checks
-        # Set the concurrency level for cocci.
-        run: CONCURRENCY_LEVEL=2 make check
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
+      - run: make check
       - run: make distclean
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-lua
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
@@ -767,11 +770,11 @@ jobs:
       # Check compilation against systemd
       - run: ldd src/suricata | grep libsystemd &> /dev/null
 
-  # Fedora 38 build using GCC.
-  fedora-38-gcc:
-    name: Fedora 38 (gcc, debug, asan, wshadow, rust-strict)
+  # Fedora 39 build using GCC.
+  fedora-39-gcc:
+    name: Fedora 39 (gcc, debug, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
-    container: fedora:38
+    container: fedora:39
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -781,6 +784,9 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - run: |
           dnf -y install \
@@ -834,7 +840,7 @@ jobs:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
@@ -856,11 +862,11 @@ jobs:
       - run: suricata-update -V
       - run: suricatasc -h
 
-  # Fedora 39 build using Clang.
-  fedora-39-clang:
-    name: Fedora 39 (clang, debug, asan, wshadow, rust-strict, systemd)
+  # Fedora 40 build using Clang.
+  fedora-40-clang:
+    name: Fedora 40 (clang, debug, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
-    container: fedora:39
+    container: fedora:40
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -877,6 +883,9 @@ jobs:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - run: |
           dnf -y install \
@@ -933,7 +942,7 @@ jobs:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
@@ -957,11 +966,11 @@ jobs:
       # Check compilation against systemd
       - run: ldd src/suricata | grep libsystemd &> /dev/null
 
-  # Fedora 39 build using GCC.
-  fedora-39-gcc:
-    name: Fedora 39 (gcc, debug, asan, wshadow, rust-strict)
+  # Fedora 40 build using GCC.
+  fedora-40-gcc:
+    name: Fedora 40 (gcc, debug, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
-    container: fedora:39
+    container: fedora:40
     needs: [prepare-deps, prepare-cbindgen]
     steps:
 
@@ -971,6 +980,9 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: cargo-registry
+
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
 
       - run: |
           dnf -y install \
@@ -1024,7 +1036,7 @@ jobs:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
           ac_cv_func_malloc_0_nonnull: "yes"
-      - run: make -j2
+      - run: make -j ${{ env.CPUS }}
       - run: ASAN_OPTIONS="detect_leaks=0" ./src/suricata -u -l .
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz
@@ -1049,12 +1061,15 @@ jobs:
   # This job builds and tests Suricata as a non-root user as some
   # issues only show up when not running as root, and by default all
   # jobs in GitHub actions are run as root inside the container.
-  fedora-39-non-root:
-    name: Fedora 39 (non-root, debug, clang, asan, wshadow, rust-strict, systemd)
+  fedora-40-non-root:
+    name: Fedora 40 (non-root, debug, clang, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
-    container: fedora:39
+    container: fedora:40
     needs: [prepare-deps, prepare-cbindgen]
     steps:
+      - name: Determine number of CPUs
+        run: echo CPUS=$(nproc --all) >> $GITHUB_ENV
+
       - run: |
           dnf -y install \
                 autoconf \
@@ -1120,7 +1135,7 @@ jobs:
           CC: "clang"
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
 
-      - run: sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" make -j2
+      - run: sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" make -j ${{ env.CPUS }}
         working-directory: /home/suricata/suricata
 
       - run: sudo -u suricata -s make check

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Now checkout Suricata for the bundle script.
       - name: Checking out Suricata
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
       - name: Fetching libhtp
         run: |
@@ -194,7 +194,7 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
       # Download and extract dependency archives created during prep
       # job.
@@ -312,7 +312,7 @@ jobs:
           path: ~/.cargo/registry
           key: cargo-registry
 
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
       # Download and extract dependency archives created during prep
       # job.
@@ -402,7 +402,7 @@ jobs:
           key: ${{ github.job }}-dnf
       - run: echo "keepcache=1" >> /etc/dnf/dnf.conf
 
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
       # Prebuild check for duplicate SIDs
       - name: Check for duplicate SIDs

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -176,8 +176,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -384,8 +384,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -476,8 +476,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -567,8 +567,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -662,8 +662,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -857,8 +857,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -1127,8 +1127,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -1197,8 +1197,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -1249,8 +1249,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - name: Install dependencies
         run: |
           apt update
@@ -1363,8 +1363,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - name: Install dependencies
         run: |
           apt update
@@ -1461,8 +1461,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Install dependencies
         run: |
@@ -1545,8 +1545,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - name: Install dependencies
         run: |
           apt update
@@ -1607,8 +1607,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Install dependencies
         run: |
@@ -1686,8 +1686,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - name: Install dependencies
         run: |
@@ -1959,8 +1959,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - run: apt update
       - run: |
@@ -2046,8 +2046,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - run: apt update
       - run: |
@@ -2124,8 +2124,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - run: apt update
       - run: |
@@ -2206,8 +2206,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - run: |
           echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list
@@ -2277,8 +2277,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
 
       - run: |
           apt update
@@ -2345,8 +2345,8 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: ${{ github.job }}-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - run: |
          brew install \
           autoconf \
@@ -2410,8 +2410,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: windows-msys2-mingw64-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2465,8 +2465,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: windows-msys2-mingw64-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2508,8 +2508,8 @@ jobs:
       - name: Cache ~/.cargo
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.cargo
-          key: windows-msys2-mingw64-cargo
+          path: ~/.cargo/registry
+          key: cargo-registry
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2542,4 +2542,3 @@ jobs:
           # need cwd in path due to dlls (see above)
           PATH="$PATH:$(pwd)" ./src/suricata --build-info
       - run: make install
-

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2393,6 +2393,7 @@ jobs:
          brew install \
           autoconf \
           automake \
+          cbindgen \
           curl \
           hiredis \
           jansson \
@@ -2401,15 +2402,12 @@ jobs:
           libnet \
           libtool \
           libyaml \
-          pyyaml \
           lua \
           pcre2 \
           pkg-config \
           python \
           rust \
           xz
-      - name: Install cbindgen
-        run: cargo install --debug --version 0.24.3 cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3.5.3
       - name: Downloading prep archive
@@ -2419,6 +2417,12 @@ jobs:
           path: prep
       - run: tar xvf prep/libhtp.tar.gz
       - run: tar xvf prep/suricata-update.tar.gz
+      - name: Create Python virtual environment
+        run: python3 -m venv ./testenv
+      - name: Install PyYAML
+        run: |
+          . ./testenv/bin/activate
+          pip install pyyaml
       - run: ./autogen.sh
       - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --prefix="$HOME/.local/"
       - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make -j2
@@ -2426,9 +2430,15 @@ jobs:
       - run: rm libhtp/VERSION && make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
-        run: python3 ./suricata-verify/run.py -q --debug-failed
+        run: |
+          . ./testenv/bin/activate
+          python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
-      - run: suricata-update -V
+      - name: Check Suricata-Update
+        run: |
+          . ./testenv/bin/activate
+          which suricata-update
+          python3 $(which suricata-update) -V
       - run: suricatasc -h
 
   windows-msys2-mingw64-npcap:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -161,9 +161,9 @@ jobs:
           cargo install --target x86_64-unknown-linux-musl --debug cbindgen
           cp $HOME/.cargo/bin/cbindgen .
       - name: Uploading prep archive
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
-          name: prep
+          name: cbindgen
           path: .
 
   almalinux-9:
@@ -412,12 +412,6 @@ jobs:
       - run: tar xvf prep/libhtp.tar.gz
       - run: tar xvf prep/suricata-update.tar.gz
       - run: tar xvf prep/suricata-verify.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install system packages
         run: |
           yum -y install dnf-plugins-core
@@ -457,6 +451,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
+      - uses: ./.github/actions/install-cbindgen
       - name: Configuring
         run: |
           ./autogen.sh
@@ -1298,12 +1293,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: ./configure --disable-shared --enable-unittests
         env:
@@ -1421,12 +1411,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - name: Fix kernel mmap rnd bits
       # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
       # high-entropy ASLR in much newer kernels that GitHub runners are
@@ -1515,12 +1500,7 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="$DEFAULT_CFLAGS -DNDEBUG" ./configure --enable-unittests
       - run: make -j2
@@ -1664,12 +1644,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - name: Fix kernel mmap rnd bits
       # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
       # high-entropy ASLR in much newer kernels that GitHub runners are
@@ -1744,12 +1719,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: AFL_HARDEN=1 ac_cv_func_realloc_0_nonnull=yes ac_cv_func_malloc_0_nonnull=yes CFLAGS="-fsanitize=address -fno-omit-frame-pointer" CXXFLAGS=$CFLAGS CC=afl-clang-fast CXX=afl-clang-fast++ LDFLAGS="-fsanitize=address" ./configure --enable-fuzztargets --disable-shared
       - run: AFL_HARDEN=1 make -j2
@@ -1831,12 +1801,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-netmap
       - run: make -j2
@@ -1968,12 +1933,7 @@ jobs:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-dpdk
       - run: make -j2
@@ -2209,11 +2169,7 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $(grep rust-version rust/Cargo.toml.in|sed 's/\"//g'|awk '{print $3}') -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
+      - uses: ./.github/actions/install-cbindgen
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: tar xf prep/suricata-verify.tar.gz
@@ -2289,11 +2245,7 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
       - run: make -j2
@@ -2362,11 +2314,7 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
-      - name: Setup cbindgen
-        run: |
-          mkdir -p $HOME/.cargo/bin
-          cp prep/cbindgen $HOME/.cargo/bin
-          chmod 755 $HOME/.cargo/bin/cbindgen
+      - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
       - run: make -j2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,6 +2,10 @@ name: builds
 
 on:
   push:
+    paths-ignore:
+      # Don't run this workflow if only files under doc/ have been
+      # modified.
+      - "doc/**"
   pull_request:
   workflow_dispatch:
     inputs:
@@ -11,6 +15,10 @@ on:
       SU_BRANCH:
       SV_REPO:
       SV_BRANCH:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions: read-all
 
@@ -147,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo
           key: ${{ github.job }}-cargo
@@ -174,13 +182,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -290,7 +298,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           # TODO: Find some variable that matches the job name.
@@ -299,7 +307,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -382,13 +390,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -474,13 +482,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -528,7 +536,7 @@ jobs:
                 which \
                 zlib-devel
       - name: Download suricata.tar.gz
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: dist
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
@@ -547,7 +555,7 @@ jobs:
           test -e /usr/local/lib/suricata/python/suricata/update/configs/modify.conf
           test -e /usr/local/lib/suricata/python/suricata/update/configs/threshold.in
           test -e /usr/local/lib/suricata/python/suricata/update/configs/update.yaml
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -565,13 +573,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -619,9 +627,10 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - uses: ./.github/actions/install-cbindgen
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -645,7 +654,7 @@ jobs:
       - run: llvm-profdata merge -o default.profdata $(find suricata-verify/tests/ -name '*.profraw')
       - run: llvm-cov show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           fail_ci_if_error: false
           flags: suricata-verify
@@ -660,13 +669,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -714,9 +723,10 @@ jobs:
                 systemd-devel \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - uses: ./.github/actions/install-cbindgen
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -767,7 +777,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -808,9 +818,10 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: ./.github/actions/install-cbindgen
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -855,13 +866,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -907,9 +918,10 @@ jobs:
                 systemd-devel \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
       - uses: ./.github/actions/install-cbindgen
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -955,7 +967,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -996,9 +1008,10 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - uses: ./.github/actions/install-cbindgen
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1081,9 +1094,10 @@ jobs:
                 which \
                 zlib-devel
       - run: adduser suricata
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - uses: ./.github/actions/install-cbindgen
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1125,13 +1139,13 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -1172,8 +1186,9 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1195,13 +1210,13 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
 
       - name: Cache RPMs
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: /var/cache/dnf
           key: ${{ github.job }}-dnf
@@ -1224,18 +1239,22 @@ jobs:
           dnf -y install dnf-plugins-core epel-release
           dnf config-manager --set-enabled crb
 
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - uses: ./.github/actions/install-cbindgen
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      
+      - name: Install minimal dependencies
+        run: ./scripts/docs-almalinux9-minimal-build.sh
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: ./autogen.sh
-      - uses: ./.github/actions/install-cbindgen
-
-      - name: Install minimal dependencies
-        run: ./scripts/docs-almalinux9-minimal-build.sh
-
       - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure
       - run: make -j ${{ env.CPUS }}
       - run: ./src/suricata --build-info # check if we can run Suricata
@@ -1247,7 +1266,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1297,8 +1316,9 @@ jobs:
       # packaged Rust version is too old for coverage, so get from rustup
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1347,7 +1367,7 @@ jobs:
       - run: llvm-profdata-14 merge -o htp-test.profdata /tmp/htp-test.profraw
       - run: llvm-cov-14 show libhtp/test/test_all -instr-profile=htp-test.profdata --show-instantiations --ignore-filename-regex="^/root/.*" >> coverage.txt
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           fail_ci_if_error: false
           flags: unittests
@@ -1415,8 +1435,9 @@ jobs:
       # packaged Rust version is too old for coverage, so get from rustup
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.63.0 -y
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1447,7 +1468,7 @@ jobs:
       - run: llvm-profdata-14 merge -o default.profdata $(find /tmp/ -name '*.profraw')
       - run: llvm-cov-14 show ./src/suricata -instr-profile=default.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
         with:
           fail_ci_if_error: false
           flags: fuzzcorpus
@@ -1459,7 +1480,7 @@ jobs:
     needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1503,8 +1524,9 @@ jobs:
                 zlib1g-dev \
                 exuberant-ctags \
                 dpdk-dev
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1543,7 +1565,7 @@ jobs:
     needs: debian-12-dist
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1582,7 +1604,7 @@ jobs:
       - run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.62.0 -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Download suricata.tar.gz
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: dist
       - run: tar zxvf suricata-*.tar.gz --strip-components=1
@@ -1605,7 +1627,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1648,8 +1670,9 @@ jobs:
                 zlib1g \
                 zlib1g-dev \
                 exuberant-ctags
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1684,7 +1707,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1723,8 +1746,9 @@ jobs:
                 zlib1g \
                 zlib1g-dev
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1741,7 +1765,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1792,11 +1816,19 @@ jobs:
                 linux-headers-$(uname -r)
 
       - name: Checkout Netmap repository
-        uses: actions/checkout@v3.5.3
+        if: steps.netmap-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           repository: luigirizzo/netmap
           # gets cloned to $GITHUB_WORKSPACE/netmap/
           path: netmap/
+
+      - name: Save Netmap Cache
+        if: steps.netmap-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: netmap/
+          key: netmap-git
 
       - name: Compile and install Netmap
         run: |
@@ -1805,8 +1837,9 @@ jobs:
           make -j2
           sudo make install
 
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1824,7 +1857,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1839,8 +1872,9 @@ jobs:
             git \
             libtool
 
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1868,7 +1902,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -1937,8 +1971,9 @@ jobs:
           ninja -C build install
           ldconfig
           cd $HOME
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -1957,7 +1992,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2009,8 +2044,9 @@ jobs:
               texlive-latex-extra \
               zlib1g \
               zlib1g-dev
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2044,7 +2080,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2092,8 +2128,9 @@ jobs:
               texlive-latex-extra \
               zlib1g \
               zlib1g-dev
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2108,7 +2145,7 @@ jobs:
         run: |
           mkdir dist
           mv suricata-*.tar.gz dist
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         name: Uploading distribution
         with:
           name: dist
@@ -2122,7 +2159,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2171,8 +2208,9 @@ jobs:
               texlive-latex-extra \
               zlib1g \
               zlib1g-dev
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2204,7 +2242,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2248,8 +2286,9 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2275,7 +2314,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2317,8 +2356,9 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION_KNOWN -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2343,7 +2383,7 @@ jobs:
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2367,9 +2407,10 @@ jobs:
           rust \
           xz
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
       - name: Downloading prep archive
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2408,7 +2449,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2421,8 +2462,9 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2463,7 +2505,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2476,8 +2518,9 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep
@@ -2506,7 +2549,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - name: Cache ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -2519,8 +2562,9 @@ jobs:
       # preinstalled one to be picked up by configure
       - name: cbindgen
         run: cargo install --root /usr --force --debug --version 0.24.3 cbindgen
-      - uses: actions/checkout@v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
         with:
           name: prep
           path: prep

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -142,7 +142,7 @@ jobs:
           cd ..
           tar zcf suricata-verify.tar.gz suricata-verify
       - name: Uploading prep archive
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         with:
           name: prep
           path: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -170,7 +170,7 @@ jobs:
     name: AlmaLinux 9
     runs-on: ubuntu-latest
     container: almalinux:9
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -256,6 +256,7 @@ jobs:
       #    git clone --depth 1 --branch suricata https://github.com/catenacyber/cppclean
       #    cd cppclean
       #    python3 setup.py install
+      - uses: ./.github/actions/install-cbindgen
       - name: Configuring
         run: |
           ./autogen.sh
@@ -286,7 +287,7 @@ jobs:
     name: AlmaLinux 9 Test Templates
     runs-on: ubuntu-latest
     container: almalinux:9
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
       - name: Cache RPMs
         uses: actions/cache@v3.3.1
@@ -357,6 +358,7 @@ jobs:
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: rustup component add rustfmt
       - run: rustup component add clippy
+      - uses: ./.github/actions/install-cbindgen
       - name: Build
         run: |
           ./autogen.sh
@@ -558,7 +560,7 @@ jobs:
     name: Fedora 38 (Suricata Verify codecov)
     runs-on: ubuntu-latest
     container: fedora:38
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
 
       # Cache Rust stuff.
@@ -619,6 +621,7 @@ jobs:
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -652,7 +655,7 @@ jobs:
     name: Fedora 38 (clang, debug, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
     container: fedora:38
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
 
       # Cache Rust stuff.
@@ -713,6 +716,7 @@ jobs:
                 zlib-devel
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -758,7 +762,7 @@ jobs:
     name: Fedora 38 (gcc, debug, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
     container: fedora:38
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
 
       # Cache Rust stuff.
@@ -806,6 +810,7 @@ jobs:
                 zlib-devel
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -904,6 +909,7 @@ jobs:
                 zlib-devel
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -992,6 +998,7 @@ jobs:
                 zlib-devel
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -1033,7 +1040,7 @@ jobs:
     name: Fedora 39 (non-root, debug, clang, asan, wshadow, rust-strict, systemd)
     runs-on: ubuntu-latest
     container: fedora:39
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
       - run: |
           dnf -y install \
@@ -1076,6 +1083,7 @@ jobs:
       - run: adduser suricata
       - uses: actions/checkout@v3.5.3
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      - uses: ./.github/actions/install-cbindgen
         with:
           name: prep
           path: prep
@@ -1178,11 +1186,12 @@ jobs:
           else
             exit 0
           fi
+
   almalinux-9-minimal-recommended-dependecies:
     name: AlmaLinux 9 (Minimal/Recommended Build)
     runs-on: ubuntu-latest
     container: almalinux:9
-    needs: [prepare-deps]
+    needs: [prepare-deps, prepare-cbindgen]
     steps:
       # Cache Rust stuff.
       - name: Cache cargo registry
@@ -1222,6 +1231,7 @@ jobs:
           path: prep
       - run: tar xf prep/libhtp.tar.gz
       - run: ./autogen.sh
+      - uses: ./.github/actions/install-cbindgen
 
       - name: Install minimal dependencies
         run: ./scripts/docs-almalinux9-minimal-build.sh

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -6,6 +6,10 @@ on:
     paths-ignore:
       - "doc/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 jobs:
  Fuzzing:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,12 @@ on:
   schedule:
     - cron: '18 21 * * 1'
 
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze
@@ -31,13 +37,14 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.5.3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3.26.12
       with:
         languages: ${{ matrix.language }}
+        queries: security-extended
 
     - run: |
        sudo apt-get update
@@ -55,4 +62,4 @@ jobs:
        ./configure
        make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3.26.12

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DEBIAN_FRONTEND: "noninteractive"
 
@@ -16,7 +20,7 @@ jobs:
     container: ubuntu:20.04
     steps:
       - name: Caching ~/.cargo
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo
           key: commit-check-cargo
@@ -71,7 +75,7 @@ jobs:
           cd $HOME/.cargo/bin
           curl -OL https://github.com/eqrion/cbindgen/releases/download/v0.24.3/cbindgen
           chmod 755 cbindgen
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           fetch-depth: 0
       # The action above is supposed to do this for us, but it doesn't appear to stick.
@@ -97,7 +101,7 @@ jobs:
               make -ik distclean > /dev/null
           done
       - run: sccache -s
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
         name: Uploading build log
         if: always()
         with:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,6 +12,10 @@ on:
     paths-ignore:
       - "doc/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 env:
@@ -29,7 +33,7 @@ jobs:
 
       # Cache Rust stuff.
       - name: Cache cargo registry
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo/registry
           key: cargo-registry
@@ -85,7 +89,7 @@ jobs:
       # My patience simply ran too short to keep on looking. See follow-on
       # action to manually fix this up.
       - name: Checkout - might be merge commit!
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           fetch-depth: 0
         # Use last commit of branch, not potential merge commit!

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read #  to fetch code (actions/checkout)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-rust:
     name: Check Rust
@@ -18,7 +22,7 @@ jobs:
     container: almalinux:9
     steps:
       - name: Cache rust
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo
           key: check-rust
@@ -69,7 +73,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install cbindgen
         run: cargo install --debug cbindgen
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       - run: git config --global --add safe.directory /__w/suricata/suricata
       - run: ./scripts/bundle.sh
       - run: ./autogen.sh

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -8,6 +8,12 @@ on:
     paths-ignore:
       - "doc/**"
 
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan-build:
     name: Scan-build
@@ -15,7 +21,7 @@ jobs:
     container: ubuntu:24.04
     steps:
       - name: Cache scan-build
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
         with:
           path: ~/.cargo
           key: scan-build
@@ -63,7 +69,8 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - run: git config --global --add safe.directory /__w/suricata/suricata
       - run: ./scripts/bundle.sh
       - run: ./autogen.sh
       - run: scan-build-18 ./configure --enable-dpdk --enable-nfqueue --enable-nflog

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Declare default permissions as read only.
 permissions: read-all
 
@@ -17,39 +21,36 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      actions: read
-      contents: read
+      id-token: write
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v3.5.3
-        with:
-          persist-credentials: false
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v1.0.1
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
           repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
-          # Publish the results to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories, `publish_results` will automatically be set to `false`,
-          # regardless of the value entered here.
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          # And it's free for you!
           publish_results: true
 
-      # Upload the results as artifacts (optional).
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      # Optional.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.1.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v2 # v1.0.26
+      - name: "Upload SARIF results"
+        uses: github/codeql-action/upload-sarif@ea2cd92c21b192add69983116b8b3222b09da33b # v1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
https://github.com/OISF/suricata/pull/11975 but with more syncing against master to make merges easier, and reduce the differences.

- **github-ci: run macos python jobs in virtualenv**
- **github-ci: break out cbindgen installation to action**
- **github-ci: install prepared cbindgen on rpm distros**
- **github-action: share cargo cache for windows jobs**
- **github-action: share cargo registry cache**
- **github-ci: sync with master branch**
- **github-ci: remove Fedora 38, add Fedora 40**
- **github-ci: add ubuntu 24.04 cocci build**
- **github-ci: pin missed actions/cache**
- **github-ci: pin missed actions/checkout**
- **github-ci: sync almalinux builds with master**
- **github-ci: pin actions/upload-artifact to newer version**
- **github-ci: don't install cbindgen on centos stream 9**
