### PR TITLE
schema/tls: add missing custom fields chain/cert - v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -273,6 +273,7 @@ The default is to log certificate subject and issuer. If ``extended`` is
 enabled, then the log gets more verbose.
 
 By using ``custom`` it is possible to select which TLS fields to log.
+**Note that this will disable ``extended`` logging.**
 
 ARP
 ~~~

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6586,9 +6586,29 @@
         "tls": {
             "type": "object",
             "properties": {
+                "certificate": {
+                    "type": "string"
+                },
+                "chain": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "client": {
                     "type": "object",
                     "properties": {
+                        "certificate": {
+                            "type": "string"
+                        },
+                        "chain": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "fingerprint": {
                             "type": "string"
                         },

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -382,7 +382,7 @@ static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
 
     /* tls subjectaltname */
     if (tls_ctx->fields & LOG_TLS_FIELD_SUBJECTALTNAME)
-        JsonTlsLogIssuer(js, ssl_state);
+        JsonTlsLogSAN(js, ssl_state);
 
     /* tls session resumption */
     if (tls_ctx->fields & LOG_TLS_FIELD_SESSION_RESUMED)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -272,6 +272,7 @@ outputs:
             # session id
             #session-resumption: no
             # custom controls which TLS fields that are included in eve-log
+            # WARNING: enabling custom disables extended logging.
             #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4, subjectaltname]
         - files:
             force-magic: no   # force logging magic on all logged files


### PR DESCRIPTION
Previous PR: #11844 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7287

Describe changes:
- rebase
- add `chain` and `certificate` as fields for `tls.client`, too
- document that `extended` is disabled if `custom` logging is used, for TLS
- fix bug that would duplicate `issuerdn` field if `subjectaltname` was enabled, in custom mode

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2098
