### PR TITLE
profiling: Correct profiling data array size

### DIFF
--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -72,8 +72,8 @@ SCProfilePacketData packet_profile_data6[257]; /**< all proto's + tunnel */
 SCProfilePacketData packet_profile_tmm_data4[TMM_SIZE][257];
 SCProfilePacketData packet_profile_tmm_data6[TMM_SIZE][257];
 
-SCProfilePacketData packet_profile_app_data4[TMM_SIZE][257];
-SCProfilePacketData packet_profile_app_data6[TMM_SIZE][257];
+SCProfilePacketData packet_profile_app_data4[ALPROTO_MAX][257];
+SCProfilePacketData packet_profile_app_data6[ALPROTO_MAX][257];
 
 SCProfilePacketData packet_profile_app_pd_data4[257];
 SCProfilePacketData packet_profile_app_pd_data6[257];


### PR DESCRIPTION
The profiling arrays are incorrectly sized by the number of thread modules. Since they contain app-layer protocol data, they should be sized by ALPROTO_MAX.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7334

Describe changes:
- Size packet-based profiling arrays that cover app-layer protocols properly


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
