### PR TITLE
schema/tls: add missing custom fields chain/cert - 70x backport - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5389,9 +5389,29 @@
         "tls": {
             "type": "object",
             "properties": {
+                "certificate": {
+                    "type": "string"
+                },
+                "chain": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "client": {
                     "type": "object",
                     "properties": {
+                        "certificate": {
+                            "type": "string"
+                        },
+                        "chain": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "fingerprint": {
                             "type": "string"
                         },


### PR DESCRIPTION
Task #7287

(cherry picked from commit 2eefc4dac84a186b788b670a8c21f05417002952)

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7288
Original: https://redmine.openinfosecfoundation.org/issues/7287

Describe changes:
- Clean cherry-pick of https://github.com/OISF/suricata/pull/11979/commits/ca6ccdf014387ac61f75573f1edd8b5dd89609d0

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2101
