### PR TITLE
eve/tls: reimplement basic and extended logging in terms of custom - v2

### DIFF
--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -181,7 +181,8 @@ outputs:
             # session id
             #session-resumption: no
             # custom controls which TLS fields that are included in eve-log
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4]
+            # WARNING: enabling custom disables extended logging.
+            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4, subjectaltname, client, client_certificate, client_chain, client_alpns, server_alpns]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -24,32 +24,19 @@
  */
 
 #include "suricata-common.h"
-#include "detect.h"
-#include "pkt-var.h"
-#include "conf.h"
 
-#include "threads.h"
-#include "threadvars.h"
-#include "tm-threads.h"
-
-#include "util-print.h"
-#include "util-time.h"
-#include "util-unittest.h"
-
-#include "util-debug.h"
 #include "app-layer-parser.h"
-#include "output.h"
 #include "app-layer-ssl.h"
 #include "app-layer.h"
-#include "util-privs.h"
-#include "util-buffer.h"
-
-#include "util-logopenfile.h"
+#include "conf.h"
+#include "output-json-tls.h"
+#include "output-json.h"
+#include "output.h"
+#include "threadvars.h"
+#include "util-debug.h"
 #include "util-ja3.h"
 #include "util-ja4.h"
-
-#include "output-json.h"
-#include "output-json-tls.h"
+#include "util-time.h"
 
 SC_ATOMIC_EXTERN(unsigned int, cert_id);
 

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -76,6 +76,8 @@ SC_ATOMIC_EXTERN(unsigned int, cert_id);
 #define LOG_TLS_FIELD_CLIENT_CHAIN      (1 << 15)
 #define LOG_TLS_FIELD_JA4               (1 << 16)
 #define LOG_TLS_FIELD_SUBJECTALTNAME    (1 << 17)
+#define LOG_TLS_FIELD_CLIENT_ALPNS      (1 << 18)
+#define LOG_TLS_FIELD_SERVER_ALPNS      (1 << 19)
 
 typedef struct {
     const char *name;
@@ -102,6 +104,8 @@ TlsFields tls_fields[] = {
     { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN },
     { "ja4", LOG_TLS_FIELD_JA4 },
     { "subjectaltname", LOG_TLS_FIELD_SUBJECTALTNAME },
+    { "client_alpns", LOG_TLS_FIELD_CLIENT_ALPNS },
+    { "server_alpns", LOG_TLS_FIELD_SERVER_ALPNS },
     { NULL, -1 },
     // clang-format on
 };
@@ -444,6 +448,14 @@ static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
     /* tls ja4 */
     if (tls_ctx->fields & LOG_TLS_FIELD_JA4)
         JsonTlsLogSCJA4(js, ssl_state);
+
+    if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_ALPNS) {
+        JsonTlsLogAlpns(js, &ssl_state->client_connp, "client_alpns");
+    }
+
+    if (tls_ctx->fields & LOG_TLS_FIELD_SERVER_ALPNS) {
+        JsonTlsLogAlpns(js, &ssl_state->server_connp, "server_alpns");
+    }
 
     if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT) {
         const bool log_cert = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CERT) != 0;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -82,16 +82,29 @@ typedef struct {
     uint64_t flag;
 } TlsFields;
 
-TlsFields tls_fields[] = { { "version", LOG_TLS_FIELD_VERSION },
-    { "subject", LOG_TLS_FIELD_SUBJECT }, { "issuer", LOG_TLS_FIELD_ISSUER },
-    { "serial", LOG_TLS_FIELD_SERIAL }, { "fingerprint", LOG_TLS_FIELD_FINGERPRINT },
-    { "not_before", LOG_TLS_FIELD_NOTBEFORE }, { "not_after", LOG_TLS_FIELD_NOTAFTER },
-    { "sni", LOG_TLS_FIELD_SNI }, { "certificate", LOG_TLS_FIELD_CERTIFICATE },
-    { "chain", LOG_TLS_FIELD_CHAIN }, { "session_resumed", LOG_TLS_FIELD_SESSION_RESUMED },
-    { "ja3", LOG_TLS_FIELD_JA3 }, { "ja3s", LOG_TLS_FIELD_JA3S },
-    { "client", LOG_TLS_FIELD_CLIENT }, { "client_certificate", LOG_TLS_FIELD_CLIENT_CERT },
-    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN }, { "ja4", LOG_TLS_FIELD_JA4 },
-    { "subjectaltname", LOG_TLS_FIELD_SUBJECTALTNAME }, { NULL, -1 } };
+TlsFields tls_fields[] = {
+    // clang-format off
+    { "version", LOG_TLS_FIELD_VERSION },
+    { "subject", LOG_TLS_FIELD_SUBJECT },
+    { "issuer", LOG_TLS_FIELD_ISSUER },
+    { "serial", LOG_TLS_FIELD_SERIAL },
+    { "fingerprint", LOG_TLS_FIELD_FINGERPRINT },
+    { "not_before", LOG_TLS_FIELD_NOTBEFORE },
+    { "not_after", LOG_TLS_FIELD_NOTAFTER },
+    { "sni", LOG_TLS_FIELD_SNI },
+    { "certificate", LOG_TLS_FIELD_CERTIFICATE },
+    { "chain", LOG_TLS_FIELD_CHAIN },
+    { "session_resumed", LOG_TLS_FIELD_SESSION_RESUMED },
+    { "ja3", LOG_TLS_FIELD_JA3 },
+    { "ja3s", LOG_TLS_FIELD_JA3S },
+    { "client", LOG_TLS_FIELD_CLIENT },
+    { "client_certificate", LOG_TLS_FIELD_CLIENT_CERT },
+    { "client_chain", LOG_TLS_FIELD_CLIENT_CHAIN },
+    { "ja4", LOG_TLS_FIELD_JA4 },
+    { "subjectaltname", LOG_TLS_FIELD_SUBJECTALTNAME },
+    { NULL, -1 },
+    // clang-format on
+};
 
 typedef struct OutputTlsCtx_ {
     uint32_t flags;  /** Store mode */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -663,13 +663,6 @@ static OutputTlsCtx *OutputTlsInitCtx(ConfNode *conf)
         tls_ctx->flags |= LOG_TLS_SESSION_RESUMPTION;
     }
 
-    if ((tls_ctx->fields & LOG_TLS_FIELD_JA3) &&
-            Ja3IsDisabled("fields")) {
-        /* JA3 is disabled, so don't log any JA3 fields */
-        tls_ctx->fields &= ~LOG_TLS_FIELD_JA3;
-        tls_ctx->fields &= ~LOG_TLS_FIELD_JA3S;
-    }
-
     if ((tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE) &&
             (tls_ctx->fields & LOG_TLS_FIELD_CHAIN)) {
         SCLogWarning("Both 'certificate' and 'chain' contains the top "

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -38,8 +38,6 @@
 #include "util-ja4.h"
 #include "util-time.h"
 
-SC_ATOMIC_EXTERN(unsigned int, cert_id);
-
 #define LOG_TLS_FIELD_VERSION           (1 << 0)
 #define LOG_TLS_FIELD_SUBJECT           (1 << 1)
 #define LOG_TLS_FIELD_ISSUER            (1 << 2)

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -53,11 +53,6 @@
 
 SC_ATOMIC_EXTERN(unsigned int, cert_id);
 
-#define LOG_TLS_DEFAULT                 0
-#define LOG_TLS_EXTENDED                (1 << 0)
-#define LOG_TLS_CUSTOM                  (1 << 1)
-#define LOG_TLS_SESSION_RESUMPTION      (1 << 2)
-
 #define LOG_TLS_FIELD_VERSION           (1 << 0)
 #define LOG_TLS_FIELD_SUBJECT           (1 << 1)
 #define LOG_TLS_FIELD_ISSUER            (1 << 2)
@@ -110,12 +105,35 @@ TlsFields tls_fields[] = {
     // clang-format on
 };
 
+// clang-format off
+static const uint64_t BASIC_FIELDS = \
+    LOG_TLS_FIELD_SUBJECT |
+    LOG_TLS_FIELD_ISSUER |
+    LOG_TLS_FIELD_SUBJECTALTNAME;
+// clang-format on
+
+// clang-format off
+static const uint64_t EXTENDED_FIELDS = \
+    BASIC_FIELDS |
+    LOG_TLS_FIELD_VERSION |
+    LOG_TLS_FIELD_SERIAL |
+    LOG_TLS_FIELD_FINGERPRINT |
+    LOG_TLS_FIELD_NOTBEFORE |
+    LOG_TLS_FIELD_NOTAFTER |
+    LOG_TLS_FIELD_JA3 |
+    LOG_TLS_FIELD_JA3S |
+    LOG_TLS_FIELD_JA4 |
+    LOG_TLS_FIELD_CLIENT |
+    LOG_TLS_FIELD_CLIENT_ALPNS |
+    LOG_TLS_FIELD_SERVER_ALPNS |
+    LOG_TLS_FIELD_SNI;
+// clang-format on
+
 typedef struct OutputTlsCtx_ {
-    uint32_t flags;  /** Store mode */
     uint64_t fields; /** Store fields */
+    bool session_resumed;
     OutputJsonCtx *eve_ctx;
 } OutputTlsCtx;
-
 
 typedef struct JsonTlsLogThread_ {
     OutputTlsCtx *tlslog_ctx;
@@ -371,95 +389,79 @@ static void JsonTlsLogClientCert(
     }
 }
 
-void JsonTlsLogJSONBasic(JsonBuilder *js, SSLState *ssl_state)
+static void JsonTlsLogFields(JsonBuilder *js, SSLState *ssl_state, uint64_t fields)
 {
     /* tls subject */
-    JsonTlsLogSubject(js, ssl_state);
-
-    /* tls issuerdn */
-    JsonTlsLogIssuer(js, ssl_state);
-
-    /* tls subjectaltname */
-    JsonTlsLogSAN(js, ssl_state);
-
-    /* tls session resumption */
-    JsonTlsLogSessionResumed(js, ssl_state);
-}
-
-static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
-                                 SSLState *ssl_state)
-{
-    /* tls subject */
-    if (tls_ctx->fields & LOG_TLS_FIELD_SUBJECT)
+    if (fields & LOG_TLS_FIELD_SUBJECT)
         JsonTlsLogSubject(js, ssl_state);
 
     /* tls issuerdn */
-    if (tls_ctx->fields & LOG_TLS_FIELD_ISSUER)
+    if (fields & LOG_TLS_FIELD_ISSUER)
         JsonTlsLogIssuer(js, ssl_state);
 
     /* tls subjectaltname */
-    if (tls_ctx->fields & LOG_TLS_FIELD_SUBJECTALTNAME)
+    if (fields & LOG_TLS_FIELD_SUBJECTALTNAME)
         JsonTlsLogSAN(js, ssl_state);
 
     /* tls session resumption */
-    if (tls_ctx->fields & LOG_TLS_FIELD_SESSION_RESUMED)
+    if (fields & LOG_TLS_FIELD_SESSION_RESUMED)
         JsonTlsLogSessionResumed(js, ssl_state);
 
     /* tls serial */
-    if (tls_ctx->fields & LOG_TLS_FIELD_SERIAL)
+    if (fields & LOG_TLS_FIELD_SERIAL)
         JsonTlsLogSerial(js, ssl_state);
 
     /* tls fingerprint */
-    if (tls_ctx->fields & LOG_TLS_FIELD_FINGERPRINT)
+    if (fields & LOG_TLS_FIELD_FINGERPRINT)
         JsonTlsLogFingerprint(js, ssl_state);
 
     /* tls sni */
-    if (tls_ctx->fields & LOG_TLS_FIELD_SNI)
+    if (fields & LOG_TLS_FIELD_SNI)
         JsonTlsLogSni(js, ssl_state);
 
     /* tls version */
-    if (tls_ctx->fields & LOG_TLS_FIELD_VERSION)
+    if (fields & LOG_TLS_FIELD_VERSION)
         JsonTlsLogVersion(js, ssl_state);
 
     /* tls notbefore */
-    if (tls_ctx->fields & LOG_TLS_FIELD_NOTBEFORE)
+    if (fields & LOG_TLS_FIELD_NOTBEFORE)
         JsonTlsLogNotBefore(js, ssl_state);
 
     /* tls notafter */
-    if (tls_ctx->fields & LOG_TLS_FIELD_NOTAFTER)
+    if (fields & LOG_TLS_FIELD_NOTAFTER)
         JsonTlsLogNotAfter(js, ssl_state);
 
     /* tls certificate */
-    if (tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE)
+    if (fields & LOG_TLS_FIELD_CERTIFICATE)
         JsonTlsLogCertificate(js, &ssl_state->server_connp);
 
     /* tls chain */
-    if (tls_ctx->fields & LOG_TLS_FIELD_CHAIN)
+    if (fields & LOG_TLS_FIELD_CHAIN)
         JsonTlsLogChain(js, &ssl_state->server_connp);
 
     /* tls ja3_hash */
-    if (tls_ctx->fields & LOG_TLS_FIELD_JA3)
+    if (fields & LOG_TLS_FIELD_JA3)
         JsonTlsLogJa3(js, ssl_state);
 
     /* tls ja3s */
-    if (tls_ctx->fields & LOG_TLS_FIELD_JA3S)
+    if (fields & LOG_TLS_FIELD_JA3S)
         JsonTlsLogJa3S(js, ssl_state);
 
     /* tls ja4 */
-    if (tls_ctx->fields & LOG_TLS_FIELD_JA4)
+    if (fields & LOG_TLS_FIELD_JA4)
         JsonTlsLogSCJA4(js, ssl_state);
 
-    if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_ALPNS) {
+    if (fields & LOG_TLS_FIELD_CLIENT_ALPNS) {
         JsonTlsLogAlpns(js, &ssl_state->client_connp, "client_alpns");
     }
 
-    if (tls_ctx->fields & LOG_TLS_FIELD_SERVER_ALPNS) {
+    if (fields & LOG_TLS_FIELD_SERVER_ALPNS) {
         JsonTlsLogAlpns(js, &ssl_state->server_connp, "server_alpns");
     }
 
-    if (tls_ctx->fields & LOG_TLS_FIELD_CLIENT) {
-        const bool log_cert = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CERT) != 0;
-        const bool log_chain = (tls_ctx->fields & LOG_TLS_FIELD_CLIENT_CHAIN) != 0;
+    if (fields & LOG_TLS_FIELD_CLIENT) {
+        const bool log_cert = (fields & LOG_TLS_FIELD_CLIENT_CERT) != 0;
+        const bool log_chain = (fields & LOG_TLS_FIELD_CLIENT_CHAIN) != 0;
         if (HasClientCert(&ssl_state->client_connp)) {
             jb_open_object(js, "client");
             JsonTlsLogClientCert(js, &ssl_state->client_connp, log_cert, log_chain);
@@ -468,55 +470,12 @@ static void JsonTlsLogJSONCustom(OutputTlsCtx *tls_ctx, JsonBuilder *js,
     }
 }
 
-static bool JsonTlsLogJSONExtendedAux(void *vtx, JsonBuilder *tjs)
-{
-    SSLState *state = (SSLState *)vtx;
-    JsonTlsLogJSONBasic(tjs, state);
-
-    /* tls serial */
-    JsonTlsLogSerial(tjs, state);
-
-    /* tls fingerprint */
-    JsonTlsLogFingerprint(tjs, state);
-
-    /* tls sni */
-    JsonTlsLogSni(tjs, state);
-
-    /* tls version */
-    JsonTlsLogVersion(tjs, state);
-
-    /* tls notbefore */
-    JsonTlsLogNotBefore(tjs, state);
-
-    /* tls notafter */
-    JsonTlsLogNotAfter(tjs, state);
-
-    /* tls ja3 */
-    JsonTlsLogJa3(tjs, state);
-
-    /* tls ja3s */
-    JsonTlsLogJa3S(tjs, state);
-
-    /* tls ja4 */
-    JsonTlsLogSCJA4(tjs, state);
-
-    JsonTlsLogAlpns(tjs, &state->client_connp, "client_alpns");
-    JsonTlsLogAlpns(tjs, &state->server_connp, "server_alpns");
-
-    if (HasClientCert(&state->client_connp)) {
-        jb_open_object(tjs, "client");
-        JsonTlsLogClientCert(tjs, &state->client_connp, false, false);
-        jb_close(tjs);
-    }
-    return true;
-}
-
 bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *tjs)
 {
+    SSLState *state = (SSLState *)vtx;
     jb_open_object(tjs, "tls");
-    bool r = JsonTlsLogJSONExtendedAux(vtx, tjs);
-    jb_close(tjs);
-    return r;
+    JsonTlsLogFields(tjs, state, EXTENDED_FIELDS);
+    return jb_close(tjs);
 }
 
 static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
@@ -531,9 +490,9 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
     }
 
     if ((ssl_state->server_connp.cert0_issuerdn == NULL ||
-            ssl_state->server_connp.cert0_subject == NULL) &&
+                ssl_state->server_connp.cert0_subject == NULL) &&
             ((ssl_state->flags & SSL_AL_FLAG_SESSION_RESUMED) == 0 ||
-            (tls_ctx->flags & LOG_TLS_SESSION_RESUMPTION) == 0) &&
+                    (!tls_ctx->session_resumed)) &&
             ((ssl_state->flags & SSL_AL_FLAG_LOG_WITHOUT_CERT) == 0)) {
         return 0;
     }
@@ -545,18 +504,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
     jb_open_object(js, "tls");
 
-    /* log custom fields */
-    if (tls_ctx->flags & LOG_TLS_CUSTOM) {
-        JsonTlsLogJSONCustom(tls_ctx, js, ssl_state);
-    }
-    /* log extended */
-    else if (tls_ctx->flags & LOG_TLS_EXTENDED) {
-        JsonTlsLogJSONExtendedAux(ssl_state, js);
-    }
-    /* log basic */
-    else {
-        JsonTlsLogJSONBasic(js, ssl_state);
-    }
+    JsonTlsLogFields(js, ssl_state, tls_ctx->fields);
 
     /* print original application level protocol when it have been changed
        because of STARTTLS, HTTP CONNECT, or similar. */
@@ -623,8 +571,7 @@ static OutputTlsCtx *OutputTlsInitCtx(ConfNode *conf)
     if (unlikely(tls_ctx == NULL))
         return NULL;
 
-    tls_ctx->flags = LOG_TLS_DEFAULT;
-    tls_ctx->fields = 0;
+    tls_ctx->fields = BASIC_FIELDS;
 
     if (conf == NULL)
         return tls_ctx;
@@ -632,13 +579,13 @@ static OutputTlsCtx *OutputTlsInitCtx(ConfNode *conf)
     const char *extended = ConfNodeLookupChildValue(conf, "extended");
     if (extended) {
         if (ConfValIsTrue(extended)) {
-            tls_ctx->flags = LOG_TLS_EXTENDED;
+            tls_ctx->fields = EXTENDED_FIELDS;
         }
     }
 
     ConfNode *custom = ConfNodeLookupChild(conf, "custom");
     if (custom) {
-        tls_ctx->flags = LOG_TLS_CUSTOM;
+        tls_ctx->fields = 0;
         ConfNode *field;
         TAILQ_FOREACH(field, &custom->head, next)
         {
@@ -660,7 +607,8 @@ static OutputTlsCtx *OutputTlsInitCtx(ConfNode *conf)
 
     const char *session_resumption = ConfNodeLookupChildValue(conf, "session-resumption");
     if (session_resumption == NULL || ConfValIsTrue(session_resumption)) {
-        tls_ctx->flags |= LOG_TLS_SESSION_RESUMPTION;
+        tls_ctx->fields |= LOG_TLS_FIELD_SESSION_RESUMED;
+        tls_ctx->session_resumed = true;
     }
 
     if ((tls_ctx->fields & LOG_TLS_FIELD_CERTIFICATE) &&

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -28,7 +28,6 @@ void JsonTlsLogRegister(void);
 
 #include "app-layer-ssl.h"
 
-void JsonTlsLogJSONBasic(JsonBuilder *js, SSLState *ssl_state);
 bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js);
 
 #endif /* SURICATA_OUTPUT_JSON_TLS_H */

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,7 +26,8 @@
 
 void JsonTlsLogRegister(void);
 
-#include "app-layer-ssl.h"
+/* For JsonBuilder. */
+#include "rust.h"
 
 bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -273,7 +273,7 @@ outputs:
             #session-resumption: no
             # custom controls which TLS fields that are included in eve-log
             # WARNING: enabling custom disables extended logging.
-            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4, subjectaltname]
+            #custom: [subject, issuer, session_resumed, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, ja3, ja3s, ja4, subjectaltname, client, client_certificate, client_chain, client_alpns, server_alpns]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,


### PR DESCRIPTION
Commit c79a382 added ALPN logging to extended TLS output but there was no way to add this to custom. To prevent this from happening in the future, implement basic and extended logging in terms of custom.

Ticket: https://redmine.openinfosecfoundation.org/issues/7333

Changes from previous PR https://github.com/OISF/suricata/pull/11984:
- one line removal of unused code
- update doc and configuration example to have a complete list of custom fields