### PR TITLE
Remove duplicate function declarations-v3

### DIFF
--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -74,8 +74,6 @@ static inline int AppLayerDecoderEventsIsEventSet(
     return 0;
 }
 
-void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events);
-void AppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events);
 int DetectEngineGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type);
 
 #endif /* SURICATA_APP_LAYER_EVENTS_H */

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -48,9 +48,6 @@ void PatternMatchThreadDestroy(MpmThreadCtx *mpm_thread_ctx, uint16_t);
 
 int PatternMatchPrepareGroup(DetectEngineCtx *, SigGroupHead *);
 
-TmEcode DetectEngineThreadCtxInit(ThreadVars *, void *, void **);
-TmEcode DetectEngineThreadCtxDeinit(ThreadVars *, void *);
-
 int SignatureHasPacketContent(const Signature *);
 int SignatureHasStreamContent(const Signature *);
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -63,6 +63,8 @@
 
 #include "detect-engine-loader.h"
 
+#include "detect-engine-alert.h"
+
 #include "util-classification-config.h"
 #include "util-reference-config.h"
 #include "util-threshold-config.h"

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -74,7 +74,6 @@ bool DetectEngineBufferTypeSupportsMultiInstanceGetById(
         const DetectEngineCtx *de_ctx, const int id);
 bool DetectEngineBufferTypeSupportsFramesGetById(const DetectEngineCtx *de_ctx, const int id);
 const char *DetectEngineBufferTypeGetDescriptionById(const DetectEngineCtx *de_ctx, const int id);
-const DetectBufferType *DetectEngineBufferTypeGetById(const DetectEngineCtx *de_ctx, const int id);
 int DetectEngineBufferTypeGetByIdTransforms(
         DetectEngineCtx *de_ctx, const int id, TransformData *transforms, int transform_cnt);
 void DetectEngineBufferRunSetupCallback(const DetectEngineCtx *de_ctx, const int id, Signature *s);

--- a/src/detect-http-header.h
+++ b/src/detect-http-header.h
@@ -25,7 +25,6 @@
 #define SURICATA_DETECT_HTTP_HEADER_H
 
 void DetectHttpHeaderRegister(void);
-void DetectHttpRawHeaderRegister(void);
 void DetectHttpRequestHeaderRegister(void);
 void DetectHttpResponseHeaderRegister(void);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1594,8 +1594,6 @@ void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, 
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size);
 void RuleMatchCandidateTxArrayFree(DetectEngineThreadCtx *det_ctx);
 
-void AlertQueueInit(DetectEngineThreadCtx *det_ctx);
-void AlertQueueFree(DetectEngineThreadCtx *det_ctx);
 void AlertQueueAppend(DetectEngineThreadCtx *det_ctx, const Signature *s, Packet *p, uint64_t tx_id,
         uint8_t alert_flags);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -41,6 +41,7 @@
 #include "flow-spare-pool.h"
 
 #include "stream-tcp.h"
+#include "stream-tcp-cache.h"
 
 #include "util-device.h"
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -121,7 +121,6 @@ int StreamTcpSetMemcap(uint64_t);
 uint64_t StreamTcpGetMemcap(void);
 int StreamTcpCheckMemcap(uint64_t);
 uint64_t StreamTcpMemuseCounter(void);
-uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 
 int StreamTcpSegmentForEach(const Packet *p, uint8_t flag,
                         StreamSegmentCallback CallbackFunc,
@@ -204,8 +203,5 @@ void StreamTcpUpdateAppLayerProgress(TcpSession *ssn, char direction,
 
 uint64_t StreamTcpGetUsable(const TcpStream *stream, const bool eof);
 uint64_t StreamDataRightEdge(const TcpStream *stream, const bool eof);
-
-void StreamTcpThreadCacheEnable(void);
-void StreamTcpThreadCacheCleanup(void);
 
 #endif /* SURICATA_STREAM_TCP_H */

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -185,7 +185,6 @@ int RunmodeIsUnittests(void);
 #else
 #define RunmodeIsUnittests() 0
 #endif
-int SCRunmodeGet(void);
 
 /**
  * \brief Get the current run mode.

--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -392,12 +392,6 @@ typedef struct SCProfileDetectCtx_ {
     pthread_mutex_t data_m;
 } SCProfileDetectCtx;
 
-void SCProfilingRulesGlobalInit(void);
-void SCProfilingRuleDestroyCtx(struct SCProfileDetectCtx_ *);
-void SCProfilingRuleInitCounters(DetectEngineCtx *);
-void SCProfilingRuleUpdateCounter(DetectEngineThreadCtx *, uint16_t, uint64_t, int);
-void SCProfilingRuleThreadSetup(struct SCProfileDetectCtx_ *, DetectEngineThreadCtx *);
-void SCProfilingRuleThreadCleanup(DetectEngineThreadCtx *);
 int SCProfileRuleStart(Packet *p);
 json_t *SCProfileRuleTriggerDump(DetectEngineCtx *de_ctx);
 void SCProfileRuleStartCollection(void);


### PR DESCRIPTION
Ticket: #7297

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7297

Describe changes:
-Remove duplicate function declarations fro header files
-I used this to find the duplicates:
```
cat src/*.h | grep -E "^[a-zA-Z_].*\(.*\);" | sort | uniq -c | awk '$1 == 2'
```
- Then to find specific files where the funtions are, I used:
```
grep -Rn "DetectEngineBufferTypeGetById" src/*.h

```
Previous pr #11990 

