### PR TITLE
dpdk/hw_offload: add support for vlan stripping - v2

### DIFF
--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -125,6 +125,7 @@ static void DPDKDerefConfig(void *conf);
 #define DPDK_CONFIG_DEFAULT_MULTICAST_MODE              1
 #define DPDK_CONFIG_DEFAULT_CHECKSUM_VALIDATION         1
 #define DPDK_CONFIG_DEFAULT_CHECKSUM_VALIDATION_OFFLOAD 1
+#define DPDK_CONFIG_DEFAULT_VLAN_STRIP                  0
 #define DPDK_CONFIG_DEFAULT_COPY_MODE                   "none"
 #define DPDK_CONFIG_DEFAULT_COPY_INTERFACE              "none"
 
@@ -136,6 +137,7 @@ DPDKIfaceConfigAttributes dpdk_yaml = {
     .checksum_checks = "checksum-checks",
     .checksum_checks_offload = "checksum-checks-offload",
     .mtu = "mtu",
+    .vlan_strip_enabled = "vlan-strip-offload",
     .rss_hf = "rss-hash-functions",
     .mempool_size = "mempool-size",
     .mempool_cache_size = "mempool-cache-size",
@@ -616,6 +618,14 @@ static int ConfigSetChecksumOffload(DPDKIfaceConfig *iconf, int entry_bool)
     SCReturnInt(0);
 }
 
+static int ConfigSetVlanStrip(DPDKIfaceConfig *iconf, int entry_bool)
+{
+    SCEnter();
+    iconf->vlan_strip_enabled = entry_bool;
+
+    SCReturnInt(0);
+}
+
 static int ConfigSetCopyIface(DPDKIfaceConfig *iconf, const char *entry_str)
 {
     SCEnter();
@@ -804,6 +814,13 @@ static int ConfigLoad(DPDKIfaceConfig *iconf, const char *iface)
                      ? ConfigSetChecksumOffload(
                                iconf, DPDK_CONFIG_DEFAULT_CHECKSUM_VALIDATION_OFFLOAD)
                      : ConfigSetChecksumOffload(iconf, entry_bool);
+    if (retval < 0)
+        SCReturnInt(retval);
+
+    retval = ConfGetChildValueBoolWithDefault(
+                     if_root, if_default, dpdk_yaml.vlan_strip_enabled, &entry_bool) != 1
+                     ? ConfigSetVlanStrip(iconf, DPDK_CONFIG_DEFAULT_VLAN_STRIP)
+                     : ConfigSetVlanStrip(iconf, entry_bool);
     if (retval < 0)
         SCReturnInt(retval);
 
@@ -1191,6 +1208,19 @@ static void PortConfSetChsumOffload(const DPDKIfaceConfig *iconf,
     }
 }
 
+static void PortConfSetVlanOffload(const DPDKIfaceConfig *iconf,
+        const struct rte_eth_dev_info *dev_info, struct rte_eth_conf *port_conf)
+{
+    if (iconf->vlan_strip_enabled) {
+        SCLogConfig("%s: hardware vlan stripping enabled", iconf->iface);
+        if (dev_info->rx_offload_capa & RTE_ETH_RX_OFFLOAD_VLAN_STRIP) {
+            port_conf->rxmode.offloads |= RTE_ETH_RX_OFFLOAD_VLAN_STRIP;
+        } else {
+            SCLogWarning("%s: hardware vlan stripping not supported", iconf->iface);
+        }
+    }
+}
+
 static void DeviceInitPortConf(const DPDKIfaceConfig *iconf,
         const struct rte_eth_dev_info *dev_info, struct rte_eth_conf *port_conf)
 {
@@ -1212,6 +1242,7 @@ static void DeviceInitPortConf(const DPDKIfaceConfig *iconf,
     PortConfSetRSSConf(iconf, dev_info, port_conf);
     PortConfSetChsumOffload(iconf, dev_info, port_conf);
     DeviceSetMTU(port_conf, iconf->mtu);
+    PortConfSetVlanOffload(iconf, dev_info, port_conf);
 
     if (dev_info->tx_offload_capa & RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE) {
         port_conf->txmode.offloads |= RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE;

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -31,6 +31,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *checksum_checks;
     const char *checksum_checks_offload;
     const char *mtu;
+    const char *vlan_strip_enabled;
     const char *rss_hf;
     const char *mempool_size;
     const char *mempool_cache_size;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -66,6 +66,7 @@ typedef struct DPDKIfaceConfig_ {
     uint64_t rss_hf;
     /* set maximum transmission unit of the device in bytes */
     uint16_t mtu;
+    bool vlan_strip_enabled;
     uint16_t nb_rx_queues;
     uint16_t nb_rx_desc;
     uint16_t nb_tx_queues;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -757,6 +757,7 @@ dpdk:
       checksum-checks: true # if Suricata should validate checksums
       checksum-checks-offload: true # if possible offload checksum validation to the NIC (saves Suricata resources)
       mtu: 1500 # Set MTU of the device in bytes
+      vlan-strip-offload: false # if possible enable hardware vlan stripping
       # rss-hash-functions: 0x0 # advanced configuration option, use only if you use untested NIC card and experience RSS warnings,
       # For `rss-hash-functions` use hexadecimal 0x01ab format to specify RSS hash function flags - DumpRssFlags can help (you can see output if you use -vvv option during Suri startup)
       # setting auto to rss_hf sets the default RSS hash functions (based on IP addresses)
@@ -792,6 +793,7 @@ dpdk:
       checksum-checks: true
       checksum-checks-offload: true
       mtu: 1500
+      vlan-strip-offload: false
       rss-hash-functions: auto
       mempool-size: 65535
       mempool-cache-size: 257


### PR DESCRIPTION
Utilize DPDK API for hardware vlan stripping if supported by NIC.

Ticket: 7330

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7330

Previous PR [#11974](https://github.com/OISF/suricata/pull/11974)

Describe changes:
v2
- add SCLogWarning, SCLogConfig for setting vlan stripping
- create function PortConfSetVlanOffload that enables the vlan stripping and logging

v1
- add option to enable hardware offload / strip of vlan tags with DPDK API on supported NICs
- option can be enabled in suricata.yaml 


