### PR TITLE
detect: add new_de_ctx release in case of errors in initialization - 70x backport - v1

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3919,12 +3919,12 @@ static int DetectEngineMultiTenantReloadTenant(uint32_t tenant_id, const char *f
     new_de_ctx->tenant_path = SCStrdup(filename);
     if (new_de_ctx->tenant_path == NULL) {
         SCLogError("Failed to duplicate path");
-        goto error;
+        goto new_de_ctx_error;
     }
 
     if (SigLoadSignatures(new_de_ctx, NULL, 0) < 0) {
         SCLogError("Loading signatures failed.");
-        goto error;
+        goto new_de_ctx_error;
     }
 
     DetectEngineAddToMaster(new_de_ctx);
@@ -3933,6 +3933,9 @@ static int DetectEngineMultiTenantReloadTenant(uint32_t tenant_id, const char *f
     DetectEngineMoveToFreeList(old_de_ctx);
     DetectEngineDeReference(&old_de_ctx);
     return 0;
+
+new_de_ctx_error:
+    DetectEngineCtxFree(new_de_ctx);
 
 error:
     DetectEngineDeReference(&old_de_ctx);


### PR DESCRIPTION
Detect engine tenant reloading function hasn't got engine release call under error label, so it is possible memory leak in case of errors in further new detect engine initialization.

Bug: #7303
(cherry picked from commit adcac9ee0f8a20b68ca394ce0628063bc5c2ce7c)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
original: https://redmine.openinfosecfoundation.org/issues/7303
backport: https://redmine.openinfosecfoundation.org/issues/7307


Describe changes:
- clean backport of https://github.com/OISF/suricata/pull/11868