### PR TITLE
conf: init parser after check with stat() - 70x backport - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -560,11 +560,6 @@ ConfYamlLoadFileWithPrefix(const char *filename, const char *prefix)
     int ret;
     ConfNode *root = ConfGetNode(prefix);
 
-    if (yaml_parser_initialize(&parser) != 1) {
-        SCLogError("failed to initialize yaml parser.");
-        return -1;
-    }
-
     struct stat stat_buf;
     /* coverity[toctou] */
     if (stat(filename, &stat_buf) == 0) {
@@ -574,6 +569,11 @@ ConfYamlLoadFileWithPrefix(const char *filename, const char *prefix)
                     filename);
             return -1;
         }
+    }
+
+    if (yaml_parser_initialize(&parser) != 1) {
+        SCLogError("failed to initialize yaml parser.");
+        return -1;
     }
 
     /* coverity[toctou] */


### PR DESCRIPTION
Commit changes are made to avoid possible memory leaks. If the parser is initialized before configuration file checking, there was no deinit call before function return. Do check config file existance and type before YAML parser initialization, so we don't need to deinit parser before exiting the function.

Bug: #7302
(cherry picked from commit 87e6e9374ff40847d3e7408afcd404374b629337)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
original - https://redmine.openinfosecfoundation.org/issues/7302
backport - https://redmine.openinfosecfoundation.org/issues/7308

Describe changes:
- clean backport of https://github.com/OISF/suricata/pull/11925