### PR TITLE
dpdk/hw_offload: add support for vlan stripping - v3

### DIFF
--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -31,6 +31,7 @@ typedef struct DPDKIfaceConfigAttributes_ {
     const char *checksum_checks;
     const char *checksum_checks_offload;
     const char *mtu;
+    const char *vlan_strip_offload;
     const char *rss_hf;
     const char *mempool_size;
     const char *mempool_cache_size;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -66,6 +66,7 @@ typedef struct DPDKIfaceConfig_ {
     uint64_t rss_hf;
     /* set maximum transmission unit of the device in bytes */
     uint16_t mtu;
+    bool vlan_strip_enabled;
     uint16_t nb_rx_queues;
     uint16_t nb_rx_desc;
     uint16_t nb_tx_queues;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -757,6 +757,7 @@ dpdk:
       checksum-checks: true # if Suricata should validate checksums
       checksum-checks-offload: true # if possible offload checksum validation to the NIC (saves Suricata resources)
       mtu: 1500 # Set MTU of the device in bytes
+      vlan-strip-offload: false # if possible enable hardware vlan stripping
       # rss-hash-functions: 0x0 # advanced configuration option, use only if you use untested NIC card and experience RSS warnings,
       # For `rss-hash-functions` use hexadecimal 0x01ab format to specify RSS hash function flags - DumpRssFlags can help (you can see output if you use -vvv option during Suri startup)
       # setting auto to rss_hf sets the default RSS hash functions (based on IP addresses)
@@ -792,6 +793,7 @@ dpdk:
       checksum-checks: true
       checksum-checks-offload: true
       mtu: 1500
+      vlan-strip-offload: false
       rss-hash-functions: auto
       mempool-size: 65535
       mempool-cache-size: 257


### PR DESCRIPTION
Utilize DPDK API for hardware vlan stripping if supported by NIC.

Ticket: 7330

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7330

Previous PR [#11997](https://github.com/OISF/suricata/pull/11997)

Describe changes:
v3
- minor changes in variable names
- call SCLogConfig only when VLAN stripping is supported
- change return type of ConfigSetVlanStrip to void

v2
- add SCLogWarning, SCLogConfig for setting vlan stripping
- create function PortConfSetVlanOffload that enables the vlan stripping and logging

v1
- add option to enable hardware offload / strip of vlan tags with DPDK API on supported NICs
- option can be enabled in suricata.yaml 

