### PR TITLE
app-layer events: consistently use uint8_t/u8 as the event id

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -340,6 +340,9 @@
                 },
                 "type": {
                     "type": "string"
+                },
+                "code": {
+                    "type": "integer"
                 }
             },
             "additionalProperties": false

--- a/rust/derive/src/applayerevent.rs
+++ b/rust/derive/src/applayerevent.rs
@@ -98,7 +98,7 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
                 event_id: std::os::raw::c_int,
                 event_name: *mut *const std::os::raw::c_char,
                 event_type: *mut #crate_id::core::AppLayerEventType,
-            ) -> i8 {
+            ) -> std::os::raw::c_int {
                 #crate_id::applayer::get_event_info_by_id::<#name>(event_id, event_name, event_type)
             }
 

--- a/rust/derive/src/applayerevent.rs
+++ b/rust/derive/src/applayerevent.rs
@@ -41,7 +41,7 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
                 let cname = format!("{}\0", event_name);
                 event_names.push(event_name);
                 event_cstrings.push(cname);
-                event_ids.push(i as i32);
+                event_ids.push(i as u8);
             }
         }
         _ => panic!("AppLayerEvent can only be derived for enums"),
@@ -60,14 +60,14 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #crate_id::applayer::AppLayerEvent for #name {
-            fn from_id(id: i32) -> Option<#name> {
+            fn from_id(id: u8) -> Option<#name> {
                 match id {
                     #( #event_ids => Some(#name::#fields) ,)*
                     _ => None,
                 }
             }
 
-            fn as_i32(&self) -> i32 {
+            fn as_u8(&self) -> u8 {
                 match *self {
                     #( #name::#fields => #event_ids ,)*
                 }
@@ -88,14 +88,14 @@ pub fn derive_app_layer_event(input: TokenStream) -> TokenStream {
 
             unsafe extern "C" fn get_event_info(
                 event_name: *const std::os::raw::c_char,
-                event_id: *mut std::os::raw::c_int,
+                event_id: *mut u8,
                 event_type: *mut #crate_id::core::AppLayerEventType,
             ) -> std::os::raw::c_int {
                 #crate_id::applayer::get_event_info::<#name>(event_name, event_id, event_type)
             }
 
             unsafe extern "C" fn get_event_info_by_id(
-                event_id: std::os::raw::c_int,
+                event_id: u8,
                 event_name: *mut *const std::os::raw::c_char,
                 event_type: *mut #crate_id::core::AppLayerEventType,
             ) -> std::os::raw::c_int {

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -445,7 +445,7 @@ pub type StateGetTxFn            = unsafe extern "C" fn (*mut c_void, u64) -> *m
 pub type StateGetTxCntFn         = unsafe extern "C" fn (*mut c_void) -> u64;
 pub type StateGetProgressFn = unsafe extern "C" fn (*mut c_void, u8) -> c_int;
 pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
-pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> i8;
+pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> c_int;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
 pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, u8) -> AppLayerGetFileState;
@@ -590,7 +590,7 @@ pub trait AppLayerEvent {
         event_id: std::os::raw::c_int,
         event_name: *mut *const std::os::raw::c_char,
         event_type: *mut core::AppLayerEventType,
-    ) -> i8;
+    ) -> std::os::raw::c_int;
 }
 
 /// Generic `get_info_info` implementation for enums implementing
@@ -634,7 +634,7 @@ pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
     event_id: std::os::raw::c_int,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
-) -> i8 {
+) -> std::os::raw::c_int {
     if let Some(e) = T::from_id(event_id) {
         *event_name = e.to_cstring().as_ptr() as *const std::os::raw::c_char;
         *event_type = core::AppLayerEventType::APP_LAYER_EVENT_TYPE_TRANSACTION;

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -444,8 +444,8 @@ pub type StateTxFreeFn  = unsafe extern "C" fn (*mut c_void, u64);
 pub type StateGetTxFn            = unsafe extern "C" fn (*mut c_void, u64) -> *mut c_void;
 pub type StateGetTxCntFn         = unsafe extern "C" fn (*mut c_void) -> u64;
 pub type StateGetProgressFn = unsafe extern "C" fn (*mut c_void, u8) -> c_int;
-pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, *mut c_int, *mut AppLayerEventType) -> c_int;
-pub type GetEventInfoByIdFn = unsafe extern "C" fn (c_int, *mut *const c_char, *mut AppLayerEventType) -> c_int;
+pub type GetEventInfoFn     = unsafe extern "C" fn (*const c_char, event_id: *mut u8, *mut AppLayerEventType) -> c_int;
+pub type GetEventInfoByIdFn = unsafe extern "C" fn (event_id: u8, *mut *const c_char, *mut AppLayerEventType) -> c_int;
 pub type LocalStorageNewFn  = extern "C" fn () -> *mut c_void;
 pub type LocalStorageFreeFn = extern "C" fn (*mut c_void);
 pub type GetTxFilesFn       = unsafe extern "C" fn (*mut c_void, u8) -> AppLayerGetFileState;
@@ -569,7 +569,7 @@ impl LoggerFlags {
 /// derive AppLayerEvent.
 pub trait AppLayerEvent {
     /// Return the enum variant of the given ID.
-    fn from_id(id: i32) -> Option<Self> where Self: std::marker::Sized;
+    fn from_id(id: u8) -> Option<Self> where Self: std::marker::Sized;
 
     /// Convert the enum variant to a C-style string (suffixed with \0).
     fn to_cstring(&self) -> &str;
@@ -578,16 +578,16 @@ pub trait AppLayerEvent {
     fn from_string(s: &str) -> Option<Self> where Self: std::marker::Sized;
 
     /// Return the ID value of the enum variant.
-    fn as_i32(&self) -> i32;
+    fn as_u8(&self) -> u8;
 
     unsafe extern "C" fn get_event_info(
         event_name: *const std::os::raw::c_char,
-        event_id: *mut std::os::raw::c_int,
+        event_id: *mut u8,
         event_type: *mut core::AppLayerEventType,
     ) -> std::os::raw::c_int;
 
     unsafe extern "C" fn get_event_info_by_id(
-        event_id: std::os::raw::c_int,
+        event_id: u8,
         event_name: *mut *const std::os::raw::c_char,
         event_type: *mut core::AppLayerEventType,
     ) -> std::os::raw::c_int;
@@ -611,7 +611,7 @@ pub trait AppLayerEvent {
 #[inline(always)]
 pub unsafe fn get_event_info<T: AppLayerEvent>(
     event_name: *const std::os::raw::c_char,
-    event_id: *mut std::os::raw::c_int,
+    event_id: *mut u8,
     event_type: *mut core::AppLayerEventType,
 ) -> std::os::raw::c_int {
     if event_name.is_null() {
@@ -619,11 +619,13 @@ pub unsafe fn get_event_info<T: AppLayerEvent>(
     }
 
     let event = match CStr::from_ptr(event_name).to_str().map(T::from_string) {
-        Ok(Some(event)) => event.as_i32(),
-        _ => -1,
+        Ok(Some(event)) => event.as_u8(),
+        _ => {
+            return -1;
+        }
     };
     *event_type = core::AppLayerEventType::APP_LAYER_EVENT_TYPE_TRANSACTION;
-    *event_id = event as std::os::raw::c_int;
+    *event_id = event;
     return 0;
 }
 
@@ -631,7 +633,7 @@ pub unsafe fn get_event_info<T: AppLayerEvent>(
 /// AppLayerEvent.
 #[inline(always)]
 pub unsafe fn get_event_info_by_id<T: AppLayerEvent>(
-    event_id: std::os::raw::c_int,
+    event_id: u8,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut core::AppLayerEventType,
 ) -> std::os::raw::c_int {

--- a/rust/src/ftp/event.rs
+++ b/rust/src/ftp/event.rs
@@ -33,7 +33,7 @@ pub enum FtpEvent {
 /// Unsafe as called from C.
 #[no_mangle]
 pub unsafe extern "C" fn ftp_get_event_info(
-    event_name: *const c_char, event_id: *mut c_int, event_type: *mut AppLayerEventType,
+    event_name: *const c_char, event_id: *mut u8, event_type: *mut AppLayerEventType,
 ) -> c_int {
     crate::applayer::get_event_info::<FtpEvent>(event_name, event_id, event_type)
 }
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn ftp_get_event_info(
 /// Unsafe as called from C.
 #[no_mangle]
 pub unsafe extern "C" fn ftp_get_event_info_by_id(
-    event_id: c_int, event_name: *mut *const c_char, event_type: *mut AppLayerEventType,
+    event_id: u8, event_name: *mut *const c_char, event_type: *mut AppLayerEventType,
 ) -> c_int {
     crate::applayer::get_event_info_by_id::<FtpEvent>(event_id, event_name, event_type) as c_int
 }

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2203,7 +2203,7 @@ pub unsafe extern "C" fn rs_smb_get_tx_data(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_state_get_event_info_by_id(
-    event_id: std::os::raw::c_int,
+    event_id: u8,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut AppLayerEventType,
 ) -> std::os::raw::c_int {
@@ -2213,7 +2213,7 @@ pub unsafe extern "C" fn rs_smb_state_get_event_info_by_id(
 #[no_mangle]
 pub unsafe extern "C" fn rs_smb_state_get_event_info(
     event_name: *const std::os::raw::c_char,
-    event_id: *mut std::os::raw::c_int,
+    event_id: *mut u8,
     event_type: *mut AppLayerEventType,
 ) -> std::os::raw::c_int {
     SMBEvent::get_event_info(event_name, event_id, event_type)

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2206,7 +2206,7 @@ pub unsafe extern "C" fn rs_smb_state_get_event_info_by_id(
     event_id: std::os::raw::c_int,
     event_name: *mut *const std::os::raw::c_char,
     event_type: *mut AppLayerEventType,
-) -> i8 {
+) -> std::os::raw::c_int {
     SMBEvent::get_event_info_by_id(event_id, event_name, event_type)
 }
 

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1435,17 +1435,18 @@ static int DNP3GetAlstateProgress(void *tx, uint8_t direction)
 /**
  * \brief App-layer support.
  */
-static int DNP3StateGetEventInfo(const char *event_name, int *event_id,
-    AppLayerEventType *event_type)
+static int DNP3StateGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
-    *event_id = SCMapEnumNameToValue(event_name, dnp3_decoder_event_table);
-    if (*event_id == -1) {
+    int value = SCMapEnumNameToValue(event_name, dnp3_decoder_event_table);
+    if (value == -1) {
         SCLogError("Event \"%s\" not present in "
                    "the DNP3 enum event map table.",
                 event_name);
         return -1;
     }
 
+    *event_id = (uint8_t)value;
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
@@ -1454,8 +1455,8 @@ static int DNP3StateGetEventInfo(const char *event_name, int *event_id,
 /**
  * \brief App-layer support.
  */
-static int DNP3StateGetEventInfoById(int event_id, const char **event_name,
-                                     AppLayerEventType *event_type)
+static int DNP3StateGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type)
 {
     *event_name = SCMapEnumValueToName(event_id, dnp3_decoder_event_table);
     if (*event_name == NULL) {

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -48,8 +48,8 @@ SCEnumCharMap app_layer_event_pkt_table[ ] = {
       -1 },
 };
 
-int AppLayerGetEventInfoById(int event_id, const char **event_name,
-                                     AppLayerEventType *event_type)
+int AppLayerGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type)
 {
     *event_name = SCMapEnumValueToName(event_id, app_layer_event_pkt_table);
     if (*event_name == NULL) {
@@ -161,16 +161,22 @@ SCEnumCharMap det_ctx_event_table[] = {
     { NULL, -1 },
 };
 
-int DetectEngineGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type)
+int DetectEngineGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
-    *event_id = SCMapEnumNameToValue(event_name, det_ctx_event_table);
-    if (*event_id == -1) {
+    int value = SCMapEnumNameToValue(event_name, det_ctx_event_table);
+    if (value == -1) {
         SCLogError("event \"%s\" not present in "
                    "det_ctx's enum map table.",
                 event_name);
         /* this should be treated as fatal */
         return -1;
+    } else if (value > UINT8_MAX) {
+        SCLogError("event \"%s\" has invalid value", event_name);
+        /* this should be treated as fatal */
+        return -1;
     }
+    *event_id = (uint8_t)value;
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;

--- a/src/app-layer-events.h
+++ b/src/app-layer-events.h
@@ -55,8 +55,8 @@ enum {
 
 int AppLayerGetPktEventInfo(const char *event_name, int *event_id);
 
-int AppLayerGetEventInfoById(int event_id, const char **event_name,
-                             AppLayerEventType *event_type);
+int AppLayerGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type);
 void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t event);
 
 static inline int AppLayerDecoderEventsIsEventSet(
@@ -76,6 +76,7 @@ static inline int AppLayerDecoderEventsIsEventSet(
 
 void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events);
 void AppLayerDecoderEventsFreeEvents(AppLayerDecoderEvents **events);
-int DetectEngineGetEventInfo(const char *event_name, int *event_id, AppLayerEventType *event_type);
+int DetectEngineGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type);
 
 #endif /* SURICATA_APP_LAYER_EVENTS_H */

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2718,11 +2718,11 @@ void *HtpGetTxForH2(void *alstate)
     return NULL;
 }
 
-static int HTPStateGetEventInfo(const char *event_name,
-                         int *event_id, AppLayerEventType *event_type)
+static int HTPStateGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
-    *event_id = SCMapEnumNameToValue(event_name, http_decoder_event_table);
-    if (*event_id == -1) {
+    int value = SCMapEnumNameToValue(event_name, http_decoder_event_table);
+    if (value == -1) {
         SCLogError("event \"%s\" not present in "
                    "http's enum map table.",
                 event_name);
@@ -2730,13 +2730,14 @@ static int HTPStateGetEventInfo(const char *event_name,
         return -1;
     }
 
+    *event_id = (uint8_t)value;
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
 }
 
-static int HTPStateGetEventInfoById(int event_id, const char **event_name,
-                                    AppLayerEventType *event_type)
+static int HTPStateGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type)
 {
     *event_name = SCMapEnumValueToName(event_id, http_decoder_event_table);
     if (*event_name == NULL) {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -93,10 +93,10 @@ typedef struct AppLayerParserProtoCtx_
     AppLayerGetTxIteratorFunc StateGetTxIterator;
     int complete_ts;
     int complete_tc;
-    int (*StateGetEventInfoById)(int event_id, const char **event_name,
-                                 AppLayerEventType *event_type);
-    int (*StateGetEventInfo)(const char *event_name,
-                             int *event_id, AppLayerEventType *event_type);
+    int (*StateGetEventInfoById)(
+            uint8_t event_id, const char **event_name, AppLayerEventType *event_type);
+    int (*StateGetEventInfo)(
+            const char *event_name, uint8_t *event_id, AppLayerEventType *event_type);
 
     AppLayerStateData *(*GetStateData)(void *state);
     AppLayerTxData *(*GetTxData)(void *tx);
@@ -531,8 +531,8 @@ void AppLayerParserRegisterStateProgressCompletionStatus(
 }
 
 void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
-    int (*StateGetEventInfoById)(int event_id, const char **event_name,
-                                 AppLayerEventType *event_type))
+        int (*StateGetEventInfoById)(
+                uint8_t event_id, const char **event_name, AppLayerEventType *event_type))
 {
     SCEnter();
 
@@ -553,8 +553,8 @@ void AppLayerParserRegisterGetFrameFuncs(uint8_t ipproto, AppProto alproto,
 }
 
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
-    int (*StateGetEventInfo)(const char *event_name, int *event_id,
-                             AppLayerEventType *event_type))
+        int (*StateGetEventInfo)(
+                const char *event_name, uint8_t *event_id, AppLayerEventType *event_type))
 {
     SCEnter();
 
@@ -1100,7 +1100,7 @@ int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto,
 }
 
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
-                    int *event_id, AppLayerEventType *event_type)
+        uint8_t *event_id, AppLayerEventType *event_type)
 {
     SCEnter();
     const int ipproto_map = FlowGetProtoMapping(ipproto);
@@ -1109,8 +1109,8 @@ int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *ev
     SCReturnInt(r);
 }
 
-int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, int event_id,
-                    const char **event_name, AppLayerEventType *event_type)
+int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, uint8_t event_id,
+        const char **event_name, AppLayerEventType *event_type)
 {
     SCEnter();
     const int ipproto_map = FlowGetProtoMapping(ipproto);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -195,11 +195,11 @@ void AppLayerParserRegisterGetTxIterator(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterStateProgressCompletionStatus(
         AppProto alproto, const int ts, const int tc);
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
-    int (*StateGetEventInfo)(const char *event_name, int *event_id,
-                             AppLayerEventType *event_type));
+        int (*StateGetEventInfo)(
+                const char *event_name, uint8_t *event_id, AppLayerEventType *event_type));
 void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
-    int (*StateGetEventInfoById)(int event_id, const char **event_name,
-                                 AppLayerEventType *event_type));
+        int (*StateGetEventInfoById)(
+                uint8_t event_id, const char **event_name, AppLayerEventType *event_type));
 void AppLayerParserRegisterGetFrameFuncs(uint8_t ipproto, AppProto alproto,
         AppLayerParserGetFrameIdByNameFn GetFrameIdByName,
         AppLayerParserGetFrameNameByIdFn GetFrameNameById);
@@ -239,9 +239,9 @@ uint64_t AppLayerParserGetTxCnt(const Flow *, void *alstate);
 void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint64_t tx_id);
 int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t direction);
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
-                    int *event_id, AppLayerEventType *event_type);
-int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, int event_id,
-                    const char **event_name, AppLayerEventType *event_type);
+        uint8_t *event_id, AppLayerEventType *event_type);
+int AppLayerParserGetEventInfoById(uint8_t ipproto, AppProto alproto, uint8_t event_id,
+        const char **event_name, AppLayerEventType *event_type);
 
 uint64_t AppLayerParserGetTransactionActive(const Flow *f, AppLayerParserState *pstate, uint8_t direction);
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -51,10 +51,10 @@ typedef struct AppLayerParser {
     const int complete_tc;
     int (*StateGetProgress)(void *alstate, uint8_t direction);
 
-    int (*StateGetEventInfo)(const char *event_name,
-                             int *event_id, AppLayerEventType *event_type);
-    int (*StateGetEventInfoById)(int event_id, const char **event_name,
-                                  AppLayerEventType *event_type);
+    int (*StateGetEventInfo)(
+            const char *event_name, uint8_t *event_id, AppLayerEventType *event_type);
+    int (*StateGetEventInfoById)(
+            uint8_t event_id, const char **event_name, AppLayerEventType *event_type);
 
     void *(*LocalStorageAlloc)(void);
     void (*LocalStorageFree)(void *);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1650,11 +1650,11 @@ static void SMTPFreeMpmState(void)
     }
 }
 
-static int SMTPStateGetEventInfo(const char *event_name,
-                          int *event_id, AppLayerEventType *event_type)
+static int SMTPStateGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
-    *event_id = SCMapEnumNameToValue(event_name, smtp_decoder_event_table);
-    if (*event_id == -1) {
+    int value = SCMapEnumNameToValue(event_name, smtp_decoder_event_table);
+    if (value == -1) {
         SCLogError("event \"%s\" not present in "
                    "smtp's enum map table.",
                 event_name);
@@ -1662,13 +1662,14 @@ static int SMTPStateGetEventInfo(const char *event_name,
         return -1;
     }
 
+    *event_id = (uint8_t)value;
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
 }
 
-static int SMTPStateGetEventInfoById(int event_id, const char **event_name,
-                                     AppLayerEventType *event_type)
+static int SMTPStateGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type)
 {
     *event_name = SCMapEnumValueToName(event_id, smtp_decoder_event_table);
     if (*event_name == NULL) {

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2994,11 +2994,11 @@ static const char *SSLStateGetFrameNameById(const uint8_t frame_id)
     return name;
 }
 
-static int SSLStateGetEventInfo(const char *event_name,
-                         int *event_id, AppLayerEventType *event_type)
+static int SSLStateGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
-    *event_id = SCMapEnumNameToValue(event_name, tls_decoder_event_table);
-    if (*event_id == -1) {
+    int value = SCMapEnumNameToValue(event_name, tls_decoder_event_table);
+    if (value == -1) {
         SCLogError("event \"%s\" not present in "
                    "ssl's enum map table.",
                 event_name);
@@ -3006,13 +3006,14 @@ static int SSLStateGetEventInfo(const char *event_name,
         return -1;
     }
 
+    *event_id = (uint8_t)value;
     *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
 }
 
-static int SSLStateGetEventInfoById(int event_id, const char **event_name,
-                                    AppLayerEventType *event_type)
+static int SSLStateGetEventInfoById(
+        uint8_t event_id, const char **event_name, AppLayerEventType *event_type)
 {
     *event_name = SCMapEnumValueToName(event_id, tls_decoder_event_table);
     if (*event_name == NULL) {

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -67,8 +67,8 @@ static void TFTPStateTxFree(void *state, uint64_t tx_id)
     rs_tftp_state_tx_free(state, tx_id);
 }
 
-static int TFTPStateGetEventInfo(const char *event_name, int *event_id,
-    AppLayerEventType *event_type)
+static int TFTPStateGetEventInfo(
+        const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {
     return -1;
 }

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -247,7 +247,7 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
         }
 
         int r;
-        int event_id = 0;
+        uint8_t event_id = 0;
         if (!needs_detctx) {
             r = AppLayerParserGetEventInfo(ipproto, alproto, event_name, &event_id, &event_type);
         } else {
@@ -265,10 +265,6 @@ static int DetectAppLayerEventSetup(DetectEngineCtx *de_ctx, Signature *s, const
                         alproto_name, event_name);
                 return -3;
             }
-        }
-        if (event_id > UINT8_MAX) {
-            SCLogWarning("app-layer-event keyword's id has invalid value");
-            return -4;
         }
         data = SCCalloc(1, sizeof(*data));
         if (unlikely(data == NULL))


### PR DESCRIPTION
Builds on #12009 to be consistent about the data type used for event IDs. #12009 shows us how important this is especially when something passes an ffi boundary.
