### PR TITLE
userguide: fix integer keyword matches list format - v1

### DIFF
--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -20,14 +20,14 @@ Comparison modes
 ----------------
 
 Integers can be matched for
-* Equality
-* Inequality
-* Greater than
-* Less than
-* Range
-* Negated range
-* Bitmask
-* Negated Bitmask
+  * Equality
+  * Inequality
+  * Greater than
+  * Less than
+  * Range
+  * Negated range
+  * Bitmask
+  * Negated Bitmask
 
 .. note::
 


### PR DESCRIPTION
List wasn't being properly rendered.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- Fix the formatting so that it actually shows the items like a list.
 
While checking the documentation, I noticed that what seemed supposed to be a list wasn't being rendered as such (cf https://docs.suricata.io/en/latest/rules/integer-keywords.html#comparison-modes)