### PR TITLE
detect/analyzer: add more details for the tcp window keyword-v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -52,6 +52,7 @@
 #include "detect-flowbits.h"
 #include "util-var-name.h"
 #include "detect-icmp-id.h"
+#include "detect-tcp-window.h"
 
 static int rule_warnings_only = 0;
 
@@ -929,6 +930,14 @@ static void DumpMatches(RuleAnalyzer *ctx, JsonBuilder *js, const SigMatchData *
                 const DetectIcmpIdData *cd = (const DetectIcmpIdData *)smd->ctx;
                 jb_open_object(js, "id");
                 jb_set_uint(js, "number", SCNtohs(cd->id));
+                jb_close(js);
+                break;
+            }
+            case DETECT_WINDOW: {
+                const DetectWindowData *wd = (const DetectWindowData *)smd->ctx;
+                jb_open_object(js, "window");
+                jb_set_uint(js, "size", wd->size);
+                jb_set_bool(js, "negate", wd->negated);
                 jb_close(js);
                 break;
             }


### PR DESCRIPTION
Ticket: 6352

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/6352

Describe changes:
-detect/analyzer: add more details for the tcp window keyword
-I need help with this, am  I in the right direction?
-Also am thinking of below tests and would like to know if i need to add more, i tested for exact and negated size
```
alert tcp any any -> any any (msg:"TCP window size"; window:30336; sid:1;)
alert tcp any any -> any any (msg:"TCP window size"; window:!1024; sid:2;)
```



=
