### PR TITLE
lua: update to newer lua crate - fix header copy issue - v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -67,7 +67,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.1" }
+suricata-lua-sys = { version = "0.1.0-alpha.3" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -35,16 +35,19 @@ RUST_TARGET = --target $(host_triplet)
 endif
 
 all-local: Cargo.toml
+	mkdir -p $(abs_top_builddir)/rust/gen
 if HAVE_CYGPATH
 	cd $(abs_top_srcdir)/rust && \
 		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(e_rustdir)/target" \
+    SURICATA_LUA_SYS_HEADER_DST="$(e_rustdir)/gen" \
 		$(CARGO) build $(RELEASE) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 else
 	cd $(abs_top_srcdir)/rust && \
 		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
 		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
+    SURICATA_LUA_SYS_HEADER_DST="$(abs_top_builddir)/rust/gen" \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
 endif
@@ -57,9 +60,6 @@ endif
 			$(RUST_SURICATA_LIBDIR)/${RUST_SURICATA_LIBNAME}; \
 	fi
 	$(MAKE) gen/rust-bindings.h
-	mkdir -p $(abs_top_builddir)/rust/gen
-	cp -a $(RUST_SURICATA_LIBDIR)/build/suricata-lua-sys-*/out/lua/*.h \
-		$(abs_top_builddir)/rust/gen/
 
 install-library:
 	$(MKDIR_P) "$(DESTDIR)$(libdir)"


### PR DESCRIPTION
Often when modifying Rust code and re-issuing make, one can run into this error:

```
cp -a ../rust/target/debug/build/suricata-lua-sys-*/out/lua/*.h \
	/home/jason/oisf/dev/suricata/bindgen/rust/gen/
cp: will not overwrite just-created '/home/jason/oisf/dev/suricata/bindgen/rust/gen/lapi.h' with '../rust/target/debug/build/suricata-lua-sys-eab3deb07b92b383/out/lua/lapi.h'
cp: will not overwrite just-created '/home/jason/oisf/dev/suricata/bindgen/rust/gen/lauxlib.h' with '../rust/target/debug/build/suricata-lua-sys-eab3deb07b92b383/out/lua/lauxlib.h'
```

I've updated the `suricata-lua-sys` crate to write out the headers to a specific location if requested, instead of our Makefile having best guess where the headers are, occasionally picking up multiple copies when multiple `../rust/target/debug/build/suricata-lua-sys-****` directories exist.

There is no actual update to the Lua embedded Lua code here, just build system stuff.