### PR TITLE
main-7.0.x backport: profiling: Correct profiling data array size

### DIFF
--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -75,8 +75,8 @@ SCProfilePacketData packet_profile_data6[257]; /**< all proto's + tunnel */
 SCProfilePacketData packet_profile_tmm_data4[TMM_SIZE][257];
 SCProfilePacketData packet_profile_tmm_data6[TMM_SIZE][257];
 
-SCProfilePacketData packet_profile_app_data4[TMM_SIZE][257];
-SCProfilePacketData packet_profile_app_data6[TMM_SIZE][257];
+SCProfilePacketData packet_profile_app_data4[ALPROTO_MAX][257];
+SCProfilePacketData packet_profile_app_data6[ALPROTO_MAX][257];
 
 SCProfilePacketData packet_profile_app_pd_data4[257];
 SCProfilePacketData packet_profile_app_pd_data6[257];


### PR DESCRIPTION
Backport of [issue 7334]( https://redmine.openinfosecfoundation.org/issues/7334)

The profiling arrays are incorrectly sized by the number of thread modules. Since they contain app-layer protocol data, they should be sized by ALPROTO_MAX.

(cherry picked from commit 799822c3db46648edadae570404d74f6ec42efdd)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7335

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
