### PR TITLE
main-7.0.x backport: stream/reassembly: optimize GetBlock

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1037,22 +1037,6 @@ static void GetSessionSize(TcpSession *ssn, Packet *p)
 }
 #endif
 
-static StreamingBufferBlock *GetBlock(const StreamingBuffer *sb, const uint64_t offset)
-{
-    StreamingBufferBlock *blk = sb->head;
-    if (blk == NULL)
-        return NULL;
-
-    for ( ; blk != NULL; blk = SBB_RB_NEXT(blk)) {
-        if (blk->offset >= offset)
-            return blk;
-        else if ((blk->offset + blk->len) > offset) {
-            return blk;
-        }
-    }
-    return NULL;
-}
-
 static inline bool GapAhead(const TcpStream *stream, StreamingBufferBlock *cur_blk)
 {
     StreamingBufferBlock *nblk = SBB_RB_NEXT(cur_blk);
@@ -1088,7 +1072,8 @@ static bool GetAppBuffer(const TcpStream *stream, const uint8_t **data, uint32_t
         *data_len = mydata_len;
     } else {
         SCLogDebug("block mode");
-        StreamingBufferBlock *blk = GetBlock(&stream->sb, offset);
+        StreamingBufferBlock key = { .offset = offset, .len = 0 };
+        StreamingBufferBlock *blk = SBB_RB_FIND_INCLUSIVE((struct SBB *)&stream->sb.sbb_tree, &key);
         if (blk == NULL) {
             *data = NULL;
             *data_len = 0;


### PR DESCRIPTION
Current GetBlock degrees the sbb search from rb tree to line, which costs much cpu time, and could be replaced by SBB_RB_FIND_INCLUSIVE. It reduces time complexity from O(nlogn) to O(logn).

Ticket: 7208.
(cherry picked from commit 951bcff9702f1f39c00293d68d286fd77008b037)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7275

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
