### PR TITLE
draft: Build-info: remove obsolete rust support line-v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2567,7 +2567,6 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Landlock support:                        ${enable_landlock}
   Systemd support:                         ${enable_systemd}
 
-  Rust support:                            ${enable_rust}
   Rust strict mode:                        ${enable_rust_strict}
   Rust compiler path:                      ${RUSTC}
   Rust compiler version:                   ${rust_compiler_version}


### PR DESCRIPTION
Ticket: #6705

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/6705

Describe changes:
- Remove obsolete rust support line-v1
- Running `./src/suricata --build-info` no longer shows rust support but am not sure if this is all that was recquired for this ticket

