### PR TITLE
misc: fix build of rules profiling

### DIFF
--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -287,14 +287,6 @@ extern thread_local int profiling_prefilter_entered;
     (det_ctx)->prefilter_bytes += (bytes);                                                         \
     (det_ctx)->prefilter_bytes_called++
 
-struct SCProfileDetectCtx_;
-void SCProfilingRulesGlobalInit(void);
-void SCProfilingRuleDestroyCtx(struct SCProfileDetectCtx_ *);
-void SCProfilingRuleInitCounters(DetectEngineCtx *);
-void SCProfilingRuleUpdateCounter(DetectEngineThreadCtx *, uint16_t, uint64_t, int);
-void SCProfilingRuleThreadSetup(struct SCProfileDetectCtx_ *, DetectEngineThreadCtx *);
-void SCProfilingRuleThreadCleanup(DetectEngineThreadCtx *);
-
 void SCProfilingKeywordsGlobalInit(void);
 void SCProfilingKeywordDestroyCtx(DetectEngineCtx *);//struct SCProfileKeywordDetectCtx_ *);
 void SCProfilingKeywordInitCounters(DetectEngineCtx *);
@@ -392,6 +384,12 @@ typedef struct SCProfileDetectCtx_ {
     pthread_mutex_t data_m;
 } SCProfileDetectCtx;
 
+void SCProfilingRulesGlobalInit(void);
+void SCProfilingRuleDestroyCtx(struct SCProfileDetectCtx_ *);
+void SCProfilingRuleInitCounters(DetectEngineCtx *);
+void SCProfilingRuleUpdateCounter(DetectEngineThreadCtx *, uint16_t, uint64_t, int);
+void SCProfilingRuleThreadSetup(struct SCProfileDetectCtx_ *, DetectEngineThreadCtx *);
+void SCProfilingRuleThreadCleanup(DetectEngineThreadCtx *);
 int SCProfileRuleStart(Packet *p);
 json_t *SCProfileRuleTriggerDump(DetectEngineCtx *de_ctx);
 void SCProfileRuleStartCollection(void);


### PR DESCRIPTION
The patch a0fc2b8628d8a281ef7a2943614b507498c80ca3 has removed the declaration of functions used when building with ruleset profiling only (without --enable-profiling). This is causing a build failure.

This patch moves the declaration to the rules profiling section to be sure it is always there.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7345

Describe changes:
- fix build when only --enable-profiling-rules is used
