### PR TITLE
configure: Remove obsolete rust support line-v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2167,7 +2167,6 @@ fi
     AM_CONDITIONAL([HAVE_RUST],true)
     AC_SUBST([CARGO], [$CARGO])
 
-    enable_rust="yes"
     rust_compiler_version=$($RUSTC --version)
     rustc_version=$(echo "$rust_compiler_version" | sed 's/^.*[[^0-9]]\([[0-9]]*\.[[0-9]]*\.[[0-9]]*\).*$/\1/')
     cargo_version_output=$($CARGO --version)
@@ -2567,7 +2566,6 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Landlock support:                        ${enable_landlock}
   Systemd support:                         ${enable_systemd}
 
-  Rust support:                            ${enable_rust}
   Rust strict mode:                        ${enable_rust_strict}
   Rust compiler path:                      ${RUSTC}
   Rust compiler version:                   ${rust_compiler_version}


### PR DESCRIPTION
Ticket: #6705

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/6705

Describe changes:
-remove  obsolete rust support line
-Remove the definion enable_rust="yes"
-previous pr #12040 

