### PR TITLE
memcap/stats: full reporting of memcap/stats via socket and output

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6396,6 +6396,42 @@
                         },
                         "memuse": {
                             "type": "integer"
+                        },
+                        "byterange": {
+                            "type": "object",
+                            "properties": {
+                                "memcap": {
+                                    "type": "integer"
+                                },
+                                "memuse": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "host": {
+                    "type": "object",
+                    "properties": {
+                        "memcap": {
+                            "type": "integer"
+                        },
+                        "memuse": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ippair": {
+                    "type": "object",
+                    "properties": {
+                        "memcap": {
+                            "type": "integer"
+                        },
+                        "memuse": {
+                            "type": "integer"
                         }
                     },
                     "additionalProperties": false

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -174,6 +174,16 @@ uint64_t FTPMemcapGlobalCounter(void)
     return tmpval;
 }
 
+int FTPSetMemcap(uint64_t size)
+{
+    if ((uint64_t)SC_ATOMIC_GET(ftp_memcap) < size) {
+        SC_ATOMIC_SET(ftp_memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
 /**
  *  \brief Check if alloc'ing "size" would mean we're over memcap
  *

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -185,6 +185,7 @@ typedef struct FtpDataState_ {
 void RegisterFTPParsers(void);
 void FTPParserRegisterTests(void);
 void FTPParserCleanup(void);
+int FTPSetMemcap(uint64_t size);
 uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 

--- a/src/app-layer-htp-range.c
+++ b/src/app-layer-htp-range.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -41,6 +41,28 @@ ContainerTHashTable ContainerUrlRangeList;
 static void HttpRangeBlockDerefContainer(HttpRangeContainerBlock *b);
 
 #define CONTAINER_URLRANGE_HASH_SIZE 256
+
+int HTPByteRangeSetMemcap(uint64_t size)
+{
+    if (size == 0 || (uint64_t)SC_ATOMIC_GET(ContainerUrlRangeList.ht->memuse) < size) {
+        SC_ATOMIC_SET(ContainerUrlRangeList.ht->config.memcap, size);
+        return 1;
+    }
+
+    return 0;
+}
+
+uint64_t HTPByteRangeMemcapGlobalCounter(void)
+{
+    uint64_t tmpval = SC_ATOMIC_GET(ContainerUrlRangeList.ht->config.memcap);
+    return tmpval;
+}
+
+uint64_t HTPByteRangeMemuseGlobalCounter(void)
+{
+    uint64_t tmpval = SC_ATOMIC_GET(ContainerUrlRangeList.ht->memuse);
+    return tmpval;
+}
 
 int HttpRangeContainerBufferCompare(HttpRangeContainerBuffer *a, HttpRangeContainerBuffer *b)
 {

--- a/src/app-layer-htp-range.h
+++ b/src/app-layer-htp-range.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021 Open Information Security Foundation
+/* Copyright (C) 2024 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -110,5 +110,9 @@ HttpRangeContainerBlock *HttpRangeContainerOpenFile(const unsigned char *key, ui
         uint32_t data_len);
 
 void HttpRangeFreeBlock(HttpRangeContainerBlock *b);
+
+uint64_t HTPByteRangeMemcapGlobalCounter(void);
+uint64_t HTPByteRangeMemuseGlobalCounter(void);
+int HTPByteRangeSetMemcap(uint64_t);
 
 #endif /* SURICATA_APP_LAYER_HTP_RANGE_H */

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -31,6 +31,7 @@
 #include "app-layer-protos.h"
 #include "app-layer-expectation.h"
 #include "app-layer-ftp.h"
+#include "app-layer-htp-range.h"
 #include "app-layer-detect-proto.h"
 #include "app-layer-frames.h"
 #include "stream-tcp-reassemble.h"
@@ -1113,6 +1114,12 @@ void AppLayerRegisterGlobalCounters(void)
     StatsRegisterGlobalCounter("ftp.memuse", FTPMemuseGlobalCounter);
     StatsRegisterGlobalCounter("ftp.memcap", FTPMemcapGlobalCounter);
     StatsRegisterGlobalCounter("app_layer.expectations", ExpectationGetCounter);
+    StatsRegisterGlobalCounter("http.byterange.memuse", HTPByteRangeMemuseGlobalCounter);
+    StatsRegisterGlobalCounter("http.byterange.memcap", HTPByteRangeMemcapGlobalCounter);
+    StatsRegisterGlobalCounter("ippair.memuse", IPPairGetMemuse);
+    StatsRegisterGlobalCounter("ippair.memcap", IPPairGetMemuse);
+    StatsRegisterGlobalCounter("host.memuse", HostGetMemuse);
+    StatsRegisterGlobalCounter("host.memcap", HostGetMemcap);
 }
 
 static bool IsAppLayerErrorExceptionPolicyStatsValid(enum ExceptionPolicy policy)

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -86,50 +86,20 @@ const char *RunModeUnixSocketGetDefaultMode(void)
     return "autofp";
 }
 
-#define MEMCAPS_MAX 7
-static MemcapCommand memcaps[MEMCAPS_MAX] = {
+static MemcapCommand memcaps[] = {
     {
-        "stream",
-        StreamTcpSetMemcap,
-        StreamTcpGetMemcap,
-        StreamTcpMemuseCounter,
+            "stream",
+            StreamTcpSetMemcap,
+            StreamTcpGetMemcap,
+            StreamTcpMemuseCounter,
     },
-    {
-        "stream-reassembly",
-        StreamTcpReassembleSetMemcap,
-        StreamTcpReassembleGetMemcap,
-        StreamTcpReassembleMemuseGlobalCounter
-    },
-    {
-        "flow",
-        FlowSetMemcap,
-        FlowGetMemcap,
-        FlowGetMemuse
-    },
-    {
-        "applayer-proto-http",
-        HTPSetMemcap,
-        HTPGetMemcap,
-        HTPMemuseGlobalCounter
-    },
-    {
-        "defrag",
-        DefragTrackerSetMemcap,
-        DefragTrackerGetMemcap,
-        DefragTrackerGetMemuse
-    },
-    {
-        "ippair",
-        IPPairSetMemcap,
-        IPPairGetMemcap,
-        IPPairGetMemuse
-    },
-    {
-        "host",
-        HostSetMemcap,
-        HostGetMemcap,
-        HostGetMemuse
-    },
+    { "stream-reassembly", StreamTcpReassembleSetMemcap, StreamTcpReassembleGetMemcap,
+            StreamTcpReassembleMemuseGlobalCounter },
+    { "flow", FlowSetMemcap, FlowGetMemcap, FlowGetMemuse },
+    { "applayer-proto-http", HTPSetMemcap, HTPGetMemcap, HTPMemuseGlobalCounter },
+    { "defrag", DefragTrackerSetMemcap, DefragTrackerGetMemcap, DefragTrackerGetMemuse },
+    { "ippair", IPPairSetMemcap, IPPairGetMemcap, IPPairGetMemuse },
+    { "host", HostSetMemcap, HostGetMemcap, HostGetMemuse },
 };
 
 float MemcapsGetPressure(void)
@@ -1523,7 +1493,6 @@ TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data)
     char *memcap = NULL;
     char *value_str = NULL;
     uint64_t value;
-    int i;
 
     json_t *jarg = json_object_get(cmd, "config");
     if (!json_is_string(jarg)) {
@@ -1549,7 +1518,7 @@ TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data)
         return TM_ECODE_FAILED;
     }
 
-    for (i = 0; i < MEMCAPS_MAX; i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(memcaps); i++) {
         if (strcmp(memcaps[i].name, memcap) == 0 && memcaps[i].SetFunc) {
             int updated = memcaps[i].SetFunc(value);
             char message[150];
@@ -1592,7 +1561,6 @@ TmEcode UnixSocketSetMemcap(json_t *cmd, json_t* answer, void *data)
 TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data)
 {
     char *memcap = NULL;
-    int i;
 
     json_t *jarg = json_object_get(cmd, "config");
     if (!json_is_string(jarg)) {
@@ -1601,7 +1569,7 @@ TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data)
     }
     memcap = (char *)json_string_value(jarg);
 
-    for (i = 0; i < MEMCAPS_MAX; i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(memcaps); i++) {
         if (strcmp(memcaps[i].name, memcap) == 0 && memcaps[i].GetFunc) {
             char str[50];
             uint64_t val = memcaps[i].GetFunc();
@@ -1632,7 +1600,6 @@ TmEcode UnixSocketShowMemcap(json_t *cmd, json_t *answer, void *data)
 TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data)
 {
     json_t *jmemcaps = json_array();
-    int i;
 
     if (jmemcaps == NULL) {
         json_object_set_new(answer, "message",
@@ -1640,7 +1607,7 @@ TmEcode UnixSocketShowAllMemcap(json_t *cmd, json_t *answer, void *data)
         return TM_ECODE_FAILED;
     }
 
-    for (i = 0; i < MEMCAPS_MAX; i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(memcaps); i++) {
         json_t *jobj = json_object();
         if (jobj == NULL) {
             json_decref(jmemcaps);

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -44,7 +44,9 @@
 #include "defrag-hash.h"
 #include "ippair.h"
 #include "app-layer.h"
+#include "app-layer-ftp.h"
 #include "app-layer-htp-mem.h"
+#include "app-layer-htp-range.h"
 #include "host-bit.h"
 
 #include "util-misc.h"
@@ -97,9 +99,12 @@ static MemcapCommand memcaps[] = {
             StreamTcpReassembleMemuseGlobalCounter },
     { "flow", FlowSetMemcap, FlowGetMemcap, FlowGetMemuse },
     { "applayer-proto-http", HTPSetMemcap, HTPGetMemcap, HTPMemuseGlobalCounter },
+    { "applayer-proto-http-byterange", HTPByteRangeSetMemcap, HTPByteRangeMemcapGlobalCounter,
+            HTPByteRangeMemuseGlobalCounter },
     { "defrag", DefragTrackerSetMemcap, DefragTrackerGetMemcap, DefragTrackerGetMemuse },
     { "ippair", IPPairSetMemcap, IPPairGetMemcap, IPPairGetMemuse },
     { "host", HostSetMemcap, HostGetMemcap, HostGetMemuse },
+    { "ftp", FTPSetMemcap, FTPMemcapGlobalCounter, FTPMemuseGlobalCounter },
 };
 
 float MemcapsGetPressure(void)

--- a/src/util-thash.h
+++ b/src/util-thash.h
@@ -122,7 +122,7 @@ typedef int (*THashOutputFunc)(void *output_ctx, const uint8_t *data, const uint
 typedef int (*THashFormatFunc)(const void *in_data, char *output, size_t output_size);
 
 typedef struct THashDataConfig_ {
-    uint64_t memcap;
+    SC_ATOMIC_DECLARE(uint64_t, memcap);
     uint32_t hash_rand;
     uint32_t hash_size;
     uint32_t prealloc;
@@ -161,8 +161,9 @@ typedef struct THashTableContext_ {
  *  \retval 1 it fits
  *  \retval 0 no fit
  */
-#define THASH_CHECK_MEMCAP(ctx, size) \
-    ((((uint64_t)SC_ATOMIC_GET((ctx)->memuse) + (uint64_t)(size)) <= (ctx)->config.memcap))
+#define THASH_CHECK_MEMCAP(ctx, size)                                                              \
+    ((((uint64_t)SC_ATOMIC_GET((ctx)->memuse) + (uint64_t)(size)) <=                               \
+            SC_ATOMIC_GET((ctx)->config.memcap)))
 
 #define THashIncrUsecnt(h) \
     (void)SC_ATOMIC_ADD((h)->use_cnt, 1)


### PR DESCRIPTION
Ensure memcap/memuse stats are reported and available via the socket interface. See the table in Redmine issue 845 for coverage

Link to ticket: https://redmine.openinfosecfoundation.org/issues/845

Describe changes:
- New memcap/memuse stats for: http.byterange, ippair, host
- New memcap settings via socket for: FTP, HTTP byterange


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
