### PR TITLE
eve: threadinit/deinit callbacks are optional for filetypes

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1050,9 +1050,11 @@ static int LogFileTypePrepare(
                     &json_ctx->file_ctx->filetype.init_data) < 0) {
             return -1;
         }
-        if (json_ctx->filetype->ThreadInit(json_ctx->file_ctx->filetype.init_data, 0,
-                    &json_ctx->file_ctx->filetype.thread_data) < 0) {
-            return -1;
+        if (json_ctx->filetype->ThreadInit) {
+            if (json_ctx->filetype->ThreadInit(json_ctx->file_ctx->filetype.init_data, 0,
+                        &json_ctx->file_ctx->filetype.thread_data) < 0) {
+                return -1;
+            }
         }
         json_ctx->file_ctx->filetype.filetype = json_ctx->filetype;
     }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -871,7 +871,7 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCReturnInt(0);
     }
 
-    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE) {
+    if (lf_ctx->type == LOGFILE_TYPE_FILETYPE && lf_ctx->filetype.filetype->ThreadDeinit) {
         lf_ctx->filetype.filetype->ThreadDeinit(
                 lf_ctx->filetype.init_data, lf_ctx->filetype.thread_data);
     }


### PR DESCRIPTION
Only call ThreadInit and ThreadDeinit for custom eve filetypes if they
exist. They are not required by all filetypes.

Ticket: https://redmine.openinfosecfoundation.org/issues/7359
