### PR TITLE
TLS-JSON: Allow logging of client handshake parameters

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1040,6 +1040,9 @@ If extended logging is enabled the following fields are also included:
 * "ja4": The JA4 client fingerprint for TLS
 * "client_alpns": array of strings with ALPN values
 * "server_alpns": array of strings with ALPN values
+* "client": structure containing "ciphers", "exts", "sig_algs", for client
+  hello supported cipher suites, extensions, and signature algorithms,
+  respectively, in the order that they're mentioned (ie. unsorted)
 
 JA3 and JA4 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints'/'app-layer.protocols.tls.ja4-fingerprints' to 'yes').
 

--- a/rust/src/ja4.rs
+++ b/rust/src/ja4.rs
@@ -275,6 +275,24 @@ pub unsafe extern "C" fn SCJA4GetHash(j: &mut JA4, out: &mut [u8; 36]) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn SCJA4GetCiphers(j: &mut JA4, out: *mut usize) -> *const u16 {
+    *out = j.ciphersuites.len();
+    j.ciphersuites.as_ptr() as *const u16
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4GetExtensions(j: &mut JA4, out: *mut usize) -> *const u16 {
+    *out = j.extensions.len();
+    j.extensions.as_ptr() as *const u16
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCJA4GetSigAlgs(j: &mut JA4, out: *mut usize) -> *const u16 {
+    *out = j.signature_algorithms.len();
+    j.signature_algorithms.as_ptr()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn SCJA4Free(j: &mut JA4) {
     let ja4: Box<JA4> = Box::from_raw(j);
     std::mem::drop(ja4);

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -58,6 +58,7 @@
 #define LOG_TLS_FIELD_SUBJECTALTNAME  BIT_U64(17)
 #define LOG_TLS_FIELD_CLIENT_ALPNS    BIT_U64(18)
 #define LOG_TLS_FIELD_SERVER_ALPNS    BIT_U64(19)
+#define LOG_TLS_FIELD_CLIENT_HELLO    BIT_U64(20)
 
 typedef struct {
     const char *name;
@@ -86,6 +87,7 @@ TlsFields tls_fields[] = {
     { "subjectaltname", LOG_TLS_FIELD_SUBJECTALTNAME },
     { "client_alpns", LOG_TLS_FIELD_CLIENT_ALPNS },
     { "server_alpns", LOG_TLS_FIELD_SERVER_ALPNS },
+    { "client_hello", LOG_TLS_FIELD_CLIENT_HELLO },
     { NULL, -1 },
     // clang-format on
 };
@@ -301,6 +303,41 @@ static void JsonTlsLogAlpns(JsonBuilder *js, SSLStateConnp *connp, const char *o
     jb_close(js);
 }
 
+static void JsonTlsLogClientHello(JsonBuilder *js, SSLState *ssl_state)
+{
+    const uint16_t *val;
+    uintptr_t i, nr;
+
+    if (ssl_state->client_connp.ja4 == NULL) {
+        return;
+    }
+
+    jb_open_object(js, "client");
+
+    val = SCJA4GetCiphers(ssl_state->client_connp.ja4, &nr);
+    jb_open_array(js, "ciphers");
+    for (i = 0; i < nr; i++) {
+        jb_append_uint(js, val[i]);
+    }
+    jb_close(js);
+
+    val = SCJA4GetExtensions(ssl_state->client_connp.ja4, &nr);
+    jb_open_array(js, "exts");
+    for (i = 0; i < nr; i++) {
+        jb_append_uint(js, val[i]);
+    }
+    jb_close(js);
+
+    val = SCJA4GetSigAlgs(ssl_state->client_connp.ja4, &nr);
+    jb_open_array(js, "sig_algs");
+    for (i = 0; i < nr; i++) {
+        jb_append_uint(js, val[i]);
+    }
+    jb_close(js);
+
+    jb_close(js);
+}
+
 static void JsonTlsLogCertificate(JsonBuilder *js, SSLStateConnp *connp)
 {
     if (TAILQ_EMPTY(&connp->certs)) {
@@ -452,6 +489,10 @@ static void JsonTlsLogFields(JsonBuilder *js, SSLState *ssl_state, uint64_t fiel
             JsonTlsLogClientCert(js, &ssl_state->client_connp, log_cert, log_chain);
             jb_close(js);
         }
+    }
+
+    if (fields & LOG_TLS_FIELD_CLIENT_HELLO) {
+        JsonTlsLogClientHello(js, ssl_state);
     }
 }
 


### PR DESCRIPTION
## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6695

## Description
Add a new custom log field "client_hello" which logs the following:
1. TLS extensions, excluding GREASE, SNI and ALPN
2. All cipher suites, excluding GREASE
3. All signature algorithms, excluding GREASE

The use-case is for logging TLS handshake parameters in order to survey them, and so that JA4 hashes can be computed offline (in the case that they're not already computed for the purposes of rule matching).

My questions are:
- should we exclude grease/SNI/ALPN or keep them in...
- is this schema acceptable? or should I flatten it out?
- in future should we looking at moving more things into rust, eg. put ALPNs and other parameters there to avoid duplication between C and rust structs, and have rust become something a "TLS handshake" struct, which can compute a JA3 or a JA4 as needed? It seems to me like that would simplify a lot and maximise the amount of safe code