### PR TITLE
detect/filestore: fix options handling and filestore impact

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -5799,12 +5799,12 @@ libhtp:\n\
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
 
-    FAIL_IF((PacketAlertCheck(p1, 1)));
+    FAIL_IF((PacketAlertCheck(p1, 2)));
 
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
 
-    FAIL_IF((PacketAlertCheck(p1, 1)));
+    FAIL_IF((PacketAlertCheck(p1, 2)));
 
     r = AppLayerParserParse(
             &th_v, alp_tctx, &f, ALPROTO_HTTP1, STREAM_TOCLIENT, httpbuf2, httplen2);

--- a/src/detect-engine-file.c
+++ b/src/detect-engine-file.c
@@ -194,7 +194,15 @@ uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx 
     if (ffc == NULL) {
         SCReturnInt(DETECT_ENGINE_INSPECT_SIG_CANT_MATCH_FILES);
     } else if (ffc->head == NULL) {
-        SCReturnInt(DETECT_ENGINE_INSPECT_SIG_NO_MATCH);
+        if (s->flags & SIG_FLAG_FILESTORE) {
+            if (s->filestore_ctx && (s->filestore_ctx->scope == FILESTORE_SCOPE_TX)) {
+                det_ctx->filestore[det_ctx->filestore_cnt].file_id = 0;
+                det_ctx->filestore[det_ctx->filestore_cnt].tx_id = det_ctx->tx_id;
+                det_ctx->filestore_cnt++;
+            }
+            SCReturnInt(DETECT_ENGINE_INSPECT_SIG_MATCH);
+        } else
+            SCReturnInt(DETECT_ENGINE_INSPECT_SIG_NO_MATCH);
     }
 
     uint8_t r = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;


### PR DESCRIPTION
The filestore keyword had an influence on the signature matching when it should not.

Also the options of filestore were not honored correctly.

This patch updates the logic in filestore keyword handling to fix the problems.

Tickets: 7356 7357

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to tickets:
- https://redmine.openinfosecfoundation.org/issues/7356
- https://redmine.openinfosecfoundation.org/issues/7357

Describe changes:
- alert when filestore keyword is present without file in progress
- fix flow option of filestore
- fix tx option of filestore

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=https://github.com/regit/suricata-verify/
SV_BRANCH=issue-7347
