### PR TITLE
dpdk: add initial unittests for DPDK codebase v6

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -786,6 +786,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -809,6 +810,7 @@ jobs:
                 lz4-devel \
                 make \
                 parallel \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python \
@@ -829,7 +831,7 @@ jobs:
       - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow" ./configure --disable-shared
       - run: make check
       - run: make distclean
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -884,6 +886,7 @@ jobs:
                 cbindgen \
                 ccache \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -904,6 +907,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -920,7 +924,7 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
           LDFLAGS: "-fsanitize=address"
@@ -982,6 +986,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -1004,6 +1009,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1020,7 +1026,7 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: CC="clang" CFLAGS="$DEFAULT_CFLAGS -Wshadow -fsanitize=address -fno-omit-frame-pointer" ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           LDFLAGS: "-fsanitize=address"
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -1075,6 +1081,7 @@ jobs:
                 cbindgen \
                 ccache \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -1095,6 +1102,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1111,7 +1119,7 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: ./configure --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         env:
           CFLAGS: "${{ env.DEFAULT_CFLAGS }} -Wshadow -fsanitize=address -fno-omit-frame-pointer"
           LDFLAGS: "-fsanitize=address"
@@ -1160,6 +1168,7 @@ jobs:
                 ccache \
                 clang \
                 diffutils \
+                dpdk-devel \
                 file-devel \
                 gcc \
                 gcc-c++ \
@@ -1180,6 +1189,7 @@ jobs:
                 libtool \
                 lz4-devel \
                 make \
+                numactl-devel \
                 pcre2-devel \
                 pkgconfig \
                 python3-yaml \
@@ -1204,7 +1214,7 @@ jobs:
       - run: sudo -u suricata -s ./autogen.sh
         working-directory: /home/suricata/suricata
 
-      - run: sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue --enable-dpdk
         working-directory: /home/suricata/suricata
         env:
           ac_cv_func_realloc_0_nonnull: "yes"
@@ -1453,6 +1463,7 @@ jobs:
                 automake \
                 clang-14 \
                 curl \
+                dpdk-dev \
                 git \
                 jq \
                 libtool \
@@ -1496,7 +1507,7 @@ jobs:
       - run: tar xf prep/libhtp.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --disable-shared --enable-unittests
+      - run: ./configure --enable-warnings --disable-shared --enable-unittests --enable-dpdk
         env:
           CC: "clang-14"
           CXX: "clang++-14"
@@ -2906,6 +2917,7 @@ jobs:
                 autoconf \
                 build-essential \
                 ccache \
+                dpdk-dev \
                 curl \
                 git \
                 jq \
@@ -2917,6 +2929,7 @@ jobs:
                 libcap-ng-dev \
                 libcap-ng0 \
                 libmagic-dev \
+                libnuma-dev \
                 libjansson-dev \
                 libgeoip-dev \
                 libhiredis-dev \
@@ -2946,7 +2959,7 @@ jobs:
       - run: tar xf prep/suricata-update.tar.gz
       - uses: ./.github/actions/install-cbindgen
       - run: ./autogen.sh
-      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build
+      - run: CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --enable-fuzztargets --enable-ebpf --enable-ebpf-build --enable-dpdk
       - run: make -j ${{ env.CPUS }}
       - run: make check
       - run: tar xf prep/suricata-verify.tar.gz

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2530,7 +2530,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 22.11.4, 21.11.6, 20.11.10, 19.11.14 ]
+        dpdk_version: [ 23.11.2, 22.11.4, 21.11.6, 20.11.10, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2530,7 +2530,7 @@ jobs:
     needs: [ prepare-deps, prepare-cbindgen ]
     strategy:
       matrix:
-        dpdk_version: [ 23.11.2, 22.11.4, 21.11.6, 20.11.10, 19.11.14 ]
+        dpdk_version: [ 23.11.2, 22.11.6, 21.11.8, 20.11.10, 19.11.14 ]
     steps:
 
       # Cache Rust stuff.

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -49,6 +49,7 @@
 #include "util-conf.h"
 #include "suricata.h"
 #include "util-affinity.h"
+#include "conf-yaml-loader.h"
 
 #ifdef HAVE_DPDK
 
@@ -1800,6 +1801,351 @@ int RunModeIdsDpdkWorkers(void)
 #endif /* HAVE_DPDK */
     SCReturnInt(0);
 }
+
+#if defined(HAVE_DPDK) && defined(UNITTESTS)
+// prep stage
+static void DPDKRunmodeSetThreadsInit(const char *input, size_t input_len)
+{
+    // prep stage - config
+    ConfCreateContextBackup();
+    ConfInit();
+    int ret = ConfYamlLoadString(input, input_len);
+    if (ret != 0) {
+        FatalError("Unable to load configuration");
+    }
+    // prep stage - threading
+    RunModeInitializeThreadSettings();
+    // prep stage - interfaces
+    LiveBuildDeviceListCustom("unittest-ifaces", "iface");
+    LiveDeviceFinalize();
+    // prep stage - DPDK Threading
+    AutoRemainingThreadsInit(true);
+}
+
+// pre-test check stage
+#define SKIP_INCOMPATIBLE_ENVIRONMENT                                                              \
+    do {                                                                                           \
+        int ret = UnitTestsUtilAffinityVerifyCPURequirement();                                     \
+        FAIL_IF(ret < 0);                                                                          \
+        if (ret != 0)                                                                              \
+            return ret;                                                                            \
+    } while (0)
+
+// cleanup stage
+static void DPDKRunmodeSetThreadsDeinit(void)
+{
+    LiveDeviceListClean();
+    ConfDeInit();
+    ConfRestoreContextBackup();
+}
+
+static int DPDKRunmodeSetThreads01(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ \"0-1\" ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"0-1\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF(r != -EINVAL);
+
+    DPDKRunmodeSetThreadsDeinit();
+
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads02(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0,1 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"0-3\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF(iconf.threads != 2);
+    FAIL_IF(r != 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads03(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "auto");
+    FAIL_IF(iconf.threads != 2);
+    FAIL_IF(r != 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads04(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF(iconf1.threads != 1);
+    FAIL_IF(r1 != 0);
+    FAIL_IF(iconf2.threads != 1);
+    FAIL_IF(r2 != 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads05(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev1\n\
+    - iface: test_dev2\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-3\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf1 = { 0 };
+    int r1 = ConfigSetThreads(&iconf1, "auto");
+    DPDKIfaceConfig iconf2 = { 0 };
+    int r2 = ConfigSetThreads(&iconf2, "auto");
+    FAIL_IF(iconf1.threads != 2);
+    FAIL_IF(r1 != 0);
+    FAIL_IF(iconf2.threads != 1);
+    FAIL_IF(r2 != 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads06(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "-2");
+    FAIL_IF(r != -ERANGE);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "0");
+    FAIL_IF(r != -ERANGE);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "1");
+    FAIL_IF(r != 0);
+    FAIL_IF(iconf.threads != 1);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "abc");
+    FAIL_IF(r != -EINVAL);
+
+    memset(&iconf, 0, sizeof(iconf));
+    r = ConfigSetThreads(&iconf, "99999999999999");
+    FAIL_IF(r == 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetThreads07(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+unittest-ifaces:\n\
+    - iface: test_dev\n\
+threading:\n\
+    set-cpu-affinity: yes\n\
+    cpu-affinity:\n\
+        - management-cpu-set:\n\
+            cpu: [ 0 ] \n\
+        - worker-cpu-set:\n\
+            cpu: [ \"1-2\" ]\n\
+";
+
+    DPDKRunmodeSetThreadsInit(input, strlen(input));
+    SKIP_INCOMPATIBLE_ENVIRONMENT;
+
+    DPDKIfaceConfig iconf = { 0 };
+    int r = ConfigSetThreads(&iconf, "2");
+    FAIL_IF(iconf.threads != 2);
+    FAIL_IF(r != 0);
+
+    DPDKRunmodeSetThreadsDeinit();
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize01(void)
+{
+    DPDKIfaceConfig iconf;
+    const char *entry_str;
+
+    entry_str = NULL;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != -EINVAL);
+
+    entry_str = "";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != -EINVAL);
+
+    entry_str = "-1";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != -EINVAL);
+
+    entry_str = "999999999999999999";
+    r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != -EINVAL);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize02(void)
+{
+    DPDKIfaceConfig iconf;
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "auto");
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != 0);
+    FAIL_IF(iconf.mempool_cache_size >= RTE_MEMPOOL_CACHE_MAX_SIZE);
+    FAIL_IF(iconf.mempool_cache_size >= iconf.mempool_size / 1.5);
+    FAIL_IF(iconf.mempool_size % iconf.mempool_cache_size != 0);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize03(void)
+{
+    DPDKIfaceConfig iconf;
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", 1);
+    iconf.mempool_size = 1023;
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != 0);
+    FAIL_IF(iconf.mempool_cache_size != 1);
+
+    PASS;
+}
+
+static int DPDKRunmodeSetMempoolCacheSize04(void)
+{
+    DPDKIfaceConfig iconf;
+    char entry_str[32];
+
+    snprintf(entry_str, sizeof(entry_str), "%d", RTE_MEMPOOL_CACHE_MAX_SIZE + 1);
+    int r = ConfigSetMempoolCacheSize(&iconf, entry_str);
+    FAIL_IF(r != -ERANGE);
+
+    PASS;
+}
+
+/**
+ * \brief This function registers unit tests for AlertFastLog API.
+ */
+void DPDKRunmodeRegisterTests(void)
+{
+
+    UtRegisterTest("DPDKRunmodeSetThreads01", DPDKRunmodeSetThreads01);
+    UtRegisterTest("DPDKRunmodeSetThreads02", DPDKRunmodeSetThreads02);
+    UtRegisterTest("DPDKRunmodeSetThreads03", DPDKRunmodeSetThreads03);
+    UtRegisterTest("DPDKRunmodeSetThreads04", DPDKRunmodeSetThreads04);
+    UtRegisterTest("DPDKRunmodeSetThreads05", DPDKRunmodeSetThreads05);
+    UtRegisterTest("DPDKRunmodeSetThreads06", DPDKRunmodeSetThreads06);
+    UtRegisterTest("DPDKRunmodeSetThreads07", DPDKRunmodeSetThreads07);
+
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize01", DPDKRunmodeSetMempoolCacheSize01);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize02", DPDKRunmodeSetMempoolCacheSize02);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize03", DPDKRunmodeSetMempoolCacheSize03);
+    UtRegisterTest("DPDKRunmodeSetMempoolCacheSize04", DPDKRunmodeSetMempoolCacheSize04);
+}
+#endif /* UNITTESTS and HAVE_DPDK */
 
 /**
  * @}

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -359,10 +359,51 @@ static void ConfigSetIface(DPDKIfaceConfig *iconf, const char *entry_str)
     SCReturn;
 }
 
+static int32_t remaining_auto_cpus = -1;
+/**
+ * Initialize the number of remaining auto-assigned threads
+ * \param total_cpus Total number of CPU cores available
+ * \param force_reinit Force reinitialization of the remaining threads after auto-assign
+ */
+static void AutoRemainingThreadsInit(bool force_reinit)
+{
+    if (remaining_auto_cpus == -1 || force_reinit) {
+        ThreadsAffinityType *wtaf = GetAffinityTypeFromName("worker-cpu-set");
+        if (wtaf == NULL)
+            FatalError("Worker-cpu-set not listed in the threading section");
+
+        int32_t total_cpus = UtilAffinityGetAffinedCPUNum(wtaf);
+        if (total_cpus == 0)
+            FatalError("No worker CPU cores with affinity were configured");
+
+        int32_t ldevs = LiveGetDeviceCount();
+        if (ldevs == 0)
+            FatalError("No devices configured");
+        remaining_auto_cpus = total_cpus % ldevs;
+    }
+}
+
+/**
+ * Decrease the number of remaining auto-assigned threads by one
+ * \return Remaining number of the auto-assigned leftover threads
+ */
+static bool AutoRemainingThreadsUsedOne(void)
+{
+    if (remaining_auto_cpus == -1) {
+        FatalError("Not yet initialized");
+    }
+
+    if (remaining_auto_cpus > 0) {
+        remaining_auto_cpus--;
+        return true;
+    }
+
+    return false;
+}
+
 static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
 {
     SCEnter();
-    static int32_t remaining_auto_cpus = -1;
     if (!threading_set_cpu_affinity) {
         SCLogError("DPDK runmode requires configured thread affinity");
         SCReturnInt(-EINVAL);
@@ -412,15 +453,9 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
             SCReturnInt(-ERANGE);
         }
 
-        if (remaining_auto_cpus > 0) {
+        AutoRemainingThreadsInit(false);
+        if (AutoRemainingThreadsUsedOne()) {
             iconf->threads++;
-            remaining_auto_cpus--;
-        } else if (remaining_auto_cpus == -1) {
-            remaining_auto_cpus = (int32_t)sched_cpus % LiveGetDeviceCount();
-            if (remaining_auto_cpus > 0) {
-                iconf->threads++;
-                remaining_auto_cpus--;
-            }
         }
         SCLogConfig("%s: auto-assigned %u threads", iconf->iface, iconf->threads);
         SCReturnInt(0);

--- a/src/runmode-dpdk.h
+++ b/src/runmode-dpdk.h
@@ -45,4 +45,6 @@ int RunModeIdsDpdkWorkers(void);
 void RunModeDpdkRegister(void);
 const char *RunModeDpdkGetDefaultMode(void);
 
+void DPDKRunmodeRegisterTests(void);
+
 #endif /* SURICATA_RUNMODE_DPDK_H */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -122,6 +122,8 @@
 #include "source-windivert.h"
 #endif
 
+#include "runmode-dpdk.h"
+
 #endif /* UNITTESTS */
 
 void TmqhSetup (void);
@@ -212,6 +214,9 @@ static void RegisterUnittests(void)
     SCProtoNameRegisterTests();
     UtilCIDRTests();
     OutputJsonStatsRegisterTests();
+#ifdef HAVE_DPDK
+    DPDKRunmodeRegisterTests();
+#endif
 }
 #endif
 

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -352,12 +352,15 @@ uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType 
  */
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf)
 {
-    cpu_set_t tmpset;
     SCMutexLock(&mod_taf->taf_mutex);
     SCMutexLock(&static_taf->taf_mutex);
-    CPU_XOR(&tmpset, &mod_taf->cpu_set, &static_taf->cpu_set);
+    int max_cpus = UtilCpuGetNumProcessorsOnline();
+    for (int cpu = 0; cpu < max_cpus; cpu++) {
+        if (CPU_ISSET(cpu, &mod_taf->cpu_set) && CPU_ISSET(cpu, &static_taf->cpu_set)) {
+            CPU_CLR(cpu, &mod_taf->cpu_set);
+        }
+    }
     SCMutexUnlock(&static_taf->taf_mutex);
-    mod_taf->cpu_set = tmpset;
     SCMutexUnlock(&mod_taf->taf_mutex);
 }
 #endif /* HAVE_DPDK */

--- a/src/util-affinity.c
+++ b/src/util-affinity.c
@@ -319,7 +319,38 @@ uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf)
     return ncpu;
 }
 
-#ifdef HAVE_DPDK
+#ifdef __linux__
+#ifdef UNITTESTS
+/**
+ * \brief Verify that the CPU requirement is met
+ * \retval 0 if the requirement is met, 2 if the test is skipped, negative number otherwise
+ */
+int UnitTestsUtilAffinityVerifyCPURequirement(void)
+{
+    ThreadsAffinityType *wtaf = GetAffinityTypeFromName("worker-cpu-set");
+    if (wtaf == NULL) {
+        SCLogError("Specify worker-cpu-set list in the threading section");
+        SCReturnInt(-EINVAL);
+    }
+    ThreadsAffinityType *mtaf = GetAffinityTypeFromName("management-cpu-set");
+    if (mtaf == NULL) {
+        SCLogError("Specify management-cpu-set list in the threading section");
+        SCReturnInt(-EINVAL);
+    }
+    UtilAffinityCpusExclude(wtaf, mtaf);
+    uint32_t sched_cpus = UtilAffinityGetAffinedCPUNum(wtaf) + UtilAffinityGetAffinedCPUNum(mtaf);
+
+    if (UtilCpuGetNumProcessorsOnline() < sched_cpus) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg),
+                "not enough cpus in the system, the test requires at least %d cores", sched_cpus);
+        SKIP(err_msg);
+    }
+    return 0;
+}
+
+#endif /* UNITTESTS */
+
 /**
  * Find if CPU sets overlap
  * \return 1 if CPUs overlap, 0 otherwise
@@ -363,4 +394,4 @@ void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *
     SCMutexUnlock(&static_taf->taf_mutex);
     SCMutexUnlock(&mod_taf->taf_mutex);
 }
-#endif /* HAVE_DPDK */
+#endif /* __linux__ */

--- a/src/util-affinity.h
+++ b/src/util-affinity.h
@@ -88,10 +88,14 @@ ThreadsAffinityType * GetAffinityTypeFromName(const char *name);
 
 uint16_t AffinityGetNextCPU(ThreadsAffinityType *taf);
 uint16_t UtilAffinityGetAffinedCPUNum(ThreadsAffinityType *taf);
-#ifdef HAVE_DPDK
+#ifdef __linux__
 uint16_t UtilAffinityCpusOverlap(ThreadsAffinityType *taf1, ThreadsAffinityType *taf2);
 void UtilAffinityCpusExclude(ThreadsAffinityType *mod_taf, ThreadsAffinityType *static_taf);
-#endif /* HAVE_DPDK */
+
+#ifdef UNITTESTS
+int UnitTestsUtilAffinityVerifyCPURequirement(void);
+#endif /* UNITTESTS */
+#endif /* __linux__ */
 
 void BuildCpusetWithCallback(const char *name, ConfNode *node,
                              void (*Callback)(int i, void * data),

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -340,6 +340,8 @@ int LiveDeviceListClean(void)
         SCFree(pd);
     }
 
+    // set the list to NULL
+    TAILQ_INIT(&live_devices);
     SCReturnInt(TM_ECODE_OK);
 }
 
@@ -451,6 +453,9 @@ void LiveDeviceFinalize(void)
         }
         SCFree(ld);
     }
+
+    // set the list to NULL
+    TAILQ_INIT(&pre_live_devices);
 }
 
 static void LiveDevExtensionFree(void *x)

--- a/src/util-dpdk-bonding.c
+++ b/src/util-dpdk-bonding.c
@@ -52,7 +52,10 @@ uint16_t BondingMemberDevicesGet(
 {
 #ifdef HAVE_DPDK_BOND
 #if RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     int32_t len = rte_eth_bond_members_get(bond_pid, bonded_devs, bonded_devs_length);
+#pragma GCC diagnostic pop
 #else
     int32_t len = rte_eth_bond_slaves_get(bond_pid, bonded_devs, bonded_devs_length);
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(23, 11, 0, 0) */

--- a/src/util-unittest.c
+++ b/src/util-unittest.c
@@ -188,7 +188,7 @@ void UtListTests(const char *regex_arg)
 uint32_t UtRunTests(const char *regex_arg)
 {
     UtTest *ut;
-    uint32_t good = 0, bad = 0, matchcnt = 0;
+    uint32_t good = 0, skip = 0, bad = 0, matchcnt = 0;
     int ret = 0, rcomp = 0;
 
     StreamTcpInitMemuse();
@@ -225,22 +225,28 @@ uint32_t UtRunTests(const char *regex_arg)
                     ret = 0;
                 }
 
-                printf("%s\n", ret ? "pass" : "FAILED");
-
                 if (!ret) {
                     if (unittests_fatal == 1) {
                         fprintf(stderr, "ERROR: unittest failed.\n");
                         exit(EXIT_FAILURE);
                     }
                     bad++;
+                    printf("FAILED\n");
+                } else if (ret == 2) {
+                    skip++;
+                    printf("skip\n");
                 } else {
                     good++;
+                    printf("pass\n");
                 }
             }
         }
         if(matchcnt > 0){
             printf("==== TEST RESULTS ====\n");
             printf("PASSED: %" PRIu32 "\n", good);
+            if (skip > 0) {
+                printf("SKIPPED: %" PRIu32 "\n", skip);
+            }
             printf("FAILED: %" PRIu32 "\n", bad);
             printf("======================\n");
         } else {

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -106,6 +106,18 @@ extern int unittests_fatal;
         return 1; \
     } while (0)
 
+/**
+ * \brief Skip the test.
+ *
+ * Used to skip the tests that cannot be run in the current environment.
+ * The aim is to keep this at 0.
+ */
+#define SKIP(reason)                                                                               \
+    do {                                                                                           \
+        SCLogInfo("Test skipped: %s", reason);                                                     \
+        return 2;                                                                                  \
+    } while (0)
+
 #endif
 
 #endif /* SURICATA_UTIL_UNITTEST_H */


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6927
Follow-up of: #12081   

Describe changes:
v6:
- github ci runs reverted to suppressing the "deprecated" error
- expanded the explanation in the commit now
v5:
- fixed the includes
- github ci runs with experimental DPDK features in the build test for DPDK v23.11.*
- no more GCC deprecation warning pushes

v4
- fixed live device cleaning function
- silenced 23.11 DPDK bond warning about "deprecated" (experimental) function on Fedora 40 builds
- rebased

v3
- comments from Philippe
- I left TAILQ_INIT in the finalize/cleanup functions - all elements of the arrays are cleaned but not the base pointer of the array itself. TAILQ_* functions don't offer reset function but TAILQ_INIT provides the desired outcome
- moved guards around - per Philippe's suggestions

v2
- added a FatalError check on the number of LiveDevices
- changed #if HAVE_DPDK to #if defined(HAVE_DPDK) && defined(UNITTESTS)
- enabled unit tests in the Github workflow runs on Ubuntu and Fedora tasks

v1
- function-guarded variable
- fix the CPU exclude logic
- add DPDK unit tests