### PR TITLE
transform/base64: Add "set_error" to detect if buffer is valid base64 encoded content

### DIFF
--- a/doc/userguide/rules/transforms.rst
+++ b/doc/userguide/rules/transforms.rst
@@ -198,6 +198,11 @@ This transform is similar to the keyword ``base64_decode``: the buffer is decode
 the optional values for ``mode``, ``offset`` and ``bytes`` and is available for matching
 on the decoded data.
 
+The optional value ``set_error`` can also be specified; this causes the output buffer to be
+a fixed value when the input buffer cannot be decoded. This can be used in situations to determine
+if the content is base64-decoded. The fixed output buffer used when the input buffer cannot
+be decoded *and* ``set_error`` is specified is: ``BASE64_ECODE_BUF``.
+
 After this transform completes, the buffer will contain only bytes that could be bases64-decoded.
 If the decoding process encountered invalid bytes, those will not be included in the buffer.
 
@@ -209,12 +214,13 @@ The option values must be ``,`` separated and can appear in any order.
 
 Format::
 
-    from_base64: [[bytes <value>] [, offset <offset_value> [, mode: strict|rfc4648|rfc2045]]]
+    from_base64: [[bytes <value>] [, offset <offset_value> [, mode: strict|rfc4648|rfc2045] [, set_error]]]
 
 There are defaults for each of the options:
 - ``bytes`` defaults to the length of the input buffer
 - ``offset`` defaults to ``0`` and must be less than ``65536``
 - ``mode`` defaults to ``rfc4648``
+- ``set_error`` No default.
 
 Note that both ``bytes`` and ``offset`` may be variables from `byte_extract` and/or `byte_math` in
 later versions of Suricata. They are not supported yet.
@@ -243,3 +249,13 @@ This example transforms `"Zm 9v Ym Fy"` to `"foobar"`::
 
        content:"/?arg=Zm 9v Ym Fy"; from_base64: offset 6, mode rfc2045; \
        content:"foobar";
+
+This example uses ``set_error`` to test if the input is not-base64 encoded::
+
+       content:"Unencoded content"; from_base64: set_error; \
+       content:"BASE64_ECODE_BUF";
+
+This example uses ``set_error`` to test if the input is base64 encoded::
+
+       content:"/?arg=Zm 9v Ym Fy"; from_base64: set_error; \
+       content:!"BASE64_ECODE_BUF"; content: "foobar";

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -37,6 +37,8 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
+#define FROMBASE64_ERROR_BUFFER_VALUE ("BASE64_ECODE_BUF")
+#define FROMBASE64_ERROR_BUFFER_SIZE  (sizeof(FROMBASE64_ERROR_BUFFER_VALUE) - 1)
 static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
@@ -151,6 +153,9 @@ static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options)
     if (num_decoded > 0) {
         //            PrintRawDataFp(stdout, output, b64data->decoded_len);
         InspectionBufferCopy(buffer, decoded, num_decoded);
+    } else if (b64d->flags & DETECT_TRANSFORM_BASE64_FLAG_SET_ERROR) {
+        InspectionBufferCopy(
+                buffer, (uint8_t *)FROMBASE64_ERROR_BUFFER_VALUE, FROMBASE64_ERROR_BUFFER_SIZE);
     }
 }
 


### PR DESCRIPTION
This PR adds to the `from_base64` decode and provides an indication of whether the input buffer is properly encoded as a base64 buffer. Use `set_error` and if the buffer cannot be decoded, the output buffer will be set to `BASE64_ECODE_BUF`

Use this rule snippet to test whether the input is not properly encoded:
```
      content:"Unencoded content"; from_base64: set_error;  content:"BASE64_ECODE_BUF";
```

Use this rule snippet to test if the input is base64 encoded:
```
       content:"/?arg=Zm 9v Ym Fy"; from_base64: set_error;  content:!"BASE64_ECODE_BUF"; content: "foobar";
```
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7114

Describe changes:
- Add `set_error` to the transform's available option list
- Update the transform to set the output buffer when `set_error` is used
- Document new behavior

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2117
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
