### PR TITLE
suricata/bpf: fix -Wshorten-64-to-32 warning

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -505,7 +505,7 @@ static void SetBpfStringFromFile(char *filename)
     char *bpf_filter = NULL;
     char *bpf_comment_tmp = NULL;
     char *bpf_comment_start =  NULL;
-    uint32_t bpf_len = 0;
+    size_t bpf_len = 0;
     SCStat st;
     FILE *fp = NULL;
     size_t nm = 0;
@@ -520,7 +520,8 @@ static void SetBpfStringFromFile(char *filename)
         SCLogError("Failed to stat file %s", filename);
         exit(EXIT_FAILURE);
     }
-    bpf_len = st.st_size + 1;
+    // st.st_size is signed on Windows
+    bpf_len = ((size_t)(st.st_size)) + 1;
 
     bpf_filter = SCCalloc(1, bpf_len);
     if (unlikely(bpf_filter == NULL)) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7366
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- suricata/bpf: fix -Wshorten-64-to-32 warning

Next "batch" after https://github.com/OISF/suricata/pull/11958 with one dedicated ticket