### PR TITLE
RFC - WIP - userguide: explain rule types and categorization - v1

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -349,3 +349,74 @@ reassembled streams, TLS-, SSL-, SSH-, FTP- and dcerpc-buffers.
 
 Note that there are some exceptions, e.g. the ``http_raw_uri`` keyword.
 See :ref:`rules-http-uri-normalization` for more information.
+
+
+Rule's Types and Categorization
+-------------------------------
+
+Once parsed, Suricata rules are categorized for performance and further
+processing (as different rule types will be handled by specific modules).
+
+This categorization is done taking into consideration the type of keywords used.
+This will impact:
+
+  - scope
+  - how often/ when is the rule matched against traffic
+  - against what the rule matches
+
+The following table lists all Suricata signature types, and how they impact the
+aspects aforementioned.
+
+.. list-table:: Suricata Rule Types
+    :header-rows: 1
+
+    * - Type
+      - Scope
+      - Inspected
+      - Matches
+      - Keyword Examples
+    * - Decode Events Only
+      - Packet
+      - Per-packet basis
+      - Packets that are broken on an IP address level
+      - ---
+    * - Packet
+      - Packet
+      - Per-packet basis
+      - Packet-level info (e.g.: header info, ttl...)
+      - ---
+    * - IP Only
+      - Flow
+      - Once per direction
+      - On the flow, on IP address level
+      - ---
+    * - IP Only (negated address)
+      - Flow
+      - Once per direction
+      - On the flow, on IP address level (negated addressed)
+      - ---
+    * - Protocol Detection Only
+      - Flow
+      - Once per direction, when protocol detection is done
+      - app-layer-protocol keyword
+      - app-layer-protocol
+    * - Packet-Stream
+      - Flow, if stateful
+      - Match against the reassembled stream. If stream unavailable, match per-packet
+      - Flow, if stateful, per-packet if not
+      - 'content' with 'starts with' or 'depth'
+    * - Stream
+      - Flow, if stateful
+      - Flow, if stateful, per-packet basis if not
+      - Match on payload
+      - Match against the reassembled stream. If stream unavailable, match per-packet
+    * - Application Layer Protocol
+      - Flow
+      - Once per flow
+      - Match on protocol field
+      - protocol field of a rule
+    * - Application Layer Protocol Transactions
+      - Flow
+      - Per reassembled stream segment
+      - Matches on buffer keywords
+      - `http.host`, `rfb.secresult`, application-layer protocol-related keywords


### PR DESCRIPTION
Add documentation about the rule types introduced by commit 2696fda04168cb82.
----

Compiled docs: https://suri-rtd-test.readthedocs.io/en/doc-sigtypes-et-properties-v1/rules/intro.html#rule-s-types-and-categorization

This is a WIP, the table needs reviewing and expanding:

TODO:
- more examples 
- reviewing whether some of the explanations are actually correct
- feedback on where's the best place for this section to go is also welcome

There are some workflows that I would like to add to the documentation, too, somehow, but must find a good solution for not simply bringing images, but ideally something that can be generated from code description.

The purpose of this documentation is both for better informing our users, and also work as foundational work for the upcoming SuriCon presentation about the same topic.

Examples:
![APP_Layer, Packet, TX, STREAM-v20241029 drawio(1)](https://github.com/user-attachments/assets/30683712-968c-431c-b09a-3e910c52237e)

![OverallAlgoHorizontal-20241029-BiggerFontFriendlyLabels drawio](https://github.com/user-attachments/assets/b5ed61b8-201e-4b31-bfc7-507931c6f510)
