### PR TITLE
lua: update lua crate

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed3f46aa1b92feb15880f722bbce121e769bda1770f0090121cd6c920d89450"
+checksum = "dc101e1a884910f4730ca0c815f7cb2712a161729896b2ed64cd495b1946b693"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -69,7 +69,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.3" }
+suricata-lua-sys = { version = "0.1.0-alpha.4" }
 
 [dev-dependencies]
 test-case = "~3.3.1"


### PR DESCRIPTION
Update lua crate to 0.1.0-alpha.4. This update will force a rewrite of
the headers if the env var SURICATA_LUA_SYS_HEADER_DST changes. This
fixes the issue where the headers may not be written.

The cause is that Rust dependencies are cached, and if your editor is
using rust-analyzer, it might cache the built without this var being
set, so these headers are not available to Suricata. This crate update
forces the re-run of the Lua build.rs if this env var changes, fixing
this issue.
