### PR TITLE
userguide/runmodes: fix typo 

### DIFF
--- a/doc/userguide/performance/runmodes.rst
+++ b/doc/userguide/performance/runmodes.rst
@@ -12,7 +12,7 @@ a queue. Packets will be processed by one thread at a time, but there
 can be multiple packets being processed at a time by the engine (see
 :ref:`suricata-yaml-max-pending-packets`). A thread can have one or
 more thread-modules. If they have more modules, they can only be
-active one a a time.  The way threads, modules and queues are arranged
+active one at a time.  The way threads, modules and queues are arranged
 together is called the "Runmode".
 
 Different runmodes


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket (#7383) at 
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Describe changes:
- fixed a typo in the documentation

