### PR TITLE
Applayer plugin 5053 v3.11

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -109,7 +109,7 @@ impl From<Direction> for u8 {
 pub type AppProto = u16;
 
 pub const ALPROTO_UNKNOWN : AppProto = 0;
-pub static mut ALPROTO_FAILED : AppProto = 0; // updated during init
+pub const ALPROTO_FAILED : AppProto = 1;
 
 pub const IPPROTO_TCP : u8 = 6;
 pub const IPPROTO_UDP : u8 = 17;
@@ -252,7 +252,6 @@ pub fn init_ffi(context: &'static SuricataContext)
 {
     unsafe {
         SC = Some(context);
-        ALPROTO_FAILED = StringToAppProto("failed\0".as_ptr());
     }
 }
 

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -469,7 +469,7 @@ fn probe(input: &[u8], direction: Direction, rdir: *mut u8) -> AppProto {
         Ok((_, msg)) => {
             let ldap_msg = LdapMessage::from(msg);
             if ldap_msg.is_unknown() {
-                return unsafe { ALPROTO_FAILED };
+                return ALPROTO_FAILED;
             }
             if direction == Direction::ToServer && !ldap_msg.is_request() {
                 unsafe {
@@ -487,7 +487,7 @@ fn probe(input: &[u8], direction: Direction, rdir: *mut u8) -> AppProto {
             return ALPROTO_UNKNOWN;
         }
         Err(_e) => {
-            return unsafe { ALPROTO_FAILED };
+            return ALPROTO_FAILED;
         }
     }
 }

--- a/rust/src/modbus/modbus.rs
+++ b/rust/src/modbus/modbus.rs
@@ -281,7 +281,7 @@ pub extern "C" fn rs_modbus_probe(
     match MODBUS_PARSER.probe(slice, Direction::Unknown) {
         Status::Recognized => unsafe { ALPROTO_MODBUS },
         Status::Incomplete => ALPROTO_UNKNOWN,
-        Status::Unrecognized => unsafe { ALPROTO_FAILED },
+        Status::Unrecognized => ALPROTO_FAILED,
     }
 }
 

--- a/rust/src/ntp/ntp.rs
+++ b/rust/src/ntp/ntp.rs
@@ -259,7 +259,7 @@ pub extern "C" fn ntp_probing_parser(_flow: *const Flow,
             return ALPROTO_UNKNOWN;
         },
         Err(_) => {
-            return unsafe{ALPROTO_FAILED};
+            return ALPROTO_FAILED;
         },
     }
 }

--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -496,7 +496,6 @@ fn register_pattern_probe(proto: u8) -> i8 {
         "ACK\0",
         "BYE\0",
         "CANCEL\0",
-        "UPDATE\0",
         "REFER\0",
         "PRACK\0",
         "SUBSCRIBE\0",
@@ -526,6 +525,16 @@ fn register_pattern_probe(proto: u8) -> i8 {
             0,
             core::Direction::ToClient as u8,
         );
+        if proto == core::IPPROTO_UDP {
+            r |= AppLayerProtoDetectPMRegisterPatternCS(
+                proto,
+                ALPROTO_SIP,
+                "UPDATE\0".as_ptr() as *const std::os::raw::c_char,
+                "UPDATE".len() as u16,
+                0,
+                core::Direction::ToServer as u8,
+            );
+        }
     }
 
     if r == 0 {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2154,7 +2154,7 @@ fn smb_probe_tcp(flags: u8, slice: &[u8], rdir: *mut u8, begins: bool) -> AppPro
             }
     }
     SCLogDebug!("no smb");
-    unsafe { return ALPROTO_FAILED; }
+    return ALPROTO_FAILED;
 }
 
 // probing confirmation parser

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -129,7 +129,7 @@ def patch_app_layer_protos_h(protoname):
     open(filename, "w").write(output.getvalue())
 
 def patch_app_layer_protos_c(protoname):
-    filename = "src/app-layer-protos.c"
+    filename = "src/app-layer.c"
     print("Patching %s." % (filename))
     output = io.StringIO()
 

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -160,6 +160,9 @@ typedef struct AppLayerProtoDetectCtx_ {
      * for protocol detection.  This table is independent of the
      * ipproto. */
     const char *alproto_names[ALPROTO_MAX];
+
+    /* Protocol expectations, like ftp-data on tcp */
+    uint8_t expectation_proto[ALPROTO_MAX];
 } AppLayerProtoDetectCtx;
 
 typedef struct AppLayerProtoDetectAliases_ {
@@ -2111,27 +2114,25 @@ void AppLayerProtoDetectSupportedAppProtocols(AppProto *alprotos)
     SCReturn;
 }
 
-uint8_t expectation_proto[ALPROTO_MAX];
-
 static void AppLayerProtoDetectPEGetIpprotos(AppProto alproto,
                                              uint8_t *ipprotos)
 {
-    if (expectation_proto[alproto] == IPPROTO_TCP) {
+    if (alpd_ctx.expectation_proto[alproto] == IPPROTO_TCP) {
         ipprotos[IPPROTO_TCP / 8] |= 1 << (IPPROTO_TCP % 8);
     }
-    if (expectation_proto[alproto] == IPPROTO_UDP) {
+    if (alpd_ctx.expectation_proto[alproto] == IPPROTO_UDP) {
         ipprotos[IPPROTO_UDP / 8] |= 1 << (IPPROTO_UDP % 8);
     }
 }
 
 void AppLayerRegisterExpectationProto(uint8_t proto, AppProto alproto)
 {
-    if (expectation_proto[alproto]) {
-        if (proto != expectation_proto[alproto]) {
+    if (alpd_ctx.expectation_proto[alproto]) {
+        if (proto != alpd_ctx.expectation_proto[alproto]) {
             SCLogError("Expectation on 2 IP protocols are not supported");
         }
     }
-    expectation_proto[alproto] = proto;
+    alpd_ctx.expectation_proto[alproto] = proto;
 }
 
 /***** Unittests *****/

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -292,7 +292,7 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
     }
 
     /* alproto bit field */
-    uint8_t pm_results_bf[(ALPROTO_MAX / 8) + 1];
+    uint8_t pm_results_bf[(AlprotoMax / 8) + 1];
     memset(pm_results_bf, 0, sizeof(pm_results_bf));
 
     /* loop through unique pattern id's. Can't use search_cnt here,
@@ -324,7 +324,7 @@ static inline int PMGetProtoInspect(AppLayerProtoDetectThreadCtx *tctx,
 /** \internal
  *  \brief Run Pattern Sigs against buffer
  *  \param direction direction for the patterns
- *  \param pm_results[out] AppProto array of size ALPROTO_MAX */
+ *  \param pm_results[out] AppProto array of size AlprotoMax */
 static AppProto AppLayerProtoDetectPMGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f,
         const uint8_t *buf, uint32_t buflen, uint8_t flags, AppProto *pm_results, bool *rflow)
 {
@@ -804,7 +804,7 @@ static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParser
                    "register the probing parser.  min_depth >= max_depth");
         goto error;
     }
-    if (alproto <= ALPROTO_UNKNOWN || alproto >= ALPROTO_MAX) {
+    if (alproto <= ALPROTO_UNKNOWN || alproto >= AlprotoMax) {
         SCLogError("Invalid arguments sent to register "
                    "the probing parser.  Invalid alproto - %d",
                 alproto);
@@ -1411,7 +1411,7 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f
     AppProto pm_alproto = ALPROTO_UNKNOWN;
 
     if (!FLOW_IS_PM_DONE(f, flags)) {
-        AppProto pm_results[ALPROTO_MAX];
+        AppProto pm_results[AlprotoMax];
         uint16_t pm_matches = AppLayerProtoDetectPMGetProto(
                 tctx, f, buf, buflen, flags, pm_results, reverse_flow);
         if (pm_matches > 0) {
@@ -1725,12 +1725,12 @@ int AppLayerProtoDetectSetup(void)
         }
     }
 
-    alpd_ctx.alproto_names = SCCalloc(ALPROTO_MAX, sizeof(char *));
+    alpd_ctx.alproto_names = SCCalloc(AlprotoMax, sizeof(char *));
     if (unlikely(alpd_ctx.alproto_names == NULL)) {
         FatalError("Unable to alloc alproto_names.");
     }
     // to realloc when dynamic protos are added
-    alpd_ctx.expectation_proto = SCCalloc(ALPROTO_MAX, sizeof(uint8_t));
+    alpd_ctx.expectation_proto = SCCalloc(AlprotoMax, sizeof(uint8_t));
     if (unlikely(alpd_ctx.expectation_proto == NULL)) {
         FatalError("Unable to alloc expectation_proto.");
     }
@@ -2090,7 +2090,7 @@ AppProto AppLayerProtoDetectGetProtoByName(const char *alproto_name)
 
     AppProto a;
     AppProto b = StringToAppProto(alproto_name);
-    for (a = 0; a < ALPROTO_MAX; a++) {
+    for (a = 0; a < AlprotoMax; a++) {
         if (alpd_ctx.alproto_names[a] != NULL && AppProtoEquals(b, a)) {
             // That means return HTTP_ANY if HTTP1 or HTTP2 is enabled
             SCReturnCT(b, "AppProto");
@@ -2121,11 +2121,11 @@ void AppLayerProtoDetectSupportedAppProtocols(AppProto *alprotos)
 {
     SCEnter();
 
-    memset(alprotos, 0, ALPROTO_MAX * sizeof(AppProto));
+    memset(alprotos, 0, AlprotoMax * sizeof(AppProto));
 
     int alproto;
 
-    for (alproto = 0; alproto != ALPROTO_MAX; alproto++) {
+    for (alproto = 0; alproto != AlprotoMax; alproto++) {
         if (alpd_ctx.alproto_names[alproto] != NULL)
             alprotos[alproto] = 1;
     }
@@ -2229,7 +2229,7 @@ static int AppLayerProtoDetectTest03(void)
     AppLayerProtoDetectSetup();
 
     uint8_t l7data[] = "HTTP/1.1 200 OK\r\nServer: Apache/1.0\r\n\r\n";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2276,7 +2276,7 @@ static int AppLayerProtoDetectTest04(void)
     uint8_t l7data[] = "HTTP/1.1 200 OK\r\nServer: Apache/1.0\r\n\r\n";
     Flow f;
     memset(&f, 0x00, sizeof(f));
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
 
@@ -2314,7 +2314,7 @@ static int AppLayerProtoDetectTest05(void)
     AppLayerProtoDetectSetup();
 
     uint8_t l7data[] = "HTTP/1.1 200 OK\r\nServer: Apache/1.0\r\n\r\n<HTML><BODY>Blahblah</BODY></HTML>";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2358,7 +2358,7 @@ static int AppLayerProtoDetectTest06(void)
     AppLayerProtoDetectSetup();
 
     uint8_t l7data[] = "220 Welcome to the OISF FTP server\r\n";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2404,7 +2404,7 @@ static int AppLayerProtoDetectTest07(void)
     Flow f;
     memset(&f, 0x00, sizeof(f));
     f.protomap = FlowGetProtoMapping(IPPROTO_TCP);
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
 
     const char *buf = "HTTP";
@@ -2458,7 +2458,7 @@ static int AppLayerProtoDetectTest08(void)
         0x20, 0x4c, 0x4d, 0x20, 0x30, 0x2e, 0x31, 0x32,
         0x00
     };
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2513,7 +2513,7 @@ static int AppLayerProtoDetectTest09(void)
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x02, 0x02
     };
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2563,7 +2563,7 @@ static int AppLayerProtoDetectTest10(void)
         0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00,
         0x2b, 0x10, 0x48, 0x60, 0x02, 0x00, 0x00, 0x00
     };
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2608,7 +2608,7 @@ static int AppLayerProtoDetectTest11(void)
 
     uint8_t l7data[] = "CONNECT www.ssllabs.com:443 HTTP/1.0\r\n";
     uint8_t l7data_resp[] = "HTTP/1.1 405 Method Not Allowed\r\n";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     memset(pm_results, 0, sizeof(pm_results));
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2733,7 +2733,7 @@ static int AppLayerProtoDetectTest13(void)
 
     uint8_t l7data[] = "CONNECT www.ssllabs.com:443 HTTP/1.0\r\n";
     uint8_t l7data_resp[] = "HTTP/1.1 405 Method Not Allowed\r\n";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
 
     Flow f;
     memset(&f, 0x00, sizeof(f));
@@ -2804,7 +2804,7 @@ static int AppLayerProtoDetectTest14(void)
 
     uint8_t l7data[] = "CONNECT www.ssllabs.com:443 HTTP/1.0\r\n";
     uint8_t l7data_resp[] = "HTTP/1.1 405 Method Not Allowed\r\n";
-    AppProto pm_results[ALPROTO_MAX];
+    AppProto pm_results[AlprotoMax];
     uint32_t cnt;
     Flow f;
     memset(&f, 0x00, sizeof(f));

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -67,8 +67,6 @@
 
 typedef struct AppLayerProtoDetectProbingParserElement_ {
     AppProto alproto;
-    /* \todo calculate at runtime and get rid of this var */
-    uint32_t alproto_mask;
     /* the min length of data that has to be supplied to invoke the parser */
     uint16_t min_depth;
     /* the max length of data after which this parser won't be invoked */
@@ -89,8 +87,6 @@ typedef struct AppLayerProtoDetectProbingParserPort_ {
     /* wether to use this probing parser port-based */
     // WebSocket has this set to false as it only works with protocol change
     bool use_ports;
-
-    uint32_t alproto_mask;
 
     /* the max depth for all the probing parsers registered for this port */
     uint16_t dp_max_depth;
@@ -480,11 +476,20 @@ static AppProto AppLayerProtoDetectPEGetProto(Flow *f, uint8_t flags)
 }
 
 static inline AppProto PPGetProto(const AppLayerProtoDetectProbingParserElement *pe, Flow *f,
-        uint8_t flags, const uint8_t *buf, uint32_t buflen, uint32_t *alproto_masks, uint8_t *rdir)
+        uint8_t flags, const uint8_t *buf, uint32_t buflen, uint32_t *alproto_masks, uint8_t *rdir,
+        uint8_t *nb_tried)
 {
     while (pe != NULL) {
-        if ((buflen < pe->min_depth)  ||
-            (alproto_masks[0] & pe->alproto_mask)) {
+        // callers make alproto_masks and nb_tried are either both defined or both NULL
+        if (alproto_masks != NULL) {
+            DEBUG_VALIDATE_BUG_ON(*nb_tried >= 32);
+            if (buflen < pe->min_depth || (alproto_masks[0] & BIT_U32(*nb_tried))) {
+                // skip if already failed once
+                pe = pe->next;
+                *nb_tried = *nb_tried + 1;
+                continue;
+            }
+        } else if (buflen < pe->min_depth) {
             pe = pe->next;
             continue;
         }
@@ -498,9 +503,12 @@ static inline AppProto PPGetProto(const AppLayerProtoDetectProbingParserElement 
         if (AppProtoIsValid(alproto)) {
             SCReturnUInt(alproto);
         }
-        if (alproto == ALPROTO_FAILED ||
-            (pe->max_depth != 0 && buflen > pe->max_depth)) {
-            alproto_masks[0] |= pe->alproto_mask;
+        if (alproto_masks != NULL) {
+            if ((alproto == ALPROTO_FAILED || (pe->max_depth != 0 && buflen > pe->max_depth))) {
+                // This PE failed, mask it from now on
+                alproto_masks[0] |= BIT_U32(*nb_tried);
+            }
+            *nb_tried = *nb_tried + 1;
         }
         pe = pe->next;
     }
@@ -524,8 +532,20 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f, const uint8_t *buf, uint3
     const AppLayerProtoDetectProbingParserElement *pe1 = NULL;
     const AppLayerProtoDetectProbingParserElement *pe2 = NULL;
     AppProto alproto = ALPROTO_UNKNOWN;
+    // number of tried protocols :
+    // used against alproto_masks to see if al tried protocols failed
+    // Instead of keeping a bitmask for all protocols, we
+    // use only the protocols relevant to this flow, so as to
+    // have alproto_masks a u32 but we have more than 32 alprotos
+    // in Suricata, but we do not allow more than 32 probing parsers
+    // on one flow.
+    // alproto_masks is consistent throughout different calls here
+    // from different packets in the flow.
+    // We can have up to 4 calls to PPGetProto with a mask :
+    // destination port (probing parser), source port,
+    // and again with the reversed flow in case of midstream.
+    uint8_t nb_tried = 0;
     uint32_t *alproto_masks = NULL;
-    uint32_t mask = 0;
     uint8_t idir = (flags & (STREAM_TOSERVER | STREAM_TOCLIENT));
     uint8_t dir = idir;
     uint16_t dp = f->protodetect_dp ? f->protodetect_dp : FLOW_GET_DP(f);
@@ -607,26 +627,22 @@ again_midstream:
 
     /* run the parser(s): always call with original direction */
     uint8_t rdir = 0;
-    alproto = PPGetProto(pe0, f, flags, buf, buflen, alproto_masks, &rdir);
+    // pe0 can change based on the flow state, do not use mask for it
+    alproto = PPGetProto(pe0, f, flags, buf, buflen, NULL, &rdir, NULL);
     if (AppProtoIsValid(alproto))
         goto end;
-    alproto = PPGetProto(pe1, f, flags, buf, buflen, alproto_masks, &rdir);
+    alproto = PPGetProto(pe1, f, flags, buf, buflen, alproto_masks, &rdir, &nb_tried);
     if (AppProtoIsValid(alproto))
         goto end;
-    alproto = PPGetProto(pe2, f, flags, buf, buflen, alproto_masks, &rdir);
+    alproto = PPGetProto(pe2, f, flags, buf, buflen, alproto_masks, &rdir, &nb_tried);
     if (AppProtoIsValid(alproto))
         goto end;
 
     /* get the mask we need for this direction */
     if (dir == idir) {
-        if (pp_port_dp && pp_port_sp)
-            mask = pp_port_dp->alproto_mask|pp_port_sp->alproto_mask;
-        else if (pp_port_dp)
-            mask = pp_port_dp->alproto_mask;
-        else if (pp_port_sp)
-            mask = pp_port_sp->alproto_mask;
-
-        if (alproto_masks[0] == mask) {
+        // if we tried 3 protocols, we set probing parsing done if
+        // alproto_masks[0] = 7 = 0b111 = BIT_U32(3) - 1 = 1<<3 - 1
+        if (alproto_masks[0] == BIT_U32(nb_tried) - 1) {
             FLOW_SET_PP_DONE(f, dir);
             SCLogDebug("%s, mask is now %08x, needed %08x, so done",
                     (dir == STREAM_TOSERVER) ? "toserver":"toclient",
@@ -688,17 +704,6 @@ static void AppLayerProtoDetectPPGetIpprotos(AppProto alproto,
     }
 
     SCReturn;
-}
-
-static uint32_t AppLayerProtoDetectProbingParserGetMask(AppProto alproto)
-{
-    SCEnter();
-
-    if (!(alproto > ALPROTO_UNKNOWN && alproto < ALPROTO_FAILED)) {
-        FatalError("Unknown protocol detected - %u", alproto);
-    }
-
-    SCReturnUInt(BIT_U32(alproto));
 }
 
 static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParserElementAlloc(void)
@@ -794,7 +799,6 @@ static AppLayerProtoDetectProbingParserElement *AppLayerProtoDetectProbingParser
     AppLayerProtoDetectProbingParserElement *pe = AppLayerProtoDetectProbingParserElementAlloc();
 
     pe->alproto = alproto;
-    pe->alproto_mask = AppLayerProtoDetectProbingParserGetMask(alproto);
     pe->min_depth = min_depth;
     pe->max_depth = max_depth;
     pe->next = NULL;
@@ -825,7 +829,6 @@ AppLayerProtoDetectProbingParserElementDuplicate(AppLayerProtoDetectProbingParse
     AppLayerProtoDetectProbingParserElement *new_pe = AppLayerProtoDetectProbingParserElementAlloc();
 
     new_pe->alproto = pe->alproto;
-    new_pe->alproto_mask = pe->alproto_mask;
     new_pe->min_depth = pe->min_depth;
     new_pe->max_depth = pe->max_depth;
     new_pe->ProbingParserTs = pe->ProbingParserTs;
@@ -859,15 +862,12 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
             if (pp_port->dp != NULL) {
                 printf("    Port: %"PRIu16 "\n", pp_port->port);
 
-                printf("        Destination port: (max-depth: %"PRIu16 ", "
-                        "mask - %"PRIu32")\n",
-                        pp_port->dp_max_depth,
-                        pp_port->alproto_mask);
+                printf("        Destination port: (max-depth: %" PRIu16 ")\n",
+                        pp_port->dp_max_depth);
                 pp_pe = pp_port->dp;
                 for ( ; pp_pe != NULL; pp_pe = pp_pe->next) {
 
                     printf("            alproto: %s\n", AppProtoToString(pp_pe->alproto));
-                    printf("            mask: %"PRIu32 "\n", pp_pe->alproto_mask);
                     printf("            min_depth: %"PRIu32 "\n", pp_pe->min_depth);
                     printf("            max_depth: %"PRIu32 "\n", pp_pe->max_depth);
 
@@ -879,15 +879,11 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                 continue;
             }
 
-            printf("        Source port: (max-depth: %"PRIu16 ", "
-                   "mask - %"PRIu32")\n",
-                   pp_port->sp_max_depth,
-                   pp_port->alproto_mask);
+            printf("        Source port: (max-depth: %" PRIu16 ")\n", pp_port->sp_max_depth);
             pp_pe = pp_port->sp;
             for ( ; pp_pe != NULL; pp_pe = pp_pe->next) {
 
                 printf("            alproto: %s\n", AppProtoToString(pp_pe->alproto));
-                printf("            mask: %"PRIu32 "\n", pp_pe->alproto_mask);
                 printf("            min_depth: %"PRIu32 "\n", pp_pe->min_depth);
                 printf("            max_depth: %"PRIu32 "\n", pp_pe->max_depth);
 
@@ -1030,7 +1026,6 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
                 AppLayerProtoDetectProbingParserElement *dup_pe =
                     AppLayerProtoDetectProbingParserElementDuplicate(zero_pe);
                 AppLayerProtoDetectProbingParserElementAppend(&curr_port->dp, dup_pe);
-                curr_port->alproto_mask |= dup_pe->alproto_mask;
             }
 
             zero_pe = zero_port->sp;
@@ -1047,7 +1042,6 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
                 AppLayerProtoDetectProbingParserElement *dup_pe =
                     AppLayerProtoDetectProbingParserElementDuplicate(zero_pe);
                 AppLayerProtoDetectProbingParserElementAppend(&curr_port->sp, dup_pe);
-                curr_port->alproto_mask |= dup_pe->alproto_mask;
             }
         } /* if (zero_port != NULL) */
     } /* if (curr_port == NULL) */
@@ -1088,7 +1082,6 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
             curr_port->dp_max_depth < new_pe->max_depth) {
             curr_port->dp_max_depth = new_pe->max_depth;
         }
-        curr_port->alproto_mask |= new_pe->alproto_mask;
         head_pe = &curr_port->dp;
     } else {
         curr_pe->ProbingParserTs = ProbingParser2;
@@ -1101,7 +1094,6 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
             curr_port->sp_max_depth < new_pe->max_depth) {
             curr_port->sp_max_depth = new_pe->max_depth;
         }
-        curr_port->alproto_mask |= new_pe->alproto_mask;
         head_pe = &curr_port->sp;
     }
     AppLayerProtoDetectProbingParserElementAppend(head_pe, new_pe);
@@ -1119,9 +1111,8 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
                     temp_port->dp_max_depth < curr_pe->max_depth) {
                     temp_port->dp_max_depth = curr_pe->max_depth;
                 }
-                AppLayerProtoDetectProbingParserElementAppend(&temp_port->dp,
-                                                              AppLayerProtoDetectProbingParserElementDuplicate(curr_pe));
-                temp_port->alproto_mask |= curr_pe->alproto_mask;
+                AppLayerProtoDetectProbingParserElementAppend(
+                        &temp_port->dp, AppLayerProtoDetectProbingParserElementDuplicate(curr_pe));
             } else {
                 if (temp_port->sp == NULL)
                     temp_port->sp_max_depth = curr_pe->max_depth;
@@ -1131,9 +1122,8 @@ static void AppLayerProtoDetectInsertNewProbingParser(AppLayerProtoDetectProbing
                     temp_port->sp_max_depth < curr_pe->max_depth) {
                     temp_port->sp_max_depth = curr_pe->max_depth;
                 }
-                AppLayerProtoDetectProbingParserElementAppend(&temp_port->sp,
-                                                              AppLayerProtoDetectProbingParserElementDuplicate(curr_pe));
-                temp_port->alproto_mask |= curr_pe->alproto_mask;
+                AppLayerProtoDetectProbingParserElementAppend(
+                        &temp_port->sp, AppLayerProtoDetectProbingParserElementDuplicate(curr_pe));
             }
             temp_port = temp_port->next;
         } /* while */
@@ -2870,14 +2860,12 @@ typedef struct AppLayerProtoDetectPPTestDataElement_ {
     const char *alproto_name;
     AppProto alproto;
     uint16_t port;
-    uint32_t alproto_mask;
     uint32_t min_depth;
     uint32_t max_depth;
 } AppLayerProtoDetectPPTestDataElement;
 
 typedef struct AppLayerProtoDetectPPTestDataPort_ {
     uint16_t port;
-    uint32_t alproto_mask;
     uint16_t dp_max_depth;
     uint16_t sp_max_depth;
 
@@ -2912,10 +2900,6 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
         for (k = 0; k < ip_proto[i].no_of_port; k++, pp_port = pp_port->next) {
             if (pp_port->port != ip_proto[i].port[k].port)
                 goto end;
-            if (pp_port->alproto_mask != ip_proto[i].port[k].alproto_mask)
-                goto end;
-            if (pp_port->alproto_mask != ip_proto[i].port[k].alproto_mask)
-                goto end;
             if (pp_port->dp_max_depth != ip_proto[i].port[k].dp_max_depth)
                 goto end;
             if (pp_port->sp_max_depth != ip_proto[i].port[k].sp_max_depth)
@@ -2929,9 +2913,6 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
                  j++, pp_element = pp_element->next) {
 
                 if (pp_element->alproto != ip_proto[i].port[k].toserver_element[j].alproto) {
-                    goto end;
-                }
-                if (pp_element->alproto_mask != ip_proto[i].port[k].toserver_element[j].alproto_mask) {
                     goto end;
                 }
                 if (pp_element->min_depth != ip_proto[i].port[k].toserver_element[j].min_depth) {
@@ -2950,9 +2931,6 @@ static int AppLayerProtoDetectPPTestData(AppLayerProtoDetectProbingParser *pp,
 #endif
             for (j = 0 ; j < ip_proto[i].port[k].tc_no_of_element; j++, pp_element = pp_element->next) {
                 if (pp_element->alproto != ip_proto[i].port[k].toclient_element[j].alproto) {
-                    goto end;
-                }
-                if (pp_element->alproto_mask != ip_proto[i].port[k].toclient_element[j].alproto_mask) {
                     goto end;
                 }
                 if (pp_element->min_depth != ip_proto[i].port[k].toclient_element[j].min_depth) {
@@ -3126,100 +3104,76 @@ static int AppLayerProtoDetectTest15(void)
                                   ProbingParserDummyForTesting, NULL);
 
     AppLayerProtoDetectPPTestDataElement element_ts_80[] = {
-        { "http", ALPROTO_HTTP1, 80, 1 << ALPROTO_HTTP1, 5, 8 },
-        { "smb", ALPROTO_SMB, 80, 1 << ALPROTO_SMB, 5, 6 },
-        { "ftp", ALPROTO_FTP, 80, 1 << ALPROTO_FTP, 7, 10 },
-        { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 0 },
-        { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-        { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 25 },
-        { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
+        { "http", ALPROTO_HTTP1, 80, 5, 8 },
+        { "smb", ALPROTO_SMB, 80, 5, 6 },
+        { "ftp", ALPROTO_FTP, 80, 7, 10 },
+        { "smtp", ALPROTO_SMTP, 0, 12, 0 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "irc", ALPROTO_IRC, 0, 12, 25 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 },
     };
-    AppLayerProtoDetectPPTestDataElement element_tc_80[] = { { "http", ALPROTO_HTTP1, 80,
-                                                                     1 << ALPROTO_HTTP1, 5, 8 },
-        { "smb", ALPROTO_SMB, 80, 1 << ALPROTO_SMB, 5, 6 },
-        { "ftp", ALPROTO_FTP, 80, 1 << ALPROTO_FTP, 7, 10 },
-        { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-        { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 14 },
-        { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-        { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 17 } };
+    AppLayerProtoDetectPPTestDataElement element_tc_80[] = { { "http", ALPROTO_HTTP1, 80, 5, 8 },
+        { "smb", ALPROTO_SMB, 80, 5, 6 }, { "ftp", ALPROTO_FTP, 80, 7, 10 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 }, { "irc", ALPROTO_IRC, 0, 12, 14 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 }, { "smtp", ALPROTO_SMTP, 0, 12, 17 } };
 
     AppLayerProtoDetectPPTestDataElement element_ts_81[] = {
-        { "dcerpc", ALPROTO_DCERPC, 81, 1 << ALPROTO_DCERPC, 9, 10 },
-          { "ftp", ALPROTO_FTP, 81, 1 << ALPROTO_FTP, 7, 15 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 0 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 25 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-        };
-    AppLayerProtoDetectPPTestDataElement element_tc_81[] = {
-        { "ftp", ALPROTO_FTP, 81, 1 << ALPROTO_FTP, 7, 15 },
-          { "dcerpc", ALPROTO_DCERPC, 81, 1 << ALPROTO_DCERPC, 9, 10 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 14 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 17 }
-        };
+        { "dcerpc", ALPROTO_DCERPC, 81, 9, 10 },
+        { "ftp", ALPROTO_FTP, 81, 7, 15 },
+        { "smtp", ALPROTO_SMTP, 0, 12, 0 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "irc", ALPROTO_IRC, 0, 12, 25 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+    };
+    AppLayerProtoDetectPPTestDataElement element_tc_81[] = { { "ftp", ALPROTO_FTP, 81, 7, 15 },
+        { "dcerpc", ALPROTO_DCERPC, 81, 9, 10 }, { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+        { "irc", ALPROTO_IRC, 0, 12, 14 }, { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "smtp", ALPROTO_SMTP, 0, 12, 17 } };
 
     AppLayerProtoDetectPPTestDataElement element_ts_85[] = {
-        { "dcerpc", ALPROTO_DCERPC, 85, 1 << ALPROTO_DCERPC, 9, 10 },
-          { "ftp", ALPROTO_FTP, 85, 1 << ALPROTO_FTP, 7, 15 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 0 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 25 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-        };
-    AppLayerProtoDetectPPTestDataElement element_tc_85[] = {
-        { "dcerpc", ALPROTO_DCERPC, 85, 1 << ALPROTO_DCERPC, 9, 10 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 14 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 17 }
-        };
+        { "dcerpc", ALPROTO_DCERPC, 85, 9, 10 },
+        { "ftp", ALPROTO_FTP, 85, 7, 15 },
+        { "smtp", ALPROTO_SMTP, 0, 12, 0 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "irc", ALPROTO_IRC, 0, 12, 25 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+    };
+    AppLayerProtoDetectPPTestDataElement element_tc_85[] = { { "dcerpc", ALPROTO_DCERPC, 85, 9,
+                                                                     10 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 }, { "irc", ALPROTO_IRC, 0, 12, 14 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 }, { "smtp", ALPROTO_SMTP, 0, 12, 17 } };
 
     AppLayerProtoDetectPPTestDataElement element_ts_90[] = {
-        { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 0 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 25 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-        };
-    AppLayerProtoDetectPPTestDataElement element_tc_90[] = {
-        { "ftp", ALPROTO_FTP, 90, 1 << ALPROTO_FTP, 7, 15 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 14 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 17 }
-        };
+        { "smtp", ALPROTO_SMTP, 0, 12, 0 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "irc", ALPROTO_IRC, 0, 12, 25 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+    };
+    AppLayerProtoDetectPPTestDataElement element_tc_90[] = { { "ftp", ALPROTO_FTP, 90, 7, 15 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 }, { "irc", ALPROTO_IRC, 0, 12, 14 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 }, { "smtp", ALPROTO_SMTP, 0, 12, 17 } };
 
     AppLayerProtoDetectPPTestDataElement element_ts_0[] = {
-        { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 0 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 25 },
-          { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-        };
-    AppLayerProtoDetectPPTestDataElement element_tc_0[] = {
-        { "jabber", ALPROTO_JABBER, 0, 1 << ALPROTO_JABBER, 12, 23 },
-          { "irc", ALPROTO_IRC, 0, 1 << ALPROTO_IRC, 12, 14 },
-          { "tls", ALPROTO_TLS, 0, 1 << ALPROTO_TLS, 12, 18 },
-          { "smtp", ALPROTO_SMTP, 0, 1 << ALPROTO_SMTP, 12, 17 }
-        };
-
+        { "smtp", ALPROTO_SMTP, 0, 12, 0 },
+        { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "irc", ALPROTO_IRC, 0, 12, 25 },
+        { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+    };
+    AppLayerProtoDetectPPTestDataElement element_tc_0[] = { { "jabber", ALPROTO_JABBER, 0, 12, 23 },
+        { "irc", ALPROTO_IRC, 0, 12, 14 }, { "tls", ALPROTO_TLS, 0, 12, 18 },
+        { "smtp", ALPROTO_SMTP, 0, 12, 17 } };
 
     AppLayerProtoDetectPPTestDataElement element_ts_85_udp[] = {
-        { "imap", ALPROTO_IMAP, 85, 1 << ALPROTO_IMAP, 12, 23 },
-        };
+        { "imap", ALPROTO_IMAP, 85, 12, 23 },
+    };
     AppLayerProtoDetectPPTestDataElement element_tc_85_udp[] = {
-        { "imap", ALPROTO_IMAP, 85, 1 << ALPROTO_IMAP, 12, 23 },
-        };
+        { "imap", ALPROTO_IMAP, 85, 12, 23 },
+    };
 
     AppLayerProtoDetectPPTestDataPort ports_tcp[] = {
         {
                 80,
-                ((1 << ALPROTO_HTTP1) | (1 << ALPROTO_SMB) | (1 << ALPROTO_FTP) |
-                        (1 << ALPROTO_SMTP) | (1 << ALPROTO_TLS) | (1 << ALPROTO_IRC) |
-                        (1 << ALPROTO_JABBER)),
-                ((1 << ALPROTO_HTTP1) | (1 << ALPROTO_SMB) | (1 << ALPROTO_FTP) |
-                        (1 << ALPROTO_JABBER) | (1 << ALPROTO_IRC) | (1 << ALPROTO_TLS) |
-                        (1 << ALPROTO_SMTP)),
+                23,
                 23,
                 element_ts_80,
                 element_tc_80,
@@ -3228,52 +3182,35 @@ static int AppLayerProtoDetectTest15(void)
         },
         {
                 81,
-                ((1 << ALPROTO_DCERPC) | (1 << ALPROTO_FTP) | (1 << ALPROTO_SMTP) |
-                        (1 << ALPROTO_TLS) | (1 << ALPROTO_IRC) | (1 << ALPROTO_JABBER)),
-                ((1 << ALPROTO_FTP) | (1 << ALPROTO_DCERPC) | (1 << ALPROTO_JABBER) |
-                        (1 << ALPROTO_IRC) | (1 << ALPROTO_TLS) | (1 << ALPROTO_SMTP)),
+                23,
                 23,
                 element_ts_81,
                 element_tc_81,
                 sizeof(element_ts_81) / sizeof(AppLayerProtoDetectPPTestDataElement),
                 sizeof(element_tc_81) / sizeof(AppLayerProtoDetectPPTestDataElement),
         },
-        { 85,
-                ((1 << ALPROTO_DCERPC) | (1 << ALPROTO_FTP) | (1 << ALPROTO_SMTP) |
-                        (1 << ALPROTO_TLS) | (1 << ALPROTO_IRC) | (1 << ALPROTO_JABBER)),
-                ((1 << ALPROTO_DCERPC) | (1 << ALPROTO_JABBER) | (1 << ALPROTO_IRC) |
-                        (1 << ALPROTO_TLS) | (1 << ALPROTO_SMTP)),
-                23, element_ts_85, element_tc_85,
+        { 85, 23, 23, element_ts_85, element_tc_85,
                 sizeof(element_ts_85) / sizeof(AppLayerProtoDetectPPTestDataElement),
                 sizeof(element_tc_85) / sizeof(AppLayerProtoDetectPPTestDataElement) },
-        { 90,
-                ((1 << ALPROTO_SMTP) | (1 << ALPROTO_TLS) | (1 << ALPROTO_IRC) |
-                        (1 << ALPROTO_JABBER)),
-                ((1 << ALPROTO_FTP) | (1 << ALPROTO_JABBER) | (1 << ALPROTO_IRC) |
-                        (1 << ALPROTO_TLS) | (1 << ALPROTO_SMTP)),
-                23, element_ts_90, element_tc_90,
+        { 90, 23, 23, element_ts_90, element_tc_90,
                 sizeof(element_ts_90) / sizeof(AppLayerProtoDetectPPTestDataElement),
                 sizeof(element_tc_90) / sizeof(AppLayerProtoDetectPPTestDataElement) },
-        { 0,
-                ((1 << ALPROTO_SMTP) | (1 << ALPROTO_TLS) | (1 << ALPROTO_IRC) |
-                        (1 << ALPROTO_JABBER)),
-                ((1 << ALPROTO_JABBER) | (1 << ALPROTO_IRC) | (1 << ALPROTO_TLS) |
-                        (1 << ALPROTO_SMTP)),
-                23, element_ts_0, element_tc_0,
+        { 0, 23, 23, element_ts_0, element_tc_0,
                 sizeof(element_ts_0) / sizeof(AppLayerProtoDetectPPTestDataElement),
                 sizeof(element_tc_0) / sizeof(AppLayerProtoDetectPPTestDataElement) }
     };
 
     AppLayerProtoDetectPPTestDataPort ports_udp[] = {
-        { 85,
-            (1 << ALPROTO_IMAP),
-            (1 << ALPROTO_IMAP),
-            23,
-            element_ts_85_udp, element_tc_85_udp,
-            sizeof(element_ts_85_udp) / sizeof(AppLayerProtoDetectPPTestDataElement),
-            sizeof(element_tc_85_udp) / sizeof(AppLayerProtoDetectPPTestDataElement),
-            },
-        };
+        {
+                85,
+                23,
+                23,
+                element_ts_85_udp,
+                element_tc_85_udp,
+                sizeof(element_ts_85_udp) / sizeof(AppLayerProtoDetectPPTestDataElement),
+                sizeof(element_tc_85_udp) / sizeof(AppLayerProtoDetectPPTestDataElement),
+        },
+    };
 
     AppLayerProtoDetectPPTestDataIPProto ip_proto[] = {
         { IPPROTO_TCP,

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -158,8 +158,9 @@ typedef struct AppLayerProtoDetectCtx_ {
 
     /* Indicates the protocols that have registered themselves
      * for protocol detection.  This table is independent of the
-     * ipproto. */
-    const char *alproto_names[ALPROTO_MAX];
+     * ipproto. It should be allocated to contain ALPROTO_MAX
+     * protocols. */
+    const char **alproto_names;
 
     /* Protocol expectations, like ftp-data on tcp.
      * It should be allocated to contain ALPROTO_MAX
@@ -1724,6 +1725,10 @@ int AppLayerProtoDetectSetup(void)
         }
     }
 
+    alpd_ctx.alproto_names = SCCalloc(ALPROTO_MAX, sizeof(char *));
+    if (unlikely(alpd_ctx.alproto_names == NULL)) {
+        FatalError("Unable to alloc alproto_names.");
+    }
     // to realloc when dynamic protos are added
     alpd_ctx.expectation_proto = SCCalloc(ALPROTO_MAX, sizeof(uint8_t));
     if (unlikely(alpd_ctx.expectation_proto == NULL)) {
@@ -1760,6 +1765,8 @@ int AppLayerProtoDetectDeSetup(void)
         }
     }
 
+    SCFree(alpd_ctx.alproto_names);
+    alpd_ctx.alproto_names = NULL;
     SCFree(alpd_ctx.expectation_proto);
     alpd_ctx.expectation_proto = NULL;
 
@@ -1776,6 +1783,7 @@ void AppLayerProtoDetectRegisterProtocol(AppProto alproto, const char *alproto_n
 {
     SCEnter();
 
+    // should have just been realloced when dynamic protos is added
     if (alpd_ctx.alproto_names[alproto] == NULL)
         alpd_ctx.alproto_names[alproto] = alproto_name;
 

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -33,13 +33,23 @@
 struct FrameConfig {
     SC_ATOMIC_DECLARE(uint64_t, types);
 };
-static struct FrameConfig frame_config[ALPROTO_MAX];
+/* This array should be allocated to contain ALPROTO_MAX protocols. */
+static struct FrameConfig *frame_config;
 
 void FrameConfigInit(void)
 {
+    frame_config = SCCalloc(ALPROTO_MAX, sizeof(struct FrameConfig));
+    if (unlikely(frame_config == NULL)) {
+        FatalError("Unable to alloc frame_config.");
+    }
     for (AppProto p = 0; p < ALPROTO_MAX; p++) {
         SC_ATOMIC_INIT(frame_config[p].types);
     }
+}
+
+void FrameConfigDeInit(void)
+{
+    SCFree(frame_config);
 }
 
 void FrameConfigEnableAll(void)

--- a/src/app-layer-frames.c
+++ b/src/app-layer-frames.c
@@ -33,16 +33,16 @@
 struct FrameConfig {
     SC_ATOMIC_DECLARE(uint64_t, types);
 };
-/* This array should be allocated to contain ALPROTO_MAX protocols. */
+/* This array should be allocated to contain AlprotoMax protocols. */
 static struct FrameConfig *frame_config;
 
 void FrameConfigInit(void)
 {
-    frame_config = SCCalloc(ALPROTO_MAX, sizeof(struct FrameConfig));
+    frame_config = SCCalloc(AlprotoMax, sizeof(struct FrameConfig));
     if (unlikely(frame_config == NULL)) {
         FatalError("Unable to alloc frame_config.");
     }
-    for (AppProto p = 0; p < ALPROTO_MAX; p++) {
+    for (AppProto p = 0; p < AlprotoMax; p++) {
         SC_ATOMIC_INIT(frame_config[p].types);
     }
 }
@@ -55,7 +55,7 @@ void FrameConfigDeInit(void)
 void FrameConfigEnableAll(void)
 {
     const uint64_t bits = UINT64_MAX;
-    for (AppProto p = 0; p < ALPROTO_MAX; p++) {
+    for (AppProto p = 0; p < AlprotoMax; p++) {
         struct FrameConfig *fc = &frame_config[p];
         SC_ATOMIC_OR(fc->types, bits);
     }

--- a/src/app-layer-frames.h
+++ b/src/app-layer-frames.h
@@ -106,6 +106,7 @@ FramesContainer *AppLayerFramesGetContainer(Flow *f);
 FramesContainer *AppLayerFramesSetupContainer(Flow *f);
 
 void FrameConfigInit(void);
+void FrameConfigDeInit(void);
 void FrameConfigEnableAll(void);
 void FrameConfigEnable(const AppProto p, const uint8_t type);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -249,8 +249,8 @@ int AppLayerParserSetup(void)
 {
     SCEnter();
     // initial allocation that will later be grown using realloc,
-    // when new protocols register themselves and make ALPROTO_MAX grow
-    alp_ctx.ctxs = SCCalloc(ALPROTO_MAX, sizeof(AppLayerParserProtoCtx[FLOW_PROTO_MAX]));
+    // when new protocols register themselves and make AlprotoMax grow
+    alp_ctx.ctxs = SCCalloc(AlprotoMax, sizeof(AppLayerParserProtoCtx[FLOW_PROTO_MAX]));
     if (unlikely(alp_ctx.ctxs == NULL)) {
         FatalError("Unable to alloc alp_ctx.ctxs.");
     }
@@ -261,7 +261,7 @@ void AppLayerParserPostStreamSetup(void)
 {
     /* lets set a default value for stream_depth */
     for (int flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
-        for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
             if (!(alp_ctx.ctxs[alproto][flow_proto].internal_flags &
                         APP_LAYER_PARSER_INT_STREAM_DEPTH_SET)) {
                 alp_ctx.ctxs[alproto][flow_proto].stream_depth = stream_config.reassembly_depth;
@@ -290,14 +290,14 @@ AppLayerParserThreadCtx *AppLayerParserThreadCtxAlloc(void)
     if (tctx == NULL)
         goto end;
 
-    tctx->alproto_local_storage = SCCalloc(ALPROTO_MAX, sizeof(void *[FLOW_PROTO_MAX]));
+    tctx->alproto_local_storage = SCCalloc(AlprotoMax, sizeof(void *[FLOW_PROTO_MAX]));
     if (unlikely(tctx->alproto_local_storage == NULL)) {
         SCFree(tctx);
         tctx = NULL;
         goto end;
     }
     for (uint8_t flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
-        for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
             uint8_t ipproto = FlowGetReverseProtoMapping(flow_proto);
 
             tctx->alproto_local_storage[alproto][flow_proto] =
@@ -314,7 +314,7 @@ void AppLayerParserThreadCtxFree(AppLayerParserThreadCtx *tctx)
     SCEnter();
 
     for (uint8_t flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
-        for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
             uint8_t ipproto = FlowGetReverseProtoMapping(flow_proto);
 
             AppLayerParserDestroyProtocolParserLocalStorage(
@@ -1688,7 +1688,7 @@ static void ValidateParser(AppProto alproto)
 static void ValidateParsers(void)
 {
     AppProto p = 0;
-    for ( ; p < ALPROTO_MAX; p++) {
+    for (; p < AlprotoMax; p++) {
         ValidateParser(p);
     }
 }
@@ -1788,7 +1788,7 @@ void AppLayerParserRegisterUnittests(void)
     AppLayerParserProtoCtx *ctx;
 
     for (ip = 0; ip < FLOW_PROTO_DEFAULT; ip++) {
-        for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (alproto = 0; alproto < AlprotoMax; alproto++) {
             ctx = &alp_ctx.ctxs[alproto][ip];
             if (ctx->RegisterUnittests == NULL)
                 continue;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -54,6 +54,7 @@
 #include "app-layer-ike.h"
 #include "app-layer-http2.h"
 #include "app-layer-imap.h"
+#include "util-plugin.h"
 
 struct AppLayerParserThreadCtx_ {
     void *(*alproto_local_storage)[FLOW_PROTO_MAX];
@@ -1745,6 +1746,15 @@ void AppLayerParserRegisterProtocolParsers(void)
     } else {
         SCLogInfo("Protocol detection and parser disabled for pop3 protocol.");
     }
+#ifdef HAVE_PLUGINS
+    for (size_t i = 0; i < app_layer_plugins_nb; i++) {
+        SCAppLayerPlugin *app_layer_plugin = SCPluginFindAppLayerByIndex(i);
+        if (app_layer_plugin == NULL) {
+            break;
+        }
+        app_layer_plugin->Register();
+    }
+#endif
 
     ValidateParsers();
 }

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -32,6 +32,7 @@ typedef struct AppProtoStringTuple {
 
 const AppProtoStringTuple AppProtoStrings[ALPROTO_MAX] = {
     { ALPROTO_UNKNOWN, "unknown" },
+    { ALPROTO_FAILED, "failed" },
     { ALPROTO_HTTP1, "http1" },
     { ALPROTO_FTP, "ftp" },
     { ALPROTO_SMTP, "smtp" },
@@ -69,7 +70,6 @@ const AppProtoStringTuple AppProtoStrings[ALPROTO_MAX] = {
     { ALPROTO_BITTORRENT_DHT, "bittorrent-dht" },
     { ALPROTO_POP3, "pop3" },
     { ALPROTO_HTTP, "http" },
-    { ALPROTO_FAILED, "failed" },
 };
 
 const char *AppProtoToString(AppProto alproto)

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -75,16 +75,17 @@ enum AppProtoEnum {
     ALPROTO_HTTP,
 
     /* keep last */
-    ALPROTO_MAX,
+    ALPROTO_MAX_STATIC,
 };
 // NOTE: if ALPROTO's get >= 256, update SignatureNonPrefilterStore
 
 /* not using the enum as that is a unsigned int, so 4 bytes */
 typedef uint16_t AppProto;
+extern AppProto AlprotoMax;
 
 static inline bool AppProtoIsValid(AppProto a)
 {
-    return ((a > ALPROTO_FAILED && a < ALPROTO_MAX));
+    return ((a > ALPROTO_FAILED && a < AlprotoMax));
 }
 
 // whether a signature AppProto matches a flow (or signature) AppProto
@@ -171,5 +172,7 @@ const char *AppProtoToString(AppProto alproto);
  * \retval alproto App layer protocol id, or ALPROTO_UNKNOWN.
  */
 AppProto StringToAppProto(const char *proto_name);
+
+void AppProtoRegisterProtoString(AppProto alproto, const char *proto_name);
 
 #endif /* SURICATA_APP_LAYER_PROTOS_H */

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -27,6 +27,11 @@
 
 enum AppProtoEnum {
     ALPROTO_UNKNOWN = 0,
+    /* used by the probing parser when alproto detection fails
+     * permanently for that particular stream */
+    ALPROTO_FAILED = 1,
+
+    // Beginning of real/normal protocols
     ALPROTO_HTTP1,
     ALPROTO_FTP,
     ALPROTO_SMTP,
@@ -69,9 +74,6 @@ enum AppProtoEnum {
     // HTTP for any version (ALPROTO_HTTP1 (version 1) or ALPROTO_HTTP2)
     ALPROTO_HTTP,
 
-    /* used by the probing parser when alproto detection fails
-     * permanently for that particular stream */
-    ALPROTO_FAILED,
     /* keep last */
     ALPROTO_MAX,
 };
@@ -82,7 +84,7 @@ typedef uint16_t AppProto;
 
 static inline bool AppProtoIsValid(AppProto a)
 {
-    return ((a > ALPROTO_UNKNOWN && a < ALPROTO_FAILED));
+    return ((a > ALPROTO_FAILED && a < ALPROTO_MAX));
 }
 
 // whether a signature AppProto matches a flow (or signature) AppProto

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -101,7 +101,7 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
     if (p == NULL)
         FatalError("Call to %s with NULL pointer.", __FUNCTION__);
 
-    if (alproto == ALPROTO_UNKNOWN || alproto >= ALPROTO_FAILED)
+    if (!AppProtoIsValid(alproto))
         FatalError("Unknown or invalid AppProto '%s'.", p->name);
 
     BUG_ON(strcmp(p->name, AppProtoToString(alproto)) != 0);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -95,9 +95,9 @@ typedef struct AppLayerCounters_ {
 } AppLayerCounters;
 
 /* counter names. Only used at init. */
-AppLayerCounterNames applayer_counter_names[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
+AppLayerCounterNames (*applayer_counter_names)[FLOW_PROTO_APPLAYER_MAX];
 /* counter id's. Used that runtime. */
-AppLayerCounters applayer_counters[FLOW_PROTO_APPLAYER_MAX][ALPROTO_MAX];
+AppLayerCounters (*applayer_counters)[FLOW_PROTO_APPLAYER_MAX];
 /* Exception policy global counters ids */
 ExceptionPolicyCounters eps_error_summary;
 
@@ -144,7 +144,7 @@ static inline int ProtoDetectDone(const Flow *f, const TcpSession *ssn, uint8_t 
  */
 static void AppLayerIncFlowCounter(ThreadVars *tv, Flow *f)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].counter_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].counter_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -152,7 +152,7 @@ static void AppLayerIncFlowCounter(ThreadVars *tv, Flow *f)
 
 void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].counter_tx_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].counter_tx_id;
     if (likely(tv && id > 0)) {
         StatsAddUI64(tv, id, step);
     }
@@ -160,7 +160,7 @@ void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step)
 
 void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].gap_error_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].gap_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -168,7 +168,7 @@ void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f)
 
 void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].alloc_error_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].alloc_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -176,7 +176,7 @@ void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f)
 
 void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].parser_error_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].parser_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -184,7 +184,7 @@ void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f)
 
 void AppLayerIncInternalErrorCounter(ThreadVars *tv, Flow *f)
 {
-    const uint16_t id = applayer_counters[f->protomap][f->alproto].internal_error_id;
+    const uint16_t id = applayer_counters[f->alproto][f->protomap].internal_error_id;
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
@@ -197,7 +197,7 @@ static void AppLayerIncrErrorExcPolicyCounter(ThreadVars *tv, Flow *f, enum Exce
         return;
     }
 #endif
-    uint16_t id = applayer_counters[f->protomap][f->alproto].eps_error.eps_id[policy];
+    uint16_t id = applayer_counters[f->alproto][f->protomap].eps_error.eps_id[policy];
     /* for the summary values */
     uint16_t g_id = eps_error_summary.eps_id[policy];
 
@@ -1132,8 +1132,8 @@ static void AppLayerSetupExceptionPolicyPerProtoCounters(
             g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
         for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
             if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
-                snprintf(applayer_counter_names[ipproto_map][alproto].eps_name[i],
-                        sizeof(applayer_counter_names[ipproto_map][alproto].eps_name[i]),
+                snprintf(applayer_counter_names[alproto][ipproto_map].eps_name[i],
+                        sizeof(applayer_counter_names[alproto][ipproto_map].eps_name[i]),
                         "app_layer.error.%s%s.exception_policy.%s", alproto_str, ipproto_suffix,
                         ExceptionPolicyEnumToString(i, true));
             }
@@ -1148,6 +1148,15 @@ void AppLayerSetupCounters(void)
     const char *str = "app_layer.flow.";
     const char *estr = "app_layer.error.";
 
+    applayer_counter_names =
+            SCCalloc(ALPROTO_MAX, sizeof(AppLayerCounterNames[FLOW_PROTO_APPLAYER_MAX]));
+    if (unlikely(applayer_counter_names == NULL)) {
+        FatalError("Unable to alloc applayer_counter_names.");
+    }
+    applayer_counters = SCCalloc(ALPROTO_MAX, sizeof(AppLayerCounters[FLOW_PROTO_APPLAYER_MAX]));
+    if (unlikely(applayer_counters == NULL)) {
+        FatalError("Unable to alloc applayer_counters.");
+    }
     /* We don't log stats counters if exception policy is `ignore`/`not set` */
     if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
         /* Register global counters for app layer error exception policy summary */
@@ -1178,62 +1187,62 @@ void AppLayerSetupCounters(void)
                 AppLayerProtoDetectSupportedIpprotos(alproto, ipprotos_all);
                 if ((ipprotos_all[IPPROTO_TCP / 8] & (1 << (IPPROTO_TCP % 8))) &&
                         (ipprotos_all[IPPROTO_UDP / 8] & (1 << (IPPROTO_UDP % 8)))) {
-                    snprintf(applayer_counter_names[ipproto_map][alproto].name,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].name),
-                            "%s%s%s", str, alproto_str, ipproto_suffix);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].tx_name,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].tx_name),
-                            "%s%s%s", tx_str, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[alproto][ipproto_map].name,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].name), "%s%s%s",
+                            str, alproto_str, ipproto_suffix);
+                    snprintf(applayer_counter_names[alproto][ipproto_map].tx_name,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].tx_name), "%s%s%s",
+                            tx_str, alproto_str, ipproto_suffix);
 
                     if (ipproto == IPPROTO_TCP) {
-                        snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
-                                sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                        snprintf(applayer_counter_names[alproto][ipproto_map].gap_error,
+                                sizeof(applayer_counter_names[alproto][ipproto_map].gap_error),
                                 "%s%s%s.gap", estr, alproto_str, ipproto_suffix);
                     }
-                    snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].alloc_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].alloc_error),
                             "%s%s%s.alloc", estr, alproto_str, ipproto_suffix);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].parser_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].parser_error),
                             "%s%s%s.parser", estr, alproto_str, ipproto_suffix);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].internal_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].internal_error),
                             "%s%s%s.internal", estr, alproto_str, ipproto_suffix);
 
                     AppLayerSetupExceptionPolicyPerProtoCounters(
                             ipproto_map, alproto, alproto_str, ipproto_suffix);
                 } else {
-                    snprintf(applayer_counter_names[ipproto_map][alproto].name,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].name),
-                            "%s%s", str, alproto_str);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].tx_name,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].tx_name),
-                            "%s%s", tx_str, alproto_str);
+                    snprintf(applayer_counter_names[alproto][ipproto_map].name,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].name), "%s%s", str,
+                            alproto_str);
+                    snprintf(applayer_counter_names[alproto][ipproto_map].tx_name,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].tx_name), "%s%s",
+                            tx_str, alproto_str);
 
                     if (ipproto == IPPROTO_TCP) {
-                        snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
-                                sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                        snprintf(applayer_counter_names[alproto][ipproto_map].gap_error,
+                                sizeof(applayer_counter_names[alproto][ipproto_map].gap_error),
                                 "%s%s.gap", estr, alproto_str);
                     }
-                    snprintf(applayer_counter_names[ipproto_map][alproto].alloc_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].alloc_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].alloc_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].alloc_error),
                             "%s%s.alloc", estr, alproto_str);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].parser_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].parser_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].parser_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].parser_error),
                             "%s%s.parser", estr, alproto_str);
-                    snprintf(applayer_counter_names[ipproto_map][alproto].internal_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].internal_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].internal_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].internal_error),
                             "%s%s.internal", estr, alproto_str);
                     AppLayerSetupExceptionPolicyPerProtoCounters(
                             ipproto_map, alproto, alproto_str, "");
                 }
             } else if (alproto == ALPROTO_FAILED) {
-                snprintf(applayer_counter_names[ipproto_map][alproto].name,
-                        sizeof(applayer_counter_names[ipproto_map][alproto].name),
-                        "%s%s%s", str, "failed", ipproto_suffix);
+                snprintf(applayer_counter_names[alproto][ipproto_map].name,
+                        sizeof(applayer_counter_names[alproto][ipproto_map].name), "%s%s%s", str,
+                        "failed", ipproto_suffix);
                 if (ipproto == IPPROTO_TCP) {
-                    snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
-                            sizeof(applayer_counter_names[ipproto_map][alproto].gap_error),
+                    snprintf(applayer_counter_names[alproto][ipproto_map].gap_error,
+                            sizeof(applayer_counter_names[alproto][ipproto_map].gap_error),
                             "%sfailed%s.gap", estr, ipproto_suffix);
                 }
             }
@@ -1264,41 +1273,41 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
 
         for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
             if (alprotos[alproto] == 1) {
-                applayer_counters[ipproto_map][alproto].counter_id =
-                    StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);
+                applayer_counters[alproto][ipproto_map].counter_id =
+                        StatsRegisterCounter(applayer_counter_names[alproto][ipproto_map].name, tv);
 
-                applayer_counters[ipproto_map][alproto].counter_tx_id =
-                    StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].tx_name, tv);
+                applayer_counters[alproto][ipproto_map].counter_tx_id = StatsRegisterCounter(
+                        applayer_counter_names[alproto][ipproto_map].tx_name, tv);
 
                 if (ipproto == IPPROTO_TCP) {
-                    applayer_counters[ipproto_map][alproto].gap_error_id = StatsRegisterCounter(
-                            applayer_counter_names[ipproto_map][alproto].gap_error, tv);
+                    applayer_counters[alproto][ipproto_map].gap_error_id = StatsRegisterCounter(
+                            applayer_counter_names[alproto][ipproto_map].gap_error, tv);
                 }
-                applayer_counters[ipproto_map][alproto].alloc_error_id = StatsRegisterCounter(
-                        applayer_counter_names[ipproto_map][alproto].alloc_error, tv);
-                applayer_counters[ipproto_map][alproto].parser_error_id = StatsRegisterCounter(
-                        applayer_counter_names[ipproto_map][alproto].parser_error, tv);
-                applayer_counters[ipproto_map][alproto].internal_error_id = StatsRegisterCounter(
-                        applayer_counter_names[ipproto_map][alproto].internal_error, tv);
+                applayer_counters[alproto][ipproto_map].alloc_error_id = StatsRegisterCounter(
+                        applayer_counter_names[alproto][ipproto_map].alloc_error, tv);
+                applayer_counters[alproto][ipproto_map].parser_error_id = StatsRegisterCounter(
+                        applayer_counter_names[alproto][ipproto_map].parser_error, tv);
+                applayer_counters[alproto][ipproto_map].internal_error_id = StatsRegisterCounter(
+                        applayer_counter_names[alproto][ipproto_map].internal_error, tv);
                 /* We don't log stats counters if exception policy is `ignore`/`not set` */
                 if (g_stats_eps_per_app_proto_errors &&
                         g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
                     for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1;
                             i < EXCEPTION_POLICY_MAX; i++) {
                         if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
-                            applayer_counters[ipproto_map][alproto]
+                            applayer_counters[alproto][ipproto_map]
                                     .eps_error.eps_id[i] = StatsRegisterCounter(
-                                    applayer_counter_names[ipproto_map][alproto].eps_name[i], tv);
+                                    applayer_counter_names[alproto][ipproto_map].eps_name[i], tv);
                         }
                     }
                 }
             } else if (alproto == ALPROTO_FAILED) {
-                applayer_counters[ipproto_map][alproto].counter_id =
-                    StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].name, tv);
+                applayer_counters[alproto][ipproto_map].counter_id =
+                        StatsRegisterCounter(applayer_counter_names[alproto][ipproto_map].name, tv);
 
                 if (ipproto == IPPROTO_TCP) {
-                    applayer_counters[ipproto_map][alproto].gap_error_id = StatsRegisterCounter(
-                            applayer_counter_names[ipproto_map][alproto].gap_error, tv);
+                    applayer_counters[alproto][ipproto_map].gap_error_id = StatsRegisterCounter(
+                            applayer_counter_names[alproto][ipproto_map].gap_error, tv);
                 }
             }
         }
@@ -1307,8 +1316,8 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
 
 void AppLayerDeSetupCounters(void)
 {
-    memset(applayer_counter_names, 0, sizeof(applayer_counter_names));
-    memset(applayer_counters, 0, sizeof(applayer_counters));
+    SCFree(applayer_counter_names);
+    SCFree(applayer_counters);
 }
 
 /***** Unittests *****/

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1013,12 +1013,12 @@ void AppLayerListSupportedProtocols(void)
     SCEnter();
 
     AppProto alproto;
-    AppProto alprotos[ALPROTO_MAX];
+    AppProto alprotos[AlprotoMax];
 
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
     printf("=========Supported App Layer Protocols=========\n");
-    for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+    for (alproto = 0; alproto < AlprotoMax; alproto++) {
         if (alprotos[alproto] == 1)
             printf("%s\n", AppLayerGetProtoName(alproto));
     }
@@ -1027,11 +1027,54 @@ void AppLayerListSupportedProtocols(void)
 }
 
 /***** Setup/General Registration *****/
+static void AppLayerNamesSetup(void)
+{
+    AppProtoRegisterProtoString(ALPROTO_UNKNOWN, "unknown");
+    AppProtoRegisterProtoString(ALPROTO_FAILED, "failed");
+    AppProtoRegisterProtoString(ALPROTO_HTTP1, "http1");
+    AppProtoRegisterProtoString(ALPROTO_FTP, "ftp");
+    AppProtoRegisterProtoString(ALPROTO_SMTP, "smtp");
+    AppProtoRegisterProtoString(ALPROTO_TLS, "tls");
+    AppProtoRegisterProtoString(ALPROTO_SSH, "ssh");
+    AppProtoRegisterProtoString(ALPROTO_IMAP, "imap");
+    AppProtoRegisterProtoString(ALPROTO_JABBER, "jabber");
+    AppProtoRegisterProtoString(ALPROTO_SMB, "smb");
+    AppProtoRegisterProtoString(ALPROTO_DCERPC, "dcerpc");
+    AppProtoRegisterProtoString(ALPROTO_IRC, "irc");
+    AppProtoRegisterProtoString(ALPROTO_DNS, "dns");
+    AppProtoRegisterProtoString(ALPROTO_MODBUS, "modbus");
+    AppProtoRegisterProtoString(ALPROTO_ENIP, "enip");
+    AppProtoRegisterProtoString(ALPROTO_DNP3, "dnp3");
+    AppProtoRegisterProtoString(ALPROTO_NFS, "nfs");
+    AppProtoRegisterProtoString(ALPROTO_NTP, "ntp");
+    AppProtoRegisterProtoString(ALPROTO_FTPDATA, "ftp-data");
+    AppProtoRegisterProtoString(ALPROTO_TFTP, "tftp");
+    AppProtoRegisterProtoString(ALPROTO_IKE, "ike");
+    AppProtoRegisterProtoString(ALPROTO_KRB5, "krb5");
+    AppProtoRegisterProtoString(ALPROTO_QUIC, "quic");
+    AppProtoRegisterProtoString(ALPROTO_DHCP, "dhcp");
+    AppProtoRegisterProtoString(ALPROTO_SNMP, "snmp");
+    AppProtoRegisterProtoString(ALPROTO_SIP, "sip");
+    AppProtoRegisterProtoString(ALPROTO_RFB, "rfb");
+    AppProtoRegisterProtoString(ALPROTO_MQTT, "mqtt");
+    AppProtoRegisterProtoString(ALPROTO_PGSQL, "pgsql");
+    AppProtoRegisterProtoString(ALPROTO_TELNET, "telnet");
+    AppProtoRegisterProtoString(ALPROTO_WEBSOCKET, "websocket");
+    AppProtoRegisterProtoString(ALPROTO_LDAP, "ldap");
+    AppProtoRegisterProtoString(ALPROTO_DOH2, "doh2");
+    AppProtoRegisterProtoString(ALPROTO_TEMPLATE, "template");
+    AppProtoRegisterProtoString(ALPROTO_RDP, "rdp");
+    AppProtoRegisterProtoString(ALPROTO_HTTP2, "http2");
+    AppProtoRegisterProtoString(ALPROTO_BITTORRENT_DHT, "bittorrent-dht");
+    AppProtoRegisterProtoString(ALPROTO_POP3, "pop3");
+    AppProtoRegisterProtoString(ALPROTO_HTTP, "http");
+}
 
 int AppLayerSetup(void)
 {
     SCEnter();
 
+    AppLayerNamesSetup();
     AppLayerProtoDetectSetup();
     AppLayerParserSetup();
 
@@ -1144,16 +1187,16 @@ static void AppLayerSetupExceptionPolicyPerProtoCounters(
 void AppLayerSetupCounters(void)
 {
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
-    AppProto alprotos[ALPROTO_MAX];
+    AppProto alprotos[AlprotoMax];
     const char *str = "app_layer.flow.";
     const char *estr = "app_layer.error.";
 
     applayer_counter_names =
-            SCCalloc(ALPROTO_MAX, sizeof(AppLayerCounterNames[FLOW_PROTO_APPLAYER_MAX]));
+            SCCalloc(AlprotoMax, sizeof(AppLayerCounterNames[FLOW_PROTO_APPLAYER_MAX]));
     if (unlikely(applayer_counter_names == NULL)) {
         FatalError("Unable to alloc applayer_counter_names.");
     }
-    applayer_counters = SCCalloc(ALPROTO_MAX, sizeof(AppLayerCounters[FLOW_PROTO_APPLAYER_MAX]));
+    applayer_counters = SCCalloc(AlprotoMax, sizeof(AppLayerCounters[FLOW_PROTO_APPLAYER_MAX]));
     if (unlikely(applayer_counters == NULL)) {
         FatalError("Unable to alloc applayer_counters.");
     }
@@ -1178,7 +1221,7 @@ void AppLayerSetupCounters(void)
         const char *ipproto_suffix = (ipproto == IPPROTO_TCP) ? "_tcp" : "_udp";
         uint8_t ipprotos_all[256 / 8];
 
-        for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
             if (alprotos[alproto] == 1) {
                 const char *tx_str = "app_layer.tx.";
                 const char *alproto_str = AppLayerGetProtoName(alproto);
@@ -1253,7 +1296,7 @@ void AppLayerSetupCounters(void)
 void AppLayerRegisterThreadCounters(ThreadVars *tv)
 {
     const uint8_t ipprotos[] = { IPPROTO_TCP, IPPROTO_UDP };
-    AppProto alprotos[ALPROTO_MAX];
+    AppProto alprotos[AlprotoMax];
     AppLayerProtoDetectSupportedAppProtocols(alprotos);
 
     /* We don't log stats counters if exception policy is `ignore`/`not set` */
@@ -1271,7 +1314,7 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
         const uint8_t ipproto = ipprotos[p];
         const uint8_t ipproto_map = FlowGetProtoMapping(ipproto);
 
-        for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+        for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
             if (alprotos[alproto] == 1) {
                 applayer_counters[alproto][ipproto_map].counter_id =
                         StatsRegisterCounter(applayer_counter_names[alproto][ipproto_map].name, tv);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1039,6 +1039,7 @@ int AppLayerSetup(void)
     AppLayerProtoDetectPrepareState();
 
     AppLayerSetupCounters();
+    FrameConfigInit();
 
     SCReturnInt(0);
 }
@@ -1051,6 +1052,7 @@ int AppLayerDeSetup(void)
     AppLayerParserDeSetup();
 
     AppLayerDeSetupCounters();
+    FrameConfigDeInit();
 
     SCReturnInt(0);
 }

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -625,10 +625,11 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     } mpm_stats[max_buffer_type_id];
     memset(mpm_stats, 0x00, sizeof(mpm_stats));
 
-    uint32_t alstats[ALPROTO_MAX] = {0};
+    uint32_t alstats[AlprotoMax];
+    memset(alstats, 0, AlprotoMax * sizeof(uint32_t));
     uint32_t mpm_sizes[max_buffer_type_id][256];
     memset(mpm_sizes, 0, sizeof(mpm_sizes));
-    uint32_t alproto_mpm_bufs[ALPROTO_MAX][max_buffer_type_id];
+    uint32_t alproto_mpm_bufs[AlprotoMax][max_buffer_type_id];
     memset(alproto_mpm_bufs, 0, sizeof(alproto_mpm_bufs));
 
     DEBUG_VALIDATE_BUG_ON(sgh->init == NULL);
@@ -790,7 +791,7 @@ static json_t *RulesGroupPrintSghStats(const DetectEngineCtx *de_ctx, const SigG
     json_object_set_new(types, "any5", json_integer(any5_cnt));
     json_object_set_new(stats, "types", types);
 
-    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
+    for (AppProto i = 0; i < AlprotoMax; i++) {
         if (alstats[i] > 0) {
             json_t *app = json_object();
             json_object_set_new(app, "total", json_integer(alstats[i]));

--- a/src/detect-engine-file.h
+++ b/src/detect-engine-file.h
@@ -28,4 +28,7 @@ uint8_t DetectFileInspectGeneric(DetectEngineCtx *de_ctx, DetectEngineThreadCtx 
         const struct DetectEngineAppInspectionEngine_ *engine, const Signature *s, Flow *f,
         uint8_t flags, void *_alstate, void *tx, uint64_t tx_id);
 
+void DetectFileRegisterProto(
+        AppProto alproto, int direction, int to_client_progress, int to_server_progress);
+
 #endif /* SURICATA_DETECT_ENGINE_FILE_H */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1972,7 +1972,7 @@ static void PrepareMpms(DetectEngineCtx *de_ctx, SigGroupHead *sh)
     const int max_buffer_id = de_ctx->buffer_type_id + 1;
     const uint32_t max_sid = DetectEngineGetMaxSigId(de_ctx) / 8 + 1;
 
-    AppProto engines[max_buffer_id][ALPROTO_MAX];
+    AppProto engines[max_buffer_id][AlprotoMax];
     memset(engines, 0, sizeof(engines));
     int engines_idx[max_buffer_id];
     memset(engines_idx, 0, sizeof(engines_idx));

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -521,7 +521,7 @@ void PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 
         /* per alproto to set is_last_for_progress per alproto because the inspect
          * loop skips over engines that are not the correct alproto */
-        for (AppProto a = 1; a < ALPROTO_FAILED; a++) {
+        for (AppProto a = ALPROTO_FAILED + 1; a < ALPROTO_MAX; a++) {
             int last_tx_progress = 0;
             bool last_tx_progress_set = false;
             PrefilterEngine *prev_engine = NULL;

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -521,7 +521,7 @@ void PrefilterSetupRuleGroup(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 
         /* per alproto to set is_last_for_progress per alproto because the inspect
          * loop skips over engines that are not the correct alproto */
-        for (AppProto a = ALPROTO_FAILED + 1; a < ALPROTO_MAX; a++) {
+        for (AppProto a = ALPROTO_FAILED + 1; a < AlprotoMax; a++) {
             int last_tx_progress = 0;
             bool last_tx_progress_set = false;
             PrefilterEngine *prev_engine = NULL;

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -277,6 +277,7 @@
 #include "util-path.h"
 #include "util-mpm-ac.h"
 #include "runmodes.h"
+#include "util-plugin.h"
 
 int DETECT_TBLSIZE = 0;
 int DETECT_TBLSIZE_IDX = DETECT_TBLSIZE_STATIC;
@@ -683,6 +684,18 @@ void SigTableSetup(void)
     ScDetectRfbRegister();
     ScDetectSipRegister();
     ScDetectTemplateRegister();
+
+#ifdef HAVE_PLUGINS
+    for (size_t i = 0; i < app_layer_plugins_nb; i++) {
+        SCAppLayerPlugin *app_layer_plugin = SCPluginFindAppLayerByIndex(i);
+        if (app_layer_plugin == NULL) {
+            break;
+        }
+        if (app_layer_plugin->KeywordsRegister != NULL) {
+            app_layer_plugin->KeywordsRegister();
+        }
+    }
+#endif
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -181,7 +181,7 @@ static void AppLayerInspectEngineRegisterInternal(const char *name, AppProto alp
     }
     SCLogDebug("name %s id %d", name, sm_list);
 
-    if ((alproto >= ALPROTO_FAILED) || (!(dir == SIG_FLAG_TOSERVER || dir == SIG_FLAG_TOCLIENT)) ||
+    if ((alproto == ALPROTO_FAILED) || (!(dir == SIG_FLAG_TOSERVER || dir == SIG_FLAG_TOCLIENT)) ||
             (sm_list < DETECT_SM_LIST_MATCH) || (sm_list >= SHRT_MAX) ||
             (progress < 0 || progress >= SHRT_MAX) || (Callback == NULL)) {
         SCLogError("Invalid arguments");

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -97,11 +97,11 @@ static void SetupDetectEngineConfig(DetectEngineCtx *de_ctx) {
     if (de_ctx->filedata_config)
         return;
 
-    de_ctx->filedata_config = SCMalloc(ALPROTO_MAX * sizeof(DetectFileDataCfg));
+    de_ctx->filedata_config = SCMalloc(AlprotoMax * sizeof(DetectFileDataCfg));
     if (unlikely(de_ctx->filedata_config == NULL))
         return;
     /* initialize default */
-    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
+    for (AppProto i = 0; i < AlprotoMax; i++) {
         de_ctx->filedata_config[i].content_limit = FILEDATA_CONTENT_LIMIT;
         de_ctx->filedata_config[i].content_inspect_min_size = FILEDATA_CONTENT_INSPECT_MIN_SIZE;
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1736,8 +1736,7 @@ int DetectSignatureAddTransform(Signature *s, int transform, void *options)
 
 int DetectSignatureSetAppProto(Signature *s, AppProto alproto)
 {
-    if (alproto == ALPROTO_UNKNOWN ||
-        alproto >= ALPROTO_FAILED) {
+    if (!AppProtoIsValid(alproto)) {
         SCLogError("invalid alproto %u", alproto);
         return -1;
     }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -68,55 +68,80 @@
 #include "string.h"
 #include "detect-parse.h"
 #include "detect-engine-iponly.h"
+#include "detect-engine-file.h"
 #include "app-layer-detect-proto.h"
 
 #include "action-globals.h"
 #include "util-validate.h"
 
+// file protocols with common file handling
+typedef struct {
+    AppProto alproto;
+    int direction;
+    int to_client_progress;
+    int to_server_progress;
+} DetectFileHandlerProtocol_t;
+
 /* Table with all filehandler registrations */
 DetectFileHandlerTableElmt filehandler_table[DETECT_TBLSIZE_STATIC];
 
+#define ALPROTO_WITHFILES_MAX 16
+
+// file protocols with common file handling
+DetectFileHandlerProtocol_t al_protocols[ALPROTO_WITHFILES_MAX] = {
+    { .alproto = ALPROTO_NFS, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
+    { .alproto = ALPROTO_SMB, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
+    { .alproto = ALPROTO_FTP, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
+    { .alproto = ALPROTO_FTPDATA, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
+    { .alproto = ALPROTO_HTTP1,
+            .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
+            .to_client_progress = HTP_RESPONSE_BODY,
+            .to_server_progress = HTP_REQUEST_BODY },
+    { .alproto = ALPROTO_HTTP2,
+            .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
+            .to_client_progress = HTTP2StateDataServer,
+            .to_server_progress = HTTP2StateDataClient },
+    { .alproto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }, { .alproto = ALPROTO_UNKNOWN }
+};
+
+void DetectFileRegisterProto(
+        AppProto alproto, int direction, int to_client_progress, int to_server_progress)
+{
+    size_t i = 0;
+    while (i < ALPROTO_WITHFILES_MAX && al_protocols[i].alproto != ALPROTO_UNKNOWN) {
+        i++;
+    }
+    if (i == ALPROTO_WITHFILES_MAX) {
+        return;
+    }
+    al_protocols[i].alproto = alproto;
+    al_protocols[i].direction = direction;
+    al_protocols[i].to_client_progress = to_client_progress;
+    al_protocols[i].to_server_progress = to_server_progress;
+    al_protocols[i + 1].alproto = ALPROTO_UNKNOWN;
+}
+
 void DetectFileRegisterFileProtocols(DetectFileHandlerTableElmt *reg)
 {
-    // file protocols with common file handling
-    typedef struct {
-        AppProto al_proto;
-        int direction;
-        int to_client_progress;
-        int to_server_progress;
-    } DetectFileHandlerProtocol_t;
-    static DetectFileHandlerProtocol_t al_protocols[] = {
-        { .al_proto = ALPROTO_NFS, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
-        { .al_proto = ALPROTO_SMB, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
-        { .al_proto = ALPROTO_FTP, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
-        { .al_proto = ALPROTO_FTPDATA, .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT },
-        { .al_proto = ALPROTO_HTTP1,
-                .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
-                .to_client_progress = HTP_RESPONSE_BODY,
-                .to_server_progress = HTP_REQUEST_BODY },
-        { .al_proto = ALPROTO_HTTP2,
-                .direction = SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT,
-                .to_client_progress = HTTP2StateDataServer,
-                .to_server_progress = HTTP2StateDataClient },
-        { .al_proto = ALPROTO_SMTP, .direction = SIG_FLAG_TOSERVER }
-    };
-
-    for (size_t i = 0; i < ARRAY_SIZE(al_protocols); i++) {
+    for (size_t i = 0; i < AlprotoMax; i++) {
+        if (al_protocols[i].alproto == ALPROTO_UNKNOWN) {
+            break;
+        }
         int direction = al_protocols[i].direction == 0
                                 ? (int)(SIG_FLAG_TOSERVER | SIG_FLAG_TOCLIENT)
                                 : al_protocols[i].direction;
 
         if (direction & SIG_FLAG_TOCLIENT) {
             DetectAppLayerMpmRegister(reg->name, SIG_FLAG_TOCLIENT, reg->priority, reg->PrefilterFn,
-                    reg->GetData, al_protocols[i].al_proto, al_protocols[i].to_client_progress);
-            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].al_proto,
+                    reg->GetData, al_protocols[i].alproto, al_protocols[i].to_client_progress);
+            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].alproto,
                     SIG_FLAG_TOCLIENT, al_protocols[i].to_client_progress, reg->Callback,
                     reg->GetData);
         }
         if (direction & SIG_FLAG_TOSERVER) {
             DetectAppLayerMpmRegister(reg->name, SIG_FLAG_TOSERVER, reg->priority, reg->PrefilterFn,
-                    reg->GetData, al_protocols[i].al_proto, al_protocols[i].to_server_progress);
-            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].al_proto,
+                    reg->GetData, al_protocols[i].alproto, al_protocols[i].to_server_progress);
+            DetectAppLayerInspectEngineRegister(reg->name, al_protocols[i].alproto,
                     SIG_FLAG_TOSERVER, al_protocols[i].to_server_progress, reg->Callback,
                     reg->GetData);
         }

--- a/src/flow-private.h
+++ b/src/flow-private.h
@@ -74,7 +74,7 @@ enum {
     FLOW_PROTO_MAX,
 };
 /* max used in app-layer (counters) */
-#define FLOW_PROTO_APPLAYER_MAX FLOW_PROTO_UDP + 1
+#define FLOW_PROTO_APPLAYER_MAX (FLOW_PROTO_UDP + 1)
 
 /*
  * Variables

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -67,7 +67,7 @@ int SCOutputRegisterTxLogger(LoggerId id, const char *name, AppProto alproto, Tx
         ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit)
 {
     if (list == NULL) {
-        list = SCCalloc(ALPROTO_MAX, sizeof(OutputTxLogger *));
+        list = SCCalloc(AlprotoMax, sizeof(OutputTxLogger *));
         if (unlikely(list == NULL)) {
             SCLogError("Failed to allocate OutputTx list");
             return -1;
@@ -542,14 +542,14 @@ end:
 static TmEcode OutputTxLogThreadInit(ThreadVars *tv, const void *_initdata, void **data)
 {
     OutputTxLoggerThreadData *td =
-            SCCalloc(1, sizeof(*td) + ALPROTO_MAX * sizeof(OutputLoggerThreadStore *));
+            SCCalloc(1, sizeof(*td) + AlprotoMax * sizeof(OutputLoggerThreadStore *));
     if (td == NULL)
         return TM_ECODE_FAILED;
 
     *data = (void *)td;
     SCLogDebug("OutputTxLogThreadInit happy (*data %p)", *data);
 
-    for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+    for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
         OutputTxLogger *logger = list[alproto];
         while (logger) {
             if (logger->ThreadInit) {
@@ -598,7 +598,7 @@ static TmEcode OutputTxLogThreadDeinit(ThreadVars *tv, void *thread_data)
 {
     OutputTxLoggerThreadData *op_thread_data = (OutputTxLoggerThreadData *)thread_data;
 
-    for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+    for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
         OutputLoggerThreadStore *store = op_thread_data->store[alproto];
         OutputTxLogger *logger = list[alproto];
 
@@ -628,7 +628,7 @@ static TmEcode OutputTxLogThreadDeinit(ThreadVars *tv, void *thread_data)
 static uint32_t OutputTxLoggerGetActiveCount(void)
 {
     uint32_t cnt = 0;
-    for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+    for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
         for (OutputTxLogger *p = list[alproto]; p != NULL; p = p->next) {
             cnt++;
         }
@@ -650,7 +650,7 @@ static uint32_t OutputTxLoggerGetActiveCount(void)
 void OutputTxLoggerRegister (void)
 {
     BUG_ON(list);
-    list = SCCalloc(ALPROTO_MAX, sizeof(OutputTxLogger *));
+    list = SCCalloc(AlprotoMax, sizeof(OutputTxLogger *));
     if (unlikely(list == NULL)) {
         FatalError("Failed to allocate OutputTx list");
     }
@@ -664,7 +664,7 @@ void OutputTxShutdown(void)
     if (list == NULL) {
         return;
     }
-    for (AppProto alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+    for (AppProto alproto = 0; alproto < AlprotoMax; alproto++) {
         OutputTxLogger *logger = list[alproto];
         while (logger) {
             OutputTxLogger *next_logger = logger->next;

--- a/src/output.c
+++ b/src/output.c
@@ -835,7 +835,7 @@ void TmModuleLoggerRegister(void)
 
 EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto)
 {
-    if (alproto < ALPROTO_MAX) {
+    if (alproto < AlprotoMax) {
         return &simple_json_applayer_loggers[alproto];
     }
     return NULL;
@@ -857,7 +857,7 @@ static void RegisterSimpleJsonApplayerLogger(
  */
 void OutputRegisterRootLoggers(void)
 {
-    simple_json_applayer_loggers = SCCalloc(ALPROTO_MAX, sizeof(EveJsonSimpleAppLayerLogger));
+    simple_json_applayer_loggers = SCCalloc(AlprotoMax, sizeof(EveJsonSimpleAppLayerLogger));
     if (unlikely(simple_json_applayer_loggers == NULL)) {
         FatalError("Failed to allocate simple_json_applayer_loggers");
     }

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -757,8 +757,9 @@ void RunModeInitializeOutputs(void)
     char tls_log_enabled = 0;
     char tls_store_present = 0;
 
-    // ALPROTO_MAX is set to its final value
-    LoggerId logger_bits[ALPROTO_MAX] = { 0 };
+    // AlprotoMax is set to its final value
+    LoggerId logger_bits[AlprotoMax];
+    memset(logger_bits, 0, AlprotoMax * sizeof(LoggerId));
     TAILQ_FOREACH(output, &outputs->head, next) {
 
         output_config = ConfNodeLookupChild(output, output->val);
@@ -884,7 +885,7 @@ void RunModeInitializeOutputs(void)
 
     /* register the logger bits to the app-layer */
     AppProto a;
-    for (a = 0; a < ALPROTO_MAX; a++) {
+    for (a = 0; a < AlprotoMax; a++) {
         if (AppLayerParserSupportsFiles(IPPROTO_TCP, a)) {
             if (g_file_logger_enabled)
                 logger_bits[a] |= BIT_U32(LOGGER_FILE);
@@ -919,7 +920,6 @@ void RunModeInitializeOutputs(void)
             AppLayerParserRegisterLoggerBits(IPPROTO_TCP, a, logger_bits[a]);
         if (udp)
             AppLayerParserRegisterLoggerBits(IPPROTO_UDP, a, logger_bits[a]);
-
     }
     OutputSetupActiveLoggers();
 }

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -52,4 +52,15 @@ typedef struct SCCapturePlugin_ {
 
 int SCPluginRegisterCapture(SCCapturePlugin *);
 
+typedef struct SCAppLayerPlugin_ {
+    char *name;
+    char *logname;
+    char *confname;
+    void (*Register)(void);
+    bool (*Logger)(void *tx, void *jb);
+    void (*KeywordsRegister)(void);
+} SCAppLayerPlugin;
+
+int SCPluginRegisterAppLayer(SCAppLayerPlugin *);
+
 #endif /* __SURICATA_PLUGIN_H */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -361,7 +361,6 @@ void GlobalsInitPreConfig(void)
     SupportFastPatternForSigMatchTypes();
     SCThresholdConfGlobalInit();
     SCProtoNameInit();
-    FrameConfigInit();
 }
 
 void GlobalsDestroy(void)

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -36,32 +36,15 @@ extern const char *configNoChecksum;
 const uint8_t separator[] = {0x01, 0xD5, 0xCA, 0x7A};
 SCInstance surifuzz;
 AppProto forceLayer = 0;
+char *target_suffix = NULL;
 SC_ATOMIC_EXTERN(unsigned int, engine_stage);
 
 int LLVMFuzzerInitialize(int *argc, char ***argv)
 {
-    char *target_suffix = strrchr((*argv)[0], '_');
-    if (target_suffix != NULL) {
-        AppProto applayer = StringToAppProto(target_suffix + 1);
-        if (applayer != ALPROTO_UNKNOWN) {
-            forceLayer = applayer;
-            printf("Forcing %s=%" PRIu16 "\n", AppProtoToString(forceLayer), forceLayer);
-            return 0;
-        }
-    }
+    target_suffix = strrchr((*argv)[0], '_');
     // else
-    const char *forceLayerStr = getenv("FUZZ_APPLAYER");
-    if (forceLayerStr) {
-        if (ByteExtractStringUint16(&forceLayer, 10, 0, forceLayerStr) < 0) {
-            forceLayer = 0;
-            printf("Invalid numeric value for FUZZ_APPLAYER environment variable");
-        } else {
-            printf("Forcing %s\n", AppProtoToString(forceLayer));
-        }
-    }
-    // http is the output name, but we want to fuzz HTTP1
-    if (forceLayer == ALPROTO_HTTP) {
-        forceLayer = ALPROTO_HTTP1;
+    if (!target_suffix) {
+        target_suffix = getenv("FUZZ_APPLAYER");
     }
     return 0;
 }
@@ -96,6 +79,17 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         PostConfLoadedSetup(&surifuzz);
         alp_tctx = AppLayerParserThreadCtxAlloc();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
+        if (target_suffix != NULL) {
+            AppProto applayer = StringToAppProto(target_suffix + 1);
+            if (applayer != ALPROTO_UNKNOWN) {
+                forceLayer = applayer;
+                printf("Forcing %s=%" PRIu16 "\n", AppProtoToString(forceLayer), forceLayer);
+            }
+        }
+        // http is the output name, but we want to fuzz HTTP1
+        if (forceLayer == ALPROTO_HTTP) {
+            forceLayer = ALPROTO_HTTP1;
+        }
     }
 
     if (size < HEADER_LEN) {

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -96,7 +96,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         return 0;
     }
 
-    if (data[0] >= ALPROTO_MAX) {
+    if (data[0] >= AlprotoMax) {
         return 0;
     }
     //no UTHBuildFlow to have storage

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -30,8 +30,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     Flow *f;
     TcpSession ssn;
     bool reverse;
-    AppProto alproto;
-    AppProto alproto2;
 
     if (alpd_tctx == NULL) {
         //global init
@@ -66,31 +64,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (data[0] & STREAM_TOSERVER) {
         flags = STREAM_TOSERVER;
     }
-    alproto = AppLayerProtoDetectGetProto(
+    AppLayerProtoDetectGetProto(
             alpd_tctx, f, data + HEADER_LEN, size - HEADER_LEN, f->proto, flags, &reverse);
-    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && f->proto == IPPROTO_TCP) {
-        /* If we find a valid protocol at the start of a stream :
-         * check that with smaller input
-         * we find the same protocol or ALPROTO_UNKNOWN.
-         * Otherwise, we have evasion with TCP splitting
-         */
-        for (size_t i = 0; i < size-HEADER_LEN && i < PROTO_DETECT_MAX_LEN; i++) {
-            // reset detection at each try cf probing_parser_toserver_alproto_masks
-            AppLayerProtoDetectReset(f);
-            alproto2 = AppLayerProtoDetectGetProto(
-                    alpd_tctx, f, data + HEADER_LEN, i, f->proto, flags, &reverse);
-            if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto) {
-                printf("Failed with input length %" PRIuMAX " versus %" PRIuMAX
-                       ", found %s instead of %s\n",
-                        (uintmax_t)i, (uintmax_t)size - HEADER_LEN, AppProtoToString(alproto2),
-                        AppProtoToString(alproto));
-                printf("Assertion failure: %s-%s\n", AppProtoToString(alproto2),
-                        AppProtoToString(alproto));
-                fflush(stdout);
-                abort();
-            }
-        }
-    }
     FlowFree(f);
 
     return 0;

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -9,7 +9,7 @@
 #include "suricata.h"
 #include "app-layer-detect-proto.h"
 #include "flow-util.h"
-#include "app-layer-parser.h"
+#include "app-layer.h"
 #include "util-unittest-helper.h"
 #include "conf-yaml-loader.h"
 
@@ -43,9 +43,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         MpmTableSetup();
         SpmTableSetup();
         EngineModeSetIDS();
-        AppLayerProtoDetectSetup();
-        AppLayerParserSetup();
-        AppLayerParserRegisterProtocolParsers();
+        AppLayerSetup();
         alpd_tctx = AppLayerProtoDetectGetCtxThread();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
     }

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -33,7 +33,7 @@ enum ExceptionPolicy {
     EXCEPTION_POLICY_REJECT,
 };
 
-#define EXCEPTION_POLICY_MAX EXCEPTION_POLICY_REJECT + 1
+#define EXCEPTION_POLICY_MAX (EXCEPTION_POLICY_REJECT + 1)
 
 /* Max length = possible exception policy scenarios + counter names
  * + exception policy type. E.g.:

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -22,6 +22,7 @@
 #include "util-plugin.h"
 #include "util-debug.h"
 #include "conf.h"
+#include "app-layer-protos.h"
 
 #ifdef HAVE_PLUGINS
 
@@ -147,5 +148,39 @@ SCCapturePlugin *SCPluginFindCaptureByName(const char *name)
         }
     }
     return plugin;
+}
+
+static SCAppLayerPlugin **app_layer_plugins = NULL;
+size_t app_layer_plugins_nb = 0;
+#define ARRAY_CAP_STEP 16
+static size_t app_layer_plugins_cap = 0;
+
+int SCPluginRegisterAppLayer(SCAppLayerPlugin *plugin)
+{
+    if (app_layer_plugins_nb == app_layer_plugins_cap) {
+        void *tmp = SCRealloc(app_layer_plugins,
+                sizeof(SCAppLayerPlugin *) * (app_layer_plugins_cap + ARRAY_CAP_STEP));
+        if (tmp == NULL) {
+            return 1;
+        }
+        app_layer_plugins_cap += ARRAY_CAP_STEP;
+        app_layer_plugins = tmp;
+    }
+    if (app_layer_plugins_nb < app_layer_plugins_cap) {
+        app_layer_plugins[app_layer_plugins_nb] = plugin;
+        AppProtoRegisterProtoString(
+                (AppProto)(ALPROTO_MAX_STATIC + app_layer_plugins_nb), plugin->name);
+        app_layer_plugins_nb++;
+        return 0;
+    }
+    return 1;
+}
+
+SCAppLayerPlugin *SCPluginFindAppLayerByIndex(size_t i)
+{
+    if (i < app_layer_plugins_nb) {
+        return app_layer_plugins[i];
+    }
+    return NULL;
 }
 #endif

--- a/src/util-plugin.h
+++ b/src/util-plugin.h
@@ -25,4 +25,8 @@ SCCapturePlugin *SCPluginFindCaptureByName(const char *name);
 
 bool RegisterPlugin(SCPlugin *, void *);
 
+SCAppLayerPlugin *SCPluginFindAppLayerByIndex(size_t i);
+
+extern size_t app_layer_plugins_nb;
+
 #endif /* SURICATA_UTIL_PLUGIN_H */

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -820,7 +820,7 @@ void SCProfilingPrintPacketProfile(Packet *p)
 
     /* count ticks for app layer */
     uint64_t app_total = 0;
-    for (AppProto i = 1; i < ALPROTO_FAILED; i++) {
+    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
         const PktProfilingAppData *pdt = &p->profile->app[i];
 
         if (p->proto == IPPROTO_TCP) {

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -158,11 +158,11 @@ SCProfilingInit(void)
             memset(&packet_profile_data6, 0, sizeof(packet_profile_data6));
             memset(&packet_profile_tmm_data4, 0, sizeof(packet_profile_tmm_data4));
             memset(&packet_profile_tmm_data6, 0, sizeof(packet_profile_tmm_data6));
-            packet_profile_app_data4 = SCCalloc(ALPROTO_MAX * 257, sizeof(SCProfilePacketData));
+            packet_profile_app_data4 = SCCalloc(AlprotoMax * 257, sizeof(SCProfilePacketData));
             if (packet_profile_app_data4 == NULL) {
                 FatalError("Failed to allocate packet_profile_app_data4");
             }
-            packet_profile_app_data6 = SCCalloc(ALPROTO_MAX * 257, sizeof(SCProfilePacketData));
+            packet_profile_app_data6 = SCCalloc(AlprotoMax * 257, sizeof(SCProfilePacketData));
             if (packet_profile_app_data6 == NULL) {
                 FatalError("Failed to allocate packet_profile_app_data6");
             }
@@ -503,7 +503,7 @@ void SCProfilingDumpPacketStats(void)
             "--------------------", "------", "-----", "----------", "------------", "------------", "-----------");
 
     total = 0;
-    for (AppProto a = 0; a < ALPROTO_MAX; a++) {
+    for (AppProto a = 0; a < AlprotoMax; a++) {
         for (int p = 0; p < 257; p++) {
             SCProfilePacketData *pd = &packet_profile_app_data4[a * 257 + p];
             total += pd->tot;
@@ -512,7 +512,7 @@ void SCProfilingDumpPacketStats(void)
             total += pd->tot;
         }
     }
-    for (AppProto a = 0; a < ALPROTO_MAX; a++) {
+    for (AppProto a = 0; a < AlprotoMax; a++) {
         for (int p = 0; p < 257; p++) {
             SCProfilePacketData *pd = &packet_profile_app_data4[a * 257 + p];
             if (pd->cnt == 0) {
@@ -531,7 +531,7 @@ void SCProfilingDumpPacketStats(void)
         }
     }
 
-    for (AppProto a = 0; a < ALPROTO_MAX; a++) {
+    for (AppProto a = 0; a < AlprotoMax; a++) {
         for (int p = 0; p < 257; p++) {
             SCProfilePacketData *pd = &packet_profile_app_data6[a * 257 + p];
             if (pd->cnt == 0) {
@@ -820,7 +820,7 @@ void SCProfilingPrintPacketProfile(Packet *p)
 
     /* count ticks for app layer */
     uint64_t app_total = 0;
-    for (AppProto i = 0; i < ALPROTO_MAX; i++) {
+    for (AppProto i = 0; i < AlprotoMax; i++) {
         const PktProfilingAppData *pdt = &p->profile->app[i];
 
         if (p->proto == IPPROTO_TCP) {
@@ -951,7 +951,7 @@ static void SCProfilingUpdatePacketAppRecord(int alproto, uint8_t ipproto, PktPr
 static void SCProfilingUpdatePacketAppRecords(Packet *p)
 {
     int i;
-    for (i = 0; i < ALPROTO_MAX; i++) {
+    for (i = 0; i < AlprotoMax; i++) {
         PktProfilingAppData *pdt = &p->profile->app[i];
 
         if (pdt->ticks_spent > 0) {
@@ -1199,7 +1199,7 @@ PktProfiling *SCProfilePacketStart(void)
 {
     uint64_t sample = SC_ATOMIC_ADD(samples, 1);
     if (sample % rate == 0)
-        return SCCalloc(1, sizeof(PktProfiling) + ALPROTO_MAX * sizeof(PktProfilingAppData));
+        return SCCalloc(1, sizeof(PktProfiling) + AlprotoMax * sizeof(PktProfilingAppData));
     return NULL;
 }
 

--- a/src/util-profiling.h
+++ b/src/util-profiling.h
@@ -203,12 +203,12 @@ PktProfiling *SCProfilePacketStart(void);
         (dp)->proto_detect_ticks_spent = 0;                         \
     }
 
-#define PACKET_PROFILING_APP_STORE(dp, p)                           \
-    if (profiling_packets_enabled && (p)->profile != NULL) {        \
-        if ((dp)->alproto < ALPROTO_MAX) {                          \
-            (p)->profile->app[(dp)->alproto].ticks_spent += (dp)->ticks_spent;   \
-            (p)->profile->proto_detect += (dp)->proto_detect_ticks_spent;        \
-        }                                                           \
+#define PACKET_PROFILING_APP_STORE(dp, p)                                                          \
+    if (profiling_packets_enabled && (p)->profile != NULL) {                                       \
+        if ((dp)->alproto < AlprotoMax) {                                                          \
+            (p)->profile->app[(dp)->alproto].ticks_spent += (dp)->ticks_spent;                     \
+            (p)->profile->proto_detect += (dp)->proto_detect_ticks_spent;                          \
+        }                                                                                          \
     }
 
 #define PACKET_PROFILING_DETECT_START(p, id)                        \


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5053

Describe changes:
- get ready to use dynamic number of app-layer protos (also work with static constant) in some places
- preventive fix of macro with parenthesis cc @jufajardini 

#12066 with review taken into account 
- making ALPROTO_FAILED constant=1
- more verbose commit messages
- get rid of a limit or 32 app-layer protocols for protocol detection with probing parsers.

This limit was luckily not a real problem for now.
The bug is setting probing parser done too soon. This may happen if the first packet does not have a full PDU...
- ALPROTO_TEMPLATE=32 is not really meaningful
- ALPROTO_RDP probes only one byte ! (which may be a problem in itself)
- ALPROTO_BITTORRENT_DHT and ALPROTO_POP3 do not probe
- ALPROTO_HTTP2 has probing but only on one side, the other side being a pattern. So we can technically get a different behavior but it is in an edge case that is not a real usage of HTTP2 : with a flow having HTTP2 where we only see server talking to client if the first packet has not enough data for a HTTP2 header.

Example plugin at https://github.com/catenacyber/suricata-zabbix