### PR TITLE
Dev/ldap v0.2: small improvements to the LDAP parser

### DIFF
--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -617,7 +617,7 @@ const PARSER_NAME: &[u8] = b"ldap\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
-    let default_port = CString::new("389").unwrap();
+    let default_port = CString::new("[389, 3268]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const c_char,
         default_port: default_port.as_ptr(),
@@ -674,7 +674,7 @@ pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
 
 #[no_mangle]
 pub unsafe extern "C" fn SCRegisterLdapUdpParser() {
-    let default_port = CString::new("389").unwrap();
+    let default_port = CString::new("[389, 3268]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const c_char,
         default_port: default_port.as_ptr(),

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1188,11 +1188,11 @@ app-layer:
       tcp:
         enabled: yes
         detection-ports:
-          dp: 389
+          dp: 389, 3268
       udp:
         enabled: yes
         detection-ports:
-          dp: 389
+          dp: 389, 3268
       # Maximum number of live LDAP transactions per flow
       # max-tx: 1024
 


### PR DESCRIPTION
## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [NA] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [NA] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [NA] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues


Describe changes:

This pull request does minor changes to the LDAP app-layer:
- add port 3268 to the default monitored ports. This port is used by ActiveDirectory for global operations (not local to the current domain)
- Add support for the STARTTLS extended operation, so now the TLS handshake (and the Certificate) can be inspected and logged. It also takes care to check if STARTTLS succeeds, to avoid errors.

The STARTTLS work will have a matching PR in suricata-verify

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2128