### PR TITLE
Lua dataset/v7

### DIFF
--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -129,20 +129,19 @@ void DetectLuaRegister(void)
 #define DEFAULT_LUA_ALLOC_LIMIT       500000
 #define DEFAULT_LUA_INSTRUCTION_LIMIT 500000
 
-#if 0
 /** \brief dump stack from lua state to screen */
-void LuaDumpStack(lua_State *state)
+void LuaDumpStack(lua_State *state, const char *prefix)
 {
     int size = lua_gettop(state);
-    int i;
+    printf("%s: size %d\n", prefix, size);
 
-    for (i = 1; i <= size; i++) {
+    for (int i = 1; i <= size; i++) {
         int type = lua_type(state, i);
-        printf("Stack size=%d, level=%d, type=%d, ", size, i, type);
+        printf("- %s: Stack size=%d, level=%d, type=%d, ", prefix, size, i, type);
 
         switch (type) {
             case LUA_TFUNCTION:
-                printf("function %s", lua_tostring(state, i) ? "true" : "false");
+                printf("function %s", lua_tostring(state, i));
                 break;
             case LUA_TBOOLEAN:
                 printf("bool %s", lua_toboolean(state, i) ? "true" : "false");
@@ -164,7 +163,6 @@ void LuaDumpStack(lua_State *state)
         printf("\n");
     }
 }
-#endif
 
 /**
  * \brief Common function to run the Lua match function and process

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -523,6 +523,18 @@ static void *DetectLuaThreadInit(void *data)
         goto error;
     }
 
+    /* thread_init call */
+    lua_getglobal(t->luastate, "thread_init");
+    if (lua_isfunction(t->luastate, -1)) {
+        if (lua_pcall(t->luastate, 0, 0, 0) != 0) {
+            SCLogError("couldn't run script 'thread_init' function: %s",
+                    lua_tostring(t->luastate, -1));
+            goto error;
+        }
+    } else {
+        lua_pop(t->luastate, 1);
+    }
+
     return (void *)t;
 
 error:

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -66,5 +66,6 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
         Flow *f);
 
 void DetectLuaPostSetup(Signature *s);
+void LuaDumpStack(lua_State *state, const char *prefix);
 
 #endif /* SURICATA_DETECT_LUA_H */


### PR DESCRIPTION
Initial dataset support for lua.

Changes since https://github.com/OISF/suricata/pull/12090:

More idiomatic lua:
```lua
function init (args)
    local needs = {}
    needs["packet"] = tostring(true)
    return needs
end

function thread_init (args)
    conn_new, err = dataset.new()
    ret, err = conn_new:get("conn-seen")
    if err ~= nil then
        SCLogWarning("dataset warning: " .. err)
        return 0
    end
end

function match (args)
    ipver, srcip, dstip, proto, sp, dp = SCFlowTuple()
    str = ipver .. ":<" .. srcip .. ">:<" .. dstip .. ">:" .. dp

    ret, err = conn_new:add(str, #str);
    if ret == 1 then
        SCLogInfo(str .. " => " .. ret)
    end
    return ret
end
```

One question is if we should add support for `require`, so that to be able to use `dataset` a script author would have to include `require dataset` or `require suricata.dataset` before being able to use it...

https://redmine.openinfosecfoundation.org/issues/7243

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2129
