### PR TITLE
suricata: fix list-keywords option

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1514,6 +1514,14 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "/tmp/ut.profraw"
       - run: llvm-profdata-14 merge -o ut.profdata /tmp/ut.profraw
+      - run: ./src/suricata --list-keywords -l /tmp
+        env:
+          LLVM_PROFILE_FILE: "/tmp/lk.profraw"
+      - run: llvm-profdata-14 merge -o ut.profdata /tmp/lk.profraw
+      - run: ./src/suricata --list-app-layer-protos -l /tmp
+        env:
+          LLVM_PROFILE_FILE: "/tmp/la.profraw"
+      - run: llvm-profdata-14 merge -o ut.profdata /tmp/la.profraw
       - run: llvm-cov-14 show ./src/suricata -instr-profile=ut.profdata --show-instantiations --ignore-filename-regex="^/root/.*" > coverage.txt
       - run: |
           cd rust

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -36,6 +36,7 @@ int ListKeywords(const char *keyword_info)
     MpmTableSetup();
     SpmTableSetup();
     AppLayerSetup();
+    SigTableInit();
     SigTableSetup(); /* load the rule keywords */
     return SigTableList(keyword_info);
 }


### PR DESCRIPTION
The list keywords option was crashing due to improper init.

Ticket: 7397

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7397

Describe changes:
- fix list keywords