### PR TITLE
output/http: log invalid status as a string

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2014,6 +2014,9 @@
                 "status": {
                     "type": "integer"
                 },
+                "status_str": {
+                    "type": "string"
+                },
                 "true_client_ip": {
                     "type": "string"
                 },

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -296,12 +296,8 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
     if (resp > 0) {
         jb_set_uint(js, "status", (uint32_t)resp);
     } else if (tx->response_status != NULL) {
-        const size_t status_size = bstr_len(tx->response_status) * 2 + 1;
-        char status_string[status_size];
-        BytesToStringBuffer(bstr_ptr(tx->response_status), bstr_len(tx->response_status),
-                status_string, status_size);
-        unsigned int val = strtoul(status_string, NULL, 10);
-        jb_set_uint(js, "status", val);
+        jb_set_string_from_bytes(js, "status_str", bstr_ptr(tx->response_status),
+                (uint32_t)bstr_len(tx->response_status));
     }
 
     htp_header_t *h_location = htp_table_get_c(tx->response_headers, "location");


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7311

Describe changes:
- output/http: log invalid status as a string

Also fix integer warning on the way

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2085

From https://github.com/OISF/suricata/pull/11904 in its own PR