### PR TITLE
lua: update lua crate with better header copying

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1049,7 +1049,7 @@ dependencies = [
 [[package]]
 name = "suricata-lua-sys"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/jasonish/suricata-lua-sys?branch=copy-fix#df4a9c42168f060684a47ab4c0846bb335d7e160"
+source = "git+https://github.com/jasonish/suricata-lua-sys?branch=copy-fix#186720637e9ee2d34db250198d5363f68faf6a90"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed3f46aa1b92feb15880f722bbce121e769bda1770f0090121cd6c920d89450"
+checksum = "2db6abfb8d28b60a0d984272123ed1bec6c45a5f729f6393921482007406babf"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1049,8 +1049,7 @@ dependencies = [
 [[package]]
 name = "suricata-lua-sys"
 version = "0.1.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db6abfb8d28b60a0d984272123ed1bec6c45a5f729f6393921482007406babf"
+source = "git+https://github.com/jasonish/suricata-lua-sys?branch=copy-fix#df4a9c42168f060684a47ab4c0846bb335d7e160"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -71,6 +71,7 @@ suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
 #suricata-lua-sys = { version = "0.1.0-alpha.5" }
 suricata-lua-sys = { git = "https://github.com/jasonish/suricata-lua-sys", branch = "copy-fix" }
+#suricata-lua-sys = { path = "../../../suricata-lua-sys" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -69,7 +69,8 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.5" }
+#suricata-lua-sys = { version = "0.1.0-alpha.5" }
+suricata-lua-sys = { git = "https://github.com/jasonish/suricata-lua-sys", branch = "copy-fix" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -69,7 +69,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.3" }
+suricata-lua-sys = { version = "0.1.0-alpha.5" }
 
 [dev-dependencies]
 test-case = "~3.3.1"


### PR DESCRIPTION
Update lua crate to 0.1.0-alpha.5. This update will rewrite the headers if the env var SURICATA_LUA_SYS_HEADER_DST changes. This fixes the issue where the headers may not be written.

The cause is that Rust dependencies are cached, and if your editor is using rust-analyzer, it might cache the built without this var being set, so these headers are not available to Suricata. This crate update forces the re-run of the Lua build.rs if this env var changes, fixing this issue.

This new Lua crate is also smarter about writing out the headers, don't overwrite if the destination appears to be the same as the source, as this can force subsequent invocations of make to rebuild the C source.

Fixes this issue in PR https://github.com/OISF/suricata/pull/12104:
- The MacOS build had different environment variables between the calls to `make <build>` and `make install`, which smarter build systems can detect, if there are vars that matter to the build. In this case it was the library search path.
- But was able to fix this on the Lua crate side by not always copying the headers as part of the build, for example if the destination exists and is newer then the source header.
