### PR TITLE
rust: put all rust/cargo env vars in CARGO_ENV

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed3f46aa1b92feb15880f722bbce121e769bda1770f0090121cd6c920d89450"
+checksum = "2db6abfb8d28b60a0d984272123ed1bec6c45a5f729f6393921482007406babf"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -69,7 +69,7 @@ time = "~0.3.36"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.3" }
+suricata-lua-sys = { version = "0.1.0-alpha.5" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -34,23 +34,24 @@ if RUST_CROSS_COMPILE
 RUST_TARGET = --target $(host_triplet)
 endif
 
+if HAVE_CYGPATH
+CARGO_ENV =	@rustup_home@ \
+		CARGO_HOME="$(CARGO_HOME)" \
+		CARGO_TARGET_DIR="$(e_rustdir)/target" \
+		SURICATA_LUA_SYS_HEADER_DST="$(e_rustdir)/gen"
+else
+CARGO_ENV =	@rustup_home@ \
+		CARGO_HOME="$(CARGO_HOME)" \
+		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
+		SURICATA_LUA_SYS_HEADER_DST="$(abs_top_builddir)/rust/gen"
+endif
+
 all-local: Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
-if HAVE_CYGPATH
 	cd $(abs_top_srcdir)/rust && \
-		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
-		CARGO_TARGET_DIR="$(e_rustdir)/target" \
-		SURICATA_LUA_SYS_HEADER_DST="$(e_rustdir)/gen" \
-		$(CARGO) build $(RELEASE) \
-			--features "$(RUST_FEATURES)" $(RUST_TARGET)
-else
-	cd $(abs_top_srcdir)/rust && \
-		@rustup_home@ CARGO_HOME="$(CARGO_HOME)" \
-		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
-		SURICATA_LUA_SYS_HEADER_DST="$(abs_top_builddir)/rust/gen" \
+		$(CARGO_ENV) \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)
-endif
 	if test -e $(RUST_SURICATA_LIBDIR)/suricata.lib; then \
 		cp -a $(RUST_SURICATA_LIBDIR)/suricata.lib \
 			$(RUST_SURICATA_LIBDIR)/${RUST_SURICATA_LIBNAME}; \
@@ -76,12 +77,11 @@ distclean-local:
 
 check:
 	cd $(abs_top_srcdir)/rust && \
-		CARGO_HOME="$(CARGO_HOME)" @rustup_home@ \
-		CARGO_TARGET_DIR="$(abs_top_builddir)/rust/target" \
+		$(CARGO_ENV) \
 		$(CARGO) test --all $(RELEASE) --features "$(RUST_FEATURES)"
 
 vendor:
-	CARGO_HOME="$(CARGO_HOME)" @rustup_home@ $(CARGO) vendor
+	$(CARGO_ENV) $(CARGO) vendor
 
 if HAVE_CBINDGEN
 gen/rust-bindings.h: $(RUST_SURICATA_LIB)


### PR DESCRIPTION
To ensure that all calls to cargo use the same environment variables,
put the environment variables in CARGO_ENV so every call to cargo can
easily use the same vars.

The Cargo build system is smarter than make, it can detect a change in
an environment variable that affects the build, and the setting of
SURICATA_LUA_SYS_HEADER_DST changing could cause a rebuild.

Also update suricata-lua-sys, which is smarter about copying headers. It
will only copy if the destination does not exist, or the source header
is newer than the target, which can also prevent unnecessary rebuilds.

This is mainly to fix an issue where subsequent builds may fail,
especially when running an editor with a LSP enabled:

    Update lua crate to 0.1.0-alpha.5. This update will force a rewrite of
    the headers if the env var SURICATA_LUA_SYS_HEADER_DST changes. This
    fixes the issue where the headers may not be written.

    The cause is that Rust dependencies are cached, and if your editor is
    using rust-analyzer, it might cache the build without this var being
    set, so these headers are not available to Suricata. This crate update
    forces the re-run of the Lua build.rs if this env var changes, fixing
    this issue.
