### PR TITLE
Dns dcerpc reversed v4

### DIFF
--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -294,9 +294,11 @@ pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_cnt(vtx: *mut std::os::raw::c_void
 /// Probe input to see if it looks like DCERPC.
 fn probe(input: &[u8]) -> (bool, bool) {
     match parser::parse_dcerpc_udp_header(input) {
-        Ok((_, hdr)) => {
+        Ok((leftover_bytes, hdr)) => {
             let is_request = hdr.pkt_type == 0x00;
             let is_dcerpc = hdr.rpc_vers == 0x04 &&
+                hdr.fragnum == 0 &&
+                leftover_bytes.len() >= hdr.fraglen as usize &&
                 (hdr.flags2 & 0xfc == 0) &&
                 (hdr.drep[0] & 0xee == 0) &&
                 (hdr.drep[1] <= 3);

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1401,7 +1401,6 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f
             (flags & STREAM_TOSERVER) ? "toserver" : "toclient");
 
     AppProto alproto = ALPROTO_UNKNOWN;
-    AppProto pm_alproto = ALPROTO_UNKNOWN;
 
     if (!FLOW_IS_PM_DONE(f, flags)) {
         AppProto pm_results[ALPROTO_MAX];
@@ -1419,37 +1418,23 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f
                     FLOW_RESET_PP_DONE(f, reverse_dir);
                 }
             }
-
-            /* HACK: if detected protocol is dcerpc/udp, we run PP as well
-             * to avoid misdetecting DNS as DCERPC. */
-            if (!(ipproto == IPPROTO_UDP && alproto == ALPROTO_DCERPC))
-                goto end;
-
-            pm_alproto = alproto;
-
-            /* fall through */
+            SCReturnUInt(alproto);
         }
     }
 
     if (!FLOW_IS_PP_DONE(f, flags)) {
-        bool rflow = false;
-        alproto = AppLayerProtoDetectPPGetProto(f, buf, buflen, ipproto, flags, &rflow);
+        DEBUG_VALIDATE_BUG_ON(*reverse_flow);
+        alproto = AppLayerProtoDetectPPGetProto(f, buf, buflen, ipproto, flags, reverse_flow);
         if (AppProtoIsValid(alproto)) {
-            if (rflow) {
-                *reverse_flow = true;
-            }
-            goto end;
+            SCReturnUInt(alproto);
         }
     }
 
     /* Look if flow can be found in expectation list */
     if (!FLOW_IS_PE_DONE(f, flags)) {
+        DEBUG_VALIDATE_BUG_ON(*reverse_flow);
         alproto = AppLayerProtoDetectPEGetProto(f, flags);
     }
-
- end:
-    if (!AppProtoIsValid(alproto))
-        alproto = pm_alproto;
 
     SCReturnUInt(alproto);
 }


### PR DESCRIPTION
Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7111

Describe changes:
This is a replacement of https://github.com/OISF/suricata/pull/11679
There are 2 commits.
The first one is intended to improve DCERPC UDP detection. False positives resulted in improper work of the detection framework.
The second commit simplifies the detection framework function AppLayerProtoDetectGetProto.
It previously contained a bug that combined with a false positive in DCERPC resulted in incorrect reporting of DNS flow direction.
### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2151
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
