### PR TITLE
list-keywords: initialize sigtable before setup

### DIFF
--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -36,6 +36,7 @@ int ListKeywords(const char *keyword_info)
     MpmTableSetup();
     SpmTableSetup();
     AppLayerSetup();
+    SigTableInit();
     SigTableSetup(); /* load the rule keywords */
     return SigTableList(keyword_info);
 }


### PR DESCRIPTION
This broke with commit 2ac16ee1a6cf4b5c2dbcd8e6ab970e0bd8085860 which
separated SigTableSetup into SigTableSetup and SigTableInit.
