### PR TITLE
detect/sip.stat_code: Correct sticky buffer name

### DIFF
--- a/src/detect-sip-stat-code.c
+++ b/src/detect-sip-stat-code.c
@@ -56,7 +56,7 @@
 
 #define KEYWORD_NAME "sip.stat_code"
 #define KEYWORD_DOC  "sip-keywords.html#sip-stat-code"
-#define BUFFER_NAME  "sip.method"
+#define BUFFER_NAME  "sip.stat_code"
 #define BUFFER_DESC  "sip response status code"
 static int g_buffer_id = 0;
 


### PR DESCRIPTION
Issue: 7295

The sticky buffer name was incorrectly set to method; this commit fixes the name typo with stat_code.


SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2072
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
