### PR TITLE
detect/transform: fix leak in xor transform parse

### DIFF
--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -60,13 +60,17 @@ unsafe fn xor_parse(raw: *const std::os::raw::c_char) -> *mut c_void {
 
 #[no_mangle]
 unsafe extern "C" fn xor_setup(
-    _de: *mut c_void, s: *mut c_void, opt_str: *const std::os::raw::c_char,
+    de: *mut c_void, s: *mut c_void, opt_str: *const std::os::raw::c_char,
 ) -> c_int {
     let ctx = xor_parse(opt_str);
     if ctx.is_null() {
         return -1;
     }
-    return DetectSignatureAddTransform(s, G_TRANSFORM_XOR_ID, ctx);
+    let r = DetectSignatureAddTransform(s, G_TRANSFORM_XOR_ID, ctx);
+    if r != 0 {
+        xor_free(de, ctx);
+    }
+    return r;
 }
 
 fn xor_transform_do(input: &[u8], output: &mut [u8], ctx: &DetectTransformXorData) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7229 follow up

Describe changes:
- detect/transform: fix leak in xor transform parse

Fixes: 8984bc680112 ("transforms: move xor to rust")
