### PR TITLE
CI: Only run CodeQL python if the PR contains changed files that are python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,13 +39,24 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+    # Check if Python files are changed
+    - name: Check for Python file changes
+      id: python_check
+      run: |
+        git fetch origin ${{ github.base_ref }}
+        git diff --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} | grep '\.py$' || echo "no-python-changes"
+      continue-on-error: true
+    
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3.27.0
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
-
+      if: |
+        (matrix.language == 'cpp') || 
+        (matrix.language == 'python' && steps.python_check.outputs.result != 'no-python-changes')
+    
     - run: |
        sudo apt-get update
        sudo apt-get install libyaml-dev


### PR DESCRIPTION
Ticket: #7358

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7358

Describe changes:
- Added Conditional CodeQL Python analysis: Run only when PR modifies Python files
-Previous PR #12144 
-


