### PR TITLE
Dev/ldap v0.3: small improvements to the LDAP parser

### DIFF
--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -617,7 +617,7 @@ const PARSER_NAME: &[u8] = b"ldap\0";
 
 #[no_mangle]
 pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
-    let default_port = CString::new("389").unwrap();
+    let default_port = CString::new("[389, 3268]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const c_char,
         default_port: default_port.as_ptr(),
@@ -674,7 +674,7 @@ pub unsafe extern "C" fn SCRegisterLdapTcpParser() {
 
 #[no_mangle]
 pub unsafe extern "C" fn SCRegisterLdapUdpParser() {
-    let default_port = CString::new("389").unwrap();
+    let default_port = CString::new("[389, 3268]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const c_char,
         default_port: default_port.as_ptr(),

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1188,11 +1188,11 @@ app-layer:
       tcp:
         enabled: yes
         detection-ports:
-          dp: 389
+          dp: 389, 3268
       udp:
         enabled: yes
         detection-ports:
-          dp: 389
+          dp: 389, 3268
       # Maximum number of live LDAP transactions per flow
       # max-tx: 1024
 


### PR DESCRIPTION
Previous PR: #12119 

Description:
This pull request does minor changes to the LDAP app-layer:
- add port 3268 to the default monitored ports. This port is used by ActiveDirectory for global operations (not local to the current domain)
- Add support for the STARTTLS extended operation, so now the TLS handshake (and the Certificate) can be inspected and logged. It also takes care to check if STARTTLS succeeds, to avoid errors.

Redmine Ticket: https://redmine.openinfosecfoundation.org/issues/7394


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2128
