### PR TITLE
detect/transform: handle overlapping dotprefix

### DIFF
--- a/src/detect-transform-dotprefix.c
+++ b/src/detect-transform-dotprefix.c
@@ -116,8 +116,8 @@ static void TransformDotPrefix(InspectionBuffer *buffer, void *options)
             return;
         }
 
+        memmove(&output[1], buffer->inspect, input_len);
         output[0] = '.';
-        memcpy(&output[1], buffer->inspect, input_len);
         InspectionBufferTruncate(buffer, input_len + 1);
     }
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7229

Describe changes:
- detect/transform: handle overlapping case for dotprefix transform

Follow up on #12125 