### PR TITLE
detect: log app-layer metadata in alert with single tx

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -814,9 +814,11 @@ static inline void DetectRulePacketRules(
 
         uint64_t txid = PACKET_ALERT_NOTX;
         if ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
-                (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP)) {
+                (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP) ||
+                (pflow && pflow->alstate && AppLayerParserGetTxCnt(pflow, pflow->alstate) == 1)) {
             // if there is a stream match (TCP), or
             // a UDP specific app-layer signature,
+            // or only one transaction
             // try to use the good tx for the packet direction
             if (pflow->alstate) {
                 uint8_t dir =


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7199

May also solve https://redmine.openinfosecfoundation.org/issues/7406 and https://redmine.openinfosecfoundation.org/issues/7350

Describe changes:
- detect: log app-layer metadata in alert with single tx

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2141

Is this the right way to solve most of the cases as I remember discussing with someone ?

https://github.com/OISF/suricata/pull/12153 with unit test fix by checking the packet has a flow with app-layer state