### PR TITLE
doc/flowint: fix terminology for unset variable - v1

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -143,7 +143,12 @@ Define a var (not required), or check that one is set or not set.
 ::
 
     flowint: name, < +,-,=,>,<,>=,<=,==, != >, value;
-    flowint: name, (isset|isnotset);
+    flowint: name, (isset|notset);
+
+.. note::
+
+    It's important to observe that while similar keywords use ``isnotset``,
+    for ``flowint`` the term is ``notset``.
 
 Compare or alter a var. Add, subtract, compare greater than or less
 than, greater than or equal to, and less than or equal to are


### PR DESCRIPTION
s/isnotset/notset, for flowint

Flowints don't follow the same pattern as other similar keywords, but the docs indicated otherwise.

--

The examples are correct but if someone only read the explanation (as I did, they'd end up with a broken rule).