### PR TITLE
detect: log app-layer metadata in alert with single tx

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -813,24 +813,22 @@ static inline void DetectRulePacketRules(
         DetectRunPostMatch(tv, det_ctx, p, s);
 
         uint64_t txid = PACKET_ALERT_NOTX;
-        if ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
-                (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP)) {
+        if (pflow && pflow->alstate &&
+                ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
+                        (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP) ||
+                        AppLayerParserGetTxCnt(pflow, pflow->alstate) == 1)) {
             // if there is a stream match (TCP), or
             // a UDP specific app-layer signature,
+            // or only one transaction
             // try to use the good tx for the packet direction
-            if (pflow->alstate) {
-                uint8_t dir =
-                        (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
-                txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
-                void *tx_ptr =
-                        AppLayerParserGetTx(pflow->proto, pflow->alproto, pflow->alstate, txid);
-                AppLayerTxData *txd =
-                        tx_ptr ? AppLayerParserGetTxData(pflow->proto, pflow->alproto, tx_ptr)
-                               : NULL;
-                if (txd && txd->stream_logged < de_ctx->stream_tx_log_limit) {
-                    alert_flags |= PACKET_ALERT_FLAG_TX;
-                    txd->stream_logged++;
-                }
+            uint8_t dir = (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
+            txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
+            void *tx_ptr = AppLayerParserGetTx(pflow->proto, pflow->alproto, pflow->alstate, txid);
+            AppLayerTxData *txd =
+                    tx_ptr ? AppLayerParserGetTxData(pflow->proto, pflow->alproto, tx_ptr) : NULL;
+            if (txd && txd->stream_logged < de_ctx->stream_tx_log_limit) {
+                alert_flags |= PACKET_ALERT_FLAG_TX;
+                txd->stream_logged++;
             }
         }
         AlertQueueAppend(det_ctx, s, p, txid, alert_flags);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7199

May also solve https://redmine.openinfosecfoundation.org/issues/7406 and https://redmine.openinfosecfoundation.org/issues/7350

Describe changes:
- detect: log app-layer metadata in alert with single tx

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2141

Is this the right way to solve most of the cases as I remember discussing with someone ?

https://github.com/OISF/suricata/pull/12158 with removing redundant check for pflow->alstate