### PR TITLE
output-json: drop eve records that are too long

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -955,7 +955,7 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     return 0;
 }
 
-int OutputJsonBuilderBuffer(
+void OutputJsonBuilderBuffer(
         ThreadVars *tv, const Packet *p, Flow *f, JsonBuilder *js, OutputJsonThreadCtx *ctx)
 {
     LogFileCtx *file_ctx = ctx->file_ctx;
@@ -993,14 +993,11 @@ int OutputJsonBuilderBuffer(
                 SCLogWarning("Formatted JSON EVE record too large, will be dropped: %s", partial);
                 ctx->too_large_warning = true;
             }
-            return 0;
         }
     }
 
     MemBufferWriteRaw((*buffer), jb_ptr(js), (uint32_t)jslen);
     LogFileWrite(file_ctx, *buffer);
-
-    return 0;
 }
 
 static inline enum LogFileType FileTypeFromConf(const char *typestr)

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -981,7 +981,20 @@ int OutputJsonBuilderBuffer(
     size_t jslen = jb_len(js);
     DEBUG_VALIDATE_BUG_ON(jb_len(js) > UINT32_MAX);
     if (MEMBUFFER_OFFSET(*buffer) + jslen >= MEMBUFFER_SIZE(*buffer)) {
-        MemBufferExpand(buffer, (uint32_t)jslen);
+        size_t expand_by = MEMBUFFER_OFFSET(*buffer) + jslen + 1;
+        if (MemBufferExpand(buffer, (uint32_t)expand_by) < 0) {
+            if (!ctx->too_large_warning) {
+                /* Log a warning once, and include enough of the log
+                 * message to hopefully identify the event_type. */
+                char partial[120];
+                size_t partial_len = MIN(sizeof(partial), jslen);
+                memcpy(partial, jb_ptr(js), partial_len - 1);
+                partial[partial_len - 1] = '\0';
+                SCLogWarning("Formatted JSON EVE record too large, will be dropped: %s", partial);
+                ctx->too_large_warning = true;
+            }
+            return 0;
+        }
     }
 
     MemBufferWriteRaw((*buffer), jb_ptr(js), (uint32_t)jslen);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -90,6 +90,7 @@ typedef struct OutputJsonThreadCtx_ {
     OutputJsonCtx *ctx;
     LogFileCtx *file_ctx;
     MemBuffer *buffer;
+    bool too_large_warning;
 } OutputJsonThreadCtx;
 
 json_t *SCJsonString(const char *val);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -104,7 +104,7 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, uint64_t tx_id, OutputJsonCtx *eve_ctx);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-int OutputJsonBuilderBuffer(
+void OutputJsonBuilderBuffer(
         ThreadVars *tv, const Packet *p, Flow *f, JsonBuilder *js, OutputJsonThreadCtx *ctx);
 OutputInitResult OutputJsonInitCtx(ConfNode *);
 


### PR DESCRIPTION
- **output-json: drop eve records that are too long**
  In the situation where the mem buffer cannot be expanded to the
  requested size, drop the log message.
  
  For each JSON log context, a warning will be emitted once with a partial
  bit of the log record being dropped to identify what event types may be
  leading to large log records.
  
  This also fixes the call to MemBufferExpand which is supposed be
  passed the amount to expand by, not the new size required.
  
  Ticket: https://redmine.openinfosecfoundation.org/issues/7300
  
- **output-json: cleanup, have OutputJsonBuilderBuffer return void**
  The return value was never used.
  