### PR TITLE
detect: log app-layer metadata in alert with single tx v5

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -70,6 +70,21 @@ Alerts are event records for rule matches. They can be amended with
 metadata, such as the application layer record (HTTP, DNS, etc) an
 alert was generated for, and elements of the rule.
 
+The alert is amended with application layer metadata for signatures
+using application layer keywords. It is also the case for protocols
+over UDP as each single packet is expected to contain a PDU.
+
+For other signatures, the option ``detect.force-applayer-findtx``
+can be used to force the detect engine to find a transaction.
+These signatures need to define an app-layer protocol.
+This transaction is not guaranteed to be the relevant one,
+depending on your use case and how you define relevant here.
+If there are multiple live transactions, none will get
+picked up.
+The alert event will have ``"tx_id_forced": true`` to recognize
+these alerts.
+
+
 Metadata::
 
         - alert:

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -96,6 +96,10 @@ Logging changes
 ~~~~~~~~~~~~~~~
 - RFB security result is now consistently logged as ``security_result`` when it was
   sometimes logged with a dash instead of an underscore.
+- Application layer metadata is logged with alerts by default only for rules that
+  use application layer keywords. For other rules, the configuration parameter
+  ``detect.force-applayer-findtx`` can be used to force the detect engine to find a
+  transaction, which is not guaranteed to be the one you expect.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -115,6 +115,10 @@
         "tx_id": {
             "type": "integer"
         },
+        "tx_id_forced": {
+            "description": "the transaction for this alert event was forced, so the transaction may not be the one you expect",
+            "type": "boolean"
+        },
         "files": {
             "type": "array",
             "minItems": 1,

--- a/src/decode.h
+++ b/src/decode.h
@@ -257,6 +257,8 @@ typedef struct PacketAlert_ {
 #define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
 /** alert is in a frame, frame_id set */
 #define PACKET_ALERT_FLAG_FRAME 0x20
+/** alert in a tx was forced */
+#define PACKET_ALERT_FLAG_TX_FORCED 0x040
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2928,6 +2928,12 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
                          "and 255, will default to 4");
         }
     }
+    int force_applayer = 0;
+    if ((ConfGetBool("detect.force-applayer-findtx", &force_applayer)) == 1) {
+        if (force_applayer == 1) {
+            de_ctx->force_applayer = true;
+        }
+    }
 
     /* parse port grouping priority settings */
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -813,15 +813,15 @@ static inline void DetectRulePacketRules(
         DetectRunPostMatch(tv, det_ctx, p, s);
 
         uint64_t txid = PACKET_ALERT_NOTX;
-        if ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
-                (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP)) {
-            // if there is a stream match (TCP), or
-            // a UDP specific app-layer signature,
-            // try to use the good tx for the packet direction
-            if (pflow->alstate) {
-                uint8_t dir =
-                        (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
-                txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
+        if (pflow && pflow->alstate) {
+            uint8_t dir = (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
+            txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
+            if ((s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP) ||
+                    (de_ctx->force_applayer &&
+                            AppLayerParserGetTxCnt(pflow, pflow->alstate) == txid + 1)) {
+                // if there is a UDP specific app-layer signature,
+                // or only one live transaction
+                // try to use the good tx for the packet direction
                 void *tx_ptr =
                         AppLayerParserGetTx(pflow->proto, pflow->alproto, pflow->alstate, txid);
                 AppLayerTxData *txd =
@@ -829,6 +829,9 @@ static inline void DetectRulePacketRules(
                                : NULL;
                 if (txd && txd->stream_logged < de_ctx->stream_tx_log_limit) {
                     alert_flags |= PACKET_ALERT_FLAG_TX;
+                    if (pflow->proto != IPPROTO_UDP) {
+                        alert_flags |= PACKET_ALERT_FLAG_TX_FORCED;
+                    }
                     txd->stream_logged++;
                 }
             }

--- a/src/detect.h
+++ b/src/detect.h
@@ -887,6 +887,9 @@ typedef struct DetectEngineCtx_ {
     /* maximum number of times a tx will get logged for a stream-only rule match */
     uint8_t stream_tx_log_limit;
 
+    /* force app-layer tx finding for alerts with signatures not having app-layer keywords */
+    uint8_t force_applayer;
+
     /* registration id for per thread ctx for the filemagic/file.magic keywords */
     int filemagic_thread_ctx_id;
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -221,6 +221,9 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, JsonBuilder *js, ui
     if (pa->flags & PACKET_ALERT_FLAG_TX) {
         jb_set_uint(js, "tx_id", pa->tx_id);
     }
+    if (pa->flags & PACKET_ALERT_FLAG_TX_FORCED) {
+        jb_set_bool(js, "tx_id_forced", true);
+    }
 
     jb_open_object(js, "alert");
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1702,6 +1702,10 @@ detect:
   inspection-recursion-limit: 3000
   # maximum number of times a tx will get logged for a stream-only rule match
   # stream-tx-log-limit: 4
+  # try to find an app-layer transaction for rules without app-layer keywords
+  # allows to log app-layer metadata in alert
+  # but the transaction may not be the relevant one.
+  # force-applayer-findtx: no
   # If set to yes, the loading of signatures will be made after the capture
   # is started. This will limit the downtime in IPS mode.
   #delayed-detect: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7199

May also solve https://redmine.openinfosecfoundation.org/issues/7406 and https://redmine.openinfosecfoundation.org/issues/7350

Describe changes:
- detect: log app-layer metadata in alert with single tx

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2146

https://github.com/OISF/suricata/pull/12166 with big changes
- Uses a suricata.yaml config option `detect.force-applayer-findtx`
- output alert with `tx_id_forced: true` in such cases
- documentation !
- removes the check `PACKET_ALERT_FLAG_STREAM_MATCH` as overridden by the new one : one live tx + config ok

Answering https://github.com/OISF/suricata/pull/12166#discussion_r1861730832 : 
> I would like to see a per protocol analysis of how we can be sure that this condition provides us with a relevant tx.

I think/fear that for every protocol, there does not exist a condition robust enough to provide the relevant tx for all use cases = set of rules + people expectations

Do you have such a condition ?

> We've decided it's worse to log the wrong one, than to log none.

I think there is quite a demand to log something, and since I think we cannot be always right, we can ask the user to turn on some configuration parameter to ask for it