### PR TITLE
rust: fix latest clippy issues - v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -32,7 +32,7 @@ crc = "~1.8.1"
 lzma-rs = { version = "~0.2.0", features = ["stream"] }
 memchr = "~2.4.1"
 num = "~0.2.1"
-num-derive = "~0.2.5"
+num-derive = "~0.4.2"
 num-traits = "~0.2.14"
 widestring = "~0.4.3"
 flate2 = "~1.0.19"

--- a/rust/src/ldap/filters.rs
+++ b/rust/src/ldap/filters.rs
@@ -33,7 +33,7 @@ pub enum Filter {
     ExtensibleMatch(MatchingRuleAssertion),
 }
 
-impl<'a> From<ldap_parser::filter::Filter<'a>> for Filter {
+impl From<ldap_parser::filter::Filter<'_>> for Filter {
     fn from(f: ldap_parser::filter::Filter) -> Self {
         match f {
             ldap_parser::filter::Filter::And(val) => {
@@ -123,7 +123,7 @@ pub struct PartialAttribute {
     pub attr_vals: Vec<AttributeValue>,
 }
 
-impl<'a> From<&ldap_parser::filter::PartialAttribute<'a>> for PartialAttribute {
+impl From<&ldap_parser::filter::PartialAttribute<'_>> for PartialAttribute {
     fn from(value: &ldap_parser::filter::PartialAttribute) -> Self {
         let attr_type = LdapString(value.attr_type.0.to_string());
         let attr_vals: Vec<AttributeValue> = value
@@ -145,7 +145,7 @@ pub struct Attribute {
     pub attr_vals: Vec<AttributeValue>,
 }
 
-impl<'a> From<&ldap_parser::filter::Attribute<'a>> for Attribute {
+impl From<&ldap_parser::filter::Attribute<'_>> for Attribute {
     fn from(value: &ldap_parser::filter::Attribute) -> Self {
         let attr_type = LdapString(value.attr_type.0.to_string());
         let attr_vals: Vec<AttributeValue> = value
@@ -166,7 +166,7 @@ pub struct AttributeValueAssertion {
     pub attribute_desc: LdapString,
     pub assertion_value: Vec<u8>,
 }
-impl<'a> From<&ldap_parser::filter::AttributeValueAssertion<'a>> for AttributeValueAssertion {
+impl From<&ldap_parser::filter::AttributeValueAssertion<'_>> for AttributeValueAssertion {
     fn from(value: &ldap_parser::filter::AttributeValueAssertion) -> Self {
         let attribute_desc = LdapString(value.attribute_desc.0.to_string());
         let assertion_value = value.assertion_value.to_vec();
@@ -203,7 +203,7 @@ pub enum Substring {
     Any(AssertionValue),
     Final(AssertionValue),
 }
-impl<'a> From<ldap_parser::filter::Substring<'a>> for Substring {
+impl From<ldap_parser::filter::Substring<'_>> for Substring {
     fn from(value: ldap_parser::filter::Substring) -> Self {
         match value {
             ldap_parser::filter::Substring::Initial(val) => {

--- a/rust/src/ldap/types.rs
+++ b/rust/src/ldap/types.rs
@@ -342,7 +342,7 @@ pub struct Control {
     pub control_value: Option<Vec<u8>>,
 }
 
-impl<'a> From<ldap_parser::ldap::LdapMessage<'a>> for LdapMessage {
+impl From<ldap_parser::ldap::LdapMessage<'_>> for LdapMessage {
     fn from(ldap_msg: ldap_parser::ldap::LdapMessage) -> Self {
         let message_id = MessageID(ldap_msg.message_id.0);
         let protocol_op = match ldap_msg.protocol_op {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -53,6 +53,9 @@
 // cf https://github.com/mozilla/cbindgen/issues/709
 #![allow(unused_doc_comments)]
 
+// Allow for now, but need to be fixed.
+#![allow(static_mut_refs)]
+
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -34,7 +34,7 @@ pub struct NbssRecord<'a> {
     pub data: &'a[u8],
 }
 
-impl<'a> NbssRecord<'a> {
+impl NbssRecord<'_> {
     pub fn is_valid(&self) -> bool {
         let valid = match self.message_type {
             NBSS_MSGTYPE_SESSION_MESSAGE |

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -480,7 +480,8 @@ impl SMBTransactionTreeConnect {
 
 #[derive(Debug)]
 pub struct SMBTransaction {
-    pub id: u64,    /// internal id
+    /// internal id
+    pub id: u64,
 
     /// version, command and status
     pub vercmd: SMBVerCmdStat,

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -817,7 +817,7 @@ pub struct SmbRecord<'a> {
     pub data: &'a[u8],
 }
 
-impl<'a> SmbRecord<'a> {
+impl SmbRecord<'_> {
     pub fn has_unicode_support(&self) -> bool {
         self.flags2 & 0x8000_u16 != 0
     }

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -60,7 +60,7 @@ pub struct Smb2Record<'a> {
     pub data: &'a [u8],
 }
 
-impl<'a> Smb2Record<'a> {
+impl Smb2Record<'_> {
     pub fn is_request(&self) -> bool {
         self.direction == 0
     }

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -82,7 +82,7 @@ pub struct SNMPTransaction<'a> {
     tx_data: applayer::AppLayerTxData,
 }
 
-impl<'a> Transaction for SNMPTransaction<'a> {
+impl Transaction for SNMPTransaction<'_> {
     fn id(&self) -> u64 {
         self.id
     }

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -167,7 +167,7 @@ pub struct SshPacketKeyExchange<'a> {
 
 const SSH_HASSH_STRING_DELIMITER_SLICE: [u8; 1] = [b';'];
 
-impl<'a> SshPacketKeyExchange<'a> {
+impl SshPacketKeyExchange<'_> {
     pub fn generate_hassh(
         &self, hassh_string: &mut Vec<u8>, hassh: &mut Vec<u8>, to_server: &bool,
     ) {

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -50,7 +50,7 @@ pub struct X509(X509Certificate<'static>);
 
 pub struct SCGeneralName<'a>(&'a GeneralName<'a>);
 
-impl<'a> fmt::Display for SCGeneralName<'a> {
+impl fmt::Display for SCGeneralName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             GeneralName::DNSName(s) => write!(f, "{}", s),


### PR DESCRIPTION
- **rust: update num-dervice to 0.4.2**
  This prevents the clippy warning:
  
  508 | #[derive(FromPrimitive, Debug)]
      |          ^------------
      |          |
      |          `FromPrimitive` is not local
      |          move the `impl` block outside of this constant `_IMPL_NUM_FromPrimitive_FOR_IsakmpPayloadType`
  509 | pub enum IsakmpPayloadType {
      |          ----------------- `IsakmpPayloadType` is not local
      |
      = note: the derive macro `FromPrimitive` defines the non-local `impl`, and may need to be changed
      = note: the derive macro `FromPrimitive` may come from an old version of the `num_derive` crate, try updating your dependency with `cargo update -p num_derive`
      = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
      = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
      = note: this warning originates in the derive macro `FromPrimitive` (in Nightly builds, run with -Z macro-backtrace for more info)
  

- **rust: remove unnecessary lifetimes**
  Fix provided by cargo clippy --fix.
  

- **rust/smb: fix rustdoc line**
  '///' style rust comments/documentation come before the item being
  documented.
  
  Spotted by clippy.
  

- **rust: allow static_mut_refs for now**
  But we should fix all these soon.
  