### PR TITLE
rust: fix latest clippy issues - v2

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -95,8 +95,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
  "synstructure 0.13.1",
 ]
@@ -107,8 +107,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -288,8 +288,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -323,8 +323,8 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "synstructure 0.12.6",
 ]
@@ -544,8 +544,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b9a93a84b0d3ec3e70e02d332dc33ac6dfac9cde63e17fcb77172dededa62"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -612,13 +612,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.2.5"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -687,8 +687,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -784,15 +784,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
@@ -802,20 +793,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
- "proc-macro2 1.0.89",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -905,8 +887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a585d3c22887d23bb06dd602b8ce96c2a716e1fa89beec8bfb49e466f2d643"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -937,8 +919,8 @@ version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -1041,8 +1023,8 @@ name = "suricata-derive"
 version = "8.0.0-dev"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1057,23 +1039,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1083,8 +1054,8 @@ version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1094,10 +1065,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
- "unicode-xid 0.2.6",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1106,8 +1077,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -1127,8 +1098,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -1138,8 +1109,8 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
  "test-case-core",
 ]
@@ -1159,8 +1130,8 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]
 
@@ -1229,12 +1200,6 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -1309,7 +1274,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
- "proc-macro2 1.0.89",
- "quote 1.0.37",
+ "proc-macro2",
+ "quote",
  "syn 2.0.87",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -32,7 +32,7 @@ crc = "~1.8.1"
 lzma-rs = { version = "~0.2.0", features = ["stream"] }
 memchr = "~2.4.1"
 num = "~0.2.1"
-num-derive = "~0.2.5"
+num-derive = "~0.4.2"
 num-traits = "~0.2.14"
 widestring = "~0.4.3"
 flate2 = "~1.0.19"

--- a/rust/src/ldap/filters.rs
+++ b/rust/src/ldap/filters.rs
@@ -33,7 +33,7 @@ pub enum Filter {
     ExtensibleMatch(MatchingRuleAssertion),
 }
 
-impl<'a> From<ldap_parser::filter::Filter<'a>> for Filter {
+impl From<ldap_parser::filter::Filter<'_>> for Filter {
     fn from(f: ldap_parser::filter::Filter) -> Self {
         match f {
             ldap_parser::filter::Filter::And(val) => {
@@ -123,7 +123,7 @@ pub struct PartialAttribute {
     pub attr_vals: Vec<AttributeValue>,
 }
 
-impl<'a> From<&ldap_parser::filter::PartialAttribute<'a>> for PartialAttribute {
+impl From<&ldap_parser::filter::PartialAttribute<'_>> for PartialAttribute {
     fn from(value: &ldap_parser::filter::PartialAttribute) -> Self {
         let attr_type = LdapString(value.attr_type.0.to_string());
         let attr_vals: Vec<AttributeValue> = value
@@ -145,7 +145,7 @@ pub struct Attribute {
     pub attr_vals: Vec<AttributeValue>,
 }
 
-impl<'a> From<&ldap_parser::filter::Attribute<'a>> for Attribute {
+impl From<&ldap_parser::filter::Attribute<'_>> for Attribute {
     fn from(value: &ldap_parser::filter::Attribute) -> Self {
         let attr_type = LdapString(value.attr_type.0.to_string());
         let attr_vals: Vec<AttributeValue> = value
@@ -166,7 +166,7 @@ pub struct AttributeValueAssertion {
     pub attribute_desc: LdapString,
     pub assertion_value: Vec<u8>,
 }
-impl<'a> From<&ldap_parser::filter::AttributeValueAssertion<'a>> for AttributeValueAssertion {
+impl From<&ldap_parser::filter::AttributeValueAssertion<'_>> for AttributeValueAssertion {
     fn from(value: &ldap_parser::filter::AttributeValueAssertion) -> Self {
         let attribute_desc = LdapString(value.attribute_desc.0.to_string());
         let assertion_value = value.assertion_value.to_vec();
@@ -203,7 +203,7 @@ pub enum Substring {
     Any(AssertionValue),
     Final(AssertionValue),
 }
-impl<'a> From<ldap_parser::filter::Substring<'a>> for Substring {
+impl From<ldap_parser::filter::Substring<'_>> for Substring {
     fn from(value: ldap_parser::filter::Substring) -> Self {
         match value {
             ldap_parser::filter::Substring::Initial(val) => {

--- a/rust/src/ldap/types.rs
+++ b/rust/src/ldap/types.rs
@@ -342,7 +342,7 @@ pub struct Control {
     pub control_value: Option<Vec<u8>>,
 }
 
-impl<'a> From<ldap_parser::ldap::LdapMessage<'a>> for LdapMessage {
+impl From<ldap_parser::ldap::LdapMessage<'_>> for LdapMessage {
     fn from(ldap_msg: ldap_parser::ldap::LdapMessage) -> Self {
         let message_id = MessageID(ldap_msg.message_id.0);
         let protocol_op = match ldap_msg.protocol_op {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -53,6 +53,13 @@
 // cf https://github.com/mozilla/cbindgen/issues/709
 #![allow(unused_doc_comments)]
 
+// Allow unknown lints, our MSRV doesn't know them all, for
+// example static_mut_refs.
+#![allow(unknown_lints)]
+
+// Allow for now, but need to be fixed.
+#![allow(static_mut_refs)]
+
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/rust/src/smb/nbss_records.rs
+++ b/rust/src/smb/nbss_records.rs
@@ -34,7 +34,7 @@ pub struct NbssRecord<'a> {
     pub data: &'a[u8],
 }
 
-impl<'a> NbssRecord<'a> {
+impl NbssRecord<'_> {
     pub fn is_valid(&self) -> bool {
         let valid = match self.message_type {
             NBSS_MSGTYPE_SESSION_MESSAGE |

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -480,7 +480,8 @@ impl SMBTransactionTreeConnect {
 
 #[derive(Debug)]
 pub struct SMBTransaction {
-    pub id: u64,    /// internal id
+    /// internal id
+    pub id: u64,
 
     /// version, command and status
     pub vercmd: SMBVerCmdStat,

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -817,7 +817,7 @@ pub struct SmbRecord<'a> {
     pub data: &'a[u8],
 }
 
-impl<'a> SmbRecord<'a> {
+impl SmbRecord<'_> {
     pub fn has_unicode_support(&self) -> bool {
         self.flags2 & 0x8000_u16 != 0
     }

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -60,7 +60,7 @@ pub struct Smb2Record<'a> {
     pub data: &'a [u8],
 }
 
-impl<'a> Smb2Record<'a> {
+impl Smb2Record<'_> {
     pub fn is_request(&self) -> bool {
         self.direction == 0
     }

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -82,7 +82,7 @@ pub struct SNMPTransaction<'a> {
     tx_data: applayer::AppLayerTxData,
 }
 
-impl<'a> Transaction for SNMPTransaction<'a> {
+impl Transaction for SNMPTransaction<'_> {
     fn id(&self) -> u64 {
         self.id
     }

--- a/rust/src/ssh/parser.rs
+++ b/rust/src/ssh/parser.rs
@@ -167,7 +167,7 @@ pub struct SshPacketKeyExchange<'a> {
 
 const SSH_HASSH_STRING_DELIMITER_SLICE: [u8; 1] = [b';'];
 
-impl<'a> SshPacketKeyExchange<'a> {
+impl SshPacketKeyExchange<'_> {
     pub fn generate_hassh(
         &self, hassh_string: &mut Vec<u8>, hassh: &mut Vec<u8>, to_server: &bool,
     ) {

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -50,7 +50,7 @@ pub struct X509(X509Certificate<'static>);
 
 pub struct SCGeneralName<'a>(&'a GeneralName<'a>);
 
-impl<'a> fmt::Display for SCGeneralName<'a> {
+impl fmt::Display for SCGeneralName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             GeneralName::DNSName(s) => write!(f, "{}", s),


### PR DESCRIPTION
- **rust: update num-derive to 0.4.2**
  This prevents the clippy warning:
  
  508 | #[derive(FromPrimitive, Debug)]
      |          ^------------
      |          |
      |          `FromPrimitive` is not local
      |          move the `impl` block outside of this constant `_IMPL_NUM_FromPrimitive_FOR_IsakmpPayloadType`
  509 | pub enum IsakmpPayloadType {
      |          ----------------- `IsakmpPayloadType` is not local
      |
      = note: the derive macro `FromPrimitive` defines the non-local `impl`, and may need to be changed
      = note: the derive macro `FromPrimitive` may come from an old version of the `num_derive` crate, try updating your dependency with `cargo update -p num_derive`
      = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
      = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
      = note: this warning originates in the derive macro `FromPrimitive` (in Nightly builds, run with -Z macro-backtrace for more info)
    

- **rust: remove unnecessary lifetimes**
  Fix provided by cargo clippy --fix.
  

- **rust/smb: fix rustdoc line**
  '///' style rust comments/documentation come before the item being
  documented.
  
  Spotted by clippy.
  

- **rust: allow static_mut_refs for now**
  But we should fix all these soon.
  