### PR TITLE
output-json: drop eve records that are too long - v2

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -955,7 +955,7 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     return 0;
 }
 
-int OutputJsonBuilderBuffer(
+void OutputJsonBuilderBuffer(
         ThreadVars *tv, const Packet *p, Flow *f, JsonBuilder *js, OutputJsonThreadCtx *ctx)
 {
     LogFileCtx *file_ctx = ctx->file_ctx;
@@ -994,14 +994,12 @@ int OutputJsonBuilderBuffer(
                 SCLogWarning("Formatted JSON EVE record too large, will be dropped: %s", partial);
                 ctx->too_large_warning = true;
             }
-            return 0;
+            return;
         }
     }
 
     MemBufferWriteRaw((*buffer), jb_ptr(js), (uint32_t)jslen);
     LogFileWrite(file_ctx, *buffer);
-
-    return 0;
 }
 
 static inline enum LogFileType FileTypeFromConf(const char *typestr)

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -90,6 +90,7 @@ typedef struct OutputJsonThreadCtx_ {
     OutputJsonCtx *ctx;
     LogFileCtx *file_ctx;
     MemBuffer *buffer;
+    bool too_large_warning;
 } OutputJsonThreadCtx;
 
 json_t *SCJsonString(const char *val);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -104,7 +104,7 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
 JsonBuilder *CreateEveHeaderWithTxId(const Packet *p, enum OutputJsonLogDirection dir,
         const char *event_type, JsonAddrInfo *addr, uint64_t tx_id, OutputJsonCtx *eve_ctx);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
-int OutputJsonBuilderBuffer(
+void OutputJsonBuilderBuffer(
         ThreadVars *tv, const Packet *p, Flow *f, JsonBuilder *js, OutputJsonThreadCtx *ctx);
 OutputInitResult OutputJsonInitCtx(ConfNode *);
 

--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -65,6 +65,11 @@ int MemBufferExpand(MemBuffer **buffer, uint32_t expand_by) {
         return -1;
     }
 
+    /* Adjust expand_by to next multiple of 4k. */
+    if (expand_by % 4096 != 0) {
+        expand_by = expand_by - (expand_by % 4096) + 4096;
+    }
+
     size_t total_size = (*buffer)->size + sizeof(MemBuffer) + expand_by;
 
     MemBuffer *tbuffer = SCRealloc(*buffer, total_size);


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/12165

- Fix math in determining how much to expand by
- Expand by multiples of 4k (separate commit, easy to drop if needed)

Ticket: https://redmine.openinfosecfoundation.org/issues/7300

Should be suitable for backport as-is.
