### PR TITLE
requires: check for existence of keyword - v2

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -216,9 +216,10 @@ requires
 --------
 
 The ``requires`` keyword allows a rule to require specific Suricata
-features to be enabled, or the Suricata version to match an
-expression. Rules that do not meet the requirements will by ignored,
-and Suricata will not treat them as errors.
+features to be enabled, specific keywords to be available, or the
+Suricata version to match an expression. Rules that do not meet the
+requirements will be ignored, and Suricata will not treat them as
+errors.
 
 When parsing rules, the parser attempts to process the ``requires``
 keywords before others. This allows it to occur after keywords that
@@ -228,7 +229,7 @@ still adhere to the basic known formats of Suricata rules.
 
 The format is::
 
-   requires: feature geoip, version >= 7.0.0
+   requires: feature geoip, version >= 7.0.0, keyword foobar
 
 To require multiple features, the feature sub-keyword must be
 specified multiple times::
@@ -243,7 +244,7 @@ and *or* expressions may expressed with ``|`` like::
 
    requires: version >= 7.0.4 < 8 | >= 8.0.3
 
-to express that a rules requires version 7.0.4 or greater, but less
+to express that a rule requires version 7.0.4 or greater, but less
 than 8, **OR** greater than or equal to 8.0.3. Which could be useful
 if a keyword wasn't added until 7.0.4 and the 8.0.3 patch releases, as
 it would not exist in 8.0.1.

--- a/rust/src/detect/requires.rs
+++ b/rust/src/detect/requires.rs
@@ -57,6 +57,9 @@ enum RequiresError {
 
     /// Passed in requirements not a valid UTF-8 string.
     Utf8Error,
+
+    /// An unknown requirement was provided.
+    UnknownRequirement(String),
 }
 
 impl RequiresError {
@@ -70,6 +73,7 @@ impl RequiresError {
             Self::BadRequires => "Failed to parse requires expression\0",
             Self::MultipleVersions => "Version may only be specified once\0",
             Self::Utf8Error => "Requires expression is not valid UTF-8\0",
+            Self::UnknownRequirement(_) => "Unknown requirements\0",
         };
         msg.as_ptr() as *const c_char
     }
@@ -169,6 +173,9 @@ struct Requires {
     /// - All of the inner most must evaluate to true.
     /// - To pass, any of the outer must be true.
     pub version: Vec<Vec<RuleRequireVersion>>,
+
+    /// Unknown parameters to requires.
+    pub unknown: Vec<String>,
 }
 
 fn parse_op(input: &str) -> IResult<&str, VersionCompareOp> {
@@ -242,6 +249,7 @@ fn parse_requires(mut input: &str) -> Result<Requires, RequiresError> {
                 // Unknown keyword, allow by warn in case we extend
                 // this in the future.
                 SCLogWarning!("Unknown requires keyword: {}", keyword);
+                requires.unknown.push(format!("{} {}", keyword, value));
             }
         }
 
@@ -291,6 +299,12 @@ fn check_version(
 fn check_requires(
     requires: &Requires, suricata_version: &SuricataVersion,
 ) -> Result<(), RequiresError> {
+    if !requires.unknown.is_empty() {
+        return Err(RequiresError::UnknownRequirement(
+            requires.unknown.join(","),
+        ));
+    }
+
     if !requires.version.is_empty() {
         let mut errs = VecDeque::new();
         let mut ok = 0;
@@ -594,6 +608,7 @@ mod test {
                         patch: 0,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -610,6 +625,7 @@ mod test {
                         patch: 0,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -626,6 +642,7 @@ mod test {
                         patch: 2,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -652,6 +669,7 @@ mod test {
                         }
                     }
                 ]],
+                unknown: vec![],
             }
         );
     }
@@ -748,11 +766,11 @@ mod test {
         assert!(check_requires(&requires, &SuricataVersion::new(9, 0, 0)).is_err());
 
         // Unknown keyword.
-        let requires = parse_requires("feature lua, foo bar, version >= 7.0.3").unwrap();
+        let requires = parse_requires("feature true_lua, foo bar, version >= 7.0.3").unwrap();
         assert_eq!(
             requires,
             Requires {
-                features: vec!["lua".to_string()],
+                features: vec!["true_lua".to_string()],
                 version: vec![vec![RuleRequireVersion {
                     op: VersionCompareOp::Gte,
                     version: SuricataVersion {
@@ -761,8 +779,14 @@ mod test {
                         patch: 3,
                     }
                 }]],
+                unknown: vec!["foo bar".to_string()],
             }
         );
+
+        // This should not pass the requires check as it contains an
+        // unknown requires keyword.
+        //check_requires(&requires, &SuricataVersion::new(8, 0, 0)).unwrap();
+        assert!(check_requires(&requires, &SuricataVersion::new(8, 0, 0)).is_err());
     }
 
     #[test]
@@ -801,5 +825,11 @@ mod test {
                 },],
             ]
         );
+    }
+
+    #[test]
+    fn test_requires_keyword() {
+        let requires = parse_requires("keyword true_bar").unwrap();
+        assert!(check_requires(&requires, &SuricataVersion::new(8, 0, 0)).is_err());
     }
 }

--- a/rust/src/feature.rs
+++ b/rust/src/feature.rs
@@ -32,6 +32,15 @@ mod mock {
     pub fn requires(feature: &str) -> bool {
         return feature.starts_with("true");
     }
+
+    /// Check for a keyword returning true if found.
+    ///
+    /// This a "mock" variant of `has_keyword` that will return true
+    /// for any keyword starting with string `true`, and false for
+    /// anything else.
+    pub fn has_keyword(keyword: &str) -> bool {
+        return keyword.starts_with("true");
+    }
 }
 
 #[cfg(not(test))]
@@ -41,12 +50,21 @@ mod real {
 
     extern "C" {
         fn RequiresFeature(feature: *const c_char) -> bool;
+        fn SigTableHasKeyword(keyword: *const c_char) -> bool;
     }
 
     /// Check for a feature returning true if found.
     pub fn requires(feature: &str) -> bool {
         if let Ok(feature) = CString::new(feature) {
             unsafe { RequiresFeature(feature.as_ptr()) }
+        } else {
+            false
+        }
+    }
+
+    pub fn has_keyword(keyword: &str) -> bool {
+        if let Ok(keyword) = CString::new(keyword) {
+            unsafe { SigTableHasKeyword(keyword.as_ptr()) }
         } else {
             false
         }

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -347,6 +347,28 @@ static void SigMultilinePrint(int i, const char *prefix)
     printf("\n");
 }
 
+/** \brief Check if a keyword exists. */
+bool SigTableHasKeyword(const char *keyword)
+{
+    for (int i = 0; i < DETECT_TBLSIZE; i++) {
+        if (sigmatch_table[i].flags & SIGMATCH_NOT_BUILT) {
+            continue;
+        }
+
+        const char *name = sigmatch_table[i].name;
+
+        if (name == NULL || strlen(name) == 0) {
+            continue;
+        }
+
+        if (strcmp(keyword, name) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 int SigTableList(const char *keyword)
 {
     size_t size = DETECT_TBLSIZE;

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -24,6 +24,8 @@
 #ifndef SURICATA_DETECT_ENGINE_REGISTER_H
 #define SURICATA_DETECT_ENGINE_REGISTER_H
 
+#include "suricata-common.h"
+
 enum DetectKeywordId {
     DETECT_SID,
     DETECT_PRIORITY,
@@ -341,5 +343,6 @@ void SigTableCleanup(void);
 void SigTableInit(void);
 void SigTableSetup(void);
 void SigTableRegisterTests(void);
+bool SigTableHasKeyword(const char *keyword);
 
 #endif /* SURICATA_DETECT_ENGINE_REGISTER_H */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/12138

Changes from previous PR:
- Add ticket for unknown requirements (should be backported)
- Doc typo.

Ticket for requires keyword: https://redmine.openinfosecfoundation.org/issues/7403

Ticket for unknown requirements: https://redmine.openinfosecfoundation.org/issues/7418

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2133