### PR TITLE
util/debug: increase max length of message

### DIFF
--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -80,8 +80,8 @@ typedef enum {
 #define SC_LOG_DEF_LOG_FORMAT_REL_CONFIG "[%i] %d: %S: %M"
 #define SC_LOG_DEF_LOG_FORMAT_DEBUG      "%d: %S: %M [%n:%f:%l]"
 
-/* The maximum length of the log message */
-#define SC_LOG_MAX_LOG_MSG_LEN 2048
+/* The maximum length of the log message: we add max rule size and other info */
+#define SC_LOG_MAX_LOG_MSG_LEN 8192 + PATH_MAX + 512
 
 /* The maximum length of the log format */
 #define SC_LOG_MAX_LOG_FORMAT_LEN 128


### PR DESCRIPTION
Update of #12183 

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Increase size to take into account the file name
- Better commit message

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2152
