### PR TITLE
detect/transforms: test in place modifications of buffers

### DIFF
--- a/rust/src/detect/transforms/hash.rs
+++ b/rust/src/detect/transforms/hash.rs
@@ -231,9 +231,15 @@ mod tests {
 
     #[test]
     fn test_sha256_transform() {
-        let buf = b" A B C D ";
+        let mut buf = Vec::with_capacity(SC_SHA256_LEN);
+        buf.extend_from_slice(b" A B C D ");
         let mut out = vec![0; SC_SHA256_LEN];
-        sha256_transform_do(buf, &mut out);
+        sha256_transform_do(&buf, &mut out);
         assert_eq!(out, b"\xd6\xbf\x7d\x8d\x69\x53\x02\x4d\x0d\x84\x5c\x99\x9b\xae\x93\xcc\xac\x68\xea\xab\x9a\xc9\x77\xd0\xfd\x30\x6a\xf5\x9a\x3d\xe4\x3a");
+        // test in place
+        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+        buf.resize(SC_SHA256_LEN, 0);
+        sha256_transform_do(&still_buf, &mut buf);
+        assert_eq!(&buf, b"\xd6\xbf\x7d\x8d\x69\x53\x02\x4d\x0d\x84\x5c\x99\x9b\xae\x93\xcc\xac\x68\xea\xab\x9a\xc9\x77\xd0\xfd\x30\x6a\xf5\x9a\x3d\xe4\x3a");
     }
 }

--- a/rust/src/detect/transforms/strip_whitespace.rs
+++ b/rust/src/detect/transforms/strip_whitespace.rs
@@ -35,13 +35,15 @@ unsafe extern "C" fn strip_whitespace_setup(
 
 fn strip_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     let mut nb = 0;
-    // seems faster than writing one byte at a time via
-    // for (i, o) in input.iter().filter(|c| !matches!(*c, b'\t' | b'\n' | b'\x0B' | b'\x0C' | b'\r' | b' ')).zip(output)
-    for subslice in input.split(|c| matches!(*c, b'\t' | b'\n' | b'\x0B' | b'\x0C' | b'\r' | b' '))
+    for (i, o) in input
+        .iter()
+        .filter(|c| !matches!(*c, b'\t' | b'\n' | b'\x0B' | b'\x0C' | b'\r' | b' '))
+        .zip(output)
     {
-        output[nb..nb + subslice.len()].copy_from_slice(subslice);
-        nb += subslice.len();
+        *o = *i;
+        nb += 1;
     }
+    // do not use faster copy_from_slice because input and output may overlap (point to the same data)
     return nb as u32;
 }
 
@@ -124,13 +126,21 @@ mod tests {
         );
         assert_eq!(&out[..exp.len()], exp);
 
-        let buf = b"I  \t J";
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"I  \t J");
         let mut out = vec![0; buf.len()];
         let exp = b"IJ";
         assert_eq!(
-            strip_whitespace_transform_do(buf, &mut out),
+            strip_whitespace_transform_do(&buf, &mut out),
             exp.len() as u32
         );
         assert_eq!(&out[..exp.len()], exp);
+        // test in place
+        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+        assert_eq!(
+            strip_whitespace_transform_do(&still_buf, &mut buf),
+            exp.len() as u32
+        );
+        assert_eq!(&still_buf[..exp.len()], b"IJ");
     }
 }

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -135,9 +135,14 @@ mod tests {
 
     #[test]
     fn test_url_decode_transform() {
-        let buf = b"Suricata%20is+%27%61wesome%21%27%25%30%30%ZZ%4";
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"Suricata%20is+%27%61wesome%21%27%25%30%30%ZZ%4");
         let mut out = vec![0; buf.len()];
-        let nb = url_decode_transform_do(buf, &mut out);
+        let nb = url_decode_transform_do(&buf, &mut out);
         assert_eq!(&out[..nb as usize], b"Suricata is 'awesome!'%00%ZZ%4");
+        // test in place
+        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+        let nb = url_decode_transform_do(&still_buf, &mut buf);
+        assert_eq!(&still_buf[..nb as usize], b"Suricata is 'awesome!'%00%ZZ%4");
     }
 }

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -143,10 +143,15 @@ mod tests {
 
     #[test]
     fn test_xor_transform() {
-        let buf = b"example.com";
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"example.com");
         let mut out = vec![0; buf.len()];
         let ctx = xor_parse_do("0a0DC8ff").unwrap();
-        xor_transform_do(buf, &mut out, &ctx);
+        xor_transform_do(&buf, &mut out, &ctx);
         assert_eq!(out, b"ou\xa9\x92za\xad\xd1ib\xa5");
+        // test in place
+        let still_buf = unsafe { std::slice::from_raw_parts(buf.as_ptr(), buf.len()) };
+        xor_transform_do(&still_buf, &mut buf, &ctx);
+        assert_eq!(&still_buf, b"ou\xa9\x92za\xad\xd1ib\xa5");
     }
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7409

Describe changes:
- detect/transforms: fix and test in place modifications of buffers (aka do not use memcpy)