### PR TITLE
flow/manager: fix multi instance row tracking

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -500,7 +500,7 @@ static uint32_t FlowTimeoutHash(FlowManagerTimeoutThread *td, SCTime_t ts, const
  *  \param hash_max upper bound of the row slice
  *  \param counters Flow timeout counters to be passed
  *  \param rows number of rows for this worker unit
- *  \param pos position of the beginning of row slice in the hash table
+ *  \param pos absolute position of the beginning of row slice in the hash table
  *
  *  \retval number of successfully timed out flows
  */
@@ -514,7 +514,7 @@ static uint32_t FlowTimeoutHashInChunks(FlowManagerTimeoutThread *td, SCTime_t t
     uint32_t rows_left = rows;
 
 again:
-    start = hash_min + (*pos);
+    start = (*pos);
     if (start >= hash_max) {
         start = hash_min;
     }


### PR DESCRIPTION
In multi instance flow manager setups, each flow manager gets a slice of the hash table to manage. Due to a logic error in the chunked scanning of the hash slice, instances beyond the first would always rescan the same subslice of their slice.

The `pos` variable that is used to keep the state of what the starting position for the next scan was supposed to be was treated as if it held a relative value. Relative to the bounds of the slice. It was however, holding an absolute position. This meant that when doing it's bounds check it was always considered out of bounds.

This patch addresses the issue by correctly handling the fact that the value is absolute.

Bug: #7365.

https://redmine.openinfosecfoundation.org/issues/7365