### PR TITLE
Datasets locking/v3

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -84,6 +84,7 @@ include = [
     "FtpEvent",
     "SCSigTableElmt",
     "SCTransformTableElmt",
+    "DataRepType",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/src/detect/datasets.rs
+++ b/rust/src/detect/datasets.rs
@@ -1,0 +1,105 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Shivani Bhardwaj <shivani@oisf.net>
+
+//! This module exposes items from the datasets C code to Rust.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::ffi::{c_char, CStr};
+use base64::{Engine, engine::general_purpose::STANDARD};
+
+/// Opaque Dataset type defined in C
+#[derive(Copy, Clone)]
+pub enum Dataset {}
+
+// Simple C type converted to Rust
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+pub struct DataRepType {
+    pub value: u16,
+}
+
+// Extern fns operating on the opaque Dataset type above
+/// cbindgen:ignore
+extern {
+    pub fn DatasetAdd(set: &Dataset, data: *const u8, len: u32) -> i32;
+    pub fn DatasetAddwRep(set: &Dataset, data: *const u8, len: u32, rep: *const DataRepType) -> i32;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ProcessDatasets(set: &Dataset, name: *const c_char, fname: *const c_char, fmode: *const c_char) -> i32 {
+    let file_string = CStr::from_ptr(fname).to_str().unwrap();
+    let mode = CStr::from_ptr(fmode).to_str().unwrap();
+    let set_name = CStr::from_ptr(name).to_str().unwrap();
+    let filename = Path::new(file_string);
+ //   SCLogNotice!("Path: {:?}", filename);
+    if let Ok(lines) = read_lines(filename, mode) {
+        for line in lines.flatten() {
+//            SCLogNotice!("{}", line);
+            let v: Vec<&str> = line.split(',').collect();
+            // Ignore empty and invalid lines in dataset/rep file
+            if v.is_empty() || v.len() > 2 {
+                continue;
+            }
+            if v.len() == 1 {
+                // Dataset
+                let mut decoded: Vec<u8> = vec![];
+                if STANDARD.decode_vec(v[0], &mut decoded).is_err() {
+                    // FatalErrorOnInit STODO
+                    SCLogError!("bad base64 encoding {}", set_name);
+                    return -2;
+                }
+                DatasetAdd(&set, decoded.as_ptr(), decoded.len() as u32);
+            } else {
+                // Datarep
+                let mut decoded: Vec<u8> = vec![];
+                if STANDARD.decode_vec(v[0], &mut decoded).is_err() {
+                    // FatalErrorOnInit STODO
+                    SCLogError!("bad base64 encoding {}", set_name);
+                    return -2;
+                }
+                if let Ok(val) = v[1].to_string().parse::<u16>() {
+                    let rep: DataRepType = DataRepType { value: val };
+                    DatasetAddwRep(&set, decoded.as_ptr(), decoded.len() as u32, &rep);
+                } else {
+                    // FatalErrorOnInit STODO
+                    SCLogError!("Invalid datarep value {}", set_name);
+                    return -2;
+                }
+            }
+        }
+    } else {
+        SCLogNotice!("Couldn't open file");
+        return -1;
+    }
+    SCLogNotice!("All OK from rust parser");
+    0
+}
+
+fn read_lines<P>(filename: P, fmode: &str) -> io::Result<io::Lines<io::BufReader<File>>>
+where P: AsRef<Path>, {
+    let file: File;
+    if fmode == "r" {
+        file = File::open(filename)?;
+    } else {
+        file = OpenOptions::new().append(true).create(true).open(filename)?;
+    }
+    Ok(io::BufReader::new(file).lines())
+}

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -29,6 +29,7 @@ pub mod transforms;
 pub mod uint;
 pub mod uri;
 pub mod tojson;
+pub mod datasets;
 
 use crate::core::AppProto;
 use std::os::raw::{c_int, c_void};

--- a/src/datasets-reputation.h
+++ b/src/datasets-reputation.h
@@ -24,9 +24,7 @@
 #ifndef SURICATA_DATASETS_REPUTATION_H
 #define SURICATA_DATASETS_REPUTATION_H
 
-typedef struct DataRepType {
-    uint16_t value;
-} DataRepType;
+#include "rust-bindings.h"
 
 typedef struct DataRepResultType {
     bool found;

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -19,6 +19,7 @@
 #define SURICATA_DATASETS_H
 
 #include "util-thash.h"
+#include "rust.h"
 #include "datasets-reputation.h"
 
 int DatasetsInit(void);

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -47,8 +47,6 @@
 #define DETECT_DATASET_CMD_ISNOTSET 2
 #define DETECT_DATASET_CMD_ISSET    3
 
-int DetectDatasetMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
-        const Signature *, const SigMatchCtx *);
 static int DetectDatasetSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectDatasetFree (DetectEngineCtx *, void *);
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7398

Previous PR: https://github.com/OISF/suricata/pull/12182

Changes since v2:
- fixed cbindgen issues
- fixed s-v test failures

Note: This is NOT the exact replication of the code in master yet. Not sure how to move/use macros in Rust which are like `FatalErrorOnInit` that use atomic vars on C side.