### PR TITLE
De only/v2

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -2029,6 +2029,7 @@ int SigPrepareStage4(DetectEngineCtx *de_ctx)
     if (de_ctx->decoder_event_sgh != NULL) {
         /* no need to set filestore count here as that would make a
          * signature not decode event only. */
+        SigGroupHeadBuildNonPrefilterArray(de_ctx, de_ctx->decoder_event_sgh);
     }
 
     int dump_grouping = 0;


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/7414
https://redmine.openinfosecfoundation.org/issues/7433

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2159

Changes since #12217:
- remove unused payload logging code
- don't create timestamp in an otherwise unused buffer