### PR TITLE
7.0.x: backport treating unknown requirements as unsatisfied with opt-out flag - v1

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -212,6 +212,8 @@ If the value is src_ip then the source IP in the generated event (src_ip
 field in JSON) is the target of the attack. If target is set to dest_ip
 then the target is the destination IP in the generated event.
 
+.. _keyword_requires:
+
 requires
 --------
 
@@ -219,6 +221,11 @@ The ``requires`` keyword allows a rule to require specific Suricata
 features to be enabled, or the Suricata version to match an
 expression. Rules that do not meet the requirements will by ignored,
 and Suricata will not treat them as errors.
+
+Requirements that follow the valid format of ``<keyword>
+<expression>`` but are not known to Suricata are allowed for future
+compatiblity, however unknown requirement expressions will lead to the
+requirement not being met, skipping the rule.
 
 When parsing rules, the parser attempts to process the ``requires``
 keywords before others. This allows it to occur after keywords that

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -37,8 +37,23 @@ dedicated new configuration.
 Upgrading to 7.0.7
 ------------------
 - Unknown requirements in the ``requires`` keyword will now be treated
-  as unmet requirements, causing the rule to not be loaded. See
-  :ref:`keyword_requires`.
+  as unsatisfied requirements, causing the rule to not be loaded. See
+  :ref:`keyword_requires`. To opt out of this change and to ignore
+  uknown requirements, effectively treating them as satified the
+  ``ignore-unknown-requirements`` configuration option can be used.
+
+  Command line example::
+
+    --set ignore-unknown-requirements=true
+
+  Or as a top-level configuration option in ``suricata.yaml``:
+
+  .. code-block:: yaml
+
+    default-rule-path: /var/lib/suricata/rules
+    rule-files:
+      - suricata.rules
+    ignore-unknown-requirements: true
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -34,6 +34,12 @@ also check all the new features that have been added but are not covered by
 this guide. Those features are either not enabled by default or require
 dedicated new configuration.
 
+Upgrading to 7.0.7
+------------------
+- Unknown requirements in the ``requires`` keyword will now be treated
+  as unmet requirements, causing the rule to not be loaded. See
+  :ref:`keyword_requires`.
+
 Upgrading 6.0 to 7.0
 --------------------
 

--- a/rust/src/detect/requires.rs
+++ b/rust/src/detect/requires.rs
@@ -57,6 +57,9 @@ enum RequiresError {
 
     /// Passed in requirements not a valid UTF-8 string.
     Utf8Error,
+
+    /// An unknown requirement was provided.
+    UnknownRequirement(String),
 }
 
 impl RequiresError {
@@ -70,6 +73,7 @@ impl RequiresError {
             Self::BadRequires => "Failed to parse requires expression\0",
             Self::MultipleVersions => "Version may only be specified once\0",
             Self::Utf8Error => "Requires expression is not valid UTF-8\0",
+            Self::UnknownRequirement(_) => "Unknown requirements\0",
         };
         msg.as_ptr() as *const c_char
     }
@@ -169,6 +173,9 @@ struct Requires {
     /// - All of the inner most must evaluate to true.
     /// - To pass, any of the outer must be true.
     pub version: Vec<Vec<RuleRequireVersion>>,
+
+    /// Unknown parameters to requires.
+    pub unknown: Vec<String>,
 }
 
 fn parse_op(input: &str) -> IResult<&str, VersionCompareOp> {
@@ -242,6 +249,7 @@ fn parse_requires(mut input: &str) -> Result<Requires, RequiresError> {
                 // Unknown keyword, allow by warn in case we extend
                 // this in the future.
                 SCLogWarning!("Unknown requires keyword: {}", keyword);
+                requires.unknown.push(format!("{} {}", keyword, value));
             }
         }
 
@@ -291,6 +299,12 @@ fn check_version(
 fn check_requires(
     requires: &Requires, suricata_version: &SuricataVersion,
 ) -> Result<(), RequiresError> {
+    if !requires.unknown.is_empty() {
+        return Err(RequiresError::UnknownRequirement(
+            requires.unknown.join(","),
+        ));
+    }
+
     if !requires.version.is_empty() {
         let mut errs = VecDeque::new();
         let mut ok = 0;
@@ -594,6 +608,7 @@ mod test {
                         patch: 0,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -610,6 +625,7 @@ mod test {
                         patch: 0,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -626,6 +642,7 @@ mod test {
                         patch: 2,
                     }
                 }]],
+                unknown: vec![],
             }
         );
 
@@ -652,6 +669,7 @@ mod test {
                         }
                     }
                 ]],
+                unknown: vec![],
             }
         );
     }
@@ -748,11 +766,11 @@ mod test {
         assert!(check_requires(&requires, &SuricataVersion::new(9, 0, 0)).is_err());
 
         // Unknown keyword.
-        let requires = parse_requires("feature lua, foo bar, version >= 7.0.3").unwrap();
+        let requires = parse_requires("feature true_lua, foo bar, version >= 7.0.3").unwrap();
         assert_eq!(
             requires,
             Requires {
-                features: vec!["lua".to_string()],
+                features: vec!["true_lua".to_string()],
                 version: vec![vec![RuleRequireVersion {
                     op: VersionCompareOp::Gte,
                     version: SuricataVersion {
@@ -761,8 +779,14 @@ mod test {
                         patch: 3,
                     }
                 }]],
+                unknown: vec!["foo bar".to_string()],
             }
         );
+
+        // This should not pass the requires check as it contains an
+        // unknown requires keyword.
+        //check_requires(&requires, &SuricataVersion::new(8, 0, 0)).unwrap();
+        assert!(check_requires(&requires, &SuricataVersion::new(8, 0, 0)).is_err());
     }
 
     #[test]
@@ -801,5 +825,11 @@ mod test {
                 },],
             ]
         );
+    }
+
+    #[test]
+    fn test_requires_keyword() {
+        let requires = parse_requires("keyword true_bar").unwrap();
+        assert!(check_requires(&requires, &SuricataVersion::new(8, 0, 0)).is_err());
     }
 }


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7434

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2162
