### PR TITLE
Fuzz protodetect sip 7435 v1

### DIFF
--- a/rust/src/sip/sip.rs
+++ b/rust/src/sip/sip.rs
@@ -496,7 +496,6 @@ fn register_pattern_probe(proto: u8) -> i8 {
         "ACK\0",
         "BYE\0",
         "CANCEL\0",
-        "UPDATE\0",
         "REFER\0",
         "PRACK\0",
         "SUBSCRIBE\0",
@@ -526,6 +525,16 @@ fn register_pattern_probe(proto: u8) -> i8 {
             0,
             core::Direction::ToClient as u8,
         );
+        if proto == core::IPPROTO_UDP {
+            r |= AppLayerProtoDetectPMRegisterPatternCS(
+                proto,
+                ALPROTO_SIP,
+                "UPDATE\0".as_ptr() as *const std::os::raw::c_char,
+                "UPDATE".len() as u16,
+                0,
+                core::Direction::ToServer as u8,
+            );
+        }
     }
 
     if r == 0 {

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -30,8 +30,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     Flow *f;
     TcpSession ssn;
     bool reverse;
-    AppProto alproto;
-    AppProto alproto2;
 
     if (alpd_tctx == NULL) {
         //global init
@@ -66,31 +64,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (data[0] & STREAM_TOSERVER) {
         flags = STREAM_TOSERVER;
     }
-    alproto = AppLayerProtoDetectGetProto(
+    AppLayerProtoDetectGetProto(
             alpd_tctx, f, data + HEADER_LEN, size - HEADER_LEN, f->proto, flags, &reverse);
-    if (alproto != ALPROTO_UNKNOWN && alproto != ALPROTO_FAILED && f->proto == IPPROTO_TCP) {
-        /* If we find a valid protocol at the start of a stream :
-         * check that with smaller input
-         * we find the same protocol or ALPROTO_UNKNOWN.
-         * Otherwise, we have evasion with TCP splitting
-         */
-        for (size_t i = 0; i < size-HEADER_LEN && i < PROTO_DETECT_MAX_LEN; i++) {
-            // reset detection at each try cf probing_parser_toserver_alproto_masks
-            AppLayerProtoDetectReset(f);
-            alproto2 = AppLayerProtoDetectGetProto(
-                    alpd_tctx, f, data + HEADER_LEN, i, f->proto, flags, &reverse);
-            if (alproto2 != ALPROTO_UNKNOWN && alproto2 != alproto) {
-                printf("Failed with input length %" PRIuMAX " versus %" PRIuMAX
-                       ", found %s instead of %s\n",
-                        (uintmax_t)i, (uintmax_t)size - HEADER_LEN, AppProtoToString(alproto2),
-                        AppProtoToString(alproto));
-                printf("Assertion failure: %s-%s\n", AppProtoToString(alproto2),
-                        AppProtoToString(alproto));
-                fflush(stdout);
-                abort();
-            }
-        }
-    }
     FlowFree(f);
 
     return 0;

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -9,7 +9,7 @@
 #include "suricata.h"
 #include "app-layer-detect-proto.h"
 #include "flow-util.h"
-#include "app-layer-parser.h"
+#include "app-layer.h"
 #include "util-unittest-helper.h"
 #include "conf-yaml-loader.h"
 
@@ -43,9 +43,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         MpmTableSetup();
         SpmTableSetup();
         EngineModeSetIDS();
-        AppLayerProtoDetectSetup();
-        AppLayerParserSetup();
-        AppLayerParserRegisterProtocolParsers();
+        AppLayerSetup();
         alpd_tctx = AppLayerProtoDetectGetCtxThread();
         SC_ATOMIC_SET(engine_stage, SURICATA_RUNTIME);
     }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7435
https://redmine.openinfosecfoundation.org/issues/7436

Describe changes:
- fuzz : fix target fuzz_applayerprotodetectgetproto with right init sequence
- fix bug found with it : SIP cannot use `UPDATE` (over TCP) as protocol detection pattern as HTTP/1 already uses it

Part of https://github.com/OISF/suricata/pull/12163