### PR TITLE
flowint: add isnotset support (70x backport) - v1

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -135,7 +135,7 @@ Define a var (not required), or check that one is set or not set.
 ::
 
     flowint: name, < +,-,=,>,<,>=,<=,==, != >, value;
-    flowint: name, (isset|isnotset);
+    flowint: name, (isset|notset|isnotset);
 
 Compare or alter a var. Add, subtract, compare greater than or less
 than, greater than or equal to, and less than or equal to are

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -194,14 +194,11 @@ static inline int SCSigGetFlowintType(Signature *sig)
     while (sm != NULL) {
         if (sm->type == DETECT_FLOWINT) {
             fi = (DetectFlowintData *)sm->ctx;
-            if (fi->modifier == FLOWINT_MODIFIER_LT ||
-                fi->modifier == FLOWINT_MODIFIER_LE ||
-                fi->modifier == FLOWINT_MODIFIER_EQ ||
-                fi->modifier == FLOWINT_MODIFIER_NE ||
-                fi->modifier == FLOWINT_MODIFIER_GE ||
-                fi->modifier == FLOWINT_MODIFIER_GT ||
-                fi->modifier == FLOWINT_MODIFIER_ISNOTSET ||
-                fi->modifier == FLOWINT_MODIFIER_ISSET) {
+            if (fi->modifier == FLOWINT_MODIFIER_LT || fi->modifier == FLOWINT_MODIFIER_LE ||
+                    fi->modifier == FLOWINT_MODIFIER_EQ || fi->modifier == FLOWINT_MODIFIER_NE ||
+                    fi->modifier == FLOWINT_MODIFIER_GE || fi->modifier == FLOWINT_MODIFIER_GT ||
+                    fi->modifier == FLOWINT_MODIFIER_ISNOTSET ||
+                    fi->modifier == FLOWINT_MODIFIER_ISSET) {
                 read++;
             } else {
 #ifdef DEBUG

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -200,7 +200,7 @@ static inline int SCSigGetFlowintType(Signature *sig)
                 fi->modifier == FLOWINT_MODIFIER_NE ||
                 fi->modifier == FLOWINT_MODIFIER_GE ||
                 fi->modifier == FLOWINT_MODIFIER_GT ||
-                fi->modifier == FLOWINT_MODIFIER_NOTSET ||
+                fi->modifier == FLOWINT_MODIFIER_ISNOTSET ||
                 fi->modifier == FLOWINT_MODIFIER_ISSET) {
                 read++;
             } else {

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -48,7 +48,10 @@
 #include "util-profiling.h"
 
 /*                         name             modifiers          value      */
-#define PARSE_REGEX "^\\s*([a-zA-Z][\\w\\d_./]+)\\s*,\\s*([+=-]{1}|==|!=|<|<=|>|>=|isset|notset|isnotset)\\s*,?\\s*([a-zA-Z][\\w\\d]+|[\\d]{1,10})?\\s*$"
+#define PARSE_REGEX                                                                                \
+    "^\\s*([a-zA-Z][\\w\\d_./"                                                                     \
+    "]+)\\s*,\\s*([+=-]{1}|==|!=|<|<=|>|>=|isset|notset|isnotset)\\s*,?\\s*([a-zA-Z][\\w\\d]+|["   \
+    "\\d]{1,10})?\\s*$"
 /* Varnames must begin with a letter */
 
 static DetectParseRegex parse_regex;
@@ -1001,9 +1004,8 @@ static int DetectFlowintTestParseIsset10(void)
     if (sfd) DetectFlowintFree(NULL, sfd);
     sfd = DetectFlowintParse(de_ctx, "myvar, notset");
     DetectFlowintPrintData(sfd);
-    if (sfd != NULL && !strcmp(sfd->name, "myvar")
-            && sfd->targettype == FLOWINT_TARGET_SELF
-            && sfd->modifier == FLOWINT_MODIFIER_ISNOTSET) {
+    if (sfd != NULL && !strcmp(sfd->name, "myvar") && sfd->targettype == FLOWINT_TARGET_SELF &&
+            sfd->modifier == FLOWINT_MODIFIER_ISNOTSET) {
 
         result &= 1;
     } else {
@@ -1192,7 +1194,9 @@ static int DetectFlowintTestPacket02Real(void)
     de_ctx->flags |= DE_QUIET;
 
     const char *sigs[5];
-    sigs[0] = "alert tcp any any -> any any (msg:\"Setting a flowint counter\"; content:\"GET\"; flowint:myvar,notset; flowint:maxvar,isnotset; flowint: myvar,=,1; flowint: maxvar,=,6; sid:101;)";
+    sigs[0] = "alert tcp any any -> any any (msg:\"Setting a flowint counter\"; content:\"GET\"; "
+              "flowint:myvar,notset; flowint:maxvar,isnotset; flowint: myvar,=,1; flowint: "
+              "maxvar,=,6; sid:101;)";
     sigs[1] = "alert tcp any any -> any any (msg:\"Adding to flowint counter\"; content:\"Unauthorized\"; flowint:myvar,isset; flowint: myvar,+,2; sid:102;)";
     sigs[2] = "alert tcp any any -> any any (msg:\"if the flowint counter is 3 create a new counter\"; content:\"Unauthorized\"; flowint: myvar, isset; flowint: myvar,==,3; flowint:cntpackets,notset; flowint: cntpackets, =, 0; sid:103;)";
     sigs[3] = "alert tcp any any -> any any (msg:\"and count the rest of the packets received without generating alerts!!!\"; flowint: cntpackets,isset; flowint: cntpackets, +, 1; noalert;sid:104;)";

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -48,7 +48,7 @@
 #include "util-profiling.h"
 
 /*                         name             modifiers          value      */
-#define PARSE_REGEX "^\\s*([a-zA-Z][\\w\\d_./]+)\\s*,\\s*([+=-]{1}|==|!=|<|<=|>|>=|isset|notset)\\s*,?\\s*([a-zA-Z][\\w\\d]+|[\\d]{1,10})?\\s*$"
+#define PARSE_REGEX "^\\s*([a-zA-Z][\\w\\d_./]+)\\s*,\\s*([+=-]{1}|==|!=|<|<=|>|>=|isset|notset|isnotset)\\s*,?\\s*([a-zA-Z][\\w\\d]+|[\\d]{1,10})?\\s*$"
 /* Varnames must begin with a letter */
 
 static DetectParseRegex parse_regex;
@@ -140,7 +140,7 @@ int DetectFlowintMatch(DetectEngineThreadCtx *det_ctx,
         goto end;
     }
 
-    if (sfd->modifier == FLOWINT_MODIFIER_NOTSET) {
+    if (sfd->modifier == FLOWINT_MODIFIER_ISNOTSET) {
         SCLogDebug(" Not set %s? = %u", sfd->name,(fv) ? 0 : 1);
         if (fv == NULL)
             ret = 1;
@@ -280,8 +280,8 @@ static DetectFlowintData *DetectFlowintParse(DetectEngineCtx *de_ctx, const char
         modifier = FLOWINT_MODIFIER_GT;
     if (strcmp("isset", modstr) == 0)
         modifier = FLOWINT_MODIFIER_ISSET;
-    if (strcmp("notset", modstr) == 0)
-        modifier = FLOWINT_MODIFIER_NOTSET;
+    if (strcmp("notset", modstr) == 0 || strcmp("isnotset", modstr) == 0)
+        modifier = FLOWINT_MODIFIER_ISNOTSET;
 
     if (modifier == FLOWINT_MODIFIER_UNKNOWN) {
         SCLogError("Unknown modifier");
@@ -293,7 +293,7 @@ static DetectFlowintData *DetectFlowintParse(DetectEngineCtx *de_ctx, const char
         goto error;
 
     /* If we need another arg, check it out(isset doesn't need another arg) */
-    if (modifier != FLOWINT_MODIFIER_ISSET && modifier != FLOWINT_MODIFIER_NOTSET) {
+    if (modifier != FLOWINT_MODIFIER_ISSET && modifier != FLOWINT_MODIFIER_ISNOTSET) {
         if (ret < 4)
             goto error;
 
@@ -398,7 +398,7 @@ static int DetectFlowintSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
         case FLOWINT_MODIFIER_GE:
         case FLOWINT_MODIFIER_GT:
         case FLOWINT_MODIFIER_ISSET:
-        case FLOWINT_MODIFIER_NOTSET:
+        case FLOWINT_MODIFIER_ISNOTSET:
             SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
             break;
         default:
@@ -1003,7 +1003,7 @@ static int DetectFlowintTestParseIsset10(void)
     DetectFlowintPrintData(sfd);
     if (sfd != NULL && !strcmp(sfd->name, "myvar")
             && sfd->targettype == FLOWINT_TARGET_SELF
-            && sfd->modifier == FLOWINT_MODIFIER_NOTSET) {
+            && sfd->modifier == FLOWINT_MODIFIER_ISNOTSET) {
 
         result &= 1;
     } else {
@@ -1192,7 +1192,7 @@ static int DetectFlowintTestPacket02Real(void)
     de_ctx->flags |= DE_QUIET;
 
     const char *sigs[5];
-    sigs[0] = "alert tcp any any -> any any (msg:\"Setting a flowint counter\"; content:\"GET\"; flowint: myvar, notset; flowint:maxvar,notset; flowint: myvar,=,1; flowint: maxvar,=,6; sid:101;)";
+    sigs[0] = "alert tcp any any -> any any (msg:\"Setting a flowint counter\"; content:\"GET\"; flowint:myvar,notset; flowint:maxvar,isnotset; flowint: myvar,=,1; flowint: maxvar,=,6; sid:101;)";
     sigs[1] = "alert tcp any any -> any any (msg:\"Adding to flowint counter\"; content:\"Unauthorized\"; flowint:myvar,isset; flowint: myvar,+,2; sid:102;)";
     sigs[2] = "alert tcp any any -> any any (msg:\"if the flowint counter is 3 create a new counter\"; content:\"Unauthorized\"; flowint: myvar, isset; flowint: myvar,==,3; flowint:cntpackets,notset; flowint: cntpackets, =, 0; sid:103;)";
     sigs[3] = "alert tcp any any -> any any (msg:\"and count the rest of the packets received without generating alerts!!!\"; flowint: cntpackets,isset; flowint: cntpackets, +, 1; noalert;sid:104;)";

--- a/src/detect-flowint.h
+++ b/src/detect-flowint.h
@@ -40,7 +40,7 @@ enum {
     FLOWINT_MODIFIER_GT,
     /** Checking if a var is set (keyword isset/notset)*/
     FLOWINT_MODIFIER_ISSET,
-    FLOWINT_MODIFIER_NOTSET,
+    FLOWINT_MODIFIER_ISNOTSET,
 
     FLOWINT_MODIFIER_UNKNOWN
 };


### PR DESCRIPTION
Similar keywords use `isnotset`, while `flowint` only accepted `notset` Opted to change the code, not only the regex, to keep the underlying code also following the same patterns.

Task #7426

(cherry picked from commit 6e4a501e7c96a705df084fd1e74668bc70a00b89)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7427

Describe changes:
- Mostly a clean cherry-pick of 6e4a501e7c9
- clang formatting changes

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2167