### PR TITLE
Detect log alert tx one 7199 - v8

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -695,7 +695,7 @@ meaning it will repeat its actions over and over again. With the
 option inspection-recursion-limit you can limit this action.
 
 The stream-tx-log-limit defines the maximum number of times a
-transaction will get logged for a stream-only rule match.
+transaction will get logged for rules without app-layer keywords.
 This is meant to avoid logging the same data an arbitrary number
 of times.
 

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -70,6 +70,21 @@ Alerts are event records for rule matches. They can be amended with
 metadata, such as the application layer record (HTTP, DNS, etc) an
 alert was generated for, and elements of the rule.
 
+The alert is amended with application layer metadata for signatures
+using application layer keywords. It is also the case for protocols
+over UDP as each single packet is expected to contain a PDU.
+
+For other signatures, the option ``guess-applayer-tx``
+can be used to force the detect engine to tie a transaction
+to an alert.
+This transaction is not guaranteed to be the relevant one,
+depending on your use case and how you define relevant here.
+If there are multiple live transactions, none will get
+picked up.
+The alert event will have ``"tx_guessed": true`` to recognize
+these alerts.
+
+
 Metadata::
 
         - alert:

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -99,6 +99,10 @@ Logging changes
 ~~~~~~~~~~~~~~~
 - RFB security result is now consistently logged as ``security_result`` when it was
   sometimes logged with a dash instead of an underscore.
+- Application layer metadata is logged with alerts by default **only for rules that
+  use application layer keywords**. For other rules, the configuration parameter
+  ``detect.guess-applayer-tx`` can be used to force the detect engine to find a
+  transaction, which is not guaranteed to be the one you expect.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -115,6 +115,10 @@
         "tx_id": {
             "type": "integer"
         },
+        "tx_guessed": {
+            "description": "the signature that triggered this alert didn't tie to a transaction, so the transaction (and metadata) logged is a forced estimation and may not be the one you expect",
+            "type": "boolean"
+        },
         "files": {
             "type": "array",
             "minItems": 1,

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -114,8 +114,9 @@ pub struct AppLayerTxData {
     /// STREAM_TOCLIENT: file tx , files only in toclient dir
     /// STREAM_TOSERVER|STREAM_TOCLIENT: files possible in both dirs
     pub file_tx: u8,
-    /// Number of times this tx data has already been logged for one stream match
-    pub stream_logged: u8,
+    /// Number of times this tx data has already been logged for signatures
+    /// not using application layer keywords
+    pub guessed_applayer_logged: u8,
 
     /// detection engine flags for use by detection engine
     detect_flags_ts: u64,
@@ -154,7 +155,7 @@ impl AppLayerTxData {
             files_stored: 0,
             file_flags: 0,
             file_tx: 0,
-            stream_logged: 0,
+            guessed_applayer_logged: 0,
             detect_flags_ts: 0,
             detect_flags_tc: 0,
             de_state: std::ptr::null_mut(),
@@ -177,7 +178,7 @@ impl AppLayerTxData {
             files_stored: 0,
             file_flags: 0,
             file_tx: 0,
-            stream_logged: 0,
+            guessed_applayer_logged: 0,
             detect_flags_ts,
             detect_flags_tc,
             de_state: std::ptr::null_mut(),

--- a/src/decode.h
+++ b/src/decode.h
@@ -257,6 +257,8 @@ typedef struct PacketAlert_ {
 #define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
 /** alert is in a frame, frame_id set */
 #define PACKET_ALERT_FLAG_FRAME 0x20
+/** alert in a tx was forced */
+#define PACKET_ALERT_FLAG_TX_GUESSED 0x040
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2931,10 +2931,10 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
                de_ctx->inspection_recursion_limit);
 
     // default value is 4
-    de_ctx->stream_tx_log_limit = 4;
+    de_ctx->guess_applayer_log_limit = 4;
     if (ConfGetInt("detect.stream-tx-log-limit", &value) == 1) {
         if (value >= 0 && value <= UINT8_MAX) {
-            de_ctx->stream_tx_log_limit = (uint8_t)value;
+            de_ctx->guess_applayer_log_limit = (uint8_t)value;
         } else {
             SCLogWarning("Invalid value for detect-engine.stream-tx-log-limit: must be between 0 "
                          "and 255, will default to 4");

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2940,6 +2940,12 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
                          "and 255, will default to 4");
         }
     }
+    int guess_applayer = 0;
+    if ((ConfGetBool("detect.guess-applayer-tx", &guess_applayer)) == 1) {
+        if (guess_applayer == 1) {
+            de_ctx->guess_applayer = true;
+        }
+    }
 
     /* parse port grouping priority settings */
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -827,12 +827,12 @@ static inline void DetectRulePacketRules(
                 AppLayerTxData *txd =
                         tx_ptr ? AppLayerParserGetTxData(pflow->proto, pflow->alproto, tx_ptr)
                                : NULL;
-                if (txd && txd->stream_logged < de_ctx->stream_tx_log_limit) {
+                if (txd && txd->guessed_applayer_logged < de_ctx->guess_applayer_log_limit) {
                     alert_flags |= PACKET_ALERT_FLAG_TX;
                     if (pflow->proto != IPPROTO_UDP) {
                         alert_flags |= PACKET_ALERT_FLAG_TX_GUESSED;
                     }
-                    txd->stream_logged++;
+                    txd->guessed_applayer_logged++;
                 }
             }
         }

--- a/src/detect.c
+++ b/src/detect.c
@@ -813,15 +813,15 @@ static inline void DetectRulePacketRules(
         DetectRunPostMatch(tv, det_ctx, p, s);
 
         uint64_t txid = PACKET_ALERT_NOTX;
-        if ((alert_flags & PACKET_ALERT_FLAG_STREAM_MATCH) ||
-                (s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP)) {
-            // if there is a stream match (TCP), or
-            // a UDP specific app-layer signature,
-            // try to use the good tx for the packet direction
-            if (pflow->alstate) {
-                uint8_t dir =
-                        (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
-                txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
+        if (pflow && pflow->alstate) {
+            uint8_t dir = (p->flowflags & FLOW_PKT_TOCLIENT) ? STREAM_TOCLIENT : STREAM_TOSERVER;
+            txid = AppLayerParserGetTransactionInspectId(pflow->alparser, dir);
+            if ((s->alproto != ALPROTO_UNKNOWN && pflow->proto == IPPROTO_UDP) ||
+                    (de_ctx->guess_applayer &&
+                            AppLayerParserGetTxCnt(pflow, pflow->alstate) == txid + 1)) {
+                // if there is a UDP specific app-layer signature,
+                // or only one live transaction
+                // try to use the good tx for the packet direction
                 void *tx_ptr =
                         AppLayerParserGetTx(pflow->proto, pflow->alproto, pflow->alstate, txid);
                 AppLayerTxData *txd =
@@ -829,6 +829,9 @@ static inline void DetectRulePacketRules(
                                : NULL;
                 if (txd && txd->stream_logged < de_ctx->stream_tx_log_limit) {
                     alert_flags |= PACKET_ALERT_FLAG_TX;
+                    if (pflow->proto != IPPROTO_UDP) {
+                        alert_flags |= PACKET_ALERT_FLAG_TX_GUESSED;
+                    }
                     txd->stream_logged++;
                 }
             }

--- a/src/detect.h
+++ b/src/detect.h
@@ -889,6 +889,9 @@ typedef struct DetectEngineCtx_ {
     /* maximum number of times a tx will get logged for a stream-only rule match */
     uint8_t stream_tx_log_limit;
 
+    /* force app-layer tx finding for alerts with signatures not having app-layer keywords */
+    bool guess_applayer;
+
     /* registration id for per thread ctx for the filemagic/file.magic keywords */
     int filemagic_thread_ctx_id;
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -886,8 +886,8 @@ typedef struct DetectEngineCtx_ {
     /* maximum recursion depth for content inspection */
     int inspection_recursion_limit;
 
-    /* maximum number of times a tx will get logged for a stream-only rule match */
-    uint8_t stream_tx_log_limit;
+    /* maximum number of times a tx will get logged for rules not using app-layer keywords */
+    uint8_t guess_applayer_log_limit;
 
     /* force app-layer tx finding for alerts with signatures not having app-layer keywords */
     bool guess_applayer;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -221,6 +221,9 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, JsonBuilder *js, ui
     if (pa->flags & PACKET_ALERT_FLAG_TX) {
         jb_set_uint(js, "tx_id", pa->tx_id);
     }
+    if (pa->flags & PACKET_ALERT_FLAG_TX_GUESSED) {
+        jb_set_bool(js, "tx_guessed", true);
+    }
 
     jb_open_object(js, "alert");
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1700,7 +1700,7 @@ detect:
     toserver-groups: 25
   sgh-mpm-context: auto
   inspection-recursion-limit: 3000
-  # maximum number of times a tx will get logged for a stream-only rule match
+  # maximum number of times a tx will get logged for rules without app-layer keywords
   # stream-tx-log-limit: 4
   # try to tie an app-layer transaction for rules without app-layer keywords
   # if there is only one live transaction for the flow

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1702,6 +1702,11 @@ detect:
   inspection-recursion-limit: 3000
   # maximum number of times a tx will get logged for a stream-only rule match
   # stream-tx-log-limit: 4
+  # try to tie an app-layer transaction for rules without app-layer keywords
+  # if there is only one live transaction for the flow
+  # allows to log app-layer metadata in alert
+  # but the transaction may not be the relevant one.
+  # guess-applayer-tx: no
   # If set to yes, the loading of signatures will be made after the capture
   # is started. This will limit the downtime in IPS mode.
   #delayed-detect: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7199
Also solves https://redmine.openinfosecfoundation.org/issues/7350

May also solve https://redmine.openinfosecfoundation.org/issues/7406

Follow up on @catenacyber work - https://github.com/OISF/suricata/pull/12197
just to adjust the terminology we're trying to agree upon

Describe changes:
- use `guess-applayer-tx` and similar terminology throughout to keep everything tied:
  - config
  - log
  - code

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2168