### PR TITLE
dpdk: set ice PMD RSS key length to 52 bytes for all DPDK versions

### DIFF
--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -49,11 +49,7 @@ static void iceDeviceSetRSSHashFunction(uint64_t *rss_hf)
 void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf)
 {
     iceDeviceSetRSSHashFunction(&rss_conf->rss_hf);
-#if RTE_VERSION < RTE_VERSION_NUM(23, 11, 0, 0)
-    rss_conf->rss_key_len = 40;
-#else
     rss_conf->rss_key_len = 52;
-#endif
 }
 
 #endif /* HAVE_DPDK */


### PR DESCRIPTION
ICE driver (Intel E810 NIC) requires/supports 52-byte long RSS key. The 52 byte key length was mandatory from DPDK 23.11 when Suricata was starting with independently configured ice PMD.

However, Suricata failed to start when ice PMD was part of net_bonding PMD, requiring 52 byte RSS key even in DPDK versions lower than 23.11. Since the support for the longer key is present since DPDK 19.11 the key is set to 52 bytes for all versions.

https://redmine.openinfosecfoundation.org/issues/7444

Describe changes:
- remove versioning macro

