### PR TITLE
detect: don't run pkt sigs on ffr pkts v2

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -781,6 +781,10 @@ static inline void DetectRulePacketRules(
             goto next; // handle sig in DetectRunFrame
         }
 
+        /* skip pkt sigs for flow end packets */
+        if ((p->flags & PKT_PSEUDO_STREAM_END) != 0 && s->type == SIG_TYPE_PKT)
+            goto next;
+
         /* don't run mask check for stateful rules.
          * There we depend on prefilter */
         if ((s->mask & scratch->pkt_mask) != s->mask) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7318

Describe changes:
-  This patch skips signatures of the SIG_TYPE_PKT for flow end packets

https://github.com/OISF/suricata/pull/12095 rebased with rebased SV test

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2173
