### PR TITLE
detect: don't run pkt sigs on ffr pkts

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -781,6 +781,10 @@ static inline void DetectRulePacketRules(
             goto next; // handle sig in DetectRunFrame
         }
 
+        /* skip pkt sigs for flow end packets */
+        if ((p->flags & PKT_PSEUDO_STREAM_END) != 0 && s->type == SIG_TYPE_PKT)
+            goto next;
+
         /* don't run mask check for stateful rules.
          * There we depend on prefilter */
         if ((s->mask & scratch->pkt_mask) != s->mask) {


### PR DESCRIPTION
Last packet from the TLS TCP session moves TCP state to CLOSED.

This flags the app-layer with APP_LAYER_PARSER_EOF_TS or APP_LAYER_PARSER_EOF_TC depending on the direction of the final packet. This flag will just have been set in a single direction.

This leads to the last packet updating the inspect id in that packets direction.

At the end of the TLS session a pseudo packet is created, because:
 - flow has ended
 - inspected tx id == 0, for at least one direction
 - total txs is 1

Then a packet rule matches:

```
alert tcp any any -> any 443 (flow: to_server;                  \
        flowbits:isset,tls_error;                               \
        sid:09901033; rev:1;                                    \
        msg:"Allow TLS error handling (outgoing packet)"; )
```

The `SIG_MASK_REQUIRE_REAL_PKT` is not preventing the match, as the `flowbits` keyword doesn't set it.

To avoid this match. This patch skips signatures of the `SIG_TYPE_PKT` for flow end packets.

Ticket: #7318.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2174