### PR TITLE
output/log: Improve error handling if log output initialization/open fails.

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -733,7 +733,7 @@ LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *parent_ctx)
             entry->isopen = true;
             ret_ctx = entry->ctx;
         } else {
-            SCLogError(
+            SCLogDebug(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -346,14 +346,17 @@ static void ThreadLogFileHashFreeFunc(void *data)
     BUG_ON(data == NULL);
     ThreadLogFileHashEntry *thread_ent = (ThreadLogFileHashEntry *)data;
 
-    if (thread_ent) {
+    if (!thread_ent)
+        return;
+
+    if (thread_ent->isopen) {
         LogFileCtx *lf_ctx = thread_ent->ctx;
         /* Free the leaf log file entries */
         if (!lf_ctx->threaded) {
             LogFileFreeCtx(lf_ctx);
         }
-        SCFree(thread_ent);
     }
+    SCFree(thread_ent);
 }
 
 bool SCLogOpenThreadedFile(const char *log_path, const char *append, LogFileCtx *parent_ctx)
@@ -712,6 +715,7 @@ LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *parent_ctx)
     if (!parent_ctx->threaded)
         return parent_ctx;
 
+    LogFileCtx *ret_ctx = NULL;
     SCMutexLock(&parent_ctx->threads->mutex);
     /* Find this thread's entry */
     ThreadLogFileHashEntry *entry = LogFileThread2Slot(parent_ctx->threads, thread_id);
@@ -721,12 +725,13 @@ LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *parent_ctx)
 
     bool new = entry->isopen;
     /* has it been opened yet? */
-    if (!entry->isopen) {
+    if (!new) {
         SCLogDebug("%s: Opening new file for thread/id %d to file %s [ctx %p]", t_thread_name,
                 thread_id, parent_ctx->filename, parent_ctx);
         if (LogFileNewThreadedCtx(
                     parent_ctx, parent_ctx->filename, parent_ctx->threads->append, entry)) {
             entry->isopen = true;
+            ret_ctx = entry->ctx;
         } else {
             SCLogError(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
@@ -742,7 +747,7 @@ LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *parent_ctx)
         }
     }
 
-    return entry->ctx;
+    return ret_ctx;
 }
 
 /** \brief LogFileThreadedName() Create file name for threaded EVE storage


### PR DESCRIPTION
Handle output object initialization failures.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7447

Describe changes:
- Return NULL when open fails
- Ensure object is open before using output context
- Remove extraneous error message in failure case.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2182
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
