### PR TITLE
var: Use 16-bit container for type

### DIFF
--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -56,8 +56,7 @@ enum DetectKeywordId {
     DETECT_FLOW,
     /* end prefilter sort */
 
-    /* values used in util-var.c go here, to avoid int overflows
-     * TODO update var logic to use a larger type, see #6855. */
+    /* values used in util-var.c go here, to avoid int overflows */
     DETECT_THRESHOLD,
     DETECT_FLOWBITS,
     DETECT_FLOWVAR,

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -524,8 +524,8 @@ static void FlowThresholdEntryListFree(FlowThresholdEntryList *list)
 /** struct for storing per flow thresholds. This will be stored in the Flow::flowvar list, so it
  * needs to follow the GenericVar header format. */
 typedef struct FlowVarThreshold_ {
-    uint8_t type;
-    uint8_t pad[7];
+    uint16_t type;
+    uint8_t pad[6];
     struct GenericVar_ *next;
     FlowThresholdEntryList *thresholds;
 } FlowVarThreshold;

--- a/src/flow-bit.h
+++ b/src/flow-bit.h
@@ -28,8 +28,8 @@
 #include "util-var.h"
 
 typedef struct FlowBit_ {
-    uint8_t type; /* type, DETECT_FLOWBITS in this case */
-    uint8_t pad[3];
+    uint16_t type; /* type, DETECT_FLOWBITS in this case */
+    uint8_t pad[2];
     uint32_t idx; /* name idx */
     GenericVar *next; /* right now just implement this as a list,
                        * in the long run we have think of something

--- a/src/flow-var.h
+++ b/src/flow-var.h
@@ -46,13 +46,14 @@ typedef struct FlowVarTypeInt_ {
 
 /** Generic Flowvar Structure */
 typedef struct FlowVar_ {
-    uint8_t type;       /* type, DETECT_FLOWVAR in this case */
+    uint16_t type; /* type, DETECT_FLOWVAR in this case */
     uint8_t datatype;
-    uint16_t keylen;
+    uint8_t pad;
     uint32_t idx;       /* name idx */
     GenericVar *next;   /* right now just implement this as a list,
                          * in the long run we have think of something
                          * faster. */
+    uint16_t keylen;
     union {
         FlowVarTypeStr fv_str;
         FlowVarTypeInt fv_int;

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -46,17 +46,16 @@ enum VarTypes {
     VAR_TYPE_IPPAIR_VAR,
 };
 
-/** \todo see ticket #6855. The type field should be 16 bits. */
 typedef struct GenericVar_ {
-    uint8_t type; /**< variable type, uses detection sm_type */
-    uint8_t pad[3];
+    uint16_t type; /**< variable type, uses detection sm_type */
+    uint8_t pad[2];
     uint32_t idx;
     struct GenericVar_ *next;
 } GenericVar;
 
 typedef struct XBit_ {
-    uint8_t type;       /* type, DETECT_XBITS in this case */
-    uint8_t pad[3];
+    uint16_t type; /* type, DETECT_XBITS in this case */
+    uint8_t pad[2];
     uint32_t idx;       /* name idx */
     GenericVar *next;
     uint32_t expire;


### PR DESCRIPTION
Continuation of #12253  

Issue: 6855: Match sigmatch type field in var and bit structs

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6855

Describe changes:
- Increase `type` in flowbit, flowvar and generic var
- Ensure type, idx, and next pointers align on each struct.

Updates:
- Removed todo referencing issue from detect-engine-register.h
### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
