### PR TITLE
general/typo: Fix typo in stacksize msg

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -967,7 +967,7 @@ void RunModeInitializeThreadSettings(void)
         size_t size;
         if (pthread_attr_getstacksize(&attr, &size) == 0 && size < 512 * 1024) {
             threading_set_stack_size = 512 * 1024;
-            SCLogNotice("thread stack size of %" PRIuMAX " to too small: setting to 512k",
+            SCLogNotice("thread stack size of %" PRIuMAX " too small: setting to 512k",
                     (uintmax_t)size);
         }
     }


### PR DESCRIPTION
Fix typo when defaulting stack-size


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
