### PR TITLE
analysis: report rule state altered by other rule - v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1047,6 +1047,8 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             break;
     }
 
+    jb_set_bool(ctx.js, "rule_state_dependency", s->init_data->rule_state_dependency);
+
     jb_open_array(ctx.js, "flags");
     if (s->flags & SIG_FLAG_SRC_ANY) {
         jb_append_string(ctx.js, "src_any");

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -630,6 +630,7 @@ int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx)
 
             if (to_state) {
                 s->init_data->init_flags |= SIG_FLAG_INIT_STATE_MATCH;
+                s->init_data->rule_state_dependency = true;
                 SCLogDebug("made SID %u stateful because it depends on "
                         "stateful rules that set flowbit %s", s->id, varname);
             }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1537,6 +1537,9 @@ Signature *SigAlloc (void)
      * overwritten, we can then assign the default value of 3 */
     sig->prio = -1;
 
+    /* rule interdepency is false, at start */
+    sig->init_data->rule_state_dependency = false;
+
     sig->init_data->list = DETECT_SM_LIST_NOTSET;
     return sig;
 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -597,6 +597,9 @@ typedef struct SignatureInitData_ {
 
     /* highest list/buffer id which holds a DETECT_CONTENT */
     uint32_t max_content_list_id;
+
+    /* inter-signature state dependency */
+    bool rule_state_dependency;
 } SignatureInitData;
 
 /** \brief Signature container */


### PR DESCRIPTION
Flowbits can make a rule such as a packet rule be treated as a stateful rule, without actually changing the rule type.

Add a flag to allow report such cases via the engine analysis.

Task #7456 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7456

Describe changes:
- add a flag (bool) that is set when the flowbits analysis makes non stateful rules, such as a packet rule, a stateful one, so we can report that in the engine analysis report. Not a fan of the names used, but couldn't come up with something else...

Wasn't sure about using this as another `SIG_INIT_FLAG` or even as flag that could have other values, so decided to go with this as a proof of concept, sort of.

The output will also be tested with SV tests that should accompany the rule types doc.

Moved on with this work before the rule types documentation as this should also be present in the `engine-analysis` examples seen there.

Output example:
```json
{
  "raw": "alert ip any any -> any any (msg:\"Flowbit isset ored flowbits\"; flowbits:isset,fb1|fb5; sid:1801;)",
  "id": 1801,
  "gid": 1,
  "rev": 0,
  "msg": "Flowbit isset ored flowbits",
  "app_proto": "unknown",
  "requirements": [
    "flow"
  ],
  "type": "pkt",
  "rule_state_dependency": true,
  "flags": [
    "src_any",
    "dst_any",
    "sp_any",
    "dp_any",
    "need_flowvar",
    "toserver",
    "toclient"
  ],
  "pkt_engines": [
    {
      "name": "packet",
      "is_mpm": false
    }
  ],
  "frame_engines": [],
  "engines": [],
  "lists": {
    "packet": {
      "matches": [
        {
          "name": "flowbits",
          "flowbits": {
            "cmd": "isset",
            "names": [
              "fb1",
              "fb5"
            ],
            "operator": "or"
          }
        }
      ]
    }
  }
}
```