### PR TITLE
7.0.x: backport commit to not log empty IP addresses and ports - v1

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -581,8 +581,10 @@ void JsonAddrInfoInit(const Packet *p, enum OutputJsonLogDirection dir, JsonAddr
         case IPPROTO_SCTP:
             addr->sp = sp;
             addr->dp = dp;
+            addr->log_port = true;
             break;
         default:
+            addr->log_port = false;
             break;
     }
 
@@ -880,11 +882,21 @@ JsonBuilder *CreateEveHeader(const Packet *p, enum OutputJsonLogDirection dir,
         JsonAddrInfoInit(p, dir, &addr_info);
         addr = &addr_info;
     }
-    jb_set_string(js, "src_ip", addr->src_ip);
-    jb_set_uint(js, "src_port", addr->sp);
-    jb_set_string(js, "dest_ip", addr->dst_ip);
-    jb_set_uint(js, "dest_port", addr->dp);
-    jb_set_string(js, "proto", addr->proto);
+    if (addr->src_ip[0] != '\0') {
+        jb_set_string(js, "src_ip", addr->src_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "src_port", addr->sp);
+    }
+    if (addr->dst_ip[0] != '\0') {
+        jb_set_string(js, "dest_ip", addr->dst_ip);
+    }
+    if (addr->log_port) {
+        jb_set_uint(js, "dest_port", addr->dp);
+    }
+    if (addr->proto[0] != '\0') {
+        jb_set_string(js, "proto", addr->proto);
+    }
 
     /* icmp */
     switch (p->proto) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -52,6 +52,8 @@ typedef struct JsonAddrInfo_ {
     Port sp;
     Port dp;
     char proto[JSON_PROTO_LEN];
+    // Ports are logged only when provided by the transport protocol.
+    bool log_port;
 } JsonAddrInfo;
 
 extern const JsonAddrInfo json_addr_info_zero;


### PR DESCRIPTION
This commit enhances the JSON output by introducing a feature for conditional port logging.
Now, port logging is dependent on the underlying protocol
(such as TCP, UDP, or SCTP), where port information is pertinent, while it
avoids unnecessary logging for protocols where a port is not utilized (e.g. ARP).

Furthermore, this update ensures that IP addresses and the protocol have
meaningful values set, rather than being logged as empty strings.

These changes will make each log entry more precise, eliminating cases where
5-tuple fields are empty or set to zero, indicating the absence of a field.

Backported to address ticket: https://redmine.openinfosecfoundation.org/issues/7460

Ticket: #7460

(cherry picked from commit a1c6328156ffa1e3d690fa180b0395f9dcd9f52e)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2189
