### PR TITLE
doh2: really enforce 65K dns message limit

### DIFF
--- a/rules/http2-events.rules
+++ b/rules/http2-events.rules
@@ -21,3 +21,4 @@ alert http2 any any -> any any (msg:"SURICATA HTTP2 too many streams"; flow:esta
 alert http2 any any -> any any (msg:"SURICATA HTTP2 authority host mismatch"; flow:established,to_server; app-layer-event:http2.authority_host_mismatch; classtype:protocol-command-decode; sid:2290013; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 user info in uri"; flow:established,to_server; app-layer-event:http2.userinfo_in_uri; classtype:protocol-command-decode; sid:2290014; rev:1;)
 alert http2 any any -> any any (msg:"SURICATA HTTP2 reassembly limit reached"; flow:established; app-layer-event:http2.reassembly_limit_reached; classtype:protocol-command-decode; sid:2290015; rev:1;)
+alert http2 any any -> any any (msg:"SURICATA HTTP2 dns too long"; flow:established; app-layer-event:http2.dns_too_long; classtype:protocol-command-decode; sid:2290016; rev:1;)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7464

Describe changes:
- doh2: really enforce 65K dns message limit
