### PR TITLE
detect/content: account for distance variables

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -182,6 +182,8 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
                     }
 
                     if (stream_start_offset != 0 && prev_buffer_offset == 0) {
+                        SCLogDebug("stream_start_offset: %" PRIi32 ", depth %" PRIu32,
+                                stream_start_offset, depth);
                         if (depth <= stream_start_offset) {
                             goto no_match;
                         } else if (depth >= (stream_start_offset + buffer_len)) {
@@ -189,6 +191,8 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
                         } else {
                             depth = depth - stream_start_offset;
                         }
+                        SCLogDebug("depth is now %" PRIu32 ", stream_start_offset: %" PRIi32, depth,
+                                stream_start_offset);
                     }
                 }
 
@@ -202,7 +206,10 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
                             depth = prev_buffer_offset + cd->depth;
                         }
 
-                        SCLogDebug("cd->depth %"PRIu32", depth %"PRIu32, cd->depth, depth);
+                        SCLogDebug("cd->depth %" PRIu32 ", depth %" PRIu32
+                                   " , prev_offset %" PRIi32,
+                                cd->depth, depth, prev_buffer_offset);
+                        depth += offset;
                     }
                 }
 
@@ -246,8 +253,8 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
             /* If the value came from a variable, make sure to adjust the depth so it's relative
              * to the offset value.
              */
-            if (cd->flags & (DETECT_CONTENT_DISTANCE_VAR|DETECT_CONTENT_OFFSET_VAR|DETECT_CONTENT_DEPTH_VAR)) {
-                 depth += offset;
+            if (cd->flags & (DETECT_CONTENT_OFFSET_VAR | DETECT_CONTENT_DEPTH_VAR)) {
+                depth += offset;
             }
 
             /* update offset with prev_offset if we're searching for


### PR DESCRIPTION
Under some cases (see the issue), the depth and offset values are used twice. This commit disregards the distance variable (if any), when computing the final depth.

Issue: 7390

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7390

Describe changes:
- Avoid double add when there's a distance variable involved.


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2191
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
