### PR TITLE
ci: run CodeQL only on python changes

### DIFF
--- a/.github/workflows/codeqlpy.yml
+++ b/.github/workflows/codeqlpy.yml
@@ -3,13 +3,15 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - "doc/**"
+    paths:
+      - "python/**"
+      - "**/*.py"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-    paths-ignore:
-      - "doc/**"
+    paths:
+      - "python/**"
+      - "**/*.py"
   schedule:
     - cron: '18 21 * * 1'
 
@@ -33,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp' ]
+        language: [ 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7358

Describe changes:
- ci: run CodeQL only on python changes

#12151 taking the approach of duplicating the file because it is easier to have the check in `on` section than using [strategy.matrix.exclude](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixexclude) where it looks complex to have the list of different files