### PR TITLE
analysis: report rule state altered by other rule - v2

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -1047,6 +1047,16 @@ void EngineAnalysisRules2(const DetectEngineCtx *de_ctx, const Signature *s)
             break;
     }
 
+    if (s->init_data->is_rule_state_dependant) {
+        jb_open_object(ctx.js, "rule_state_dependant");
+        jb_set_uint(ctx.js, "rule_depends_on_sid", s->init_data->rule_state_dependant_id);
+        jb_set_string(ctx.js, "rule_depends_on_flowbit",
+                VarNameStoreSetupLookup(s->init_data->rule_state_variable_idx, VAR_TYPE_FLOW_BIT));
+        jb_close(ctx.js);
+    } else {
+        jb_set_bool(ctx.js, "rule_state_dependant", s->init_data->is_rule_state_dependant);
+    }
+
     jb_open_array(ctx.js, "flags");
     if (s->flags & SIG_FLAG_SRC_ANY) {
         jb_append_string(ctx.js, "src_any");

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -630,6 +630,11 @@ int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx)
 
             if (to_state) {
                 s->init_data->init_flags |= SIG_FLAG_INIT_STATE_MATCH;
+                s->init_data->is_rule_state_dependant = true;
+                // fetch the signature id that sets the flowbit making the isset rule stateful
+                s->init_data->rule_state_dependant_id =
+                        de_ctx->sig_array[array[i].set_sids[array[i].set_sids_idx - 1]]->id;
+                s->init_data->rule_state_variable_idx = i;
                 SCLogDebug("made SID %u stateful because it depends on "
                         "stateful rules that set flowbit %s", s->id, varname);
             }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1537,6 +1537,9 @@ Signature *SigAlloc (void)
      * overwritten, we can then assign the default value of 3 */
     sig->prio = -1;
 
+    /* rule interdepency is false, at start */
+    sig->init_data->is_rule_state_dependant = false;
+
     sig->init_data->list = DETECT_SM_LIST_NOTSET;
     return sig;
 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -597,6 +597,11 @@ typedef struct SignatureInitData_ {
 
     /* highest list/buffer id which holds a DETECT_CONTENT */
     uint32_t max_content_list_id;
+
+    /* inter-signature state dependency */
+    bool is_rule_state_dependant;
+    uint32_t rule_state_dependant_id;
+    uint32_t rule_state_variable_idx;
 } SignatureInitData;
 
 /** \brief Signature container */


### PR DESCRIPTION
Flowbits can make a rule such as a packet rule be treated as a stateful rule, without actually changing the rule type.

Add a flag to allow reporting such cases via engine analysis.

Task #7456

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7456

Previous PR: https://github.com/OISF/suricata/pull/12286

Output samples:
`flowbits:set` rule
```json
{
  "raw": "alert http any any -> any any (msg:\"Setting flowbit fb2, app_tx rule\";http.uri;content:\"something\";flowbits:set,fb2;sid:1901;)",
  "id": 1901,
  "gid": 1,
  "rev": 0,
  "msg": "Setting flowbit fb2, app_tx rule",
  "app_proto": "http_any",
  "requirements": [
    "flow"
  ],
  "type": "app_tx",
  "rule_state_dependant": false,
}
```

`flowbits:isset` rule
```json
{
  "raw": "alert ip any any -> any any (msg:\"Is-Setting flowbit fb2, pkt rule\";flowbits:isset,fb2;sid:1904;)",
  "id": 1904,
  "gid": 1,
  "rev": 0,
  "msg": "Is-Setting flowbit fb2, pkt rule",
  "app_proto": "unknown",
  "requirements": [
    "flow"
  ],
  "type": "pkt",
  "rule_state_dependant": {
    "rule_depends_on_sid": 1901,
    "rule_depends_on_flowbit": "fb2"
  },
}
```

Describe changes:
- besides indicating that there is a dependency, indicate
- what flowbit causes it
- what is the rule id setting said flowbit
- I've tried to keep the `init_data` mostly generic, in case there are other scenarios where this could happen - but at least when it's time to report this via the `engine-analysis`, we need the info to fetch the variable name
- I've removed/ discarded the idea of showing a counter of other signatures also affecting, as it's basically only the `set` command that does that, from what I could understand

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2201
