### PR TITLE
detect: add ldap.request.option keyword - v1

### DIFF
--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -49,3 +49,4 @@ Suricata Rules
    differences-from-snort
    multi-buffer-matching
    tag
+   ldap-keywords

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -1,0 +1,44 @@
+LDAP Keywords
+=============
+
+.. role:: example-rule-action
+.. role:: example-rule-header
+.. role:: example-rule-options
+.. role:: example-rule-emphasis
+
+ldap.request.operation
+----------------------
+
+Suricata has a ``ldap.request.operation`` keyword that can be used in signatures to identify
+and filter network packets based on Lightweight Directory Access Protocol request operations.
+
+Syntax::
+
+ ldap.request.operation: operation;
+
+ldap.request.operation uses :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
+
+.. table:: **Operation values for ldap.request.operation keyword**
+
+    ====  ================================================
+    Code  Request Operation
+    ====  ================================================
+    0     BindRequest
+    2     UnbindRequest
+    3     SearchRequest
+    6     ModifyRequest
+    8     AddRequest
+    10    DelRequest
+    12    ModDnRequest
+    14    CompareRequest
+    23    ExtendedRequest
+    ====  ================================================
+
+Example
+^^^^^^^^
+
+Example of a signature that would alert if the packet has an LDAP bind request operation:
+
+.. container:: example-rule
+
+  alert tcp any any -> any any (msg:"Test LDAP bind request"; :example-rule-emphasis:`ldap.request.operation:0;` sid:1;)

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -1,0 +1,94 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::ldap::{LdapTransaction, ALPROTO_LDAP};
+use crate::detect::uint::{
+    rs_detect_u8_free, rs_detect_u8_match, rs_detect_u8_parse, DetectUintData,
+};
+use crate::detect::{
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableElmt, SigMatchAppendSMToList,
+};
+
+use std::os::raw::{c_int, c_void};
+
+static mut G_LDAP_REQUEST_OPERATION_KW_ID: c_int = 0;
+static mut G_LDAP_REQUEST_OPERATION_BUFFER_ID: c_int = 0;
+
+unsafe extern "C" fn ldap_detect_request_operation_setup(
+    de: *mut c_void, s: *mut c_void, raw: *const libc::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_LDAP) != 0 {
+        return -1;
+    }
+    let ctx = rs_detect_u8_parse(raw) as *mut c_void;
+    if ctx.is_null() {
+        return -1;
+    }
+    if SigMatchAppendSMToList(
+        de,
+        s,
+        G_LDAP_REQUEST_OPERATION_KW_ID,
+        ctx,
+        G_LDAP_REQUEST_OPERATION_BUFFER_ID,
+    )
+    .is_null()
+    {
+        ldap_detect_request_operation_free(std::ptr::null_mut(), ctx);
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ldap_detect_request_operation_match(
+    _de: *mut c_void, _f: *mut c_void, _flags: u8, _state: *mut c_void, tx: *mut c_void,
+    _sig: *const c_void, ctx: *const c_void,
+) -> c_int {
+    let tx = cast_pointer!(tx, LdapTransaction);
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    let option: u8 = match &tx.request {
+        Some(request) => request.protocol_op.to_u8(),
+        None => 0,
+    };
+    return rs_detect_u8_match(option, ctx);
+}
+
+unsafe extern "C" fn ldap_detect_request_operation_free(_de: *mut c_void, ctx: *mut c_void) {
+    // Just unbox...
+    let ctx = cast_pointer!(ctx, DetectUintData<u8>);
+    rs_detect_u8_free(ctx);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ScDetectLdapRegister() {
+    let kw = SCSigTableElmt {
+        name: b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
+        desc: b"match LDAP request operation\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ldap-keywords.html#ldap.request.operation\0".as_ptr() as *const libc::c_char,
+        AppLayerTxMatch: Some(ldap_detect_request_operation_match),
+        Setup: ldap_detect_request_operation_setup,
+        Free: Some(ldap_detect_request_operation_free),
+        flags: 0,
+    };
+    G_LDAP_REQUEST_OPERATION_KW_ID = DetectHelperKeywordRegister(&kw);
+    G_LDAP_REQUEST_OPERATION_BUFFER_ID = DetectHelperBufferRegister(
+        b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
+        ALPROTO_LDAP,
+        false,
+        true,
+    );
+}

--- a/rust/src/ldap/ldap.rs
+++ b/rust/src/ldap/ldap.rs
@@ -33,7 +33,7 @@ static LDAP_MAX_TX_DEFAULT: usize = 256;
 
 static mut LDAP_MAX_TX: usize = LDAP_MAX_TX_DEFAULT;
 
-static mut ALPROTO_LDAP: AppProto = ALPROTO_UNKNOWN;
+pub(super) static mut ALPROTO_LDAP: AppProto = ALPROTO_UNKNOWN;
 
 const STARTTLS_OID: &str = "1.3.6.1.4.1.1466.20037";
 

--- a/rust/src/ldap/mod.rs
+++ b/rust/src/ldap/mod.rs
@@ -21,3 +21,4 @@ pub mod filters;
 pub mod ldap;
 pub mod logger;
 pub mod types;
+pub mod detect;

--- a/rust/src/ldap/types.rs
+++ b/rust/src/ldap/types.rs
@@ -300,6 +300,34 @@ pub enum ProtocolOp {
     Unknown,
 }
 
+impl ProtocolOp {
+    pub fn to_u8(&self) -> u8 {
+        match self {
+            ProtocolOp::BindRequest(_) => 0,
+            ProtocolOp::BindResponse(_) => 1,
+            ProtocolOp::UnbindRequest => 2,
+            ProtocolOp::SearchRequest(_) => 3,
+            ProtocolOp::SearchResultEntry(_) => 4,
+            ProtocolOp::SearchResultDone(_) => 5,
+            ProtocolOp::SearchResultReference(_) => 19,
+            ProtocolOp::ModifyRequest(_) => 6,
+            ProtocolOp::ModifyResponse(_) => 7,
+            ProtocolOp::AddRequest(_) => 8,
+            ProtocolOp::AddResponse(_) => 9,
+            ProtocolOp::DelRequest(_) => 10,
+            ProtocolOp::DelResponse(_) => 11,
+            ProtocolOp::ModDnRequest(_) => 12,
+            ProtocolOp::ModDnResponse(_) => 13,
+            ProtocolOp::CompareRequest(_) => 14,
+            ProtocolOp::CompareResponse(_) => 15,
+            ProtocolOp::ExtendedRequest(_) => 23,
+            ProtocolOp::ExtendedResponse(_) => 24,
+            ProtocolOp::IntermediateResponse(_) => 25,
+            ProtocolOp::Unknown => 255,
+        }
+    }
+}
+
 impl Display for ProtocolOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -707,6 +707,7 @@ void SigTableSetup(void)
     ScDetectRfbRegister();
     ScDetectSipRegister();
     ScDetectTemplateRegister();
+    ScDetectLdapRegister();
 
     /* close keyword registration */
     DetectBufferTypeCloseRegistration();


### PR DESCRIPTION
Ticket: [#7453](https://redmine.openinfosecfoundation.org/issues/7453)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

**Link to ticket:** https://redmine.openinfosecfoundation.org/issues/7453

### Description:
- Add ldap.request.operation keyword

### ldap.rs
- Change ``static mut`` to ``pub(super) static mut`` so I can use ALPROTO_LDAP on file ldap/detect.rs

### mod.rs
- Include ``detect``

### types.rs
- Implement function to convert enum to u8. I used the existing ldap pcaps in S-V and [RFC 4511](https://datatracker.ietf.org/doc/html/rfc4511) to set the values

### detect-engine-register.c
- Include ``ScDetectLdapRegister()``

### detect.rs
- Create new file to implement ldap keywords

### ldap-keywords.rst
- Create new file to document ldap keywords

### index.rst
- Include ``ldap-keywords``  

##

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2206
