### PR TITLE
Add clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@ Checks: "
 "
 WarningsAsErrors: "
       bugprone-unsafe-functions,
+      clang-analyzer-unix.Malloc,
 "
 HeaderFileExtensions:
   - ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: "
       -readability-braces-around-statements,
       -readability-avoid-const-params-in-decls,
       -bugprone-easily-swappable-parameters,
+      -misc-include-cleaner,
 "
 WarningsAsErrors: "
       bugprone-unsafe-functions,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,30 @@
+---
+Checks: "
+      bugprone-*,
+      cert-*,
+      clang-analyzer-*,
+      concurrency-*,
+      misc-*,
+      modernize-*,
+      performance-*,
+      portability-*,
+      readability-*,
+      -readability-identifier-length,
+      -readability-braces-around-statements,
+      -readability-avoid-const-params-in-decls,
+      -bugprone-easily-swappable-parameters,
+"
+WarningsAsErrors: "
+      bugprone-unsafe-functions,
+"
+HeaderFileExtensions:
+  - ''
+  - 'h'
+ImplementationFileExtensions:
+  - 'c'
+FormatStyle:     none
+CheckOptions:
+  bugprone-unsafe-functions.ReportDefaultFunctions: 'true'
+  bugprone-unsafe-functions.ReportMoreUnsafeFunctions: 'true'
+  bugprone-unsafe-functions.CustomFunctions: '^strtok$,strtok_r;^sprintf$,snprintf;^strcat$,strlcat;^strcpy$,strlcpy;^strncpy$,strlcat;^strncat$,strlcpy;^strndup$,,is OS specific;^strchrnul$;^rand$;^rand_r$;^index$;^rindex$;^bzero$,^memset$'
+  readability-function-cognitive-complexity.Threshold: 50

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,7 @@ HeaderFileExtensions:
   - 'h'
 ImplementationFileExtensions:
   - 'c'
-FormatStyle:     none
+FormatStyle: 'file'
 CheckOptions:
   bugprone-unsafe-functions.ReportDefaultFunctions: 'true'
   bugprone-unsafe-functions.ReportMoreUnsafeFunctions: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ test.sh
 /libsuricata-config
 !/libsuricata-config.in
 !/.readthedocs.yaml
+compile_commands.json

--- a/configure.ac
+++ b/configure.ac
@@ -224,6 +224,11 @@
         [], [
             #include <x86intrin.h> 
             ])
+    AC_CHECK_DECL([quick_exit],
+        AC_DEFINE([HAVE_QUICK_EXIT], [1], [Use quick_exit]),
+        [], [
+            #include <stdlib.h>
+            ])
 
     AC_CHECK_HEADERS([malloc.h])
     AC_CHECK_DECL([malloc_trim],

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -111,7 +111,7 @@ uint32_t ftp_max_line_len = 4096;
 SC_ATOMIC_DECLARE(uint64_t, ftp_memuse);
 SC_ATOMIC_DECLARE(uint64_t, ftp_memcap);
 
-static FTPTransaction *FTPGetOldestTx(const FtpState *, FTPTransaction *);
+static FTPTransaction *FTPGetOldestTx(const FtpState * /*ftp_state*/, FTPTransaction * /*starttx*/);
 
 static void FTPParseMemcap(void)
 {
@@ -375,7 +375,8 @@ static AppLayerResult FTPGetLineForDirection(
             SCReturnStruct(APP_LAYER_OK);
         }
         SCReturnStruct(APP_LAYER_INCOMPLETE(input->consumed, input->len + 1));
-    } else if (*current_line_truncated) {
+    }
+    if (*current_line_truncated) {
         // Whatever came in with first LF should also get discarded
         *current_line_truncated = false;
         line->len = 0;
@@ -507,7 +508,8 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
 
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS)) {
         SCReturnStruct(APP_LAYER_OK);
-    } else if (input == NULL || input_len == 0) {
+    }
+    if (input == NULL || input_len == 0) {
         SCReturnStruct(APP_LAYER_ERROR);
     }
 
@@ -520,7 +522,8 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
         res = FTPGetLineForDirection(&line, &ftpi, &state->current_line_truncated_ts);
         if (res.status == 1) {
             return res;
-        } else if (res.status == -1) {
+        }
+        if (res.status == -1) {
             break;
         }
         const FtpCommand *cmd_descriptor;
@@ -617,11 +620,9 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
                         FtpTransferCmdFree(data);
                         SCLogDebug("No expectation created.");
                         SCReturnStruct(APP_LAYER_ERROR);
-                    } else {
-                        SCLogDebug("Expectation created [direction: %s, dynamic port %"PRIu16"].",
-                            state->active ? "to server" : "to client",
-                            state->dyn_port);
                     }
+                    SCLogDebug("Expectation created [direction: %s, dynamic port %" PRIu16 "].",
+                            state->active ? "to server" : "to client", state->dyn_port);
 
                     /* reset the dyn port to avoid duplicate */
                     state->dyn_port = 0;
@@ -713,7 +714,8 @@ static AppLayerResult FTPParseResponse(Flow *f, void *ftp_state, AppLayerParserS
         res = FTPGetLineForDirection(&line, &ftpi, &state->current_line_truncated_tc);
         if (res.status == 1) {
             return res;
-        } else if (res.status == -1) {
+        }
+        if (res.status == -1) {
             break;
         }
         FTPTransaction *tx = FTPGetOldestTx(state, lasttx);
@@ -929,7 +931,7 @@ static void FTPStateTransactionFree(void *state, uint64_t tx_id)
     TAILQ_FOREACH(tx, &ftp_state->tx_list, next) {
         if (tx_id < tx->tx_id)
             break;
-        else if (tx_id > tx->tx_id)
+        if (tx_id > tx->tx_id)
             continue;
 
         if (tx == ftp_state->curr_tx)
@@ -1046,7 +1048,7 @@ static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
  * \retval 1 when the command is parsed, 0 otherwise
  */
 static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
-        AppLayerParserState *pstate, StreamSlice stream_slice, void *local_data, uint8_t direction)
+        AppLayerParserState *pstate, StreamSlice stream_slice, uint8_t direction)
 {
     const uint8_t *input = StreamSliceGetData(&stream_slice);
     uint32_t input_len = StreamSliceGetDataLen(&stream_slice);
@@ -1116,10 +1118,8 @@ static AppLayerResult FTPDataParse(Flow *f, FtpDataState *ftpdata_state,
 
         /* open with fixed track_id 0 as we can have just one
          * file per ftp-data flow. */
-        if (FileOpenFileWithId(ftpdata_state->files, &sbcfg,
-                         0ULL, (uint8_t *) ftpdata_state->file_name,
-                         ftpdata_state->file_len,
-                         input, input_len, flags) != 0) {
+        if (FileOpenFileWithId(ftpdata_state->files, &sbcfg, 0ULL, ftpdata_state->file_name,
+                    ftpdata_state->file_len, input, input_len, flags) != 0) {
             SCLogDebug("Can't open file");
             ret = -1;
         }
@@ -1171,13 +1171,13 @@ out:
 static AppLayerResult FTPDataParseRequest(Flow *f, void *ftp_state, AppLayerParserState *pstate,
         StreamSlice stream_slice, void *local_data)
 {
-    return FTPDataParse(f, ftp_state, pstate, stream_slice, local_data, STREAM_TOSERVER);
+    return FTPDataParse(f, ftp_state, pstate, stream_slice, STREAM_TOSERVER);
 }
 
 static AppLayerResult FTPDataParseResponse(Flow *f, void *ftp_state, AppLayerParserState *pstate,
         StreamSlice stream_slice, void *local_data)
 {
-    return FTPDataParse(f, ftp_state, pstate, stream_slice, local_data, STREAM_TOCLIENT);
+    return FTPDataParse(f, ftp_state, pstate, stream_slice, STREAM_TOCLIENT);
 }
 
 #ifdef DEBUG
@@ -1260,8 +1260,7 @@ static int FTPDataGetAlstateProgress(void *tx, uint8_t direction)
     FtpDataState *ftpdata_state = (FtpDataState *)tx;
     if (direction == ftpdata_state->direction)
         return ftpdata_state->state;
-    else
-        return FTPDATA_STATE_FINISHED;
+    return FTPDATA_STATE_FINISHED;
 }
 
 static AppLayerGetFileState FTPDataStateGetTxFiles(void *tx, uint8_t direction)

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -53,38 +53,44 @@ void DetectHTTP2sizeUpdateRegisterTests (void);
 static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2frametypeSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2frametypeFree (DetectEngineCtx *, void *);
+static int DetectHTTP2frametypeSetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2frametypeFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2errorcodeSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2errorcodeFree (DetectEngineCtx *, void *);
+static int DetectHTTP2errorcodeSetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2errorcodeFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2priorityMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2prioritySetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2priorityFree (DetectEngineCtx *, void *);
+static int DetectHTTP2prioritySetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2priorityFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2windowMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2windowSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2windowFree (DetectEngineCtx *, void *);
+static int DetectHTTP2windowSetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2windowFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2sizeUpdateMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2sizeUpdateSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2sizeUpdateFree (DetectEngineCtx *, void *);
+static int DetectHTTP2sizeUpdateSetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2sizeUpdateFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2settingsMatch(DetectEngineThreadCtx *det_ctx,
                                      Flow *f, uint8_t flags, void *state, void *txv, const Signature *s,
                                      const SigMatchCtx *ctx);
-static int DetectHTTP2settingsSetup (DetectEngineCtx *, Signature *, const char *);
-void DetectHTTP2settingsFree (DetectEngineCtx *, void *);
+static int DetectHTTP2settingsSetup(
+        DetectEngineCtx * /*de_ctx*/, Signature * /*s*/, const char * /*str*/);
+void DetectHTTP2settingsFree(DetectEngineCtx * /*de_ctx*/, void * /*ptr*/);
 
 static int DetectHTTP2headerNameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg);
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -26,19 +26,11 @@
 
 #include "detect.h"
 #include "detect-parse.h"
-#include "detect-content.h"
-
 #include "detect-engine.h"
 #include "detect-engine-uint.h"
-#include "detect-engine-mpm.h"
-#include "detect-engine-prefilter.h"
-#include "detect-engine-content-inspection.h"
 #include "detect-engine-helper.h"
-
 #include "detect-http2.h"
 #include "util-byte.h"
-#include "rust.h"
-#include "util-profiling.h"
 
 #ifdef UNITTESTS
 void DetectHTTP2frameTypeRegisterTests (void);

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -595,5 +595,5 @@ static int DetectHTTP2headerNameSetup(DetectEngineCtx *de_ctx, Signature *s, con
 }
 
 #ifdef UNITTESTS
-#include "tests/detect-http2.c"
+#include "tests/detect-http2.c" // NOLINT(bugprone-suspicious-include)
 #endif

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1849,21 +1849,21 @@ static int SockFanoutSeteBPF(AFPThreadVars *ptv)
     return 0;
 }
 
-static int SetEbpfFilter(AFPThreadVars *ptv)
+static TmEcode SetEbpfFilter(AFPThreadVars *ptv)
 {
     int pfd = ptv->ebpf_filter_fd;
     if (pfd == -1) {
         SCLogError("Filter file descriptor is invalid");
-        return -1;
+        return TM_ECODE_FAILED;
     }
 
     if (setsockopt(ptv->socket, SOL_SOCKET, SO_ATTACH_BPF, &pfd, sizeof(pfd))) {
         SCLogError("Error setting ebpf: %s", strerror(errno));
-        return -1;
+        return TM_ECODE_FAILED;
     }
     SCLogInfo("Activated eBPF filter on socket");
 
-    return 0;
+    return TM_ECODE_OK;
 }
 #endif
 

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -499,10 +499,14 @@ void SCLogErr(int x, const char *file, const char *func, const int line, const c
 
 #endif /* DEBUG */
 
+#if !HAVE_QUICK_EXIT
+#define quick_exit exit
+#endif
+
 #define FatalError(...)                                                                            \
     do {                                                                                           \
         SCLogError(__VA_ARGS__);                                                                   \
-        exit(EXIT_FAILURE);                                                                        \
+        quick_exit(EXIT_FAILURE);                                                                  \
     } while (0)
 
 /** \brief Fatal error IF we're starting up, and configured to consider
@@ -515,7 +519,7 @@ void SCLogErr(int x, const char *file, const char *func, const int line, const c
         (void)ConfGetBool("engine.init-failure-fatal", &init_errors_fatal);                        \
         if (init_errors_fatal && (SC_ATOMIC_GET(engine_stage) == SURICATA_INIT)) {                 \
             SCLogError(__VA_ARGS__);                                                               \
-            exit(EXIT_FAILURE);                                                                    \
+            quick_exit(EXIT_FAILURE);                                                              \
         }                                                                                          \
         SCLogWarning(__VA_ARGS__);                                                                 \
     } while (0)

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -280,6 +280,7 @@ alloc_error:
     }
     bpf_map_data->last = 0;
     SCLogError("Can't allocate bpf map name");
+    SCFree(bpf_map_data);
     return -1;
 }
 

--- a/src/util-lua-sandbox.c
+++ b/src/util-lua-sandbox.c
@@ -26,7 +26,6 @@
 #include "lua.h"
 #include "lauxlib.h"
 #include "lualib.h"
-#include "util-debug.h"
 
 #include "util-debug.h"
 #include "util-validate.h"

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -29,6 +29,7 @@
 #ifndef SURICATA_UTIL_MEMCMP_H
 #define SURICATA_UTIL_MEMCMP_H
 
+// NOLINTNEXTLINE(misc-header-include-cycle)
 #include "suricata-common.h"
 #include "util-optimize.h"
 

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -36,7 +36,7 @@
 /** \brief compare two patterns, converting the 2nd to lowercase
  *  \warning *ONLY* the 2nd pattern is converted to lowercase
  */
-static inline int SCMemcmpLowercase(const void *, const void *, size_t);
+static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n);
 
 void MemcmpRegisterTests(void);
 


### PR DESCRIPTION
This patchset adds a .clang-tidy file. It will be used by clangd to provide additional diagnostics in the code.

Some of the warnings especially the ones about using magic number are quite verbose but this may be a good idea to implement fixes to improve the situation.

Note: the forbidden functions part requires clang-20 (so compilation from git) to work

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/3837

Describe changes:
- Add clang-tidy file
- Fix a thread safety warning to be able to use concurrency checks
