### PR TITLE
flow/var: Release key storage

### DIFF
--- a/src/flow-var.c
+++ b/src/flow-var.c
@@ -166,6 +166,7 @@ void FlowVarFree(FlowVar *fv)
     if (fv->datatype == FLOWVAR_TYPE_STR) {
         if (fv->data.fv_str.value != NULL)
             SCFree(fv->data.fv_str.value);
+        SCFree(fv->key);
     }
     SCFree(fv);
 }


### PR DESCRIPTION
Issue: 7466

This commit releases the memory for the flow variable "key" when the flow variable is of type string. The key is allocated in the Lua extension logic.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7466

Describe changes:
- Release memory for the "key" value for flow variables of type string


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2209
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
