### PR TITLE
Update sawp dependencies to 0.13.1 due to SPDX license compatibility.

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -48,8 +48,8 @@ kerberos-parser = { version = "~0.7.1", default-features = false }
 # Kerberos parsing still depends on der-parser 6.0.1.
 der-parser6 = { package = "der-parser", version = "~6.0.1", default-features = false }
 
-sawp-modbus = "~0.12.1"
-sawp = "~0.12.1"
+sawp-modbus = "~0.13.1"
+sawp = "~0.13.1"
 ntp-parser = "~0.6.0"
 ipsec-parser = "~0.7.0"
 snmp-parser = "~0.9.0"


### PR DESCRIPTION
Bump the version of sawp used to one that is corrected upstream to be compatible with SPDX license scanners.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [X] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [X] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [N/A] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [N/A] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
      
Describe changes:
- Update sawp dependencies to 0.13.1 due to SPDX license compatibility. -- Upstream diff: https://github.com/CybercentreCanada/sawp/compare/sawp-0.12.1...sawp-0.13.1
