### PR TITLE
Datasets locking/v5

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -84,6 +84,7 @@ include = [
     "FtpEvent",
     "SCSigTableElmt",
     "SCTransformTableElmt",
+    "DataRepType",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/src/detect/datasets.rs
+++ b/rust/src/detect/datasets.rs
@@ -1,0 +1,112 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Shivani Bhardwaj <shivani@oisf.net>
+
+//! This module exposes items from the datasets C code to Rust.
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+use std::ffi::{c_char, CStr};
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufRead};
+use std::path::Path;
+
+/// Opaque Dataset type defined in C
+#[derive(Copy, Clone)]
+pub enum Dataset {}
+
+// Simple C type converted to Rust
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+pub struct DataRepType {
+    pub value: u16,
+}
+
+// Extern fns operating on the opaque Dataset type above
+/// cbindgen:ignore
+extern "C" {
+    pub fn DatasetAdd(set: &Dataset, data: *const u8, len: u32) -> i32;
+    pub fn DatasetAddwRep(set: &Dataset, data: *const u8, len: u32, rep: *const DataRepType)
+        -> i32;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ProcessDatasets(
+    set: &Dataset, name: *const c_char, fname: *const c_char, fmode: *const c_char,
+) -> i32 {
+    let file_string = CStr::from_ptr(fname).to_str().unwrap();
+    let mode = CStr::from_ptr(fmode).to_str().unwrap();
+    let set_name = CStr::from_ptr(name).to_str().unwrap();
+    let filename = Path::new(file_string);
+    let mut is_dataset = false;
+    if let Ok(lines) = read_lines(filename, mode) {
+        for line in lines.map_while(Result::ok) {
+            let v: Vec<&str> = line.split(',').collect();
+            // Ignore empty and invalid lines in dataset/rep file
+            if v.is_empty() || v.len() > 2 {
+                continue;
+            }
+            if v.len() == 1 {
+                is_dataset = true;
+                // Dataset
+                let mut decoded: Vec<u8> = vec![];
+                if STANDARD.decode_vec(v[0], &mut decoded).is_err() {
+                    SCLogError!("bad base64 encoding {}", set_name);
+                    return -2;
+                }
+                DatasetAdd(set, decoded.as_ptr(), decoded.len() as u32);
+            } else {
+                if is_dataset {
+                    SCLogError!("Cannot mix dataset and datarep values");
+                    return -2;
+                }
+                // Datarep
+                let mut decoded: Vec<u8> = vec![];
+                if STANDARD.decode_vec(v[0], &mut decoded).is_err() {
+                    SCLogError!("bad base64 encoding {}", set_name);
+                    return -2;
+                }
+                if let Ok(val) = v[1].to_string().parse::<u16>() {
+                    let rep: DataRepType = DataRepType { value: val };
+                    DatasetAddwRep(set, decoded.as_ptr(), decoded.len() as u32, &rep);
+                } else {
+                    SCLogError!("Invalid datarep value {}", set_name);
+                    return -2;
+                }
+            }
+        }
+    } else {
+        return -1;
+    }
+    0
+}
+
+fn read_lines<P>(filename: P, fmode: &str) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file: File = if fmode == "r" {
+        File::open(filename)?
+    } else {
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .read(true)
+            .open(filename)?
+    };
+    Ok(io::BufReader::new(file).lines())
+}

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -29,6 +29,7 @@ pub mod transforms;
 pub mod uint;
 pub mod uri;
 pub mod tojson;
+pub mod datasets;
 
 use crate::core::AppProto;
 use std::os::raw::{c_int, c_void};

--- a/src/datasets-reputation.h
+++ b/src/datasets-reputation.h
@@ -24,9 +24,7 @@
 #ifndef SURICATA_DATASETS_REPUTATION_H
 #define SURICATA_DATASETS_REPUTATION_H
 
-typedef struct DataRepType {
-    uint16_t value;
-} DataRepType;
+#include "rust-bindings.h"
 
 typedef struct DataRepResultType {
     bool found;

--- a/src/datasets.h
+++ b/src/datasets.h
@@ -19,6 +19,7 @@
 #define SURICATA_DATASETS_H
 
 #include "util-thash.h"
+#include "rust.h"
 #include "datasets-reputation.h"
 
 int DatasetsInit(void);

--- a/src/detect-dataset.c
+++ b/src/detect-dataset.c
@@ -47,8 +47,6 @@
 #define DETECT_DATASET_CMD_ISNOTSET 2
 #define DETECT_DATASET_CMD_ISSET    3
 
-int DetectDatasetMatch (ThreadVars *, DetectEngineThreadCtx *, Packet *,
-        const Signature *, const SigMatchCtx *);
 static int DetectDatasetSetup (DetectEngineCtx *, Signature *, const char *);
 void DetectDatasetFree (DetectEngineCtx *, void *);
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/7398

Previous PR: https://github.com/OISF/suricata/pull/12326

Changes since v4:
- error on mixing dataset and datarep values
- rustfmt on datasets.rs

Note: This introduces a change in behavior for the case when one or more datasets read from a specific file were not added to the hash for some reason.

|option |  value | master |   this branch   |
|-----------|----------|------------|--------------------|
| `init-errors-fatal` | true | error | error |
| `init-errors-fatal` | false | skip over this dataset | error |
------------------------------------------------------------------------------------

Q: Wdyt about this change in behavior? I do not understand why we'd want to allow adding partial datasets from a file..
