### PR TITLE
Draft: transform/from_base64: Signal error condition (use with absent)

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -118,8 +118,13 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
         SCReturnInt(-1);
     }
 
+    if (smd == NULL) {
+        KEYWORD_PROFILING_END(det_ctx, smd->type, 0);
+        SCReturnInt(0);
+    }
+
     // we want the ability to match on bsize: 0
-    if (smd == NULL || buffer == NULL) {
+    if (buffer == NULL && smd->type != DETECT_ABSENT) {
         KEYWORD_PROFILING_END(det_ctx, smd->type, 0);
         SCReturnInt(0);
     }
@@ -384,11 +389,11 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
 
     } else if (smd->type == DETECT_ABSENT) {
         const DetectAbsentData *id = (DetectAbsentData *)smd->ctx;
-        if (!id->or_else) {
+        if (id->or_else || buffer_len == 0) {
             // we match only on absent buffer
-            goto no_match;
+            goto match;
         }
-        goto match;
+        goto no_match;
     } else if (smd->type == DETECT_ISDATAAT) {
         SCLogDebug("inspecting isdataat");
 

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -88,7 +88,7 @@ static int DetectAbsentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
         return -1;
     }
     if (s->init_data->curbuf == NULL || s->init_data->list != (int)s->init_data->curbuf->id) {
-        SCLogError("unspected buffer for absent keyword");
+        SCLogError("no buffer for absent keyword");
         return -1;
     }
     const DetectBufferType *b = DetectEngineBufferTypeGetById(de_ctx, s->init_data->list);


### PR DESCRIPTION
Extend the from_base64 transform to signal cases when the buffer cannot be base64-decoded.

A transform option named `set_error` is added to modify the transform buffer. By default, the transform buffer is unmodified if the content cannot be base64-decoded. If `set_error` is specified as a transform option and the buffer can't be base64-decoded, the buffer is truncated. In these cases, the `absent` keyword can be used with `set_error` to trigger an alert.

For example: `content:"/?arg="; from_base64: set_error; absent;` will trigger an alert since the content is not base64-encoded.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7114

Describe changes:
- Update transform option parser to recognize `set_error`
- Document `set_error` behavior
- Update the transform to truncate the buffer if `set_error` was specified and the buffer cannot be base64-decoe.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2212
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
