### PR TITLE
fuzz/detect: forbid rule with any pcre on stream

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -454,21 +454,13 @@ void SigParseRequiredContentSize(
 bool DetectContentPMATCHValidateCallback(const Signature *s)
 {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    bool has_pcre = false;
-    bool has_content = false;
     for (SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH]; sm != NULL; sm = sm->next) {
         if (sm->type == DETECT_PCRE) {
-            has_pcre = true;
-        } else if (sm->type == DETECT_CONTENT) {
-            has_content = true;
-            break;
+            // Fuzzing does not allow rules with pcre on payload
+            // as it is known to be a bad rule for performance causing possible timeouts
+            // Engine analysis has more generic warn_pcre_no_content about this
+            return false;
         }
-    }
-    if (has_pcre && !has_content) {
-        // Fuzzing does not allow rules with pcre and without content on payload
-        // as it is known to be a bad rule for performance causing possible timeouts
-        // Engine analysis has more generic warn_pcre_no_content about this
-        return false;
     }
 #endif
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4858

Describe changes:
- fuzz/detect: forbid rule with any pcre on stream

Because such rules cause timeouts on oss-fuzz and block other findings

Completes commit 378f678d95ebf232095ae4812fff8cfa73506d96