### PR TITLE
src: remove unused struct fields v2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6509,9 +6509,6 @@
                         "pseudo": {
                             "type": "integer"
                         },
-                        "pseudo_failed": {
-                            "type": "integer"
-                        },
                         "reassembly_exception_policy": {
                             "description":
                                     "How many times reassembly memcap exception policy was applied, and which one",

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -3303,7 +3303,6 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
         if (det_ctx->base64_decoded == NULL) {
             return TM_ECODE_FAILED;
         }
-        det_ctx->base64_decoded_len_max = de_ctx->base64_decode_max_len;
         det_ctx->base64_decoded_len = 0;
     }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1139,7 +1139,6 @@ typedef struct DetectEngineThreadCtx_ {
 
     uint8_t *base64_decoded;
     int base64_decoded_len;
-    int base64_decoded_len_max;
 
     /* counter for the filestore array below -- up here for cache reasons. */
     uint16_t filestore_cnt;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1137,9 +1137,6 @@ typedef struct DetectEngineThreadCtx_ {
     /* byte_* values */
     uint64_t *byte_values;
 
-    uint8_t *base64_decoded;
-    int base64_decoded_len;
-
     /* counter for the filestore array below -- up here for cache reasons. */
     uint16_t filestore_cnt;
 
@@ -1180,6 +1177,9 @@ typedef struct DetectEngineThreadCtx_ {
     uint64_t frame_inspect_progress; /**< used to set Frame::inspect_progress after all inspection
                                         on a frame is complete. */
     Packet *p;
+
+    uint8_t *base64_decoded;
+    int base64_decoded_len;
 
     uint16_t alert_queue_size;
     uint16_t alert_queue_capacity;

--- a/src/source-pcap-file-directory-helper.h
+++ b/src/source-pcap-file-directory-helper.h
@@ -44,7 +44,6 @@ typedef struct PcapFileDirectoryVars_
     PcapFileFileVars *current_file;
     bool should_loop;
     bool should_recurse;
-    uint8_t cur_dir_depth;
     time_t delay;
     time_t poll_interval;
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -319,7 +319,6 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             CleanupPcapFileThreadVars(ptv);
             SCReturnInt(TM_ECODE_OK);
         }
-        pv->cur_dir_depth = 0;
 
         int should_recurse;
         pv->should_recurse = false;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6032,7 +6032,6 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
             IsStreamTcpSessionMemcapExceptionPolicyStatsValid);
 
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);
-    stt->counter_tcp_pseudo_failed = StatsRegisterCounter("tcp.pseudo_failed", tv);
     stt->counter_tcp_invalid_checksum = StatsRegisterCounter("tcp.invalid_checksum", tv);
     stt->counter_tcp_midstream_pickups = StatsRegisterCounter("tcp.midstream_pickups", tv);
     if (stream_config.midstream) {

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -102,8 +102,6 @@ typedef struct StreamTcpThread_ {
     ExceptionPolicyCounters counter_tcp_ssn_memcap_eps;
     /** pseudo packets processed */
     uint16_t counter_tcp_pseudo;
-    /** pseudo packets failed to setup */
-    uint16_t counter_tcp_pseudo_failed;
     /** packets rejected because their csum is invalid */
     uint16_t counter_tcp_invalid_checksum;
     /** midstream pickups */

--- a/src/util-mpm.c
+++ b/src/util-mpm.c
@@ -108,7 +108,6 @@ int32_t MpmFactoryRegisterMpmCtxProfile(
     else
         pitem->next = nitem;
 
-    de_ctx->mpm_ctx_factory_container->no_of_items++;
     return nitem->id;
 }
 

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -124,7 +124,6 @@ typedef struct MpmCtxFactoryItem {
 
 typedef struct MpmCtxFactoryContainer_ {
     MpmCtxFactoryItem *items;
-    int32_t no_of_items;
     int32_t max_id;
 } MpmCtxFactoryContainer;
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just a simple cleanup

Describe changes:
- src: remove unused struct fields
- stats: remove unused counter_tcp_pseudo_failed

https://github.com/OISF/suricata/pull/12299 with additional commit to make scan-build happy : removing unused field created a hole/padding in a struct and we could improve it further by rearranging fields order to avoid such hole/padding