### PR TITLE
dns: improved handling of corrupt additionals

### DIFF
--- a/rules/dns-events.rules
+++ b/rules/dns-events.rules
@@ -17,3 +17,6 @@ alert dns any any -> any any (msg:"SURICATA DNS Infinite loop"; app-layer-event:
 
 # Suricata's maximum number of DNS name labels was reached while parsing a resource name.
 alert dns any any -> any any (msg:"SURICATA DNS Too many labels"; app-layer-event:dns.too_many_labels; classtype:protocol-command-decode; sid:224010; rev:1;)
+
+alert dns any any -> any any (msg:"SURICATA DNS invalid additionals"; app-layer-event:dns.invalid_additionals; classtype:protocol-command-decode; sid:2240011; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS invalid authorities"; app-layer-event:dns.invalid_authorities; classtype:protocol-command-decode; sid:2240012; rev:1;)

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -135,6 +135,8 @@ pub enum DNSEvent {
     InfiniteLoop,
     /// Too many labels were found.
     TooManyLabels,
+    InvalidAdditionals,
+    InvalidAuthorities,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -256,7 +258,9 @@ pub struct DNSMessage {
     pub queries: Vec<DNSQueryEntry>,
     pub answers: Vec<DNSAnswerEntry>,
     pub authorities: Vec<DNSAnswerEntry>,
+    pub invalid_authorities: bool,
     pub additionals: Vec<DNSAnswerEntry>,
+    pub invalid_additionals: bool,
 }
 
 #[derive(Debug, Default)]
@@ -399,6 +403,12 @@ pub(crate) fn dns_parse_request(input: &[u8]) -> Result<DNSTransaction, DNSParse
             let opcode = ((request.header.flags >> 11) & 0xf) as u8;
 
             let mut tx = DNSTransaction::new(Direction::ToServer);
+            if request.invalid_additionals {
+                tx.set_event(DNSEvent::InvalidAdditionals);
+            }
+            if request.invalid_authorities {
+                tx.set_event(DNSEvent::InvalidAuthorities);
+            }
             tx.request = Some(request);
 
             if z_flag {
@@ -452,6 +462,12 @@ pub(crate) fn dns_parse_response(input: &[u8]) -> Result<DNSTransaction, DNSPars
             let flags = response.header.flags;
 
             let mut tx = DNSTransaction::new(Direction::ToClient);
+            if response.invalid_additionals {
+                tx.set_event(DNSEvent::InvalidAdditionals);
+            }
+            if response.invalid_authorities {
+                tx.set_event(DNSEvent::InvalidAuthorities);
+            }
             tx.response = Some(response);
 
             if flags & 0x8000 == 0 {
@@ -1601,7 +1617,7 @@ mod tests {
     fn test_dns_event_from_id() {
         assert_eq!(DNSEvent::from_id(0), Some(DNSEvent::MalformedData));
         assert_eq!(DNSEvent::from_id(3), Some(DNSEvent::ZFlagSet));
-        assert_eq!(DNSEvent::from_id(9), None);
+        assert_eq!(DNSEvent::from_id(99), None);
     }
 
     #[test]


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7228

Describe changes:
- dns: improved handling of corrupt additionals

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2032

https://github.com/OISF/suricata/pull/11794 rebased after latest DNS changes (like https://github.com/OISF/suricata/pull/11870 )

@jasonish what do you think about it ?
