### PR TITLE
fuzz: use lower pcre limits

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -453,25 +453,6 @@ void SigParseRequiredContentSize(
  */
 bool DetectContentPMATCHValidateCallback(const Signature *s)
 {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    bool has_pcre = false;
-    bool has_content = false;
-    for (SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH]; sm != NULL; sm = sm->next) {
-        if (sm->type == DETECT_PCRE) {
-            has_pcre = true;
-        } else if (sm->type == DETECT_CONTENT) {
-            has_content = true;
-            break;
-        }
-    }
-    if (has_pcre && !has_content) {
-        // Fuzzing does not allow rules with pcre and without content on payload
-        // as it is known to be a bad rule for performance causing possible timeouts
-        // Engine analysis has more generic warn_pcre_no_content about this
-        return false;
-    }
-#endif
-
     if (!(s->flags & SIG_FLAG_DSIZE)) {
         return true;
     }

--- a/src/detect-pcre.h
+++ b/src/detect-pcre.h
@@ -36,8 +36,13 @@
 
 #define DETECT_PCRE_CAPTURE_MAX         8
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#define SC_MATCH_LIMIT_DEFAULT           350
+#define SC_MATCH_LIMIT_RECURSION_DEFAULT 150
+#else
 #define SC_MATCH_LIMIT_DEFAULT           3500
 #define SC_MATCH_LIMIT_RECURSION_DEFAULT 1500
+#endif
 
 typedef struct DetectPcreData_ {
     DetectParseRegex parse_regex;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4858

Describe changes:
- fuzz/detect: lower pcre limits for fuzzing

Because such rules cause timeouts on oss-fuzz and block other findings

Alternative to https://github.com/OISF/suricata/pull/12344

Reverts commit 378f678d95ebf232095ae4812fff8cfa73506d96

oss-fuzz reproducer runs in 5 seconds now (timeout is like 30)