### PR TITLE
util/misc: add time parser

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -396,6 +396,7 @@ void GlobalsDestroy(void)
     TmqhCleanup();
     TmModuleRunDeInit();
     ParseSizeDeinit();
+    ParseTimeDeinit();
 
 #ifdef HAVE_DPDK
     DPDKCleanupEAL();
@@ -2876,6 +2877,7 @@ int InitGlobal(void)
 #endif
 
     ParseSizeInit();
+    ParseTimeInit();
     RunModeRegisterRunModes();
 
     /* Initialize the configuration module. */

--- a/src/util-misc.h
+++ b/src/util-misc.h
@@ -23,7 +23,7 @@
 
 #ifndef SURICATA_UTIL_MISC_H
 #define SURICATA_UTIL_MISC_H
-
+#include "util-time.h"
 /**
  * \brief Generic API that can be used by all to log an
  *        invalid conf entry.
@@ -45,10 +45,14 @@ int ParseSizeStringU8(const char *, uint8_t *);
 int ParseSizeStringU16(const char *, uint16_t *);
 int ParseSizeStringU32(const char *, uint32_t *);
 int ParseSizeStringU64(const char *, uint64_t *);
+int ParseTimeString(const char *, SCTime_t *);
 
 #ifdef UNITTESTS
 void UtilMiscRegisterTests(void);
 #endif /* UNITTESTS */
+
+void ParseTimeInit(void);
+void ParseTimeDeinit(void);
 
 void ParseSizeInit(void);
 void ParseSizeDeinit(void);


### PR DESCRIPTION
1. The idea is to have a time unit parser that can be used by keywords that let you define time as precisely as microseconds or as loosely as hours.
2. In the future work, this would apply to `flow.rate` keyword, for example, where one can define bytes (kb, b, mb, gb) and time (us, ms, s, m, h) as they wish. Exact same application would come for use in defining elephant flows in suricata.yaml (an exhibit for that is in https://github.com/OISF/suricata/pull/12325)

Thoughts?
If this is acceptable, I thought we could merge it first.

