### PR TITLE
var: Use 16-bit container for type

### DIFF
--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -56,8 +56,7 @@ enum DetectKeywordId {
     DETECT_FLOW,
     /* end prefilter sort */
 
-    /* values used in util-var.c go here, to avoid int overflows
-     * TODO update var logic to use a larger type, see #6855. */
+    /* values used in util-var.c go here, to avoid int overflows */
     DETECT_THRESHOLD,
     DETECT_FLOWBITS,
     DETECT_FLOWVAR,

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -524,8 +524,8 @@ static void FlowThresholdEntryListFree(FlowThresholdEntryList *list)
 /** struct for storing per flow thresholds. This will be stored in the Flow::flowvar list, so it
  * needs to follow the GenericVar header format. */
 typedef struct FlowVarThreshold_ {
-    uint8_t type;
-    uint8_t pad[7];
+    uint16_t type;
+    uint8_t pad[6];
     struct GenericVar_ *next;
     FlowThresholdEntryList *thresholds;
 } FlowVarThreshold;

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -200,9 +200,8 @@ error:
 }
 
 /** \brief Store flowvar in det_ctx so we can exec it post-match */
-int DetectVarStoreMatchKeyValue(DetectEngineThreadCtx *det_ctx,
-        uint8_t *key, uint16_t key_len,
-        uint8_t *buffer, uint16_t len, int type)
+int DetectVarStoreMatchKeyValue(DetectEngineThreadCtx *det_ctx, uint8_t *key, uint16_t key_len,
+        uint8_t *buffer, uint16_t len, uint16_t type)
 {
     DetectVarList *fs = SCCalloc(1, sizeof(*fs));
     if (unlikely(fs == NULL))
@@ -220,9 +219,8 @@ int DetectVarStoreMatchKeyValue(DetectEngineThreadCtx *det_ctx,
 }
 
 /** \brief Store flowvar in det_ctx so we can exec it post-match */
-int DetectVarStoreMatch(DetectEngineThreadCtx *det_ctx,
-        uint32_t idx,
-        uint8_t *buffer, uint16_t len, int type)
+int DetectVarStoreMatch(
+        DetectEngineThreadCtx *det_ctx, uint32_t idx, uint8_t *buffer, uint16_t len, uint16_t type)
 {
     DetectVarList *fs = det_ctx->varlist;
 

--- a/src/detect-flowvar.h
+++ b/src/detect-flowvar.h
@@ -38,10 +38,9 @@ typedef struct DetectFlowvarData_ {
 void DetectFlowvarRegister (void);
 
 int DetectFlowvarPostMatchSetup(DetectEngineCtx *de_ctx, Signature *s, uint32_t idx);
-int DetectVarStoreMatch(DetectEngineThreadCtx *,
-        uint32_t, uint8_t *, uint16_t, int);
-int DetectVarStoreMatchKeyValue(DetectEngineThreadCtx *,
-        uint8_t *, uint16_t, uint8_t *, uint16_t, int);
+int DetectVarStoreMatch(DetectEngineThreadCtx *, uint32_t, uint8_t *, uint16_t, uint16_t);
+int DetectVarStoreMatchKeyValue(
+        DetectEngineThreadCtx *, uint8_t *, uint16_t, uint8_t *, uint16_t, uint16_t);
 
 /* For use only by DetectFlowvarProcessList() */
 void DetectVarProcessListInternal(DetectVarList *fs, Flow *f, Packet *p);

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -158,7 +158,7 @@ static int GetFlowVarByKey(lua_State *luastate, Flow *f, FlowVar **ret_fv)
         LUA_ERROR("key len out of range: max 256");
     }
 
-    FlowVar *fv = FlowVarGetByKey(f, (const uint8_t *)keystr, (uint16_t)keylen);
+    FlowVar *fv = FlowVarGetByKey(f, (const uint8_t *)keystr, (uint8_t)keylen);
     if (fv == NULL) {
         LUA_ERROR("no flow var");
     }
@@ -331,7 +331,7 @@ static int LuaSetFlowvarByKey(lua_State *luastate)
     }
     memcpy(keybuf, keystr, keylen);
     keybuf[keylen] = '\0';
-    FlowVarAddKeyValue(f, keybuf, (uint16_t)keylen, buffer, (uint16_t)len);
+    FlowVarAddKeyValue(f, keybuf, (uint8_t)keylen, buffer, (uint16_t)len);
 
     return 0;
 }

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -298,7 +298,7 @@ static int LuaSetFlowvarByKey(lua_State *luastate)
     }
     keylen = lua_tonumber(luastate, 2);
     if (keylen < 0 || keylen > 0xff) {
-        LUA_ERROR("key len out of range: max 256");
+        LUA_ERROR("key len out of range: max 255");
     }
 
     if (!lua_isstring(luastate, 3)) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -749,10 +749,11 @@ typedef struct DetectReplaceList_ {
 /** list for flowvar store candidates, to be stored from
  *  post-match function */
 typedef struct DetectVarList_ {
+    uint16_t type; /**< type of store candidate POSTMATCH or ALWAYS */
+    uint8_t pad[2];
     uint32_t idx;                       /**< flowvar name idx */
     uint16_t len;                       /**< data len */
     uint16_t key_len;
-    int type;                           /**< type of store candidate POSTMATCH or ALWAYS */
     uint8_t *key;
     uint8_t *buffer;                    /**< alloc'd buffer, may be freed by
                                              post-match, post-non-match */

--- a/src/flow-bit.h
+++ b/src/flow-bit.h
@@ -28,8 +28,8 @@
 #include "util-var.h"
 
 typedef struct FlowBit_ {
-    uint8_t type; /* type, DETECT_FLOWBITS in this case */
-    uint8_t pad[3];
+    uint16_t type; /* type, DETECT_FLOWBITS in this case */
+    uint8_t pad[2];
     uint32_t idx; /* name idx */
     GenericVar *next; /* right now just implement this as a list,
                        * in the long run we have think of something

--- a/src/flow-var.c
+++ b/src/flow-var.c
@@ -51,7 +51,7 @@ static void FlowVarUpdateInt(FlowVar *fv, uint32_t value)
  *  \note flow is not locked by this function, caller is
  *        responsible
  */
-FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, uint16_t keylen)
+FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, FlowVarKeyLenType keylen)
 {
     if (f == NULL)
         return NULL;
@@ -91,7 +91,8 @@ FlowVar *FlowVarGet(Flow *f, uint32_t idx)
 }
 
 /* add a flowvar to the flow, or update it */
-void FlowVarAddKeyValue(Flow *f, uint8_t *key, uint16_t keysize, uint8_t *value, uint16_t size)
+void FlowVarAddKeyValue(
+        Flow *f, uint8_t *key, FlowVarKeyLenType keylen, uint8_t *value, uint16_t size)
 {
     FlowVar *fv = SCCalloc(1, sizeof(FlowVar));
     if (unlikely(fv == NULL))
@@ -103,7 +104,7 @@ void FlowVarAddKeyValue(Flow *f, uint8_t *key, uint16_t keysize, uint8_t *value,
     fv->data.fv_str.value = value;
     fv->data.fv_str.value_len = size;
     fv->key = key;
-    fv->keylen = keysize;
+    fv->keylen = keylen;
     fv->next = NULL;
 
     GenericVarAppend(&f->flowvar, (GenericVar *)fv);

--- a/src/flow-var.h
+++ b/src/flow-var.h
@@ -33,6 +33,7 @@
 #define FLOWVAR_TYPE_STR 1
 #define FLOWVAR_TYPE_INT 2
 
+typedef uint8_t FlowVarKeyLenType;
 /** Struct used to hold the string data type for flowvars */
 typedef struct FlowVarTypeStr {
     uint8_t *value;
@@ -46,9 +47,9 @@ typedef struct FlowVarTypeInt_ {
 
 /** Generic Flowvar Structure */
 typedef struct FlowVar_ {
-    uint8_t type;       /* type, DETECT_FLOWVAR in this case */
+    uint16_t type; /* type, DETECT_FLOWVAR in this case */
     uint8_t datatype;
-    uint16_t keylen;
+    FlowVarKeyLenType keylen;
     uint32_t idx;       /* name idx */
     GenericVar *next;   /* right now just implement this as a list,
                          * in the long run we have think of something
@@ -63,12 +64,13 @@ typedef struct FlowVar_ {
 /** Flowvar Interface API */
 
 void FlowVarAddIdValue(Flow *, uint32_t id, uint8_t *value, uint16_t size);
-void FlowVarAddKeyValue(Flow *f, uint8_t *key, uint16_t keysize, uint8_t *value, uint16_t size);
+void FlowVarAddKeyValue(
+        Flow *f, uint8_t *key, FlowVarKeyLenType keylen, uint8_t *value, uint16_t size);
 
 void FlowVarAddIntNoLock(Flow *, uint32_t, uint32_t);
 void FlowVarAddInt(Flow *, uint32_t, uint32_t);
 FlowVar *FlowVarGet(Flow *, uint32_t);
-FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, uint16_t keylen);
+FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, FlowVarKeyLenType keylen);
 void FlowVarFree(FlowVar *);
 void FlowVarPrint(GenericVar *);
 

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -46,17 +46,16 @@ enum VarTypes {
     VAR_TYPE_IPPAIR_VAR,
 };
 
-/** \todo see ticket #6855. The type field should be 16 bits. */
 typedef struct GenericVar_ {
-    uint8_t type; /**< variable type, uses detection sm_type */
-    uint8_t pad[3];
+    uint16_t type; /**< variable type, uses detection sm_type */
+    uint8_t pad[2];
     uint32_t idx;
     struct GenericVar_ *next;
 } GenericVar;
 
 typedef struct XBit_ {
-    uint8_t type;       /* type, DETECT_XBITS in this case */
-    uint8_t pad[3];
+    uint16_t type; /* type, DETECT_XBITS in this case */
+    uint8_t pad[2];
     uint32_t idx;       /* name idx */
     GenericVar *next;
     uint32_t expire;


### PR DESCRIPTION
Continuation of #12356 

Issue: 6855: Match sigmatch type field in var and bit structs

Align the size and datatype of type, idx, and next members across:
- FlowVarThreshold
- FlowBit
- FlowVar
- GenericVar
- XBit
- DetectVarList

Note that the FlowVar structure has been intentionally constrained to match the structure size prior to this commit. To achieve this, the keylen member was restricted to 8 bits after it was confirmed its value is checked against a max of 0xff.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6855

Describe changes:
- Increase `type` in flowbit, flowvar and generic var
- Ensure type, idx, and next pointers align on each struct.

Updates:
- CI fix -- `int` variable was assigned to `uint16_t`

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
