### PR TITLE
log/file: Ensure file ctx pointer is returned .

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -737,6 +737,8 @@ LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *parent_ctx)
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }
+    } else {
+        ret_ctx = entry->ctx;
     }
     SCMutexUnlock(&parent_ctx->threads->mutex);
 


### PR DESCRIPTION
The fix for issue 7447 introduced an error with threaded eve output.

The changes that were committed for that issue mishandled the return value when a file is being opened for the 2nd or higher time.

Instead of returning the existing file context, null was returned.


Describe changes:
- When an output file is first opened, ensure that the file ctx pointer is returned.


### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
