### PR TITLE
output/log: Improve error handling (backport of 7447)

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -731,7 +731,7 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
             entry->isopen = true;
             ret_ctx = entry->ctx;
         } else {
-            SCLogError(
+            SCLogDebug(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -347,14 +347,17 @@ static void ThreadLogFileHashFreeFunc(void *data)
     BUG_ON(data == NULL);
     ThreadLogFileHashEntry *thread_ent = (ThreadLogFileHashEntry *)data;
 
-    if (thread_ent) {
+    if (!thread_ent)
+        return;
+
+    if (thread_ent->isopen) {
         LogFileCtx *lf_ctx = thread_ent->ctx;
         /* Free the leaf log file entries */
         if (!lf_ctx->threaded) {
             LogFileFreeCtx(lf_ctx);
         }
-        SCFree(thread_ent);
     }
+    SCFree(thread_ent);
 }
 
 bool SCLogOpenThreadedFile(const char *log_path, const char *append, LogFileCtx *parent_ctx)
@@ -711,6 +714,7 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
     if (!parent_ctx->threaded)
         return parent_ctx;
 
+    LogFileCtx *ret_ctx = NULL;
     SCMutexLock(&parent_ctx->threads->mutex);
     /* Find this thread's entry */
     ThreadLogFileHashEntry *entry = LogFileThread2Slot(parent_ctx->threads);
@@ -719,12 +723,13 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
 
     bool new = entry->isopen;
     /* has it been opened yet? */
-    if (!entry->isopen) {
-        SCLogDebug("Opening new file for thread/slot %d to file %s [ctx %p]", entry->slot_number,
-                parent_ctx->filename, parent_ctx);
+    if (!new) {
+        SCLogDebug("%s: Opening new file for thread/id %d to file %s [ctx %p]", t_thread_name,
+                SCGetThreadIdLong(), parent_ctx->filename, parent_ctx);
         if (LogFileNewThreadedCtx(
                     parent_ctx, parent_ctx->filename, parent_ctx->threads->append, entry)) {
             entry->isopen = true;
+            ret_ctx = entry->ctx;
         } else {
             SCLogError(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
@@ -740,7 +745,7 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
         }
     }
 
-    return entry->ctx;
+    return ret_ctx;
 }
 
 /** \brief LogFileThreadedName() Create file name for threaded EVE storage

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -735,6 +735,8 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }
+    } else {
+        ret_ctx = entry->ctx;
     }
     SCMutexUnlock(&parent_ctx->threads->mutex);
 


### PR DESCRIPTION
Continuation of #12347 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7448

Describe changes:
- Backport of changes from #12271 
- Fix for incorrect file ctx pointer (f5d56cae7ee7f8279163ae94bd9519f4c5f98a29)
Updates:
- Cherry-pick f5d56cae7ee7f8279163ae94bd9519f4c5f98a29

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
