### PR TITLE
output/log: Improve error handling (backport of 7447)

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -731,7 +731,7 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
             entry->isopen = true;
             ret_ctx = entry->ctx;
         } else {
-            SCLogError(
+            SCLogDebug(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -735,6 +735,8 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }
+    } else {
+        ret_ctx = entry->ctx;
     }
     SCMutexUnlock(&parent_ctx->threads->mutex);
 


### PR DESCRIPTION
Continuation of #12384 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7448

Describe changes:
- Backport of changes from #12271 
- Fix for incorrect file ctx pointer (f5d56cae7ee7f8279163ae94bd9519f4c5f98a29)

Updates:
- Cherry-pick f5d56cae7ee7f8279163ae94bd9519f4c5f98a29
- DEBUG build CI fix.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
