### PR TITLE
Batch backport to 7.0.x: Issues 7448, 7493

### DIFF
--- a/src/flow-var.c
+++ b/src/flow-var.c
@@ -166,6 +166,7 @@ void FlowVarFree(FlowVar *fv)
     if (fv->datatype == FLOWVAR_TYPE_STR) {
         if (fv->data.fv_str.value != NULL)
             SCFree(fv->data.fv_str.value);
+        SCFree(fv->key);
     }
     SCFree(fv);
 }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -731,7 +731,7 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
             entry->isopen = true;
             ret_ctx = entry->ctx;
         } else {
-            SCLogError(
+            SCLogDebug(
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -735,6 +735,8 @@ LogFileCtx *LogFileEnsureExists(LogFileCtx *parent_ctx)
                     "Unable to open slot %d for file %s", entry->slot_number, parent_ctx->filename);
             (void)HashTableRemove(parent_ctx->threads->ht, entry, 0);
         }
+    } else {
+        ret_ctx = entry->ctx;
     }
     SCMutexUnlock(&parent_ctx->threads->mutex);
 


### PR DESCRIPTION
Continuation of #12391

Link to tickets:
-  https://redmine.openinfosecfoundation.org/issues/7448
-  https://redmine.openinfosecfoundation.org/issues/7493

Describe changes:
- Backport of changes from #12271 
- Fix for incorrect file ctx pointer (f5d56cae7ee7f8279163ae94bd9519f4c5f98a29)
- Cherry-pick f5d56cae7ee7f8279163ae94bd9519f4c5f98a29
- DEBUG build CI fix.

Updates:
- Added fix for 7493 (from issue 7466)

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
