### PR TITLE
Protodetect probing mask32 7437 v3

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -626,7 +626,7 @@ again_midstream:
         else if (pp_port_sp)
             mask = pp_port_sp->alproto_mask;
 
-        if (alproto_masks[0] == mask) {
+        if ((alproto_masks[0] & mask) == mask) {
             FLOW_SET_PP_DONE(f, dir);
             SCLogDebug("%s, mask is now %08x, needed %08x, so done",
                     (dir == STREAM_TOSERVER) ? "toserver":"toclient",

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1699,7 +1699,7 @@ static AppProto SMTPServerProbingParser(
         return ALPROTO_UNKNOWN;
     }
     AppProto r = ALPROTO_UNKNOWN;
-    if (f->todstbytecnt > 4 && f->alproto_ts == ALPROTO_UNKNOWN) {
+    if (f->todstbytecnt > 4 && (f->alproto_ts == ALPROTO_UNKNOWN || f->alproto_ts == ALPROTO_TLS)) {
         // Only validates SMTP if client side is unknown
         // despite having received bytes.
         r = ALPROTO_SMTP;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7495 
https://redmine.openinfosecfoundation.org/issues/7469

(blocking https://redmine.openinfosecfoundation.org/issues/7437 )

Describe changes:
- protocol detection: finish probing parser asap
- smtp: improve probing parser in case of TLS first from client 

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2200

https://github.com/OISF/suricata/pull/12307 with simpler change that will be backported

This will require a QA baseline update as highlighted by the SV test