### PR TITLE
http: prepare libhtp.rs aliases for htp opaque htp_tx_t

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -26,6 +26,7 @@
 
 #include "suricata-common.h"
 #include "app-layer-htp-file.h"
+#include "app-layer-htp-libhtp.h"
 #include "app-layer-htp-range.h"
 #include "app-layer-events.h"
 #include "util-validate.h"
@@ -181,9 +182,9 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     // Then, we will try to handle reassembly of different ranges of the same file
     uint8_t *keyurl;
     uint32_t keylen;
-    if (tx->request_hostname != NULL) {
-        uint32_t hlen = (uint32_t)bstr_len(tx->request_hostname);
-        if (bstr_len(tx->request_hostname) > UINT16_MAX) {
+    if (htp_tx_request_hostname(tx) != NULL) {
+        uint32_t hlen = (uint32_t)bstr_len(htp_tx_request_hostname(tx));
+        if (bstr_len(htp_tx_request_hostname(tx)) > UINT16_MAX) {
             hlen = UINT16_MAX;
         }
         keylen = hlen + filename_len;
@@ -191,7 +192,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
         if (keyurl == NULL) {
             SCReturnInt(-1);
         }
-        memcpy(keyurl, bstr_ptr(tx->request_hostname), hlen);
+        memcpy(keyurl, bstr_ptr(htp_tx_request_hostname(tx)), hlen);
         memcpy(keyurl + hlen, filename, filename_len);
     } else {
         // do not reassemble file without host info
@@ -402,9 +403,9 @@ static int HTPFileParserTest01(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -476,8 +477,8 @@ static int HTPFileParserTest02(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
     FAIL_IF_NULL(tx_ud->files_ts.tail);
@@ -568,9 +569,9 @@ static int HTPFileParserTest03(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
@@ -664,9 +665,9 @@ static int HTPFileParserTest04(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
@@ -730,9 +731,9 @@ static int HTPFileParserTest05(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
@@ -805,9 +806,9 @@ static int HTPFileParserTest06(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
@@ -870,8 +871,8 @@ static int HTPFileParserTest07(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);
@@ -1192,9 +1193,9 @@ static int HTPFileParserTest11(void)
 
     htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, http_state, 0);
     FAIL_IF_NULL(tx);
-    FAIL_IF_NULL(tx->request_method);
+    FAIL_IF_NULL(htp_tx_request_method(tx));
 
-    FAIL_IF(memcmp(bstr_util_strdup_to_c(tx->request_method), "POST", 4) != 0);
+    FAIL_IF(memcmp(bstr_util_strdup_to_c(htp_tx_request_method(tx)), "POST", 4) != 0);
 
     HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
     FAIL_IF_NULL(tx_ud);

--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -96,6 +96,31 @@
 #define HTP_RESPONSE_PROGRESS_TRAILER  HTP_RESPONSE_TRAILER
 #define HTP_RESPONSE_PROGRESS_COMPLETE HTP_RESPONSE_COMPLETE
 
+// Functions introduced to handle opaque htp_tx_t
+#define htp_tx_flags(tx)                    tx->flags
+#define htp_tx_is_protocol_0_9(tx)          tx->is_protocol_0_9
+#define htp_tx_request_auth_type(tx)        tx->request_auth_type
+#define htp_tx_request_hostname(tx)         tx->request_hostname
+#define htp_tx_request_line(tx)             tx->request_line
+#define htp_tx_request_message_len(tx)      tx->request_message_len
+#define htp_tx_request_method(tx)           tx->request_method
+#define htp_tx_request_method_number(tx)    tx->request_method_number
+#define htp_tx_request_port_number(tx)      tx->request_port_number
+#define htp_tx_request_progress(tx)         tx->request_progress
+#define htp_tx_request_protocol(tx)         tx->request_protocol
+#define htp_tx_request_protocol_number(tx)  tx->request_protocol_number
+#define htp_tx_request_uri(tx)              tx->request_uri
+#define htp_tx_request_headers(tx)          tx->request_headers
+#define htp_tx_response_headers(tx)         tx->response_headers
+#define htp_tx_response_protocol(tx)        tx->response_protocol
+#define htp_tx_response_line(tx)            tx->response_line
+#define htp_tx_response_message(tx)         tx->response_message
+#define htp_tx_response_message_len(tx)     tx->response_message_len
+#define htp_tx_response_status(tx)          tx->response_status
+#define htp_tx_response_status_number(tx)   tx->response_status_number
+#define htp_tx_response_progress(tx)        tx->response_progress
+#define htp_tx_response_protocol_number(tx) tx->response_protocol_number
+
 bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, bool uri_include_all);
 
 #endif /* SURICATA_APP_LAYER_HTP_LIBHTP__H */

--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -27,6 +27,7 @@
 
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
+#include "app-layer-htp-libhtp.h"
 #include "app-layer-htp-xff.h"
 
 #ifndef HAVE_MEMRCHR
@@ -140,8 +141,8 @@ int HttpXFFGetIPFromTx(const Flow *f, uint64_t tx_id, HttpXFFCfg *xff_cfg,
     }
 
     htp_header_t *h_xff = NULL;
-    if (tx->request_headers != NULL) {
-        h_xff = htp_table_get_c(tx->request_headers, xff_cfg->header);
+    if (htp_tx_request_headers(tx) != NULL) {
+        h_xff = htp_table_get_c(htp_tx_request_headers(tx), xff_cfg->header);
     }
 
     if (h_xff != NULL && bstr_len(h_xff->value) >= XFF_CHAIN_MINLEN &&

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -178,11 +178,10 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->request_headers == NULL)
+        if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                "Cookie");
+        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "Cookie");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;
@@ -206,11 +205,11 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->response_headers == NULL)
+        if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->response_headers,
-                "Set-Cookie");
+        htp_header_t *h =
+                (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), "Set-Cookie");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -92,12 +92,12 @@ static uint8_t *GetBufferForTX(
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)
             return NULL;
-        headers = tx->request_headers;
+        headers = htp_tx_request_headers(tx);
     } else {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_RESPONSE_PROGRESS_HEADERS)
             return NULL;
-        headers = tx->response_headers;
+        headers = htp_tx_response_headers(tx);
     }
     if (headers == NULL)
         return NULL;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -85,12 +85,12 @@ static uint8_t *GetBufferForTX(
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)
             return NULL;
-        headers = tx->request_headers;
+        headers = htp_tx_request_headers(tx);
     } else {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_RESPONSE_PROGRESS_HEADERS)
             return NULL;
-        headers = tx->response_headers;
+        headers = htp_tx_response_headers(tx);
     }
     if (headers == NULL)
         return NULL;
@@ -555,9 +555,9 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     htp_tx_t *tx = (htp_tx_t *)txv;
     htp_table_t *headers;
     if (flags & STREAM_TOSERVER) {
-        headers = tx->request_headers;
+        headers = htp_tx_request_headers(tx);
     } else {
-        headers = tx->response_headers;
+        headers = htp_tx_response_headers(tx);
     }
     size_t no_of_headers = htp_table_size(headers);
     if (local_id == 0) {

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -54,11 +54,10 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->request_headers == NULL)
+        if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                                                          HEADER_NAME);
+        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), HEADER_NAME);
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);
@@ -110,11 +109,10 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->response_headers == NULL)
+        if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->response_headers,
-                                                          HEADER_NAME);
+        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), HEADER_NAME);
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -243,11 +243,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->request_hostname == NULL)
+        if (htp_tx_request_hostname(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->request_hostname);
-        const uint8_t *data = bstr_ptr(tx->request_hostname);
+        const uint32_t data_len = bstr_len(htp_tx_request_hostname(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_request_hostname(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);
@@ -347,11 +347,10 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         uint32_t data_len = 0;
 
         if (tx->parsed_uri == NULL || tx->parsed_uri->hostname == NULL) {
-            if (tx->request_headers == NULL)
+            if (htp_tx_request_headers(tx) == NULL)
                 return NULL;
 
-            htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                    "Host");
+            htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "Host");
             if (h == NULL || h->value == NULL)
                 return NULL;
 

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -204,11 +204,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->request_method == NULL)
+        if (htp_tx_request_method(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->request_method);
-        const uint8_t *data = bstr_ptr(tx->request_method);
+        const uint32_t data_len = bstr_len(htp_tx_request_method(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_request_method(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -92,9 +92,9 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         htp_tx_t *tx = (htp_tx_t *)txv;
 
         if (flow_flags & STREAM_TOSERVER)
-            str = tx->request_protocol;
+            str = htp_tx_request_protocol(tx);
         else if (flow_flags & STREAM_TOCLIENT)
-            str = tx->response_protocol;
+            str = htp_tx_response_protocol(tx);
 
         if (str == NULL) {
             SCLogDebug("HTTP protocol not set");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -159,11 +159,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
-        if (unlikely(tx->request_line == NULL)) {
+        if (unlikely(htp_tx_request_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->request_line);
-        const uint8_t *data = bstr_ptr(tx->request_line);
+        const uint32_t data_len = bstr_len(htp_tx_request_line(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_request_line(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -158,11 +158,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
-        if (unlikely(tx->response_line == NULL)) {
+        if (unlikely(htp_tx_response_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->response_line);
-        const uint8_t *data = bstr_ptr(tx->response_line);
+        const uint32_t data_len = bstr_len(htp_tx_response_line(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_response_line(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -92,14 +92,14 @@ static uint8_t *GetBufferForTX(
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)
             return NULL;
-        line = tx->request_line;
-        headers = tx->request_headers;
+        line = htp_tx_request_line(tx);
+        headers = htp_tx_request_headers(tx);
     } else {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_RESPONSE_PROGRESS_HEADERS)
             return NULL;
-        headers = tx->response_headers;
-        line = tx->response_line;
+        headers = htp_tx_response_headers(tx);
+        line = htp_tx_response_line(tx);
     }
     if (line == NULL || headers == NULL)
         return NULL;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -162,11 +162,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->response_status == NULL)
+        if (htp_tx_response_status(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->response_status);
-        const uint8_t *data = bstr_ptr(tx->response_status);
+        const uint32_t data_len = bstr_len(htp_tx_response_status(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_response_status(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -171,11 +171,11 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->response_message == NULL)
+        if (htp_tx_response_message(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(tx->response_message);
-        const uint8_t *data = bstr_ptr(tx->response_message);
+        const uint32_t data_len = bstr_len(htp_tx_response_message(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_response_message(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -162,11 +162,10 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         htp_tx_t *tx = (htp_tx_t *)txv;
 
-        if (tx->request_headers == NULL)
+        if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                "User-Agent");
+        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "User-Agent");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP UA header not present in this request");
             return NULL;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -322,11 +322,11 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (!buffer->initialized) {
         htp_tx_t *tx = (htp_tx_t *)txv;
-        if (unlikely(tx->request_uri == NULL)) {
+        if (unlikely(htp_tx_request_uri(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(tx->request_uri);
-        const uint8_t *data = bstr_ptr(tx->request_uri);
+        const uint32_t data_len = bstr_len(htp_tx_request_uri(tx));
+        const uint8_t *data = bstr_ptr(htp_tx_request_uri(tx));
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -48,6 +48,7 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
+#include "app-layer-htp-libhtp.h"
 
 #include "stream-tcp.h"
 
@@ -376,12 +377,12 @@ static int DetectLuaMatch (DetectEngineThreadCtx *det_ctx,
                 if (tx == NULL)
                     continue;
 
-                if ((tlua->flags & FLAG_DATATYPE_HTTP_REQUEST_LINE) && tx->request_line != NULL &&
-                        bstr_len(tx->request_line) > 0) {
+                if ((tlua->flags & FLAG_DATATYPE_HTTP_REQUEST_LINE) &&
+                        htp_tx_request_line(tx) != NULL && bstr_len(htp_tx_request_line(tx)) > 0) {
                     lua_pushliteral(tlua->luastate, "http.request_line"); /* stack at -2 */
                     LuaPushStringBuffer(tlua->luastate,
-                                     (const uint8_t *)bstr_ptr(tx->request_line),
-                                     bstr_len(tx->request_line));
+                            (const uint8_t *)bstr_ptr(htp_tx_request_line(tx)),
+                            bstr_len(htp_tx_request_line(tx)));
                     lua_settable(tlua->luastate, -3);
                 }
             }
@@ -422,12 +423,12 @@ static int DetectLuaAppMatchCommon (DetectEngineThreadCtx *det_ctx,
             htp_tx_t *tx = NULL;
             tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, det_ctx->tx_id);
             if (tx != NULL) {
-                if ((tlua->flags & FLAG_DATATYPE_HTTP_REQUEST_LINE) && tx->request_line != NULL &&
-                        bstr_len(tx->request_line) > 0) {
+                if ((tlua->flags & FLAG_DATATYPE_HTTP_REQUEST_LINE) &&
+                        htp_tx_request_line(tx) != NULL && bstr_len(htp_tx_request_line(tx)) > 0) {
                     lua_pushliteral(tlua->luastate, "http.request_line"); /* stack at -2 */
                     LuaPushStringBuffer(tlua->luastate,
-                                     (const uint8_t *)bstr_ptr(tx->request_line),
-                                     bstr_len(tx->request_line));
+                            (const uint8_t *)bstr_ptr(htp_tx_request_line(tx)),
+                            bstr_len(htp_tx_request_line(tx)));
                     lua_settable(tlua->luastate, -3);
                 }
             }

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -38,6 +38,7 @@
 
 #include "output.h"
 #include "app-layer-htp.h"
+#include "app-layer-htp-libhtp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "util-privs.h"
@@ -63,11 +64,11 @@ static int HttpGetRequestHost(lua_State *luastate)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    if (tx->request_hostname == NULL)
+    if (htp_tx_request_hostname(tx) == NULL)
         return LuaCallbackError(luastate, "no request hostname");
 
-    return LuaPushStringBuffer(luastate,
-            bstr_ptr(tx->request_hostname), bstr_len(tx->request_hostname));
+    return LuaPushStringBuffer(
+            luastate, bstr_ptr(htp_tx_request_hostname(tx)), bstr_len(htp_tx_request_hostname(tx)));
 }
 
 static int HttpGetRequestUriRaw(lua_State *luastate)
@@ -79,11 +80,11 @@ static int HttpGetRequestUriRaw(lua_State *luastate)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    if (tx->request_uri == NULL)
+    if (htp_tx_request_uri(tx) == NULL)
         return LuaCallbackError(luastate, "no request uri");
 
-    return LuaPushStringBuffer(luastate,
-            bstr_ptr(tx->request_uri), bstr_len(tx->request_uri));
+    return LuaPushStringBuffer(
+            luastate, bstr_ptr(htp_tx_request_uri(tx)), bstr_len(htp_tx_request_uri(tx)));
 }
 
 static int HttpGetRequestUriNormalized(lua_State *luastate)
@@ -118,11 +119,11 @@ static int HttpGetRequestLine(lua_State *luastate)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    if (tx->request_line == NULL)
+    if (htp_tx_request_line(tx) == NULL)
         return LuaCallbackError(luastate, "no request_line");
 
-    return LuaPushStringBuffer(luastate,
-            bstr_ptr(tx->request_line), bstr_len(tx->request_line));
+    return LuaPushStringBuffer(
+            luastate, bstr_ptr(htp_tx_request_line(tx)), bstr_len(htp_tx_request_line(tx)));
 }
 
 static int HttpGetResponseLine(lua_State *luastate)
@@ -134,11 +135,11 @@ static int HttpGetResponseLine(lua_State *luastate)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    if (tx->response_line == NULL)
+    if (htp_tx_response_line(tx) == NULL)
         return LuaCallbackError(luastate, "no response_line");
 
-    return LuaPushStringBuffer(luastate,
-            bstr_ptr(tx->response_line), bstr_len(tx->response_line));
+    return LuaPushStringBuffer(
+            luastate, bstr_ptr(htp_tx_response_line(tx)), bstr_len(tx->response_line));
 }
 
 static int HttpGetHeader(lua_State *luastate, int dir)
@@ -154,9 +155,9 @@ static int HttpGetHeader(lua_State *luastate, int dir)
     if (name == NULL)
         return LuaCallbackError(luastate, "1st argument missing, empty or wrong type");
 
-    htp_table_t *headers = tx->request_headers;
+    htp_table_t *headers = htp_tx_request_headers(tx);
     if (dir == 1)
-        headers = tx->response_headers;
+        headers = htp_tx_response_headers(tx);
     if (headers == NULL)
         return LuaCallbackError(luastate, "tx has no headers");
 
@@ -224,10 +225,10 @@ static int HttpGetHeaders(lua_State *luastate, int dir)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    htp_table_t *table = tx->request_headers;
+    htp_table_t *table = htp_tx_request_headers(tx);
     if (dir == 1)
-        table = tx->response_headers;
-    if (tx->request_headers == NULL)
+        table = htp_tx_response_headers(tx);
+    if (htp_tx_request_headers(tx) == NULL)
         return LuaCallbackError(luastate, "no headers");
 
     lua_newtable(luastate);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/2696

Describe changes:
- prepare libhtp-rs by defining aliases for the new values used by libhtp-rs

This allow to go one small step further

The big libhtp-rs commit will remove app-layer-htp-libhtp.h which defines these aliases

https://github.com/OISF/suricata/pull/12407 next round