### PR TITLE
Dynamic alprotos : make SNMP totally dynamic v5

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -84,6 +84,8 @@ include = [
     "FtpEvent",
     "SCSigTableElmt",
     "SCTransformTableElmt",
+    "OutputJsonLogDirection",
+    "EveJsonTxLoggerRegistrationData",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -472,12 +472,45 @@ pub type ApplyTxConfigFn = unsafe extern "C" fn (*mut c_void, *mut c_void, c_int
 pub type GetFrameIdByName = unsafe extern "C" fn(*const c_char) -> c_int;
 pub type GetFrameNameById = unsafe extern "C" fn(u8) -> *const c_char;
 
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum OutputJsonLogDirection {
+    LOG_DIR_PACKET = 0,
+    LOG_DIR_FLOW = 1,
+    LOG_DIR_FLOW_TOCLIENT = 2,
+    LOG_DIR_FLOW_TOSERVER = 3,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct EveJsonTxLoggerRegistrationData {
+    pub confname: *const c_char,
+    pub logname: *const c_char,
+    pub alproto: AppProto,
+    pub dir: u8,
+    // EveJsonSimpleTxLogFunc, cannot use JsonBuilder as it is not #[repr(C)]
+    pub LogTx: unsafe extern "C" fn(*const c_void, *mut c_void) -> bool,
+}
+
+// Defined in output.h
+/// cbindgen:ignore
+extern {
+    pub fn OutputPreRegisterLogger(reg_data: EveJsonTxLoggerRegistrationData) -> c_int;
+}
+
+// Defined in detect-engine-register.h
+/// cbindgen:ignore
+extern {
+    pub fn SigTablePreRegister(cb: unsafe extern "C" fn ());
+}
 
 // Defined in app-layer-register.h
 /// cbindgen:ignore
 extern {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
     pub fn AppLayerRegisterParserAlias(parser_name: *const c_char, alias_name: *const c_char);
+    pub fn AppProtoNewProtoFromString(name: *const c_char) -> AppProto;
 }
 
 #[allow(non_snake_case)]

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -19,10 +19,10 @@
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::snmp::snmp::SNMPTransaction;
-use crate::snmp::snmp_parser::{NetworkAddress,PduType};
+use crate::snmp::snmp_parser::{NetworkAddress, PduType};
 use std::borrow::Cow;
 
-fn str_of_pdu_type(t:&PduType) -> Cow<str> {
+fn str_of_pdu_type(t: &PduType) -> Cow<str> {
     match t {
         &PduType::GetRequest => Cow::Borrowed("get_request"),
         &PduType::GetNextRequest => Cow::Borrowed("get_next_request"),
@@ -37,8 +37,7 @@ fn str_of_pdu_type(t:&PduType) -> Cow<str> {
     }
 }
 
-fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<(), JsonError>
-{
+fn snmp_log_response(jsb: &mut JsonBuilder, tx: &SNMPTransaction) -> Result<(), JsonError> {
     jsb.open_object("snmp")?;
     jsb.set_uint("version", tx.version as u64)?;
     if tx.encrypted {
@@ -53,7 +52,9 @@ fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<
                 jsb.set_string("trap_type", &format!("{:?}", trap_type))?;
                 jsb.set_string("trap_oid", &oid.to_string())?;
                 match address {
-                    NetworkAddress::IPv4(ip) => {jsb.set_string("trap_address", &ip.to_string())?;},
+                    NetworkAddress::IPv4(ip) => {
+                        jsb.set_string("trap_address", &ip.to_string())?;
+                    }
                 }
             }
             if !info.vars.is_empty() {
@@ -77,7 +78,10 @@ fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder) -> bool
-{
+pub unsafe extern "C" fn rs_snmp_log_json_response(
+    tx: *const std::os::raw::c_void, jsb: *mut std::os::raw::c_void,
+) -> bool {
+    let tx = cast_pointer!(tx, SNMPTransaction);
+    let jsb = cast_pointer!(jsb, JsonBuilder);
     snmp_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -20,6 +20,8 @@
 use crate::snmp::snmp_parser::*;
 use crate::core::{self, *};
 use crate::applayer::{self, *};
+use super::log::rs_snmp_log_json_response;
+use super::detect::ScDetectSNMPRegister;
 use std;
 use std::ffi::CString;
 
@@ -410,20 +412,28 @@ pub unsafe extern "C" fn rs_register_snmp_parser() {
         get_frame_name_by_id: None,
     };
     let ip_proto_str = CString::new("udp").unwrap();
+    ALPROTO_SNMP = AppProtoNewProtoFromString(PARSER_NAME.as_ptr() as *const std::os::raw::c_char);
+    let reg_data = EveJsonTxLoggerRegistrationData {
+        confname: b"eve-log.snmp\0".as_ptr() as *const std::os::raw::c_char,
+        logname: b"JsonSNMPLog\0".as_ptr() as *const std::os::raw::c_char,
+        alproto: ALPROTO_SNMP,
+        dir: OutputJsonLogDirection::LOG_DIR_PACKET as u8,
+        LogTx: rs_snmp_log_json_response,
+    };
+    OutputPreRegisterLogger(reg_data);
+    SigTablePreRegister(ScDetectSNMPRegister);
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         // port 161
-        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
-        // store the allocated ID for the probe function
-        ALPROTO_SNMP = alproto;
+        _ = AppLayerRegisterProtocolDetection(&parser, 1);
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
-            let _ = AppLayerRegisterParser(&parser, alproto);
+            let _ = AppLayerRegisterParser(&parser, ALPROTO_SNMP);
         }
         // port 162
         let default_port_traps = CString::new("162").unwrap();
         parser.default_port = default_port_traps.as_ptr();
         let _ = AppLayerRegisterProtocolDetection(&parser, 1);
         if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
-            let _ = AppLayerRegisterParser(&parser, alproto);
+            let _ = AppLayerRegisterParser(&parser, ALPROTO_SNMP);
         }
         AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_SNMP);
     } else {

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -161,12 +161,14 @@ typedef struct AppLayerProtoDetectCtx_ {
      * ipproto. It should be allocated to contain ALPROTO_MAX
      * protocols. */
     const char **alproto_names;
+    size_t alproto_names_len;
 
     /* Protocol expectations, like ftp-data on tcp.
      * It should be allocated to contain ALPROTO_MAX
      * app-layer protocols. For each protocol, an iptype
      * is referenced (or 0 if there is no expectation). */
     uint8_t *expectation_proto;
+    size_t expectation_proto_len;
 } AppLayerProtoDetectCtx;
 
 typedef struct AppLayerProtoDetectAliases_ {
@@ -1729,11 +1731,13 @@ int AppLayerProtoDetectSetup(void)
     if (unlikely(alpd_ctx.alproto_names == NULL)) {
         FatalError("Unable to alloc alproto_names.");
     }
+    alpd_ctx.alproto_names_len = g_alproto_max;
     // to realloc when dynamic protos are added
     alpd_ctx.expectation_proto = SCCalloc(g_alproto_max, sizeof(uint8_t));
     if (unlikely(alpd_ctx.expectation_proto == NULL)) {
         FatalError("Unable to alloc expectation_proto.");
     }
+    alpd_ctx.expectation_proto_len = g_alproto_max;
     AppLayerExpectationSetup();
 
     SCReturnInt(0);
@@ -1767,8 +1771,10 @@ int AppLayerProtoDetectDeSetup(void)
 
     SCFree(alpd_ctx.alproto_names);
     alpd_ctx.alproto_names = NULL;
+    alpd_ctx.alproto_names_len = 0;
     SCFree(alpd_ctx.expectation_proto);
     alpd_ctx.expectation_proto = NULL;
+    alpd_ctx.expectation_proto_len = 0;
 
     SpmDestroyGlobalThreadCtx(alpd_ctx.spm_global_thread_ctx);
 
@@ -1783,7 +1789,16 @@ void AppLayerProtoDetectRegisterProtocol(AppProto alproto, const char *alproto_n
 {
     SCEnter();
 
-    // should have just been realloced when dynamic protos is added
+    if (alpd_ctx.alproto_names_len <= alproto && alproto < g_alproto_max) {
+        void *tmp = SCRealloc(alpd_ctx.alproto_names, sizeof(char *) * g_alproto_max);
+        if (unlikely(tmp == NULL)) {
+            FatalError("Unable to realloc alproto_names.");
+        }
+        alpd_ctx.alproto_names = tmp;
+        memset(&alpd_ctx.alproto_names[alpd_ctx.alproto_names_len], 0,
+                sizeof(char *) * (g_alproto_max - alpd_ctx.alproto_names_len));
+        alpd_ctx.alproto_names_len = g_alproto_max;
+    }
     if (alpd_ctx.alproto_names[alproto] == NULL)
         alpd_ctx.alproto_names[alproto] = alproto_name;
 
@@ -2136,6 +2151,9 @@ void AppLayerProtoDetectSupportedAppProtocols(AppProto *alprotos)
 static void AppLayerProtoDetectPEGetIpprotos(AppProto alproto,
                                              uint8_t *ipprotos)
 {
+    if (alproto >= alpd_ctx.expectation_proto_len) {
+        return;
+    }
     if (alpd_ctx.expectation_proto[alproto] == IPPROTO_TCP) {
         ipprotos[IPPROTO_TCP / 8] |= 1 << (IPPROTO_TCP % 8);
     }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -124,6 +124,7 @@ typedef struct AppLayerParserProtoCtx_
 
 typedef struct AppLayerParserCtx_ {
     AppLayerParserProtoCtx (*ctxs)[FLOW_PROTO_MAX];
+    size_t ctxs_len;
 } AppLayerParserCtx;
 
 struct AppLayerParserState_ {
@@ -254,6 +255,7 @@ int AppLayerParserSetup(void)
     if (unlikely(alp_ctx.ctxs == NULL)) {
         FatalError("Unable to alloc alp_ctx.ctxs.");
     }
+    alp_ctx.ctxs_len = g_alproto_max;
     SCReturnInt(0);
 }
 
@@ -425,6 +427,20 @@ void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
         void *(*StateAlloc)(void *, AppProto), void (*StateFree)(void *))
 {
     SCEnter();
+
+    if (alp_ctx.ctxs_len <= alproto && alproto < g_alproto_max) {
+        // Realloc now as AppLayerParserRegisterStateFuncs is called first
+        void *tmp = SCRealloc(
+                alp_ctx.ctxs, sizeof(AppLayerParserProtoCtx[FLOW_PROTO_MAX]) * g_alproto_max);
+        if (unlikely(tmp == NULL)) {
+            FatalError("Unable to realloc alp_ctx.ctxs.");
+        }
+        alp_ctx.ctxs = tmp;
+        memset(&alp_ctx.ctxs[alp_ctx.ctxs_len], 0,
+                sizeof(AppLayerParserProtoCtx[FLOW_PROTO_MAX]) *
+                        (g_alproto_max - alp_ctx.ctxs_len));
+        alp_ctx.ctxs_len = g_alproto_max;
+    }
 
     alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].StateAlloc = StateAlloc;
     alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].StateFree = StateFree;
@@ -1683,7 +1699,6 @@ bad:
 }
 #undef BOTH_SET
 #undef BOTH_SET_OR_BOTH_UNSET
-#undef THREE_SET_OR_THREE_UNSET
 #undef THREE_SET
 
 static void ValidateParser(AppProto alproto)

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -71,6 +71,12 @@ AppProto StringToAppProto(const char *proto_name)
     return ALPROTO_UNKNOWN;
 }
 
+AppProto AppProtoNewProtoFromString(const char *proto_name)
+{
+    AppProtoRegisterProtoString(g_alproto_max, proto_name);
+    return g_alproto_max - 1;
+}
+
 void AppProtoRegisterProtoString(AppProto alproto, const char *proto_name)
 {
     if (alproto < ALPROTO_MAX_STATIC) {

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -56,7 +56,6 @@ enum AppProtoEnum {
     ALPROTO_KRB5,
     ALPROTO_QUIC,
     ALPROTO_DHCP,
-    ALPROTO_SNMP,
     ALPROTO_SIP,
     ALPROTO_RFB,
     ALPROTO_MQTT,
@@ -78,6 +77,7 @@ enum AppProtoEnum {
     /* keep last */
     ALPROTO_MAX_STATIC,
     // After this ALPROTO_MAX_STATIC can come dynamic alproto ids
+    // For example, ALPROTO_SNMP is now dynamic
 };
 // NOTE: if ALPROTO's get >= 256, update SignatureNonPrefilterStore
 

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -175,6 +175,8 @@ const char *AppProtoToString(AppProto alproto);
  */
 AppProto StringToAppProto(const char *proto_name);
 
+AppProto AppProtoNewProtoFromString(const char *proto_name);
+
 void AppProtoRegisterProtoString(AppProto alproto, const char *proto_name);
 
 #endif /* SURICATA_APP_LAYER_PROTOS_H */

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1055,7 +1055,6 @@ static void AppLayerNamesSetup(void)
     AppProtoRegisterProtoString(ALPROTO_KRB5, "krb5");
     AppProtoRegisterProtoString(ALPROTO_QUIC, "quic");
     AppProtoRegisterProtoString(ALPROTO_DHCP, "dhcp");
-    AppProtoRegisterProtoString(ALPROTO_SNMP, "snmp");
     AppProtoRegisterProtoString(ALPROTO_SIP, "sip");
     AppProtoRegisterProtoString(ALPROTO_RFB, "rfb");
     AppProtoRegisterProtoString(ALPROTO_MQTT, "mqtt");

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -730,7 +730,6 @@ void SigTableSetup(void)
     DetectVlanIdRegister();
     DetectVlanLayersRegister();
 
-    ScDetectSNMPRegister();
     ScDetectDHCPRegister();
     ScDetectWebsocketRegister();
     ScDetectEnipRegister();

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -120,7 +120,9 @@ void DetectFileRegisterProto(
     al_protocols[i].direction = direction;
     al_protocols[i].to_client_progress = to_client_progress;
     al_protocols[i].to_server_progress = to_server_progress;
-    al_protocols[i + 1].alproto = ALPROTO_UNKNOWN;
+    if (i + 1 < ALPROTO_WITHFILES_MAX) {
+        al_protocols[i + 1].alproto = ALPROTO_UNKNOWN;
+    }
 }
 
 void DetectFileRegisterFileProtocols(DetectFileHandlerTableElmt *reg)

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -33,13 +33,6 @@
 
 void OutputJsonRegister(void);
 
-enum OutputJsonLogDirection {
-    LOG_DIR_PACKET = 0,
-    LOG_DIR_FLOW,
-    LOG_DIR_FLOW_TOCLIENT,
-    LOG_DIR_FLOW_TOSERVER,
-};
-
 #define JSON_ADDR_LEN 46
 #define JSON_PROTO_LEN 16
 

--- a/src/output.c
+++ b/src/output.c
@@ -885,8 +885,6 @@ void OutputRegisterRootLoggers(void)
             ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, rs_quic_to_json, NULL);
     // ALPROTO_DHCP TODO missing
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_SNMP, (EveJsonSimpleTxLogFunc)rs_snmp_log_json_response, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RFB, rs_rfb_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_MQTT, JsonMQTTAddMetadata, NULL);
@@ -1084,12 +1082,7 @@ void OutputRegisterLoggers(void)
     SCLogDebug("quic json logger registered.");
     /* DHCP JSON logger. */
     JsonDHCPLogRegister();
-    /* SNMP JSON logger. */
-    OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonSNMPLog", "eve-log.snmp",
-            OutputJsonLogInitSub, ALPROTO_SNMP, JsonGenericDirPacketLogger, JsonLogThreadInit,
-            JsonLogThreadDeinit);
 
-    SCLogDebug("SNMP JSON logger registered.");
     /* SIP JSON logger. */
     OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", "JsonSIPLog", "eve-log.sip",
             OutputJsonLogInitSub, ALPROTO_SIP, JsonGenericDirPacketLogger, JsonLogThreadInit,

--- a/src/output.c
+++ b/src/output.c
@@ -1148,7 +1148,7 @@ void OutputRegisterLoggers(void)
                 JsonLogThreadInit, JsonLogThreadDeinit);
         SCLogDebug(
                 "%s JSON logger registered.", AppProtoToString(preregistered_loggers[i].alproto));
-        RegisterSimpleJsonApplayerLogger(
-                preregistered_loggers[i].alproto, preregistered_loggers[i].LogTx, NULL);
+        RegisterSimpleJsonApplayerLogger(preregistered_loggers[i].alproto,
+                (EveJsonSimpleTxLogFunc)preregistered_loggers[i].LogTx, NULL);
     }
 }

--- a/src/output.c
+++ b/src/output.c
@@ -975,6 +975,15 @@ int OutputPreRegisterLogger(EveJsonTxLoggerRegistrationData reg_data)
     return 0;
 }
 
+static TxLogger JsonLoggerFromDir(uint8_t dir)
+{
+    if (dir == LOG_DIR_PACKET) {
+        return JsonGenericDirPacketLogger;
+    }
+    BUG_ON(dir != LOG_DIR_FLOW);
+    return JsonGenericDirFlowLogger;
+}
+
 /**
  * \brief Register all non-root logging modules.
  */
@@ -1135,8 +1144,8 @@ void OutputRegisterLoggers(void)
     for (size_t i = 0; i < preregistered_loggers_nb; i++) {
         OutputRegisterTxSubModule(LOGGER_JSON_TX, "eve-log", preregistered_loggers[i].logname,
                 preregistered_loggers[i].confname, OutputJsonLogInitSub,
-                preregistered_loggers[i].alproto, JsonGenericDirFlowLogger, JsonLogThreadInit,
-                JsonLogThreadDeinit);
+                preregistered_loggers[i].alproto, JsonLoggerFromDir(preregistered_loggers[i].dir),
+                JsonLogThreadInit, JsonLogThreadDeinit);
         SCLogDebug(
                 "%s JSON logger registered.", AppProtoToString(preregistered_loggers[i].alproto));
         RegisterSimpleJsonApplayerLogger(

--- a/src/output.h
+++ b/src/output.h
@@ -174,6 +174,7 @@ typedef struct EveJsonTxLoggerRegistrationData {
     const char *confname;
     const char *logname;
     AppProto alproto;
+    uint8_t dir;
     EveJsonSimpleTxLogFunc LogTx;
 } EveJsonTxLoggerRegistrationData;
 

--- a/src/output.h
+++ b/src/output.h
@@ -26,6 +26,7 @@
 
 #include "decode.h"
 #include "tm-modules.h"
+#include "rust.h"
 
 #define DEFAULT_LOG_MODE_APPEND     "yes"
 #define DEFAULT_LOG_FILETYPE        "regular"
@@ -169,14 +170,6 @@ typedef struct EveJsonSimpleAppLayerLogger {
 } EveJsonSimpleAppLayerLogger;
 
 EveJsonSimpleAppLayerLogger *SCEveJsonSimpleGetLogger(AppProto alproto);
-
-typedef struct EveJsonTxLoggerRegistrationData {
-    const char *confname;
-    const char *logname;
-    AppProto alproto;
-    uint8_t dir;
-    EveJsonSimpleTxLogFunc LogTx;
-} EveJsonTxLoggerRegistrationData;
 
 int OutputPreRegisterLogger(EveJsonTxLoggerRegistrationData reg_data);
 

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -64,7 +64,7 @@ typedef struct SCAppLayerPlugin_ {
     char *logname;
     char *confname;
     uint8_t dir;
-    bool (*Logger)(void *tx, void *jb);
+    bool (*Logger)(const void *tx, void *jb);
 } SCAppLayerPlugin;
 
 int SCPluginRegisterAppLayer(SCAppLayerPlugin *);

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -53,7 +53,7 @@ typedef struct SCCapturePlugin_ {
 int SCPluginRegisterCapture(SCCapturePlugin *);
 
 // Every change in the API used by plugins should change this number
-#define SC_PLUGIN_API_VERSION 8
+#define SC_PLUGIN_API_VERSION 0x801
 
 typedef struct SCAppLayerPlugin_ {
     // versioning to check suricata/plugin API compatibility
@@ -63,6 +63,7 @@ typedef struct SCAppLayerPlugin_ {
     void (*KeywordsRegister)(void);
     char *logname;
     char *confname;
+    uint8_t dir;
     bool (*Logger)(void *tx, void *jb);
 } SCAppLayerPlugin;
 

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -175,6 +175,7 @@ int SCPluginRegisterAppLayer(SCAppLayerPlugin *plugin)
             .confname = plugin->confname,
             .logname = plugin->logname,
             .alproto = alproto,
+            .dir = plugin->dir,
             .LogTx = (EveJsonSimpleTxLogFunc)plugin->Logger,
         };
         if (OutputPreRegisterLogger(reg_data) != 0) {

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -159,8 +159,7 @@ int SCPluginRegisterAppLayer(SCAppLayerPlugin *plugin)
     if (plugin->version != SC_PLUGIN_API_VERSION) {
         return 1;
     }
-    AppProto alproto = g_alproto_max;
-    AppProtoRegisterProtoString(alproto, plugin->name);
+    AppProto alproto = AppProtoNewProtoFromString(plugin->name);
     if (plugin->Register) {
         if (AppLayerParserPreRegister(plugin->Register) != 0) {
             return 1;

--- a/src/util-plugin.c
+++ b/src/util-plugin.c
@@ -176,7 +176,7 @@ int SCPluginRegisterAppLayer(SCAppLayerPlugin *plugin)
             .logname = plugin->logname,
             .alproto = alproto,
             .dir = plugin->dir,
-            .LogTx = (EveJsonSimpleTxLogFunc)plugin->Logger,
+            .LogTx = plugin->Logger,
         };
         if (OutputPreRegisterLogger(reg_data) != 0) {
             return 1;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5053

Describe changes:
- detect: fix overflow for files protocol as reported by coverity
- snmp: register protocol dynamically, to do so :
  - make some arrays even more dynamic
  - add an helper function AppProtoNewProtoFromString
  - have plugins be able to log flow or packet direction (update SC_PLUGIN_API_VERSION)

https://github.com/OISF/suricata/pull/12414 with obsolete comment removed