### PR TITLE
Detect rule hook/v7

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -107,6 +107,9 @@ typedef struct AppLayerParserProtoCtx_
     AppLayerParserGetFrameIdByNameFn GetFrameIdByName;
     AppLayerParserGetFrameNameByIdFn GetFrameNameById;
 
+    AppLayerParserGetStateIdByNameFn GetStateIdByName;
+    AppLayerParserGetStateNameByIdFn GetStateNameById;
+
     /* each app-layer has its own value */
     uint32_t stream_depth;
 
@@ -544,6 +547,16 @@ void AppLayerParserRegisterGetEventInfoById(uint8_t ipproto, AppProto alproto,
     alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].StateGetEventInfoById =
             StateGetEventInfoById;
 
+    SCReturn;
+}
+
+void AppLayerParserRegisterGetStateFuncs(uint8_t ipproto, AppProto alproto,
+        AppLayerParserGetStateIdByNameFn GetIdByNameFunc,
+        AppLayerParserGetStateNameByIdFn GetNameByIdFunc)
+{
+    SCEnter();
+    alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateIdByName = GetIdByNameFunc;
+    alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateNameById = GetNameByIdFunc;
     SCReturn;
 }
 
@@ -1576,6 +1589,35 @@ void AppLayerParserSetStreamDepthFlag(uint8_t ipproto, AppProto alproto, void *s
         }
     }
     SCReturn;
+}
+
+/**
+ *  \param id progress value id to get the name for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+int AppLayerParserGetStateIdByName(
+        uint8_t ipproto, AppProto alproto, const char *name, const int direction)
+{
+    if (alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateIdByName != NULL) {
+        return alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateIdByName(
+                name, direction);
+    } else {
+        return -1;
+    }
+}
+
+/**
+ *  \param id progress value id to get the name for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+const char *AppLayerParserGetStateNameById(
+        uint8_t ipproto, AppProto alproto, const int id, const int direction)
+{
+    if (alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateNameById != NULL) {
+        return alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].GetStateNameById(id, direction);
+    } else {
+        return NULL;
+    }
 }
 
 int AppLayerParserGetFrameIdByName(uint8_t ipproto, AppProto alproto, const char *name)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -155,6 +155,17 @@ typedef AppLayerGetTxIterTuple (*AppLayerGetTxIteratorFunc)
 
 /***** Parser related registration *****/
 
+/**
+ *  \param name progress name to get the id for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+typedef int (*AppLayerParserGetStateIdByNameFn)(const char *name, const int direction);
+/**
+ *  \param id progress value id to get the name for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+typedef const char *(*AppLayerParserGetStateNameByIdFn)(const int id, const int direction);
+
 typedef int (*AppLayerParserGetFrameIdByNameFn)(const char *frame_name);
 typedef const char *(*AppLayerParserGetFrameNameByIdFn)(const uint8_t id);
 
@@ -206,6 +217,9 @@ void AppLayerParserRegisterGetFrameFuncs(uint8_t ipproto, AppProto alproto,
         AppLayerParserGetFrameNameByIdFn GetFrameNameById);
 void AppLayerParserRegisterSetStreamDepthFlag(uint8_t ipproto, AppProto alproto,
         void (*SetStreamDepthFlag)(void *tx, uint8_t flags));
+void AppLayerParserRegisterGetStateFuncs(uint8_t ipproto, AppProto alproto,
+        AppLayerParserGetStateIdByNameFn GetStateIdByName,
+        AppLayerParserGetStateNameByIdFn GetStateNameById);
 
 void AppLayerParserRegisterTxDataFunc(uint8_t ipproto, AppProto alproto,
         AppLayerTxData *(*GetTxData)(void *tx));
@@ -293,6 +307,18 @@ void AppLayerParserSetStreamDepthFlag(uint8_t ipproto, AppProto alproto, void *s
 int AppLayerParserIsEnabled(AppProto alproto);
 int AppLayerParserGetFrameIdByName(uint8_t ipproto, AppProto alproto, const char *name);
 const char *AppLayerParserGetFrameNameById(uint8_t ipproto, AppProto alproto, const uint8_t id);
+/**
+ *  \param name progress name to get the id for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+int AppLayerParserGetStateIdByName(
+        uint8_t ipproto, AppProto alproto, const char *name, int direction);
+/**
+ *  \param id progress value id to get the name for
+ *  \param direction STREAM_TOSERVER/STREAM_TOCLIENT
+ */
+const char *AppLayerParserGetStateNameById(
+        uint8_t ipproto, AppProto alproto, const int id, int direction);
 
 /***** Cleanup *****/
 

--- a/src/app-layer-register.c
+++ b/src/app-layer-register.c
@@ -188,6 +188,11 @@ int AppLayerRegisterParser(const struct AppLayerParser *p, AppProto alproto)
                 p->ip_proto, alproto, p->GetFrameIdByName, p->GetFrameNameById);
     }
 
+    if (p->GetStateIdByName && p->GetStateNameById) {
+        AppLayerParserRegisterGetStateFuncs(
+                p->ip_proto, alproto, p->GetStateIdByName, p->GetStateNameById);
+    }
+
     return 0;
 }
 

--- a/src/app-layer-register.h
+++ b/src/app-layer-register.h
@@ -74,6 +74,8 @@ typedef struct AppLayerParser {
     AppLayerParserGetFrameIdByNameFn GetFrameIdByName;
     AppLayerParserGetFrameNameByIdFn GetFrameNameById;
 
+    AppLayerParserGetStateIdByNameFn GetStateIdByName;
+    AppLayerParserGetStateNameByIdFn GetStateNameById;
 } AppLayerParser;
 
 /**

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1664,6 +1664,7 @@ static int SupportedHandshakeType(const uint8_t type)
 }
 
 /**
+ *  \param input_len length of bytes after record header. Can be 0 (e.g. for server hello done).
  *  \retval parsed number of consumed bytes
  *  \retval < 0 error
  */
@@ -1673,9 +1674,6 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, const uint8_t *input,
     const uint8_t *initial_input = input;
     int rc;
 
-    if (input_len == 0) {
-        return 0;
-    }
     DEBUG_VALIDATE_BUG_ON(RecordAlreadyProcessed(ssl_state->curr_connp));
 
     switch (ssl_state->curr_connp->handshake_type) {

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -291,30 +291,36 @@ static uint64_t SSLGetTxCnt(void *state)
     return 1;
 }
 
+static void UpdateClientState(SSLState *ssl_state, enum TlsStateClient s)
+{
+#ifdef DEBUG
+    enum TlsStateClient old = ssl_state->client_state;
+#endif
+    ssl_state->client_state = s;
+#ifdef DEBUG
+    SCLogDebug("toserver: state updated to %u from %u", s, old);
+#endif
+}
+
+static void UpdateServerState(SSLState *ssl_state, enum TlsStateServer s)
+{
+#ifdef DEBUG
+    enum TlsStateServer old = ssl_state->server_state;
+#endif
+    ssl_state->server_state = s;
+#ifdef DEBUG
+    SCLogDebug("toclient: state updated to %u from %u", s, old);
+#endif
+}
+
 static int SSLGetAlstateProgress(void *tx, uint8_t direction)
 {
     SSLState *ssl_state = (SSLState *)tx;
-
-    /* we don't care about direction, only that app-layer parser is done
-       and have sent an EOF */
-    if (ssl_state->flags & SSL_AL_FLAG_STATE_FINISHED) {
-        return TLS_STATE_FINISHED;
+    if (direction & STREAM_TOCLIENT) {
+        return ssl_state->server_state;
+    } else {
+        return ssl_state->client_state;
     }
-
-    /* we want the logger to log when the handshake is done, even if the
-       state is not finished */
-    if (ssl_state->flags & SSL_AL_FLAG_HANDSHAKE_DONE) {
-        return TLS_HANDSHAKE_DONE;
-    }
-
-    if (direction == STREAM_TOSERVER &&
-        (ssl_state->server_connp.cert0_subject != NULL ||
-         ssl_state->server_connp.cert0_issuerdn != NULL))
-    {
-        return TLS_STATE_CERT_READY;
-    }
-
-    return TLS_STATE_IN_PROGRESS;
 }
 
 static AppLayerTxData *SSLGetTxData(void *vtx)
@@ -1609,6 +1615,11 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
         ssl_state->curr_connp->ja3_hash = Ja3GenerateHash(ssl_state->curr_connp->ja3_str);
     }
 
+    if (ssl_state->curr_connp == &ssl_state->client_connp) {
+        UpdateClientState(ssl_state, TLS_STATE_CLIENT_HELLO_DONE);
+    } else {
+        UpdateServerState(ssl_state, TLS_STATE_SERVER_HELLO);
+    }
 end:
     return 0;
 }
@@ -1634,6 +1645,11 @@ static inline int SSLv3ParseHandshakeTypeCertificate(SSLState *ssl_state, SSLSta
         SCLogDebug("error parsing cert, reset state");
         SSLParserHSReset(connp);
         /* fall through to still consume the cert bytes */
+    }
+    if (connp == &ssl_state->client_connp) {
+        UpdateClientState(ssl_state, TLS_STATE_CLIENT_CERT_DONE);
+    } else {
+        UpdateServerState(ssl_state, TLS_STATE_SERVER_CERT_DONE);
     }
     return input_len;
 }
@@ -1703,7 +1719,6 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, const uint8_t *input,
             break;
 
         case SSLV3_HS_CERTIFICATE:
-
             rc = SSLv3ParseHandshakeTypeCertificate(ssl_state,
                     direction ? &ssl_state->server_connp : &ssl_state->client_connp, initial_input,
                     input_len);
@@ -1727,6 +1742,9 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, const uint8_t *input,
             SCLogDebug("new session ticket");
             break;
         case SSLV3_HS_SERVER_HELLO_DONE:
+            if (direction) {
+                UpdateServerState(ssl_state, TLS_STATE_SERVER_HELLO_DONE);
+            }
             break;
         default:
             SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
@@ -2290,6 +2308,7 @@ static struct SSLDecoderResult SSLv2Decode(uint8_t direction, SSLState *ssl_stat
 
             ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_HELLO;
             ssl_state->current_flags |= SSL_AL_FLAG_SSL_CLIENT_HS;
+            UpdateClientState(ssl_state, TLS_STATE_CLIENT_HELLO_DONE);
 
             const uint16_t version = (uint16_t)(input[0] << 8) | input[1];
             SCLogDebug("SSLv2: version %04x", version);
@@ -2319,6 +2338,7 @@ static struct SSLDecoderResult SSLv2Decode(uint8_t direction, SSLState *ssl_stat
             } else {
                 ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_KEYX;
             }
+            UpdateServerState(ssl_state, TLS_STATE_SERVER_CERT_DONE);
 
             /* fall through */
         case SSLV2_MT_SERVER_VERIFY:
@@ -2371,6 +2391,7 @@ static struct SSLDecoderResult SSLv2Decode(uint8_t direction, SSLState *ssl_stat
         case SSLV2_MT_SERVER_HELLO:
             ssl_state->current_flags = SSL_AL_FLAG_STATE_SERVER_HELLO;
             ssl_state->current_flags |= SSL_AL_FLAG_SSL_SERVER_HS;
+            UpdateServerState(ssl_state, TLS_STATE_SERVER_HELLO);
 
             break;
     }
@@ -2556,7 +2577,11 @@ static struct SSLDecoderResult SSLv3Decode(uint8_t direction, SSLState *ssl_stat
 
             /* if we see (encrypted) application data, then this means the
                handshake must be done */
-            ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+            if (ssl_state->curr_connp == &ssl_state->client_connp) {
+                UpdateClientState(ssl_state, TLS_STATE_CLIENT_HANDSHAKE_DONE);
+            } else {
+                UpdateServerState(ssl_state, TLS_STATE_SERVER_HANDSHAKE_DONE);
+            }
 
             if (ssl_config.encrypt_mode != SSL_CNF_ENC_HANDLE_FULL) {
                 SCLogDebug("setting APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD");
@@ -2684,7 +2709,10 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
                     (direction == 1 &&
                             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC)))) {
         /* flag session as finished if APP_LAYER_PARSER_EOF is set */
-        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
+        if (direction == 0)
+            UpdateClientState(ssl_state, TLS_STATE_CLIENT_FINISHED);
+        else
+            UpdateServerState(ssl_state, TLS_STATE_SERVER_FINISHED);
         SCReturnStruct(APP_LAYER_OK);
     } else if (input == NULL || input_len == 0) {
         SCReturnStruct(APP_LAYER_ERROR);
@@ -2792,19 +2820,22 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
     /* mark handshake as done if we have subject and issuer */
     if ((ssl_state->flags & SSL_AL_FLAG_NEED_CLIENT_CERT) &&
             ssl_state->client_connp.cert0_subject && ssl_state->client_connp.cert0_issuerdn) {
-        SCLogDebug("SSL_AL_FLAG_HANDSHAKE_DONE");
-        ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+        /* update both sides to keep existing behavior */
+        UpdateClientState(ssl_state, TLS_STATE_CLIENT_HANDSHAKE_DONE);
+        UpdateServerState(ssl_state, TLS_STATE_SERVER_HANDSHAKE_DONE);
     } else if ((ssl_state->flags & SSL_AL_FLAG_NEED_CLIENT_CERT) == 0 &&
                ssl_state->server_connp.cert0_subject && ssl_state->server_connp.cert0_issuerdn) {
-        SCLogDebug("SSL_AL_FLAG_HANDSHAKE_DONE");
-        ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+        /* update both sides to keep existing behavior */
+        UpdateClientState(ssl_state, TLS_STATE_CLIENT_HANDSHAKE_DONE);
+        UpdateServerState(ssl_state, TLS_STATE_SERVER_HANDSHAKE_DONE);
     }
 
     /* flag session as finished if APP_LAYER_PARSER_EOF is set */
     if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS) &&
         AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC)) {
-        SCLogDebug("SSL_AL_FLAG_STATE_FINISHED");
-        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
+        /* update both sides to keep existing behavior */
+        UpdateClientState(ssl_state, TLS_STATE_CLIENT_FINISHED);
+        UpdateServerState(ssl_state, TLS_STATE_SERVER_FINISHED);
     }
 
     return APP_LAYER_OK;
@@ -3272,7 +3303,7 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetAlstateProgress);
 
         AppLayerParserRegisterStateProgressCompletionStatus(
-                ALPROTO_TLS, TLS_STATE_FINISHED, TLS_STATE_FINISHED);
+                ALPROTO_TLS, TLS_STATE_CLIENT_FINISHED, TLS_STATE_SERVER_FINISHED);
 
         ConfNode *enc_handle = ConfGetNode("app-layer.protocols.tls.encryption-handling");
         if (enc_handle != NULL && enc_handle->val != NULL) {

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -43,6 +43,58 @@
 #include "util-enum.h"
 #include "util-validate.h"
 
+static SCEnumCharMap tls_state_client_table[] = {
+    {
+            "client_in_progress",
+            TLS_STATE_CLIENT_IN_PROGRESS,
+    },
+    {
+            "client_hello_done",
+            TLS_STATE_CLIENT_HELLO_DONE,
+    },
+    {
+            "client_cert_done",
+            TLS_STATE_CLIENT_CERT_DONE,
+    },
+    {
+            "client_handshake_done",
+            TLS_STATE_CLIENT_HANDSHAKE_DONE,
+    },
+    {
+            "client_finished",
+            TLS_STATE_CLIENT_FINISHED,
+    },
+    { NULL, -1 },
+};
+
+static SCEnumCharMap tls_state_server_table[] = {
+    {
+            "server_in_progress",
+            TLS_STATE_SERVER_IN_PROGRESS,
+    },
+    {
+            "server_hello",
+            TLS_STATE_SERVER_HELLO,
+    },
+    {
+            "server_cert_done",
+            TLS_STATE_SERVER_CERT_DONE,
+    },
+    {
+            "server_hello_done",
+            TLS_STATE_SERVER_HELLO_DONE,
+    },
+    {
+            "server_handshake_done",
+            TLS_STATE_SERVER_HANDSHAKE_DONE,
+    },
+    {
+            "server_finished",
+            TLS_STATE_SERVER_FINISHED,
+    },
+    { NULL, -1 },
+};
+
 SCEnumCharMap tls_frame_table[] = {
     {
             "pdu",
@@ -2996,6 +3048,26 @@ static AppProto SSLProbingParser(Flow *f, uint8_t direction,
     return ALPROTO_FAILED;
 }
 
+static int SSLStateGetStateIdByName(const char *name, const int direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? tls_state_client_table : tls_state_server_table;
+
+    int id = SCMapEnumNameToValue(name, map);
+    if (id < 0) {
+        return -1;
+    }
+    return id;
+}
+
+static const char *SSLStateGetStateNameById(const int id, const int direction)
+{
+    SCEnumCharMap *map =
+            direction == STREAM_TOSERVER ? tls_state_client_table : tls_state_server_table;
+    const char *name = SCMapEnumValueToName(id, map);
+    return name;
+}
+
 static int SSLStateGetFrameIdByName(const char *frame_name)
 {
     int id = SCMapEnumNameToValue(frame_name, tls_frame_table);
@@ -3282,7 +3354,8 @@ void RegisterSSLParsers(void)
 
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOCLIENT,
                                      SSLParseServerRecord);
-
+        AppLayerParserRegisterGetStateFuncs(
+                IPPROTO_TCP, ALPROTO_TLS, SSLStateGetStateIdByName, SSLStateGetStateNameById);
         AppLayerParserRegisterGetFrameFuncs(
                 IPPROTO_TCP, ALPROTO_TLS, SSLStateGetFrameIdByName, SSLStateGetFrameNameById);
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfo);

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -73,11 +73,21 @@ enum {
     TLS_DECODER_EVENT_INVALID_SSL_RECORD,
 };
 
-enum {
-    TLS_STATE_IN_PROGRESS = 0,
-    TLS_STATE_CERT_READY = 1,
-    TLS_HANDSHAKE_DONE = 2,
-    TLS_STATE_FINISHED = 3
+enum TlsStateClient {
+    TLS_STATE_CLIENT_IN_PROGRESS = 0,
+    TLS_STATE_CLIENT_HELLO_DONE,
+    TLS_STATE_CLIENT_CERT_DONE,
+    TLS_STATE_CLIENT_HANDSHAKE_DONE,
+    TLS_STATE_CLIENT_FINISHED,
+};
+
+enum TlsStateServer {
+    TLS_STATE_SERVER_IN_PROGRESS = 0,
+    TLS_STATE_SERVER_HELLO,
+    TLS_STATE_SERVER_CERT_DONE,
+    TLS_STATE_SERVER_HELLO_DONE,
+    TLS_STATE_SERVER_HANDSHAKE_DONE,
+    TLS_STATE_SERVER_FINISHED,
 };
 
 /* Flag to indicate that server will now on send encrypted msgs */
@@ -101,16 +111,10 @@ enum {
 #define SSL_AL_FLAG_STATE_SERVER_KEYX           BIT_U32(12)
 #define SSL_AL_FLAG_STATE_UNKNOWN               BIT_U32(13)
 
-/* flag to indicate that session is finished */
-#define SSL_AL_FLAG_STATE_FINISHED              BIT_U32(14)
-
 /* flags specific to HeartBeat state */
 #define SSL_AL_FLAG_HB_INFLIGHT                 BIT_U32(15)
 #define SSL_AL_FLAG_HB_CLIENT_INIT              BIT_U32(16)
 #define SSL_AL_FLAG_HB_SERVER_INIT              BIT_U32(17)
-
-/* flag to indicate that handshake is done */
-#define SSL_AL_FLAG_HANDSHAKE_DONE              BIT_U32(18)
 
 /* Session resumed without a full handshake */
 #define SSL_AL_FLAG_SESSION_RESUMED             BIT_U32(20)
@@ -310,6 +314,9 @@ typedef struct SSLState_ {
     uint32_t current_flags;
 
     SSLStateConnp *curr_connp;
+
+    enum TlsStateClient client_state;
+    enum TlsStateServer server_state;
 
     SSLStateConnp client_connp;
     SSLStateConnp server_connp;

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -996,7 +996,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
 
 /***** Utility *****/
 
-AppProto AppLayerGetProtoByName(char *alproto_name)
+AppProto AppLayerGetProtoByName(const char *alproto_name)
 {
     SCEnter();
     AppProto r = AppLayerProtoDetectGetProtoByName(alproto_name);

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -63,7 +63,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *app_tctx,
  *
  * \param The internal protocol id.
  */
-AppProto AppLayerGetProtoByName(char *alproto_name);
+AppProto AppLayerGetProtoByName(const char *alproto_name);
 
 /**
  * \brief Given the internal protocol id, returns a string representation

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -1945,9 +1945,8 @@ static int DetectByteExtractTest43(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "three", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_OFFSET_VAR |
-                      DETECT_CONTENT_OFFSET) ||
-        cd->offset != bed->local_id) {
+            cd->flags != (DETECT_CONTENT_OFFSET_VAR | DETECT_CONTENT_OFFSET | DETECT_CONTENT_MPM) ||
+            cd->offset != bed->local_id) {
         printf("three failed\n");
         result = 0;
         goto end;
@@ -2049,9 +2048,8 @@ static int DetectByteExtractTest44(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_OFFSET_VAR |
-                      DETECT_CONTENT_OFFSET) ||
-        cd->offset != bed1->local_id) {
+            cd->flags != (DETECT_CONTENT_OFFSET_VAR | DETECT_CONTENT_OFFSET | DETECT_CONTENT_MPM) ||
+            cd->offset != bed1->local_id) {
         printf("four failed\n");
         result = 0;
         goto end;
@@ -2158,10 +2156,8 @@ static int DetectByteExtractTest45(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "three", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_DEPTH_VAR |
-                      DETECT_CONTENT_DEPTH) ||
-        cd->depth != bed->local_id ||
-        cd->offset != 0) {
+            cd->flags != (DETECT_CONTENT_DEPTH_VAR | DETECT_CONTENT_DEPTH | DETECT_CONTENT_MPM) ||
+            cd->depth != bed->local_id || cd->offset != 0) {
         printf("three failed\n");
         result = 0;
         goto end;
@@ -2263,9 +2259,8 @@ static int DetectByteExtractTest46(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_DEPTH_VAR |
-                      DETECT_CONTENT_DEPTH) ||
-        cd->depth != bed1->local_id) {
+            cd->flags != (DETECT_CONTENT_DEPTH_VAR | DETECT_CONTENT_DEPTH | DETECT_CONTENT_MPM) ||
+            cd->depth != bed1->local_id) {
         printf("four failed\n");
         result = 0;
         goto end;
@@ -2372,11 +2367,9 @@ static int DetectByteExtractTest47(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "three", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_DISTANCE_VAR |
-                      DETECT_CONTENT_DISTANCE) ||
-        cd->distance != bed->local_id ||
-        cd->offset != 0 ||
-        cd->depth != 0) {
+            cd->flags !=
+                    (DETECT_CONTENT_DISTANCE_VAR | DETECT_CONTENT_DISTANCE | DETECT_CONTENT_MPM) ||
+            cd->distance != bed->local_id || cd->offset != 0 || cd->depth != 0) {
         printf("three failed\n");
         result = 0;
         goto end;
@@ -2478,12 +2471,9 @@ static int DetectByteExtractTest48(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_DISTANCE_VAR |
-                      DETECT_CONTENT_DISTANCE |
-                      DETECT_CONTENT_DISTANCE_NEXT) ||
-        cd->distance != bed1->local_id ||
-        cd->depth != 0 ||
-        cd->offset != 0) {
+            cd->flags != (DETECT_CONTENT_DISTANCE_VAR | DETECT_CONTENT_DISTANCE |
+                                 DETECT_CONTENT_DISTANCE_NEXT | DETECT_CONTENT_MPM) ||
+            cd->distance != bed1->local_id || cd->depth != 0 || cd->offset != 0) {
         printf("four failed\n");
         result = 0;
         goto end;
@@ -2592,12 +2582,8 @@ static int DetectByteExtractTest49(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "three", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_WITHIN_VAR |
-                      DETECT_CONTENT_WITHIN) ||
-        cd->within != bed->local_id ||
-        cd->offset != 0 ||
-        cd->depth != 0 ||
-        cd->distance != 0) {
+            cd->flags != (DETECT_CONTENT_WITHIN_VAR | DETECT_CONTENT_WITHIN | DETECT_CONTENT_MPM) ||
+            cd->within != bed->local_id || cd->offset != 0 || cd->depth != 0 || cd->distance != 0) {
         printf("three failed\n");
         result = 0;
         goto end;
@@ -2699,13 +2685,10 @@ static int DetectByteExtractTest50(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_WITHIN_VAR |
-                      DETECT_CONTENT_WITHIN|
-                      DETECT_CONTENT_WITHIN_NEXT) ||
-        cd->within != bed1->local_id ||
-        cd->depth != 0 ||
-        cd->offset != 0 ||
-        cd->distance != 0) {
+            cd->flags != (DETECT_CONTENT_WITHIN_VAR | DETECT_CONTENT_WITHIN |
+                                 DETECT_CONTENT_WITHIN_NEXT | DETECT_CONTENT_MPM) ||
+            cd->within != bed1->local_id || cd->depth != 0 || cd->offset != 0 ||
+            cd->distance != 0) {
         printf("four failed\n");
         result = 0;
         goto end;
@@ -2970,7 +2953,7 @@ static int DetectByteExtractTest53(void)
     SigMatch *sm = s->init_data->smlists[DETECT_SM_LIST_PMATCH];
     FAIL_IF(sm->type != DETECT_CONTENT);
     DetectContentData *cd = (DetectContentData *)sm->ctx;
-    FAIL_IF(cd->flags != 0);
+    FAIL_IF(cd->flags != (DETECT_CONTENT_MPM | DETECT_CONTENT_NO_DOUBLE_INSPECTION_REQUIRED));
 
     sm = sm->next;
     FAIL_IF_NULL(sm);
@@ -3092,11 +3075,8 @@ static int DetectByteExtractTest54(void)
         goto end;
     }
     bjd = (DetectBytejumpData *)sm->ctx;
-    if (bjd->flags != DETECT_BYTEJUMP_OFFSET_VAR || bjd->offset != 1) {
-        printf("four failed\n");
-        result = 0;
-        goto end;
-    }
+    FAIL_IF(bjd->flags != DETECT_BYTEJUMP_OFFSET_VAR);
+    FAIL_IF(bjd->offset != 1);
 
     if (sm->next != NULL)
         goto end;
@@ -3197,12 +3177,10 @@ static int DetectByteExtractTest55(void)
     }
     cd = (DetectContentData *)sm->ctx;
     if (strncmp((char *)cd->content, "four", cd->content_len) != 0 ||
-        cd->flags != (DETECT_CONTENT_DISTANCE_VAR |
-                      DETECT_CONTENT_WITHIN_VAR |
-                      DETECT_CONTENT_DISTANCE |
-                      DETECT_CONTENT_WITHIN) ||
-        cd->within != bed1->local_id ||
-        cd->distance != bed2->local_id) {
+            cd->flags !=
+                    (DETECT_CONTENT_DISTANCE_VAR | DETECT_CONTENT_WITHIN_VAR |
+                            DETECT_CONTENT_DISTANCE | DETECT_CONTENT_WITHIN | DETECT_CONTENT_MPM) ||
+            cd->within != bed1->local_id || cd->distance != bed2->local_id) {
         printf("four failed: ");
         goto end;
     }
@@ -3829,8 +3807,8 @@ static int DetectByteExtractTest60(void)
         goto end;
     }
     cd = (DetectContentData *)sm->ctx;
-    if (cd->flags != DETECT_CONTENT_RELATIVE_NEXT ||
-        strncmp((char *)cd->content, "three", cd->content_len) != 0) {
+    if (cd->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_MPM) ||
+            strncmp((char *)cd->content, "three", cd->content_len) != 0) {
         printf("one failed\n");
         result = 0;
         goto end;
@@ -3950,8 +3928,8 @@ static int DetectByteExtractTest61(void)
         goto end;
     }
     cd = (DetectContentData *)sm->ctx;
-    if (cd->flags != DETECT_CONTENT_RELATIVE_NEXT ||
-        strncmp((char *)cd->content, "three", cd->content_len) != 0) {
+    if (cd->flags != (DETECT_CONTENT_RELATIVE_NEXT | DETECT_CONTENT_MPM) ||
+            strncmp((char *)cd->content, "three", cd->content_len) != 0) {
         printf("one failed\n");
         result = 0;
         goto end;

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -1504,7 +1504,7 @@ static int DetectContentParseTest19(void)
     FAIL_IF_NOT(s->init_data->smlists[DETECT_SM_LIST_PMATCH] == NULL);
 
     DetectContentData *data = (DetectContentData *)sm->ctx;
-    FAIL_IF_NOT(data->flags == DETECT_CONTENT_DISTANCE);
+    FAIL_IF_NOT(data->flags == (DETECT_CONTENT_DISTANCE | DETECT_CONTENT_MPM));
 
     s = DetectEngineAppendSig(de_ctx,
             "alert tcp any any -> any any "

--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1645,6 +1645,12 @@ void SignatureSetType(DetectEngineCtx *de_ctx, Signature *s)
     BUG_ON(s->type != SIG_TYPE_NOT_SET);
     int iponly = 0;
 
+    if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+        s->type = SIG_TYPE_APP_TX;
+        SCLogNotice("%u: set to app_tx due to hook type app", s->id);
+        SCReturn;
+    }
+
     /* see if the sig is dp only */
     if (SignatureIsPDOnly(de_ctx, s) == 1) {
         s->type = SIG_TYPE_PDONLY;

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -167,7 +167,6 @@ static int DetectLoadSigFile(
         sig = DetectEngineAppendSig(de_ctx, line);
         if (sig != NULL) {
             if (rule_engine_analysis_set || fp_engine_analysis_set) {
-                RetrieveFPForSig(de_ctx, sig);
                 if (fp_engine_analysis_set) {
                     EngineAnalysisFP(de_ctx, sig, line);
                 }

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -2514,7 +2514,7 @@ void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *
     for (; app != NULL; app = app->next) {
         DEBUG_VALIDATE_BUG_ON(app->smd == NULL);
         SigMatchData *smd = app->smd;
-        do {
+        while (smd) {
             switch (smd->type) {
                 case DETECT_CONTENT: {
                     const DetectContentData *cd = (const DetectContentData *)smd->ctx;
@@ -2542,7 +2542,7 @@ void EngineAnalysisAddAllRulePatterns(DetectEngineCtx *de_ctx, const Signature *
             if (smd->is_last)
                 break;
             smd++;
-        } while (1);
+        }
     }
     const DetectEnginePktInspectionEngine *pkt = s->pkt_inspect;
     for (; pkt != NULL; pkt = pkt->next) {

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -2418,12 +2418,7 @@ int DetectSetFastPatternAndItsId(DetectEngineCtx *de_ctx)
 {
     uint32_t cnt = 0;
     for (Signature *s = de_ctx->sig_list; s != NULL; s = s->next) {
-        if (s->flags & SIG_FLAG_PREFILTER)
-            continue;
-
-        RetrieveFPForSig(de_ctx, s);
         if (s->init_data->mpm_sm != NULL) {
-            s->flags |= SIG_FLAG_PREFILTER;
             cnt++;
         }
     }

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -501,6 +501,8 @@ void SigTableInit(void)
 
 void SigTableSetup(void)
 {
+    (void)DetectBufferTypeRegister("hook");
+
     DetectSidRegister();
     DetectPriorityRegister();
     DetectPrefilterRegister();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -666,7 +666,7 @@ static void AppendAppInspectEngine(DetectEngineCtx *de_ctx,
     new_engine->sm_list = t->sm_list;
     new_engine->sm_list_base = t->sm_list_base;
     new_engine->smd = smd;
-    new_engine->match_on_null = DetectContentInspectionMatchOnAbsentBuffer(smd);
+    new_engine->match_on_null = smd ? DetectContentInspectionMatchOnAbsentBuffer(smd) : false;
     new_engine->progress = t->progress;
     new_engine->v2 = t->v2;
     SCLogDebug("sm_list %d new_engine->v2 %p/%p/%p", new_engine->sm_list, new_engine->v2.Callback,
@@ -732,6 +732,7 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
     const int files_id = DetectBufferTypeGetByName("files");
     bool head_is_mpm = false;
     uint8_t last_id = DE_STATE_FLAG_BASE;
+    SCLogNotice("%u: setup app inspect engines. %u buffers", s->id, s->init_data->buffer_index);
 
     for (uint32_t x = 0; x < s->init_data->buffer_index; x++) {
         SigMatchData *smd = SigMatchList2DataArray(s->init_data->buffers[x].head);
@@ -769,6 +770,25 @@ int DetectEngineAppInspectionEngine2Signature(DetectEngineCtx *de_ctx, Signature
                 }
             }
         }
+    }
+
+    /* handle rules that have an app-layer hook w/o bringing their own app inspect engine,
+     * e.g. `alert dns:request_complete ... (sid:1;)`
+     *
+     * Here we use a minimal stub inspect engine in which we set:
+     * - alproto
+     * - progress
+     * - sm_list/sm_list_base to get the mapping to the "hook" name
+     *
+     * The inspect engine has no callback and is thus considered a straight match.
+     */
+    if (s->init_data->buffer_index == 0 && s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+        const int hook_id = DetectBufferTypeGetByName("hook");
+        DetectEngineAppInspectionEngine t = { .alproto = s->init_data->hook.t.app.alproto,
+            .progress = (uint16_t)s->init_data->hook.t.app.app_progress,
+            .sm_list = hook_id,
+            .sm_list_base = hook_id };
+        AppendAppInspectEngine(de_ctx, &t, s, NULL, mpm_list, files_id, &last_id, &head_is_mpm);
     }
 
     if ((s->init_data->init_flags & SIG_FLAG_INIT_STATE_MATCH) &&

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -445,14 +445,18 @@ void DetectFlowFree(DetectEngineCtx *de_ctx, void *ptr)
 static void
 PrefilterPacketFlowMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *pectx)
 {
+    SCEnter();
+
     const PrefilterPacketHeaderCtx *ctx = pectx;
 
     if (!PrefilterPacketHeaderExtraMatch(ctx, p))
         return;
 
     if (FlowMatch(p->flags, p->flowflags, ctx->v1.u16[0], ctx->v1.u16[1])) {
+        SCLogDebug("match: adding sids");
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
+    SCReturn;
 }
 
 static void

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -940,6 +940,9 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
     }
     s->init_data->negated = false;
 
+    const enum DetectKeywordId idx = SigTableGetIndex(st);
+    s->init_data->has_possible_prefilter |= de_ctx->sm_types_prefilter[idx];
+
     if (st->flags & SIGMATCH_INFO_DEPRECATED) {
 #define URL "https://suricata.io/our-story/deprecation-policy/"
         if (st->alternative == 0)
@@ -1047,7 +1050,6 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
         /* handle 'silent' error case */
         if (setup_ret == -2) {
-            enum DetectKeywordId idx = SigTableGetIndex(st);
             if (de_ctx->sm_types_silent_error[idx] == false) {
                 de_ctx->sm_types_silent_error[idx] = true;
                 return -1;
@@ -1902,6 +1904,61 @@ SigMatchData* SigMatchList2DataArray(SigMatch *head)
     return out;
 }
 
+extern int g_skip_prefilter;
+
+static void SigSetupPrefilter(DetectEngineCtx *de_ctx, Signature *s)
+{
+    SCEnter();
+    if (s->init_data->prefilter_sm != NULL || s->init_data->mpm_sm != NULL) {
+        SCReturn;
+    }
+
+    SCLogDebug("s %u: set up prefilter/mpm", s->id);
+    RetrieveFPForSig(de_ctx, s);
+    if (s->init_data->mpm_sm != NULL) {
+        s->flags |= SIG_FLAG_PREFILTER;
+        SCReturn;
+    }
+
+    SCLogDebug("s %u: no mpm; prefilter? de_ctx->prefilter_setting %u "
+               "s->init_data->has_possible_prefilter %s",
+            s->id, de_ctx->prefilter_setting, BOOL2STR(s->init_data->has_possible_prefilter));
+
+    if (!s->init_data->has_possible_prefilter)
+        SCReturn;
+
+    if (!g_skip_prefilter && de_ctx->prefilter_setting == DETECT_PREFILTER_AUTO &&
+            !(s->flags & SIG_FLAG_PREFILTER)) {
+        int prefilter_list = DETECT_TBLSIZE;
+        /* get the keyword supporting prefilter with the lowest type */
+        for (int i = 0; i < DETECT_SM_LIST_MAX; i++) {
+            for (SigMatch *sm = s->init_data->smlists[i]; sm != NULL; sm = sm->next) {
+                if (sigmatch_table[sm->type].SupportsPrefilter != NULL) {
+                    if (sigmatch_table[sm->type].SupportsPrefilter(s)) {
+                        prefilter_list = MIN(prefilter_list, sm->type);
+                    }
+                }
+            }
+        }
+
+        /* apply that keyword as prefilter */
+        if (prefilter_list != DETECT_TBLSIZE) {
+            for (int i = 0; i < DETECT_SM_LIST_MAX; i++) {
+                for (SigMatch *sm = s->init_data->smlists[i]; sm != NULL; sm = sm->next) {
+                    if (sm->type == prefilter_list) {
+                        s->init_data->prefilter_sm = sm;
+                        s->flags |= SIG_FLAG_PREFILTER;
+                        SCLogConfig("sid %u: prefilter is on \"%s\"", s->id,
+                                sigmatch_table[sm->type].name);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    SCReturn;
+}
+
 /**
  *  \internal
  *  \brief validate a just parsed signature for internal inconsistencies
@@ -2243,6 +2300,8 @@ static Signature *SigInitHelper(DetectEngineCtx *de_ctx, const char *sigstr,
     for (uint32_t x = 0; x < sig->init_data->buffer_index; x++) {
         DetectEngineBufferRunSetupCallback(de_ctx, sig->init_data->buffers[x].id, sig);
     }
+
+    SigSetupPrefilter(de_ctx, sig);
 
     /* validate signature, SigValidate will report the error reason */
     if (SigValidate(de_ctx, sig) == 0) {

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1106,6 +1106,61 @@ error:
     return -1;
 }
 
+static const char *SignatureHookTypeToString(enum SignatureHookType t)
+{
+    switch (t) {
+        case SIGNATURE_HOOK_TYPE_NOT_SET:
+            return "not_set";
+        case SIGNATURE_HOOK_TYPE_APP:
+            return "app";
+            // case SIGNATURE_HOOK_TYPE_PKT:
+            //     return "pkt";
+    }
+    return "unknown";
+}
+
+static SignatureHook SetAppHook(const AppProto alproto, int progress)
+{
+    SignatureHook h = {
+        .type = SIGNATURE_HOOK_TYPE_APP,
+        .t.app.alproto = alproto,
+        .t.app.app_progress = progress,
+    };
+    return h;
+}
+
+static int SigParseProtoHookApp(Signature *s, const char *p, const char *h)
+{
+    if (strcmp(h, "request_complete") == 0) {
+        s->flags |= SIG_FLAG_TOSERVER;
+        s->init_data->hook = SetAppHook(s->alproto,
+                AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOSERVER));
+    } else if (strcmp(h, "response_complete") == 0) {
+        s->flags |= SIG_FLAG_TOCLIENT;
+        s->init_data->hook = SetAppHook(s->alproto,
+                AppLayerParserGetStateProgressCompletionStatus(s->alproto, STREAM_TOCLIENT));
+    } else {
+        const int progress_ts = AppLayerParserGetStateIdByName(
+                IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOSERVER);
+        if (progress_ts >= 0) {
+            s->flags |= SIG_FLAG_TOSERVER;
+            s->init_data->hook = SetAppHook(s->alproto, progress_ts);
+        } else {
+            const int progress_tc = AppLayerParserGetStateIdByName(
+                    IPPROTO_TCP /* TODO */, s->alproto, h, STREAM_TOCLIENT);
+            if (progress_tc < 0) {
+                return -1;
+            }
+            s->flags |= SIG_FLAG_TOCLIENT;
+            s->init_data->hook = SetAppHook(s->alproto, progress_tc);
+        }
+    }
+    SCLogNotice("protocol:%s hook:%s: type:%s alproto:%u hook:%d", p, h,
+            SignatureHookTypeToString(s->init_data->hook.type), s->init_data->hook.t.app.alproto,
+            s->init_data->hook.t.app.app_progress);
+    return 0;
+}
+
 /**
  * \brief Parses the protocol supplied by the Signature.
  *
@@ -1121,13 +1176,35 @@ error:
 static int SigParseProto(Signature *s, const char *protostr)
 {
     SCEnter();
+    if (strlen(protostr) > 32)
+        return -1;
 
-    int r = DetectProtoParse(&s->proto, (char *)protostr);
+    char proto[33];
+    strlcpy(proto, protostr, 33);
+    const char *p = proto;
+    const char *h = NULL;
+
+    bool has_hook = strchr(proto, ':') != NULL;
+    if (has_hook) {
+        char *xsaveptr = NULL;
+        p = strtok_r(proto, ":", &xsaveptr);
+        h = strtok_r(NULL, ":", &xsaveptr);
+        SCLogNotice("p: '%s' h: '%s'", p, h);
+    }
+
+    int r = DetectProtoParse(&s->proto, p);
     if (r < 0) {
-        s->alproto = AppLayerGetProtoByName((char *)protostr);
+        s->alproto = AppLayerGetProtoByName(p);
         /* indicate that the signature is app-layer */
         if (s->alproto != ALPROTO_UNKNOWN) {
             s->flags |= SIG_FLAG_APPLAYER;
+
+            if (h) {
+                if (SigParseProtoHookApp(s, p, h) < 0) {
+                    SCLogError("protocol \"%s\" does not support hook \"%s\"", p, h);
+                    SCReturnInt(-1);
+                }
+            }
 
             AppLayerProtoDetectSupportedIpprotos(s->alproto, s->proto.proto);
         }
@@ -1137,7 +1214,7 @@ static int SigParseProto(Signature *s, const char *protostr)
                        "is not yet supported OR detection has been disabled for "
                        "protocol through the yaml option "
                        "app-layer.protocols.%s.detection-enabled",
-                    protostr, protostr);
+                    p, p);
             SCReturnInt(-1);
         }
     }
@@ -2044,6 +2121,21 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
                 SCLogDebug("b->id %d nlists %d", b->id, nlists);
                 bufdir[b->id].ts += (app->dir == 0);
                 bufdir[b->id].tc += (app->dir == 1);
+
+                /* only allow rules to use the hook for engines at that
+                 * exact progress for now. */
+                if (s->init_data->hook.type == SIGNATURE_HOOK_TYPE_APP) {
+                    if ((s->flags & SIG_FLAG_TOSERVER) && (app->dir == 0) &&
+                            app->progress != s->init_data->hook.t.app.app_progress) {
+                        SCLogError("engine progress value doesn't match hook");
+                        SCReturnInt(0);
+                    }
+                    if ((s->flags & SIG_FLAG_TOCLIENT) && (app->dir == 1) &&
+                            app->progress != s->init_data->hook.t.app.app_progress) {
+                        SCLogError("engine progress value doesn't match hook");
+                        SCReturnInt(0);
+                    }
+                }
             }
         }
 

--- a/src/detect-tls-alpn.c
+++ b/src/detect-tls-alpn.c
@@ -70,10 +70,10 @@ void DetectTlsAlpnRegister(void)
     sigmatch_table[DETECT_TLS_ALPN].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_TLS_ALPN].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerMultiRegister("tls.alpn", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0, TlsAlpnGetData, 2,
-            TLS_STATE_IN_PROGRESS);
-    DetectAppLayerMultiRegister(
-            "tls.alpn", ALPROTO_TLS, SIG_FLAG_TOCLIENT, 0, TlsAlpnGetData, 2, TLS_STATE_CERT_READY);
+    DetectAppLayerMultiRegister("tls.alpn", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CLIENT_HELLO_DONE, TlsAlpnGetData, 2, TLS_STATE_CLIENT_HELLO_DONE);
+    DetectAppLayerMultiRegister("tls.alpn", ALPROTO_TLS, SIG_FLAG_TOCLIENT, TLS_STATE_SERVER_HELLO,
+            TlsAlpnGetData, 2, TLS_STATE_SERVER_HELLO);
 
     DetectBufferTypeSetDescriptionByName("tls.alpn", "TLS APLN");
 

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -84,16 +84,16 @@ void DetectTlsFingerprintRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_FINGERPRINT].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerInspectEngineRegister("tls.cert_fingerprint", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_fingerprint", SIG_FLAG_TOCLIENT, 2,
-            PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, TLS_STATE_SERVER_CERT_DONE);
 
     DetectAppLayerInspectEngineRegister("tls.cert_fingerprint", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_CLIENT_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_fingerprint", SIG_FLAG_TOSERVER, 2,
-            PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, TLS_STATE_CLIENT_CERT_DONE);
 
     DetectBufferTypeSetDescriptionByName("tls.cert_fingerprint",
             "TLS certificate fingerprint");

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -80,16 +80,16 @@ void DetectTlsIssuerRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerInspectEngineRegister("tls.cert_issuer", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_CLIENT_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_issuer", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_CLIENT_CERT_DONE);
 
     DetectAppLayerInspectEngineRegister("tls.cert_issuer", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_issuer", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_SERVER_CERT_DONE);
 
     DetectBufferTypeSetDescriptionByName("tls.cert_issuer",
             "TLS certificate issuer");

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -84,16 +84,16 @@ void DetectTlsSerialRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_SERIAL].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerInspectEngineRegister("tls.cert_serial", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_serial", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_SERVER_CERT_DONE);
 
     DetectAppLayerInspectEngineRegister("tls.cert_serial", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_CLIENT_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_serial", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_CLIENT_CERT_DONE);
 
     DetectBufferTypeSetDescriptionByName("tls.cert_serial",
             "TLS certificate serial number");

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -80,16 +80,16 @@ void DetectTlsSubjectRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerInspectEngineRegister("tls.cert_subject", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_CLIENT_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_subject", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_CLIENT_CERT_DONE);
 
     DetectAppLayerInspectEngineRegister("tls.cert_subject", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectBufferGeneric, GetData);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectBufferGeneric, GetData);
 
     DetectAppLayerMpmRegister("tls.cert_subject", SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_TLS, TLS_STATE_CERT_READY);
+            GetData, ALPROTO_TLS, TLS_STATE_SERVER_CERT_DONE);
 
     DetectBufferTypeSupportsMultiInstance("tls.cert_subject");
 

--- a/src/detect-tls-cert-validity.c
+++ b/src/detect-tls-cert-validity.c
@@ -124,7 +124,7 @@ void DetectTlsValidityRegister (void)
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 
     DetectAppLayerInspectEngineRegister("tls_validity", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectGenericList, NULL);
 
     g_tls_validity_buffer_id = DetectBufferTypeGetByName("tls_validity");
 }

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -122,10 +122,10 @@ void DetectTlsCertsRegister(void)
     sigmatch_table[DETECT_AL_TLS_CERTS].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_TLS_CERTS].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOCLIENT, TLS_STATE_CERT_READY,
-            TlsCertsGetData, 2, 1);
-    DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOSERVER, TLS_STATE_CERT_READY,
-            TlsCertsGetData, 2, 1);
+    DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
+            TLS_STATE_SERVER_CERT_DONE, TlsCertsGetData, 2, 1);
+    DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CLIENT_CERT_DONE, TlsCertsGetData, 2, 1);
 
     DetectBufferTypeSetDescriptionByName("tls.certs", "TLS certificate");
 
@@ -253,7 +253,7 @@ void DetectTlsCertChainLenRegister(void)
     sigmatch_table[KEYWORD_ID].Free = DetectTLSCertChainLenFree;
 
     DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectGenericList, NULL);
 
     g_tls_cert_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
 }

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -73,11 +73,11 @@ void DetectTlsSniRegister(void)
     sigmatch_table[DETECT_AL_TLS_SNI].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_AL_TLS_SNI].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerInspectEngineRegister("tls.sni", ALPROTO_TLS, SIG_FLAG_TOSERVER, 0,
-            DetectEngineInspectBufferGeneric, GetData);
+    DetectAppLayerInspectEngineRegister("tls.sni", ALPROTO_TLS, SIG_FLAG_TOSERVER,
+            TLS_STATE_CLIENT_HELLO_DONE, DetectEngineInspectBufferGeneric, GetData);
 
-    DetectAppLayerMpmRegister(
-            "tls.sni", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData, ALPROTO_TLS, 0);
+    DetectAppLayerMpmRegister("tls.sni", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData,
+            ALPROTO_TLS, TLS_STATE_CLIENT_HELLO_DONE);
 
     DetectBufferTypeSetDescriptionByName("tls.sni",
             "TLS Server Name Indication (SNI) extension");

--- a/src/detect-tls-subjectaltname.c
+++ b/src/detect-tls-subjectaltname.c
@@ -73,7 +73,7 @@ void DetectTlsSubjectAltNameRegister(void)
     sigmatch_table[DETECT_AL_TLS_SUBJECTALTNAME].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("tls.subjectaltname", ALPROTO_TLS, SIG_FLAG_TOCLIENT, 0,
-            TlsSubjectAltNameGetData, 2, TLS_STATE_CERT_READY);
+            TlsSubjectAltNameGetData, 2, TLS_STATE_SERVER_CERT_DONE);
 
     DetectBufferTypeSetDescriptionByName("tls.subjectaltname", "TLS Subject Alternative Name");
 

--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -142,10 +142,10 @@ void DetectTlsRegister (void)
     g_tls_cert_fingerprint_list_id = DetectBufferTypeRegister("tls.cert_fingerprint");
 
     DetectAppLayerInspectEngineRegister("tls_cert", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
+            TLS_STATE_SERVER_CERT_DONE, DetectEngineInspectGenericList, NULL);
 
     DetectAppLayerInspectEngineRegister("tls_cert", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CERT_READY, DetectEngineInspectGenericList, NULL);
+            TLS_STATE_CLIENT_CERT_DONE, DetectEngineInspectGenericList, NULL);
 }
 
 /**

--- a/src/detect.c
+++ b/src/detect.c
@@ -1219,6 +1219,9 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             if (unlikely(engine->stream && can->stream_stored)) {
                 match = can->stream_result;
                 TRACE_SID_TXS(s->id, tx, "stream skipped, stored result %d used instead", match);
+            } else if (engine->v2.Callback == NULL) {
+                /* TODO is this the cleanest way to support a non-app sig on a app hook? */
+                match = DETECT_ENGINE_INSPECT_SIG_MATCH;
             } else {
                 KEYWORD_PROFILING_SET_LIST(det_ctx, engine->sm_list);
                 DEBUG_VALIDATE_BUG_ON(engine->v2.Callback == NULL);

--- a/src/detect.h
+++ b/src/detect.h
@@ -551,6 +551,9 @@ typedef struct SignatureInitData_ {
     bool src_contains_negation;
     bool dst_contains_negation;
 
+    /** see if any of the sigmatches supports an enabled prefilter */
+    bool has_possible_prefilter;
+
     /* used to hold flags that are used during init */
     uint32_t init_flags;
     /* coccinelle: SignatureInitData:init_flags:SIG_FLAG_INIT_ */

--- a/src/detect.h
+++ b/src/detect.h
@@ -538,7 +538,29 @@ typedef struct SignatureInitDataBuffer_ {
     SigMatch *tail;
 } SignatureInitDataBuffer;
 
+enum SignatureHookType {
+    SIGNATURE_HOOK_TYPE_NOT_SET,
+    // SIGNATURE_HOOK_TYPE_PKT,
+    SIGNATURE_HOOK_TYPE_APP,
+};
+
+// dns:request_complete should add DetectBufferTypeGetByName("dns:request_complete");
+// TODO to json
+typedef struct SignatureHook_ {
+    enum SignatureHookType type;
+    union {
+        struct {
+            AppProto alproto;
+            /** progress value of the app-layer hook specified in the rule. Sets the app_proto
+             *  specific progress value. */
+            int app_progress;
+        } app;
+    } t;
+} SignatureHook;
+
 typedef struct SignatureInitData_ {
+    SignatureHook hook;
+
     /** Number of sigmatches. Used for assigning SigMatch::idx */
     uint16_t sm_cnt;
 

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -500,6 +500,6 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 void LogTlsLogRegister(void)
 {
     OutputRegisterTxModuleWithProgress(LOGGER_TLS, MODULE_NAME, "tls-log", LogTlsLogInitCtx,
-            ALPROTO_TLS, LogTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE, LogTlsLogThreadInit,
-            LogTlsLogThreadDeinit);
+            ALPROTO_TLS, LogTlsLogger, TLS_STATE_CLIENT_HANDSHAKE_DONE,
+            TLS_STATE_SERVER_HANDSHAKE_DONE, LogTlsLogThreadInit, LogTlsLogThreadDeinit);
 }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -669,6 +669,6 @@ void JsonTlsLogRegister (void)
 {
     /* register as child of eve-log */
     OutputRegisterTxSubModuleWithProgress(LOGGER_JSON_TX, "eve-log", "JsonTlsLog", "eve-log.tls",
-            OutputTlsLogInitSub, ALPROTO_TLS, JsonTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE,
-            JsonTlsLogThreadInit, JsonTlsLogThreadDeinit);
+            OutputTlsLogInitSub, ALPROTO_TLS, JsonTlsLogger, TLS_STATE_SERVER_HANDSHAKE_DONE,
+            TLS_STATE_CLIENT_HANDSHAKE_DONE, JsonTlsLogThreadInit, JsonTlsLogThreadDeinit);
 }

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -748,8 +748,8 @@ static OutputInitResult OutputLuaLogInit(ConfNode *conf)
         } else if (opts.alproto == ALPROTO_TLS) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_TLS;
-            om->tc_log_progress = TLS_HANDSHAKE_DONE;
-            om->ts_log_progress = TLS_HANDSHAKE_DONE;
+            om->tc_log_progress = TLS_STATE_SERVER_HANDSHAKE_DONE;
+            om->ts_log_progress = TLS_STATE_CLIENT_HANDSHAKE_DONE;
             AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
         } else if (opts.alproto == ALPROTO_DNS) {
             om->TxLogFunc = LuaTxLogger;


### PR DESCRIPTION
Some initial support for rule hooks, where you can specify where the rule should be hooked into the engine.

Currently only:
```
    Generic:
            <app_proto>:request_done and <app_proto>:response_done
    
    Per protocol, it uses the registered progress (state) values. E.g.
    
            tls:client_hello_done
    
    A rule ruleset could be:
    
            pass tls:client_hello_done any any -> any any (tls.sni; content:"www.google.com"; sid:21; alert;)
            drop tls:client_hello_done any any -> any any (sid:22;)
    
    The pass rule is evaluated when the client hello is parsed, and if it
    doesn't match the drop rule will be evaluated.
```

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2239

https://redmine.openinfosecfoundation.org/issues/7485