### PR TITLE
gen/refactor: transform and misc related changes for improved transform support

### DIFF
--- a/rust/src/detect/transforms/casechange.rs
+++ b/rust/src/detect/transforms/casechange.rs
@@ -41,7 +41,7 @@ fn tolower_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn tolower_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn tolower_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -106,7 +106,7 @@ fn toupper_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn toupper_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn toupper_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/compress_whitespace.rs
+++ b/rust/src/detect/transforms/compress_whitespace.rs
@@ -51,7 +51,7 @@ fn compress_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 #[no_mangle]
-unsafe extern "C" fn compress_whitespace_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn compress_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/dotprefix.rs
+++ b/rust/src/detect/transforms/dotprefix.rs
@@ -43,7 +43,7 @@ fn dot_prefix_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn dot_prefix_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn dot_prefix_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input_len = InspectionBufferLength(buffer);
     if input_len == 0 {
         return;

--- a/rust/src/detect/transforms/hash.rs
+++ b/rust/src/detect/transforms/hash.rs
@@ -51,7 +51,7 @@ fn md5_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn md5_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn md5_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -107,7 +107,7 @@ fn sha1_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn sha1_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn sha1_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -163,7 +163,7 @@ fn sha256_transform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn sha256_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn sha256_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/http_headers.rs
+++ b/rust/src/detect/transforms/http_headers.rs
@@ -54,7 +54,7 @@ fn header_lowertransform_do(input: &[u8], output: &mut [u8]) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn header_lowertransform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn header_lowertransform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -120,7 +120,7 @@ fn strip_pseudo_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 #[no_mangle]
-unsafe extern "C" fn strip_pseudo_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_pseudo_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -37,7 +37,7 @@ pub struct SCTransformTableElmt {
     pub flags: u16,
     pub Setup: unsafe extern "C" fn(de: *mut c_void, s: *mut c_void, raw: *const c_char) -> c_int,
     pub Free: Option<unsafe extern "C" fn(de: *mut c_void, ptr: *mut c_void)>,
-    pub Transform: unsafe extern "C" fn(inspect_buf: *mut c_void, options: *mut c_void),
+    pub Transform: unsafe extern "C" fn(det: *mut c_void, inspect_buf: *mut c_void, options: *mut c_void),
     pub TransformValidate:
         Option<unsafe extern "C" fn(content: *const u8, len: u16, context: *mut c_void) -> bool>,
 }

--- a/rust/src/detect/transforms/strip_whitespace.rs
+++ b/rust/src/detect/transforms/strip_whitespace.rs
@@ -48,7 +48,7 @@ fn strip_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 #[no_mangle]
-unsafe extern "C" fn strip_whitespace_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -88,7 +88,7 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
 }
 
 #[no_mangle]
-unsafe extern "C" fn url_decode_transform(buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn url_decode_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -82,7 +82,7 @@ fn xor_transform_do(input: &[u8], output: &mut [u8], ctx: &DetectTransformXorDat
 }
 
 #[no_mangle]
-unsafe extern "C" fn xor_transform(buffer: *mut c_void, ctx: *mut c_void) {
+unsafe extern "C" fn xor_transform(_det: *mut c_void, buffer: *mut c_void, ctx: *mut c_void) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -80,7 +80,7 @@ static InspectionBuffer *GetSMBData(DetectEngineThreadCtx *det_ctx,
         SCLogDebug("have data!");
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -106,7 +106,7 @@ static InspectionBuffer *GetDCEData(DetectEngineThreadCtx *det_ctx,
             buffer->flags |= DETECT_CI_FLAGS_DCE_BE;
         }
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -79,8 +79,8 @@ static InspectionBuffer *GetSMBData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         SCLogDebug("have data!");
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }
@@ -105,8 +105,8 @@ static InspectionBuffer *GetDCEData(DetectEngineThreadCtx *det_ctx,
         } else {
             buffer->flags |= DETECT_CI_FLAGS_DCE_BE;
         }
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -166,8 +166,8 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
         }
 
         SCLogDebug("tx %p data %p data_len %u", tx, tx->buffer, tx->buffer_len);
-        InspectionBufferSetup(det_ctx, list_id, buffer, tx->buffer, tx->buffer_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, tx->buffer, tx->buffer_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-dnp3.c
+++ b/src/detect-dnp3.c
@@ -167,7 +167,7 @@ static InspectionBuffer *GetDNP3Data(DetectEngineThreadCtx *det_ctx,
 
         SCLogDebug("tx %p data %p data_len %u", tx, tx->buffer, tx->buffer_len);
         InspectionBufferSetup(det_ctx, list_id, buffer, tx->buffer, tx->buffer_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-dns-answer-name.c
+++ b/src/detect-dns-answer-name.c
@@ -64,7 +64,7 @@ static InspectionBuffer *GetBuffer(DetectEngineThreadCtx *det_ctx,
         InspectionBufferSetupMultiEmpty(buffer);
         return NULL;
     }
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
     return buffer;
 }

--- a/src/detect-dns-query-name.c
+++ b/src/detect-dns-query-name.c
@@ -64,7 +64,7 @@ static InspectionBuffer *GetBuffer(DetectEngineThreadCtx *det_ctx,
         InspectionBufferSetupMultiEmpty(buffer);
         return NULL;
     }
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
     return buffer;
 }

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -85,7 +85,7 @@ static InspectionBuffer *DnsQueryGetData(DetectEngineThreadCtx *det_ctx,
         InspectionBufferSetupMultiEmpty(buffer);
         return NULL;
     }
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -57,7 +57,7 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -137,8 +137,9 @@ int DetectHelperTransformRegister(const SCTransformTableElmt *kw)
     sigmatch_table[DETECT_TBLSIZE_IDX].desc = kw->desc;
     sigmatch_table[DETECT_TBLSIZE_IDX].url = kw->url;
     sigmatch_table[DETECT_TBLSIZE_IDX].flags = kw->flags;
-    sigmatch_table[DETECT_TBLSIZE_IDX].Transform =
-            (void (*)(InspectionBuffer * buffer, void *options)) kw->Transform;
+    sigmatch_table[DETECT_TBLSIZE_IDX].Transform = (void (*)(
+            struct DetectEngineThreadCtx_ * det_ctx, InspectionBuffer * buffer, void *options))
+                                                           kw->Transform;
     sigmatch_table[DETECT_TBLSIZE_IDX].TransformValidate = (bool (*)(
             const uint8_t *content, uint16_t content_len, void *context))kw->TransformValidate;
     sigmatch_table[DETECT_TBLSIZE_IDX].Setup =
@@ -167,7 +168,7 @@ InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ct
         InspectionBufferSetupMultiEmpty(buffer);
         return NULL;
     }
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
     return buffer;
 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -56,8 +56,7 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         if (!GetBuf(txv, flow_flags, &b, &b_len))
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -113,7 +113,6 @@ void DetectEngineFrameMpmRegister(DetectEngineCtx *de_ctx, const char *name, int
                 const DetectBufferMpmRegistry *mpm_reg, int list_id),
         AppProto alproto, uint8_t type);
 
-
 int PrefilterGenericMpmFrameRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistry *mpm_reg, int list_id);
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -105,6 +105,9 @@ static uint32_t DetectEngineTenantGetIdFromLivedev(const void *ctx, const Packet
 static uint32_t DetectEngineTenantGetIdFromVlanId(const void *ctx, const Packet *p);
 static uint32_t DetectEngineTenantGetIdFromPcap(const void *ctx, const Packet *p);
 
+static inline void InspectionBufferApplyTransformsInternal(
+        DetectEngineThreadCtx *, InspectionBuffer *, const DetectEngineTransforms *);
+
 static DetectEngineAppInspectionEngine *g_app_inspect_engines = NULL;
 static DetectEnginePktInspectionEngine *g_pkt_inspect_engines = NULL;
 static DetectEngineFrameInspectionEngine *g_frame_inspect_engines = NULL;
@@ -1557,6 +1560,27 @@ InspectionBuffer *InspectionBufferMultipleForListGet(
     return buffer;
 }
 
+static inline void InspectionBufferApplyTransformsInternal(DetectEngineThreadCtx *det_ctx,
+        InspectionBuffer *buffer, const DetectEngineTransforms *transforms)
+{
+    if (transforms) {
+        for (int i = 0; i < DETECT_TRANSFORMS_MAX; i++) {
+            const int id = transforms->transforms[i].transform;
+            if (id == 0)
+                break;
+            BUG_ON(sigmatch_table[id].Transform == NULL);
+            sigmatch_table[id].Transform(det_ctx, buffer, transforms->transforms[i].options);
+            SCLogDebug("applied transform %s", sigmatch_table[id].name);
+        }
+    }
+}
+
+void InspectionBufferApplyTransforms(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
+        const DetectEngineTransforms *transforms)
+{
+    InspectionBufferApplyTransformsInternal(det_ctx, buffer, transforms);
+}
+
 void InspectionBufferInit(InspectionBuffer *buffer, uint32_t initial_size)
 {
     memset(buffer, 0, sizeof(*buffer));
@@ -1591,11 +1615,10 @@ void InspectionBufferSetupMulti(DetectEngineThreadCtx *det_ctx, InspectionBuffer
     buffer->len = 0;
     buffer->initialized = true;
 
-    InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+    InspectionBufferApplyTransformsInternal(det_ctx, buffer, transforms);
 }
 
-/** \brief setup the buffer with our initial data */
-void InspectionBufferSetup(DetectEngineThreadCtx *det_ctx, const int list_id,
+static inline void InspectionBufferSetupInternal(DetectEngineThreadCtx *det_ctx, const int list_id,
         InspectionBuffer *buffer, const uint8_t *data, const uint32_t data_len)
 {
 #ifdef DEBUG_VALIDATION
@@ -1612,6 +1635,21 @@ void InspectionBufferSetup(DetectEngineThreadCtx *det_ctx, const int list_id,
     buffer->inspect_len = buffer->orig_len = data_len;
     buffer->len = 0;
     buffer->initialized = true;
+}
+/** \brief setup the buffer with our initial data */
+void InspectionBufferSetup(DetectEngineThreadCtx *det_ctx, const int list_id,
+        InspectionBuffer *buffer, const uint8_t *data, const uint32_t data_len)
+{
+    InspectionBufferSetupInternal(det_ctx, list_id, buffer, data, data_len);
+}
+
+/** \brief setup the buffer with our initial data */
+void InspectionBufferSetupAndApplyTransforms(DetectEngineThreadCtx *det_ctx, const int list_id,
+        InspectionBuffer *buffer, const uint8_t *data, const uint32_t data_len,
+        const DetectEngineTransforms *transforms)
+{
+    InspectionBufferSetupInternal(det_ctx, list_id, buffer, data, data_len);
+    InspectionBufferApplyTransformsInternal(det_ctx, buffer, transforms);
 }
 
 void InspectionBufferFree(InspectionBuffer *buffer)
@@ -1709,21 +1747,6 @@ bool DetectEngineBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_lis
     }
 
     return true;
-}
-
-void InspectionBufferApplyTransforms(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
-        const DetectEngineTransforms *transforms)
-{
-    if (transforms) {
-        for (int i = 0; i < DETECT_TRANSFORMS_MAX; i++) {
-            const int id = transforms->transforms[i].transform;
-            if (id == 0)
-                break;
-            BUG_ON(sigmatch_table[id].Transform == NULL);
-            sigmatch_table[id].Transform(det_ctx, buffer, transforms->transforms[i].options);
-            SCLogDebug("applied transform %s", sigmatch_table[id].name);
-        }
-    }
 }
 
 static void DetectBufferTypeSetupDetectEngine(DetectEngineCtx *de_ctx)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2599,6 +2599,9 @@ DetectEngineCtx *DetectEngineCtxInitWithPrefix(const char *prefix, uint32_t tena
 static void DetectEngineCtxFreeThreadKeywordData(DetectEngineCtx *de_ctx)
 {
     HashListTableFree(de_ctx->keyword_hash);
+#if UNITTESTS
+    de_ctx->keyword_hash = NULL;
+#endif
 }
 
 static void DetectEngineCtxFreeFailedSigs(DetectEngineCtx *de_ctx)
@@ -2671,7 +2674,6 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
 
     MpmFactoryDeRegisterAllMpmCtxProfiles(de_ctx);
 
-    DetectEngineCtxFreeThreadKeywordData(de_ctx);
     SRepDestroy(de_ctx);
     DetectEngineCtxFreeFailedSigs(de_ctx);
 
@@ -2694,6 +2696,7 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     DetectPortCleanupList(de_ctx, de_ctx->udp_priorityports);
 
     DetectBufferTypeFreeDetectEngine(de_ctx);
+    DetectEngineCtxFreeThreadKeywordData(de_ctx);
     SCClassConfDeinit(de_ctx);
     SCReferenceConfDeinit(de_ctx);
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1578,8 +1578,8 @@ void InspectionBufferSetupMultiEmpty(InspectionBuffer *buffer)
 }
 
 /** \brief setup the buffer with our initial data */
-void InspectionBufferSetupMulti(InspectionBuffer *buffer, const DetectEngineTransforms *transforms,
-        const uint8_t *data, const uint32_t data_len)
+void InspectionBufferSetupMulti(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
+        const DetectEngineTransforms *transforms, const uint8_t *data, const uint32_t data_len)
 {
 #ifdef DEBUG_VALIDATION
     DEBUG_VALIDATE_BUG_ON(!buffer->multi);
@@ -1589,7 +1589,7 @@ void InspectionBufferSetupMulti(InspectionBuffer *buffer, const DetectEngineTran
     buffer->len = 0;
     buffer->initialized = true;
 
-    InspectionBufferApplyTransforms(buffer, transforms);
+    InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
 }
 
 /** \brief setup the buffer with our initial data */
@@ -1709,7 +1709,7 @@ bool DetectEngineBufferTypeValidateTransform(DetectEngineCtx *de_ctx, int sm_lis
     return true;
 }
 
-void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
+void InspectionBufferApplyTransforms(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms)
 {
     if (transforms) {
@@ -1718,7 +1718,7 @@ void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
             if (id == 0)
                 break;
             BUG_ON(sigmatch_table[id].Transform == NULL);
-            sigmatch_table[id].Transform(buffer, transforms->transforms[i].options);
+            sigmatch_table[id].Transform(det_ctx, buffer, transforms->transforms[i].options);
             SCLogDebug("applied transform %s", sigmatch_table[id].name);
         }
     }

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -30,6 +30,9 @@
 void InspectionBufferInit(InspectionBuffer *buffer, uint32_t initial_size);
 void InspectionBufferSetup(DetectEngineThreadCtx *det_ctx, const int list_id,
         InspectionBuffer *buffer, const uint8_t *data, const uint32_t data_len);
+void InspectionBufferSetupAndApplyTransforms(DetectEngineThreadCtx *det_ctx, const int list_id,
+        InspectionBuffer *buffer, const uint8_t *data, const uint32_t data_len,
+        const DetectEngineTransforms *transforms);
 void InspectionBufferFree(InspectionBuffer *buffer);
 void *InspectionBufferCheckAndExpand(InspectionBuffer *buffer, uint32_t min_size);
 void InspectionBufferTruncate(InspectionBuffer *buffer, uint32_t buf_len);

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -34,13 +34,13 @@ void InspectionBufferFree(InspectionBuffer *buffer);
 void *InspectionBufferCheckAndExpand(InspectionBuffer *buffer, uint32_t min_size);
 void InspectionBufferTruncate(InspectionBuffer *buffer, uint32_t buf_len);
 void InspectionBufferCopy(InspectionBuffer *buffer, uint8_t *buf, uint32_t buf_len);
-void InspectionBufferApplyTransforms(InspectionBuffer *buffer,
+void InspectionBufferApplyTransforms(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
         const DetectEngineTransforms *transforms);
 void InspectionBufferClean(DetectEngineThreadCtx *det_ctx);
 InspectionBuffer *InspectionBufferGet(DetectEngineThreadCtx *det_ctx, const int list_id);
 void InspectionBufferSetupMultiEmpty(InspectionBuffer *buffer);
-void InspectionBufferSetupMulti(InspectionBuffer *buffer, const DetectEngineTransforms *transforms,
-        const uint8_t *data, const uint32_t data_len);
+void InspectionBufferSetupMulti(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer,
+        const DetectEngineTransforms *transforms, const uint8_t *data, const uint32_t data_len);
 InspectionBuffer *InspectionBufferMultipleForListGet(
         DetectEngineThreadCtx *det_ctx, const int list_id, uint32_t local_id);
 

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -193,7 +193,8 @@ static inline InspectionBuffer *FiledataWithXformsGetDataCallback(DetectEngineTh
         return buffer;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, base_buffer->inspect, base_buffer->inspect_len);
+    InspectionBufferSetupMulti(
+            det_ctx, buffer, transforms, base_buffer->inspect, base_buffer->inspect_len);
     buffer->inspect_offset = base_buffer->inspect_offset;
     SCLogDebug("xformed buffer %p size %u", buffer, buffer->inspect_len);
     SCReturnPtr(buffer, "InspectionBuffer");
@@ -352,7 +353,7 @@ static InspectionBuffer *FiledataGetDataCallback(DetectEngineThreadCtx *det_ctx,
         SCLogDebug("content inspected: %" PRIu64, cur_file->content_inspected);
     }
 
-    InspectionBufferSetupMulti(buffer, NULL, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, NULL, data, data_len);
     SCLogDebug("[list %d] [before] buffer offset %" PRIu64 "; buffer len %" PRIu32
                "; data_len %" PRIu32 "; file_size %" PRIu64,
             list_id, buffer->inspect_offset, buffer->inspect_len, data_len, file_size);

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -291,7 +291,7 @@ static InspectionBuffer *FilemagicGetDataCallback(DetectEngineThreadCtx *det_ctx
     const uint8_t *data = (const uint8_t *)cur_file->magic;
     uint32_t data_len = (uint32_t)strlen(cur_file->magic);
 
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
 
     SCReturnPtr(buffer, "InspectionBuffer");
 }

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -228,7 +228,7 @@ static InspectionBuffer *FilenameGetDataCallback(DetectEngineThreadCtx *det_ctx,
     const uint8_t *data = cur_file->name;
     uint32_t data_len = cur_file->name_len;
 
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
 
     SCReturnPtr(buffer, "InspectionBuffer");
 }

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -203,7 +203,7 @@ static inline InspectionBuffer *HttpRequestBodyXformsGetDataCallback(DetectEngin
 
     InspectionBufferSetup(det_ctx, list_id, buffer, base_buffer->inspect, base_buffer->inspect_len);
     buffer->inspect_offset = base_buffer->inspect_offset;
-    InspectionBufferApplyTransforms(buffer, transforms);
+    InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     SCLogDebug("xformed buffer %p size %u", buffer, buffer->inspect_len);
     SCReturnPtr(buffer, "InspectionBuffer");
 }

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -191,8 +191,8 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -219,8 +219,8 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -240,8 +240,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -261,8 +260,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -192,7 +192,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -220,7 +220,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -241,7 +241,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -262,7 +262,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -155,7 +155,7 @@ static InspectionBuffer *GetBuffer1ForTX(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -176,7 +176,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -154,8 +154,8 @@ static InspectionBuffer *GetBuffer1ForTX(DetectEngineThreadCtx *det_ctx,
         if (rawdata_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, rawdata, rawdata_len, transforms);
     }
 
     return buffer;
@@ -175,8 +175,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -159,8 +159,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -198,8 +197,8 @@ static uint8_t DetectEngineInspectBufferHttpHeader(DetectEngineCtx *de_ctx,
             goto end;
         }
         /* setup buffer and apply transforms */
-        InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, rawdata, rawdata_len, transforms);
     }
 
     const uint32_t data_len = buffer->inspect_len;
@@ -253,8 +252,8 @@ static void PrefilterMpmHttpHeader(DetectEngineThreadCtx *det_ctx, const void *p
             return;
 
         /* setup buffer and apply transforms */
-        InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, ctx->transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, rawdata, rawdata_len, ctx->transforms);
     }
 
     const uint32_t data_len = buffer->inspect_len;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -160,7 +160,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -199,7 +199,7 @@ static uint8_t DetectEngineInspectBufferHttpHeader(DetectEngineCtx *de_ctx,
         }
         /* setup buffer and apply transforms */
         InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     const uint32_t data_len = buffer->inspect_len;
@@ -254,7 +254,7 @@ static void PrefilterMpmHttpHeader(DetectEngineThreadCtx *det_ctx, const void *p
 
         /* setup buffer and apply transforms */
         InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(buffer, ctx->transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, ctx->transforms);
     }
 
     const uint32_t data_len = buffer->inspect_len;
@@ -523,7 +523,7 @@ static InspectionBuffer *GetHttp2HeaderData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, b, b_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");
@@ -601,8 +601,8 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     // hdr_td->len is the number of header buffers
     if (local_id < hdr_td->len) {
         // we have one valid header buffer
-        InspectionBufferSetupMulti(
-                buffer, transforms, hdr_td->items[local_id].buffer, hdr_td->items[local_id].len);
+        InspectionBufferSetupMulti(det_ctx, buffer, transforms, hdr_td->items[local_id].buffer,
+                hdr_td->items[local_id].len);
         buffer->flags = DETECT_CI_FLAGS_SINGLE;
         SCReturnPtr(buffer, "InspectionBuffer");
     } // else there are no more header buffer to get

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -69,7 +69,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -92,7 +92,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -125,7 +125,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -148,7 +148,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -68,8 +68,8 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -91,8 +91,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -124,8 +123,8 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -147,8 +146,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -250,7 +250,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->request_hostname);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -271,7 +271,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -292,7 +292,7 @@ static InspectionBuffer *GetRawData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -363,7 +363,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -249,8 +249,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->request_hostname);
         const uint8_t *data = bstr_ptr(tx->request_hostname);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -270,8 +270,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -291,8 +290,7 @@ static InspectionBuffer *GetRawData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -362,8 +360,8 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
             data_len = bstr_len(tx->parsed_uri->hostname);
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -211,7 +211,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->request_method);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -232,7 +232,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -210,8 +210,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->request_method);
         const uint8_t *data = bstr_ptr(tx->request_method);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -231,8 +231,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -109,7 +109,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -123,7 +123,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     if (buffer->inspect == NULL) {
         InspectionBufferSetup(
                 det_ctx, list_id, buffer, (const uint8_t *)"HTTP/2", strlen("HTTP/2"));
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -108,8 +108,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -121,9 +121,8 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        InspectionBufferSetup(
-                det_ctx, list_id, buffer, (const uint8_t *)"HTTP/2", strlen("HTTP/2"));
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, (const uint8_t *)"HTTP/2", strlen("HTTP/2"), transforms);
     }
 
     return buffer;

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -199,7 +199,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             tx_ud->request_headers_raw_len : tx_ud->response_headers_raw_len;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -220,7 +220,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -198,8 +198,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = ts ?
             tx_ud->request_headers_raw_len : tx_ud->response_headers_raw_len;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -219,8 +219,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -88,7 +88,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -166,7 +166,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->request_line);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -87,8 +87,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -165,8 +164,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->request_line);
         const uint8_t *data = bstr_ptr(tx->request_line);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -88,7 +88,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -165,7 +165,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->response_line);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -87,8 +87,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -164,8 +163,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->response_line);
         const uint8_t *data = bstr_ptr(tx->response_line);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -160,7 +160,7 @@ static InspectionBuffer *GetBuffer1ForTX(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -159,8 +159,8 @@ static InspectionBuffer *GetBuffer1ForTX(DetectEngineThreadCtx *det_ctx,
         if (rawdata_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, rawdata, rawdata_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, rawdata, rawdata_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -169,7 +169,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->response_status);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -192,7 +192,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -168,8 +168,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->response_status);
         const uint8_t *data = bstr_ptr(tx->response_status);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -191,8 +191,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -79,8 +79,8 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        InspectionBufferSetup(det_ctx, list_id, buffer, (const uint8_t *)"", 0);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, (const uint8_t *)"", 0, transforms);
     }
 
     return buffer;
@@ -177,8 +177,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->response_message);
         const uint8_t *data = bstr_ptr(tx->response_message);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -80,7 +80,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
         InspectionBufferSetup(det_ctx, list_id, buffer, (const uint8_t *)"", 0);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -178,7 +178,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->response_message);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -176,7 +176,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(h->value);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -199,7 +199,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -175,8 +175,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(h->value);
         const uint8_t *data = bstr_ptr(h->value);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -198,8 +198,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -237,8 +237,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx_ud->request_uri_normalized);
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;
@@ -260,8 +260,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -328,8 +327,8 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = bstr_len(tx->request_uri);
         const uint8_t *data = bstr_ptr(tx->request_uri);
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -238,7 +238,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -261,7 +261,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -329,7 +329,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = bstr_ptr(tx->request_uri);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -113,7 +113,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)icmpv4h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-icmpv4hdr.c
+++ b/src/detect-icmpv4hdr.c
@@ -112,8 +112,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = hlen;
         const uint8_t *data = (const uint8_t *)icmpv4h;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -117,8 +117,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = hlen;
         const uint8_t *data = (const uint8_t *)icmpv6h;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-icmpv6hdr.c
+++ b/src/detect-icmpv6hdr.c
@@ -118,7 +118,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)icmpv6h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-ike-key-exchange-payload.c
+++ b/src/detect-ike-key-exchange-payload.c
@@ -82,8 +82,7 @@ static InspectionBuffer *GetKeyExchangeData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-key-exchange-payload.c
+++ b/src/detect-ike-key-exchange-payload.c
@@ -83,7 +83,7 @@ static InspectionBuffer *GetKeyExchangeData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-nonce-payload.c
+++ b/src/detect-ike-nonce-payload.c
@@ -83,7 +83,7 @@ static InspectionBuffer *GetNonceData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-nonce-payload.c
+++ b/src/detect-ike-nonce-payload.c
@@ -82,8 +82,7 @@ static InspectionBuffer *GetNonceData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-spi.c
+++ b/src/detect-ike-spi.c
@@ -100,7 +100,7 @@ static InspectionBuffer *GetInitiatorData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -121,7 +121,7 @@ static InspectionBuffer *GetResponderData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-spi.c
+++ b/src/detect-ike-spi.c
@@ -99,8 +99,7 @@ static InspectionBuffer *GetInitiatorData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;
@@ -120,8 +119,7 @@ static InspectionBuffer *GetResponderData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -58,7 +58,7 @@ static InspectionBuffer *IkeVendorGetData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-ipaddr.c
+++ b/src/detect-ipaddr.c
@@ -128,7 +128,7 @@ static InspectionBuffer *GetDataSrc(DetectEngineThreadCtx *det_ctx,
         } else {
             return NULL;
         }
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -152,7 +152,7 @@ static InspectionBuffer *GetDataDst(DetectEngineThreadCtx *det_ctx,
         } else {
             return NULL;
         }
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ipv4hdr.c
+++ b/src/detect-ipv4hdr.c
@@ -113,8 +113,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = hlen;
         const uint8_t *data = (const uint8_t *)ip4h;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ipv4hdr.c
+++ b/src/detect-ipv4hdr.c
@@ -114,7 +114,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)ip4h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -115,7 +115,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)ip6h;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-ipv6hdr.c
+++ b/src/detect-ipv6hdr.c
@@ -114,8 +114,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = hlen;
         const uint8_t *data = (const uint8_t *)ip6h;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-ja4-hash.c
+++ b/src/detect-ja4-hash.c
@@ -148,7 +148,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, 0);
         InspectionBufferCopy(buffer, data, JA4_HEX_LEN);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;
@@ -170,7 +170,7 @@ static InspectionBuffer *Ja4DetectGetHash(DetectEngineThreadCtx *det_ctx,
 
         InspectionBufferSetup(det_ctx, list_id, buffer, NULL, 0);
         InspectionBufferCopy(buffer, (uint8_t *)b, JA4_HEX_LEN);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -73,7 +73,7 @@ static InspectionBuffer *GetKrb5CNameData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, b, b_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -73,7 +73,7 @@ static InspectionBuffer *GetKrb5SNameData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, b, b_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -76,7 +76,7 @@ static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -72,7 +72,7 @@ static InspectionBuffer *QuicStringGetData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, data, data_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-quic-sni.c
+++ b/src/detect-quic-sni.c
@@ -60,7 +60,7 @@ static InspectionBuffer *GetSniData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-quic-sni.c
+++ b/src/detect-quic-sni.c
@@ -59,8 +59,7 @@ static InspectionBuffer *GetSniData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-quic-ua.c
+++ b/src/detect-quic-ua.c
@@ -60,7 +60,7 @@ static InspectionBuffer *GetUaData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-quic-ua.c
+++ b/src/detect-quic-ua.c
@@ -59,8 +59,7 @@ static InspectionBuffer *GetUaData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-quic-version.c
+++ b/src/detect-quic-version.c
@@ -60,7 +60,7 @@ static InspectionBuffer *GetVersionData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-quic-version.c
+++ b/src/detect-quic-version.c
@@ -59,8 +59,7 @@ static InspectionBuffer *GetVersionData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-sip-method.c
+++ b/src/detect-sip-method.c
@@ -118,7 +118,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-sip-method.c
+++ b/src/detect-sip-method.c
@@ -117,8 +117,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-sip-uri.c
+++ b/src/detect-sip-uri.c
@@ -96,8 +96,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-sip-uri.c
+++ b/src/detect-sip-uri.c
@@ -97,7 +97,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-smb-ntlmssp.c
+++ b/src/detect-smb-ntlmssp.c
@@ -68,8 +68,7 @@ static InspectionBuffer *GetNtlmsspUserData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }
@@ -125,8 +124,7 @@ static InspectionBuffer *GetNtlmsspDomainData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-smb-ntlmssp.c
+++ b/src/detect-smb-ntlmssp.c
@@ -69,7 +69,7 @@ static InspectionBuffer *GetNtlmsspUserData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -126,7 +126,7 @@ static InspectionBuffer *GetNtlmsspDomainData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-smb-share.c
+++ b/src/detect-smb-share.c
@@ -69,8 +69,7 @@ static InspectionBuffer *GetNamedPipeData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }
@@ -130,8 +129,7 @@ static InspectionBuffer *GetShareData(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-smb-share.c
+++ b/src/detect-smb-share.c
@@ -70,7 +70,7 @@ static InspectionBuffer *GetNamedPipeData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -131,7 +131,7 @@ static InspectionBuffer *GetShareData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-ssh-hassh-server-string.c
+++ b/src/detect-ssh-hassh-server-string.c
@@ -76,8 +76,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, hassh, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh-server-string.c
+++ b/src/detect-ssh-hassh-server-string.c
@@ -77,7 +77,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -78,7 +78,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, hasshServer, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh-server.c
+++ b/src/detect-ssh-hassh-server.c
@@ -77,8 +77,8 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, hasshServer, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, hasshServer, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh-string.c
+++ b/src/detect-ssh-hassh-string.c
@@ -60,7 +60,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
         const uint8_t flow_flags, void *txv, const int list_id)
 {
-    
+
     SCEnter();
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
@@ -76,8 +76,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, hassh, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh-string.c
+++ b/src/detect-ssh-hassh-string.c
@@ -77,7 +77,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -78,7 +78,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-hassh.c
+++ b/src/detect-ssh-hassh.c
@@ -61,7 +61,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         const DetectEngineTransforms *transforms, Flow *_f,
         const uint8_t flow_flags, void *txv, const int list_id)
 {
-    
+
     SCEnter();
 
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
@@ -77,8 +77,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, hassh, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, hassh, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-proto.c
+++ b/src/detect-ssh-proto.c
@@ -75,7 +75,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, protocol, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-proto.c
+++ b/src/detect-ssh-proto.c
@@ -74,8 +74,8 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, protocol, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, protocol, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -75,7 +75,7 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
         }
 
         InspectionBufferSetup(det_ctx, list_id, buffer, software, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-ssh-software.c
+++ b/src/detect-ssh-software.c
@@ -74,8 +74,8 @@ static InspectionBuffer *GetSshData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, software, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, software, b_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -115,8 +115,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = hlen;
         const uint8_t *data = (const uint8_t *)tcph;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tcphdr.c
+++ b/src/detect-tcphdr.c
@@ -116,7 +116,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)tcph;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-alpn.c
+++ b/src/detect-tls-alpn.c
@@ -141,7 +141,7 @@ static InspectionBuffer *TlsAlpnGetData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, a->alpn, a->size);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, a->alpn, a->size);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -151,8 +151,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(connp->cert0_fingerprint);
         const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -152,7 +152,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -141,7 +141,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -140,8 +140,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(connp->cert0_issuerdn);
         const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -150,8 +150,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(connp->cert0_serial);
         const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -151,7 +151,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -142,8 +142,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(connp->cert0_subject);
         const uint8_t *data = (uint8_t *)connp->cert0_subject;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -143,7 +143,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)connp->cert0_subject;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -101,7 +101,7 @@ static InspectionBuffer *TlsCertsGetData(DetectEngineThreadCtx *det_ctx,
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, cert->cert_data, cert->cert_len);
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, cert->cert_data, cert->cert_len);
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -171,8 +171,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(ssl_state->client_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_hash;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -172,7 +172,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_hash;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -162,7 +162,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_str->data;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -161,8 +161,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(ssl_state->client_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_str->data;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -170,7 +170,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_hash;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -169,8 +169,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(ssl_state->server_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_hash;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -161,8 +161,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(ssl_state->server_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_str->data;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -162,7 +162,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_str->data;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-random.c
+++ b/src/detect-tls-random.c
@@ -223,7 +223,7 @@ static InspectionBuffer *GetRandomTimeData(DetectEngineThreadCtx *det_ctx,
             data = ssl_state->server_connp.random;
         }
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -250,7 +250,7 @@ static InspectionBuffer *GetRandomBytesData(DetectEngineThreadCtx *det_ctx,
             data = ssl_state->server_connp.random + DETECT_TLS_RANDOM_TIME_LEN;
         }
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -277,7 +277,7 @@ static InspectionBuffer *GetRandomData(DetectEngineThreadCtx *det_ctx,
             data = ssl_state->server_connp.random;
         }
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/detect-tls-random.c
+++ b/src/detect-tls-random.c
@@ -222,8 +222,8 @@ static InspectionBuffer *GetRandomTimeData(DetectEngineThreadCtx *det_ctx,
         } else {
             data = ssl_state->server_connp.random;
         }
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }
@@ -249,8 +249,8 @@ static InspectionBuffer *GetRandomBytesData(DetectEngineThreadCtx *det_ctx,
         } else {
             data = ssl_state->server_connp.random + DETECT_TLS_RANDOM_TIME_LEN;
         }
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }
@@ -276,8 +276,8 @@ static InspectionBuffer *GetRandomData(DetectEngineThreadCtx *det_ctx,
         } else {
             data = ssl_state->server_connp.random;
         }
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
     return buffer;
 }

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -123,7 +123,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.sni;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -122,8 +122,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = strlen(ssl_state->client_connp.sni);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.sni;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-tls-subjectaltname.c
+++ b/src/detect-tls-subjectaltname.c
@@ -121,7 +121,7 @@ static InspectionBuffer *TlsSubjectAltNameGetData(DetectEngineThreadCtx *det_ctx
         return NULL;
     }
 
-    InspectionBufferSetupMulti(buffer, transforms, (const uint8_t *)connp->cert0_sans[idx],
+    InspectionBufferSetupMulti(det_ctx, buffer, transforms, (const uint8_t *)connp->cert0_sans[idx],
             strlen(connp->cert0_sans[idx]));
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -42,7 +42,8 @@ static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
-static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options);
+static void TransformFromBase64Decode(
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
 
 #define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) Base64ModeRFC4648
 
@@ -113,7 +114,8 @@ exit_path:
     SCReturnInt(r);
 }
 
-static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options)
+static void TransformFromBase64Decode(
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options)
 {
     SCDetectTransformFromBase64Data *b64d = options;
     const uint8_t *input = buffer->inspect;
@@ -171,7 +173,7 @@ static int DetectTransformFromBase64DecodeTest01(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -192,7 +194,7 @@ static int DetectTransformFromBase64DecodeTest01a(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -212,7 +214,7 @@ static int DetectTransformFromBase64DecodeTest02(void)
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     buffer_orig = buffer;
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_offset == buffer_orig.inspect_offset);
     FAIL_IF_NOT(buffer.inspect_len == buffer_orig.inspect_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -234,7 +236,7 @@ static int DetectTransformFromBase64DecodeTest03(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
@@ -255,7 +257,7 @@ static int DetectTransformFromBase64DecodeTest04(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(strncmp((const char *)input, (const char *)buffer.inspect, input_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);
@@ -279,7 +281,7 @@ static int DetectTransformFromBase64DecodeTest05(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -304,7 +306,7 @@ static int DetectTransformFromBase64DecodeTest06(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -328,7 +330,7 @@ static int DetectTransformFromBase64DecodeTest07(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == result_len);
     FAIL_IF_NOT(strncmp(result, (const char *)buffer.inspect, result_len) == 0);
     PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
@@ -349,7 +351,7 @@ static int DetectTransformFromBase64DecodeTest08(void)
     InspectionBufferInit(&buffer, input_len);
     InspectionBufferSetup(NULL, -1, &buffer, input, input_len);
     // PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
-    TransformFromBase64Decode(&buffer, &b64d);
+    TransformFromBase64Decode(NULL, &buffer, &b64d);
     FAIL_IF_NOT(buffer.inspect_len == 15);
     // PrintRawDataFp(stdout, buffer.inspect, buffer.inspect_len);
     InspectionBufferFree(&buffer);

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -38,7 +38,8 @@ typedef struct DetectTransformPcrexformData {
 
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformPcrexformFree(DetectEngineCtx *, void *);
-static void DetectTransformPcrexform(InspectionBuffer *buffer, void *options);
+static void DetectTransformPcrexform(
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
 #ifdef UNITTESTS
 void DetectTransformPcrexformRegisterTests (void);
 #endif
@@ -132,7 +133,8 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
     SCReturnInt(r);
 }
 
-static void DetectTransformPcrexform(InspectionBuffer *buffer, void *options)
+static void DetectTransformPcrexform(
+        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options)
 {
     const char *input = (const char *)buffer->inspect;
     const uint32_t input_len = buffer->inspect_len;

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -111,8 +111,8 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint32_t data_len = UDP_HEADER_LEN;
         const uint8_t *data = (const uint8_t *)udph;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(
+                det_ctx, list_id, buffer, data, data_len, transforms);
     }
 
     return buffer;

--- a/src/detect-udphdr.c
+++ b/src/detect-udphdr.c
@@ -112,7 +112,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = (const uint8_t *)udph;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
 
     return buffer;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1498,6 +1498,10 @@ static void DetectRunTx(ThreadVars *tv,
         }
         tx_id_min = tx.tx_id + 1; // next look for cur + 1
 
+        det_ctx->tx_id = tx.tx_id;
+        det_ctx->tx_id_set = true;
+        det_ctx->p = p;
+
         bool do_sort = false; // do we need to sort the tx candidate list?
         uint32_t array_idx = 0;
         uint32_t total_rules = det_ctx->match_array_cnt;
@@ -1590,9 +1594,6 @@ static void DetectRunTx(ThreadVars *tv,
         if (array_idx >= de_ctx->profile_match_logging_threshold)
             RulesDumpTxMatchArray(det_ctx, scratch->sgh, p, tx.tx_id, array_idx, x);
 #endif
-        det_ctx->tx_id = tx.tx_id;
-        det_ctx->tx_id_set = true;
-        det_ctx->p = p;
 
 #ifdef DEBUG
         for (uint32_t i = 0; i < array_idx; i++) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1286,7 +1286,7 @@ typedef struct SigTableElmt_ {
         uint8_t flags, File *, const Signature *, const SigMatchCtx *);
 
     /** InspectionBuffer transformation callback */
-    void (*Transform)(InspectionBuffer *, void *context);
+    void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
     bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
 
     /** keyword setup function pointer */

--- a/src/util-hashlist.h
+++ b/src/util-hashlist.h
@@ -42,10 +42,16 @@ typedef struct HashListTable_ {
     uint32_t (*Hash)(struct HashListTable_ *, void *, uint16_t);
     char (*Compare)(void *, uint16_t, void *, uint16_t);
     void (*Free)(void *);
+    void (*FreeWithCtx)(void *, void *);
 } HashListTable;
 
 /* prototypes */
 HashListTable* HashListTableInit(uint32_t, uint32_t (*Hash)(struct HashListTable_ *, void *, uint16_t), char (*Compare)(void *, uint16_t, void *, uint16_t), void (*Free)(void *));
+HashListTable *HashListTableInitWithCtx(uint32_t,
+        uint32_t (*Hash)(struct HashListTable_ *, void *, uint16_t),
+        char (*Compare)(void *, uint16_t, void *, uint16_t), void (*FreeWithCtx)(void *, void *));
+
+void HashListTableFreeWithCtx(void *, HashListTable *);
 void HashListTableFree(HashListTable *);
 int HashListTableAdd(HashListTable *, void *, uint16_t);
 int HashListTableRemove(HashListTable *, void *, uint16_t);

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -278,7 +278,7 @@ InspectionBuffer *Ja3DetectGetHash(DetectEngineThreadCtx *det_ctx,
 
         InspectionBufferSetup(det_ctx, list_id, buffer, NULL, 0);
         InspectionBufferCopy(buffer, ja3_hash, SC_MD5_HEX_LEN);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }
@@ -298,7 +298,7 @@ InspectionBuffer *Ja3DetectGetString(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(buffer, transforms);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
     }
     return buffer;
 }

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -297,8 +297,7 @@ InspectionBuffer *Ja3DetectGetString(DetectEngineThreadCtx *det_ctx,
         if (b == NULL || b_len == 0)
             return NULL;
 
-        InspectionBufferSetup(det_ctx, list_id, buffer, b, b_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
     }
     return buffer;
 }


### PR DESCRIPTION
Continuation of #12426


A set of changes from #12425 that improve transform support

Describe changes:
- Detection engine thread context pointer now available to individual transform functions
- Detect engine context available to transform free function
- Defer memory release of keyword hash table until engine context has been reed
- Make packet/tx_id available earlier
- Refactor transform setup/apply pattern from 2 to 1 function: InspectionBufferSetupAndApplyTransforms

Updates:
- Formatting fixup

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
