### PR TITLE
http: prepare libhtp.rs aliases for htp opaque htp_header_t

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -26,7 +26,6 @@
 
 #include "suricata-common.h"
 #include "app-layer-htp-file.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer-htp-range.h"
 #include "app-layer-events.h"
 #include "util-validate.h"

--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -124,6 +124,14 @@
 #define htp_tx_request_header(tx, header)  htp_table_get_c(tx->request_headers, header)
 #define htp_tx_response_header(tx, header) htp_table_get_c(tx->response_headers, header)
 
+// Functions introduced to handle opaque htp_header_t
+#define htp_header_name_len(h)  bstr_len(h->name)
+#define htp_header_name_ptr(h)  bstr_ptr(h->name)
+#define htp_header_name(h)      h->name
+#define htp_header_value_len(h) bstr_len(h->value)
+#define htp_header_value_ptr(h) bstr_ptr(h->value)
+#define htp_header_value(h)     h->value
+
 bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, bool uri_include_all);
 
 #endif /* SURICATA_APP_LAYER_HTP_LIBHTP__H */

--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -121,6 +121,9 @@
 #define htp_tx_response_progress(tx)        tx->response_progress
 #define htp_tx_response_protocol_number(tx) tx->response_protocol_number
 
+#define htp_tx_request_header(tx, header)  htp_table_get_c(tx->request_headers, header)
+#define htp_tx_response_header(tx, header) htp_table_get_c(tx->response_headers, header)
+
 bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, bool uri_include_all);
 
 #endif /* SURICATA_APP_LAYER_HTP_LIBHTP__H */

--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -27,7 +27,6 @@
 
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer-htp-xff.h"
 
 #ifndef HAVE_MEMRCHR

--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -141,7 +141,7 @@ int HttpXFFGetIPFromTx(const Flow *f, uint64_t tx_id, HttpXFFCfg *xff_cfg,
 
     htp_header_t *h_xff = NULL;
     if (htp_tx_request_headers(tx) != NULL) {
-        h_xff = htp_table_get_c(htp_tx_request_headers(tx), xff_cfg->header);
+        h_xff = htp_tx_request_header(tx, xff_cfg->header);
     }
 
     if (h_xff != NULL && bstr_len(h_xff->value) >= XFF_CHAIN_MINLEN &&

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -974,8 +974,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
             case HTP_STREAM_STATE_TUNNEL:
                 tx = htp_connp_get_out_tx(hstate->connp);
                 if (tx != NULL && htp_tx_response_status_number(tx) == 101) {
-                    htp_header_t *h =
-                            (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), "Upgrade");
+                    htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Upgrade");
                     if (h == NULL) {
                         break;
                     }
@@ -1141,7 +1140,7 @@ static int HTTPParseContentDispositionHeader(uint8_t *name, size_t name_len,
  */
 static int HtpRequestBodySetupMultipart(htp_tx_t *tx, HtpTxUserData *htud)
 {
-    htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "Content-Type");
+    htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Content-Type");
     if (h != NULL && bstr_len(h->value) > 0) {
         htud->mime_state = SCMimeStateInit(bstr_ptr(h->value), (uint32_t)bstr_len(h->value));
         if (htud->mime_state) {
@@ -1362,8 +1361,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
         size_t filename_len = 0;
 
         /* try Content-Disposition header first */
-        htp_header_t *h =
-                (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), "Content-Disposition");
+        htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Content-Disposition");
         if (h != NULL && bstr_len(h->value) > 0) {
             /* parse content-disposition */
             (void)HTTPParseContentDispositionHeader((uint8_t *)"filename=", 9,
@@ -1381,8 +1379,7 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
 
         if (filename != NULL) {
             // set range if present
-            htp_header_t *h_content_range =
-                    htp_table_get_c(htp_tx_response_headers(tx), "content-range");
+            htp_header_t *h_content_range = htp_tx_response_header(tx, "content-range");
             if (filename_len > SC_FILENAME_MAX) {
                 // explicitly truncate the file name if too long
                 filename_len = SC_FILENAME_MAX;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -983,7 +983,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
                         dp = (uint16_t)htp_tx_request_port_number(tx);
                     }
                     consumed = (uint32_t)htp_connp_res_data_consumed(hstate->connp);
-                    if (bstr_cmp_c(h->value, "h2c") == 0) {
+                    if (bstr_cmp_c(htp_header_value(h), "h2c") == 0) {
                         if (AppLayerProtoDetectGetProtoName(ALPROTO_HTTP2) == NULL) {
                             // if HTTP2 is disabled, keep the HTP_STREAM_STATE_TUNNEL mode
                             break;
@@ -999,7 +999,7 @@ static AppLayerResult HTPHandleResponseData(Flow *f, void *htp_state, AppLayerPa
                             SCReturnStruct(APP_LAYER_INCOMPLETE(consumed, input_len - consumed));
                         }
                         SCReturnStruct(APP_LAYER_OK);
-                    } else if (bstr_cmp_c_nocase(h->value, "WebSocket") == 0) {
+                    } else if (bstr_cmp_c_nocase(htp_header_value(h), "WebSocket") == 0) {
                         if (AppLayerProtoDetectGetProtoName(ALPROTO_WEBSOCKET) == NULL) {
                             // if WS is disabled, keep the HTP_STREAM_STATE_TUNNEL mode
                             break;
@@ -1141,8 +1141,9 @@ static int HTTPParseContentDispositionHeader(uint8_t *name, size_t name_len,
 static int HtpRequestBodySetupMultipart(htp_tx_t *tx, HtpTxUserData *htud)
 {
     htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Content-Type");
-    if (h != NULL && bstr_len(h->value) > 0) {
-        htud->mime_state = SCMimeStateInit(bstr_ptr(h->value), (uint32_t)bstr_len(h->value));
+    if (h != NULL && htp_header_value_len(h) > 0) {
+        htud->mime_state =
+                SCMimeStateInit(htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
         if (htud->mime_state) {
             htud->tsflags |= HTP_BOUNDARY_SET;
             SCReturnInt(1);
@@ -1362,10 +1363,11 @@ static int HtpResponseBodyHandle(HtpState *hstate, HtpTxUserData *htud,
 
         /* try Content-Disposition header first */
         htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Content-Disposition");
-        if (h != NULL && bstr_len(h->value) > 0) {
+        if (h != NULL && htp_header_value_len(h) > 0) {
             /* parse content-disposition */
             (void)HTTPParseContentDispositionHeader((uint8_t *)"filename=", 9,
-                    (uint8_t *) bstr_ptr(h->value), bstr_len(h->value), &filename, &filename_len);
+                    (uint8_t *)htp_header_value_ptr(h), htp_header_value_len(h), &filename,
+                    &filename_len);
         }
 
         /* fall back to name from the uri */
@@ -2943,7 +2945,7 @@ static int HTPParserTest01(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0"));
+    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -2987,7 +2989,7 @@ static int HTPParserTest01b(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0"));
+    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -3042,7 +3044,7 @@ static int HTPParserTest01c(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0"));
+    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -3098,7 +3100,7 @@ static int HTPParserTest01a(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    FAIL_IF(strcmp(bstr_util_strdup_to_c(h->value), "Victor/1.0"));
+    FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_POST);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
 
@@ -3639,11 +3641,11 @@ static int HTPParserTest10(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    char *name = bstr_util_strdup_to_c(h->name);
+    char *name = bstr_util_strdup_to_c(htp_header_name(h));
     FAIL_IF_NULL(name);
-    FAIL_IF(strcmp(name, "Host") != 0);
+    FAIL_IF(strcmp(htp_header_name(h), "Host") != 0);
 
-    char *value = bstr_util_strdup_to_c(h->value);
+    char *value = bstr_util_strdup_to_c(htp_header_value(h));
     FAIL_IF_NULL(value);
     FAIL_IF(strcmp(value, "www.google.com") != 0);
 
@@ -3817,11 +3819,11 @@ static int HTPParserTest13(void)
     htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
     FAIL_IF_NULL(h);
 
-    char *name = bstr_util_strdup_to_c(h->name);
+    char *name = bstr_util_strdup_to_c(htp_header_name(h));
     FAIL_IF_NULL(name);
     FAIL_IF(strcmp(name, "Host") != 0);
 
-    char *value = bstr_util_strdup_to_c(h->value);
+    char *value = bstr_util_strdup_to_c(htp_header_value(h));
     FAIL_IF_NULL(value);
     FAIL_IF(strcmp(value, "www.google.com\rName: Value") != 0);
 

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -37,6 +37,10 @@
 #include "app-layer-frames.h"
 
 #include <htp/htp.h>
+// Temporary include directly app-layer-htp-libhtp.h
+// This helps libhtp.rs transition by making small steps
+// app-layer-htp-libhtp.h will be removed with libhtp.rs final merge
+#include "app-layer-htp-libhtp.h"
 
 /* default request body limit */
 #define HTP_CONFIG_DEFAULT_REQUEST_BODY_LIMIT           4096U

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -33,7 +33,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer-http2.h"
 #include "rust.h"
 

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -93,7 +93,7 @@ void HTTP2MimicHttp1Request(void *alstate_orig, void *h2s)
     size_t nbheaders = htp_table_size(htp_tx_request_headers(h1tx));
     for (size_t i = 0; i < nbheaders; i++) {
         htp_header_t *h = htp_table_get_index(htp_tx_request_headers(h1tx), i, NULL);
-        rs_http2_tx_add_header(h2s, bstr_ptr(h->name), (uint32_t)bstr_len(h->name),
-                bstr_ptr(h->value), (uint32_t)bstr_len(h->value));
+        rs_http2_tx_add_header(h2s, htp_header_name_ptr(h), (uint32_t)htp_header_name_len(h),
+                htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
     }
 }

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -40,7 +40,6 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer-smtp.h"
 
 #include "flow.h"

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -58,7 +58,6 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-client-body.h"
 #include "stream-tcp.h"
 #include "util-profiling.h"

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -181,13 +181,13 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Cookie");
-        if (h == NULL || h->value == NULL) {
+        if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
-        const uint8_t *data = bstr_ptr(h->value);
+        const uint32_t data_len = htp_header_value_len(h);
+        const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);
@@ -208,13 +208,13 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Set-Cookie");
-        if (h == NULL || h->value == NULL) {
+        if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
-        const uint8_t *data = bstr_ptr(h->value);
+        const uint32_t data_len = htp_header_value_len(h);
+        const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -57,7 +57,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-cookie.h"
 #include "stream-tcp.h"
 

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -180,7 +180,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "Cookie");
+        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Cookie");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;
@@ -207,8 +207,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h =
-                (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), "Set-Cookie");
+        htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Set-Cookie");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -106,7 +106,7 @@ static uint8_t *GetBufferForTX(
     size_t no_of_headers = htp_table_size(headers);
     for (; i < no_of_headers; i++) {
         htp_header_t *h = htp_table_get_index(headers, i, NULL);
-        size_t size = bstr_size(h->name) + 2; // for \r\n
+        size_t size = htp_header_name_len(h) + 2; // for \r\n
         if (i == 0)
             size += 2;
         if (i + 1 == no_of_headers)
@@ -126,8 +126,8 @@ static uint8_t *GetBufferForTX(
             buf->buffer[buf->len++] = '\n';
         }
 
-        memcpy(buf->buffer + buf->len, bstr_ptr(h->name), bstr_size(h->name));
-        buf->len += bstr_size(h->name);
+        memcpy(buf->buffer + buf->len, htp_header_name_ptr(h), htp_header_name_len(h));
+        buf->len += htp_header_name_len(h);
         buf->buffer[buf->len++] = '\r';
         buf->buffer[buf->len++] = '\n';
 

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -60,7 +60,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -54,7 +54,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-header.h"
 #include "detect-http-header-common.h"
 

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -98,17 +98,15 @@ static uint8_t *GetBufferForTX(
     size_t no_of_headers = htp_table_size(headers);
     for (; i < no_of_headers; i++) {
         htp_header_t *h = htp_table_get_index(headers, i, NULL);
-        size_t size1 = bstr_size(h->name);
-        size_t size2 = bstr_size(h->value);
+        size_t size1 = htp_header_name_len(h);
+        size_t size2 = htp_header_value_len(h);
 
         if (flags & STREAM_TOSERVER) {
-            if (size1 == 6 &&
-                SCMemcmpLowercase("cookie", bstr_ptr(h->name), 6) == 0) {
+            if (size1 == 6 && SCMemcmpLowercase("cookie", htp_header_name_ptr(h), 6) == 0) {
                 continue;
             }
         } else {
-            if (size1 == 10 &&
-                SCMemcmpLowercase("set-cookie", bstr_ptr(h->name), 10) == 0) {
+            if (size1 == 10 && SCMemcmpLowercase("set-cookie", htp_header_name_ptr(h), 10) == 0) {
                 continue;
             }
         }
@@ -124,12 +122,12 @@ static uint8_t *GetBufferForTX(
             }
         }
 
-        memcpy(buf->buffer + buf->len, bstr_ptr(h->name), bstr_size(h->name));
-        buf->len += bstr_size(h->name);
+        memcpy(buf->buffer + buf->len, htp_header_name_ptr(h), htp_header_name_len(h));
+        buf->len += htp_header_name_len(h);
         buf->buffer[buf->len++] = ':';
         buf->buffer[buf->len++] = ' ';
-        memcpy(buf->buffer + buf->len, bstr_ptr(h->value), bstr_size(h->value));
-        buf->len += bstr_size(h->value);
+        memcpy(buf->buffer + buf->len, htp_header_value_ptr(h), htp_header_value_len(h));
+        buf->len += htp_header_value_len(h);
         buf->buffer[buf->len++] = '\r';
         buf->buffer[buf->len++] = '\n';
 #if 0 // looks like this breaks existing rules
@@ -576,8 +574,8 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
         }
         for (size_t i = 0; i < no_of_headers; i++) {
             htp_header_t *h = htp_table_get_index(headers, i, NULL);
-            size_t size1 = bstr_size(h->name);
-            size_t size2 = bstr_size(h->value);
+            size_t size1 = htp_header_name_len(h);
+            size_t size2 = htp_header_value_len(h);
             size_t size = size1 + size2 + 2;
             if (hdr_td->items[i].len < size) {
                 // Use realloc, as this pointer is not freed until HttpMultiBufHeaderThreadDataFree
@@ -587,10 +585,10 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
                 }
                 hdr_td->items[i].buffer = tmp;
             }
-            memcpy(hdr_td->items[i].buffer, bstr_ptr(h->name), size1);
+            memcpy(hdr_td->items[i].buffer, htp_header_name_ptr(h), size1);
             hdr_td->items[i].buffer[size1] = ':';
             hdr_td->items[i].buffer[size1 + 1] = ' ';
-            memcpy(hdr_td->items[i].buffer + size1 + 2, bstr_ptr(h->value), size2);
+            memcpy(hdr_td->items[i].buffer + size1 + 2, htp_header_value_ptr(h), size2);
             hdr_td->items[i].len = size;
         }
         hdr_td->len = no_of_headers;

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -57,7 +57,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), HEADER_NAME);
+        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, HEADER_NAME);
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);
@@ -112,7 +112,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_response_headers(tx), HEADER_NAME);
+        htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, HEADER_NAME);
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -58,14 +58,14 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, HEADER_NAME);
-        if (h == NULL || h->value == NULL) {
+        if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
-        const uint8_t *data = bstr_ptr(h->value);
+        const uint32_t data_len = htp_header_value_len(h);
+        const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);
@@ -113,14 +113,14 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, HEADER_NAME);
-        if (h == NULL || h->value == NULL) {
+        if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
-        const uint8_t *data = bstr_ptr(h->value);
+        const uint32_t data_len = htp_header_value_len(h);
+        const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -349,7 +349,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
             if (htp_tx_request_headers(tx) == NULL)
                 return NULL;
 
-            htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "Host");
+            htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Host");
             if (h == NULL || h->value == NULL)
                 return NULL;
 

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -55,7 +55,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "stream-tcp.h"
 #include "detect-http-host.h"
 

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -350,11 +350,11 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
                 return NULL;
 
             htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Host");
-            if (h == NULL || h->value == NULL)
+            if (h == NULL || htp_header_value(h) == NULL)
                 return NULL;
 
-            data = (const uint8_t *)bstr_ptr(h->value);
-            data_len = bstr_len(h->value);
+            data = (const uint8_t *)htp_header_value_ptr(h);
+            data_len = htp_header_value_len(h);
         } else {
             data = (const uint8_t *)bstr_ptr(tx->parsed_uri->hostname);
             data_len = bstr_len(tx->parsed_uri->hostname);

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -55,7 +55,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-method.h"
 #include "stream-tcp.h"
 

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -60,7 +60,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -51,7 +51,6 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-raw-header.h"
 
 static int DetectHttpRawHeaderSetup(DetectEngineCtx *, Signature *, const char *);

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -57,7 +57,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "stream-tcp.h"
 #include "detect-http-request-line.h"
 

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -57,7 +57,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "stream-tcp.h"
 #include "detect-http-response-line.h"
 

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -118,8 +118,8 @@ static uint8_t *GetBufferForTX(
     size_t no_of_headers = htp_table_size(headers);
     for (; i < no_of_headers; i++) {
         htp_header_t *h = htp_table_get_index(headers, i, NULL);
-        size_t size1 = bstr_size(h->name);
-        size_t size2 = bstr_size(h->value);
+        size_t size1 = htp_header_name_len(h);
+        size_t size2 = htp_header_value_len(h);
         size_t size = size1 + size2 + 4;
         if (i + 1 == no_of_headers)
             size += 2;
@@ -129,12 +129,12 @@ static uint8_t *GetBufferForTX(
             }
         }
 
-        memcpy(buf->buffer + buf->len, bstr_ptr(h->name), bstr_size(h->name));
-        buf->len += bstr_size(h->name);
+        memcpy(buf->buffer + buf->len, htp_header_name_ptr(h), htp_header_name_len(h));
+        buf->len += htp_header_name_len(h);
         buf->buffer[buf->len++] = ':';
         buf->buffer[buf->len++] = ' ';
-        memcpy(buf->buffer + buf->len, bstr_ptr(h->value), bstr_size(h->value));
-        buf->len += bstr_size(h->value);
+        memcpy(buf->buffer + buf->len, htp_header_value_ptr(h), htp_header_value_len(h));
+        buf->len += htp_header_value_len(h);
         buf->buffer[buf->len++] = '\r';
         buf->buffer[buf->len++] = '\n';
         if (i + 1 == no_of_headers) {

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -59,7 +59,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-header.h"
 #include "stream-tcp.h"
 

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -58,7 +58,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-stat-code.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp.h"

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -58,7 +58,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-stat-msg.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp.h"

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -56,7 +56,6 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "stream-tcp.h"
 #include "detect-http-ua.h"
 

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -165,13 +165,13 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
 
         htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "User-Agent");
-        if (h == NULL || h->value == NULL) {
+        if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP UA header not present in this request");
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(h->value);
-        const uint8_t *data = bstr_ptr(h->value);
+        const uint32_t data_len = htp_header_value_len(h);
+        const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetup(det_ctx, list_id, buffer, data, data_len);
         InspectionBufferApplyTransforms(buffer, transforms);

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -164,7 +164,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_table_get_c(htp_tx_request_headers(tx), "User-Agent");
+        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "User-Agent");
         if (h == NULL || h->value == NULL) {
             SCLogDebug("HTTP UA header not present in this request");
             return NULL;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -53,7 +53,6 @@
 #include "app-layer.h"
 
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "detect-http-uri.h"
 #include "stream-tcp.h"
 

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -48,7 +48,6 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 
 #include "stream-tcp.h"
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -61,7 +61,6 @@
 #include "app-layer-protos.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 
 #include "util-classification-config.h"
 #include "util-unittest.h"

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -41,7 +41,6 @@
 #include "output.h"
 #include "log-httplog.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "util-privs.h"

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -229,7 +229,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
             case LOG_HTTP_CF_REQUEST_HEADER:
             /* REQUEST HEADER */
             if (htp_tx_request_headers(tx) != NULL) {
-                h_request_hdr = htp_table_get_c(htp_tx_request_headers(tx), node->data);
+                h_request_hdr = htp_tx_request_header(tx, node->data);
             }
                 if (h_request_hdr != NULL) {
                     datalen = node->maxlen;
@@ -246,7 +246,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
             case LOG_HTTP_CF_REQUEST_COOKIE:
             /* REQUEST COOKIE */
             if (htp_tx_request_headers(tx) != NULL) {
-                h_request_hdr = htp_table_get_c(htp_tx_request_headers(tx), "Cookie");
+                h_request_hdr = htp_tx_request_header(tx, "Cookie");
                 if (h_request_hdr != NULL) {
                     cvalue_len = GetCookieValue((uint8_t *)bstr_ptr(h_request_hdr->value),
                             (uint32_t)bstr_len(h_request_hdr->value), (char *)node->data, &cvalue);
@@ -281,7 +281,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
             case LOG_HTTP_CF_RESPONSE_HEADER:
             /* RESPONSE HEADER */
             if (htp_tx_response_headers(tx) != NULL) {
-                h_response_hdr = htp_table_get_c(htp_tx_response_headers(tx), node->data);
+                h_response_hdr = htp_tx_response_header(tx, node->data);
             }
                 if (h_response_hdr != NULL) {
                     datalen = node->maxlen;
@@ -317,7 +317,7 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
     /* referer */
     htp_header_t *h_referer = NULL;
     if (htp_tx_request_headers(tx) != NULL) {
-        h_referer = htp_table_get_c(htp_tx_request_headers(tx), "referer");
+        h_referer = htp_tx_request_header(tx, "referer");
     }
     if (h_referer != NULL) {
         PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
@@ -355,7 +355,7 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
         /* Redirect? */
         if ((htp_tx_response_status_number(tx) > 300) &&
                 ((htp_tx_response_status_number(tx)) < 303)) {
-            htp_header_t *h_location = htp_table_get_c(htp_tx_response_headers(tx), "location");
+            htp_header_t *h_location = htp_tx_response_header(tx, "location");
             if (h_location != NULL) {
                 MemBufferWriteString(aft->buffer, " => ");
 
@@ -450,7 +450,7 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
         /* user agent */
         htp_header_t *h_user_agent = NULL;
         if (htp_tx_request_headers(tx) != NULL) {
-            h_user_agent = htp_table_get_c(htp_tx_request_headers(tx), "user-agent");
+            h_user_agent = htp_tx_request_header(tx, "user-agent");
         }
         if (h_user_agent != NULL) {
             PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -333,7 +333,7 @@ static void EveHttpLogJSONHeaders(
                     if (((http_ctx->flags & LOG_HTTP_EXTENDED) == 0) ||
                             ((http_ctx->flags & LOG_HTTP_EXTENDED) !=
                                     (http_fields[f].flags & LOG_HTTP_EXTENDED))) {
-                        if (bstr_cmp_c_nocase(h->name, http_fields[f].htp_field) == 0) {
+                        if (bstr_cmp_c_nocase(htp_header_name(h), http_fields[f].htp_field) == 0) {
                             tolog = true;
                             break;
                         }
@@ -346,14 +346,16 @@ static void EveHttpLogJSONHeaders(
         }
         array_empty = false;
         jb_start_object(js);
-        size_t size_name = bstr_len(h->name) < MAX_SIZE_HEADER_NAME - 1 ?
-            bstr_len(h->name) : MAX_SIZE_HEADER_NAME - 1;
-        memcpy(name, bstr_ptr(h->name), size_name);
+        size_t size_name = htp_header_name_len(h) < MAX_SIZE_HEADER_NAME - 1
+                                   ? htp_header_name_len(h)
+                                   : MAX_SIZE_HEADER_NAME - 1;
+        memcpy(name, htp_header_name_ptr(h), size_name);
         name[size_name] = '\0';
         jb_set_string(js, "name", name);
-        size_t size_value = bstr_len(h->value) < MAX_SIZE_HEADER_VALUE - 1 ?
-            bstr_len(h->value) : MAX_SIZE_HEADER_VALUE - 1;
-        memcpy(value, bstr_ptr(h->value), size_value);
+        size_t size_value = htp_header_value_len(h) < MAX_SIZE_HEADER_VALUE - 1
+                                    ? htp_header_value_len(h)
+                                    : MAX_SIZE_HEADER_VALUE - 1;
+        memcpy(value, htp_header_value_ptr(h), size_value);
         value[size_value] = '\0';
         jb_set_string(js, "value", value);
         jb_close(js);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -220,15 +220,14 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 
     if (htp_tx_request_headers(tx) != NULL) {
         /* user agent */
-        htp_header_t *h_user_agent = htp_table_get_c(htp_tx_request_headers(tx), "user-agent");
+        htp_header_t *h_user_agent = htp_tx_request_header(tx, "user-agent");
         if (h_user_agent != NULL) {
             jb_set_string_from_bytes(js, "http_user_agent", bstr_ptr(h_user_agent->value),
                     (uint32_t)bstr_len(h_user_agent->value));
         }
 
         /* x-forwarded-for */
-        htp_header_t *h_x_forwarded_for =
-                htp_table_get_c(htp_tx_request_headers(tx), "x-forwarded-for");
+        htp_header_t *h_x_forwarded_for = htp_tx_request_header(tx, "x-forwarded-for");
         if (h_x_forwarded_for != NULL) {
             jb_set_string_from_bytes(js, "xff", bstr_ptr(h_x_forwarded_for->value),
                     (uint32_t)bstr_len(h_x_forwarded_for->value));
@@ -237,7 +236,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
 
     /* content-type */
     if (htp_tx_response_headers(tx) != NULL) {
-        htp_header_t *h_content_type = htp_table_get_c(htp_tx_response_headers(tx), "content-type");
+        htp_header_t *h_content_type = htp_tx_response_header(tx, "content-type");
         if (h_content_type != NULL) {
             const size_t size = bstr_len(h_content_type->value) * 2 + 1;
             char string[size];
@@ -247,8 +246,7 @@ static void EveHttpLogJSONBasic(JsonBuilder *js, htp_tx_t *tx)
                 *p = '\0';
             jb_set_string(js, "http_content_type", string);
         }
-        htp_header_t *h_content_range =
-                htp_table_get_c(htp_tx_response_headers(tx), "content-range");
+        htp_header_t *h_content_range = htp_tx_response_header(tx, "content-range");
         if (h_content_range != NULL) {
             jb_open_object(js, "content_range");
             jb_set_string_from_bytes(js, "raw", bstr_ptr(h_content_range->value),
@@ -272,7 +270,7 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
     /* referer */
     htp_header_t *h_referer = NULL;
     if (htp_tx_request_headers(tx) != NULL) {
-        h_referer = htp_table_get_c(htp_tx_request_headers(tx), "referer");
+        h_referer = htp_tx_request_header(tx, "referer");
     }
     if (h_referer != NULL) {
         jb_set_string_from_bytes(
@@ -302,7 +300,7 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
                 (uint32_t)bstr_len(htp_tx_response_status(tx)));
     }
 
-    htp_header_t *h_location = htp_table_get_c(htp_tx_response_headers(tx), "location");
+    htp_header_t *h_location = htp_tx_response_header(tx, "location");
     if (h_location != NULL) {
         jb_set_string_from_bytes(
                 js, "redirect", bstr_ptr(h_location->value), (uint32_t)bstr_len(h_location->value));

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -39,7 +39,6 @@
 
 #include "output.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer-htp-file.h"
 #include "app-layer-htp-xff.h"
 #include "app-layer.h"

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -38,7 +38,6 @@
 
 #include "output.h"
 #include "app-layer-htp.h"
-#include "app-layer-htp-libhtp.h"
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "util-privs.h"

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -138,7 +138,7 @@ static int HttpGetResponseLine(lua_State *luastate)
         return LuaCallbackError(luastate, "no response_line");
 
     return LuaPushStringBuffer(
-            luastate, bstr_ptr(htp_tx_response_line(tx)), bstr_len(tx->response_line));
+            luastate, bstr_ptr(htp_tx_response_line(tx)), bstr_len(htp_tx_response_line(tx)));
 }
 
 static int HttpGetHeader(lua_State *luastate, int dir)

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -161,11 +161,10 @@ static int HttpGetHeader(lua_State *luastate, int dir)
         return LuaCallbackError(luastate, "tx has no headers");
 
     htp_header_t *h = (htp_header_t *)htp_table_get_c(headers, name);
-    if (h == NULL || bstr_len(h->value) == 0)
+    if (h == NULL || htp_header_value_len(h) == 0)
         return LuaCallbackError(luastate, "header not found");
 
-    return LuaPushStringBuffer(luastate,
-            bstr_ptr(h->value), bstr_len(h->value));
+    return LuaPushStringBuffer(luastate, htp_header_value_ptr(h), htp_header_value_len(h));
 }
 
 static int HttpGetRequestHeader(lua_State *luastate)
@@ -236,8 +235,8 @@ static int HttpGetHeaders(lua_State *luastate, int dir)
     size_t no_of_headers = htp_table_size(table);
     for (; i < no_of_headers; i++) {
         h = htp_table_get_index(table, i, NULL);
-        LuaPushStringBuffer(luastate, bstr_ptr(h->name), bstr_len(h->name));
-        LuaPushStringBuffer(luastate, bstr_ptr(h->value), bstr_len(h->value));
+        LuaPushStringBuffer(luastate, htp_header_name_ptr(h), htp_header_name_len(h));
+        LuaPushStringBuffer(luastate, htp_header_value_ptr(h), htp_header_value_len(h));
         lua_settable(luastate, -3);
     }
     return 1;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/2696

Describe changes:
- prepare libhtp-rs by defining aliases for the new values used by libhtp-rs

This allow to go one small step further

The big libhtp-rs commit will remove app-layer-htp-libhtp.h which defines these aliases

https://github.com/OISF/suricata/pull/12419 next round