### PR TITLE
lua: expose hash function to lua scripts - v1

### DIFF
--- a/doc/userguide/lua/index.rst
+++ b/doc/userguide/lua/index.rst
@@ -5,3 +5,4 @@ Lua support
 
    lua-usage
    lua-functions
+   libs/index

--- a/doc/userguide/lua/libs/hashlib.rst
+++ b/doc/userguide/lua/libs/hashlib.rst
@@ -1,0 +1,97 @@
+Hashing
+-------
+
+Hashing functions are expose to Lua scripts with ``suricata.hashing``
+library. For example::
+
+  local hashing = require("suricata.hashing")
+
+SHA-256
+~~~~~~~
+
+``sha256_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+SHA-256 hash the provided string returning the digest as bytes.
+
+``sha256_hex_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+SHA-256 hash the provided string returning the digest as a hex string.
+
+``sha256()``
+^^^^^^^^^^^^
+
+Returns a SHA-256 hasher that can updated multiple times, for example::
+
+  local hashing = require("suricata.hashing")
+  hasher = hashing.sha256()
+  hasher.update("www.suricata")
+  hasher.update(".io")
+  hash = hasher.finalize_to_hex()
+
+The methods on the hasher object include:
+
+* ``update(string)``: Add more data to the hasher
+* ``finalize()``: Finalize the hash returning the hash as a byte string
+* ``finalize_to_hex()``: Finalize the hash returning the has as a hex string
+
+SHA-1
+~~~~~
+
+``sha1_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+SHA-1 hash the provided string returning the digest as bytes.
+
+``sha1_hex_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+SHA-1 hash the provided string returning the digest as a hex string.
+
+``sha1()``
+^^^^^^^^^^
+
+Returns a SHA-1 hasher that can updated multiple times, for example::
+
+  local hashing = require("suricata.hashing")
+  hasher = hashing.sha1()
+  hasher.update("www.suricata")
+  hasher.update(".io")
+  hash = hasher.finalize_to_hex()
+
+The methods on the hasher object include:
+
+* ``update(string)``: Add more data to the hasher
+* ``finalize()``: Finalize the hash returning the hash as a byte string
+* ``finalize_to_hex()``: Finalize the hash returning the has as a hex string
+
+MD5
+~~~
+
+``md5_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^
+
+MD5 hash the provided string returning the digest as bytes.
+
+``md5_hex_digest(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MD5 hash the provided string returning the digest as a hex string.
+
+``md5()``
+^^^^^^^^^
+
+Returns a MD5 hasher that can updated multiple times, for example::
+
+  local hashing = require("suricata.hashing")
+  hasher = hashing.md5()
+  hasher.update("www.suricata")
+  hasher.update(".io")
+  hash = hasher.finalize_to_hex()
+
+The methods on the hasher object include:
+
+* ``update(string)``: Add more data to the hasher
+* ``finalize()``: Finalize the hash returning the hash as a byte string
+* ``finalize_to_hex()``: Finalize the hash returning the has as a hex string

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -1,0 +1,11 @@
+Lua Libraries
+=============
+
+Suricata provides Lua extensions, or libraries to Lua scripts with the
+``require`` keyword. These extensions are particular important in Lua
+rules as Lua rules are executed in a restricted sandbox environment
+without access to additional modules.
+
+.. toctree::
+
+   hashlib

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -512,6 +512,7 @@ noinst_HEADERS = \
 	util-lua-dnp3-objects.h \
 	util-lua-dns.h \
 	util-lua.h \
+	util-lua-hashlib.h \
 	util-lua-hassh.h \
 	util-lua-http.h \
 	util-lua-ja3.h \
@@ -1060,6 +1061,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-dnp3.c \
 	util-lua-dnp3-objects.c \
 	util-lua-dns.c \
+	util-lua-hashlib.c \
 	util-lua-hassh.c \
 	util-lua-http.c \
 	util-lua-ja3.c \

--- a/src/util-lua-hashlib.c
+++ b/src/util-lua-hashlib.c
@@ -27,17 +27,16 @@
  * -- One shot hash
  * hash = hashing.sha256_digest("www.suricata.io")
  *
+ * -- One shot hash to hex
+ * hash = hashing.sha256_hexdigest("www.suricata.io")
+ *
  * -- Incremental hashing
  * hasher = hashing.sha256()
  * hasher:update("www.")
  * hasher:update("suricata.io")
  * hash = hasher:finalize()
  *
- * Support hashes:
- *
- * - sha256: sha256(), sha256_digest()
- * - sha1: sha1(), sha1_digest()
- * - md5: md5(), md5_digest()
+ * Support hashes: sha256, sha1, md5
  */
 
 #include "util-lua-hashlib.h"

--- a/src/util-lua-hashlib.c
+++ b/src/util-lua-hashlib.c
@@ -1,0 +1,393 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * Hashing library for Lua.
+ *
+ * Usage:
+ *
+ * local hashing = require("suricata.hashing")
+ *
+ * -- One shot hash
+ * hash = hashing.sha256_digest("www.suricata.io")
+ *
+ * -- Incremental hashing
+ * hasher = hashing.sha256()
+ * hasher:update("www.")
+ * hasher:update("suricata.io")
+ * hash = hasher:finalize()
+ *
+ * Support hashes:
+ *
+ * - sha256: sha256(), sha256_digest()
+ * - sha1: sha1(), sha1_digest()
+ * - md5: md5(), md5_digest()
+ */
+
+#include "util-lua-hashlib.h"
+
+#include "lauxlib.h"
+#include "rust-bindings.h"
+
+#define SHA256_MT "suricata:hashlib:sha256"
+#define SHA1_MT   "suricata:hashlib:sha1"
+#define MD5_MT    "suricata:hashlib:md5"
+
+/**
+ * \brief Create a new SHA-256 hash instance.
+ */
+static int LuaHashLibSha256New(lua_State *L)
+{
+    struct SCSha256 **hasher = lua_newuserdata(L, sizeof(struct SCSha256 *));
+    *hasher = SCSha256New();
+    luaL_getmetatable(L, SHA256_MT);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+/**
+ * \brief Add more data to an existing SHA-256 hash instance.
+ */
+static int LuaHashLibSha256Update(lua_State *L)
+{
+    struct SCSha256 **hasher = luaL_checkudata(L, 1, SHA256_MT);
+    size_t data_len;
+    const char *data = luaL_checklstring(L, 2, &data_len);
+    SCSha256Update(*hasher, (const uint8_t *)data, data_len);
+    return 0;
+}
+
+static int LuaHashLibSha256Finalize(lua_State *L)
+{
+    struct SCSha256 **hasher = luaL_checkudata(L, 1, SHA256_MT);
+    uint8_t hash[SC_SHA256_LEN];
+
+    SCSha256Finalize(*hasher, hash, sizeof(hash));
+    lua_pushlstring(L, (const char *)hash, sizeof(hash));
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibSha256FinalizeToHex(lua_State *L)
+{
+    struct SCSha256 **hasher = luaL_checkudata(L, 1, SHA256_MT);
+    char hash[SC_SHA256_HEX_LEN + 1];
+
+    if (!SCSha256FinalizeToHex(*hasher, hash, sizeof(hash))) {
+        *hasher = NULL;
+        return luaL_error(L, "sha256 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)hash);
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibSha256Digest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    size_t output_len = SC_SHA256_LEN;
+    uint8_t output[output_len];
+    if (!SCSha256HashBuffer((uint8_t *)input, (uint32_t)buf_len, output, output_len)) {
+        SCLogNotice("ERROR");
+        return luaL_error(L, "sha256 hashing failed");
+    }
+
+    lua_pushlstring(L, (const char *)output, output_len);
+
+    return 1;
+}
+
+static int LuaHashLibSha256HexDigest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    char output[SC_SHA256_HEX_LEN + 1];
+    if (!SCSha256HashBufferToHex((uint8_t *)input, (uint32_t)buf_len, output, sizeof(output))) {
+        return luaL_error(L, "sha256 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)output);
+    return 1;
+}
+
+static int LuaHashLibSha256Gc(lua_State *L)
+{
+    struct SCSha256 **hasher = luaL_checkudata(L, 1, SHA256_MT);
+    if (*hasher) {
+        SCSha256Free(*hasher);
+    }
+    return 0;
+}
+
+static int LuaHashLibSha1New(lua_State *L)
+{
+    struct SCSha1 **hasher = lua_newuserdata(L, sizeof(struct SCSha1 *));
+    *hasher = SCSha1New();
+    luaL_getmetatable(L, SHA1_MT);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+static int LuaHashLibSha1Update(lua_State *L)
+{
+    struct SCSha1 **hasher = luaL_checkudata(L, 1, SHA1_MT);
+    size_t data_len;
+    const char *data = luaL_checklstring(L, 2, &data_len);
+    SCSha1Update(*hasher, (const uint8_t *)data, data_len);
+    return 0;
+}
+
+static int LuaHashLibSha1Finalize(lua_State *L)
+{
+    struct SCSha1 **hasher = luaL_checkudata(L, 1, SHA1_MT);
+    uint8_t hash[SC_SHA1_LEN];
+
+    SCSha1Finalize(*hasher, hash, sizeof(hash));
+    lua_pushlstring(L, (const char *)hash, sizeof(hash));
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibSha1FinalizeToHex(lua_State *L)
+{
+    struct SCSha1 **hasher = luaL_checkudata(L, 1, SHA1_MT);
+    char hash[SC_SHA1_HEX_LEN + 1];
+
+    if (!SCSha1FinalizeToHex(*hasher, hash, sizeof(hash))) {
+        *hasher = NULL;
+        return luaL_error(L, "sha1 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)hash);
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibSha1Digest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    uint8_t output[SC_SHA1_LEN];
+    if (!SCSha1HashBuffer((uint8_t *)input, (uint32_t)buf_len, output, sizeof(output))) {
+        return luaL_error(L, "sha1 hashing failed");
+    }
+
+    lua_pushlstring(L, (const char *)output, sizeof(output));
+    return 1;
+}
+
+static int LuaHashLibSha1HexDigest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    char output[SC_SHA1_HEX_LEN + 1];
+    if (!SCSha1HashBufferToHex((uint8_t *)input, (uint32_t)buf_len, output, sizeof(output))) {
+        return luaL_error(L, "sha1 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)output);
+    return 1;
+}
+
+static int LuaHashLibSha1Gc(lua_State *L)
+{
+    struct SCSha1 **hasher = luaL_checkudata(L, 1, SHA1_MT);
+    if (*hasher) {
+        SCSha1Free(*hasher);
+    }
+    return 0;
+}
+
+static int LuaHashLibMd5New(lua_State *L)
+{
+    struct SCMd5 **hasher = lua_newuserdata(L, sizeof(struct SCMd5 *));
+    *hasher = SCMd5New();
+    luaL_getmetatable(L, MD5_MT);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+static int LuaHashLibMd5Update(lua_State *L)
+{
+    struct SCMd5 **hasher = luaL_checkudata(L, 1, MD5_MT);
+    size_t data_len;
+    const char *data = luaL_checklstring(L, 2, &data_len);
+    SCMd5Update(*hasher, (const uint8_t *)data, data_len);
+    return 0;
+}
+
+static int LuaHashLibMd5Finalize(lua_State *L)
+{
+    struct SCMd5 **hasher = luaL_checkudata(L, 1, MD5_MT);
+    uint8_t hash[SC_MD5_LEN];
+
+    SCMd5Finalize(*hasher, hash, sizeof(hash));
+    lua_pushlstring(L, (const char *)hash, sizeof(hash));
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibMd5FinalizeToHex(lua_State *L)
+{
+    struct SCMd5 **hasher = luaL_checkudata(L, 1, MD5_MT);
+    char hash[SC_MD5_HEX_LEN + 1];
+
+    if (!SCMd5FinalizeToHex(*hasher, hash, sizeof(hash))) {
+        *hasher = NULL;
+        return luaL_error(L, "md5 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)hash);
+
+    // Finalize consumes the hasher, so set to NULL so its not free'd
+    // during garbage collection.
+    *hasher = NULL;
+
+    return 1;
+}
+
+static int LuaHashLibMd5Digest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    uint8_t output[SC_MD5_LEN];
+    if (!SCMd5HashBuffer((uint8_t *)input, (uint32_t)buf_len, output, sizeof(output))) {
+        return luaL_error(L, "md5 hashing failed");
+    }
+
+    lua_pushlstring(L, (const char *)output, sizeof(output));
+    return 1;
+}
+
+static int LuaHashLibMd5HexDigest(lua_State *L)
+{
+    size_t buf_len;
+    const char *input = luaL_checklstring(L, 1, &buf_len);
+
+    char output[SC_MD5_HEX_LEN + 1];
+    if (!SCMd5HashBufferToHex((uint8_t *)input, (size_t)buf_len, output, sizeof(output))) {
+        return luaL_error(L, "md5 hashing failed");
+    }
+
+    lua_pushstring(L, (const char *)output);
+    return 1;
+}
+
+static int LuaHashLibMd5Gc(lua_State *L)
+{
+    struct SCMd5 **hasher = luaL_checkudata(L, 1, MD5_MT);
+    if (*hasher) {
+        SCMd5Free(*hasher);
+    }
+    return 0;
+}
+
+static const struct luaL_Reg hashlib[] = {
+    // clang-format off
+    { "sha256_digest", LuaHashLibSha256Digest },
+    { "sha256_hexdigest", LuaHashLibSha256HexDigest },
+    { "sha256", LuaHashLibSha256New },
+    { "sha1_digest", LuaHashLibSha1Digest },
+    { "sha1_hexdigest", LuaHashLibSha1HexDigest },
+    { "sha1", LuaHashLibSha1New },
+    { "md5_digest", LuaHashLibMd5Digest },
+    { "md5_hexdigest", LuaHashLibMd5HexDigest },
+    { "md5", LuaHashLibMd5New },
+    { NULL, NULL },
+    // clang-format on
+};
+
+static const struct luaL_Reg sha256_meta[] = {
+    // clang-format off
+    { "update", LuaHashLibSha256Update },
+    { "finalize", LuaHashLibSha256Finalize },
+    { "finalize_to_hex", LuaHashLibSha256FinalizeToHex },
+    { "__gc", LuaHashLibSha256Gc },
+    { NULL, NULL },
+    // clang-format on
+};
+
+static const struct luaL_Reg sha1_meta[] = {
+    // clang-format off
+    { "update", LuaHashLibSha1Update },
+    { "finalize", LuaHashLibSha1Finalize },
+    { "finalize_to_hex", LuaHashLibSha1FinalizeToHex },
+    { "__gc", LuaHashLibSha1Gc },
+    { NULL, NULL },
+    // clang-format on
+};
+
+static const struct luaL_Reg md5_meta[] = {
+    // clang-format off
+    { "update", LuaHashLibMd5Update },
+    { "finalize", LuaHashLibMd5Finalize },
+    { "finalize_to_hex", LuaHashLibMd5FinalizeToHex },
+    { "__gc", LuaHashLibMd5Gc },
+    { NULL, NULL },
+    // clang-format on
+};
+
+int SCLuaLoadHashlib(lua_State *L)
+{
+    luaL_newmetatable(L, SHA256_MT);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, sha256_meta, 0);
+
+    luaL_newmetatable(L, SHA1_MT);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, sha1_meta, 0);
+
+    luaL_newmetatable(L, MD5_MT);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, md5_meta, 0);
+
+    luaL_newlib(L, hashlib);
+
+    return 1;
+}

--- a/src/util-lua-hashlib.h
+++ b/src/util-lua-hashlib.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_UTIL_LUA_HASHLIB_H
+#define SURICATA_UTIL_LUA_HASHLIB_H
+
+#include "rust.h"
+#include "lua.h"
+
+int SCLuaLoadHashlib(lua_State *l);
+
+#endif /* SURICATA_UTIL_LUA_HASHLIB_H */

--- a/src/util-lua-sandbox.c
+++ b/src/util-lua-sandbox.c
@@ -29,9 +29,9 @@
 #include "util-debug.h"
 
 #include "util-debug.h"
-#include "util-validate.h"
 #include "util-lua-sandbox.h"
 #include "util-lua-dataset.h"
+#include "util-lua-hashlib.h"
 
 #define SANDBOX_CTX "SANDBOX_CTX"
 
@@ -266,6 +266,9 @@ static int SCLuaSbRequire(lua_State *L)
 
     if (strcmp(module_name, "suricata.dataset") == 0) {
         LuaLoadDatasetLib(L);
+        return 1;
+    } else if (strcmp(module_name, "suricata.hashlib") == 0) {
+        SCLuaLoadHashlib(L);
         return 1;
     }
 


### PR DESCRIPTION
Expose md5, sha1, and sha256 to Lua scripts with
`require("suricata.hashing")`.

Draft as a few things are missing:
- Documentation
- Hex variations

But does the API look OK? I put them all into the "suricata.hashing" namespace.
But we could also do something like `require("suricata.hashing.md5")` to be
more fine grained.

Ticket: https://redmine.openinfosecfoundation.org/issues/7073

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2247

