### PR TITLE
detect/csum: rm interaction btw stream setting/csum

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -82,6 +82,14 @@ Major changes
 - Unknown requirements in the ``requires`` keyword will now be treated
   as unmet requirements, causing the rule to not be loaded. See
   :ref:`keyword_requires`.
+- The configuration setting controlling stream checksum checks no longer affects
+  checksum keyword validation. Previously, when ``stream.checksum-validation``
+  was set to ``no``, the checksum keywords (e.g., ``ipv4-csum``, ``tcpv4-csum``, etc)
+  would either match or not match according to the value used with the checksum keyword.
+  Previous behavior would return a match when ``ipv4-csum: valid`` was specified and
+  not match if ``ipv4-csum: invalid`` was used. With 8.0, a match will occur based on the
+  computed checksum and the value (``valid`` or ``invalid``) agree.
+
 
 Removals
 ~~~~~~~~

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5958,11 +5958,7 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueueNoLock *pq)
                 StatsIncr(tv, stt->counter_tcp_invalid_checksum);
                 return TM_ECODE_OK;
             }
-        } else {
-            p->flags |= PKT_IGNORE_CHECKSUM;
         }
-    } else {
-        p->flags |= PKT_IGNORE_CHECKSUM; //TODO check that this is set at creation
     }
     AppLayerProfilingReset(stt->ra_ctx->app_tctx);
 


### PR DESCRIPTION
Continuation of #12432 

Issue: 7467

Stream checksum validation no longer has a side effect of setting PKT_IGNORE_CHECKSUM and thus, no longer affects csum keyword checks.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/7467

Describe changes:
- During stream checksum validation checks, no longer set PKT_IGNORE_CHECKSUM

Updates:
- Add a note to the upgrade document describing the behavioral change.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2241
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
