### PR TITLE
rust plugins: provide bindings to register eve filetype plugins - v1

### DIFF
--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -39,6 +39,7 @@ extern {
     fn ConfGetChildValueBool(conf: *const c_void, key: *const c_char,
                              vptr: *mut c_int) -> i8;
     fn ConfGetNode(key: *const c_char) -> *const c_void;
+    fn ConfNodeLookupChild(node: *const c_void, name: *const c_char) -> *const c_void;
 }
 
 pub fn conf_get_node(key: &str) -> Option<ConfNode> {
@@ -142,6 +143,22 @@ impl ConfNode {
         return false;
     }
 
+    // Get a child node of this node by name.
+    //
+    // Wrapper around ConfNodeLookupChild.
+    //
+    // Returns None if the child is not found.
+    pub fn get_child(&self, name: &str) -> Option<ConfNode> {
+        unsafe {
+            let name = CString::new(name).unwrap();
+            let child = ConfNodeLookupChild(self.conf, name.as_ptr());
+            if child.is_null() {
+                None
+            } else {
+                Some(ConfNode { conf: child })
+            }
+        }
+    }
 }
 
 const BYTE: u64       = 1;

--- a/rust/src/ffi/eve.rs
+++ b/rust/src/ffi/eve.rs
@@ -1,0 +1,79 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Bindings to Suricata C EVE related functions such as creating a
+//! filetype.
+
+use std::ffi::{c_char, c_int, c_void, CString};
+
+/// cbindgen:ignore
+extern "C" {
+    pub fn SCRegisterEveFileType(filetype: *const EveFileType) -> bool;
+}
+
+pub type EveFileInitFn =
+    unsafe extern "C" fn(conf: *const c_void, threaded: bool, init_data: *mut *mut c_void) -> c_int;
+pub type EveFileDeinitFn = unsafe extern "C" fn(init_data: *const c_void);
+pub type EveFileWriteFn = unsafe extern "C" fn(
+    buffer: *const c_char,
+    buffer_len: c_int,
+    init_data: *const c_void,
+    thread_data: *const c_void,
+) -> c_int;
+pub type EveFileThreadInitFn = unsafe extern "C" fn(
+    init_data: *const c_void,
+    thread_id: std::os::raw::c_int,
+    thread_data: *mut *mut c_void,
+) -> c_int;
+pub type EveFileThreadDeinitFn =
+    unsafe extern "C" fn(init_data: *const c_void, thread_data: *mut c_void);
+
+/// Rust equivalent to C SCEveFileType.
+///
+/// NOTE: Needs to be kept in sync with SCEveFileType.
+///
+/// cbindgen:ignore
+#[repr(C)]
+pub struct EveFileType {
+    name: *const c_char,
+    open: EveFileInitFn,
+    thread_init: EveFileThreadInitFn,
+    write: EveFileWriteFn,
+    thread_deinit: EveFileThreadDeinitFn,
+    close: EveFileDeinitFn,
+    pad: [usize; 2],
+}
+
+impl EveFileType {
+    pub fn new(
+        name: &str, open: EveFileInitFn, close: EveFileDeinitFn, write: EveFileWriteFn,
+        thread_init: EveFileThreadInitFn, thread_deinit: EveFileThreadDeinitFn,
+    ) -> *const Self {
+        // Convert the name to C and forget.
+        let name = CString::new(name).unwrap().into_raw();
+        let file_type = Self {
+            name,
+            open,
+            close,
+            write,
+            thread_init,
+            thread_deinit,
+            pad: [0, 0],
+        };
+        Box::into_raw(Box::new(file_type))
+    }
+}

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -20,3 +20,4 @@
 pub mod hashing;
 pub mod base64;
 pub mod strings;
+pub mod eve;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -83,7 +83,7 @@ extern crate suricata_derive;
 pub mod core;
 
 #[macro_use]
-pub(crate) mod debug;
+pub mod debug;
 
 pub mod common;
 pub mod conf;

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -17,6 +17,36 @@
 
 //! Plugin utility module.
 
+use std::ffi::{c_char, CString};
+
+/// Rust representation of a C plugin.
+///
+/// Mirror of SCPlugin from C and they should be kept in sync.
+#[repr(C)]
+pub struct SCPlugin {
+    name: *const c_char,
+    license: *const c_char,
+    author: *const c_char,
+    init: unsafe extern "C" fn(),
+}
+
+impl SCPlugin {
+    pub fn new(
+        name: &str, license: &str, author: &str, init_fn: unsafe extern "C" fn(),
+    ) -> *const Self {
+        let name = CString::new(name).unwrap();
+        let license = CString::new(license).unwrap();
+        let author = CString::new(author).unwrap();
+        let plugin = SCPlugin {
+            name: name.into_raw(),
+            license: license.into_raw(),
+            author: author.into_raw(),
+            init: init_fn,
+        };
+        Box::into_raw(Box::new(plugin))
+    }
+}
+
 pub fn init() {
     unsafe {
         let context = crate::core::SCGetContext();

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -19,9 +19,9 @@
 
 pub fn init() {
     unsafe {
-        let context = super::core::SCGetContext();
-        super::core::init_ffi(context);
+        let context = crate::core::SCGetContext();
+        crate::core::init_ffi(context);
 
-        super::debug::SCSetRustLogLevel(super::debug::SCLogGetLogLevel());
+        crate::debug::LEVEL = crate::debug::SCLogGetLogLevel();
     }
 }

--- a/src/output-eve.h
+++ b/src/output-eve.h
@@ -70,6 +70,9 @@ typedef uint32_t ThreadId;
  * may be naturally thread safe. However, if sharing a single file
  * handle across all threads then your filetype will have to take care
  * of locking, etc.
+ *
+ * NOTE: This data structure needs to be kept in sync with the Rust
+ *     mirror of it in rust/src/ffi/eve.rs.
  */
 typedef struct SCEveFileType_ {
     /**

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -31,6 +31,8 @@
 
 /**
  * Structure to define a Suricata plugin.
+ *
+ * Needs to be kept in sync with SCPlugin in Rust as well.
  */
 typedef struct SCPlugin_ {
     const char *name;


### PR DESCRIPTION
First, fix some breaking changes done in the visibility cleanups with respect to Rust plugins and using our log macros.

But primarily, add Rust bindings to our C EVE filetype registration. For 7.0 my Redis example plugin provided its own bindings, (see https://github.com/jasonish/suricata-redis-output/blob/main/src/ffi.rs), but ideally those should be provided by Suricata.

This patch brings enough bindings over to register EVE filetypes such as a Redis output without having to provide any custom C bindings itself.