### PR TITLE
detect/integers: add support for negated strings when enum is used - v2

### DIFF
--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -19,7 +19,7 @@ use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag, tag_no_case, take_while};
 use nom7::character::complete::{char, digit1, hex_digit1};
 use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
-use nom7::error::{make_error, ErrorKind};
+use nom7::error::{make_error, Error, ErrorKind};
 use nom7::Err;
 use nom7::IResult;
 
@@ -58,15 +58,24 @@ pub struct DetectUintData<T> {
 /// And if this fails, will resort to using the enumeration strings.
 ///
 /// Returns Some DetectUintData on success, None on failure
-pub fn detect_parse_uint_enum<T1: DetectIntType, T2: EnumString<T1>>(s: &str) -> Option<DetectUintData<T1>> {
+pub fn detect_parse_uint_enum<T1: DetectIntType, T2: EnumString<T1>>(
+    s: &str,
+) -> Option<DetectUintData<T1>> {
     if let Ok((_, ctx)) = detect_parse_uint::<T1>(s) {
         return Some(ctx);
     }
+
+    let (s, neg) = opt::<&str, _, Error<_>, _>(char('!'))(s).ok()?;
+    let mode = if neg.is_some() {
+        DetectUintMode::DetectUintModeNe
+    } else {
+        DetectUintMode::DetectUintModeEqual
+    };
     if let Some(enum_val) = T2::from_str(s) {
         let ctx = DetectUintData::<T1> {
             arg1: enum_val.into_u(),
             arg2: T1::min_value(),
-            mode: DetectUintMode::DetectUintModeEqual,
+            mode,
         };
         return Some(ctx);
     }


### PR DESCRIPTION
Ticket: [#7513](https://redmine.openinfosecfoundation.org/issues/7513)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7513

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7513

Describe changes:
- fix red CLI for ``rfb-rules-8``

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2250
Previous PR = https://github.com/OISF/suricata/pull/12444 
