### PR TITLE
Applayer plugin 5053 v8

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -186,6 +186,16 @@ jobs:
           cat eve.json | jq -c 'select(.dns)'
           test $(cat eve.json | jq -c 'select(.dns)' | wc -l) = "1"
 
+      - name: Test app-layer plugin
+        working-directory: examples/plugins/altemplate
+        # test with RUSTFLAGS different than suricata build to test runtime compatibility
+        run: |
+          RUSTFLAGS="--cfg fuzzing -Cdebuginfo=1 -Cforce-frame-pointers -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Cllvm-args=-sanitizer-coverage-stack-depth" cargo build
+          ../../../src/suricata -S altemplate.rules --set plugins.0=./target/debug/libsuricata_altemplate.so --runmode=single -l . -c altemplate.yaml -k none -r ../../../rust/src/applayertemplate/template.pcap
+          cat eve.json | jq -c 'select(.altemplate)'
+          test $(cat eve.json | jq -c 'select(.altemplate)' | wc -l) = "3"
+        # we get 2 alerts and 1 altemplate events
+
       - name: Test library build in tree
         working-directory: examples/lib/simple
         run: make clean all

--- a/doc/userguide/devguide/libsuricata/index.rst
+++ b/doc/userguide/devguide/libsuricata/index.rst
@@ -1,7 +1,7 @@
 .. _libsuricata:
 
-LibSuricata
-===========
+LibSuricata and Plugins
+=======================
 
 Using Suricata as a Library
 ---------------------------
@@ -10,5 +10,55 @@ The ability to turn Suricata into a library that can be utilized in other tools
 is currently a work in progress, tracked by Redmine Ticket #2693:
 https://redmine.openinfosecfoundation.org/issues/2693.
 
+Plugins
+-------
+
 A related work are Suricata plugins, also in progress and tracked by Redmine
 Ticket #4101: https://redmine.openinfosecfoundation.org/issues/4101.
+
+Plugins can be used by modifying suricata.yaml ``plugins`` section to include
+the path of the dynamic library to load.
+
+Plugins should export a ``SCPluginRegister`` function that will be the entry point
+used by Suricata.
+
+Application-layer plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Application layer plugins can be added as demonstrated by example
+https://github.com/OISF/suricata/blob/master/examples/plugins/altemplate/
+
+The plugin code contains the same files as an application layer in the source tree:
+- alname.rs
+- detect.rs
+- lib.rs
+- log.rs
+- parser.rs
+
+These files will have different ``use`` statements, targetting the suricata crate.
+
+And the plugin contains also additional files:
+- plugin.rs : defines the entry point of the plugin ``SCPluginRegister``
+
+``SCPluginRegister`` should register callback that should then call ``SCPluginRegisterAppLayer``
+passing a ``SCAppLayerPlugin`` structure to suricata.
+It should also call ``suricata::plugin::init();`` to ensure the plugin has initialized
+its value of the Suricata Context, a structure needed by rust, to call some C functions,
+that cannot be found at compile time because of circular dependencies, and are therefore
+resolved at runtime.
+
+This ``SCAppLayerPlugin`` begins by a version number ``SC_PLUGIN_API_VERSION`` for runtime compatibility
+between Suricata and the plugin.
+
+Known limitations are:
+
+- Plugins can only use simple logging as defined by ``EveJsonSimpleTxLogFunc``
+  without suricata.yaml configuration, see https://github.com/OISF/suricata/pull/11160
+- Keywords cannot use validate callbacks, see https://redmine.openinfosecfoundation.org/issues/5634
+- Plugins cannot have keywords matching on mulitple protocols (like ja4),
+  see https://redmine.openinfosecfoundation.org/issues/7304
+
+.. attention:: A pure rust plugin needs to be compiled with ``RUSTFLAGS=-Clink-args=-Wl,-undefined,dynamic_lookup``
+
+This is because the plugin will link dynamically at runtime the functions defined in Suricata runtime.
+You can define this rust flags in a ``.cargo/config.toml`` file.

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -9,3 +9,8 @@ is useful if you want to send EVE output to custom destinations.
 
 A minimal capture plugin that can be used as a template, but also used
 for testing capture plugin loading and registration in CI.
+
+## altemplate
+
+An app-layer template plugin with logging and detection.
+Most code copied from rust/src/applayertemplate

--- a/examples/plugins/altemplate/.cargo/config.toml
+++ b/examples/plugins/altemplate/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+# custom flags to pass to all compiler invocations
+rustflags = ["-Clink-args=-Wl,-undefined,dynamic_lookup"]

--- a/examples/plugins/altemplate/Cargo.toml
+++ b/examples/plugins/altemplate/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "suricata-altemplate"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+nom7 = { version="7.0", package="nom" }
+libc = "~0.2.82"
+suricata = { path = "../../../rust/" }
+
+[features]
+default = ["suricata8"]
+suricata8 = []

--- a/examples/plugins/altemplate/altemplate.rules
+++ b/examples/plugins/altemplate/altemplate.rules
@@ -1,0 +1,2 @@
+alert altemplate any any -> any any (msg:"TEST"; altemplate.buffer; content:"Hello"; flow:established,to_server; sid:1; rev:1;)
+alert altemplate any any -> any any (msg:"TEST"; altemplate.buffer; content:"Bye"; flow:established,to_client; sid:2; rev:1;)

--- a/examples/plugins/altemplate/altemplate.yaml
+++ b/examples/plugins/altemplate/altemplate.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - altemplate
+        - alert
+        - flow
+
+app-layer:
+  protocols:
+    altemplate:
+      enabled: yes
+      detection-ports:
+        dp: 7000

--- a/examples/plugins/altemplate/src/detect.rs
+++ b/examples/plugins/altemplate/src/detect.rs
@@ -1,0 +1,105 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// same file as rust/src/applayertemplate/detect.rs except
+// TEMPLATE_START_REMOVE removed
+// different paths for use statements
+// keywords prefixed with altemplate instead of just template
+
+use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
+use std::os::raw::{c_int, c_void};
+use suricata::cast_pointer;
+use suricata::detect::{
+    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt,
+    SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+};
+use suricata::direction::Direction;
+
+static mut G_TEMPLATE_BUFFER_BUFFER_ID: c_int = 0;
+
+unsafe extern "C" fn template_buffer_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_TEMPLATE) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_TEMPLATE_BUFFER_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+/// Get the request/response buffer for a transaction from C.
+unsafe extern "C" fn template_buffer_get_data(
+    tx: *const c_void, flags: u8, buf: *mut *const u8, len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, TemplateTransaction);
+    if flags & Direction::ToClient as u8 != 0 {
+        if let Some(ref response) = tx.response {
+            *len = response.len() as u32;
+            *buf = response.as_ptr();
+            return true;
+        }
+    } else if let Some(ref request) = tx.request {
+        *len = request.len() as u32;
+        *buf = request.as_ptr();
+        return true;
+    }
+    return false;
+}
+
+unsafe extern "C" fn template_buffer_get(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        template_buffer_get_data,
+    );
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ScDetectTemplateRegister() {
+    // TODO create a suricata-verify test
+    // Setup a keyword structure and register it
+    let kw = SCSigTableElmt {
+        name: b"altemplate.buffer\0".as_ptr() as *const libc::c_char,
+        desc: b"Template content modifier to match on the template buffer\0".as_ptr()
+            as *const libc::c_char,
+        // TODO use the right anchor for url and write doc
+        url: b"/rules/template-keywords.html#buffer\0".as_ptr() as *const libc::c_char,
+        Setup: template_buffer_setup,
+        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _g_template_buffer_kw_id = DetectHelperKeywordRegister(&kw);
+    G_TEMPLATE_BUFFER_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"altemplate.buffer\0".as_ptr() as *const libc::c_char,
+        b"template.buffer intern description\0".as_ptr() as *const libc::c_char,
+        ALPROTO_TEMPLATE,
+        true, //toclient
+        true, //toserver
+        template_buffer_get,
+    );
+}

--- a/examples/plugins/altemplate/src/lib.rs
+++ b/examples/plugins/altemplate/src/lib.rs
@@ -1,0 +1,5 @@
+mod detect;
+mod log;
+mod parser;
+pub mod plugin;
+mod template;

--- a/examples/plugins/altemplate/src/log.rs
+++ b/examples/plugins/altemplate/src/log.rs
@@ -1,0 +1,85 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// same file as rust/src/applayertemplate/logger.rs except
+// different paths for use statements
+// open_object using altemplate instead of just template
+// Jsonbuilder using C API due to  opaque implementation
+
+use super::template::TemplateTransaction;
+use std::ffi::{c_char, CString};
+use suricata::cast_pointer;
+use suricata::jsonbuilder::JsonError;
+
+use std;
+
+// Jsonbuilder opaque with implementation using C API to feel like usual
+#[repr(C)]
+pub struct JsonBuilder {
+    _data: [u8; 0],
+}
+
+extern "C" {
+    pub fn jb_set_string(jb: &mut JsonBuilder, key: *const c_char, val: *const c_char) -> bool;
+    pub fn jb_close(jb: &mut JsonBuilder) -> bool;
+    pub fn jb_open_object(jb: &mut JsonBuilder, key: *const c_char) -> bool;
+}
+
+impl JsonBuilder {
+    pub fn close(&mut self) -> Result<(), JsonError> {
+        if unsafe { !jb_close(self) } {
+            return Err(JsonError::Memory);
+        }
+        Ok(())
+    }
+    pub fn open_object(&mut self, key: &str) -> Result<(), JsonError> {
+        let keyc = CString::new(key).unwrap();
+        if unsafe { !jb_open_object(self, keyc.as_ptr()) } {
+            return Err(JsonError::Memory);
+        }
+        Ok(())
+    }
+    pub fn set_string(&mut self, key: &str, val: &str) -> Result<(), JsonError> {
+        let keyc = CString::new(key).unwrap();
+        let valc = CString::new(val.escape_default().to_string()).unwrap();
+        if unsafe { !jb_set_string(self, keyc.as_ptr(), valc.as_ptr()) } {
+            return Err(JsonError::Memory);
+        }
+        Ok(())
+    }
+}
+
+fn log_template(tx: &TemplateTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    js.open_object("altemplate")?;
+    if let Some(ref request) = tx.request {
+        js.set_string("request", request)?;
+    }
+    if let Some(ref response) = tx.response {
+        js.set_string("response", response)?;
+    }
+    js.close()?;
+    Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_template_logger_log(
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
+) -> bool {
+    let tx = cast_pointer!(tx, TemplateTransaction);
+    let js = cast_pointer!(js, JsonBuilder);
+    log_template(tx, js).is_ok()
+}

--- a/examples/plugins/altemplate/src/parser.rs
+++ b/examples/plugins/altemplate/src/parser.rs
@@ -1,0 +1,66 @@
+/* Copyright (C) 2018 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// same file as rust/src/applayertemplate/parser.rs except this comment
+
+use nom7::{
+    bytes::streaming::{take, take_until},
+    combinator::map_res,
+    IResult,
+};
+use std;
+
+fn parse_len(input: &str) -> Result<u32, std::num::ParseIntError> {
+    input.parse::<u32>()
+}
+
+pub fn parse_message(i: &[u8]) -> IResult<&[u8], String> {
+    let (i, len) = map_res(map_res(take_until(":"), std::str::from_utf8), parse_len)(i)?;
+    let (i, _sep) = take(1_usize)(i)?;
+    let (i, msg) = map_res(take(len as usize), std::str::from_utf8)(i)?;
+    let result = msg.to_string();
+    Ok((i, result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom7::Err;
+
+    /// Simple test of some valid data.
+    #[test]
+    fn test_parse_valid() {
+        let buf = b"12:Hello World!4:Bye.";
+
+        let result = parse_message(buf);
+        match result {
+            Ok((remainder, message)) => {
+                // Check the first message.
+                assert_eq!(message, "Hello World!");
+
+                // And we should have 6 bytes left.
+                assert_eq!(remainder.len(), 6);
+            }
+            Err(Err::Incomplete(_)) => {
+                panic!("Result should not have been incomplete.");
+            }
+            Err(Err::Error(err)) | Err(Err::Failure(err)) => {
+                panic!("Result should not be an error: {:?}.", err);
+            }
+        }
+    }
+}

--- a/examples/plugins/altemplate/src/plugin.rs
+++ b/examples/plugins/altemplate/src/plugin.rs
@@ -1,0 +1,37 @@
+use super::template::rs_template_register_parser;
+use crate::detect::ScDetectTemplateRegister;
+use crate::log::rs_template_logger_log;
+use suricata::plugin::{
+    SCAppLayerPlugin, SCPlugin, SCPluginRegisterAppLayer, SC_PLUGIN_API_VERSION,
+};
+use suricata::{SCLogError, SCLogNotice};
+
+extern "C" fn altemplate_plugin_init() {
+    suricata::plugin::init();
+    SCLogNotice!("Initializing altemplate plugin");
+    let plugin = SCAppLayerPlugin {
+        version: SC_PLUGIN_API_VERSION, // api version for suricata compatibility
+        name: b"altemplate\0".as_ptr() as *const libc::c_char,
+        logname: b"JsonaltemplateLog\0".as_ptr() as *const libc::c_char,
+        confname: b"eve-log.altemplate\0".as_ptr() as *const libc::c_char,
+        Register: rs_template_register_parser,
+        Logger: rs_template_logger_log,
+        KeywordsRegister: ScDetectTemplateRegister,
+    };
+    unsafe {
+        if SCPluginRegisterAppLayer(Box::into_raw(Box::new(plugin))) != 0 {
+            SCLogError!("Failed to register altemplate plugin");
+        }
+    }
+}
+
+#[no_mangle]
+extern "C" fn SCPluginRegister() -> *const SCPlugin {
+    let plugin = SCPlugin {
+        name: b"altemplate\0".as_ptr() as *const libc::c_char,
+        license: b"MIT\0".as_ptr() as *const libc::c_char,
+        author: b"Philippe Antoine\0".as_ptr() as *const libc::c_char,
+        Init: altemplate_plugin_init,
+    };
+    Box::into_raw(Box::new(plugin))
+}

--- a/examples/plugins/altemplate/src/template.rs
+++ b/examples/plugins/altemplate/src/template.rs
@@ -1,0 +1,502 @@
+/* Copyright (C) 2018-2022 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// same file as rust/src/applayertemplate/template.rs except
+// different paths for use statements
+// remove TEMPLATE_START_REMOVE
+// name is altemplate instead of template
+
+use super::parser;
+use nom7 as nom;
+use std;
+use std::collections::VecDeque;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_void};
+use suricata::applayer::{
+    state_get_tx_iterator, AppLayerEvent, AppLayerParserConfParserEnabled,
+    AppLayerParserRegisterLogger, AppLayerParserStateIssetFlag,
+    AppLayerProtoDetectConfProtoDetectionEnabled, AppLayerRegisterParser,
+    AppLayerRegisterProtocolDetection, AppLayerResult, AppLayerStateData, AppLayerTxData,
+    RustParser, State, StreamSlice, Transaction, APP_LAYER_PARSER_EOF_TC, APP_LAYER_PARSER_EOF_TS,
+    APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+};
+use suricata::conf::conf_get;
+use suricata::core::{AppProto, ALPROTO_UNKNOWN, IPPROTO_TCP};
+use suricata::flow::Flow;
+use suricata::{
+    build_slice, cast_pointer, export_state_data_get, export_tx_data_get, SCLogError, SCLogNotice,
+};
+
+static mut TEMPLATE_MAX_TX: usize = 256;
+
+pub(super) static mut ALPROTO_TEMPLATE: AppProto = ALPROTO_UNKNOWN;
+
+#[derive(AppLayerEvent)]
+enum TemplateEvent {
+    TooManyTransactions,
+}
+
+pub struct TemplateTransaction {
+    tx_id: u64,
+    pub request: Option<String>,
+    pub response: Option<String>,
+
+    tx_data: AppLayerTxData,
+}
+
+impl Default for TemplateTransaction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TemplateTransaction {
+    pub fn new() -> TemplateTransaction {
+        Self {
+            tx_id: 0,
+            request: None,
+            response: None,
+            tx_data: AppLayerTxData::new(),
+        }
+    }
+}
+
+impl Transaction for TemplateTransaction {
+    fn id(&self) -> u64 {
+        self.tx_id
+    }
+}
+
+#[derive(Default)]
+pub struct TemplateState {
+    state_data: AppLayerStateData,
+    tx_id: u64,
+    transactions: VecDeque<TemplateTransaction>,
+    request_gap: bool,
+    response_gap: bool,
+}
+
+impl State<TemplateTransaction> for TemplateState {
+    fn get_transaction_count(&self) -> usize {
+        self.transactions.len()
+    }
+
+    fn get_transaction_by_index(&self, index: usize) -> Option<&TemplateTransaction> {
+        self.transactions.get(index)
+    }
+}
+
+impl TemplateState {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    // Free a transaction by ID.
+    fn free_tx(&mut self, tx_id: u64) {
+        let len = self.transactions.len();
+        let mut found = false;
+        let mut index = 0;
+        for i in 0..len {
+            let tx = &self.transactions[i];
+            if tx.tx_id == tx_id + 1 {
+                found = true;
+                index = i;
+                break;
+            }
+        }
+        if found {
+            self.transactions.remove(index);
+        }
+    }
+
+    pub fn get_tx(&mut self, tx_id: u64) -> Option<&TemplateTransaction> {
+        self.transactions.iter().find(|tx| tx.tx_id == tx_id + 1)
+    }
+
+    fn new_tx(&mut self) -> TemplateTransaction {
+        let mut tx = TemplateTransaction::new();
+        self.tx_id += 1;
+        tx.tx_id = self.tx_id;
+        return tx;
+    }
+
+    fn find_request(&mut self) -> Option<&mut TemplateTransaction> {
+        self.transactions
+            .iter_mut()
+            .find(|tx| tx.response.is_none())
+    }
+
+    fn parse_request(&mut self, input: &[u8]) -> AppLayerResult {
+        // We're not interested in empty requests.
+        if input.is_empty() {
+            return AppLayerResult::ok();
+        }
+
+        // If there was gap, check we can sync up again.
+        if self.request_gap {
+            if probe(input).is_err() {
+                // The parser now needs to decide what to do as we are not in sync.
+                // For this template, we'll just try again next time.
+                return AppLayerResult::ok();
+            }
+
+            // It looks like we're in sync with a message header, clear gap
+            // state and keep parsing.
+            self.request_gap = false;
+        }
+
+        let mut start = input;
+        while !start.is_empty() {
+            match parser::parse_message(start) {
+                Ok((rem, request)) => {
+                    start = rem;
+
+                    SCLogNotice!("Request: {}", request);
+                    let mut tx = self.new_tx();
+                    tx.request = Some(request);
+                    if self.transactions.len() >= unsafe { TEMPLATE_MAX_TX } {
+                        tx.tx_data
+                            .set_event(TemplateEvent::TooManyTransactions as u8);
+                    }
+                    self.transactions.push_back(tx);
+                    if self.transactions.len() >= unsafe { TEMPLATE_MAX_TX } {
+                        return AppLayerResult::err();
+                    }
+                }
+                Err(nom::Err::Incomplete(_)) => {
+                    // Not enough data. This parser doesn't give us a good indication
+                    // of how much data is missing so just ask for one more byte so the
+                    // parse is called as soon as more data is received.
+                    let consumed = input.len() - start.len();
+                    let needed = start.len() + 1;
+                    return AppLayerResult::incomplete(consumed as u32, needed as u32);
+                }
+                Err(_) => {
+                    return AppLayerResult::err();
+                }
+            }
+        }
+
+        // Input was fully consumed.
+        return AppLayerResult::ok();
+    }
+
+    fn parse_response(&mut self, input: &[u8]) -> AppLayerResult {
+        // We're not interested in empty responses.
+        if input.is_empty() {
+            return AppLayerResult::ok();
+        }
+
+        if self.response_gap {
+            if probe(input).is_err() {
+                // The parser now needs to decide what to do as we are not in sync.
+                // For this template, we'll just try again next time.
+                return AppLayerResult::ok();
+            }
+
+            // It looks like we're in sync with a message header, clear gap
+            // state and keep parsing.
+            self.response_gap = false;
+        }
+        let mut start = input;
+        while !start.is_empty() {
+            match parser::parse_message(start) {
+                Ok((rem, response)) => {
+                    start = rem;
+
+                    if let Some(tx) = self.find_request() {
+                        tx.tx_data.updated_tc = true;
+                        tx.response = Some(response);
+                        SCLogNotice!("Found response for request:");
+                        SCLogNotice!("- Request: {:?}", tx.request);
+                        SCLogNotice!("- Response: {:?}", tx.response);
+                    }
+                }
+                Err(nom::Err::Incomplete(_)) => {
+                    let consumed = input.len() - start.len();
+                    let needed = start.len() + 1;
+                    return AppLayerResult::incomplete(consumed as u32, needed as u32);
+                }
+                Err(_) => {
+                    return AppLayerResult::err();
+                }
+            }
+        }
+
+        // All input was fully consumed.
+        return AppLayerResult::ok();
+    }
+
+    fn on_request_gap(&mut self, _size: u32) {
+        self.request_gap = true;
+    }
+
+    fn on_response_gap(&mut self, _size: u32) {
+        self.response_gap = true;
+    }
+}
+
+/// Probe for a valid header.
+///
+/// As this template protocol uses messages prefixed with the size
+/// as a string followed by a ':', we look at up to the first 10
+/// characters for that pattern.
+fn probe(input: &[u8]) -> nom::IResult<&[u8], ()> {
+    let size = std::cmp::min(10, input.len());
+    let (rem, prefix) = nom::bytes::complete::take(size)(input)?;
+    nom::sequence::terminated(
+        nom::bytes::complete::take_while1(nom::character::is_digit),
+        nom::bytes::complete::tag(":"),
+    )(prefix)?;
+    Ok((rem, ()))
+}
+
+// C exports.
+
+/// C entry point for a probing parser.
+unsafe extern "C" fn rs_template_probing_parser(
+    _flow: *const Flow, _direction: u8, input: *const u8, input_len: u32, _rdir: *mut u8,
+) -> AppProto {
+    // Need at least 2 bytes.
+    if input_len > 1 && !input.is_null() {
+        let slice = build_slice!(input, input_len as usize);
+        if probe(slice).is_ok() {
+            return ALPROTO_TEMPLATE;
+        }
+    }
+    return ALPROTO_UNKNOWN;
+}
+
+extern "C" fn rs_template_state_new(
+    _orig_state: *mut c_void, _orig_proto: AppProto,
+) -> *mut c_void {
+    let state = TemplateState::new();
+    let boxed = Box::new(state);
+    return Box::into_raw(boxed) as *mut c_void;
+}
+
+unsafe extern "C" fn rs_template_state_free(state: *mut c_void) {
+    std::mem::drop(Box::from_raw(state as *mut TemplateState));
+}
+
+unsafe extern "C" fn rs_template_state_tx_free(state: *mut c_void, tx_id: u64) {
+    let state = cast_pointer!(state, TemplateState);
+    state.free_tx(tx_id);
+}
+
+unsafe extern "C" fn rs_template_parse_request(
+    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    _data: *const c_void,
+) -> AppLayerResult {
+    let eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS) > 0;
+
+    if eof {
+        // If needed, handle EOF, or pass it into the parser.
+        return AppLayerResult::ok();
+    }
+
+    let state = cast_pointer!(state, TemplateState);
+
+    if stream_slice.is_gap() {
+        // Here we have a gap signaled by the input being null, but a greater
+        // than 0 input_len which provides the size of the gap.
+        state.on_request_gap(stream_slice.gap_size());
+        AppLayerResult::ok()
+    } else {
+        let buf = stream_slice.as_slice();
+        state.parse_request(buf)
+    }
+}
+
+unsafe extern "C" fn rs_template_parse_response(
+    _flow: *const Flow, state: *mut c_void, pstate: *mut c_void, stream_slice: StreamSlice,
+    _data: *const c_void,
+) -> AppLayerResult {
+    let _eof = AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC) > 0;
+    let state = cast_pointer!(state, TemplateState);
+
+    if stream_slice.is_gap() {
+        // Here we have a gap signaled by the input being null, but a greater
+        // than 0 input_len which provides the size of the gap.
+        state.on_response_gap(stream_slice.gap_size());
+        AppLayerResult::ok()
+    } else {
+        let buf = stream_slice.as_slice();
+        state.parse_response(buf)
+    }
+}
+
+unsafe extern "C" fn rs_template_state_get_tx(state: *mut c_void, tx_id: u64) -> *mut c_void {
+    let state = cast_pointer!(state, TemplateState);
+    match state.get_tx(tx_id) {
+        Some(tx) => {
+            return tx as *const _ as *mut _;
+        }
+        None => {
+            return std::ptr::null_mut();
+        }
+    }
+}
+
+unsafe extern "C" fn rs_template_state_get_tx_count(state: *mut c_void) -> u64 {
+    let state = cast_pointer!(state, TemplateState);
+    return state.tx_id;
+}
+
+unsafe extern "C" fn rs_template_tx_get_alstate_progress(tx: *mut c_void, _direction: u8) -> c_int {
+    let tx = cast_pointer!(tx, TemplateTransaction);
+
+    // Transaction is done if we have a response.
+    if tx.response.is_some() {
+        return 1;
+    }
+    return 0;
+}
+
+export_tx_data_get!(rs_template_get_tx_data, TemplateTransaction);
+export_state_data_get!(rs_template_get_state_data, TemplateState);
+
+// Parser name as a C style string.
+const PARSER_NAME: &[u8] = b"altemplate\0";
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_template_register_parser() {
+    let default_port = CString::new("[7000]").unwrap();
+    let parser = RustParser {
+        name: PARSER_NAME.as_ptr() as *const c_char,
+        default_port: default_port.as_ptr(),
+        ipproto: IPPROTO_TCP,
+        probe_ts: Some(rs_template_probing_parser),
+        probe_tc: Some(rs_template_probing_parser),
+        min_depth: 0,
+        max_depth: 16,
+        state_new: rs_template_state_new,
+        state_free: rs_template_state_free,
+        tx_free: rs_template_state_tx_free,
+        parse_ts: rs_template_parse_request,
+        parse_tc: rs_template_parse_response,
+        get_tx_count: rs_template_state_get_tx_count,
+        get_tx: rs_template_state_get_tx,
+        tx_comp_st_ts: 1,
+        tx_comp_st_tc: 1,
+        tx_get_progress: rs_template_tx_get_alstate_progress,
+        get_eventinfo: Some(TemplateEvent::get_event_info),
+        get_eventinfo_byid: Some(TemplateEvent::get_event_info_by_id),
+        localstorage_new: None,
+        localstorage_free: None,
+        get_tx_files: None,
+        get_tx_iterator: Some(state_get_tx_iterator::<TemplateState, TemplateTransaction>),
+        get_tx_data: rs_template_get_tx_data,
+        get_state_data: rs_template_get_state_data,
+        apply_tx_config: None,
+        flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
+        get_frame_id_by_name: None,
+        get_frame_name_by_id: None,
+    };
+
+    let ip_proto_str = CString::new("tcp").unwrap();
+
+    if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+        let alproto = AppLayerRegisterProtocolDetection(&parser, 1);
+        ALPROTO_TEMPLATE = alproto;
+        if AppLayerParserConfParserEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
+            let _ = AppLayerRegisterParser(&parser, alproto);
+        }
+        if let Some(val) = conf_get("app-layer.protocols.template.max-tx") {
+            if let Ok(v) = val.parse::<usize>() {
+                TEMPLATE_MAX_TX = v;
+            } else {
+                SCLogError!("Invalid value for template.max-tx");
+            }
+        }
+        AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TEMPLATE);
+        SCLogNotice!("Rust template parser registered.");
+    } else {
+        SCLogNotice!("Protocol detector and parser disabled for TEMPLATE.");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_probe() {
+        assert!(probe(b"1").is_err());
+        assert!(probe(b"1:").is_ok());
+        assert!(probe(b"123456789:").is_ok());
+        assert!(probe(b"0123456789:").is_err());
+    }
+
+    #[test]
+    fn test_incomplete() {
+        let mut state = TemplateState::new();
+        let buf = b"5:Hello3:bye";
+
+        let r = state.parse_request(&buf[0..0]);
+        assert_eq!(
+            r,
+            AppLayerResult {
+                status: 0,
+                consumed: 0,
+                needed: 0
+            }
+        );
+
+        let r = state.parse_request(&buf[0..1]);
+        assert_eq!(
+            r,
+            AppLayerResult {
+                status: 1,
+                consumed: 0,
+                needed: 2
+            }
+        );
+
+        let r = state.parse_request(&buf[0..2]);
+        assert_eq!(
+            r,
+            AppLayerResult {
+                status: 1,
+                consumed: 0,
+                needed: 3
+            }
+        );
+
+        // This is the first message and only the first message.
+        let r = state.parse_request(&buf[0..7]);
+        assert_eq!(
+            r,
+            AppLayerResult {
+                status: 0,
+                consumed: 0,
+                needed: 0
+            }
+        );
+
+        // The first message and a portion of the second.
+        let r = state.parse_request(&buf[0..9]);
+        assert_eq!(
+            r,
+            AppLayerResult {
+                status: 1,
+                consumed: 7,
+                needed: 3
+            }
+        );
+    }
+}

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -84,7 +84,7 @@ vendor:
 	$(CARGO_ENV) $(CARGO) vendor
 
 if HAVE_CBINDGEN
-gen/rust-bindings.h: $(RUST_SURICATA_LIB)
+gen/rust-bindings.h: $(RUST_SURICATA_LIB) cbindgen.toml
 	cd $(abs_top_srcdir)/rust && \
 		cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --verify --output $(abs_top_builddir)/rust/gen/rust-bindings.h || true

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -84,6 +84,7 @@ include = [
     "FtpEvent",
     "SCSigTableElmt",
     "SCTransformTableElmt",
+    "SCPlugin",
 ]
 
 # A list of items to not include in the generated bindings

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -110,6 +110,8 @@ exclude = [
     "IPPROTO_TCP",
     "IPPROTO_UDP",
     "SRepCatGetByShortname",
+    "SIGMATCH_NOOPT",
+    "SIGMATCH_INFO_STICKY_BUFFER",
 ]
 
 # Types of items that we'll generate. If empty, then all types of item are emitted.

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -23,7 +23,6 @@ use crate::direction::Direction;
 use crate::filecontainer::FileContainer;
 use crate::flow::Flow;
 use std::os::raw::{c_void,c_char,c_int};
-use crate::core::SC;
 use std::ffi::CStr;
 use crate::core::StreamingBufferConfig;
 
@@ -480,12 +479,9 @@ pub type GetFrameNameById = unsafe extern "C" fn(u8) -> *const c_char;
 extern {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
     pub fn AppLayerRegisterParserAlias(parser_name: *const c_char, alias_name: *const c_char);
+    pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
 }
 
-#[allow(non_snake_case)]
-pub unsafe fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int {
-    (SC.unwrap().AppLayerRegisterParser)(parser, alproto)
-}
 
 // Defined in app-layer-detect-proto.h
 /// cbindgen:ignore

--- a/rust/src/applayertemplate/detect.rs
+++ b/rust/src/applayertemplate/detect.rs
@@ -19,12 +19,12 @@ use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
 /* TEMPLATE_START_REMOVE */
 use crate::conf::conf_get_node;
 /* TEMPLATE_END_REMOVE */
-use crate::direction::Direction;
 use crate::detect::{
     DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
     DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt,
     SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
 };
+use crate::direction::Direction;
 use std::os::raw::{c_int, c_void};
 
 static mut G_TEMPLATE_BUFFER_BUFFER_ID: c_int = 0;

--- a/rust/src/applayertemplate/logger.rs
+++ b/rust/src/applayertemplate/logger.rs
@@ -33,8 +33,9 @@ fn log_template(tx: &TemplateTransaction, js: &mut JsonBuilder) -> Result<(), Js
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_template_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
     let tx = cast_pointer!(tx, TemplateTransaction);
+    let js = cast_pointer!(js, JsonBuilder);
     log_template(tx, js).is_ok()
 }

--- a/rust/src/applayertemplate/mod.rs
+++ b/rust/src/applayertemplate/mod.rs
@@ -20,6 +20,6 @@
 mod parser;
 pub mod template;
 /* TEMPLATE_START_REMOVE */
-pub mod logger;
 pub mod detect;
+pub mod logger;
 /* TEMPLATE_END_REMOVE */

--- a/rust/src/applayertemplate/template.rs
+++ b/rust/src/applayertemplate/template.rs
@@ -16,7 +16,7 @@
  */
 
 use super::parser;
-use crate::applayer::{self, *};
+use crate::applayer::*;
 use crate::conf::conf_get;
 use crate::core::{AppProto, ALPROTO_UNKNOWN, IPPROTO_TCP};
 use crate::flow::Flow;
@@ -120,7 +120,9 @@ impl TemplateState {
     }
 
     fn find_request(&mut self) -> Option<&mut TemplateTransaction> {
-        self.transactions.iter_mut().find(|tx| tx.response.is_none())
+        self.transactions
+            .iter_mut()
+            .find(|tx| tx.response.is_none())
     }
 
     fn parse_request(&mut self, input: &[u8]) -> AppLayerResult {
@@ -151,11 +153,12 @@ impl TemplateState {
                     SCLogNotice!("Request: {}", request);
                     let mut tx = self.new_tx();
                     tx.request = Some(request);
-                    if self.transactions.len() >= unsafe {TEMPLATE_MAX_TX} {
-                        tx.tx_data.set_event(TemplateEvent::TooManyTransactions as u8);
+                    if self.transactions.len() >= unsafe { TEMPLATE_MAX_TX } {
+                        tx.tx_data
+                            .set_event(TemplateEvent::TooManyTransactions as u8);
                     }
                     self.transactions.push_back(tx);
-                    if self.transactions.len() >= unsafe {TEMPLATE_MAX_TX} {
+                    if self.transactions.len() >= unsafe { TEMPLATE_MAX_TX } {
                         return AppLayerResult::err();
                     }
                 }
@@ -200,7 +203,7 @@ impl TemplateState {
                 Ok((rem, response)) => {
                     start = rem;
 
-                    if let Some(tx) =  self.find_request() {
+                    if let Some(tx) = self.find_request() {
                         tx.tx_data.updated_tc = true;
                         tx.response = Some(response);
                         SCLogNotice!("Found response for request:");
@@ -387,9 +390,7 @@ pub unsafe extern "C" fn rs_template_register_parser() {
         localstorage_new: None,
         localstorage_free: None,
         get_tx_files: None,
-        get_tx_iterator: Some(
-            applayer::state_get_tx_iterator::<TemplateState, TemplateTransaction>,
-        ),
+        get_tx_iterator: Some(state_get_tx_iterator::<TemplateState, TemplateTransaction>),
         get_tx_data: rs_template_get_tx_data,
         get_state_data: rs_template_get_state_data,
         apply_tx_config: None,

--- a/rust/src/bittorrent_dht/logger.rs
+++ b/rust/src/bittorrent_dht/logger.rs
@@ -132,8 +132,9 @@ fn log_bittorrent_dht(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_bittorrent_dht_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, BitTorrentDHTTransaction);
     log_bittorrent_dht(tx, js).is_ok()
 }

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -163,8 +163,6 @@ pub struct SuricataContext {
     pub FileAppendData: SCFileAppendDataById,
     pub FileAppendGAP: SCFileAppendGAPById,
     pub FileContainerRecycle: SCFileContainerRecycle,
-
-    pub AppLayerRegisterParser: extern fn(parser: *const crate::applayer::RustParser, alproto: AppProto) -> std::os::raw::c_int,
 }
 
 #[allow(non_snake_case)]

--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use crate::dcerpc::dcerpc::*;
 use crate::dcerpc::dcerpc_udp::*;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use std::ffi::c_void;
 
 fn log_dcerpc_header_tcp(
     jsb: &mut JsonBuilder, state: &DCERPCState, tx: &DCERPCTransaction,
@@ -122,15 +123,17 @@ fn log_dcerpc_header_udp(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dcerpc_log_json_record_tcp(
-    state: &DCERPCState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
+pub unsafe extern "C" fn rs_dcerpc_log_json_record_tcp(
+    state: &DCERPCState, tx: &DCERPCTransaction, jsb: *mut c_void,
 ) -> bool {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
     log_dcerpc_header_tcp(jsb, state, tx).is_ok()
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dcerpc_log_json_record_udp(
-    state: &DCERPCUDPState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
+pub unsafe extern "C" fn rs_dcerpc_log_json_record_udp(
+    state: &DCERPCUDPState, tx: &DCERPCTransaction, jsb: *mut c_void,
 ) -> bool {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
     log_dcerpc_header_udp(jsb, state, tx).is_ok()
 }

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -76,9 +76,9 @@ pub struct SCSigTableElmt {
     >,
 }
 
-pub(crate) const SIGMATCH_NOOPT: u16 = 1; // BIT_U16(0) in detect.h
+pub const SIGMATCH_NOOPT: u16 = 1; // BIT_U16(0) in detect.h
 pub(crate) const SIGMATCH_QUOTES_MANDATORY: u16 = 0x40; // BIT_U16(6) in detect.h
-pub(crate) const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
+pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
 
 /// cbindgen:ignore
 extern {

--- a/rust/src/detect/tojson/mod.rs
+++ b/rust/src/detect/tojson/mod.rs
@@ -17,8 +17,9 @@
 
 use crate::detect::uint::{DetectIntType, DetectUintData, DetectUintMode};
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use std::ffi::c_void;
 
-pub fn detect_uint_to_json<T: DetectIntType>(
+pub(crate) fn detect_uint_to_json<T: DetectIntType>(
     js: &mut JsonBuilder, du: &DetectUintData<T>,
 ) -> Result<(), JsonError>
 where
@@ -75,14 +76,16 @@ where
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectU16ToJson(
-    js: &mut JsonBuilder, du: &DetectUintData<u16>,
+    js: *mut c_void, du: &DetectUintData<u16>,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     return detect_uint_to_json(js, du).is_ok();
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectU32ToJson(
-    js: &mut JsonBuilder, du: &DetectUintData<u32>,
+    js: *mut c_void, du: &DetectUintData<u32>,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     return detect_uint_to_json(js, du).is_ok();
 }

--- a/rust/src/dhcp/logger.rs
+++ b/rust/src/dhcp/logger.rs
@@ -69,7 +69,7 @@ impl DHCPLogger {
         return true;
     }
 
-    pub fn log(&self, tx: &DHCPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
+    fn log(&self, tx: &DHCPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
         let header = &tx.message.header;
         let options = &tx.message.options;
 
@@ -269,16 +269,17 @@ pub unsafe extern "C" fn rs_dhcp_logger_free(logger: *mut std::os::raw::c_void) 
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dhcp_logger_log(logger: *mut std::os::raw::c_void,
-                                     tx: *mut std::os::raw::c_void,
-                                     js: &mut JsonBuilder) -> bool {
+                                     tx: *const std::os::raw::c_void,
+                                     js: *mut std::os::raw::c_void) -> bool {
     let logger = cast_pointer!(logger, DHCPLogger);
     let tx = cast_pointer!(tx, DHCPTransaction);
+    let js = cast_pointer!(js, JsonBuilder);
     logger.log(tx, js).is_ok()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_dhcp_logger_do_log(logger: *mut std::os::raw::c_void,
-                                        tx: *mut std::os::raw::c_void)
+                                        tx: *const std::os::raw::c_void)
                                         -> bool {
     let logger = cast_pointer!(logger, DHCPLogger);
     let tx = cast_pointer!(tx, DHCPTransaction);

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -956,12 +956,12 @@ unsafe extern "C" fn state_get_tx(
 }
 
 #[no_mangle]
-pub extern "C" fn SCDnsTxIsRequest(tx: &mut DNSTransaction) -> bool {
+pub extern "C" fn SCDnsTxIsRequest(tx: &DNSTransaction) -> bool {
     tx.request.is_some()
 }
 
 #[no_mangle]
-pub extern "C" fn SCDnsTxIsResponse(tx: &mut DNSTransaction) -> bool {
+pub extern "C" fn SCDnsTxIsResponse(tx: &DNSTransaction) -> bool {
     tx.response.is_some()
 }
 

--- a/rust/src/enip/logger.rs
+++ b/rust/src/enip/logger.rs
@@ -1891,8 +1891,9 @@ fn log_enip(tx: &EnipTransaction, js: &mut JsonBuilder) -> Result<(), JsonError>
 
 #[no_mangle]
 pub unsafe extern "C" fn SCEnipLoggerLog(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, EnipTransaction);
     if tx.request.is_none() && tx.response.is_none() {
         return false;

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -1374,7 +1374,7 @@ impl HTTP2State {
 #[no_mangle]
 pub unsafe extern "C" fn SCDoH2GetDnsTx(
     tx: &HTTP2Transaction, flags: u8,
-) -> *mut std::os::raw::c_void {
+) -> *const std::os::raw::c_void {
     if let Some(doh) = &tx.doh {
         if flags & Direction::ToServer as u8 != 0 {
             if let Some(ref dtx) = &doh.dns_request_tx {

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -286,8 +286,9 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_http2_log_json(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, HTTP2Transaction);
     if let Ok(x) = log_http2(tx, js) {
         return x;

--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -227,8 +227,9 @@ fn log_ikev2(tx: &IKETransaction, jb: &mut JsonBuilder) -> Result<(), JsonError>
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_ike_logger_log(
-    state: &mut IKEState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
+    state: &mut IKEState, tx: *mut std::os::raw::c_void, flags: u32, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, IKETransaction);
     log_ike(state, tx, flags, js).is_ok()
 }

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -19,6 +19,7 @@
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::krb::krb5::{KRB5Transaction,test_weak_encryption};
+use std::ffi::c_void;
 
 fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), JsonError>
 {
@@ -70,7 +71,9 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
+pub unsafe extern "C" fn rs_krb5_log_json_response(tx: *const c_void, jsb: *mut c_void) -> bool
 {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let tx = cast_pointer!(tx, KRB5Transaction);
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/ldap/logger.rs
+++ b/rust/src/ldap/logger.rs
@@ -344,8 +344,9 @@ fn log_controls(controls: &Option<Vec<Control>>, js: &mut JsonBuilder) -> Result
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_ldap_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, LdapTransaction);
     log_ldap(tx, js).is_ok()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -83,7 +83,7 @@ extern crate suricata_derive;
 pub mod core;
 
 #[macro_use]
-pub(crate) mod debug;
+pub mod debug;
 
 pub mod common;
 pub mod conf;

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -21,7 +21,7 @@ use crate::mime::smtp::{MimeSmtpMd5State, MimeStateSMTP};
 use digest::Digest;
 use digest::Update;
 use md5::Md5;
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 
 fn log_subject_md5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> {
     for h in &ctx.headers[..ctx.main_headers_nb] {
@@ -36,8 +36,9 @@ fn log_subject_md5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), Json
 
 #[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpLogSubjectMd5(
-    js: &mut JsonBuilder, ctx: &MimeStateSMTP,
+    js: *mut c_void, ctx: &MimeStateSMTP,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     return log_subject_md5(js, ctx).is_ok();
 }
 
@@ -50,7 +51,8 @@ fn log_body_md5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonErr
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCMimeSmtpLogBodyMd5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> bool {
+pub unsafe extern "C" fn SCMimeSmtpLogBodyMd5(js: *mut c_void, ctx: &MimeStateSMTP) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     return log_body_md5(js, ctx).is_ok();
 }
 
@@ -79,9 +81,10 @@ fn log_field_array(
 
 #[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpLogFieldArray(
-    js: &mut JsonBuilder, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
+    js: *mut c_void, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
     config: *const std::os::raw::c_char,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let e: &CStr = CStr::from_ptr(email); //unsafe
     if let Ok(email_field) = e.to_str() {
         let c: &CStr = CStr::from_ptr(config); //unsafe
@@ -156,9 +159,10 @@ fn log_field_comma(
 
 #[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpLogFieldComma(
-    js: &mut JsonBuilder, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
+    js:  *mut c_void, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
     config: *const std::os::raw::c_char,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let e: &CStr = CStr::from_ptr(email); //unsafe
     if let Ok(email_field) = e.to_str() {
         let c: &CStr = CStr::from_ptr(config); //unsafe
@@ -183,9 +187,10 @@ fn log_field_string(
 
 #[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpLogFieldString(
-    js: &mut JsonBuilder, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
+    js: *mut c_void, ctx: &MimeStateSMTP, email: *const std::os::raw::c_char,
     config: *const std::os::raw::c_char,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let e: &CStr = CStr::from_ptr(email); //unsafe
     if let Ok(email_field) = e.to_str() {
         let c: &CStr = CStr::from_ptr(config); //unsafe
@@ -234,6 +239,7 @@ fn log_data(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCMimeSmtpLogData(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> bool {
+pub unsafe extern "C" fn SCMimeSmtpLogData(js: *mut c_void, ctx: &MimeStateSMTP) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     return log_data(js, ctx).is_ok();
 }

--- a/rust/src/modbus/log.rs
+++ b/rust/src/modbus/log.rs
@@ -17,11 +17,14 @@
 
 use super::modbus::ModbusTransaction;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
+use std::ffi::c_void;
 
 use sawp_modbus::{Data, Message, Read, Write};
 
 #[no_mangle]
-pub extern "C" fn rs_modbus_to_json(tx: &ModbusTransaction, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_modbus_to_json(tx: *const c_void, js: *mut c_void) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
+    let tx = cast_pointer!(tx, ModbusTransaction);
     log(tx, js).is_ok()
 }
 

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -318,8 +318,9 @@ fn log_mqtt(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_mqtt_logger_log(
-    tx: *mut std::os::raw::c_void, flags: u32, max_log_len: u32, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, flags: u32, max_log_len: u32, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, MQTTTransaction);
     log_mqtt(tx, flags, max_log_len as usize, js).is_ok()
 }

--- a/rust/src/mqtt/mqtt_property.rs
+++ b/rust/src/mqtt/mqtt_property.rs
@@ -58,7 +58,7 @@ pub enum MQTTProperty {
 }
 
 impl crate::mqtt::mqtt_property::MQTTProperty {
-    pub fn set_json(&self, js: &mut JsonBuilder, limit: usize) -> Result<(), JsonError> {
+    pub(crate) fn set_json(&self, js: &mut JsonBuilder, limit: usize) -> Result<(), JsonError> {
         match self {
             crate::mqtt::mqtt_property::MQTTProperty::PAYLOAD_FORMAT_INDICATOR(v) => {
                 js.set_uint("payload_format_indicator", *v as u64)?;

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -20,6 +20,7 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::nfs::types::*;
 use crate::nfs::nfs::*;
 use crc::crc32;
+use std::ffi::c_void;
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_tx_logging_is_filtered(state: &mut NFSState,
@@ -119,9 +120,10 @@ fn nfs_log_request(state: &NFSState, tx: &NFSTransaction, js: &mut JsonBuilder)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_log_json_request(state: &mut NFSState, tx: &NFSTransaction,
-        js: &mut JsonBuilder) -> bool
+pub unsafe extern "C" fn rs_nfs_log_json_request(state: &mut NFSState, tx: &NFSTransaction,
+        js: *mut c_void) -> bool
 {
+    let js = cast_pointer!(js, JsonBuilder);
     nfs_log_request(state, tx, js).is_ok()
 }
 
@@ -152,9 +154,10 @@ fn nfs_log_response(state: &NFSState, tx: &NFSTransaction, js: &mut JsonBuilder)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_nfs_log_json_response(state: &mut NFSState, tx: &NFSTransaction,
-        js: &mut JsonBuilder) -> bool
+pub unsafe extern "C" fn rs_nfs_log_json_response(state: &mut NFSState, tx: &NFSTransaction,
+        js: *mut c_void) -> bool
 {
+    let js = cast_pointer!(js, JsonBuilder);
     nfs_log_response(state, tx, js).is_ok()
 }
 
@@ -173,8 +176,9 @@ fn rpc_log_response(tx: &NFSTransaction, js: &mut JsonBuilder)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_rpc_log_json_response(tx: &NFSTransaction,
-        js: &mut JsonBuilder) -> bool
+pub unsafe extern "C" fn rs_rpc_log_json_response(tx: &NFSTransaction,
+        js: *mut c_void) -> bool
 {
+    let js = cast_pointer!(js, JsonBuilder);
     rpc_log_response(tx, js).is_ok()
 }

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -289,8 +289,9 @@ fn log_pgsql_param(param: &PgsqlParameter) -> Result<JsonBuilder, JsonError> {
 
 #[no_mangle]
 pub unsafe extern "C" fn SCPgsqlLogger(
-    tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, flags: u32, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx_pgsql = cast_pointer!(tx, PgsqlTransaction);
     SCLogDebug!(
         "----------- PGSQL rs_pgsql_logger call. Tx id is {:?}",

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -17,6 +17,8 @@
 
 //! Plugin utility module.
 
+use core::ffi::c_int;
+
 pub fn init() {
     unsafe {
         let context = super::core::SCGetContext();
@@ -24,4 +26,37 @@ pub fn init() {
 
         super::debug::SCSetRustLogLevel(super::debug::SCLogGetLogLevel());
     }
+}
+
+// Struct definitions
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct SCPlugin {
+    pub name: *const libc::c_char,
+    pub license: *const libc::c_char,
+    pub author: *const libc::c_char,
+    pub Init: extern "C" fn(),
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct SCAppLayerPlugin {
+    pub version: u64,
+    pub name: *const libc::c_char,
+    pub Register: unsafe extern "C" fn(),
+    pub KeywordsRegister: unsafe extern "C" fn(),
+    pub logname: *const libc::c_char,
+    pub confname: *const libc::c_char,
+    pub Logger: unsafe extern "C" fn(
+        tx: *const std::os::raw::c_void,
+        jb: *mut std::os::raw::c_void,
+    ) -> bool,
+}
+
+// Every change in the API used by plugins should change this number
+pub const SC_PLUGIN_API_VERSION: u64 = 8;
+
+/// cbindgen:ignore
+extern {
+    pub fn SCPluginRegisterAppLayer(plugin: *const SCAppLayerPlugin) -> c_int;
 }

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -155,8 +155,9 @@ fn log_quic(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError>
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_to_json(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, QuicTransaction);
     log_quic(tx, js).is_ok()
 }

--- a/rust/src/rdp/log.rs
+++ b/rust/src/rdp/log.rs
@@ -22,9 +22,12 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::rdp::parser::*;
 use crate::rdp::windows;
 use x509_parser::prelude::{FromDer, X509Certificate};
+use std::ffi::c_void;
 
 #[no_mangle]
-pub extern "C" fn rs_rdp_to_json(tx: &RdpTransaction, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_rdp_to_json(tx: *const c_void, js: *mut c_void) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
+    let tx = cast_pointer!(tx, RdpTransaction);
     log(tx, js).is_ok()
 }
 

--- a/rust/src/rfb/logger.rs
+++ b/rust/src/rfb/logger.rs
@@ -129,8 +129,9 @@ fn log_rfb(tx: &RFBTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_rfb_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, RFBTransaction);
     log_rfb(tx, js).is_ok()
 }

--- a/rust/src/sdp/logger.rs
+++ b/rust/src/sdp/logger.rs
@@ -21,7 +21,7 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 
 use super::parser::{ConnectionData, MediaDescription, SdpMessage};
 
-pub fn sdp_log(msg: &SdpMessage, js: &mut JsonBuilder) -> Result<(), JsonError> {
+pub(crate) fn sdp_log(msg: &SdpMessage, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.open_object("sdp")?;
 
     let origin = format!(

--- a/rust/src/sip/log.rs
+++ b/rust/src/sip/log.rs
@@ -20,6 +20,7 @@
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::sdp::logger::sdp_log;
 use crate::sip::sip::SIPTransaction;
+use std::ffi::c_void;
 
 fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.open_object("sip")?;
@@ -57,6 +58,8 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_log_json(tx: &SIPTransaction, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_sip_log_json(tx: *const c_void, js: *mut c_void) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
+    let tx = cast_pointer!(tx, SIPTransaction);
     log(tx, js).is_ok()
 }

--- a/rust/src/smb/log.rs
+++ b/rust/src/smb/log.rs
@@ -25,6 +25,7 @@ use crate::smb::smb2::*;
 use crate::dcerpc::dcerpc::*;
 use crate::smb::funcs::*;
 use crate::smb::smb_status::*;
+use std::ffi::c_void;
 
 #[cfg(not(feature = "debug"))]
 fn debug_add_progress(_js: &mut JsonBuilder, _tx: &SMBTransaction) -> Result<(), JsonError> { Ok(()) }
@@ -445,14 +446,16 @@ fn smb_common_header(jsb: &mut JsonBuilder, state: &SMBState, tx: &SMBTransactio
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_request(jsb: &mut JsonBuilder, state: &mut SMBState, tx: &SMBTransaction) -> bool
+pub unsafe extern "C" fn rs_smb_log_json_request(jsb: *mut c_void, state: &mut SMBState, tx: &SMBTransaction) -> bool
 {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
     smb_common_header(jsb, state, tx).is_ok()
 }
 
 #[no_mangle]
-pub extern "C" fn rs_smb_log_json_response(jsb: &mut JsonBuilder, state: &mut SMBState, tx: &SMBTransaction) -> bool
+pub unsafe extern "C" fn rs_smb_log_json_response(jsb: *mut c_void, state: &mut SMBState, tx: &SMBTransaction) -> bool
 {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
     smb_common_header(jsb, state, tx).is_ok()
 }
 

--- a/rust/src/snmp/log.rs
+++ b/rust/src/snmp/log.rs
@@ -21,6 +21,7 @@ use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::snmp::snmp::SNMPTransaction;
 use crate::snmp::snmp_parser::{NetworkAddress,PduType};
 use std::borrow::Cow;
+use std::ffi::c_void;
 
 fn str_of_pdu_type(t:&PduType) -> Cow<str> {
     match t {
@@ -37,7 +38,7 @@ fn str_of_pdu_type(t:&PduType) -> Cow<str> {
     }
 }
 
-fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<(), JsonError>
+fn snmp_log_response(jsb: &mut JsonBuilder, tx: &SNMPTransaction) -> Result<(), JsonError>
 {
     jsb.open_object("snmp")?;
     jsb.set_uint("version", tx.version as u64)?;
@@ -77,7 +78,9 @@ fn snmp_log_response(jsb: &mut JsonBuilder, tx: &mut SNMPTransaction) -> Result<
 }
 
 #[no_mangle]
-pub extern "C" fn rs_snmp_log_json_response(tx: &mut SNMPTransaction, jsb: &mut JsonBuilder) -> bool
+pub unsafe extern "C" fn rs_snmp_log_json_response(tx: *const c_void, jsb: *mut c_void) -> bool
 {
+    let jsb = cast_pointer!(jsb, JsonBuilder);
+    let tx = cast_pointer!(tx, SNMPTransaction);
     snmp_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/ssh/logger.rs
+++ b/rust/src/ssh/logger.rs
@@ -64,7 +64,8 @@ fn log_ssh(tx: &SSHTransaction, js: &mut JsonBuilder) -> Result<bool, JsonError>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ssh_log_json(tx: *mut std::os::raw::c_void, js: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_ssh_log_json(tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, SSHTransaction);
     if let Ok(x) = log_ssh(tx, js) {
         return x;

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -19,6 +19,7 @@
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 use crate::tftp::tftp::TFTPTransaction;
+use std::ffi::c_void;
 
 fn tftp_log_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> Result<(), JsonError> {
     jb.open_object("tftp")?;
@@ -34,6 +35,8 @@ fn tftp_log_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> Result<(), Js
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_log_json_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> bool {
+pub unsafe extern "C" fn rs_tftp_log_json_request(tx: *const c_void, jb: *mut c_void) -> bool {
+    let jb = cast_pointer!(jb, JsonBuilder);
+    let tx = cast_pointer!(tx, TFTPTransaction);
     tftp_log_request(tx, jb).is_ok()
 }

--- a/rust/src/websocket/logger.rs
+++ b/rust/src/websocket/logger.rs
@@ -58,8 +58,9 @@ pub unsafe extern "C" fn rs_websocket_logger_log(
 
 #[no_mangle]
 pub unsafe extern "C" fn SCWebSocketLogDetails(
-    tx: &WebSocketTransaction, js: *mut std::os::raw::c_void, pp: bool, pb64: bool,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void, pp: bool, pb64: bool,
 ) -> bool {
     let js = cast_pointer!(js, JsonBuilder);
+    let tx = cast_pointer!(tx, WebSocketTransaction);
     log_websocket(tx, js, pp, pb64).is_ok()
 }

--- a/rust/src/websocket/logger.rs
+++ b/rust/src/websocket/logger.rs
@@ -49,15 +49,17 @@ fn log_websocket(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_websocket_logger_log(
-    tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
+    tx: *const std::os::raw::c_void, js: *mut std::os::raw::c_void,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     let tx = cast_pointer!(tx, WebSocketTransaction);
     log_websocket(tx, js, false, false).is_ok()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn SCWebSocketLogDetails(
-    tx: &WebSocketTransaction, js: &mut JsonBuilder, pp: bool, pb64: bool,
+    tx: &WebSocketTransaction, js: *mut std::os::raw::c_void, pp: bool, pb64: bool,
 ) -> bool {
+    let js = cast_pointer!(js, JsonBuilder);
     log_websocket(tx, js, pp, pb64).is_ok()
 }

--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -45,7 +45,7 @@ pub(super) struct WebSocketPdu {
 }
 
 // cf rfc6455#section-5.2
-pub fn parse_message(i: &[u8], max_pl_size: u32) -> IResult<&[u8], WebSocketPdu> {
+pub(super) fn parse_message(i: &[u8], max_pl_size: u32) -> IResult<&[u8], WebSocketPdu> {
     let (i, flags_op) = be_u8(i)?;
     let fin = (flags_op & 0x80) != 0;
     let compress = (flags_op & 0x40) != 0;

--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -23,7 +23,7 @@ use suricata_derive::EnumStringU8;
 
 #[derive(Clone, Debug, Default, EnumStringU8)]
 #[repr(u8)]
-pub enum WebSocketOpcode {
+pub(super) enum WebSocketOpcode {
     #[default]
     Continuation = 0,
     Text = 1,
@@ -34,7 +34,7 @@ pub enum WebSocketOpcode {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct WebSocketPdu {
+pub(super) struct WebSocketPdu {
     pub flags: u8,
     pub fin: bool,
     pub compress: bool,

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -39,20 +39,20 @@ pub(super) static mut ALPROTO_WEBSOCKET: AppProto = ALPROTO_UNKNOWN;
 static mut WEBSOCKET_MAX_PAYLOAD_SIZE: u32 = 0xFFFF;
 
 #[derive(AppLayerFrameType)]
-pub enum WebSocketFrameType {
+enum WebSocketFrameType {
     Header,
     Pdu,
     Data,
 }
 
 #[derive(AppLayerEvent)]
-pub enum WebSocketEvent {
+enum WebSocketEvent {
     SkipEndOfPayload,
     ReassemblyLimitReached,
 }
 
 #[derive(Default)]
-pub struct WebSocketTransaction {
+pub(super) struct WebSocketTransaction {
     tx_id: u64,
     pub pdu: parser::WebSocketPdu,
     tx_data: AppLayerTxData,
@@ -80,7 +80,7 @@ struct WebSocketReassemblyBuffer {
 }
 
 #[derive(Default)]
-pub struct WebSocketState {
+struct WebSocketState {
     state_data: AppLayerStateData,
     tx_id: u64,
     transactions: VecDeque<WebSocketTransaction>,

--- a/rust/src/x509/log.rs
+++ b/rust/src/x509/log.rs
@@ -17,7 +17,7 @@
 
 use crate::jsonbuilder::JsonBuilder;
 use crate::x509::time::format_timestamp;
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 
 /// Helper function to log a TLS timestamp from C to JSON with the
@@ -29,8 +29,9 @@ use std::os::raw::c_char;
 /// FFI function that dereferences pointers from C.
 #[no_mangle]
 pub unsafe extern "C" fn sc_x509_log_timestamp(
-    jb: &mut JsonBuilder, key: *const c_char, timestamp: i64,
+    jb: *mut c_void, key: *const c_char, timestamp: i64,
 ) -> bool {
+    let jb = cast_pointer!(jb, JsonBuilder);
     if let Ok(key) = CStr::from_ptr(key).to_str() {
         if let Ok(timestamp) = format_timestamp(timestamp) {
             return jb.set_string(key, &timestamp).is_ok();

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -210,6 +210,8 @@ def logger_patch_output_c(proto):
         if line.find("rs_template_logger_log") > -1:
             output.write(inlines[i].replace("TEMPLATE", proto.upper()).replace(
                     "template", proto.lower()))
+            # RegisterSimpleJsonApplayerLogger( on itw own line for clang-format
+            output.write(inlines[i-1])
         if line.find("OutputTemplateLogInitSub(") > -1:
             output.write(inlines[i].replace("Template", proto))
             output.write(inlines[i+1])

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -210,8 +210,6 @@ def logger_patch_output_c(proto):
         if line.find("rs_template_logger_log") > -1:
             output.write(inlines[i].replace("TEMPLATE", proto.upper()).replace(
                     "template", proto.lower()))
-            # RegisterSimpleJsonApplayerLogger( on itw own line for clang-format
-            output.write(inlines[i-1])
         if line.find("OutputTemplateLogInitSub(") > -1:
             output.write(inlines[i].replace("Template", proto))
             output.write(inlines[i+1])

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -1456,9 +1456,10 @@ uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len)
     return c == NULL ? len : (uint16_t)(c - buffer + 1);
 }
 
-bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb)
+bool EveFTPDataAddMetadata(const void *vtx, void *vjb)
 {
     const FtpDataState *ftp_state = (FtpDataState *)vtx;
+    JsonBuilder *jb = (JsonBuilder *)vjb;
     jb_open_object(jb, "ftp_data");
 
     if (ftp_state->file_name) {

--- a/src/app-layer-ftp.h
+++ b/src/app-layer-ftp.h
@@ -190,6 +190,6 @@ uint64_t FTPMemuseGlobalCounter(void);
 uint64_t FTPMemcapGlobalCounter(void);
 
 uint16_t JsonGetNextLineFromBuffer(const char *buffer, const uint16_t len);
-bool EveFTPDataAddMetadata(void *vtx, JsonBuilder *jb);
+bool EveFTPDataAddMetadata(const void *vtx, void *jb);
 
 #endif /* SURICATA_APP_LAYER_FTP_H */

--- a/src/decode.h
+++ b/src/decode.h
@@ -28,7 +28,6 @@
 #define COUNTERS
 
 #include "suricata-common.h"
-#include "suricata-plugin.h"
 #include "threadvars.h"
 #include "util-debug.h"
 #include "decode-events.h"
@@ -455,6 +454,8 @@ struct PacketL4 {
         ICMPV6Vars icmpv6;
     } vars;
 };
+
+#define PLUGIN_VAR_SIZE 64
 
 /* sizes of the members:
  * src: 17 bytes

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -122,8 +122,8 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
         }
 
         PREFILTER_PROFILING_START(det_ctx);
-        engine->cb.PrefilterTx(
-                det_ctx, engine->pectx, p, p->flow, (void *) tx_ptr, tx->tx_id, tx->tx_data_ptr, flow_flags);
+        engine->cb.PrefilterTx(det_ctx, engine->pectx, p, p->flow, (void *)tx_ptr, tx->tx_id,
+                tx->tx_data_ptr, flow_flags);
         PREFILTER_PROFILING_END(det_ctx, engine->gid);
 
         if (tx->tx_progress > engine->ctx.tx_min_progress && engine->is_last_for_progress) {

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -108,7 +108,7 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
     PrefilterEngine *engine = sgh->tx_engines;
     do {
         // based on flow alproto, and engine, we get right tx_ptr
-        void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, alproto, engine->alproto, flow_flags);
+        const void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, alproto, engine->alproto, flow_flags);
         if (tx_ptr == NULL) {
             // incompatible engine->alproto with flow alproto
             goto next;
@@ -123,7 +123,7 @@ void DetectRunPrefilterTx(DetectEngineThreadCtx *det_ctx,
 
         PREFILTER_PROFILING_START(det_ctx);
         engine->cb.PrefilterTx(
-                det_ctx, engine->pectx, p, p->flow, tx_ptr, tx->tx_id, tx->tx_data_ptr, flow_flags);
+                det_ctx, engine->pectx, p, p->flow, (void *) tx_ptr, tx->tx_id, tx->tx_data_ptr, flow_flags);
         PREFILTER_PROFILING_END(det_ctx, engine->gid);
 
         if (tx->tx_progress > engine->ctx.tx_min_progress && engine->is_last_for_progress) {

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -40,11 +40,10 @@
 static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
+#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) Base64ModeRFC4648
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
 static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options);
-
-#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) Base64ModeRFC4648
 
 void DetectTransformFromBase64DecodeRegister(void)
 {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1102,7 +1102,7 @@ DetectRunTxSortHelper(const void *a, const void *b)
 #endif
 
 // Get inner transaction for engine
-void *DetectGetInnerTx(
+const void *DetectGetInnerTx(
         const void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags)
 {
     if (unlikely(alproto == ALPROTO_DOH2)) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -1180,7 +1180,8 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         if (!(inspect_flags & BIT_U32(engine->id)) &&
                 direction == engine->dir)
         {
-            const void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
+            const void *tx_ptr =
+                    DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
             if (tx_ptr == NULL) {
                 if (engine->alproto != ALPROTO_UNKNOWN) {
                     /* special case: file_data on 'alert tcp' will have engines
@@ -1223,8 +1224,8 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
             } else {
                 KEYWORD_PROFILING_SET_LIST(det_ctx, engine->sm_list);
                 DEBUG_VALIDATE_BUG_ON(engine->v2.Callback == NULL);
-                match = engine->v2.Callback(
-                        de_ctx, det_ctx, engine, s, f, flow_flags, alstate, (void *) tx_ptr, tx->tx_id);
+                match = engine->v2.Callback(de_ctx, det_ctx, engine, s, f, flow_flags, alstate,
+                        (void *)tx_ptr, tx->tx_id);
                 TRACE_SID_TXS(s->id, tx, "engine %p match %d", engine, match);
                 if (engine->stream) {
                     can->stream_stored = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1180,7 +1180,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
         if (!(inspect_flags & BIT_U32(engine->id)) &&
                 direction == engine->dir)
         {
-            void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
+            const void *tx_ptr = DetectGetInnerTx(tx->tx_ptr, f->alproto, engine->alproto, flow_flags);
             if (tx_ptr == NULL) {
                 if (engine->alproto != ALPROTO_UNKNOWN) {
                     /* special case: file_data on 'alert tcp' will have engines
@@ -1224,7 +1224,7 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
                 KEYWORD_PROFILING_SET_LIST(det_ctx, engine->sm_list);
                 DEBUG_VALIDATE_BUG_ON(engine->v2.Callback == NULL);
                 match = engine->v2.Callback(
-                        de_ctx, det_ctx, engine, s, f, flow_flags, alstate, tx_ptr, tx->tx_id);
+                        de_ctx, det_ctx, engine, s, f, flow_flags, alstate, (void *) tx_ptr, tx->tx_id);
                 TRACE_SID_TXS(s->id, tx, "engine %p match %d", engine, match);
                 if (engine->stream) {
                     can->stream_stored = true;

--- a/src/detect.c
+++ b/src/detect.c
@@ -1102,7 +1102,8 @@ DetectRunTxSortHelper(const void *a, const void *b)
 #endif
 
 // Get inner transaction for engine
-void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags)
+void *DetectGetInnerTx(
+        const void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags)
 {
     if (unlikely(alproto == ALPROTO_DOH2)) {
         if (engine_alproto == ALPROTO_DNS) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -1593,7 +1593,8 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx, cons
 int DetectUnregisterThreadCtxFuncs(DetectEngineCtx *, void *data, const char *name);
 int DetectRegisterThreadCtxFuncs(DetectEngineCtx *, const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *), int);
 void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
-void *DetectGetInnerTx(void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags);
+void *DetectGetInnerTx(
+        const void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags);
 
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size);
 void RuleMatchCandidateTxArrayFree(DetectEngineThreadCtx *det_ctx);

--- a/src/detect.h
+++ b/src/detect.h
@@ -1593,7 +1593,7 @@ const SigGroupHead *SigMatchSignaturesGetSgh(const DetectEngineCtx *de_ctx, cons
 int DetectUnregisterThreadCtxFuncs(DetectEngineCtx *, void *data, const char *name);
 int DetectRegisterThreadCtxFuncs(DetectEngineCtx *, const char *name, void *(*InitFunc)(void *), void *data, void (*FreeFunc)(void *), int);
 void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
-void *DetectGetInnerTx(
+const void *DetectGetInnerTx(
         const void *tx_ptr, AppProto alproto, AppProto engine_alproto, uint8_t flow_flags);
 
 void RuleMatchCandidateTxArrayInit(DetectEngineThreadCtx *det_ctx, uint32_t size);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -210,9 +210,10 @@ static void JsonDNP3LogResponse(JsonBuilder *js, DNP3Transaction *dnp3tx)
     jb_close(js);
 }
 
-bool AlertJsonDnp3(void *vtx, JsonBuilder *js)
+bool AlertJsonDnp3(const void *vtx, void *vjs)
 {
     DNP3Transaction *tx = (DNP3Transaction *)vtx;
+    JsonBuilder *js = (JsonBuilder *)vjs;
     bool logged = false;
     jb_open_object(js, "dnp3");
     if (tx->is_request && tx->done) {

--- a/src/output-json-dnp3.h
+++ b/src/output-json-dnp3.h
@@ -21,6 +21,6 @@
 #include "app-layer-dnp3.h"
 
 void JsonDNP3LogRegister(void);
-bool AlertJsonDnp3(void *vtx, JsonBuilder *js);
+bool AlertJsonDnp3(const void *vtx, void *js);
 
 #endif /* SURICATA_OUTPUT_JSON_DNP3_H */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -248,13 +248,13 @@ typedef struct LogDnsLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogDnsLogThread;
 
-bool AlertJsonDns(void *txptr, JsonBuilder *js)
+bool AlertJsonDns(const void *txptr, void *js)
 {
     return SCDnsLogJson(
             txptr, LOG_FORMAT_DETAILED | LOG_QUERIES | LOG_ANSWERS | LOG_ALL_RRTYPES, js);
 }
 
-bool AlertJsonDoh2(void *txptr, JsonBuilder *js)
+bool AlertJsonDoh2(const void *txptr, void *js)
 {
     JsonBuilderMark mark = { 0, 0, 0 };
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -265,7 +265,7 @@ bool AlertJsonDoh2(const void *txptr, void *js)
         jb_restore_mark(js, &mark);
     }
     // then log one DNS tx if any, preferring the answer
-    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
+    const void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
     if (tx_dns == NULL) {
         tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOSERVER);
     }
@@ -301,7 +301,7 @@ static int JsonDoh2Logger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         jb_restore_mark(jb, &mark);
     }
 
-    void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
+    const void *tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOCLIENT);
     if (tx_dns == NULL) {
         tx_dns = DetectGetInnerTx(txptr, ALPROTO_DOH2, ALPROTO_DNS, STREAM_TOSERVER);
     }

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -27,7 +27,7 @@
 void JsonDnsLogRegister(void);
 void JsonDoh2LogRegister(void);
 
-bool AlertJsonDns(void *vtx, JsonBuilder *js);
-bool AlertJsonDoh2(void *vtx, JsonBuilder *js);
+bool AlertJsonDns(const void *vtx, void *js);
+bool AlertJsonDoh2(const void *vtx, void *js);
 
 #endif /* SURICATA_OUTPUT_JSON_DNS_H */

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -46,9 +46,10 @@
 #include "app-layer-ftp.h"
 #include "output-json-ftp.h"
 
-bool EveFTPLogCommand(void *vtx, JsonBuilder *jb)
+bool EveFTPLogCommand(const void *vtx, void *vjb)
 {
-    FTPTransaction *tx = vtx;
+    FTPTransaction *tx = (FTPTransaction *)vtx;
+    JsonBuilder *jb = (JsonBuilder *)vjb;
     /* Preallocate array objects to simplify failure case */
     JsonBuilder *js_resplist = NULL;
     if (!TAILQ_EMPTY(&tx->response_list)) {

--- a/src/output-json-ftp.h
+++ b/src/output-json-ftp.h
@@ -24,6 +24,6 @@
 #ifndef SURICATA_OUTPUT_JSON_FTP_H
 #define SURICATA_OUTPUT_JSON_FTP_H
 
-bool EveFTPLogCommand(void *vtx, JsonBuilder *js);
+bool EveFTPLogCommand(const void *vtx, void *js);
 
 #endif /* SURICATA_OUTPUT_JSON_FTP_H */

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -60,7 +60,7 @@ typedef struct LogMQTTLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogMQTTLogThread;
 
-bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js)
+bool JsonMQTTAddMetadata(const void *vtx, void *js)
 {
     return rs_mqtt_logger_log(vtx, MQTT_DEFAULT_FLAGS, MQTT_DEFAULT_MAXLOGLEN, js);
 }

--- a/src/output-json-mqtt.h
+++ b/src/output-json-mqtt.h
@@ -25,6 +25,6 @@
 #define SURICATA_OUTPUT_JSON_MQTT_H
 
 void JsonMQTTLogRegister(void);
-bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js);
+bool JsonMQTTAddMetadata(const void *vtx, void *js);
 
 #endif /* SURICATA_OUTPUT_JSON_MQTT_H */

--- a/src/output-json-pgsql.c
+++ b/src/output-json-pgsql.c
@@ -59,7 +59,7 @@ typedef struct LogPgsqlLogThread_ {
     OutputJsonThreadCtx *ctx;
 } LogPgsqlLogThread;
 
-bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb)
+bool JsonPgsqlAddMetadata(const void *vtx, void *jb)
 {
     return SCPgsqlLogger(vtx, PGSQL_DEFAULTS, jb);
 }

--- a/src/output-json-pgsql.h
+++ b/src/output-json-pgsql.h
@@ -25,6 +25,6 @@
 #define SURICATA_OUTPUT_JSON_PGSQL_H
 
 void JsonPgsqlLogRegister(void);
-bool JsonPgsqlAddMetadata(void *vtx, JsonBuilder *jb);
+bool JsonPgsqlAddMetadata(const void *vtx, void *jb);
 
 #endif /* SURICATA_OUTPUT_JSON_PGSQL_H */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -455,12 +455,13 @@ static void JsonTlsLogFields(JsonBuilder *js, SSLState *ssl_state, uint64_t fiel
     }
 }
 
-bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *tjs)
+bool JsonTlsLogJSONExtended(const void *vtx, void *tjs)
 {
     SSLState *state = (SSLState *)vtx;
-    jb_open_object(tjs, "tls");
-    JsonTlsLogFields(tjs, state, EXTENDED_FIELDS);
-    return jb_close(tjs);
+    JsonBuilder *js = (JsonBuilder *)tjs;
+    jb_open_object(js, "tls");
+    JsonTlsLogFields(js, state, EXTENDED_FIELDS);
+    return jb_close(js);
 }
 
 static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -26,9 +26,6 @@
 
 void JsonTlsLogRegister(void);
 
-/* For JsonBuilder. */
-#include "rust.h"
-
-bool JsonTlsLogJSONExtended(void *vtx, JsonBuilder *js);
+bool JsonTlsLogJSONExtended(const void *vtx, void *js);
 
 #endif /* SURICATA_OUTPUT_JSON_TLS_H */

--- a/src/output.c
+++ b/src/output.c
@@ -894,7 +894,8 @@ void OutputRegisterRootLoggers(void)
     RegisterSimpleJsonApplayerLogger(ALPROTO_WEBSOCKET, rs_websocket_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_LDAP, rs_ldap_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_DOH2, AlertJsonDoh2, NULL);
-    RegisterSimpleJsonApplayerLogger(ALPROTO_TEMPLATE, rs_template_logger_log, NULL);
+    RegisterSimpleJsonApplayerLogger(
+            ALPROTO_TEMPLATE, (EveJsonSimpleTxLogFunc)rs_template_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RDP, (EveJsonSimpleTxLogFunc)rs_rdp_to_json, NULL);
     // special case : http2 is logged in http object
     RegisterSimpleJsonApplayerLogger(ALPROTO_HTTP2, rs_http2_log_json, "http");

--- a/src/output.c
+++ b/src/output.c
@@ -871,32 +871,27 @@ void OutputRegisterRootLoggers(void)
     // ALPROTO_DCERPC special: uses state
     RegisterSimpleJsonApplayerLogger(ALPROTO_DNS, AlertJsonDns, NULL);
     // either need a cast here or in rust for ModbusTransaction, done here
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_MODBUS, (EveJsonSimpleTxLogFunc)rs_modbus_to_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_MODBUS, rs_modbus_to_json, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_ENIP, SCEnipLoggerLog, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_DNP3, AlertJsonDnp3, NULL);
     // ALPROTO_NFS special: uses state
     // underscore instead of dash for ftp_data
     RegisterSimpleJsonApplayerLogger(ALPROTO_FTPDATA, EveFTPDataAddMetadata, "ftp_data");
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_TFTP, rs_tftp_log_json_request, NULL);
     // ALPROTO_IKE special: uses state
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_KRB5, rs_krb5_log_json_response, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, rs_quic_to_json, NULL);
     // ALPROTO_DHCP TODO missing
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_SNMP, (EveJsonSimpleTxLogFunc)rs_snmp_log_json_response, NULL);
-    RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_SNMP, rs_snmp_log_json_response, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, rs_sip_log_json, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RFB, rs_rfb_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_MQTT, JsonMQTTAddMetadata, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_PGSQL, JsonPgsqlAddMetadata, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_WEBSOCKET, rs_websocket_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_LDAP, rs_ldap_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_DOH2, AlertJsonDoh2, NULL);
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_TEMPLATE, (EveJsonSimpleTxLogFunc)rs_template_logger_log, NULL);
-    RegisterSimpleJsonApplayerLogger(ALPROTO_RDP, (EveJsonSimpleTxLogFunc)rs_rdp_to_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_TEMPLATE, rs_template_logger_log, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_RDP, rs_rdp_to_json, NULL);
     // special case : http2 is logged in http object
     RegisterSimpleJsonApplayerLogger(ALPROTO_HTTP2, rs_http2_log_json, "http");
     // underscore instead of dash for bittorrent_dht

--- a/src/output.h
+++ b/src/output.h
@@ -161,7 +161,7 @@ void OutputLoggerExitPrintStats(ThreadVars *, void *);
 void OutputSetupActiveLoggers(void);
 void OutputClearActiveLoggers(void);
 
-typedef bool (*EveJsonSimpleTxLogFunc)(void *, struct JsonBuilder *);
+typedef bool (*EveJsonSimpleTxLogFunc)(const void *, void *);
 
 typedef struct EveJsonSimpleAppLayerLogger {
     EveJsonSimpleTxLogFunc LogTx;

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -37,8 +37,6 @@ const SuricataContext suricata_context = {
     FileAppendDataById,
     FileAppendGAPById,
     FileContainerRecycle,
-
-    AppLayerRegisterParser,
 };
 
 const SuricataContext *SCGetContext(void)

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -56,9 +56,6 @@ typedef struct SuricataContext_ {
     int (*FileAppendGAPById)(FileContainer *, const StreamingBufferConfig *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
     void (*FileContainerRecycle)(FileContainer *ffc, const StreamingBufferConfig *);
-
-    int (*AppLayerRegisterParser)(const struct AppLayerParser *p, AppProto alproto);
-
 } SuricataContext;
 
 extern const SuricataContext suricata_context;

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -33,6 +33,9 @@ typedef struct HttpRangeContainerBlock HttpRangeContainerBlock;
 
 struct AppLayerParser;
 
+// opaque definition in rust not repr(C)
+typedef struct JsonBuilder JsonBuilder;
+
 typedef struct SuricataContext_ {
     SCError (*SCLogMessage)(const SCLogLevel, const char *, const unsigned int, const char *,
             const char *, const char *message);

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -137,9 +137,11 @@ void TmModuleDecodePcapFileRegister (void)
     tmm_modules[TMM_DECODEPCAPFILE].flags = TM_FLAG_DECODE_TM;
 }
 
+#if defined(HAVE_SETVBUF) && defined(OS_LINUX)
 #define PCAP_FILE_BUFFER_SIZE_DEFAULT 131072U   // 128 KiB
 #define PCAP_FILE_BUFFER_SIZE_MIN     4096U     // 4 KiB
 #define PCAP_FILE_BUFFER_SIZE_MAX     67108864U // 64MiB
+#endif
 
 void PcapFileGlobalInit(void)
 {

--- a/src/suricata-plugin.h
+++ b/src/suricata-plugin.h
@@ -22,22 +22,12 @@
 #include <stdbool.h>
 
 #include "queue.h"
+#include "rust.h"
 
 /**
  * The size of the data chunk inside each packet structure a plugin
  * has for private data (Packet->plugin_v).
  */
-#define PLUGIN_VAR_SIZE 64
-
-/**
- * Structure to define a Suricata plugin.
- */
-typedef struct SCPlugin_ {
-    const char *name;
-    const char *license;
-    const char *author;
-    void (*Init)(void);
-} SCPlugin;
 
 typedef SCPlugin *(*SCPluginRegisterFunc)(void);
 
@@ -51,9 +41,6 @@ typedef struct SCCapturePlugin_ {
 } SCCapturePlugin;
 
 int SCPluginRegisterCapture(SCCapturePlugin *);
-
-// Every change in the API used by plugins should change this number
-#define SC_PLUGIN_API_VERSION 8
 
 typedef struct SCAppLayerPlugin_ {
     // versioning to check suricata/plugin API compatibility


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4102 with all 6 subtickets

Describe changes:
- add app-layer plugin example with template protocol
- document app-layer plugins

@jufajardini what do you think about the doc ?

Jason told me this fits the tickets

https://github.com/OISF/suricata/pull/12448 using suricata as a crate by the plugin

Draft: 
- still needs to cleanup suricata for use of `pub` cf last commit about Websocket
- Should we fix  https://doc.rust-lang.org/nomicon/ffi.html says 
> Notice that it is a really bad idea to use an empty enum as FFI type
- still need to split the suricata crate into 2 with a suricata-sys crate that has 0 dependendy and is the one used by the plugin

cc @jasonish 