### PR TITLE
Cleanup nits : unused macros, better depency in makefile, remove unnecesarry field out of SuricataContext

### DIFF
--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -84,7 +84,7 @@ vendor:
 	$(CARGO_ENV) $(CARGO) vendor
 
 if HAVE_CBINDGEN
-gen/rust-bindings.h: $(RUST_SURICATA_LIB)
+gen/rust-bindings.h: $(RUST_SURICATA_LIB) cbindgen.toml
 	cd $(abs_top_srcdir)/rust && \
 		cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --verify --output $(abs_top_builddir)/rust/gen/rust-bindings.h || true

--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -23,7 +23,6 @@ use crate::direction::Direction;
 use crate::filecontainer::FileContainer;
 use crate::flow::Flow;
 use std::os::raw::{c_void,c_char,c_int};
-use crate::core::SC;
 use std::ffi::CStr;
 use crate::core::StreamingBufferConfig;
 
@@ -480,12 +479,9 @@ pub type GetFrameNameById = unsafe extern "C" fn(u8) -> *const c_char;
 extern {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
     pub fn AppLayerRegisterParserAlias(parser_name: *const c_char, alias_name: *const c_char);
+    pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
 }
 
-#[allow(non_snake_case)]
-pub unsafe fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int {
-    (SC.unwrap().AppLayerRegisterParser)(parser, alproto)
-}
 
 // Defined in app-layer-detect-proto.h
 /// cbindgen:ignore

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -163,8 +163,6 @@ pub struct SuricataContext {
     pub FileAppendData: SCFileAppendDataById,
     pub FileAppendGAP: SCFileAppendGAPById,
     pub FileContainerRecycle: SCFileContainerRecycle,
-
-    pub AppLayerRegisterParser: extern fn(parser: *const crate::applayer::RustParser, alproto: AppProto) -> std::os::raw::c_int,
 }
 
 #[allow(non_snake_case)]

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -40,11 +40,10 @@
 static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
+#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) Base64ModeRFC4648
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
 static void TransformFromBase64Decode(InspectionBuffer *buffer, void *options);
-
-#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) Base64ModeRFC4648
 
 void DetectTransformFromBase64DecodeRegister(void)
 {

--- a/src/rust-context.c
+++ b/src/rust-context.c
@@ -37,8 +37,6 @@ const SuricataContext suricata_context = {
     FileAppendDataById,
     FileAppendGAPById,
     FileContainerRecycle,
-
-    AppLayerRegisterParser,
 };
 
 const SuricataContext *SCGetContext(void)

--- a/src/rust-context.h
+++ b/src/rust-context.h
@@ -56,9 +56,6 @@ typedef struct SuricataContext_ {
     int (*FileAppendGAPById)(FileContainer *, const StreamingBufferConfig *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
     void (*FileContainerRecycle)(FileContainer *ffc, const StreamingBufferConfig *);
-
-    int (*AppLayerRegisterParser)(const struct AppLayerParser *p, AppProto alproto);
-
 } SuricataContext;
 
 extern const SuricataContext suricata_context;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -137,9 +137,11 @@ void TmModuleDecodePcapFileRegister (void)
     tmm_modules[TMM_DECODEPCAPFILE].flags = TM_FLAG_DECODE_TM;
 }
 
+#if defined(HAVE_SETVBUF) && defined(OS_LINUX)
 #define PCAP_FILE_BUFFER_SIZE_DEFAULT 131072U   // 128 KiB
 #define PCAP_FILE_BUFFER_SIZE_MIN     4096U     // 4 KiB
 #define PCAP_FILE_BUFFER_SIZE_MAX     67108864U // 64MiB
+#endif
 
 void PcapFileGlobalInit(void)
 {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, just cleanups

Describe changes:
- remove some warnings about unused macros depending on the compile options
- better depency in makefile : with a change in cbindgen.toml, we rerun cbindgen
- remove unnecesarry field out of SuricataContext

some simple commits out of https://github.com/OISF/suricata/pull/12455