### PR TITLE
protodetect: finish probing parser sooner (backport7)

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -614,7 +614,7 @@ again_midstream:
         else if (pp_port_sp)
             mask = pp_port_sp->alproto_mask;
 
-        if (alproto_masks[0] == mask) {
+        if ((alproto_masks[0] & mask) == mask) {
             FLOW_SET_PP_DONE(f, dir);
             SCLogDebug("%s, mask is now %08x, needed %08x, so done",
                     (dir == STREAM_TOSERVER) ? "toserver":"toclient",


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7496

Describe changes:
- backport of relevant commit in https://github.com/OISF/suricata/pull/12403

(the other commit is not relevant because there is no smtp probing parser in 7)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2252
