### PR TITLE
rust/logging: fix logging from plugins

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -83,7 +83,7 @@ extern crate suricata_derive;
 pub mod core;
 
 #[macro_use]
-pub(crate) mod debug;
+pub mod debug;
 
 pub mod common;
 pub mod conf;

--- a/rust/src/plugin.rs
+++ b/rust/src/plugin.rs
@@ -19,9 +19,9 @@
 
 pub fn init() {
     unsafe {
-        let context = super::core::SCGetContext();
-        super::core::init_ffi(context);
+        let context = crate::core::SCGetContext();
+        crate::core::init_ffi(context);
 
-        super::debug::SCSetRustLogLevel(super::debug::SCLogGetLogLevel());
+        crate::debug::LEVEL = crate::debug::SCLogGetLogLevel();
     }
 }


### PR DESCRIPTION
Commit 2bcc66da5826fa0e6e074a756754b295e5ac4da2 broke logging from
plugins:

- debug visibility was reduced making it unusable from an external crate
- the plugins view of the log level was broken

To fix:
- make debug pub
- minor change to initialization of the log LEVEL as seen by the plugin
  so its seen by the plugin. I'm not really sure why the previous
  version wasn't working though, but this one does
