### PR TITLE
Detect smtp keywords 7515 v1.2

### DIFF
--- a/doc/userguide/rules/smtp-keywords.rst
+++ b/doc/userguide/rules/smtp-keywords.rst
@@ -59,6 +59,27 @@ Signature example::
 
 This keyword maps to the eve.json log field ``smtp.mail_from``
 
+smtp.rcpt_to
+------------
+
+SMTP rcpt to is the one of the parameters passed to one RCPT TO command from the client.
+
+Syntax::
+
+ smtp.rcpt_to; content:"sensitive@target";
+
+Signature example::
+
+ alert smtp any any -> any any (msg:"SMTP rcpt to sensitive"; smtp.rcpt_to; content:"sensitive@target"; sid:2; rev:1;)
+
+``smtp.rcpt_to`` is a 'sticky buffer'.
+
+``smtp.rcpt_to`` is a 'multi buffer'.
+
+``smtp.rcpt_to`` can be used as ``fast_pattern``.
+
+This keyword maps to the eve.json log field ``smtp.rcpt_to[]``
+
 
 Frames
 ------

--- a/doc/userguide/rules/smtp-keywords.rst
+++ b/doc/userguide/rules/smtp-keywords.rst
@@ -40,6 +40,25 @@ Signature example::
 
 This keyword maps to the eve.json log field ``smtp.helo``
 
+smtp.mail_from
+--------------
+
+SMTP mail from is the parameter passed to the first MAIL FROM command from the client.
+
+Syntax::
+
+ smtp.mail_from; content:"spam";
+
+Signature example::
+
+ alert smtp any any -> any any (msg:"SMTP mail from spam"; smtp.mail_from; content:"spam"; sid:2; rev:1;)
+
+``smtp.mail_from`` is a 'sticky buffer'.
+
+``smtp.mail_from`` can be used as ``fast_pattern``.
+
+This keyword maps to the eve.json log field ``smtp.mail_from``
+
 
 Frames
 ------

--- a/doc/userguide/rules/smtp-keywords.rst
+++ b/doc/userguide/rules/smtp-keywords.rst
@@ -18,6 +18,29 @@ Signature Example:
 
 For additional information on the ``file.name`` keyword, see :doc:`file-keywords`.
 
+
+smtp.helo
+---------
+
+SMTP helo is the parameter passed to the first HELO command from the client.
+This keyword matches per transaction, so it can match more than once per flow,
+even if the helo occured only once at the beginning of the flow.
+
+Syntax::
+
+ smtp.helo; content:"localhost";
+
+Signature example::
+
+ alert smtp any any -> any any (msg:"SMTP helo localhost"; smtp.helo; content:"localhost"; sid:2; rev:1;)
+
+``smtp.helo`` is a 'sticky buffer'.
+
+``smtp.helo`` can be used as ``fast_pattern``.
+
+This keyword maps to the eve.json log field ``smtp.helo``
+
+
 Frames
 ------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -266,6 +266,7 @@ noinst_HEADERS = \
 	detect-smb-ntlmssp.h \
 	detect-smb-share.h \
 	detect-smb-version.h \
+	detect-smtp.h \
 	detect-ssh-hassh.h \
 	detect-ssh-hassh-server.h \
 	detect-ssh-hassh-server-string.h \
@@ -833,6 +834,7 @@ libsuricata_c_a_SOURCES = \
 	detect-smb-ntlmssp.c \
 	detect-smb-share.c \
 	detect-smb-version.c \
+	detect-smtp.c \
 	detect-ssh-hassh.c \
 	detect-ssh-hassh-server.c \
 	detect-ssh-hassh-server-string.c \

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -85,6 +85,7 @@
 
 #include "detect-smb-share.h"
 #include "detect-smb-version.h"
+#include "detect-smtp.h"
 
 #include "detect-base64-decode.h"
 #include "detect-base64-data.h"
@@ -730,6 +731,7 @@ void SigTableSetup(void)
     DetectVlanIdRegister();
     DetectVlanLayersRegister();
 
+    SCDetectSMTPRegister();
     ScDetectSNMPRegister();
     SCDetectDHCPRegister();
     ScDetectWebsocketRegister();

--- a/src/detect-smtp.h
+++ b/src/detect-smtp.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Philippe Antoine <pantoine@oisf.net>
+ */
+
+#ifndef SURICATA_DETECT_SMTP_H
+#define SURICATA_DETECT_SMTP_H
+
+void SCDetectSMTPRegister(void);
+
+#endif /* SURICATA_DETECT_SMTP_H */


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7515
https://redmine.openinfosecfoundation.org/issues/7516
https://redmine.openinfosecfoundation.org/issues/7517

Describe changes:
- adds 3 smtp keywords

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2254

#12468 with doc addition as per review