### PR TITLE
Libhtp rs v27.1 small step for src

### DIFF
--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -91,7 +91,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
  * @param[in] rawvalue
  * @param[out] range
  *
- * @return HTP_OK on success, HTP_ERROR on failure.
+ * @return HTP_STATUS_OK on success, HTP_STATUS_ERROR on failure.
  */
 int HTPParseContentRange(const bstr *rawvalue, HTTPContentRange *range)
 {
@@ -105,7 +105,7 @@ int HTPParseContentRange(const bstr *rawvalue, HTTPContentRange *range)
  * @param[in] rawvalue
  * @param[out] range
  *
- * @return HTP_OK on success, HTP_ERROR, -2, -3 on failure.
+ * @return HTP_STATUS_OK on success, HTP_STATUS_ERROR, -2, -3 on failure.
  */
 static int HTPParseAndCheckContentRange(
         const bstr *rawvalue, HTTPContentRange *range, HtpState *s, HtpTxUserData *htud)
@@ -183,7 +183,7 @@ int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filena
     uint32_t keylen;
     if (htp_tx_request_hostname(tx) != NULL) {
         uint32_t hlen = (uint32_t)bstr_len(htp_tx_request_hostname(tx));
-        if (bstr_len(htp_tx_request_hostname(tx)) > UINT16_MAX) {
+        if (hlen > UINT16_MAX) {
             hlen = UINT16_MAX;
         }
         keylen = hlen + filename_len;

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -93,7 +93,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
  *
  * @return HTP_OK on success, HTP_ERROR on failure.
  */
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
+int HTPParseContentRange(const bstr *rawvalue, HTTPContentRange *range)
 {
     uint32_t len = (uint32_t)bstr_len(rawvalue);
     return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
@@ -108,7 +108,7 @@ int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range)
  * @return HTP_OK on success, HTP_ERROR, -2, -3 on failure.
  */
 static int HTPParseAndCheckContentRange(
-        bstr *rawvalue, HTTPContentRange *range, HtpState *s, HtpTxUserData *htud)
+        const bstr *rawvalue, HTTPContentRange *range, HtpState *s, HtpTxUserData *htud)
 {
     int r = HTPParseContentRange(rawvalue, range);
     if (r != 0) {
@@ -147,8 +147,8 @@ static int HTPParseAndCheckContentRange(
  *  \retval -1 error
  */
 int HTPFileOpenWithRange(HtpState *s, HtpTxUserData *txud, const uint8_t *filename,
-        uint16_t filename_len, const uint8_t *data, uint32_t data_len, htp_tx_t *tx, bstr *rawvalue,
-        HtpTxUserData *htud)
+        uint16_t filename_len, const uint8_t *data, uint32_t data_len, const htp_tx_t *tx,
+        const bstr *rawvalue, HtpTxUserData *htud)
 {
     SCEnter();
     uint16_t flags;

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -30,12 +30,12 @@
 int HTPFileOpen(
         HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *, uint32_t, uint8_t);
 int HTPFileOpenWithRange(HtpState *, HtpTxUserData *, const uint8_t *, uint16_t, const uint8_t *,
-        uint32_t, htp_tx_t *, bstr *rawvalue, HtpTxUserData *htud);
+        uint32_t, const htp_tx_t *, const bstr *rawvalue, HtpTxUserData *htud);
 bool HTPFileCloseHandleRange(const StreamingBufferConfig *sbcfg, FileContainer *, const uint16_t,
         HttpRangeContainerBlock *, const uint8_t *, uint32_t);
 int HTPFileStoreChunk(HtpTxUserData *, const uint8_t *, uint32_t, uint8_t);
 
-int HTPParseContentRange(bstr *rawvalue, HTTPContentRange *range);
+int HTPParseContentRange(const bstr *rawvalue, HTTPContentRange *range);
 int HTPFileClose(HtpTxUserData *tx, const uint8_t *data, uint32_t data_len, uint8_t flags,
         uint8_t direction);
 

--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -137,6 +137,7 @@
 #define htp_headers_get_index(headers, index) htp_table_get_index(headers, index, NULL)
 #define htp_tx_request_headers_size(tx)       htp_table_size(tx->request_headers)
 #define htp_tx_request_header_index(tx, i)    htp_table_get_index(tx->request_headers, i, NULL);
+#define htp_headers_t                         htp_table_t
 
 bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, bool uri_include_all);
 

--- a/src/app-layer-htp-libhtp.h
+++ b/src/app-layer-htp-libhtp.h
@@ -132,6 +132,12 @@
 #define htp_header_value_ptr(h) bstr_ptr(h->value)
 #define htp_header_value(h)     h->value
 
+// Functions introduced to handle opaque htp_headers_t:
+#define htp_headers_size(headers)             htp_table_size(headers)
+#define htp_headers_get_index(headers, index) htp_table_get_index(headers, index, NULL)
+#define htp_tx_request_headers_size(tx)       htp_table_size(tx->request_headers)
+#define htp_tx_request_header_index(tx, i)    htp_table_get_index(tx->request_headers, i, NULL);
+
 bstr *SCHTPGenerateNormalizedUri(htp_tx_t *tx, htp_uri_t *uri, bool uri_include_all);
 
 #endif /* SURICATA_APP_LAYER_HTP_LIBHTP__H */

--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -139,20 +139,17 @@ int HttpXFFGetIPFromTx(const Flow *f, uint64_t tx_id, HttpXFFCfg *xff_cfg,
         return 0;
     }
 
-    htp_header_t *h_xff = NULL;
-    if (htp_tx_request_headers(tx) != NULL) {
-        h_xff = htp_tx_request_header(tx, xff_cfg->header);
-    }
+    const htp_header_t *h_xff = htp_tx_request_header(tx, xff_cfg->header);
 
-    if (h_xff != NULL && bstr_len(h_xff->value) >= XFF_CHAIN_MINLEN &&
-            bstr_len(h_xff->value) < XFF_CHAIN_MAXLEN) {
+    if (h_xff != NULL && htp_header_value_len(h_xff) >= XFF_CHAIN_MINLEN &&
+            htp_header_value_len(h_xff) < XFF_CHAIN_MAXLEN) {
 
-        memcpy(xff_chain, bstr_ptr(h_xff->value), bstr_len(h_xff->value));
-        xff_chain[bstr_len(h_xff->value)]=0;
+        memcpy(xff_chain, htp_header_value_ptr(h_xff), htp_header_value_len(h_xff));
+        xff_chain[htp_header_value_len(h_xff)] = 0;
 
         if (xff_cfg->flags & XFF_REVERSE) {
             /** Get the last IP address from the chain */
-            p_xff = memrchr(xff_chain, ' ', bstr_len(h_xff->value));
+            p_xff = memrchr(xff_chain, ' ', htp_header_value_len(h_xff));
             if (p_xff == NULL) {
                 p_xff = xff_chain;
             } else {
@@ -161,7 +158,7 @@ int HttpXFFGetIPFromTx(const Flow *f, uint64_t tx_id, HttpXFFCfg *xff_cfg,
         }
         else {
             /** Get the first IP address from the chain */
-            p_xff = memchr(xff_chain, ',', bstr_len(h_xff->value));
+            p_xff = memchr(xff_chain, ',', htp_header_value_len(h_xff));
             if (p_xff != NULL) {
                 *p_xff = 0;
             }

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2942,7 +2942,7 @@ static int HTPParserTest01(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -2986,7 +2986,7 @@ static int HTPParserTest01b(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3041,7 +3041,7 @@ static int HTPParserTest01c(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3097,7 +3097,7 @@ static int HTPParserTest01a(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3139,7 +3139,7 @@ static int HTPParserTest02(void)
 
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NOT_NULL(h);
 
     FAIL_IF_NULL(htp_tx_request_method(tx));
@@ -3193,7 +3193,7 @@ static int HTPParserTest03(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NOT_NULL(h);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_UNKNOWN);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
@@ -3234,7 +3234,7 @@ static int HTPParserTest04(void)
 
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
 
     FAIL_IF_NOT_NULL(h);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_UNKNOWN);
@@ -3308,7 +3308,7 @@ static int HTPParserTest05(void)
     FAIL_IF_NOT(htp_tx_request_method_number(tx) == HTP_METHOD_POST);
     FAIL_IF_NOT(htp_tx_request_protocol_number(tx) == HTP_PROTOCOL_V1_0);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF_NOT(htp_tx_response_status_number(tx) == 200);
@@ -3399,7 +3399,7 @@ static int HTPParserTest06(void)
     FAIL_IF(htp_tx_response_status_number(tx) != 200);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_1);
 
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     AppLayerParserThreadCtxFree(alp_tctx);
@@ -3638,7 +3638,7 @@ static int HTPParserTest10(void)
     FAIL_IF_NULL(htp_state);
 
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     char *name = bstr_util_strdup_to_c(htp_header_name(h));
@@ -3816,7 +3816,7 @@ static int HTPParserTest13(void)
     htp_state = f->alstate;
     FAIL_IF_NULL(htp_state);
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     char *name = bstr_util_strdup_to_c(htp_header_name(h));
@@ -5389,7 +5389,7 @@ static int HTPParserTest20(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5448,7 +5448,7 @@ static int HTPParserTest21(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5502,7 +5502,7 @@ static int HTPParserTest22(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5556,7 +5556,7 @@ static int HTPParserTest23(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5610,7 +5610,7 @@ static int HTPParserTest24(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_table_get_index(htp_tx_request_headers(tx), 0, NULL);
+    htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -90,9 +90,9 @@ void HTTP2MimicHttp1Request(void *alstate_orig, void *h2s)
         rs_http2_tx_set_uri(h2s, bstr_ptr(htp_tx_request_uri(h1tx)),
                 (uint32_t)bstr_len(htp_tx_request_uri(h1tx)));
     }
-    size_t nbheaders = htp_table_size(htp_tx_request_headers(h1tx));
+    size_t nbheaders = htp_tx_request_headers_size(h1tx);
     for (size_t i = 0; i < nbheaders; i++) {
-        htp_header_t *h = htp_table_get_index(htp_tx_request_headers(h1tx), i, NULL);
+        const htp_header_t *h = htp_tx_request_header_index(h1tx, i);
         rs_http2_tx_add_header(h2s, htp_header_name_ptr(h), (uint32_t)htp_header_name_len(h),
                 htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
     }

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -181,7 +181,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Cookie");
+        const htp_header_t *h = htp_tx_request_header(tx, "Cookie");
         if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;
@@ -208,7 +208,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, "Set-Cookie");
+        const htp_header_t *h = htp_tx_response_header(tx, "Set-Cookie");
         if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP cookie header not present in this request");
             return NULL;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -86,7 +86,7 @@ static uint8_t *GetBufferForTX(
         return NULL;
     }
 
-    htp_table_t *headers;
+    const htp_headers_t *headers;
     if (flags & STREAM_TOSERVER) {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -103,9 +103,9 @@ static uint8_t *GetBufferForTX(
 
     /* fill the buffer. \r\nName1\r\nName2\r\n\r\n */
     size_t i = 0;
-    size_t no_of_headers = htp_table_size(headers);
+    size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_table_get_index(headers, i, NULL);
+        htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size = htp_header_name_len(h) + 2; // for \r\n
         if (i == 0)
             size += 2;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -105,7 +105,7 @@ static uint8_t *GetBufferForTX(
     size_t i = 0;
     size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_headers_get_index(headers, i);
+        const htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size = htp_header_name_len(h) + 2; // for \r\n
         if (i == 0)
             size += 2;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -95,9 +95,9 @@ static uint8_t *GetBufferForTX(
         return NULL;
 
     size_t i = 0;
-    size_t no_of_headers = htp_table_size(headers);
+    size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_table_get_index(headers, i, NULL);
+        htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size1 = htp_header_name_len(h);
         size_t size2 = htp_header_value_len(h);
 
@@ -558,7 +558,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     } else {
         headers = htp_tx_response_headers(tx);
     }
-    size_t no_of_headers = htp_table_size(headers);
+    size_t no_of_headers = htp_headers_size(headers);
     if (local_id == 0) {
         // We initialize a big buffer on first item
         // Then, we will just use parts of it
@@ -575,7 +575,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
             hdr_td->cap = no_of_headers;
         }
         for (size_t i = 0; i < no_of_headers; i++) {
-            htp_header_t *h = htp_table_get_index(headers, i, NULL);
+            htp_header_t *h = htp_headers_get_index(headers, i);
             size_t size1 = htp_header_name_len(h);
             size_t size2 = htp_header_value_len(h);
             size_t size = size1 + size2 + 2;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -79,7 +79,7 @@ static uint8_t *GetBufferForTX(
         return NULL;
     }
 
-    htp_table_t *headers;
+    const htp_headers_t *headers;
     if (flags & STREAM_TOSERVER) {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)
@@ -552,7 +552,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     }
 
     htp_tx_t *tx = (htp_tx_t *)txv;
-    htp_table_t *headers;
+    const htp_headers_t *headers;
     if (flags & STREAM_TOSERVER) {
         headers = htp_tx_request_headers(tx);
     } else {

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -97,7 +97,7 @@ static uint8_t *GetBufferForTX(
     size_t i = 0;
     size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_headers_get_index(headers, i);
+        const htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size1 = htp_header_name_len(h);
         size_t size2 = htp_header_value_len(h);
 
@@ -575,7 +575,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
             hdr_td->cap = no_of_headers;
         }
         for (size_t i = 0; i < no_of_headers; i++) {
-            htp_header_t *h = htp_headers_get_index(headers, i);
+            const htp_header_t *h = htp_headers_get_index(headers, i);
             size_t size1 = htp_header_name_len(h);
             size_t size2 = htp_header_value_len(h);
             size_t size = size1 + size2 + 2;

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -57,7 +57,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, HEADER_NAME);
+        const htp_header_t *h = htp_tx_request_header(tx, HEADER_NAME);
         if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);
@@ -112,7 +112,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_tx_response_header(tx, HEADER_NAME);
+        const htp_header_t *h = htp_tx_response_header(tx, HEADER_NAME);
         if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP %s header not present in this request",
                        HEADER_NAME);

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -352,7 +352,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
             if (htp_tx_request_headers(tx) == NULL)
                 return NULL;
 
-            htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "Host");
+            const htp_header_t *h = htp_tx_request_header(tx, "Host");
             if (h == NULL || htp_header_value(h) == NULL)
                 return NULL;
 

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -87,7 +87,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
     if (buffer->inspect == NULL) {
-        bstr *str = NULL;
+        const bstr *str = NULL;
         htp_tx_t *tx = (htp_tx_t *)txv;
 
         if (flow_flags & STREAM_TOSERVER)

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -86,7 +86,7 @@ static uint8_t *GetBufferForTX(
     }
 
     const bstr *line = NULL;
-    htp_table_t *headers;
+    const htp_headers_t *headers;
     if (flags & STREAM_TOSERVER) {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
                 HTP_REQUEST_PROGRESS_HEADERS)

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -115,9 +115,9 @@ static uint8_t *GetBufferForTX(
     buf->buffer[buf->len++] = '\n';
 
     size_t i = 0;
-    size_t no_of_headers = htp_table_size(headers);
+    size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_table_get_index(headers, i, NULL);
+        htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size1 = htp_header_name_len(h);
         size_t size2 = htp_header_value_len(h);
         size_t size = size1 + size2 + 4;

--- a/src/detect-http-start.c
+++ b/src/detect-http-start.c
@@ -85,7 +85,7 @@ static uint8_t *GetBufferForTX(
         return NULL;
     }
 
-    bstr *line = NULL;
+    const bstr *line = NULL;
     htp_table_t *headers;
     if (flags & STREAM_TOSERVER) {
         if (AppLayerParserGetStateProgress(IPPROTO_TCP, ALPROTO_HTTP1, tx, flags) <=
@@ -117,7 +117,7 @@ static uint8_t *GetBufferForTX(
     size_t i = 0;
     size_t no_of_headers = htp_headers_size(headers);
     for (; i < no_of_headers; i++) {
-        htp_header_t *h = htp_headers_get_index(headers, i);
+        const htp_header_t *h = htp_headers_get_index(headers, i);
         size_t size1 = htp_header_name_len(h);
         size_t size2 = htp_header_value_len(h);
         size_t size = size1 + size2 + 4;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -165,7 +165,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_headers(tx) == NULL)
             return NULL;
 
-        htp_header_t *h = (htp_header_t *)htp_tx_request_header(tx, "User-Agent");
+        const htp_header_t *h = htp_tx_request_header(tx, "User-Agent");
         if (h == NULL || htp_header_value(h) == NULL) {
             SCLogDebug("HTTP UA header not present in this request");
             return NULL;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -314,8 +314,8 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
 static void EveHttpLogJSONHeaders(
         JsonBuilder *js, uint32_t direction, htp_tx_t *tx, LogHttpFileCtx *http_ctx)
 {
-    htp_table_t *headers = direction & LOG_HTTP_REQ_HEADERS ? htp_tx_request_headers(tx)
-                                                            : htp_tx_response_headers(tx);
+    const htp_headers_t *headers = direction & LOG_HTTP_REQ_HEADERS ? htp_tx_request_headers(tx)
+                                                                    : htp_tx_response_headers(tx);
     char name[MAX_SIZE_HEADER_NAME] = {0};
     char value[MAX_SIZE_HEADER_VALUE] = {0};
     size_t n = htp_headers_size(headers);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -317,13 +317,13 @@ static void EveHttpLogJSONHeaders(
                                                             : htp_tx_response_headers(tx);
     char name[MAX_SIZE_HEADER_NAME] = {0};
     char value[MAX_SIZE_HEADER_VALUE] = {0};
-    size_t n = htp_table_size(headers);
+    size_t n = htp_headers_size(headers);
     JsonBuilderMark mark = { 0, 0, 0 };
     jb_get_mark(js, &mark);
     bool array_empty = true;
     jb_open_array(js, direction & LOG_HTTP_REQ_HEADERS ? "request_headers" : "response_headers");
     for (size_t i = 0; i < n; i++) {
-        htp_header_t *h = htp_table_get_index(headers, i, NULL);
+        htp_header_t *h = htp_headers_get_index(headers, i);
         if ((http_ctx->flags & direction) == 0 && http_ctx->fields != 0) {
             bool tolog = false;
             for (HttpField f = HTTP_FIELD_ACCEPT; f < HTTP_FIELD_SIZE; f++) {

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -232,9 +232,9 @@ static int HttpGetHeaders(lua_State *luastate, int dir)
     lua_newtable(luastate);
     htp_header_t *h = NULL;
     size_t i = 0;
-    size_t no_of_headers = htp_table_size(table);
+    size_t no_of_headers = htp_headers_size(table);
     for (; i < no_of_headers; i++) {
-        h = htp_table_get_index(table, i, NULL);
+        h = htp_headers_get_index(table, i);
         LuaPushStringBuffer(luastate, htp_header_name_ptr(h), htp_header_name_len(h));
         LuaPushStringBuffer(luastate, htp_header_value_ptr(h), htp_header_value_len(h));
         lua_settable(luastate, -3);

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -154,7 +154,7 @@ static int HttpGetHeader(lua_State *luastate, int dir)
     if (name == NULL)
         return LuaCallbackError(luastate, "1st argument missing, empty or wrong type");
 
-    htp_table_t *headers = htp_tx_request_headers(tx);
+    const htp_headers_t *headers = htp_tx_request_headers(tx);
     if (dir == 1)
         headers = htp_tx_response_headers(tx);
     if (headers == NULL)
@@ -223,7 +223,7 @@ static int HttpGetHeaders(lua_State *luastate, int dir)
     if (tx == NULL)
         return LuaCallbackError(luastate, "internal error: no tx");
 
-    htp_table_t *table = htp_tx_request_headers(tx);
+    const htp_headers_t *table = htp_tx_request_headers(tx);
     if (dir == 1)
         table = htp_tx_response_headers(tx);
     if (htp_tx_request_headers(tx) == NULL)

--- a/src/util-print.c
+++ b/src/util-print.c
@@ -66,7 +66,7 @@ void PrintRawLineHexBuf(char *retbuf, uint32_t retbuflen, const uint8_t *buf, ui
     }
 }
 
-void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
+void PrintRawUriFp(FILE *fp, const uint8_t *buf, uint32_t buflen)
 {
 #define BUFFER_LENGTH 2048
     char nbuf[BUFFER_LENGTH] = "";
@@ -90,7 +90,8 @@ void PrintRawUriFp(FILE *fp, uint8_t *buf, uint32_t buflen)
     fprintf(fp, "%s", nbuf);
 }
 
-void PrintRawUriBuf(char *retbuf, uint32_t *offset, uint32_t retbuflen, uint8_t *buf, size_t buflen)
+void PrintRawUriBuf(
+        char *retbuf, uint32_t *offset, uint32_t retbuflen, const uint8_t *buf, size_t buflen)
 {
     for (size_t u = 0; u < buflen; u++) {
         if (isprint(buf[u]) && buf[u] != '\"') {

--- a/src/util-print.h
+++ b/src/util-print.h
@@ -40,8 +40,8 @@
     } while (0)
 
 void PrintBufferRawLineHex(char *, int *,int, const uint8_t *, uint32_t);
-void PrintRawUriFp(FILE *, uint8_t *, uint32_t);
-void PrintRawUriBuf(char *, uint32_t *, uint32_t, uint8_t *, size_t);
+void PrintRawUriFp(FILE *, const uint8_t *, uint32_t);
+void PrintRawUriBuf(char *, uint32_t *, uint32_t, const uint8_t *, size_t);
 void PrintRawDataFp(FILE *, const uint8_t *, uint32_t);
 void PrintRawDataToBuffer(uint8_t *dst_buf, uint32_t *dst_buf_offset_ptr, uint32_t dst_buf_size,
                           const uint8_t *src_buf, uint32_t src_buf_len);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/2696

Describe changes:
- prepare libhtp-rs by defining aliases for the new values used by libhtp-rs

This allow to go one small step further

The big libhtp-rs commit will remove app-layer-htp-libhtp.h which defines these aliases

https://github.com/OISF/suricata/pull/12442 next round

Draft : I am not sure the `const` change will please every compiler but it passed locally for me...

`git diff libhtp-rs-v27 --name-only -- src/` gives
- src/Makefile.am : remove libhtp.h 🟢 
- src/app-layer-htp-file.c : to fix in libhtp-rs-v27 still using HTP_OK in one comment 🚧 
- src/app-layer-htp-libhtp.c : removal 🟢 
- src/app-layer-htp-libhtp.h : removal 🟢 
- src/app-layer-htp.c : many changes as expected, and to be worked upon in a next PR 🚧 
- src/app-layer-htp.h : changes will remain until the final PR I think 🟢 
- src/detect-http-headers-stub.h : removal of libhtp.h 🟢 
- src/detect-http-host.c : need to keep `NULL` check for h, not only `htp_header_value(h)` ❔ 
- src/detect-http-protocol.c : #ifdef removed 🟢 
- src/detect-http-uri.c : uri_normalized access ❔ 
- src/log-httplog.c : to be worked upon 🚧 
- src/output-json-http.c : some comment 🟢 
- src/suricata.c : changes will remain until the final PR I guess 🟢 
- src/util-lua-http.c : to be worked upon 🚧 
