### PR TITLE
detect/integers: add support for negated strings when enum is used - v3

### DIFF
--- a/doc/userguide/rules/integer-keywords.rst
+++ b/doc/userguide/rules/integer-keywords.rst
@@ -55,13 +55,16 @@ Enumerations
 
 Some integers on the wire represent an enumeration, that is, some values
 have a string/meaning associated to it.
-Rules can be written using one of these strings to check for equality.
+Rules can be written using one of these strings to check for equality or inequality.
 This is meant to make rules more human-readable and equivalent for matching.
 
 Examples::
 
     websocket.opcode:text;
     websocket.opcode:1; # behaves the same
+
+    websocket.opcode:!ping;
+    websocket.opcode:!9; # behaves the same
 
 Bitmasks
 --------

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -19,7 +19,7 @@ use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag, tag_no_case, take_while};
 use nom7::character::complete::{char, digit1, hex_digit1};
 use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
-use nom7::error::{make_error, ErrorKind};
+use nom7::error::{make_error, Error, ErrorKind};
 use nom7::Err;
 use nom7::IResult;
 
@@ -58,15 +58,25 @@ pub struct DetectUintData<T> {
 /// And if this fails, will resort to using the enumeration strings.
 ///
 /// Returns Some DetectUintData on success, None on failure
-pub fn detect_parse_uint_enum<T1: DetectIntType, T2: EnumString<T1>>(s: &str) -> Option<DetectUintData<T1>> {
+pub fn detect_parse_uint_enum<T1: DetectIntType, T2: EnumString<T1>>(
+    s: &str,
+) -> Option<DetectUintData<T1>> {
     if let Ok((_, ctx)) = detect_parse_uint::<T1>(s) {
         return Some(ctx);
     }
+
+    // we need to precise the Error type, we get error[E0283]: type annotations needed
+    let (s, neg) = opt(char::<_, Error<_>>('!'))(s).ok()?;
+    let mode = if neg.is_some() {
+        DetectUintMode::DetectUintModeNe
+    } else {
+        DetectUintMode::DetectUintModeEqual
+    };
     if let Some(enum_val) = T2::from_str(s) {
         let ctx = DetectUintData::<T1> {
             arg1: enum_val.into_u(),
             arg2: T1::min_value(),
-            mode: DetectUintMode::DetectUintModeEqual,
+            mode,
         };
         return Some(ctx);
     }


### PR DESCRIPTION
Ticket: [#7513](https://redmine.openinfosecfoundation.org/issues/7513)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/issues/7513

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7513

uint.rs changes:
- add comment and simpler syntax: [line 68](https://github.com/OISF/suricata/pull/12484/commits/3613946dd5a9fcc1b932941f62c999eca1495a5a#diff-a2be1cb267fe4845f20eb77a1bffb51eb8e41b264331791773055b25c35c062aR68)

integer-keywords.rst changes:
- document the usage of negated strings when using enum: [line 58](https://github.com/OISF/suricata/pull/12484/commits/3613946dd5a9fcc1b932941f62c999eca1495a5a#diff-e2d2026f582d7be9e0b729676d5c253ce8a319c64ad6dae5bc38ed1b62377f00R58), [line 66](https://github.com/OISF/suricata/pull/12484/commits/3613946dd5a9fcc1b932941f62c999eca1495a5a#diff-e2d2026f582d7be9e0b729676d5c253ce8a319c64ad6dae5bc38ed1b62377f00R66)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2257
Previous PR = https://github.com/OISF/suricata/pull/12453
