### PR TITLE
lua: provide base64 lib to lua - v2

### DIFF
--- a/doc/userguide/lua/libs/base64.rst
+++ b/doc/userguide/lua/libs/base64.rst
@@ -31,6 +31,11 @@ padding.
 
 Decode a base64 buffer that contains no padding.
 
+``decode_lenient(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Decode a base64 buffer that may or mat not contain padding.
+
 Implementation Details
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/userguide/lua/libs/base64.rst
+++ b/doc/userguide/lua/libs/base64.rst
@@ -1,0 +1,40 @@
+Base64
+------
+
+Base64 functions are expose to Lua scripts with the
+``suricata.base64``. For example::
+
+  local base64 = require("suricata.base64")
+
+Functions
+~~~~~~~~~
+
+``encode(string)``
+^^^^^^^^^^^^^^^^^^
+
+Encode a buffer with standard base64 encoding. This standard encoding
+includes padding.
+
+``decode(string)``
+^^^^^^^^^^^^^^^^^^
+
+Decode a base64 string that contains padding.
+
+``encode_nopad(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Encode a buffer with standard base64 encoded but don't include any
+padding.
+
+``decode_nopad(string)``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Decode a base64 buffer that contains no padding.
+
+Implementation Details
+~~~~~~~~~~~~~~~~~~~~~~
+
+The base64 functions provided come from the Rust base64 library
+documented at https://docs.rs/base64 and corresponse to the
+``STANDARD`` and ``STANDARD_NO_PAD`` base64 engines provided in that
+library.

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -8,4 +8,5 @@ environment without access to additional modules.
 
 .. toctree::
 
+   base64
    hashlib

--- a/rust/src/detect/transform_base64.rs
+++ b/rust/src/detect/transform_base64.rs
@@ -21,7 +21,7 @@ use crate::detect::error::RuleParseError;
 use crate::detect::parser::{parse_var, take_until_whitespace, ResultValue};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use crate::ffi::base64::Base64Mode;
+use crate::ffi::base64::SCBase64Mode;
 
 use nom7::bytes::complete::tag;
 use nom7::character::complete::multispace0;
@@ -29,7 +29,7 @@ use nom7::sequence::preceded;
 use nom7::{Err, IResult};
 use std::str;
 
-pub const TRANSFORM_FROM_BASE64_MODE_DEFAULT: Base64Mode = Base64Mode::Base64ModeRFC4648;
+pub const TRANSFORM_FROM_BASE64_MODE_DEFAULT: SCBase64Mode = SCBase64Mode::SCBase64ModeRFC4648;
 
 const DETECT_TRANSFORM_BASE64_MAX_PARAM_COUNT: usize = 3;
 pub const DETECT_TRANSFORM_BASE64_FLAG_MODE: u8 = 0x01;
@@ -46,7 +46,7 @@ pub struct SCDetectTransformFromBase64Data {
     nbytes_str: *const c_char,
     offset: u32,
     offset_str: *const c_char,
-    mode: Base64Mode,
+    mode: SCBase64Mode,
 }
 
 impl Drop for SCDetectTransformFromBase64Data {
@@ -82,11 +82,11 @@ impl SCDetectTransformFromBase64Data {
     }
 }
 
-fn get_mode_value(value: &str) -> Option<Base64Mode> {
+fn get_mode_value(value: &str) -> Option<SCBase64Mode> {
     let res = match value {
-        "rfc4648" => Some(Base64Mode::Base64ModeRFC4648),
-        "rfc2045" => Some(Base64Mode::Base64ModeRFC2045),
-        "strict" => Some(Base64Mode::Base64ModeStrict),
+        "rfc4648" => Some(SCBase64Mode::SCBase64ModeRFC4648),
+        "rfc2045" => Some(SCBase64Mode::SCBase64ModeRFC2045),
+        "strict" => Some(SCBase64Mode::SCBase64ModeStrict),
         _ => None,
     };
 
@@ -269,7 +269,7 @@ mod tests {
         nbytes_str: &str,
         offset: u32,
         offset_str: &str,
-        mode: Base64Mode,
+        mode: SCBase64Mode,
         flags: u8,
     ) {
         let tbd = SCDetectTransformFromBase64Data {
@@ -327,7 +327,7 @@ mod tests {
         assert_eq!(val, tbd);
 
         tbd.flags = DETECT_TRANSFORM_BASE64_FLAG_MODE;
-        tbd.mode = Base64Mode::Base64ModeRFC2045;
+        tbd.mode = SCBase64Mode::SCBase64ModeRFC2045;
         tbd.offset = 0;
         tbd.nbytes = 0;
         let (_, val) = parse_transform_base64("mode rfc2045").unwrap();
@@ -344,7 +344,7 @@ mod tests {
             "",
             3933,
             "",
-            Base64Mode::Base64ModeStrict,
+            SCBase64Mode::SCBase64ModeStrict,
             DETECT_TRANSFORM_BASE64_FLAG_NBYTES
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET
                 | DETECT_TRANSFORM_BASE64_FLAG_MODE,
@@ -356,7 +356,7 @@ mod tests {
             "",
             3933,
             "",
-            Base64Mode::Base64ModeRFC2045,
+            SCBase64Mode::SCBase64ModeRFC2045,
             DETECT_TRANSFORM_BASE64_FLAG_NBYTES
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET
                 | DETECT_TRANSFORM_BASE64_FLAG_MODE,
@@ -368,7 +368,7 @@ mod tests {
             "",
             3933,
             "",
-            Base64Mode::Base64ModeRFC4648,
+            SCBase64Mode::SCBase64ModeRFC4648,
             DETECT_TRANSFORM_BASE64_FLAG_NBYTES
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET
                 | DETECT_TRANSFORM_BASE64_FLAG_MODE,
@@ -380,7 +380,7 @@ mod tests {
             "",
             0,
             "var",
-            Base64Mode::Base64ModeRFC4648,
+            SCBase64Mode::SCBase64ModeRFC4648,
             DETECT_TRANSFORM_BASE64_FLAG_NBYTES
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET_VAR
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET
@@ -393,7 +393,7 @@ mod tests {
             "var",
             3933,
             "",
-            Base64Mode::Base64ModeRFC4648,
+            SCBase64Mode::SCBase64ModeRFC4648,
             DETECT_TRANSFORM_BASE64_FLAG_NBYTES
                 | DETECT_TRANSFORM_BASE64_FLAG_NBYTES_VAR
                 | DETECT_TRANSFORM_BASE64_FLAG_OFFSET

--- a/rust/src/ffi/base64.rs
+++ b/rust/src/ffi/base64.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021-2024 Open Information Security Foundation
+/* Copyright (C) 2021-2026 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,11 +18,11 @@
 use crate::utils::base64::{decode_rfc4648, decode_rfc2045, get_decoded_buffer_size, Decoder};
 use libc::c_ulong;
 use std::os::raw::c_uchar;
-use base64::{Engine, engine::general_purpose::STANDARD};
+use base64::{Engine, engine::general_purpose::{STANDARD, STANDARD_NO_PAD}};
 
 #[repr(C)]
 #[allow(non_camel_case_types)]
-pub enum Base64ReturnCode {
+pub enum SCBase64ReturnCode {
     SC_BASE64_OK = 0,
     SC_BASE64_INVALID_ARG,
     SC_BASE64_OVERFLOW,
@@ -30,7 +30,13 @@ pub enum Base64ReturnCode {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Base64Mode {
+pub enum SCBase64Mode {
+    /// Strict, aka STANDARD.
+    SCBase64ModeStrict = 0,
+
+    /// Standard Base64 with no padding.
+    SCBase64ModeNoPad,
+
     /* If the following strings were to be passed to the decoder with RFC2045 mode,
      * the results would be as follows. See the unittest B64TestVectorsRFC2045 in
      * src/util-base64.c
@@ -46,8 +52,8 @@ pub enum Base64Mode {
      * BASE64("foobar") = "Zm$9vYm.Fy"    # According to RFC 2045, All line breaks or *other
      * characters* not found in base64 alphabet must be ignored by decoding software
      * */
-    Base64ModeRFC2045 = 0, /* SPs are allowed during transfer but must be skipped by Decoder */
-    Base64ModeStrict,
+    SCBase64ModeRFC2045, /* SPs are allowed during transfer but must be skipped by Decoder */
+
     /* If the following strings were to be passed to the decoder with RFC4648 mode,
      * the results would be as follows. See the unittest B64TestVectorsRFC4648 in
      * src/util-base64.c
@@ -63,23 +69,24 @@ pub enum Base64Mode {
      * BASE64("f") = "Zm$9vYm.Fy"    <-- Notice how the processing stops once an invalid char is
      * encountered
      * */
-    Base64ModeRFC4648, /* reject the encoded data if it contains characters outside the base alphabet */
+    SCBase64ModeRFC4648, /* reject the encoded data if it contains characters outside the base alphabet */
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Base64DecodeBufferSize(input_len: u32) -> u32 {
+pub unsafe extern "C" fn SCBase64DecodeBufferSize(input_len: u32) -> u32 {
     return get_decoded_buffer_size(input_len);
 }
+
 
 /// Base64 decode a buffer.
 ///
 /// This method exposes the Rust base64 decoder to C and should not be called from
 /// Rust code.
 ///
-/// It allows decoding in the modes described by ``Base64Mode`` enum.
+/// It allows decoding in the modes described by ``SCBase64Mode`` enum.
 #[no_mangle]
-pub unsafe extern "C" fn Base64Decode(
-    input: *const u8, len: usize, mode: Base64Mode, output: *mut u8) -> u32 {
+pub unsafe extern "C" fn SCBase64Decode(
+    input: *const u8, len: usize, mode: SCBase64Mode, output: *mut u8) -> u32 {
     if input.is_null() || len == 0 {
         return 0;
     }
@@ -89,20 +96,25 @@ pub unsafe extern "C" fn Base64Decode(
     let mut num_decoded: u32 = 0;
     let mut decoder = Decoder::new();
     match mode {
-        Base64Mode::Base64ModeRFC2045 => {
+        SCBase64Mode::SCBase64ModeRFC2045 => {
             if decode_rfc2045(&mut decoder, in_vec, out_vec, &mut num_decoded).is_err() {
                 debug_validate_bug_on!(num_decoded >= len as u32);
                 return num_decoded;
             }
         }
-        Base64Mode::Base64ModeRFC4648 => {
+        SCBase64Mode::SCBase64ModeRFC4648 => {
             if decode_rfc4648(&mut decoder, in_vec, out_vec, &mut num_decoded).is_err() {
                 debug_validate_bug_on!(num_decoded >= len as u32);
                 return num_decoded;
             }
         }
-        Base64Mode::Base64ModeStrict => {
+        SCBase64Mode::SCBase64ModeStrict => {
             if let Ok(decoded_len) = STANDARD.decode_slice(in_vec, out_vec) {
+                num_decoded = decoded_len as u32;
+            }
+        }
+        SCBase64Mode::SCBase64ModeNoPad => {
+            if let Ok(decoded_len) = STANDARD_NO_PAD.decode_slice(in_vec, out_vec) {
                 num_decoded = decoded_len as u32;
             }
         }
@@ -118,31 +130,31 @@ pub unsafe extern "C" fn Base64Decode(
 /// Rust code.
 ///
 /// The output parameter must be an allocated buffer of at least the size returned
-/// from Base64EncodeBufferSize for the input_len, and this length must be provided
+/// from SCBase64EncodeBufferSize for the input_len, and this length must be provided
 /// in the output_len variable.
 #[no_mangle]
-pub unsafe extern "C" fn Base64Encode(
+pub unsafe extern "C" fn SCBase64Encode(
     input: *const u8, input_len: c_ulong, output: *mut c_uchar, output_len: *mut c_ulong,
-) -> Base64ReturnCode {
+) -> SCBase64ReturnCode {
     if input.is_null() || output.is_null() || output_len.is_null() {
-        return Base64ReturnCode::SC_BASE64_INVALID_ARG;
+        return SCBase64ReturnCode::SC_BASE64_INVALID_ARG;
     }
     let input = std::slice::from_raw_parts(input, input_len as usize);
     let encoded = STANDARD.encode(input);
     if encoded.len() + 1 > *output_len as usize {
-        return Base64ReturnCode::SC_BASE64_OVERFLOW;
+        return SCBase64ReturnCode::SC_BASE64_OVERFLOW;
     }
     let output = std::slice::from_raw_parts_mut(&mut *output, *output_len as usize);
     output[0..encoded.len()].copy_from_slice(encoded.as_bytes());
     output[encoded.len()] = 0;
     *output_len = encoded.len() as c_ulong;
-    Base64ReturnCode::SC_BASE64_OK
+    SCBase64ReturnCode::SC_BASE64_OK
 }
 
 /// Ratio of output bytes to input bytes for Base64 Encoding is 4:3, hence the
 /// required output bytes are 4 * ceil(input_len / 3) and an additional byte for
 /// storing the NULL pointer.
 #[no_mangle]
-pub extern "C" fn Base64EncodeBufferSize(len: c_ulong) -> c_ulong {
+pub extern "C" fn SCBase64EncodeBufferSize(len: c_ulong) -> c_ulong {
     (4 * ((len) + 2) / 3) + 1
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -508,6 +508,7 @@ noinst_HEADERS = \
 	util-landlock.h \
 	util-logopenfile.h \
 	util-log-redis.h \
+	util-lua-base64lib.h \
 	util-lua-builtins.h \
 	util-lua-common.h \
 	util-lua-dataset.h \
@@ -1061,6 +1062,7 @@ libsuricata_c_a_SOURCES = \
 	util-logopenfile.c \
 	util-log-redis.c \
 	util-lua.c \
+	util-lua-base64lib.c \
 	util-lua-builtins.c \
 	util-lua-common.c \
 	util-lua-dataset.c \

--- a/src/datasets-string.c
+++ b/src/datasets-string.c
@@ -47,10 +47,9 @@ int StringAsBase64(const void *s, char *out, size_t out_size)
 {
     const StringType *str = s;
 
-    unsigned long len = Base64EncodeBufferSize(str->len);
+    unsigned long len = SCBase64EncodeBufferSize(str->len);
     uint8_t encoded_data[len];
-    if (Base64Encode((unsigned char *)str->ptr, str->len,
-        encoded_data, &len) != SC_BASE64_OK)
+    if (SCBase64Encode((unsigned char *)str->ptr, str->len, encoded_data, &len) != SC_BASE64_OK)
         return 0;
 
     strlcpy(out, (const char *)encoded_data, out_size);

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -517,11 +517,11 @@ static int DatasetLoadString(Dataset *set)
         if (r == NULL) {
             line[strlen(line) - 1] = '\0';
             SCLogDebug("line: '%s'", line);
-            uint32_t decoded_size = Base64DecodeBufferSize(strlen(line));
+            uint32_t decoded_size = SCBase64DecodeBufferSize(strlen(line));
             // coverity[alloc_strlen : FALSE]
             uint8_t decoded[decoded_size];
-            uint32_t num_decoded =
-                    Base64Decode((const uint8_t *)line, strlen(line), Base64ModeStrict, decoded);
+            uint32_t num_decoded = SCBase64Decode(
+                    (const uint8_t *)line, strlen(line), SCBase64ModeStrict, decoded);
             if (num_decoded == 0 && strlen(line) > 0) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -538,10 +538,10 @@ static int DatasetLoadString(Dataset *set)
 
             *r = '\0';
 
-            uint32_t decoded_size = Base64DecodeBufferSize(strlen(line));
+            uint32_t decoded_size = SCBase64DecodeBufferSize(strlen(line));
             uint8_t decoded[decoded_size];
-            uint32_t num_decoded =
-                    Base64Decode((const uint8_t *)line, strlen(line), Base64ModeStrict, decoded);
+            uint32_t num_decoded = SCBase64Decode(
+                    (const uint8_t *)line, strlen(line), SCBase64ModeStrict, decoded);
             if (num_decoded == 0) {
                 FatalErrorOnInit("bad base64 encoding %s/%s", set->name, set->load);
                 continue;
@@ -1606,10 +1606,10 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
 
     switch (set->type) {
         case DATASET_TYPE_STRING: {
-            uint32_t decoded_size = Base64DecodeBufferSize(strlen(string));
+            uint32_t decoded_size = SCBase64DecodeBufferSize(strlen(string));
             uint8_t decoded[decoded_size];
-            uint32_t num_decoded = Base64Decode(
-                    (const uint8_t *)string, strlen(string), Base64ModeStrict, decoded);
+            uint32_t num_decoded = SCBase64Decode(
+                    (const uint8_t *)string, strlen(string), SCBase64ModeStrict, decoded);
             if (num_decoded == 0) {
                 return -2;
             }

--- a/src/detect-base64-decode.h
+++ b/src/detect-base64-decode.h
@@ -18,8 +18,8 @@
 #ifndef SURICATA_DETECT_BASE64_DECODE_H
 #define SURICATA_DETECT_BASE64_DECODE_H
 
-void DetectBase64DecodeRegister(void);
-int DetectBase64DecodeDoMatch(DetectEngineThreadCtx *, const Signature *,
-    const SigMatchData *, const uint8_t *, uint32_t);
+void DetectSCBase64DecodeRegister(void);
+int DetectSCBase64DecodeDoMatch(DetectEngineThreadCtx *, const Signature *, const SigMatchData *,
+        const uint8_t *, uint32_t);
 
 #endif /* SURICATA_DETECT_BASE64_DECODE_H */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -665,7 +665,7 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
         SCLogDebug("lua match");
         goto match;
     } else if (smd->type == DETECT_BASE64_DECODE) {
-        if (DetectBase64DecodeDoMatch(det_ctx, s, smd, buffer, buffer_len)) {
+        if (DetectSCBase64DecodeDoMatch(det_ctx, s, smd, buffer, buffer_len)) {
             if (s->sm_arrays[DETECT_SM_LIST_BASE64_DATA] != NULL) {
                 if (det_ctx->base64_decoded_len) {
                     KEYWORD_PROFILING_END(det_ctx, smd->type, 1);

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -682,7 +682,7 @@ void SigTableSetup(void)
     DetectLuaRegister();
     DetectIPRepRegister();
     DetectAppLayerProtocolRegister();
-    DetectBase64DecodeRegister();
+    DetectSCBase64DecodeRegister();
     DetectBase64DataRegister();
     DetectTemplateRegister();
     DetectTemplate2Register();
@@ -726,7 +726,7 @@ void SigTableSetup(void)
     DetectTransformToLowerRegister();
     DetectTransformToUpperRegister();
     DetectTransformHeaderLowercaseRegister();
-    DetectTransformFromBase64DecodeRegister();
+    DetectTransformFromSCBase64DecodeRegister();
 
     DetectFileHandlerRegister();
 

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -40,7 +40,7 @@
 static int DetectTransformFromSCBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
 static void DetectTransformFromSCBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
-#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t)SCBase64ModeRFC4648
+#define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) SCBase64ModeRFC4648
 static void DetectTransformFromSCBase64DecodeRegisterTests(void);
 #endif
 static void TransformFromSCBase64Decode(InspectionBuffer *buffer, void *options);

--- a/src/detect-transform-base64.h
+++ b/src/detect-transform-base64.h
@@ -25,6 +25,6 @@
 #define SURICATA_DETECT_TRANSFORM_BASE64_H
 
 /* prototypes */
-void DetectTransformFromBase64DecodeRegister(void);
+void DetectTransformFromSCBase64DecodeRegister(void);
 
 #endif /* SURICATA_DETECT_TRANSFORM_BASE64_H */

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -111,7 +111,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
     }
 
     TAILQ_FOREACH (cert, &connp->certs, next) {
-        pemlen = Base64EncodeBufferSize(cert->cert_len);
+        pemlen = SCBase64EncodeBufferSize(cert->cert_len);
         if (pemlen > aft->enc_buf_len) {
             ptmp = (uint8_t*) SCRealloc(aft->enc_buf, sizeof(uint8_t) * pemlen);
             if (ptmp == NULL) {
@@ -127,9 +127,10 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
 
         memset(aft->enc_buf, 0, aft->enc_buf_len);
 
-        ret = Base64Encode((unsigned char*) cert->cert_data, cert->cert_len, aft->enc_buf, &pemlen);
+        ret = SCBase64Encode(
+                (unsigned char *)cert->cert_data, cert->cert_len, aft->enc_buf, &pemlen);
         if (ret != SC_BASE64_OK) {
-            SCLogWarning("Invalid return of Base64Encode function");
+            SCLogWarning("Invalid return of SCBase64Encode function");
             goto end_fwrite_fp;
         }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -616,7 +616,7 @@ static bool CalculateCommunityFlowIdv4(const Flow *f,
     if (SCSha1HashBuffer((const uint8_t *)&ipv4, sizeof(ipv4), hash, sizeof(hash)) == 1) {
         strlcpy((char *)base64buf, "1:", COMMUNITY_ID_BUF_SIZE);
         unsigned long out_len = COMMUNITY_ID_BUF_SIZE - 2;
-        if (Base64Encode(hash, sizeof(hash), base64buf+2, &out_len) == SC_BASE64_OK) {
+        if (SCBase64Encode(hash, sizeof(hash), base64buf + 2, &out_len) == SC_BASE64_OK) {
             return true;
         }
     }
@@ -665,7 +665,7 @@ static bool CalculateCommunityFlowIdv6(const Flow *f,
     if (SCSha1HashBuffer((const uint8_t *)&ipv6, sizeof(ipv6), hash, sizeof(hash)) == 1) {
         strlcpy((char *)base64buf, "1:", COMMUNITY_ID_BUF_SIZE);
         unsigned long out_len = COMMUNITY_ID_BUF_SIZE - 2;
-        if (Base64Encode(hash, sizeof(hash), base64buf+2, &out_len) == SC_BASE64_OK) {
+        if (SCBase64Encode(hash, sizeof(hash), base64buf + 2, &out_len) == SC_BASE64_OK) {
             return true;
         }
     }

--- a/src/tests/fuzz/fuzz_decodebase64.c
+++ b/src/tests/fuzz/fuzz_decodebase64.c
@@ -16,11 +16,11 @@ static int initialized = 0;
 
 static void Base64FuzzTest(const uint8_t *src, size_t len)
 {
-    uint32_t decoded_len = Base64DecodeBufferSize(len);
+    uint32_t decoded_len = SCBase64DecodeBufferSize(len);
     uint8_t *decoded = SCCalloc(decoded_len, sizeof(uint8_t));
 
-    for (uint8_t mode = Base64ModeRFC2045; mode <= Base64ModeStrict; mode++) {
-        (void)Base64Decode(src, len, mode, decoded);
+    for (uint8_t mode = SCBase64ModeRFC2045; mode <= SCBase64ModeStrict; mode++) {
+        (void)SCBase64Decode(src, len, mode, decoded);
     }
 
     SCFree(decoded);

--- a/src/util-lua-base64lib.c
+++ b/src/util-lua-base64lib.c
@@ -86,12 +86,29 @@ static int LuaBase64DecodeStandardNoPad(lua_State *L)
     return 1;
 }
 
+static int LuaBase64DecodeLenient(lua_State *L)
+{
+    size_t input_len;
+    const char *input = luaL_checklstring(L, 1, &input_len);
+    char output[input_len];
+    uint32_t n = SCBase64DecodeLenient((uint8_t *)input, (uintptr_t)input_len, (uint8_t *)output);
+    if (n == 0) {
+        return luaL_error(L, "base64 decoding failed");
+    }
+    DEBUG_VALIDATE_BUG_ON(n > input_len);
+    output[n] = '\0';
+    lua_pushstring(L, (const char *)output);
+
+    return 1;
+}
+
 static const struct luaL_Reg base64lib[] = {
     // clang-format off
     { "encode", LuaBase64EncodeStandard },
     { "encode_nopad", LuaBase64EncodeStandardNoPad },
     { "decode", LuaBase64DecodeStandard },
     { "decode_nopad", LuaBase64DecodeStandardNoPad },
+    { "decode_lenient", LuaBase64DecodeLenient },
     { NULL, NULL },
     // clang-format on
 };

--- a/src/util-lua-base64lib.c
+++ b/src/util-lua-base64lib.c
@@ -1,0 +1,104 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "rust.h"
+#include "util-lua-base64lib.h"
+#include "util-validate.h"
+
+#include "lauxlib.h"
+
+static int LuaBase64EncodeStandard(lua_State *L)
+{
+    size_t input_len;
+    const char *input = luaL_checklstring(L, 1, &input_len);
+    size_t out_len = SCBase64EncodeBufferSize(input_len);
+    char output[out_len + 1];
+    if (SCBase64Encode((uint8_t *)input, (unsigned long)input_len, (u_char *)output,
+                (unsigned long *)&out_len) != 0) {
+        return luaL_error(L, "base64 encoding failed");
+    }
+    lua_pushstring(L, (const char *)output);
+
+    return 1;
+}
+
+static int LuaBase64EncodeStandardNoPad(lua_State *L)
+{
+    size_t input_len;
+    const char *input = luaL_checklstring(L, 1, &input_len);
+    size_t out_len = SCBase64EncodeBufferSize(input_len);
+    char output[out_len + 1];
+    if (SCBase64EncodeNoPad((uint8_t *)input, (unsigned long)input_len, (u_char *)output,
+                (unsigned long *)&out_len) != 0) {
+        return luaL_error(L, "base64 encoding failed");
+    }
+    lua_pushstring(L, (const char *)output);
+
+    return 1;
+}
+
+static int LuaBase64DecodeStandard(lua_State *L)
+{
+    size_t input_len;
+    const char *input = luaL_checklstring(L, 1, &input_len);
+    char output[input_len];
+    uint32_t n = SCBase64Decode(
+            (uint8_t *)input, (uintptr_t)input_len, SCBase64ModeStrict, (uint8_t *)output);
+    if (n == 0) {
+        return luaL_error(L, "base64 decoding failed");
+    }
+    DEBUG_VALIDATE_BUG_ON(n > input_len);
+    output[n] = '\0';
+    lua_pushstring(L, (const char *)output);
+
+    return 1;
+}
+
+static int LuaBase64DecodeStandardNoPad(lua_State *L)
+{
+    size_t input_len;
+    const char *input = luaL_checklstring(L, 1, &input_len);
+    char output[input_len];
+    uint32_t n = SCBase64Decode(
+            (uint8_t *)input, (uintptr_t)input_len, SCBase64ModeNoPad, (uint8_t *)output);
+    if (n == 0) {
+        return luaL_error(L, "base64 decoding failed");
+    }
+    DEBUG_VALIDATE_BUG_ON(n > input_len);
+    output[n] = '\0';
+    lua_pushstring(L, (const char *)output);
+
+    return 1;
+}
+
+static const struct luaL_Reg base64lib[] = {
+    // clang-format off
+    { "encode", LuaBase64EncodeStandard },
+    { "encode_nopad", LuaBase64EncodeStandardNoPad },
+    { "decode", LuaBase64DecodeStandard },
+    { "decode_nopad", LuaBase64DecodeStandardNoPad },
+    { NULL, NULL },
+    // clang-format on
+};
+
+int SCLuaLoadBase64Lib(lua_State *L)
+{
+    luaL_newlib(L, base64lib);
+
+    return 1;
+}

--- a/src/util-lua-base64lib.h
+++ b/src/util-lua-base64lib.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_LUA_UTIL_BASE64LIB_H
+#define SURICATA_LUA_UTIL_BASE64LIB_H
+
+#include "lua.h"
+
+int SCLuaLoadBase64Lib(lua_State *L);
+
+#endif /* SURICATA_LUA_UTIL_BASE64LIB_H */

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -17,14 +17,16 @@
 
 #include "suricata-common.h"
 #include "util-lua-builtins.h"
-#include "util-lua-hashlib.h"
+#include "util-lua-base64lib.h"
 #include "util-lua-dataset.h"
+#include "util-lua-hashlib.h"
 
 #include "lauxlib.h"
 
 static const luaL_Reg builtins[] = {
-    { "suricata.hashlib", SCLuaLoadHashlib },
+    { "suricata.base64", SCLuaLoadBase64Lib },
     { "suricata.dataset", LuaLoadDatasetLib },
+    { "suricata.hashlib", SCLuaLoadHashlib },
     { NULL, NULL },
 };
 


### PR DESCRIPTION
Adds a Lua library exposing basic base64 functions to Lua. For details on the
function checkout the base64.rst page added in the userguide.

Commits:
- **base64: prefix base64 C API with "SC"**
- **base64: expose nopad variant to C API**
- **rust/ffi/base64: rustfmt**
- **lua: add base64 lib**
- **doc/userguide: document Lua base64 library**
- **base64: add a lenient decoder**

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2260
