### PR TITLE
Output/TLS: Allow logging of client/server handshake parameters - V2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1040,6 +1040,11 @@ If extended logging is enabled the following fields are also included:
 * "ja4": The JA4 client fingerprint for TLS
 * "client_alpns": array of strings with ALPN values
 * "server_alpns": array of strings with ALPN values
+* "client_handshake": structure containing "version", "ciphers", "exts", "sig_algs", for client
+  hello supported cipher suites, extensions, and signature algorithms,
+  respectively, in the order that they're mentioned (ie. unsorted)
+* "server_handshake": structure containing "version", "chosen cipher", "exts", for server hello
+  in the order that they're mentioned (ie. unsorted)
 
 JA3 and JA4 must be enabled in the Suricata config file (set 'app-layer.protocols.tls.ja3-fingerprints'/'app-layer.protocols.tls.ja4-fingerprints' to 'yes').
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6722,6 +6722,35 @@
                         "type": "string"
                     }
                 },
+		"client_handshake": {
+		    "type": "object",
+		    "properties": {
+			"version": {
+			    "type": "string"
+			},
+			"ciphers": {
+			    "description": "TLS client cipher(s)",
+			    "type": "array",
+			    "items": {
+				"type": "integer"
+			    }
+			},
+			"exts": {
+			    "description": "TLS client extension(s)",
+			    "type": "array",
+			    "items": {
+				"type": "integer"
+			    }
+			},
+			"sig_algs": {
+			    "description": "TLS client signature algorithm(s)",
+			    "type": "array",
+			    "items": {
+				"type": "integer"
+			    }
+			}
+		    }
+		},
                 "server_alpns": {
                     "description": "TLS server ALPN field(s)",
                     "type": "array",
@@ -6729,6 +6758,25 @@
                         "type": "string"
                     }
                 },
+		"server_handshake": {
+		    "type": "object",
+		    "properties": {
+			"version": {
+			    "type": "string"
+			},
+			"cipher": {
+			    "description": "TLS server's chosen cipher",
+			    "type": "integer"
+			},
+			"exts": {
+			    "description": "TLS server extension(s)",
+			    "type": "array",
+			    "items": {
+				"type": "integer"
+			    }
+			}
+		    }
+		},
                 "fingerprint": {
                     "type": "string"
                 },
@@ -6791,6 +6839,9 @@
                     "additionalProperties": false
                 },
                 "ja4": {
+                    "type": "string"
+                },
+                "ja4s": {
                     "type": "string"
                 }
             },

--- a/rust/src/quic/quic.rs
+++ b/rust/src/quic/quic.rs
@@ -250,7 +250,7 @@ impl QuicState {
                         // our hash is complete, let's only use strings from
                         // now on
                         if let Some(ref rja4) = c.ja4 {
-                            ja4 = Some(rja4.get_hash());
+                            ja4 = Some(rja4.get_ja4_hash());
                         }
                     }
                     for e in &c.extv {

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -695,7 +695,8 @@ static inline int TLSDecodeHSHelloVersion(SSLState *ssl_state,
     ssl_state->curr_connp->version = version;
 
     if (ssl_state->curr_connp->ja4 != NULL &&
-            ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+            ssl_state->current_flags &
+                    (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
         SCJA4SetTLSVersion(ssl_state->curr_connp->ja4, version);
     }
 
@@ -845,7 +846,7 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
     const bool enable_ja3 =
             SC_ATOMIC_GET(ssl_config.enable_ja3) && ssl_state->curr_connp->ja3_hash == NULL;
 
-    if (enable_ja3 || SC_ATOMIC_GET(ssl_config.enable_ja4)) {
+    if (enable_ja3 || ssl_state->curr_connp->ja4 != NULL) {
         JA3Buffer *ja3_cipher_suites = NULL;
 
         if (enable_ja3) {
@@ -870,7 +871,8 @@ static inline int TLSDecodeHSHelloCipherSuites(SSLState *ssl_state,
 
             if (TLSDecodeValueIsGREASE(cipher_suite) != 1) {
                 if (ssl_state->curr_connp->ja4 != NULL &&
-                        ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+                        ssl_state->current_flags &
+                                (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
                     SCJA4AddCipher(ssl_state->curr_connp->ja4, cipher_suite);
                 }
                 if (enable_ja3) {
@@ -1293,7 +1295,8 @@ static inline int TLSDecodeHSHelloExtensionALPN(
 
         /* Only record the first value for JA4 */
         if (ssl_state->curr_connp->ja4 != NULL &&
-                ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+                ssl_state->current_flags &
+                        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
             if (alpn_processed_len == 1) {
                 SCJA4SetALPN(ssl_state->curr_connp->ja4, (const char *)input, protolen);
             }
@@ -1492,7 +1495,8 @@ static inline int TLSDecodeHSHelloExtensions(SSLState *ssl_state,
         }
 
         if (ssl_state->curr_connp->ja4 != NULL &&
-                ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) {
+                ssl_state->current_flags &
+                        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
             if (TLSDecodeValueIsGREASE(ext_type) != 1) {
                 SCJA4AddExtension(ssl_state->curr_connp->ja4, ext_type);
             }
@@ -1546,11 +1550,11 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state,
     int ret;
     uint32_t parsed = 0;
 
-    /* Ensure that we have a JA4 state defined by now if we have JA4 enabled,
-       we are in a client hello and we don't have such a state yet (to avoid
-       leaking memory in case this function is entered more than once). */
-    if (SC_ATOMIC_GET(ssl_config.enable_ja4) &&
-            ssl_state->current_flags & SSL_AL_FLAG_STATE_CLIENT_HELLO &&
+    /* Ensure that we have a JA4 state defined by now, we are in a client/server hello
+       and we don't have such a state yet (to avoid leaking memory in case this function
+       is entered more than once). */
+    if (ssl_state->current_flags &
+                    (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_STATE_SERVER_HELLO) &&
             ssl_state->curr_connp->ja4 == NULL) {
         ssl_state->curr_connp->ja4 = SCJA4New();
     }
@@ -2894,6 +2898,8 @@ static void SSLStateFree(void *p)
 
     if (ssl_state->client_connp.ja4)
         SCJA4Free(ssl_state->client_connp.ja4);
+    if (ssl_state->server_connp.ja4)
+        SCJA4Free(ssl_state->server_connp.ja4);
     if (ssl_state->client_connp.ja3_str)
         Ja3BufferFree(&ssl_state->client_connp.ja3_str);
     if (ssl_state->client_connp.ja3_hash)

--- a/src/util-ja4.h
+++ b/src/util-ja4.h
@@ -24,6 +24,7 @@
 #ifndef SURICATA_UTIL_JA4_H
 #define SURICATA_UTIL_JA4_H
 
-#define JA4_HEX_LEN 36
+#define JA4_HEX_LEN  36
+#define JA4S_HEX_LEN 25
 
 #endif /* SURICATA_UTIL_JA4_H */


### PR DESCRIPTION
Add new custom log fields:
- "client_handshake" which logs the following:
1. TLS version used during handshake
2. TLS extensions, excluding GREASE, SNI and ALPN
3. All cipher suites, excluding GREASE
4. All signature algorithms, excluding GREASE

- "server_handshake" which logs the following:
1. TLS version used during handshake
2. The chosen cipher suite, excluding GREASE
3. TLS extensions, excluding GREASE

The use-case is for logging TLS handshake parameters in order to survey them, and so that JA4(S) hashes can be computed offline (in the case that they're not already computed for the purposes of rule matching).

As part of this update suricata now creates a JA4 object when the message type is ``CLIENT_HELLO | SERVER_HELLO`` to allow for custom fields without the need to explicitly enable JA4 via ``ja4-fingerprint``. That enables us to produce the handshake parameters, as well as the other JA4 related fields, without the fingerprint(s). Is that ok? I think that was the intention from the previous PR discussion?

Link to my SV tests PR: https://github.com/OISF/suricata-verify/pull/2265

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6695

Describe changes:
-
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2265
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
