### PR TITLE
Ilya bakhtin/dns dcerpc reversed v5

### DIFF
--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -300,9 +300,11 @@ pub unsafe extern "C" fn rs_dcerpc_udp_get_tx_cnt(vtx: *mut std::os::raw::c_void
 /// Probe input to see if it looks like DCERPC.
 fn probe(input: &[u8]) -> (bool, bool) {
     match parser::parse_dcerpc_udp_header(input) {
-        Ok((_, hdr)) => {
+        Ok((leftover_bytes, hdr)) => {
             let is_request = hdr.pkt_type == 0x00;
             let is_dcerpc = hdr.rpc_vers == 0x04 &&
+                hdr.fragnum == 0 &&
+                leftover_bytes.len() >= hdr.fraglen as usize &&
                 (hdr.flags2 & 0xfc == 0) &&
                 (hdr.drep[0] & 0xee == 0) &&
                 (hdr.drep[1] <= 3);

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1408,7 +1408,6 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f
             (flags & STREAM_TOSERVER) ? "toserver" : "toclient");
 
     AppProto alproto = ALPROTO_UNKNOWN;
-    AppProto pm_alproto = ALPROTO_UNKNOWN;
 
     if (!FLOW_IS_PM_DONE(f, flags)) {
         AppProto pm_results[g_alproto_max];
@@ -1426,37 +1425,23 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx, Flow *f
                     FLOW_RESET_PP_DONE(f, reverse_dir);
                 }
             }
-
-            /* HACK: if detected protocol is dcerpc/udp, we run PP as well
-             * to avoid misdetecting DNS as DCERPC. */
-            if (!(ipproto == IPPROTO_UDP && alproto == ALPROTO_DCERPC))
-                goto end;
-
-            pm_alproto = alproto;
-
-            /* fall through */
+            SCReturnUInt(alproto);
         }
     }
 
     if (!FLOW_IS_PP_DONE(f, flags)) {
-        bool rflow = false;
-        alproto = AppLayerProtoDetectPPGetProto(f, buf, buflen, ipproto, flags, &rflow);
+        DEBUG_VALIDATE_BUG_ON(*reverse_flow);
+        alproto = AppLayerProtoDetectPPGetProto(f, buf, buflen, ipproto, flags, reverse_flow);
         if (AppProtoIsValid(alproto)) {
-            if (rflow) {
-                *reverse_flow = true;
-            }
-            goto end;
+            SCReturnUInt(alproto);
         }
     }
 
     /* Look if flow can be found in expectation list */
     if (!FLOW_IS_PE_DONE(f, flags)) {
+        DEBUG_VALIDATE_BUG_ON(*reverse_flow);
         alproto = AppLayerProtoDetectPEGetProto(f, flags);
     }
-
- end:
-    if (!AppProtoIsValid(alproto))
-        alproto = pm_alproto;
 
     SCReturnUInt(alproto);
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7111

Describe changes:
- The first one is intended to improve DCERPC UDP detection. False positives resulted in improper work of the detection framework.
- The second commit simplifies the detection framework function AppLayerProtoDetectGetProto.
It previously contained a bug that combined with a false positive in DCERPC resulted in incorrect reporting of DNS flow direction.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2266

Rebase of https://github.com/OISF/suricata/pull/12134 that I approve of to get a clean green CI