### PR TITLE
fuzz: better init for signature parsing target

### DIFF
--- a/src/tests/fuzz/fuzz_siginit.c
+++ b/src/tests/fuzz/fuzz_siginit.c
@@ -24,6 +24,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         setenv("SC_LOG_FILE", "/dev/null", 0);
         //global init
         InitGlobal();
+        GlobalsInitPreConfig();
         SCRunmodeSet(RUNMODE_UNITTEST);
         MpmTableSetup();
         SpmTableSetup();


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket, fuzz target bug, https://issues.oss-fuzz.com/u/1/issues/391975646

Describe changes:
- fuzz: improve initialization for fuzz_siginit target (signature parsing)
