### PR TITLE
Libhtp rs v27.2 small step for src

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2942,7 +2942,7 @@ static int HTPParserTest01(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -2986,7 +2986,7 @@ static int HTPParserTest01b(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3041,7 +3041,7 @@ static int HTPParserTest01c(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3097,7 +3097,7 @@ static int HTPParserTest01a(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(strcmp(bstr_util_strdup_to_c(htp_header_value(h)), "Victor/1.0"));
@@ -3139,7 +3139,7 @@ static int HTPParserTest02(void)
 
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NOT_NULL(h);
 
     FAIL_IF_NULL(htp_tx_request_method(tx));
@@ -3193,7 +3193,7 @@ static int HTPParserTest03(void)
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NOT_NULL(h);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_UNKNOWN);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_0);
@@ -3234,7 +3234,7 @@ static int HTPParserTest04(void)
 
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
 
     FAIL_IF_NOT_NULL(h);
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_UNKNOWN);
@@ -3308,7 +3308,7 @@ static int HTPParserTest05(void)
     FAIL_IF_NOT(htp_tx_request_method_number(tx) == HTP_METHOD_POST);
     FAIL_IF_NOT(htp_tx_request_protocol_number(tx) == HTP_PROTOCOL_V1_0);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF_NOT(htp_tx_response_status_number(tx) == 200);
@@ -3399,7 +3399,7 @@ static int HTPParserTest06(void)
     FAIL_IF(htp_tx_response_status_number(tx) != 200);
     FAIL_IF(htp_tx_request_protocol_number(tx) != HTP_PROTOCOL_V1_1);
 
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     AppLayerParserThreadCtxFree(alp_tctx);
@@ -3638,7 +3638,7 @@ static int HTPParserTest10(void)
     FAIL_IF_NULL(htp_state);
 
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     char *name = bstr_util_strdup_to_c(htp_header_name(h));
@@ -3816,7 +3816,7 @@ static int HTPParserTest13(void)
     htp_state = f->alstate;
     FAIL_IF_NULL(htp_state);
     htp_tx_t *tx = HTPStateGetTx(htp_state, 0);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     char *name = bstr_util_strdup_to_c(htp_header_name(h));
@@ -5389,7 +5389,7 @@ static int HTPParserTest20(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5448,7 +5448,7 @@ static int HTPParserTest21(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5502,7 +5502,7 @@ static int HTPParserTest22(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5556,7 +5556,7 @@ static int HTPParserTest23(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);
@@ -5610,7 +5610,7 @@ static int HTPParserTest24(void)
     FAIL_IF_NULL(http_state);
     htp_tx_t *tx = HTPStateGetTx(http_state, 0);
     FAIL_IF_NULL(tx);
-    htp_header_t *h = htp_tx_request_header_index(tx, 0);
+    const htp_header_t *h = htp_tx_request_header_index(tx, 0);
     FAIL_IF_NULL(h);
 
     FAIL_IF(htp_tx_request_method_number(tx) != HTP_METHOD_GET);

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -99,12 +99,12 @@ typedef struct LogHttpLogThread_ {
 } LogHttpLogThread;
 
 /* Retrieves the selected cookie value */
-static uint32_t GetCookieValue(uint8_t *rawcookies, uint32_t rawcookies_len, char *cookiename,
-                                                        uint8_t **cookievalue)
+static uint32_t GetCookieValue(const uint8_t *rawcookies, uint32_t rawcookies_len, char *cookiename,
+        const uint8_t **cookievalue)
 {
-    uint8_t *p = rawcookies;
-    uint8_t *cn = p; /* ptr to cookie name start */
-    uint8_t *cv = NULL; /* ptr to cookie value start */
+    const uint8_t *p = rawcookies;
+    const uint8_t *cn = p;    /* ptr to cookie name start */
+    const uint8_t *cv = NULL; /* ptr to cookie value start */
     while (p < rawcookies + rawcookies_len) {
         if (cv == NULL && *p == '=') {
             cv = p + 1;
@@ -133,11 +133,11 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
     size_t datalen;
     char buf[128];
 
-    uint8_t *cvalue = NULL;
+    const uint8_t *cvalue = NULL;
     uint32_t cvalue_len = 0;
 
-    htp_header_t *h_request_hdr;
-    htp_header_t *h_response_hdr;
+    const htp_header_t *h_request_hdr;
+    const htp_header_t *h_response_hdr;
 
     for (i = 0; i < httplog_ctx->cf->cf_n; i++) {
         h_request_hdr = NULL;
@@ -228,28 +228,26 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
                 break;
             case LOG_HTTP_CF_REQUEST_HEADER:
             /* REQUEST HEADER */
-            if (htp_tx_request_headers(tx) != NULL) {
-                h_request_hdr = htp_tx_request_header(tx, node->data);
-            }
-                if (h_request_hdr != NULL) {
-                    datalen = node->maxlen;
-                    if (datalen == 0 || datalen > bstr_len(h_request_hdr->value)) {
-                        datalen = bstr_len(h_request_hdr->value);
-                    }
-                    PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                                    aft->buffer->size, (uint8_t *)bstr_ptr(h_request_hdr->value),
-                                    datalen);
-                } else {
-                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
+            h_request_hdr = htp_tx_request_header(tx, node->data);
+            if (h_request_hdr != NULL) {
+                datalen = node->maxlen;
+                if (datalen == 0 || datalen > htp_header_value_len(h_request_hdr)) {
+                    datalen = htp_header_value_len(h_request_hdr);
                 }
+                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
+                        htp_header_value_ptr(h_request_hdr), datalen);
+            } else {
+                MemBufferWriteString(aft->buffer, LOG_CF_NONE);
+            }
                 break;
             case LOG_HTTP_CF_REQUEST_COOKIE:
             /* REQUEST COOKIE */
             if (htp_tx_request_headers(tx) != NULL) {
                 h_request_hdr = htp_tx_request_header(tx, "Cookie");
                 if (h_request_hdr != NULL) {
-                    cvalue_len = GetCookieValue((uint8_t *)bstr_ptr(h_request_hdr->value),
-                            (uint32_t)bstr_len(h_request_hdr->value), (char *)node->data, &cvalue);
+                    cvalue_len = GetCookieValue(htp_header_value_ptr(h_request_hdr),
+                            (uint32_t)htp_header_value_len(h_request_hdr), (char *)node->data,
+                            &cvalue);
                 }
             }
                 if (cvalue_len > 0 && cvalue != NULL) {
@@ -285,12 +283,11 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const SCTime_t
             }
                 if (h_response_hdr != NULL) {
                     datalen = node->maxlen;
-                    if (datalen == 0 || datalen > bstr_len(h_response_hdr->value)) {
-                        datalen = bstr_len(h_response_hdr->value);
+                    if (datalen == 0 || datalen > htp_header_value_len(h_response_hdr)) {
+                        datalen = htp_header_value_len(h_response_hdr);
                     }
                     PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                                    aft->buffer->size, (uint8_t *)bstr_ptr(h_response_hdr->value),
-                                    datalen);
+                            aft->buffer->size, htp_header_value_ptr(h_response_hdr), datalen);
                 } else {
                     MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
@@ -315,14 +312,11 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
     LOG_CF_WRITE_STAR_SEPARATOR(aft->buffer);
 
     /* referer */
-    htp_header_t *h_referer = NULL;
-    if (htp_tx_request_headers(tx) != NULL) {
-        h_referer = htp_tx_request_header(tx, "referer");
-    }
+    const htp_header_t *h_referer = htp_tx_request_header(tx, "referer");
+
     if (h_referer != NULL) {
         PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
-                       (uint8_t *)bstr_ptr(h_referer->value),
-                       bstr_len(h_referer->value));
+                htp_header_value_ptr(h_referer), htp_header_value_len(h_referer));
     } else {
         MemBufferWriteString(aft->buffer, "<no referer>");
     }
@@ -355,13 +349,12 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
         /* Redirect? */
         if ((htp_tx_response_status_number(tx) > 300) &&
                 ((htp_tx_response_status_number(tx)) < 303)) {
-            htp_header_t *h_location = htp_tx_response_header(tx, "location");
+            const htp_header_t *h_location = htp_tx_response_header(tx, "location");
             if (h_location != NULL) {
                 MemBufferWriteString(aft->buffer, " => ");
 
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
-                               (uint8_t *)bstr_ptr(h_location->value),
-                               bstr_len(h_location->value));
+                        htp_header_value_ptr(h_location), htp_header_value_len(h_location));
             }
         }
     } else {
@@ -448,14 +441,10 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
         LOG_CF_WRITE_STAR_SEPARATOR(aft->buffer);
 
         /* user agent */
-        htp_header_t *h_user_agent = NULL;
-        if (htp_tx_request_headers(tx) != NULL) {
-            h_user_agent = htp_tx_request_header(tx, "user-agent");
-        }
+        const htp_header_t *h_user_agent = htp_tx_request_header(tx, "user-agent");
         if (h_user_agent != NULL) {
             PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
-                    (uint8_t *)bstr_ptr(h_user_agent->value),
-                    bstr_len(h_user_agent->value));
+                    htp_header_value_ptr(h_user_agent), htp_header_value_len(h_user_agent));
         } else {
             MemBufferWriteString(aft->buffer, "<useragent unknown>");
         }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -290,9 +290,7 @@ static void EveHttpLogJSONExtended(JsonBuilder *js, htp_tx_t *tx)
                 (uint32_t)bstr_len(htp_tx_request_protocol(tx)));
     }
 
-    /* response status: from libhtp:
-     * "Response status code, available only if we were able to parse it, HTP_STATUS_INVALID
-     *  otherwise. HTP_STATUS_UNKNOWN until parsing is attempted" .*/
+    /* response status */
     const int resp = htp_tx_response_status_number(tx);
     if (resp > 0) {
         jb_set_uint(js, "status", (uint32_t)resp);

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -154,13 +154,13 @@ static int HttpGetHeader(lua_State *luastate, int dir)
     if (name == NULL)
         return LuaCallbackError(luastate, "1st argument missing, empty or wrong type");
 
-    const htp_headers_t *headers = htp_tx_request_headers(tx);
-    if (dir == 1)
-        headers = htp_tx_response_headers(tx);
-    if (headers == NULL)
-        return LuaCallbackError(luastate, "tx has no headers");
+    const htp_header_t *h = NULL;
+    if (dir == 0) {
+        h = htp_tx_request_header(tx, name);
+    } else {
+        h = htp_tx_response_header(tx, name);
+    }
 
-    htp_header_t *h = (htp_header_t *)htp_table_get_c(headers, name);
     if (h == NULL || htp_header_value_len(h) == 0)
         return LuaCallbackError(luastate, "header not found");
 
@@ -226,11 +226,11 @@ static int HttpGetHeaders(lua_State *luastate, int dir)
     const htp_headers_t *table = htp_tx_request_headers(tx);
     if (dir == 1)
         table = htp_tx_response_headers(tx);
-    if (htp_tx_request_headers(tx) == NULL)
+    if (table == NULL)
         return LuaCallbackError(luastate, "no headers");
 
     lua_newtable(luastate);
-    htp_header_t *h = NULL;
+    const htp_header_t *h = NULL;
     size_t i = 0;
     size_t no_of_headers = htp_headers_size(table);
     for (; i < no_of_headers; i++) {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/2696

Describe changes:
- prepare libhtp-rs by minimizing the diff for src subdir

This allow to go one small step further

https://github.com/OISF/suricata/pull/12474 next round

`git diff libhtp-rs-v27 --name-only -- src/` gives
- src/Makefile.am : remove libhtp.h 🟢 
- src/app-layer-htp-libhtp.c : removal 🟢 
- src/app-layer-htp-libhtp.h : removal 🟢 
- src/app-layer-htp.c : many changes as expected, and to be worked upon in a next PR 🚧 
- src/app-layer-htp.h : changes will remain until the final PR I think 🟢 
- src/detect-http-headers-stub.h : removal of libhtp.h 🟢 
- src/detect-http-host.c : I do not see a better migration path for parsed uri
- src/detect-http-protocol.c : #ifdef removed 🟢 
- src/detect-http-uri.c : I do not see a better migration path for parsed uri
- src/suricata.c : #ifdef removed and only one libhtp version 🟢 
- src/util-lua-http.c : I do not see a better migration path for parsed uri
