### PR TITLE
analysis: report rule state altered by other rule - v3

### DIFF
--- a/src/detect-engine-build.c
+++ b/src/detect-engine-build.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -2092,6 +2092,8 @@ static int SigMatchPrepare(DetectEngineCtx *de_ctx)
             IPOnlyCIDRListFree(s->init_data->cidr_src);
 
         SCFree(s->init_data->buffers);
+        SCFree(s->init_data->rule_state_dependant_sids_array);
+        SCFree(s->init_data->rule_state_flowbits_ids_array);
         SCFree(s->init_data);
         s->init_data = NULL;
     }

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -624,11 +624,11 @@ int DetectFlowbitsAnalyze(DetectEngineCtx *de_ctx)
             SCLogDebug("SET flowbit %s/%u: SID %u", varname, i,
                     de_ctx->sig_array[array[i].set_sids[x]]->id);
         }
-        for (uint32_t x = 0; x < array[i].isset_sids_idx; x++) {
-            Signature *s = de_ctx->sig_array[array[i].isset_sids[x]];
-            SCLogDebug("GET flowbit %s/%u: SID %u", varname, i, s->id);
+        if (to_state) {
+            for (uint32_t x = 0; x < array[i].isset_sids_idx; x++) {
+                Signature *s = de_ctx->sig_array[array[i].isset_sids[x]];
+                SCLogDebug("GET flowbit %s/%u: SID %u", varname, i, s->id);
 
-            if (to_state) {
                 s->init_data->init_flags |= SIG_FLAG_INIT_STATE_MATCH;
                 SCLogDebug("made SID %u stateful because it depends on "
                         "stateful rules that set flowbit %s", s->id, varname);

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -1563,6 +1563,11 @@ Signature *SigAlloc (void)
      * overwritten after the Signature has been parsed, and if it hasn't been
      * overwritten, we can then assign the default value of 3 */
     sig->prio = -1;
+
+    /* rule interdepency is false, at start */
+    sig->init_data->is_rule_state_dependant = false;
+    /* first index is 0 */
+    sig->init_data->rule_state_dependant_sids_idx = 0;
 
     sig->init_data->list = DETECT_SM_LIST_NOTSET;
     return sig;

--- a/src/detect.h
+++ b/src/detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2023 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -602,6 +602,14 @@ typedef struct SignatureInitData_ {
 
     /* highest list/buffer id which holds a DETECT_CONTENT */
     uint32_t max_content_list_id;
+
+    /* inter-signature state dependency */
+    bool is_rule_state_dependant;
+    uint32_t *rule_state_dependant_sids_array;
+    uint32_t rule_state_dependant_sids_size;
+    uint32_t rule_state_dependant_sids_idx;
+    uint32_t *rule_state_flowbits_ids_array;
+    uint32_t rule_state_flowbits_ids_size;
 } SignatureInitData;
 
 /** \brief Signature container */


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/12311

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7456

Related to https://redmine.openinfosecfoundation.org/issues/7484

Describe changes:
- only walk over `isset` sids array if there are signatures that must be flagged as stateful
- rename fields
- list all upstream sids and flowbits a rule state depends on
- create JSON structure to allow for inclusion of other possible dependencies in the same object
- if no dependency exists, nothing is logged (the field `dependencies` won't be present

Output sample:
A rule with a flowbit dependency will have the `dependencies` object. Otherwise, nothing is logged.
```json
{
  "raw": "alert tcp-pkt any any -> any any (msg:\"Flowbit isset ored flowbits - pkt rule\"; flowbits:isset,fb5|fb6; sid:16;)",
  "id": 16,
  "gid": 1,
  "rev": 0,
  "msg": "Flowbit isset ored flowbits - pkt rule",
  "app_proto": "unknown",
  "requirements": [
    "flow",
    "real_pkt"
  ],
  "type": "pkt",
  "dependencies": {
    "flowbits": {
      "upstream": {
        "state_modifying_rules": {
          "sids": [
            2,
            15
          ],
          "names": [
            "fb6",
            "fb5"
          ]
        }
      }
    }
  }
}
  ```

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2270
