### PR TITLE
doc/userguide: fix typo

### DIFF
--- a/doc/userguide/performance/hyperscan.rst
+++ b/doc/userguide/performance/hyperscan.rst
@@ -51,7 +51,7 @@ The steps to build and install hyperscan are:
   cmake --build ./
   sudo cmake --install ./
 
-**Note:** Hyperscan can take a a long time to build/compile.
+**Note:** Hyperscan can take a long time to build/compile.
 
 **Note:** It may be necessary to add /usr/local/lib or
 /usr/local/lib64 to the `ld` search path. Typically this is

--- a/doc/userguide/performance/runmodes.rst
+++ b/doc/userguide/performance/runmodes.rst
@@ -12,7 +12,7 @@ a queue. Packets will be processed by one thread at a time, but there
 can be multiple packets being processed at a time by the engine (see
 :ref:`suricata-yaml-max-pending-packets`). A thread can have one or
 more thread-modules. If they have more modules, they can only be
-active one a a time.  The way threads, modules and queues are arranged
+active one at a time.  The way threads, modules and queues are arranged
 together is called the "Runmode".
 
 Different runmodes


### PR DESCRIPTION
Documentation: #7540

fixed doc/userguide/performance/hyperscan.rst
fixed doc/userguide/performance/runmodes.rst

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7540

Describe changes:
- small typo in `doc/userguide/performance/hyperscan.rst` and `doc/userguide/performance/runmodes.rst`
- this is a following from previous PR https://github.com/OISF/suricata/pull/12108

