### PR TITLE
fuzz: init reverse before calling AppLayerProtoDetectGetProto

### DIFF
--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -26,7 +26,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     Flow *f;
     TcpSession ssn;
-    bool reverse;
+    bool reverse = false;
 
     if (alpd_tctx == NULL) {
         //global init


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just fuzz target fix for https://issues.oss-fuzz.com/u/1/issues/393408795

Describe changes:
- fuzz: init reverse before calling AppLayerProtoDetectGetProto

Needed because of fec06f8ac3954c19081fcf4005543b845dbef245