### PR TITLE
output/eve: reduce fflush call count

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -17,6 +17,32 @@ can then be processed by 3rd party tools like Logstash (ELK) or jq.
 If ``ethernet`` is set to yes, then ethernet headers will be added to events
 if available.
 
+Output Buffering
+~~~~~~~~~~~~~~~~
+
+Output flushing is controlled by values in the configuration section ``heartbeat``. By default, Suricata's
+output is synchronous with little possibility that written data will not be persisted. However, if ``output.buffer-size``
+has a non-zero value, then some data may be written for the output, but not actually flushed. ``buffer-size`` bytes
+may be held in memory and written a short time later opening the possibility -- but limited -- for output data
+loss.
+
+Hence, a heartbeat mechanism is introduced to limit the amount of time buffered data may exist before being
+flushed.  Control is provided to instruct Suricata's detection threads to flush their EVE output. With default
+values, there is no change in output buffering and flushing behavior. ``output-flush-interval`` controls
+how often Suricata's detect threads will flush output in a heartbeat fashion. A value of ``0`` means
+"never"; non-zero values must be in ``[1-60]`` seconds.
+
+Flushing should be considered when ``outputs.buffer-size`` is greater than 0 to limit the amount and
+age of buffered, but not persisted, output data.  Flushing is never needed when ``buffer-size`` is ``0``.
+
+
+::
+
+   heartbeat:
+     #output-flush-interval: 0
+
+
+
 Output types
 ~~~~~~~~~~~~
 
@@ -30,6 +56,10 @@ Output types::
       # Enable for multi-threaded eve.json output; output files are amended
       # with an identifier, e.g., eve.9.json. Default: off
       #threaded: off
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      #buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -245,7 +275,7 @@ In the ``custom`` option values from both columns can be used. The
 DNS
 ~~~
 
-.. note:: 
+.. note::
 
    As of Suricata 7.0 the v1 EVE DNS format has been removed.
 

--- a/doc/userguide/partials/eve-log.yaml
+++ b/doc/userguide/partials/eve-log.yaml
@@ -7,6 +7,10 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      #buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -280,3 +284,14 @@ outputs:
         #   event-set: false                # log packets that have a decoder/stream event
         #   state-update: false             # log packets triggering a TCP state update
         #   spurious-retransmission: false  # log spurious retransmission packets
+        #
+heartbeat:
+  # The output-flush-interval value governs how often Suricata will instruct the
+  # detection threads to flush their EVE output. Specify the value in seconds [1-60]
+  # and Suricata will initiate EVE log output flushes at that interval. A value
+  # of 0 means no EVE log output flushes are initiated. When the EVE output
+  # buffer-size value is non-zero, some EVE output that was written may remain
+  # buffered. The output-flush-interval governs how much buffered data exists.
+  #
+  # The default value is: 0 (never instruct detection threads to flush output)
+  #output-flush-interval: 0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -343,6 +343,7 @@ noinst_HEADERS = \
 	ippair-storage.h \
 	ippair-timeout.h \
 	log-cf-common.h \
+	log-flush.h \
 	log-httplog.h \
 	log-pcap.h \
 	log-stats.h \
@@ -911,6 +912,7 @@ libsuricata_c_a_SOURCES = \
 	ippair-storage.c \
 	ippair-timeout.c \
 	log-cf-common.c \
+	log-flush.c \
 	log-httplog.c \
 	log-pcap.c \
 	log-stats.c \

--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -481,7 +481,15 @@ static int AlertDebugLogLogger(ThreadVars *tv, void *thread_data, const Packet *
 
 void AlertDebugLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertDebugLogLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertDebugLogCondition,
+        .ThreadInitFunc = AlertDebugLogThreadInit,
+        .ThreadDeinitFunc = AlertDebugLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketModule(LOGGER_ALERT_DEBUG, MODULE_NAME, "alert-debug", AlertDebugLogInitCtx,
-            AlertDebugLogLogger, AlertDebugLogCondition, AlertDebugLogThreadInit,
-            AlertDebugLogThreadDeinit);
+            &output_logger_functions);
 }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -76,9 +76,17 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p);
 
 void AlertFastLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_ALERT_FAST, MODULE_NAME, "fast", AlertFastLogInitCtx,
-            AlertFastLogger, AlertFastLogCondition, AlertFastLogThreadInit,
-            AlertFastLogThreadDeinit);
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertFastLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertFastLogCondition,
+        .ThreadInitFunc = AlertFastLogThreadInit,
+        .ThreadDeinitFunc = AlertFastLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
+    OutputRegisterPacketModule(
+            LOGGER_ALERT_FAST, MODULE_NAME, "fast", AlertFastLogInitCtx, &output_logger_functions);
     AlertFastLogRegisterTests();
 }
 

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -384,8 +384,15 @@ static int AlertSyslogLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 void AlertSyslogRegister (void)
 {
 #ifndef OS_WIN32
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = AlertSyslogLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = AlertSyslogCondition,
+        .ThreadInitFunc = AlertSyslogThreadInit,
+        .ThreadDeinitFunc = AlertSyslogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
     OutputRegisterPacketModule(LOGGER_ALERT_SYSLOG, MODULE_NAME, "syslog", AlertSyslogInitCtx,
-            AlertSyslogLogger, AlertSyslogCondition, AlertSyslogThreadInit,
-            AlertSyslogThreadDeinit);
+            &output_logger_functions);
 #endif /* !OS_WIN32 */
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -1315,9 +1315,12 @@ void DecodeUnregisterCounters(void);
 #define PKT_FIRST_ALERTS BIT_U32(29)
 #define PKT_FIRST_TAG    BIT_U32(30)
 
+#define PKT_PSEUDO_LOG_FLUSH BIT_U32(31) /**< Detect/log flush for protocol upgrade */
+
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) \
     ((p)->flags & (PKT_PSEUDO_STREAM_END|PKT_PSEUDO_DETECTLOG_FLUSH))
+#define PKT_IS_FLUSHPKT(p) ((p)->flags & (PKT_PSEUDO_LOG_FLUSH))
 
 #define PKT_SET_SRC(p, src_val) ((p)->pkt_src = src_val)
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2300,15 +2300,50 @@ int DetectEngineInspectPktBufferGeneric(
 }
 
 /** \internal
- *  \brief inject a pseudo packet into each detect thread that doesn't use the
- *         new det_ctx yet
+ *  \brief inject a pseudo packet into each detect thread
+ *         if the thread should flush its output logs.
  */
-static void InjectPackets(ThreadVars **detect_tvs,
-                          DetectEngineThreadCtx **new_det_ctx,
-                          int no_of_detect_tvs)
+void InjectPacketsForFlush(ThreadVars **detect_tvs, int no_of_detect_tvs)
 {
-    /* inject a fake packet if the detect thread isn't using the new ctx yet,
-     * this speeds up the process */
+    /* inject a fake packet if the detect thread that needs it. This function
+     * is called when a heartbeat log-flush request has been made
+     * and it should process a pseudo packet and flush its output logs
+     * to speed the process. */
+#if DEBUG
+    int count = 0;
+#endif
+    for (int i = 0; i < no_of_detect_tvs; i++) {
+        if (detect_tvs[i]) { // && detect_tvs[i]->inq != NULL) {
+            Packet *p = PacketGetFromAlloc();
+            if (p != NULL) {
+                SCLogDebug("Injecting pkt for tv %s[i=%d] %d", detect_tvs[i]->name, i, count++);
+                p->flags |= PKT_PSEUDO_STREAM_END;
+                p->flags |= PKT_PSEUDO_LOG_FLUSH;
+                PKT_SET_SRC(p, PKT_SRC_DETECT_RELOAD_FLUSH);
+                PacketQueue *q = detect_tvs[i]->stream_pq;
+                SCMutexLock(&q->mutex_q);
+                PacketEnqueue(q, p);
+                SCCondSignal(&q->cond_q);
+                SCMutexUnlock(&q->mutex_q);
+            }
+        }
+    }
+    SCLogDebug("leaving: thread notification count = %d", count);
+}
+
+/** \internal
+ *  \brief inject a pseudo packet into each detect thread
+ *      -that doesn't use the new det_ctx yet
+ *      -*or*, if the thread should flush its output logs.
+ */
+static void InjectPackets(
+        ThreadVars **detect_tvs, DetectEngineThreadCtx **new_det_ctx, int no_of_detect_tvs)
+{
+    /* inject a fake packet if the detect thread that needs it. This function
+     * is called if
+     *  - A thread isn't using a DE ctx and should
+     *  - Or, it should process a pseudo packet and flush its output logs.
+     * to speed the process. */
     for (int i = 0; i < no_of_detect_tvs; i++) {
         if (SC_ATOMIC_GET(new_det_ctx[i]->so_far_used_by_detect) != 1) {
             if (detect_tvs[i]->inq != NULL) {

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -209,4 +209,6 @@ void DetectEngineStateResetTxs(Flow *f);
 
 void DeStateRegisterTests(void);
 
+/* packet injection */
+void InjectPacketsForFlush(ThreadVars **detect_tvs, int no_of_detect_tvs);
 #endif /* SURICATA_DETECT_ENGINE_H */

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -73,6 +73,8 @@ typedef struct FlowWorkerThreadData_ {
 
     SC_ATOMIC_DECLARE(DetectEngineThreadCtxPtr, detect_thread);
 
+    SC_ATOMIC_DECLARE(bool, flush_ack);
+
     void *output_thread; /* Output thread data. */
     void *output_thread_flow; /* Output thread data. */
 
@@ -554,6 +556,15 @@ static TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data)
 
     SCLogDebug("packet %"PRIu64, p->pcap_cnt);
 
+    if ((PKT_IS_FLUSHPKT(p))) {
+        SCLogDebug("thread %s flushing", tv->printable_name);
+        OutputLoggerFlush(tv, p, fw->output_thread);
+        /* Ack if a flush was requested */
+        bool notset = false;
+        SC_ATOMIC_CAS(&fw->flush_ack, notset, true);
+        return TM_ECODE_OK;
+    }
+
     /* handle Flow */
     if (p->flags & PKT_WANTS_FLOW) {
         FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_FLOW);
@@ -721,6 +732,23 @@ void *FlowWorkerGetDetectCtxPtr(void *flow_worker)
     FlowWorkerThreadData *fw = flow_worker;
 
     return SC_ATOMIC_GET(fw->detect_thread);
+}
+
+void *FlowWorkerGetThreadData(void *flow_worker)
+{
+    return (FlowWorkerThreadData *)flow_worker;
+}
+
+bool FlowWorkerGetFlushAck(void *flow_worker)
+{
+    FlowWorkerThreadData *fw = flow_worker;
+    return SC_ATOMIC_GET(fw->flush_ack) == true;
+}
+
+void FlowWorkerSetFlushAck(void *flow_worker)
+{
+    FlowWorkerThreadData *fw = flow_worker;
+    SC_ATOMIC_SET(fw->flush_ack, false);
 }
 
 const char *ProfileFlowWorkerIdToString(enum ProfileFlowWorkerId fwi)

--- a/src/flow-worker.h
+++ b/src/flow-worker.h
@@ -32,6 +32,9 @@ const char *ProfileFlowWorkerIdToString(enum ProfileFlowWorkerId fwi);
 
 void FlowWorkerReplaceDetectCtx(void *flow_worker, void *detect_ctx);
 void *FlowWorkerGetDetectCtxPtr(void *flow_worker);
+void *FlowWorkerGetThreadData(void *flow_worker);
+bool FlowWorkerGetFlushAck(void *flow_worker);
+void FlowWorkerSetFlushAck(void *flow_worker);
 
 void TmModuleFlowWorkerRegister (void);
 

--- a/src/log-flush.c
+++ b/src/log-flush.c
@@ -1,0 +1,199 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect.h"
+#include "detect-engine.h"
+#include "flow-worker.h"
+#include "log-flush.h"
+#include "tm-threads.h"
+#include "conf.h"
+#include "conf-yaml-loader.h"
+#include "util-privs.h"
+
+/**
+ * \brief Trigger detect threads to flush their output logs
+ *
+ * This function is intended to be called at regular intervals to force
+ * buffered log data to be persisted
+ */
+static void WorkerFlushLogs(void)
+{
+    SCEnter();
+
+    /* count detect threads in use */
+    uint32_t no_of_detect_tvs = TmThreadCountThreadsByTmmFlags(TM_FLAG_DETECT_TM);
+    /* can be zero in unix socket mode */
+    if (no_of_detect_tvs == 0) {
+        return;
+    }
+
+    /* prepare swap structures */
+    void *fw_threads[no_of_detect_tvs];
+    ThreadVars *detect_tvs[no_of_detect_tvs];
+    memset(fw_threads, 0x00, (no_of_detect_tvs * sizeof(void *)));
+    memset(detect_tvs, 0x00, (no_of_detect_tvs * sizeof(ThreadVars *)));
+
+    /* start by initiating the log flushes */
+
+    uint32_t i = 0;
+    SCMutexLock(&tv_root_lock);
+    /* get reference to tv's and setup fw_threads array */
+    for (ThreadVars *tv = tv_root[TVT_PPT]; tv != NULL; tv = tv->next) {
+        if ((tv->tmm_flags & TM_FLAG_DETECT_TM) == 0) {
+            continue;
+        }
+        for (TmSlot *s = tv->tm_slots; s != NULL; s = s->slot_next) {
+            TmModule *tm = TmModuleGetById(s->tm_id);
+            if (!(tm->flags & TM_FLAG_DETECT_TM)) {
+                continue;
+            }
+
+            if (suricata_ctl_flags != 0) {
+                SCMutexUnlock(&tv_root_lock);
+                goto error;
+            }
+
+            fw_threads[i] = FlowWorkerGetThreadData(SC_ATOMIC_GET(s->slot_data));
+            if (fw_threads[i]) {
+                FlowWorkerSetFlushAck(fw_threads[i]);
+                SCLogDebug("Setting flush-ack for thread %s[i=%d]", tv->printable_name, i);
+                detect_tvs[i] = tv;
+            }
+
+            i++;
+            break;
+        }
+    }
+    BUG_ON(i != no_of_detect_tvs);
+
+    SCMutexUnlock(&tv_root_lock);
+
+    SCLogDebug("Creating flush pseudo packets for %d threads", no_of_detect_tvs);
+    InjectPacketsForFlush(detect_tvs, no_of_detect_tvs);
+
+    uint32_t threads_done = 0;
+retry:
+    for (i = 0; i < no_of_detect_tvs; i++) {
+        if (suricata_ctl_flags != 0) {
+            threads_done = no_of_detect_tvs;
+            break;
+        }
+        usleep(1000);
+        if (fw_threads[i] && FlowWorkerGetFlushAck(fw_threads[i])) {
+            SCLogDebug("thread slot %d has ack'd flush request", i);
+            threads_done++;
+        } else if (detect_tvs[i]) {
+            SCLogDebug("thread slot %d not yet ack'd flush request", i);
+            TmThreadsCaptureBreakLoop(detect_tvs[i]);
+        }
+    }
+    if (threads_done < no_of_detect_tvs) {
+        threads_done = 0;
+        SleepMsec(250);
+        goto retry;
+    }
+
+error:
+    return;
+}
+
+static int OutputFlushInterval(void)
+{
+    intmax_t output_flush_interval = 0;
+    if (ConfGetInt("heartbeat.output-flush-interval", &output_flush_interval) == 0) {
+        output_flush_interval = 0;
+    }
+    if (output_flush_interval < 0 || output_flush_interval > 60) {
+        SCLogConfig("flush_interval must be 0 or less than 60; using 0");
+        output_flush_interval = 0;
+    }
+
+    return (int)output_flush_interval;
+}
+
+static void *LogFlusherWakeupThread(void *arg)
+{
+    int output_flush_interval = OutputFlushInterval();
+    /* This was checked by the logic creating this thread */
+    BUG_ON(output_flush_interval == 0);
+
+    SCLogConfig("Using output-flush-interval of %d seconds", output_flush_interval);
+    /*
+     * Calculate the number of sleep intervals based on the output flush interval. This is necessary
+     * because this thread pauses a fixed amount of time to react to shutdown situations more
+     * quickly.
+     */
+    const int log_flush_sleep_time = 500; /* milliseconds */
+    const int flush_wait_count = (1000 * output_flush_interval) / log_flush_sleep_time;
+
+    ThreadVars *tv_local = (ThreadVars *)arg;
+    SCSetThreadName(tv_local->name);
+
+    if (tv_local->thread_setup_flags != 0)
+        TmThreadSetupOptions(tv_local);
+
+    /* Set the threads capability */
+    tv_local->cap_flags = 0;
+    SCDropCaps(tv_local);
+
+    TmThreadsSetFlag(tv_local, THV_INIT_DONE | THV_RUNNING);
+
+    int wait_count = 0;
+    uint64_t worker_flush_count = 0;
+    bool run = TmThreadsWaitForUnpause(tv_local);
+    while (run) {
+        usleep(log_flush_sleep_time * 1000);
+
+        if (++wait_count == flush_wait_count) {
+            worker_flush_count++;
+            WorkerFlushLogs();
+            wait_count = 0;
+        }
+
+        if (TmThreadsCheckFlag(tv_local, THV_KILL)) {
+            break;
+        }
+    }
+
+    TmThreadsSetFlag(tv_local, THV_RUNNING_DONE);
+    TmThreadWaitForFlag(tv_local, THV_DEINIT);
+    TmThreadsSetFlag(tv_local, THV_CLOSED);
+    SCLogInfo("%s: initiated %" PRIu64 " flushes", tv_local->name, worker_flush_count);
+    return NULL;
+}
+
+void LogFlushThreads(void)
+{
+    if (0 == OutputFlushInterval()) {
+        SCLogConfig("log flusher thread not used with heartbeat.output-flush-interval of 0");
+        return;
+    }
+
+    ThreadVars *tv_log_flush =
+            TmThreadCreateMgmtThread(thread_name_heartbeat, LogFlusherWakeupThread, 1);
+    if (!tv_log_flush || (TmThreadSpawn(tv_log_flush) != 0)) {
+        FatalError("Unable to create and start log flush thread");
+    }
+}

--- a/src/log-flush.h
+++ b/src/log-flush.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jlucovsky@oisf.net>
+ */
+#ifndef SURICATA_LOG_FLUSH_H__
+#define SURICATA_LOG_FLUSH_H__
+void LogFlushThreads(void);
+#endif /* SURICATA_LOG_FLUSH_H__ */

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -209,8 +209,16 @@ static bool PcapLogCondition(ThreadVars *, void *, const Packet *);
 
 void PcapLogRegister(void)
 {
-    OutputRegisterPacketModule(LOGGER_PCAP, MODULE_NAME, "pcap-log", PcapLogInitCtx, PcapLog,
-            PcapLogCondition, PcapLogDataInit, PcapLogDataDeinit);
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = PcapLog,
+        .FlushFunc = NULL,
+        .ConditionFunc = PcapLogCondition,
+        .ThreadInitFunc = PcapLogDataInit,
+        .ThreadDeinitFunc = PcapLogDataDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+    OutputRegisterPacketModule(
+            LOGGER_PCAP, MODULE_NAME, "pcap-log", PcapLogInitCtx, &output_logger_functions);
     PcapLogProfileSetup();
     SC_ATOMIC_INIT(thread_cnt);
     SC_ATOMIC_SET(thread_cnt, 1); /* first id is 1 */

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -452,7 +452,15 @@ static bool EveStreamLogCondition(ThreadVars *tv, void *data, const Packet *p)
 
 void EveStreamLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = EveStreamLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = EveStreamLogCondition,
+        .ThreadInitFunc = EveStreamLogThreadInit,
+        .ThreadDeinitFunc = EveStreamLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_STREAM, "eve-log", MODULE_NAME, "eve-log.stream",
-            EveStreamLogInitCtxSub, EveStreamLogger, EveStreamLogCondition, EveStreamLogThreadInit,
-            EveStreamLogThreadDeinit);
+            EveStreamLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-eve-stream.c
+++ b/src/output-eve-stream.c
@@ -454,7 +454,7 @@ void EveStreamLogRegister(void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = EveStreamLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = OutputJsonLogFlush,
         .ConditionFunc = EveStreamLogCondition,
         .ThreadInitFunc = EveStreamLogThreadInit,
         .ThreadDeinitFunc = EveStreamLogThreadDeinit,

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -823,6 +823,14 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
     return TM_ECODE_OK;
 }
 
+static int JsonAlertFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    JsonAlertLogThread *aft = thread_data;
+    SCLogDebug("%s flushing %s", tv->name, ((LogFileCtx *)(aft->ctx->file_ctx))->filename);
+    OutputJsonFlush(aft->ctx);
+    return 0;
+}
+
 static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonAlertLogThread *aft = thread_data;
@@ -1067,7 +1075,7 @@ void JsonAlertLogRegister (void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = JsonAlertLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = JsonAlertFlush,
         .ConditionFunc = JsonAlertLogCondition,
         .ThreadInitFunc = JsonAlertLogThreadInit,
         .ThreadDeinitFunc = JsonAlertLogThreadDeinit,

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -1065,7 +1065,15 @@ error:
 
 void JsonAlertLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonAlertLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonAlertLogCondition,
+        .ThreadInitFunc = JsonAlertLogThreadInit,
+        .ThreadDeinitFunc = JsonAlertLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_ALERT, "eve-log", MODULE_NAME, "eve-log.alert",
-            JsonAlertLogInitCtxSub, JsonAlertLogger, JsonAlertLogCondition, JsonAlertLogThreadInit,
-            JsonAlertLogThreadDeinit);
+            JsonAlertLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -449,9 +449,17 @@ static OutputInitResult JsonAnomalyLogInitCtxSub(ConfNode *conf, OutputCtx *pare
 
 void JsonAnomalyLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonAnomalyLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonAnomalyLogCondition,
+        .ThreadInitFunc = JsonAnomalyLogThreadInit,
+        .ThreadDeinitFunc = JsonAnomalyLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME, "eve-log.anomaly",
-            JsonAnomalyLogInitCtxSub, JsonAnomalyLogger, JsonAnomalyLogCondition,
-            JsonAnomalyLogThreadInit, JsonAnomalyLogThreadDeinit);
+            JsonAnomalyLogInitCtxSub, &output_logger_functions);
 
     OutputRegisterTxSubModule(LOGGER_JSON_ANOMALY, "eve-log", MODULE_NAME, "eve-log.anomaly",
             JsonAnomalyLogInitCtxHelper, ALPROTO_UNKNOWN, JsonAnomalyTxLogger,

--- a/src/output-json-anomaly.c
+++ b/src/output-json-anomaly.c
@@ -272,6 +272,14 @@ static int AnomalyJson(ThreadVars *tv, JsonAnomalyLogThread *aft, const Packet *
     return rc;
 }
 
+static int JsonAnomalyFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    JsonAnomalyLogThread *aft = thread_data;
+    SCLogDebug("%s flushing %s", tv->name, ((LogFileCtx *)(aft->ctx->file_ctx))->filename);
+    OutputJsonFlush(aft->ctx);
+    return 0;
+}
+
 static int JsonAnomalyLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonAnomalyLogThread *aft = thread_data;
@@ -451,7 +459,7 @@ void JsonAnomalyLogRegister (void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = JsonAnomalyLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = JsonAnomalyFlush,
         .ConditionFunc = JsonAnomalyLogCondition,
         .ThreadInitFunc = JsonAnomalyLogThreadInit,
         .ThreadDeinitFunc = JsonAnomalyLogThreadDeinit,

--- a/src/output-json-arp.c
+++ b/src/output-json-arp.c
@@ -103,9 +103,17 @@ static bool JsonArpLogCondition(ThreadVars *tv, void *thread_data, const Packet 
 
 void JsonArpLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonArpLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonArpLogCondition,
+        .ThreadInitFunc = JsonLogThreadInit,
+        .ThreadDeinitFunc = JsonLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_ARP, "eve-log", "JsonArpLog", "eve-log.arp",
-            OutputJsonLogInitSub, JsonArpLogger, JsonArpLogCondition, JsonLogThreadInit,
-            JsonLogThreadDeinit);
+            OutputJsonLogInitSub, &output_logger_functions);
 
     SCLogDebug("ARP JSON logger registered.");
 }

--- a/src/output-json-common.c
+++ b/src/output-json-common.c
@@ -70,6 +70,15 @@ static void OutputJsonLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
+int OutputJsonLogFlush(ThreadVars *tv, void *thread_data, const Packet *p)
+{
+    OutputJsonThreadCtx *aft = thread_data;
+    LogFileCtx *file_ctx = aft->ctx->file_ctx;
+    SCLogDebug("%s flushing %s", tv->name, file_ctx->filename);
+    LogFileFlush(file_ctx);
+    return 0;
+}
+
 OutputInitResult OutputJsonLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputInitResult result = { NULL, false };

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -392,7 +392,7 @@ void JsonDropLogRegister (void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = JsonDropLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = OutputJsonLogFlush,
         .ConditionFunc = JsonDropLogCondition,
         .ThreadInitFunc = JsonDropLogThreadInit,
         .ThreadDeinitFunc = JsonDropLogThreadDeinit,

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -390,7 +390,15 @@ static bool JsonDropLogCondition(ThreadVars *tv, void *data, const Packet *p)
 
 void JsonDropLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonDropLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonDropLogCondition,
+        .ThreadInitFunc = JsonDropLogThreadInit,
+        .ThreadDeinitFunc = JsonDropLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_DROP, "eve-log", MODULE_NAME, "eve-log.drop",
-            JsonDropLogInitCtxSub, JsonDropLogger, JsonDropLogCondition, JsonDropLogThreadInit,
-            JsonDropLogThreadDeinit);
+            JsonDropLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -562,7 +562,7 @@ void JsonFrameLogRegister(void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = JsonFrameLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = OutputJsonLogFlush,
         .ConditionFunc = JsonFrameLogCondition,
         .ThreadInitFunc = JsonFrameLogThreadInit,
         .ThreadDeinitFunc = JsonFrameLogThreadDeinit,

--- a/src/output-json-frame.c
+++ b/src/output-json-frame.c
@@ -560,7 +560,14 @@ error:
 
 void JsonFrameLogRegister(void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonFrameLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonFrameLogCondition,
+        .ThreadInitFunc = JsonFrameLogThreadInit,
+        .ThreadDeinitFunc = JsonFrameLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
     OutputRegisterPacketSubModule(LOGGER_JSON_FRAME, "eve-log", MODULE_NAME, "eve-log.frame",
-            JsonFrameLogInitCtxSub, JsonFrameLogger, JsonFrameLogCondition, JsonFrameLogThreadInit,
-            JsonFrameLogThreadDeinit);
+            JsonFrameLogInitCtxSub, &output_logger_functions);
 }

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -96,7 +96,7 @@ void JsonMetadataLogRegister (void)
 {
     OutputPacketLoggerFunctions output_logger_functions = {
         .LogFunc = JsonMetadataLogger,
-        .FlushFunc = NULL,
+        .FlushFunc = OutputJsonLogFlush,
         .ConditionFunc = JsonMetadataLogCondition,
         .ThreadInitFunc = JsonLogThreadInit,
         .ThreadDeinitFunc = JsonLogThreadDeinit,

--- a/src/output-json-metadata.c
+++ b/src/output-json-metadata.c
@@ -94,12 +94,19 @@ static bool JsonMetadataLogCondition(ThreadVars *tv, void *data, const Packet *p
 
 void JsonMetadataLogRegister (void)
 {
+    OutputPacketLoggerFunctions output_logger_functions = {
+        .LogFunc = JsonMetadataLogger,
+        .FlushFunc = NULL,
+        .ConditionFunc = JsonMetadataLogCondition,
+        .ThreadInitFunc = JsonLogThreadInit,
+        .ThreadDeinitFunc = JsonLogThreadDeinit,
+        .ThreadExitPrintStatsFunc = NULL,
+    };
+
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.metadata",
-            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
-            JsonLogThreadDeinit);
+            OutputJsonLogInitSub, &output_logger_functions);
 
     /* Kept for compatibility. */
     OutputRegisterPacketSubModule(LOGGER_JSON_METADATA, "eve-log", MODULE_NAME, "eve-log.vars",
-            OutputJsonLogInitSub, JsonMetadataLogger, JsonMetadataLogCondition, JsonLogThreadInit,
-            JsonLogThreadDeinit);
+            OutputJsonLogInitSub, &output_logger_functions);
 }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -956,6 +956,12 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     return 0;
 }
 
+void OutputJsonFlush(OutputJsonThreadCtx *ctx)
+{
+    LogFileCtx *file_ctx = ctx->file_ctx;
+    LogFileFlush(file_ctx);
+}
+
 void OutputJsonBuilderBuffer(
         ThreadVars *tv, const Packet *p, Flow *f, JsonBuilder *js, OutputJsonThreadCtx *ctx)
 {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -114,6 +114,7 @@ TmEcode JsonLogThreadDeinit(ThreadVars *t, void *data);
 
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, const Flow *f,
         JsonBuilder *js, enum OutputJsonLogDirection dir);
+int OutputJsonLogFlush(ThreadVars *tv, void *thread_data, const Packet *p);
 void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js);
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
@@ -121,5 +122,6 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 OutputJsonThreadCtx *CreateEveThreadCtx(ThreadVars *t, OutputJsonCtx *ctx);
 void FreeEveThreadCtx(OutputJsonThreadCtx *ctx);
 void JSONFormatAndAddMACAddr(JsonBuilder *js, const char *key, const uint8_t *val, bool is_array);
+void OutputJsonFlush(OutputJsonThreadCtx *ctx);
 
 #endif /* SURICATA_OUTPUT_JSON_H */

--- a/src/output.c
+++ b/src/output.c
@@ -708,6 +708,21 @@ void OutputNotifyFileRotation(void) {
     }
 }
 
+TmEcode OutputLoggerFlush(ThreadVars *tv, Packet *p, void *thread_data)
+{
+    LoggerThreadStore *thread_store = (LoggerThreadStore *)thread_data;
+    RootLogger *logger = TAILQ_FIRST(&active_loggers);
+    LoggerThreadStoreNode *thread_store_node = TAILQ_FIRST(thread_store);
+    while (logger && thread_store_node) {
+        if (logger->FlushFunc)
+            logger->FlushFunc(tv, p, thread_store_node->thread_data);
+
+        logger = TAILQ_NEXT(logger, entries);
+        thread_store_node = TAILQ_NEXT(thread_store_node, entries);
+    }
+    return TM_ECODE_OK;
+}
+
 TmEcode OutputLoggerLog(ThreadVars *tv, Packet *p, void *thread_data)
 {
     LoggerThreadStore *thread_store = (LoggerThreadStore *)thread_data;

--- a/src/output.h
+++ b/src/output.h
@@ -51,6 +51,7 @@ typedef struct OutputInitResult_ {
 typedef OutputInitResult (*OutputInitFunc)(ConfNode *);
 typedef OutputInitResult (*OutputInitSubFunc)(ConfNode *, OutputCtx *);
 typedef TmEcode (*OutputLogFunc)(ThreadVars *, Packet *, void *);
+typedef TmEcode (*OutputFlushFunc)(ThreadVars *, Packet *, void *);
 typedef uint32_t (*OutputGetActiveCountFunc)(void);
 
 typedef struct OutputModule_ {
@@ -65,6 +66,7 @@ typedef struct OutputModule_ {
     ThreadDeinitFunc ThreadDeinit;
 
     PacketLogger PacketLogFunc;
+    PacketLogger PacketFlushFunc;
     PacketLogCondition PacketConditionFunc;
     TxLogger TxLogFunc;
     TxLoggerCondition TxLogCondition;
@@ -81,17 +83,25 @@ typedef struct OutputModule_ {
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
 
+/* struct for packet module and packet sub-module registration */
+typedef struct OutputPacketLoggerFunctions_ {
+    PacketLogger LogFunc;
+    PacketLogger FlushFunc;
+    PacketLogCondition ConditionFunc;
+    ThreadInitFunc ThreadInitFunc;
+    ThreadDeinitFunc ThreadDeinitFunc;
+    ThreadExitPrintStatsFunc ThreadExitPrintStatsFunc;
+} OutputPacketLoggerFunctions;
+
 typedef TAILQ_HEAD(OutputModuleList_, OutputModule_) OutputModuleList;
 extern OutputModuleList output_modules;
 
 void OutputRegisterModule(const char *, const char *, OutputInitFunc);
 
 void OutputRegisterPacketModule(LoggerId id, const char *name, const char *conf_name,
-        OutputInitFunc InitFunc, PacketLogger LogFunc, PacketLogCondition ConditionFunc,
-        ThreadInitFunc, ThreadDeinitFunc);
+        OutputInitFunc InitFunc, OutputPacketLoggerFunctions *);
 void OutputRegisterPacketSubModule(LoggerId id, const char *parent_name, const char *name,
-        const char *conf_name, OutputInitSubFunc InitFunc, PacketLogger LogFunc,
-        PacketLogCondition ConditionFunc, ThreadInitFunc ThreadInit, ThreadDeinitFunc ThreadDeinit);
+        const char *conf_name, OutputInitSubFunc InitFunc, OutputPacketLoggerFunctions *);
 
 void OutputRegisterTxModule(LoggerId id, const char *name, const char *conf_name,
         OutputInitFunc InitFunc, AppProto alproto, TxLogger TxLogFunc, ThreadInitFunc ThreadInit,

--- a/src/output.h
+++ b/src/output.h
@@ -164,6 +164,7 @@ void OutputRegisterRootLogger(ThreadInitFunc ThreadInit, ThreadDeinitFunc Thread
 void TmModuleLoggerRegister(void);
 
 TmEcode OutputLoggerLog(ThreadVars *, Packet *, void *);
+TmEcode OutputLoggerFlush(ThreadVars *, Packet *, void *);
 TmEcode OutputLoggerThreadInit(ThreadVars *, const void *, void **);
 TmEcode OutputLoggerThreadDeinit(ThreadVars *, void *);
 void OutputLoggerExitPrintStats(ThreadVars *, void *);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -28,6 +28,7 @@
 #include "util-debug.h"
 #include "util-affinity.h"
 #include "conf.h"
+#include "log-flush.h"
 #include "runmodes.h"
 #include "runmode-af-packet.h"
 #include "runmode-af-xdp.h"
@@ -72,6 +73,7 @@ const char *thread_name_unix_socket = "US";
 const char *thread_name_detect_loader = "DL";
 const char *thread_name_counter_stats = "CS";
 const char *thread_name_counter_wakeup = "CW";
+const char *thread_name_heartbeat = "HB";
 
 /**
  * \brief Holds description for a runmode.
@@ -436,6 +438,7 @@ void RunModeDispatch(int runmode, const char *custom_mode, const char *capture_p
             BypassedFlowManagerThreadSpawn();
         }
         StatsSpawnThreads();
+        LogFlushThreads();
         TmThreadsSealThreads();
     }
 }

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -73,6 +73,7 @@ extern const char *thread_name_unix_socket;
 extern const char *thread_name_detect_loader;
 extern const char *thread_name_counter_stats;
 extern const char *thread_name_counter_wakeup;
+extern const char *thread_name_heartbeat;
 
 char *RunmodeGetActive(void);
 const char *RunModeGetMainMode(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -3021,7 +3021,7 @@ void SuricataPostInit(void)
 #if defined(HAVE_SYS_RESOURCE_H)
 #ifdef linux
         if (geteuid() == 0) {
-            SCLogWarning("setrlimit has no effet when running as root.");
+            SCLogWarning("setrlimit has no effect when running as root.");
         }
 #endif
         struct rlimit r = { 0, 0 };

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -152,6 +152,7 @@ typedef struct SCInstance_ {
     int offline;
     int verbose;
     int checksum_validation;
+    int output_flush_interval;
 
     struct timeval start_time;
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -31,6 +31,7 @@
 #include "util-byte.h"
 #include "util-conf.h"
 #include "util-path.h"
+#include "util-misc.h"
 #include "util-time.h"
 
 #if defined(HAVE_SYS_UN_H) && defined(HAVE_SYS_SOCKET_H) && defined(HAVE_SYS_TYPES_H)
@@ -223,7 +224,7 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
                         log_ctx->filename);
             }
             log_ctx->output_errors++;
-        } else {
+        } else if (log_ctx->buffer_size) {
             SCFflushUnlocked(log_ctx->fp);
         }
     }
@@ -307,8 +308,11 @@ static char *SCLogFilenameFromPattern(const char *pattern)
 static void SCLogFileCloseNoLock(LogFileCtx *log_ctx)
 {
     SCLogDebug("Closing %s", log_ctx->filename);
-    if (log_ctx->fp)
+    if (log_ctx->fp) {
+        if (log_ctx->buffer_size)
+            SCFflushUnlocked(log_ctx->fp);
         fclose(log_ctx->fp);
+    }
 
     if (log_ctx->output_errors) {
         SCLogError("There were %" PRIu64 " output errors to %s", log_ctx->output_errors,
@@ -402,8 +406,8 @@ error_exit:
  *  \retval FILE* on success
  *  \retval NULL on error
  */
-static FILE *
-SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
+static FILE *SCLogOpenFileFp(
+        const char *path, const char *append_setting, uint32_t mode, const uint32_t buffer_size)
 {
     FILE *ret = NULL;
 
@@ -426,6 +430,7 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
 
     if (ret == NULL) {
         SCLogError("Error opening file: \"%s\": %s", filename, strerror(errno));
+        goto error_exit;
     } else {
         if (mode != 0) {
 #ifdef OS_WIN32
@@ -439,7 +444,19 @@ SCLogOpenFileFp(const char *path, const char *append_setting, uint32_t mode)
         }
     }
 
+    /* Set buffering behavior */
+    if (buffer_size == 0) {
+        setbuf(ret, NULL);
+        SCLogConfig("Setting output to %s non-buffered", filename);
+    } else {
+        if (setvbuf(ret, NULL, _IOFBF, buffer_size) < 0)
+            FatalError("unable to set %s to buffered: %d", filename, buffer_size);
+        SCLogConfig("Setting output to %s buffered [limit %d bytes]", filename, buffer_size);
+    }
+
+error_exit:
     SCFree(filename);
+
     return ret;
 }
 
@@ -519,6 +536,22 @@ SCConfLogOpenGeneric(ConfNode *conf,
     if (filetype == NULL)
         filetype = DEFAULT_LOG_FILETYPE;
 
+    /* Determine the buffering for this output device; a value of 0 means to not buffer;
+     * any other value must be a multiple of 4096
+     */
+    uint32_t buffer_size = LOGFILE_EVE_BUFFER_SIZE;
+    const char *buffer_size_value = ConfNodeLookupChildValue(conf, "buffer-size");
+    if (buffer_size_value != NULL) {
+        uint32_t value;
+        if (ParseSizeStringU32(buffer_size_value, &value) < 0) {
+            FatalError("Error parsing "
+                       "buffer-size - %s. Killing engine",
+                    buffer_size_value);
+        }
+        buffer_size = value;
+    }
+
+    SCLogDebug("buffering: %s -> %d", buffer_size_value, buffer_size);
     const char *filemode = ConfNodeLookupChildValue(conf, "filemode");
     uint32_t mode = 0;
     if (filemode != NULL && StringParseUint32(&mode, 8, (uint16_t)strlen(filemode), filemode) > 0) {
@@ -563,6 +596,10 @@ SCConfLogOpenGeneric(ConfNode *conf,
         }
     }
 #endif
+    if (!(strcasecmp(filetype, DEFAULT_LOG_FILETYPE) == 0 || strcasecmp(filetype, "file") == 0)) {
+        SCLogConfig("buffering setting ignored for %s output types", filetype);
+    }
+
     // Now, what have we been asked to open?
     if (strcasecmp(filetype, "unix_stream") == 0) {
 #ifdef BUILD_WITH_UNIXSOCKET
@@ -585,8 +622,10 @@ SCConfLogOpenGeneric(ConfNode *conf,
     } else if (strcasecmp(filetype, DEFAULT_LOG_FILETYPE) == 0 ||
                strcasecmp(filetype, "file") == 0) {
         log_ctx->is_regular = 1;
+        log_ctx->buffer_size = buffer_size;
         if (!log_ctx->threaded) {
-            log_ctx->fp = SCLogOpenFileFp(log_path, append, log_ctx->filemode);
+            log_ctx->fp =
+                    SCLogOpenFileFp(log_path, append, log_ctx->filemode, log_ctx->buffer_size);
             if (log_ctx->fp == NULL)
                 return -1; // Error already logged by Open...Fp routine
         } else {
@@ -648,7 +687,8 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
     /* Reopen the file. Append is forced in case the file was not
      * moved as part of a rotation process. */
     SCLogDebug("Reopening log file %s.", log_ctx->filename);
-    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "yes", log_ctx->filemode);
+    log_ctx->fp =
+            SCLogOpenFileFp(log_ctx->filename, "yes", log_ctx->filemode, log_ctx->buffer_size);
     if (log_ctx->fp == NULL) {
         return -1; // Already logged by Open..Fp routine.
     }
@@ -827,7 +867,7 @@ static bool LogFileNewThreadedCtx(LogFileCtx *parent_ctx, const char *log_path, 
         }
         SCLogDebug("%s: thread open -- using name %s [replaces %s] - thread %d [slot %d]",
                 t_thread_name, fname, log_path, entry->internal_thread_id, entry->slot_number);
-        thread->fp = SCLogOpenFileFp(fname, append, thread->filemode);
+        thread->fp = SCLogOpenFileFp(fname, append, thread->filemode, parent_ctx->buffer_size);
         if (thread->fp == NULL) {
             goto error;
         }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -126,7 +126,7 @@ static int SCLogUnixSocketReconnect(LogFileCtx *log_ctx)
     log_ctx->fp = SCLogOpenUnixSocketFp(log_ctx->filename, log_ctx->sock_type, 0);
     if (log_ctx->fp) {
         /* Connected at last (or reconnected) */
-        SCLogNotice("Reconnected socket \"%s\"", log_ctx->filename);
+        SCLogDebug("Reconnected socket \"%s\"", log_ctx->filename);
     } else if (disconnected) {
         SCLogWarning("Reconnect failed: %s (will keep trying)", strerror(errno));
     }
@@ -190,6 +190,22 @@ static inline void OutputWriteLock(pthread_mutex_t *m)
 }
 
 /**
+ * \brief Flush a log file.
+ */
+static void SCLogFileFlushNoLock(LogFileCtx *log_ctx)
+{
+    log_ctx->bytes_since_last_flush = 0;
+    SCFflushUnlocked(log_ctx->fp);
+}
+
+static void SCLogFileFlush(LogFileCtx *log_ctx)
+{
+    OutputWriteLock(&log_ctx->fp_mutex);
+    SCLogFileFlushNoLock(log_ctx);
+    SCMutexUnlock(&log_ctx->fp_mutex);
+}
+
+/**
  * \brief Write buffer to log file.
  * \retval 0 on failure; otherwise, the return value of fwrite_unlocked (number of
  * characters successfully written).
@@ -224,8 +240,15 @@ static int SCLogFileWriteNoLock(const char *buffer, int buffer_len, LogFileCtx *
                         log_ctx->filename);
             }
             log_ctx->output_errors++;
-        } else if (log_ctx->buffer_size) {
-            SCFflushUnlocked(log_ctx->fp);
+            return ret;
+        }
+
+        log_ctx->bytes_since_last_flush += buffer_len;
+
+        if (log_ctx->buffer_size && log_ctx->bytes_since_last_flush >= log_ctx->buffer_size) {
+            SCLogDebug("%s: flushing %" PRIu64 " during write", log_ctx->filename,
+                    log_ctx->bytes_since_last_flush);
+            SCLogFileFlushNoLock(log_ctx);
         }
     }
 
@@ -248,35 +271,7 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
     } else
 #endif
     {
-
-        /* Check for rotation. */
-        if (log_ctx->rotation_flag) {
-            log_ctx->rotation_flag = 0;
-            SCConfLogReopen(log_ctx);
-        }
-
-        if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
-            time_t now = time(NULL);
-            if (now >= log_ctx->rotate_time) {
-                SCConfLogReopen(log_ctx);
-                log_ctx->rotate_time = now + log_ctx->rotate_interval;
-            }
-        }
-
-        if (log_ctx->fp) {
-            clearerr(log_ctx->fp);
-            if (1 != fwrite(buffer, buffer_len, 1, log_ctx->fp)) {
-                /* Only the first error is logged */
-                if (!log_ctx->output_errors) {
-                    SCLogError("%s error while writing to %s",
-                            ferror(log_ctx->fp) ? strerror(errno) : "unknown error",
-                            log_ctx->filename);
-                }
-                log_ctx->output_errors++;
-            } else {
-                fflush(log_ctx->fp);
-            }
-        }
+        ret = SCLogFileWriteNoLock(buffer, buffer_len, log_ctx);
     }
 
     SCMutexUnlock(&log_ctx->fp_mutex);
@@ -709,6 +704,7 @@ LogFileCtx *LogFileNewCtx(void)
 
     lf_ctx->Write = SCLogFileWrite;
     lf_ctx->Close = SCLogFileClose;
+    lf_ctx->Flush = SCLogFileFlush;
 
     return lf_ctx;
 }
@@ -975,6 +971,12 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
     SCFree(lf_ctx);
 
     SCReturnInt(1);
+}
+
+void LogFileFlush(LogFileCtx *file_ctx)
+{
+    SCLogDebug("%s: bytes-to-flush %ld", file_ctx->filename, file_ctx->bytes_since_last_flush);
+    file_ctx->Flush(file_ctx);
 }
 
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -107,6 +107,9 @@ typedef struct LogFileCtx_ {
     /** File permissions */
     uint32_t filemode;
 
+    /** File buffering */
+    uint32_t buffer_size;
+
     /** Suricata sensor name */
     char *sensor_name;
 
@@ -163,6 +166,9 @@ typedef struct LogFileCtx_ {
 
 /* flags for LogFileCtx */
 #define LOGFILE_ROTATE_INTERVAL 0x04
+
+/* Default EVE output buffering size */
+#define LOGFILE_EVE_BUFFER_SIZE (8 * 1024)
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -86,6 +86,7 @@ typedef struct LogFileCtx_ {
 
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
+    void (*Flush)(struct LogFileCtx_ *fp);
 
     LogFileTypeCtx filetype;
 
@@ -159,6 +160,9 @@ typedef struct LogFileCtx_ {
     uint64_t dropped;
 
     uint64_t output_errors;
+
+    /* Track buffered content */
+    uint64_t bytes_since_last_flush;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */
@@ -173,6 +177,7 @@ typedef struct LogFileCtx_ {
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
+void LogFileFlush(LogFileCtx *file_ctx);
 
 LogFileCtx *LogFileEnsureExists(ThreadId thread_id, LogFileCtx *lf_ctx);
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -101,6 +101,10 @@ outputs:
       # Enable for multi-threaded eve.json output; output files are amended with
       # an identifier, e.g., eve.9.json
       #threaded: false
+      # Specify the amount of buffering, in bytes, for
+      # this output type. The default value 0 means "no
+      # buffering".
+      buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
@@ -562,6 +566,16 @@ outputs:
 # Logging configuration.  This is not about logging IDS alerts/events, but
 # output about what Suricata is doing, like startup messages, errors, etc.
 logging:
+  # The flush-interval governs how often Suricata will instruct the detection
+  # threads to flush their EVE output. Specify the value in seconds [1-60]
+  # and Suricata will initiate EVE log output flushes at that interval. A value
+  # of 0 means no EVE log output flushes are initiated. When the EVE output
+  # buffer-size value is non-zero, some EVE output that was written may remain
+  # buffered. The flush-interval governs how much buffered data exists.
+  #
+  # The default value is: 0 (never instruct detection threads to flush output)
+  #flush-interval: 0
+
   # The default log level: can be overridden in an output section.
   # Note that debug level logging will only be emitted if Suricata was
   # compiled with the --enable-debug configure option.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -563,19 +563,20 @@ outputs:
       scripts:
       #   - script1.lua
 
-# Logging configuration.  This is not about logging IDS alerts/events, but
-# output about what Suricata is doing, like startup messages, errors, etc.
-logging:
-  # The flush-interval governs how often Suricata will instruct the detection
-  # threads to flush their EVE output. Specify the value in seconds [1-60]
+heartbeat:
+  # The output-flush-interval value governs how often Suricata will instruct the
+  # detection threads to flush their EVE output. Specify the value in seconds [1-60]
   # and Suricata will initiate EVE log output flushes at that interval. A value
   # of 0 means no EVE log output flushes are initiated. When the EVE output
   # buffer-size value is non-zero, some EVE output that was written may remain
-  # buffered. The flush-interval governs how much buffered data exists.
+  # buffered. The output-flush-interval governs how much buffered data exists.
   #
   # The default value is: 0 (never instruct detection threads to flush output)
-  #flush-interval: 0
+  #output-flush-interval: 0
 
+# Logging configuration.  This is not about logging IDS alerts/events, but
+# output about what Suricata is doing, like startup messages, errors, etc.
+logging:
   # The default log level: can be overridden in an output section.
   # Note that debug level logging will only be emitted if Suricata was
   # compiled with the --enable-debug configure option.


### PR DESCRIPTION
Continuation of #12525   

Reduce fflush calls on output streams (regular files only).

Output can be buffered, specify the buffer-size with `outputs.<type>.buffer-size`. A value of 0 selects no buffering; otherwise, up to the buffer-size value can be buffered. Note that this buffering is part of the stdio library.

Since output can be buffered, a mechanism that periodically flushes the output streams has been added. The `heartbeat.output-flush-interval` configuration setting specifies at what interval the output should be flushed. A value of 0 means never flush.

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [3449](https://redmine.openinfosecfoundation.org/issues/3449)

Describe changes:
- Add EVE configuration parameter to control buffering: `buffer-size`. When 0, unbuffered I/O is used; other values are used to set the stdio buffer size. The value is `outputs.eve-log.buffer-size`
- Add Suricata configuration parameter -- `heartbeat.output-flush-interval` -- to set cadence for Suricata periodically directing detect threads to flush EVE output. To be used in conjunction with `buffer-size`. Set `heartbeat.output-flush-interval` to the number of seconds Suricata should periodically cause the EVE output to be flushed. The default value is `0` which instructs Suricata never to cause the EVE output to be flushed.
- Add a mechanism to periodically send pseudo packets to detect threads to trigger a flush. Controlled by `heartbeat.output-flush-interval`
- Add "log flusher" thread when flushing is configured (`heartbeat.output-flush-interval` is between 1 and 60 in seconds).

Updates:
- Rebase
- Fixed rebase error causing DBV faults.

## Suricata build information
```
This is Suricata version 8.0.0-dev (ca94c1a8cb 2025-02-03)
Features: UNITTESTS PCAP_SET_BUFF AF_PACKET HAVE_PACKET_FANOUT LIBCAP_NG HAVE_HTP_URI_NORMALIZE_HOOK PCRE_JIT HAVE_NSS HTTP2_DECOMPRESSION HAVE_LUA HAVE_JA3 HAVE_JA4 HAVE_LIBJANSSON TLS TLS_C11 MAGIC RUST POPCNT64
SIMD support: SSE_4_2 SSE_4_1 SSE_3 SSE_2
Atomic intrinsics: 1 2 4 8 16 byte(s)
64-bits, Little-endian architecture
GCC version Ubuntu Clang 19.1.1 (1ubuntu1), C version 201112
compiled with _FORTIFY_SOURCE=0
L1 cache line size (CLS)=64
thread local storage method: _Thread_local
compiled with LibHTP v0.5.49, linked against LibHTP v0.5.49

Suricata Configuration:
  AF_PACKET support:                       yes
  AF_XDP support:                          yes
  DPDK support:                            no
  eBPF support:                            no
  XDP support:                             no
  PF_RING support:                         no
  NFQueue support:                         no
  NFLOG support:                           no
  IPFW support:                            no
  Netmap support:                          no
  DAG enabled:                             no
  Napatech enabled:                        no
  WinDivert enabled:                       no

  Unix socket enabled:                     yes
  Detection enabled:                       yes

  Libmagic support:                        yes
  libjansson support:                      yes
  hiredis support:                         no
  hiredis async with libevent:             no
  PCRE jit:                                yes
  GeoIP2 support:                          yes
  JA3 support:                             yes
  JA4 support:                             yes
  Non-bundled htp:                         no
  Hyperscan support:                       yes
  Libnet support:                          no
  liblz4 support:                          yes
  Landlock support:                        yes
  Systemd support:                         yes

  Rust strict mode:                        yes
  Rust compiler path:                      /home/jlucovsky/.cargo/bin/rustc
  Rust compiler version:                   rustc 1.83.0 (90b35a623 2024-11-26)
  Cargo path:                              /home/jlucovsky/.cargo/bin/cargo
  Cargo version:                           cargo 1.83.0 (5ffbef321 2024-10-29)

  Python support:                          yes
  Python path:                             /usr/bin/python3
  Install suricatactl:                     yes
  Install suricatasc:                      yes
  Install suricata-update:                 no, not bundled

  Profiling enabled:                       no
  Profiling locks enabled:                 no
  Profiling rules enabled:                 no

  Plugin support (experimental):           yes
  DPDK Bond PMD:                           no

Development settings:
  Coccinelle / spatch:                     no
  Unit tests enabled:                      yes
  Debug output enabled:                    no
  Debug validation enabled:                no
  Fuzz targets enabled:                    no

Generic build parameters:
  Installation prefix:
  Configuration directory:                 /etc/suricata/
  Log directory:                           /var/log/suricata/

  --prefix
  --sysconfdir                             /etc
  --localstatedir                          /var
  --datarootdir                            /share

  Host:                                    x86_64-pc-linux-gnu
  Compiler:                                ccache clang (exec name) / g++ (real)
  GCC Protect enabled:                     no
  GCC march native enabled:                yes
  GCC Profile enabled:                     no
  Position Independent Executable enabled: no
  CFLAGS                                   -ggdb3 -O0 -Wall -Wshadow -Wunused -Wuninitialized -Wchar-subscripts -Wno-unused-function -Wno-unused-parameter -Werror=sign-compare  -fno-strict-aliasing -fstack-protector-all -fno-omit-frame-pointer -O3 -fPIC -DOS_LINUX -std=c11 -march=native -I${srcdir}/../rust/gen -I${srcdir}/../rust/dist -I../rust/gen -Wunused-macros -Wimplicit-int-float-conversion
  PCAP_CFLAGS                               -I/usr/include
  SECCFLAGS
```
## Benchmarks/Measurements

Hyperfine was used to measure results with my pcap collection and ET Pro

Summary: Buffering had the biggest impact; using the flushing mechanism had little effect but is necessary for integrity.

### Recommendation: 

Adding buffering in any amount improves performance. When buffering, a flush interval of 30 seconds is recommented
- `eve-log.buffer-size: 64kb`
- `heartbeat.output-flush-interval: 30` (seconds)

Permutations benchmarked for `buffer-size` and `output-flush-interval`
- 0, 0s
- 0, 15s
- 0, 30s
- 0, 60s
- 8kb, 0s,
- 8kb, 15s
- 8kb, 30s
- 8kb, 60s
- 16kb, 0s,
- 16kb, 15s
- 16kb, 30s
- 16kb, 60s
- 32kb, 0s
- 32kb, 15s
- 32kb, 30s
- 32kb, 60s
- 64kb, 0s
- 64kb, 15s
- 64kb, 30s
- 64kb, 60s

Hyperfine output
```
Benchmark 1: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=0 -v --no-random
  Time (mean ± σ):     105.042 s ±  0.694 s    [User: 392.799 s, System: 29.616 s]
  Range (min … max):   104.219 s … 105.846 s    5 runs
 
Benchmark 2: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=0 -v --no-random
  Time (mean ± σ):     101.037 s ±  0.220 s    [User: 381.299 s, System: 23.789 s]
  Range (min … max):   100.811 s … 101.397 s    5 runs
 
Benchmark 3: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=0 -v --no-random
  Time (mean ± σ):     101.512 s ±  0.411 s    [User: 380.713 s, System: 23.808 s]
  Range (min … max):   101.208 s … 102.158 s    5 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (102.158 s). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--prepare' option which can be used to clear caches. If you did not use a cache-clearing command with '--prepare', you can either try that or consider using the '--warmup' option to fill those caches before the actual benchmark.
 
Benchmark 4: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=0 -v --no-random
  Time (mean ± σ):     100.412 s ±  1.692 s    [User: 379.998 s, System: 23.466 s]
  Range (min … max):   98.078 s … 102.255 s    5 runs
 
Benchmark 5: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=0 -v --no-random
  Time (mean ± σ):     100.482 s ±  1.554 s    [User: 378.951 s, System: 23.317 s]
  Range (min … max):   97.797 s … 101.798 s    5 runs
 
Benchmark 6: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=15 -v --no-random
  Time (mean ± σ):     113.128 s ±  0.860 s    [User: 411.860 s, System: 42.776 s]
  Range (min … max):   112.254 s … 114.216 s    5 runs
 
Benchmark 7: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=15 -v --no-random
  Time (mean ± σ):     102.134 s ±  0.792 s    [User: 381.837 s, System: 24.454 s]
  Range (min … max):   101.008 s … 102.910 s    5 runs
 
Benchmark 8: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=15 -v --no-random
  Time (mean ± σ):     101.086 s ±  1.794 s    [User: 378.685 s, System: 23.989 s]
  Range (min … max):   97.951 s … 102.333 s    5 runs
 
Benchmark 9: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=15 -v --no-random
  Time (mean ± σ):     102.027 s ±  0.244 s    [User: 380.924 s, System: 23.449 s]
  Range (min … max):   101.754 s … 102.341 s    5 runs
 
Benchmark 10: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=15 -v --no-random
  Time (mean ± σ):     102.039 s ±  0.264 s    [User: 381.812 s, System: 23.590 s]
  Range (min … max):   101.600 s … 102.266 s    5 runs
 
Benchmark 11: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=30 -v --no-random
  Time (mean ± σ):     114.094 s ±  0.654 s    [User: 413.039 s, System: 43.291 s]
  Range (min … max):   113.330 s … 114.829 s    5 runs
 
Benchmark 12: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=30 -v --no-random
  Time (mean ± σ):     102.619 s ±  1.305 s    [User: 382.924 s, System: 24.457 s]
  Range (min … max):   100.850 s … 104.346 s    5 runs
 
Benchmark 13: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=30 -v --no-random
  Time (mean ± σ):     101.627 s ±  0.466 s    [User: 381.293 s, System: 23.830 s]
  Range (min … max):   101.172 s … 102.228 s    5 runs
 
Benchmark 14: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=30 -v --no-random
  Time (mean ± σ):     102.848 s ±  1.710 s    [User: 382.499 s, System: 23.826 s]
  Range (min … max):   101.879 s … 105.893 s    5 runs
 
  Warning: The first benchmarking run for this command was significantly slower than the rest (105.893 s). This could be caused by (filesystem) caches that were not filled until after the first run. You are already using the '--prepare' option which can be used to clear caches. If you did not use a cache-clearing command with '--prepare', you can either try that or consider using the '--warmup' option to fill those caches before the actual benchmark.
 
Benchmark 15: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=30 -v --no-random
  Time (mean ± σ):     100.282 s ±  2.112 s    [User: 378.376 s, System: 23.435 s]
  Range (min … max):   97.979 s … 102.508 s    5 runs
 
Benchmark 16: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=60 -v --no-random
  Time (mean ± σ):     112.440 s ±  1.739 s    [User: 412.086 s, System: 43.432 s]
  Range (min … max):   109.535 s … 113.848 s    5 runs
 
Benchmark 17: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=60 -v --no-random
  Time (mean ± σ):     101.794 s ±  0.338 s    [User: 381.459 s, System: 24.484 s]
  Range (min … max):   101.453 s … 102.236 s    5 runs
 
Benchmark 18: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=60 -v --no-random
  Time (mean ± σ):     102.923 s ±  1.531 s    [User: 382.588 s, System: 23.935 s]
  Range (min … max):   101.700 s … 105.492 s    5 runs
 
Benchmark 19: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=60 -v --no-random
  Time (mean ± σ):     100.927 s ±  1.225 s    [User: 380.923 s, System: 23.436 s]
  Range (min … max):   98.769 s … 101.820 s    5 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Benchmark 20: ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=60 -v --no-random
  Time (mean ± σ):     101.585 s ±  0.767 s    [User: 380.448 s, System: 23.464 s]
  Range (min … max):   100.734 s … 102.420 s    5 runs
 
Summary
  ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=30 -v --no-random ran
    1.00 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=0 -v --no-random
    1.00 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=0 -v --no-random
    1.01 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=60 -v --no-random
    1.01 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=0 -v --no-random
    1.01 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=15 -v --no-random
    1.01 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=0 -v --no-random
    1.01 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=60 -v --no-random
    1.01 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=30 -v --no-random
    1.02 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=60 -v --no-random
    1.02 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=15 -v --no-random
    1.02 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=64kb --set heartbeat.output-flush-interval=15 -v --no-random
    1.02 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=15 -v --no-random
    1.02 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=8kb --set heartbeat.output-flush-interval=30 -v --no-random
    1.03 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=32kb --set heartbeat.output-flush-interval=30 -v --no-random
    1.03 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=16kb --set heartbeat.output-flush-interval=60 -v --no-random
    1.05 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=0 -v --no-random
    1.12 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=60 -v --no-random
    1.13 ± 0.03 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=15 -v --no-random
    1.14 ± 0.02 times faster than ./src/suricata -c suricata.yaml -S ~/suricata.rules -r ~/pcap -l /tmp/ll.178114 --set outputs.1.eve-log.buffer-size=0 --set heartbeat.output-flush-interval=30 -v --no-random
```