### PR TITLE
dcerpc: prevent integer underflow

### DIFF
--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -938,7 +938,7 @@ impl DCERPCState {
 
         let fraglen = self.get_hdr_fraglen().unwrap_or(0);
 
-        if cur_i.len() < (fraglen - frag_bytes_consumed) as usize {
+        if (cur_i.len() + frag_bytes_consumed as usize) < fraglen as usize {
             SCLogDebug!("Possibly fragmented data, waiting for more..");
             return AppLayerResult::incomplete(parsed as u32, fraglen as u32 - parsed as u32);
         }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7548

Describe changes:
- dcerpc: prevent integer underflow

There may be other things to do, like setting an event, but what remains to do is not clear to me.
What is clear to me is that this small change is an improvement.

First commit of https://github.com/OISF/suricata/pull/12528 with ticket