### PR TITLE
detect/entropy: Add entropy keyword 

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -669,6 +669,68 @@ Example::
 	 flow:established,to_server; content:"|00 FF|"; \
 	 byte_extract:2,0,cmp_ver,relative; content:"FooBar"; distance:0; byte_test:2,=,cmp_ver,0; sid:3;)
 
+.. _keyword_entropy:
+
+entropy
+-------
+
+The ``entropy`` keyword calculates the Shannon entropy value for content and compares it with
+an entropy value. When there is a match, rule processing will continue.
+
+The ``entropy`` keyword syntax is the keyword entropy followed by options
+and the entropy value and operator used to determine if the values agree.
+
+The minimum entropy keyword specification is::
+
+    entropy: value <entropy-spec>
+
+This results in the calculated entropy value being compared with
+`entropy-spec` using the (default) equality operator.
+
+Example::
+
+  entropy: 15.01
+
+A match occurs when the calculated entropy and specified entropy values agree.
+This is determined by calculating the entropy value and comparing it with the
+value from the rule using the specified operator.
+
+Example::
+
+  entropy: <15.01
+
+Options have default values:
+- bytes is equal to the current content length
+- offset is 0
+- equality comparison
+
+When entropy keyword options are specified, all options and "value" must
+be comma-separated. Options and value may be specified in any order.
+
+The complete format for the ``entropy`` keyword is::
+
+	entropy: [bytes <byteval>] [offset <offsetval>] value <operator><entropy-val>
+
+This example shows all possible options with default values::
+
+	entropy: bytes 0, offset 0,  value =<entropy-val>
+
+The following operators are available::
+
+ * = (default): Match when calculated value equals entropy value
+ * < Match when calculated value is strictly less than entropy value
+ * <=  Match when calculated value is less than or equal to entropy value
+ * > Match when calculated value is strictly greater than entropy value
+ * >= Match when calculated value is greater than or equal to entropy value
+ * !=  Match when calculated value is not equal to entropy value
+ * x-y Match when calculated value is within the exclusive range
+ * !x-y Match when calculated value is not within the exclusive range
+
+This example matches if the `file.data` content for an HTTP transaction has
+a Shannon entropy value of 4 or higher::
+
+	alert http any any -> any any (msg:"entropy simple test"; file.data; entropy: value >= 4; sid:1;)
+
 rpc
 ---
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -89,6 +89,8 @@ Major changes
   Suricata 8.0, ``stream.checksum-validation`` no longer affects the checksum rule keywords.
   E.g., ``ipv4-csum: valid`` will only match if the check sum is valid, even when engine
   checksum validations are disabled.
+- New rule keyword ``entropy`` for alerting based on entropy values. See
+  :ref:`keyword_entropy`.
 
 Removals
 ~~~~~~~~

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -73,3 +73,4 @@ suricata-lua-sys = { version = "0.1.0-alpha.5" }
 
 [dev-dependencies]
 test-case = "~3.3.1"
+assert_float_eq = "~1.1.4"

--- a/rust/src/detect/entropy.rs
+++ b/rust/src/detect/entropy.rs
@@ -1,0 +1,423 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Jeff Lucovsky <jlucovsky@oisf.net>
+//
+use crate::detect::error::RuleParseError;
+use crate::detect::float::{detect_match_float, detect_parse_float, DetectFloatData};
+use crate::detect::parser::take_until_whitespace;
+
+use nom7::bytes::complete::tag;
+use nom7::character::complete::multispace0;
+use nom7::sequence::preceded;
+use nom7::{Err, IResult};
+
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::slice;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct DetectEntropyData {
+    offset: i32,
+    nbytes: i32,
+    value: DetectFloatData<f64>,
+    flags: u8,
+}
+
+impl Default for DetectEntropyData {
+    fn default() -> Self {
+        DetectEntropyData {
+            offset: 0,
+            nbytes: 0,
+            value: DetectFloatData::<f64>::default(),
+            flags: 0,
+        }
+    }
+}
+impl DetectEntropyData {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+}
+
+// All options have default values except for the entropy value
+const DETECT_ENTROPY_FIXED_PARAM_COUNT: usize = 1;
+const DETECT_ENTROPY_MAX_PARAM_COUNT: usize = 4;
+pub const DETECT_ENTROPY_FLAG_BYTES: u8 = 0x01;
+pub const DETECT_ENTROPY_FLAG_OFFSET: u8 = 0x02;
+pub const DETECT_ENTROPY_FLAG_VALUE: u8 = 0x04;
+
+fn parse_entropy(input: &str) -> IResult<&str, DetectEntropyData, RuleParseError<&str>> {
+    // Inner utility function for easy error creation.
+    fn make_error(reason: String) -> nom7::Err<RuleParseError<&'static str>> {
+        Err::Error(RuleParseError::InvalidEntropy(reason))
+    }
+    let (_, values) = nom7::multi::separated_list1(
+        tag(","),
+        preceded(multispace0, nom7::bytes::complete::is_not(",")),
+    )(input)?;
+
+    if values.len() < DETECT_ENTROPY_FIXED_PARAM_COUNT
+        || values.len() > DETECT_ENTROPY_MAX_PARAM_COUNT
+    {
+        return Err(make_error(format!("Incorrect argument string; at least {} values must be specified but no more than {}: {:?}",
+            DETECT_ENTROPY_FIXED_PARAM_COUNT, DETECT_ENTROPY_MAX_PARAM_COUNT, input)));
+    }
+
+    let mut entropy = DetectEntropyData::new();
+    //for value in &values[0..] {
+    for value in values {
+        let (mut val, mut name) = take_until_whitespace(value)?;
+        val = val.trim();
+        name = name.trim();
+        match name {
+            "bytes" => {
+                if 0 != (entropy.flags & DETECT_ENTROPY_FLAG_BYTES) {
+                    return Err(make_error("bytes already set".to_string()));
+                }
+                entropy.nbytes = val
+                    .parse::<i32>()
+                    .map_err(|_| make_error(format!("invalid bytes value: {}", val)))?;
+                entropy.flags |= DETECT_ENTROPY_FLAG_BYTES;
+            }
+            "offset" => {
+                if 0 != (entropy.flags & DETECT_ENTROPY_FLAG_OFFSET) {
+                    return Err(make_error("offset already set".to_string()));
+                }
+                entropy.offset = val
+                    .parse::<i32>()
+                    .map_err(|_| make_error(format!("invalid offset value: {}", val)))?;
+                if entropy.offset > 65535 || entropy.offset < -65535 {
+                    return Err(make_error(format!(
+                        "invalid offset value: must be between -65535 and 65535: {}",
+                        val
+                    )));
+                }
+                entropy.flags |= DETECT_ENTROPY_FLAG_OFFSET;
+            }
+            "value" => {
+                if 0 != (entropy.flags & DETECT_ENTROPY_FLAG_VALUE) {
+                    return Err(make_error("value already set".to_string()));
+                }
+                if let Ok((_, ctx)) = detect_parse_float::<f64>(val) {
+                    entropy.value = ctx;
+                    entropy.flags |= DETECT_ENTROPY_FLAG_VALUE;
+                } else {
+                    return Err(make_error(format!("invalid entropy value: {}", val)));
+                }
+            }
+            _ => {
+                return Err(make_error(format!("unknown entropy option: {}", name)));
+            }
+        };
+    }
+
+    // an entropy value is required
+    if (entropy.flags & DETECT_ENTROPY_FLAG_VALUE) != DETECT_ENTROPY_FLAG_VALUE {
+        return Err(make_error(format!(
+            "required entropy parameter missing: \"{:?}\"",
+            input
+        )));
+    }
+
+    Ok((input, entropy))
+}
+
+fn calculate_entropy(data: *const u8, length: i32) -> f64 {
+    if data.is_null() || length <= 0 {
+        return 0.0;
+    }
+
+    // Convert the raw pointer to a slice safely
+    let data_slice = unsafe { slice::from_raw_parts(data, length as usize) };
+
+    // Use a 256-element array to store byte frequencies
+    let mut frequency = [0u32; 256];
+
+    // Calculate the frequency of each byte
+    for &byte in data_slice.iter() {
+        frequency[byte as usize] += 1;
+    }
+
+    // Calculate entropy using byte frequencies
+    let length_f64 = length as f64;
+    frequency.iter().fold(0.0, |entropy, &count| {
+        if count > 0 {
+            let probability = count as f64 / length_f64;
+            entropy - probability * probability.log2()
+        } else {
+            entropy
+        }
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectEntropyMatch(
+    c_data: *const c_void, length: i32, ctx: &DetectEntropyData,
+) -> bool {
+    if c_data.is_null() {
+        return false;
+    }
+
+    let buffer = std::slice::from_raw_parts(c_data as *const u8, length as usize);
+    let mut start = buffer;
+    let mut count = length;
+
+    // Adjust start and count based on offset and nbytes from context
+    if ctx.offset > 0 {
+        let offset = ctx.offset;
+        if offset > count {
+            SCLogDebug!("offset {} exceeds buffer length {}", offset, count);
+            return false;
+        }
+        start = &start[offset as usize..];
+        count -= offset;
+    }
+
+    if ctx.nbytes > 0 {
+        let nbytes = ctx.nbytes;
+        if nbytes > count {
+            SCLogDebug!("byte count {} exceeds buffer length {}", nbytes, count);
+            return false;
+        }
+        count = nbytes;
+    }
+
+    // Calculate entropy based on the adjusted buffer slice
+    let entropy = calculate_entropy(start.as_ptr(), count);
+    SCLogNotice!("entropy is {}", entropy);
+
+    // Use a hypothetical `detect_entropy_match` function to check entropy
+    detect_match_float::<f64>(&ctx.value, entropy)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectEntropyParse(c_arg: *const c_char) -> *mut DetectEntropyData {
+    if c_arg.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    if let Ok(arg) = CStr::from_ptr(c_arg).to_str() {
+        match parse_entropy(arg) {
+            Ok((_, detect)) => return Box::into_raw(Box::new(detect)),
+            Err(_) => return std::ptr::null_mut(),
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectEntropyFree(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        let _ = Box::from_raw(ptr as *mut DetectEntropyData);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::float::DetectFloatMode;
+    use num::traits::float::FloatCore;
+    // structure equality only used by test cases
+    impl PartialEq for DetectEntropyData {
+        fn eq(&self, other: &Self) -> bool {
+            self.value == other.value
+                && self.flags == other.flags
+                && self.offset == other.offset
+                && self.nbytes == other.nbytes
+        }
+    }
+
+    fn valid_test(
+        args: &str, nbytes: i32, offset: i32, value: f64, mode: DetectFloatMode, flags: u8,
+    ) {
+        let ctx = DetectFloatData {
+            arg1: value,
+            arg2: FloatCore::min_value(),
+            mode,
+        };
+        let ded = DetectEntropyData {
+            offset,
+            nbytes,
+            value: ctx,
+            flags,
+        };
+
+        let (_, val) = parse_entropy(args).unwrap();
+        assert_eq!(val, ded);
+    }
+
+    #[test]
+    fn test_parse_entropy_valid() {
+        valid_test(
+            "value 7",
+            0,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeEqual,
+            DETECT_ENTROPY_FLAG_VALUE,
+        );
+        valid_test(
+            "bytes 4, value >= 7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeGte,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, value != 7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeNe,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, value <7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeLt,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, value <= 7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeLte,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, value = 7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeEqual,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, value > 7",
+            4,
+            0,
+            7.0,
+            DetectFloatMode::DetectFloatModeGt,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES,
+        );
+        valid_test(
+            "bytes 4, offset 30, value > 7",
+            4,
+            30,
+            7.0,
+            DetectFloatMode::DetectFloatModeGt,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES | DETECT_ENTROPY_FLAG_OFFSET,
+        );
+        valid_test(
+            "bytes 4, offset 30, value 7",
+            4,
+            30,
+            7.0,
+            DetectFloatMode::DetectFloatModeEqual,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES | DETECT_ENTROPY_FLAG_OFFSET,
+        );
+        valid_test(
+            "bytes 4, offset 30,  value < 7",
+            4,
+            30,
+            7.0,
+            DetectFloatMode::DetectFloatModeLt,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES | DETECT_ENTROPY_FLAG_OFFSET,
+        );
+        valid_test(
+            "bytes 4, offset 30,value <= 7",
+            4,
+            30,
+            7.0,
+            DetectFloatMode::DetectFloatModeLte,
+            DETECT_ENTROPY_FLAG_VALUE | DETECT_ENTROPY_FLAG_BYTES | DETECT_ENTROPY_FLAG_OFFSET,
+        );
+    }
+
+    #[test]
+    fn test_parse_entropy_invalid() {
+        assert!(parse_entropy("").is_err());
+        assert!(parse_entropy("value ? 7.0").is_err());
+        assert!(parse_entropy("bytes 100").is_err());
+        assert!(parse_entropy("offset 100").is_err());
+        assert!(parse_entropy("bytes 100, offset 100").is_err());
+        assert!(parse_entropy("bytes 1, offset 10, value 7.0, extra").is_err());
+    }
+
+    #[test]
+    fn test_entropy_calculation() {
+        // Test data
+        let data = b"aaaaaaa"; // All the same byte
+        let length = data.len() as i32;
+
+        // Calculate entropy
+        let entropy = calculate_entropy(data.as_ptr(), length);
+
+        // Expected entropy is 0 (no randomness)
+        assert!(
+            (entropy - 0.0).abs() < 1e-6,
+            "Entropy should be 0.0 for identical bytes"
+        );
+
+        // Test data with more randomness
+        let data = b"abcdabcd"; // Equal distribution
+        let length = data.len() as i32;
+
+        // Calculate entropy
+        let entropy = calculate_entropy(data.as_ptr(), length);
+
+        // Expected entropy is 2 (each byte has 1/4 probability)
+        assert!(
+            (entropy - 2.0).abs() < 1e-6,
+            "Entropy should be 2.0 for uniform distribution of 4 values"
+        );
+
+        // Test empty data
+        let data: [u8; 0] = [];
+        let length = data.len() as i32;
+
+        // Calculate entropy
+        let entropy = calculate_entropy(data.as_ptr(), length);
+
+        // Expected entropy is 0 (no data)
+        assert!(
+            (entropy - 0.0).abs() < 1e-6,
+            "Entropy should be 0.0 for empty data"
+        );
+
+        // Test mixed data
+        let data = b"aaabbcc";
+        let length = data.len() as i32;
+
+        // Calculate entropy
+        let entropy = calculate_entropy(data.as_ptr(), length);
+
+        // Verify entropy is non-zero and less than maximum
+        assert!(
+            entropy > 0.0 && entropy <= 8.0,
+            "Entropy should be between 0.0 and 8.0"
+        );
+    }
+}

--- a/rust/src/detect/error.rs
+++ b/rust/src/detect/error.rs
@@ -28,6 +28,7 @@ pub enum RuleParseError<I> {
     InvalidIPRep(String),
     InvalidTransformBase64(String),
     InvalidByteExtract(String),
+    InvalidEntropy(String),
 
     Nom(I, ErrorKind),
 }

--- a/rust/src/detect/float.rs
+++ b/rust/src/detect/float.rs
@@ -1,0 +1,476 @@
+use nom7::branch::alt;
+use nom7::bytes::complete::{is_a, tag, take_while};
+use nom7::character::complete::{char, digit1};
+use nom7::combinator::{all_consuming, map_opt, opt, value, verify};
+use nom7::error::{make_error, ErrorKind};
+use nom7::sequence::tuple;
+use nom7::Err;
+use nom7::IResult;
+
+use num::traits::float::FloatCore;
+use num::traits::{FromPrimitive, ToPrimitive};
+use num::Bounded;
+
+use std::ffi::CStr;
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[repr(u8)]
+pub enum DetectFloatMode {
+    DetectFloatModeEqual,
+    DetectFloatModeLt,
+    DetectFloatModeLte,
+    DetectFloatModeGt,
+    DetectFloatModeGte,
+    DetectFloatModeRange,
+    DetectFloatModeNe,
+    DetectFloatModeNegRg,
+}
+
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+pub struct DetectFloatData<T> {
+    pub arg1: T,
+    pub arg2: T,
+    pub mode: DetectFloatMode,
+}
+
+impl<T: Default> Default for DetectFloatData<T> {
+    fn default() -> Self {
+        Self {
+            arg1: T::default(),
+            arg2: T::default(),
+            mode: DetectFloatMode::DetectFloatModeEqual,
+        }
+    }
+}
+
+pub trait DetectFloatType:
+    FromPrimitive + ToPrimitive + std::str::FromStr + Bounded + PartialOrd + FloatCore
+{
+}
+
+impl<T> DetectFloatType for T where
+    T: FromPrimitive + ToPrimitive + std::str::FromStr + Bounded + PartialOrd + FloatCore
+{
+}
+
+pub fn parse_float_value<T: DetectFloatType>(input: &str) -> IResult<&str, T> {
+    map_opt(
+        tuple((opt(tag("-")), digit1, opt(tuple((tag("."), digit1))))),
+        |(sign, integer_part, fractional_part)| {
+            let mut float_str = String::new();
+            if let Some(s) = sign {
+                float_str.push_str(s);
+            }
+            float_str.push_str(integer_part);
+            if let Some((dot, frac)) = fractional_part {
+                float_str.push_str(dot);
+                float_str.push_str(frac);
+            }
+            float_str.parse::<f64>().ok().and_then(|f| T::from_f64(f))
+        },
+    )(input)
+}
+
+fn detect_parse_float_start_equal<T: DetectFloatType>(
+    i: &str,
+) -> IResult<&str, DetectFloatData<T>> {
+    let (i, _) = opt(tag("="))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg1) = parse_float_value(i)?;
+    Ok((
+        i,
+        DetectFloatData {
+            arg1,
+            arg2: <T as FloatCore>::min_value(),
+            mode: DetectFloatMode::DetectFloatModeEqual,
+        },
+    ))
+}
+
+pub fn detect_parse_float_start_interval<T: DetectFloatType>(
+    i: &str,
+) -> IResult<&str, DetectFloatData<T>> {
+    let (i, neg) = opt(char('!'))(i)?;
+    let (i, arg1) = parse_float_value(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, _) = alt((tag("-"), tag("<>")))(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg2) = verify(parse_float_value, |x| {
+        *x > arg1 && *x - arg1 > <T as FloatCore>::epsilon()
+    })(i)?;
+    let mode = if neg.is_some() {
+        DetectFloatMode::DetectFloatModeNegRg
+    } else {
+        DetectFloatMode::DetectFloatModeRange
+    };
+    Ok((i, DetectFloatData { arg1, arg2, mode }))
+}
+
+fn detect_parse_float_mode(i: &str) -> IResult<&str, DetectFloatMode> {
+    let (i, mode) = alt((
+        value(DetectFloatMode::DetectFloatModeGte, tag(">=")),
+        value(DetectFloatMode::DetectFloatModeLte, tag("<=")),
+        value(DetectFloatMode::DetectFloatModeGt, tag(">")),
+        value(DetectFloatMode::DetectFloatModeLt, tag("<")),
+        value(DetectFloatMode::DetectFloatModeNe, tag("!=")),
+        value(DetectFloatMode::DetectFloatModeEqual, tag("=")),
+    ))(i)?;
+    Ok((i, mode))
+}
+
+fn detect_parse_float_start_symbol<T: DetectFloatType>(
+    i: &str,
+) -> IResult<&str, DetectFloatData<T>> {
+    let (i, mode) = detect_parse_float_mode(i)?;
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, arg1) = parse_float_value::<T>(i)?;
+
+    match mode {
+        DetectFloatMode::DetectFloatModeNe => {}
+        DetectFloatMode::DetectFloatModeLt => {
+            if arg1 == <T as FloatCore>::min_value() {
+                return Err(Err::Error(make_error(i, ErrorKind::Verify)));
+            }
+        }
+        DetectFloatMode::DetectFloatModeLte => {
+            if arg1 == <T as FloatCore>::max_value() {
+                return Err(Err::Error(make_error(i, ErrorKind::Verify)));
+            }
+        }
+        DetectFloatMode::DetectFloatModeGt => {
+            if arg1 == <T as FloatCore>::max_value() {
+                return Err(Err::Error(make_error(i, ErrorKind::Verify)));
+            }
+        }
+        DetectFloatMode::DetectFloatModeGte => {
+            if arg1 == <T as FloatCore>::min_value() {
+                return Err(Err::Error(make_error(i, ErrorKind::Verify)));
+            }
+        }
+        _ => {
+            return Err(Err::Error(make_error(i, ErrorKind::MapOpt)));
+        }
+    }
+
+    Ok((
+        i,
+        DetectFloatData {
+            arg1,
+            arg2: <T as FloatCore>::min_value(),
+            mode,
+        },
+    ))
+}
+
+pub fn detect_match_float<T: DetectFloatType>(x: &DetectFloatData<T>, val: T) -> bool {
+    match x.mode {
+        DetectFloatMode::DetectFloatModeEqual => val == x.arg1,
+        DetectFloatMode::DetectFloatModeNe => val != x.arg1,
+        DetectFloatMode::DetectFloatModeLt => val < x.arg1,
+        DetectFloatMode::DetectFloatModeLte => val <= x.arg1,
+        DetectFloatMode::DetectFloatModeGt => val > x.arg1,
+        DetectFloatMode::DetectFloatModeGte => val >= x.arg1,
+        DetectFloatMode::DetectFloatModeRange => val > x.arg1 && val < x.arg2,
+        DetectFloatMode::DetectFloatModeNegRg => val <= x.arg1 || val >= x.arg2,
+    }
+}
+
+pub fn detect_parse_float<T: DetectFloatType>(i: &str) -> IResult<&str, DetectFloatData<T>> {
+    let (i, float) = detect_parse_float_notending(i)?;
+    let (i, _) = all_consuming(take_while(|c| c == ' '))(i)?;
+    Ok((i, float))
+}
+
+fn detect_parse_float_notending<T: DetectFloatType>(i: &str) -> IResult<&str, DetectFloatData<T>> {
+    let (i, _) = opt(is_a(" "))(i)?;
+    let (i, float) = alt((
+        detect_parse_float_start_interval,
+        detect_parse_float_start_equal,
+        detect_parse_float_start_symbol,
+    ))(i)?;
+    Ok((i, float))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_f64_parse(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectFloatData<f64> {
+    let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
+    if let Ok(s) = ft_name.to_str() {
+        if let Ok((_, ctx)) = detect_parse_float::<f64>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed) as *mut _;
+        }
+    }
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_f64_match(
+    arg: f64, ctx: &DetectFloatData<f64>,
+) -> std::os::raw::c_int {
+    if detect_match_float::<f64>(ctx, arg) {
+        return 1;
+    }
+    return 0;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_detect_f64_free(ctx: &mut DetectFloatData<f64>) {
+    // Just unbox...
+    std::mem::drop(Box::from_raw(ctx));
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectParseF64(
+    ustr: *const std::os::raw::c_char,
+) -> *mut DetectFloatData<f64> {
+    let ft_name: &CStr = CStr::from_ptr(ustr);
+    if let Ok(s) = ft_name.to_str() {
+        if let Ok((_, ctx)) = detect_parse_float::<f64>(s) {
+            let boxed = Box::new(ctx);
+            return Box::into_raw(boxed);
+        }
+    }
+    std::ptr::null_mut()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMatchF64(
+    arg: f64, ctx: &DetectFloatData<f64>,
+) -> std::os::raw::c_int {
+    if detect_match_float(ctx, arg) {
+        1
+    } else {
+        0
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectFreeF64(ctx: *mut DetectFloatData<f64>) {
+    std::mem::drop(Box::from_raw(ctx));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_float_eq::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_detect_parse_valid() {
+        let (_, val) = detect_parse_float::<f64>("1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        // Default mode is equality
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeEqual);
+
+        let (_, val) = detect_parse_float::<f32>("1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        // Default mode is equality
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeEqual);
+
+        let (_, val) = detect_parse_float::<f64>("> 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeGt);
+
+        let (_, val) = detect_parse_float::<f64>(">= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeGte);
+
+        let (_, val) = detect_parse_float::<f64>("<= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeLte);
+
+        let (_, val) = detect_parse_float::<f64>("< 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeLt);
+
+        let (_, val) = detect_parse_float::<f64>("= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeEqual);
+
+        let (_, val) = detect_parse_float::<f64>("!= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeNe);
+
+        let (_, val) = detect_parse_float::<f64>("37.0-42.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 37.0, FloatCore::epsilon());
+        assert_float_absolute_eq!(val.arg2, 42.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeRange);
+        let (_, val) = detect_parse_float::<f64>("!37.0-42.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 37.0, FloatCore::epsilon());
+        assert_float_absolute_eq!(val.arg2, 42.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeNegRg);
+    }
+
+    #[test]
+    fn test_detect_parse_invalid() {
+        assert!(detect_parse_float::<f64>("suricata").is_err());
+
+        // range should be <lower-val> - <higher-val>
+        assert!(detect_parse_float::<f64>("42-37").is_err());
+
+        assert!(detect_parse_float::<f64>("< suricata").is_err());
+        assert!(detect_parse_float::<f64>("<= suricata").is_err());
+        assert!(detect_parse_float::<f64>("= suricata").is_err());
+        assert!(detect_parse_float::<f64>("> suricata").is_err());
+        assert!(detect_parse_float::<f64>(">= suricata").is_err());
+        assert!(detect_parse_float::<f64>("! suricata").is_err());
+        assert!(detect_parse_float::<f64>("!= suricata").is_err());
+    }
+
+    #[test]
+    fn test_detect_match_valid() {
+        let (_, val) = detect_parse_float::<f64>("1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        // Default mode is equality
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeEqual);
+        assert!(detect_match_float(&val, 1.0));
+
+        let (_, val) = detect_parse_float::<f64>("> 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeGt);
+        assert!(detect_match_float(&val, 1.1));
+        assert!(!detect_match_float(&val, 1.0));
+
+        let (_, val) = detect_parse_float::<f64>(">= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeGte);
+        assert!(detect_match_float(&val, 1.0));
+        assert!(detect_match_float(&val, 1.5));
+        assert!(!detect_match_float(&val, 0.5));
+
+        let (_, val) = detect_parse_float::<f64>("<= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeLte);
+        assert!(detect_match_float(&val, 1.0));
+        assert!(detect_match_float(&val, 0.5));
+        assert!(!detect_match_float(&val, 1.5));
+
+        let (_, val) = detect_parse_float::<f64>("< 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeLt);
+        assert!(detect_match_float(&val, 0.9));
+        assert!(!detect_match_float(&val, 1.0));
+
+        let (_, val) = detect_parse_float::<f64>("= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeEqual);
+        assert!(detect_match_float(&val, 1.0));
+        assert!(!detect_match_float(&val, 0.9));
+        assert!(!detect_match_float(&val, 1.1));
+
+        let (_, val) = detect_parse_float::<f64>("!= 1.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 1.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeNe);
+        assert!(detect_match_float(&val, 0.9));
+        assert!(detect_match_float(&val, 1.1));
+        assert!(!detect_match_float(&val, 1.0));
+
+        let (_, val) = detect_parse_float::<f64>("37.0-42.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 37.0, FloatCore::epsilon());
+        assert_float_absolute_eq!(val.arg2, 42.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeRange);
+        assert!(detect_match_float(&val, 37.1));
+        assert!(detect_match_float(&val, 41.9));
+        assert!(!detect_match_float(&val, 35.0));
+        assert!(!detect_match_float(&val, 43.0));
+
+        let (_, val) = detect_parse_float::<f64>("!37.0-42.0").unwrap();
+        assert_float_absolute_eq!(val.arg1, 37.0, FloatCore::epsilon());
+        assert_float_absolute_eq!(val.arg2, 42.0, FloatCore::epsilon());
+        assert_eq!(val.mode, DetectFloatMode::DetectFloatModeNegRg);
+        assert!(detect_match_float(&val, 37.0));
+        assert!(detect_match_float(&val, 42.0));
+        assert!(detect_match_float(&val, 35.0));
+        assert!(detect_match_float(&val, 43.0));
+        assert!(!detect_match_float(&val, 37.1));
+        assert!(!detect_match_float(&val, 41.9));
+    }
+
+    fn do_match_test(val: &str, arg1: f64, arg1_cmp: f64, arg2: f64, mode: DetectFloatMode) {
+        let c_string = CString::new(val).expect("CString::new failed");
+        unsafe {
+            let val = rs_detect_f64_parse(c_string.as_ptr());
+            assert_float_absolute_eq!((*val).arg1, arg1, FloatCore::epsilon());
+            assert_float_absolute_eq!((*val).arg2, arg2, FloatCore::epsilon());
+
+            assert_eq!((*val).mode, mode);
+            assert_eq!(1, rs_detect_f64_match(arg1_cmp, &*val));
+        }
+    }
+
+    fn do_match_test_arg1(val: &str, arg1: f64, arg1_cmp: f64, mode: DetectFloatMode) {
+        do_match_test(val, arg1, arg1_cmp, FloatCore::min_value(), mode);
+    }
+
+    fn do_parse_test(val: &str, arg1: f64, arg2: f64, mode: DetectFloatMode) {
+        let c_string = CString::new(val).expect("CString::new failed");
+        unsafe {
+            let val = rs_detect_f64_parse(c_string.as_ptr());
+            assert_float_absolute_eq!((*val).arg1, arg1, FloatCore::epsilon());
+            assert_float_absolute_eq!((*val).arg2, arg2, FloatCore::epsilon());
+
+            assert_eq!((*val).mode, mode);
+        }
+    }
+
+    fn do_parse_test_arg1(val: &str, arg1: f64, mode: DetectFloatMode) {
+        do_parse_test(val, arg1, FloatCore::min_value(), mode);
+    }
+
+    #[test]
+    fn test_rs_detect_match_valid() {
+        do_match_test_arg1("1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeEqual);
+        do_match_test_arg1("> 1.0", 1.0, 1.1, DetectFloatMode::DetectFloatModeGt);
+        do_match_test_arg1(">= 1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeGte);
+        do_match_test_arg1("<= 1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeLte);
+        do_match_test_arg1("< 1.0", 1.0, 0.9, DetectFloatMode::DetectFloatModeLt);
+        do_match_test_arg1("= 1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeEqual);
+        do_match_test_arg1("!= 1.0", 1.0, 1.1, DetectFloatMode::DetectFloatModeNe);
+        do_match_test(
+            "37.0-42.0",
+            37.0,
+            37.1,
+            42.0,
+            DetectFloatMode::DetectFloatModeRange,
+        );
+        do_match_test(
+            "37.0-42.0",
+            37.0,
+            41.9,
+            42.0,
+            DetectFloatMode::DetectFloatModeRange,
+        );
+        do_match_test_arg1(
+            ">= 4.15",
+            4.15,
+            4.150007324019584,
+            DetectFloatMode::DetectFloatModeGte,
+        );
+        do_match_test_arg1(
+            "> 4.15",
+            4.15,
+            4.150007324019584,
+            DetectFloatMode::DetectFloatModeGt,
+        );
+    }
+
+    #[test]
+    fn test_rs_detect_parse_valid() {
+        do_parse_test_arg1("1.0", 1.0, DetectFloatMode::DetectFloatModeEqual);
+        do_parse_test_arg1("> 1.0", 1.0, DetectFloatMode::DetectFloatModeGt);
+        do_parse_test_arg1(">= 1.0", 1.0, DetectFloatMode::DetectFloatModeGte);
+        do_parse_test_arg1("<= 1.0", 1.0, DetectFloatMode::DetectFloatModeLte);
+        do_parse_test_arg1("< 1.0", 1.0, DetectFloatMode::DetectFloatModeLt);
+        do_parse_test_arg1("= 1.0", 1.0, DetectFloatMode::DetectFloatModeEqual);
+        do_parse_test_arg1("!= 1.0", 1.0, DetectFloatMode::DetectFloatModeNe);
+        do_parse_test(
+            "37.0-42.0",
+            37.0,
+            42.0,
+            DetectFloatMode::DetectFloatModeRange,
+        );
+    }
+}

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod byte_extract;
 pub mod byte_math;
+pub mod entropy;
 pub mod error;
 pub mod iprep;
 pub mod parser;

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -27,6 +27,7 @@ pub mod stream_size;
 pub mod transform_base64;
 pub mod transforms;
 pub mod uint;
+pub mod float;
 pub mod uri;
 pub mod tojson;
 pub mod vlan;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,6 +147,7 @@ noinst_HEADERS = \
 	detect-engine-tag.h \
 	detect-engine-threshold.h \
 	detect-engine-uint.h \
+	detect-entropy.h \
 	detect-fast-pattern.h \
 	detect-file-data.h \
 	detect-file-hash-common.h \
@@ -718,6 +719,7 @@ libsuricata_c_a_SOURCES = \
 	detect-engine-tag.c \
 	detect-engine-threshold.c \
 	detect-engine-uint.c \
+	detect-entropy.c \
 	detect-fast-pattern.c \
 	detect-file-data.c \
 	detect-file-hash-common.c \

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -41,6 +41,7 @@
 #include "detect-bytemath.h"
 #include "detect-bytejump.h"
 #include "detect-byte-extract.h"
+#include "detect-entropy.h"
 #include "detect-replace.h"
 #include "detect-engine-content-inspection.h"
 #include "detect-uricontent.h"
@@ -482,6 +483,11 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
             det_ctx->pcre_match_start_offset = prev_offset;
         } while (1);
 
+    } else if (smd->type == DETECT_ENTROPY) {
+        if (!DetectEntropyDoMatch(det_ctx, s, smd->ctx, buffer, buffer_len)) {
+            goto no_match;
+        }
+        goto match;
     } else if (smd->type == DETECT_BYTETEST) {
         const DetectBytetestData *btd = (const DetectBytetestData *)smd->ctx;
         uint16_t btflags = btd->flags;

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -212,6 +212,7 @@
 #include "detect-quic-cyu-string.h"
 #include "detect-ja4-hash.h"
 #include "detect-ftp-command.h"
+#include "detect-entropy.h"
 
 #include "detect-bypass.h"
 #include "detect-ftpdata.h"
@@ -599,6 +600,7 @@ void SigTableSetup(void)
     DetectBytetestRegister();
     DetectBytejumpRegister();
     DetectBytemathRegister();
+    DetectEntropyRegister();
     DetectSameipRegister();
     DetectGeoipRegister();
     DetectL3ProtoRegister();

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -96,6 +96,7 @@ enum DetectKeywordId {
     DETECT_ISDATAAT,
     DETECT_URILEN,
     DETECT_ABSENT,
+    DETECT_ENTROPY,
     /* end of content inspection */
 
     DETECT_METADATA,

--- a/src/detect-entropy.c
+++ b/src/detect-entropy.c
@@ -1,0 +1,75 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+
+#include "detect.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+
+#include "detect-entropy.h"
+
+#include "rust.h"
+
+static int DetectEntropySetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    DetectEntropyData *ded = SCDetectEntropyParse(arg);
+    if (ded == NULL) {
+        goto error;
+    }
+
+    int sm_list = DETECT_SM_LIST_PMATCH;
+    if (s->init_data->list != DETECT_SM_LIST_NOTSET) {
+        if (DetectBufferGetActiveList(de_ctx, s) == -1)
+            goto error;
+
+        sm_list = s->init_data->list;
+    }
+
+    if (SigMatchAppendSMToList(de_ctx, s, DETECT_ENTROPY, (SigMatchCtx *)ded, sm_list) != NULL) {
+        SCReturnInt(0);
+    }
+
+    /* fall through */
+
+error:
+    SCLogDebug("error during entropy setup");
+    if (ded != NULL) {
+        SCDetectEntropyFree(ded);
+    }
+    SCReturnInt(-1);
+}
+
+static void DetectEntropyFree(DetectEngineCtx *de_ctx, void *ptr)
+{
+    SCDetectEntropyFree(ptr);
+}
+
+bool DetectEntropyDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
+        const SigMatchCtx *ctx, const uint8_t *buffer, const uint32_t buffer_len)
+{
+    return SCDetectEntropyMatch(buffer, buffer_len, (const DetectEntropyData *)ctx);
+}
+
+void DetectEntropyRegister(void)
+{
+    sigmatch_table[DETECT_ENTROPY].name = "entropy";
+    sigmatch_table[DETECT_ENTROPY].desc = "calculate entropy";
+    sigmatch_table[DETECT_BYTE_EXTRACT].url = "/rules/payload-keywords.html#entropy";
+    sigmatch_table[DETECT_ENTROPY].Free = DetectEntropyFree;
+    sigmatch_table[DETECT_ENTROPY].Setup = DetectEntropySetup;
+}

--- a/src/detect-entropy.h
+++ b/src/detect-entropy.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_DETECT_ENTROPY_H
+#define SURICATA_DETECT_ENTROPY_H
+
+void DetectEntropyRegister(void);
+bool DetectEntropyDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
+        const SigMatchCtx *ctx, const uint8_t *buffer, const uint32_t buffer_len);
+
+#endif


### PR DESCRIPTION
Continuation of #12385

The entropy keyword syntax is the keyword `entropy` followed by options
and the entropy value for comparison.

The minimum entropy keyword specification is:
`entropy: value <entropy-spec>`

This results in the calculated entropy value being compared with
<entropy-spec> with the equality operator.

A match occurs when the values and operator agree. This example matches
if the calculated and entropy value are the same.

When entropy keyword options are specified, all options and "value" must
be comma-separated. Options and value may be specified in any order.

Options have default values:
- bytes is equal to the current content length
- offset is 0
- comparison with value is equality

`entropy: [bytes <byteval>] [offset <offsetval>] value <entropy-spec>`

Using default values:
`entropy: bytes 0, offset 0, value =<entropy-spec>`

<entropy-spec> is: <operator> (see below) and a value, e.g., "< 4.1"

The following operators are available from the float crate introduced with this pr:
    - =  (default): Match when calculated entropy value equals specified entropy value
    - <  Match when calculated entropy value is strictly less than specified entropy value
    - <= Match when calculated entropy value is less than or equal to the specified entropy value
    - >  Match when calculated entropy value is strictly greater than specified entropy value
    - >= Match when calculated entropy value is greater than or equal to the specified entropy value
    - != Match when the calculated entropy value is not equal to the specified entropy value
    - x-y Match when calculated entropy value is in the range, exclusive
    - !x-y Match when calculated entropy value is not in the range, exclusive
Link to ticket: https://redmine.openinfosecfoundation.org/issues/4162

Describe changes:
- New float crate -- similar to unit crate -- for floating-point usage
- Entropy parsing/calculation logic
- Entropy keyword
- Add entropy handling to content inspection
- Documentation

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2232

