### PR TITLE
pgsql: don't error out with PDU parsing errors - v1

### DIFF
--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022 Open Information Security Foundation
+/* Copyright (C) 2022-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,7 +28,7 @@ use nom7::error::{make_error, ErrorKind};
 use nom7::multi::{many1, many_m_n, many_till};
 use nom7::number::streaming::{be_i16, be_i32};
 use nom7::number::streaming::{be_u16, be_u32, be_u8};
-use nom7::sequence::{terminated, tuple};
+use nom7::sequence::{terminated};
 use nom7::{Err, IResult};
 
 pub const PGSQL_LENGTH_FIELD: u32 = 4;
@@ -1137,8 +1137,8 @@ fn parse_notification_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
 }
 
 pub fn pgsql_parse_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
-    let (i, pseudo_header) = peek(tuple((be_u8, be_u32)))(i)?;
-    let (i, message) = match pseudo_header.0 {
+    let (i, tag) = peek(be_u8)(i)?;
+    let (i, message) = match tag {
         b'E' => pgsql_parse_error_response(i)?,
         b'K' => parse_backend_key_data_message(i)?,
         b'N' => pgsql_parse_notice_response(i)?,

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -727,7 +727,7 @@ pub fn parse_request(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage> {
         b'X' => parse_terminate_message(i)?,
         _ => {
             let (i, identifier) = be_u8(i)?;
-            let (i, length) = verify(be_u32, |&x| x > PGSQL_LENGTH_FIELD)(i)?;
+            let (i, length) = verify(be_u32, |&x| x >= PGSQL_LENGTH_FIELD)(i)?;
             let (i, payload) = take(length - PGSQL_LENGTH_FIELD)(i)?;
             let unknown = PgsqlFEMessage::UnknownMessageType(RegularPacket {
                 identifier,

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -630,10 +630,7 @@ unsafe extern "C" fn probing_parser_ts(
         let slice: &[u8] = build_slice!(input, input_len as usize);
 
         match parser::parse_request(slice) {
-            Ok((_, request)) => {
-                if let PgsqlFEMessage::UnknownMessageType(_) = request {
-                    return ALPROTO_FAILED;
-                }
+            Ok((_, _)) => {
                 return ALPROTO_PGSQL;
             }
             Err(Err::Incomplete(_)) => {
@@ -659,10 +656,7 @@ unsafe extern "C" fn probing_parser_tc(
         }
 
         match parser::pgsql_parse_response(slice) {
-            Ok((_, response)) => {
-                if let PgsqlBEMessage::UnknownMessageType(_) = response {
-                    return ALPROTO_FAILED;
-                }
+            Ok((_, _)) => {
                 return ALPROTO_PGSQL;
             }
             Err(Err::Incomplete(_)) => {


### PR DESCRIPTION

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5524

This isn't fully ready yet, the different errors should lead to pgsql events.
I'd also like to better handle the length error handling, to be able to actually capture that when parsing requests or responses -- and set the right event.

Describe changes:
- allow parsing response messages that have the minimum length
- don't return `AppLayerResult::err()` for parsing errors, to allow the parser to reach further messages 
- simplify responses parsing
- don't set app-proto to failure when unknown messages are parsed -- to allow the parser to check further messages

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2276
