### PR TITLE
detect/csum: rm interaction btw stream setting/csum (main-7.0.x backport)

### DIFF
--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -39,7 +39,7 @@ Upgrading to 7.0.8
 - Unknown requirements in the ``requires`` keyword will now be treated
   as unsatisfied requirements, causing the rule to not be loaded. See
   :ref:`keyword_requires`. To opt out of this change and to ignore
-  uknown requirements, effectively treating them as satified the
+  unknown requirements, effectively treating them as satisfied the
   ``ignore-unknown-requirements`` configuration option can be used.
 
   Command line example::
@@ -66,6 +66,13 @@ Upgrading to 7.0.8
   the engine will NOT log any transaction metadata if there is more than one
   live transaction, to reduce the chances of logging unrelated data.** This may
   lead to what looks like a regression in behavior, but it is a considered choice.
+- The configuration setting controlling stream checksum checks no longer affects
+  checksum keyword validation. In previous Suricata versions, when ``stream.checksum-validation``
+  was set to ``no``, the checksum keywords (e.g., ``ipv4-csum``, ``tcpv4-csum``, etc)
+  will always consider it valid; e.g., ``tcpv4-csum: invalid`` will never match. Now,
+  ``stream.checksum-validation`` no longer affects the checksum rule keywords.
+  E.g., ``ipv4-csum: valid`` will only match if the check sum is valid, even when engine
+  checksum validations are disabled.
 
 Upgrading 6.0 to 7.0
 --------------------

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5815,11 +5815,7 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueueNoLock *pq)
                 StatsIncr(tv, stt->counter_tcp_invalid_checksum);
                 return TM_ECODE_OK;
             }
-        } else {
-            p->flags |= PKT_IGNORE_CHECKSUM;
         }
-    } else {
-        p->flags |= PKT_IGNORE_CHECKSUM; //TODO check that this is set at creation
     }
     AppLayerProfilingReset(stt->ra_ctx->app_tctx);
 


### PR DESCRIPTION
Continuation of #12544 

Backport of issue 7468

Stream checksum validation no longer has a side effect of setting PKT_IGNORE_CHECKSUM and thus, no longer affects csum keyword checks.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7468

Describe changes:
- During stream checksum validation checks, no longer set PKT_IGNORE_CHECKSUM

Updates:
- Fixed documentation issue causing CI failures.

NB: Updated s-v test link: no functional changes in new pr.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2277
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
