### PR TITLE
Lua packetlib/v4

### DIFF
--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -9,3 +9,4 @@ environment without access to additional modules.
 .. toctree::
 
    hashlib
+   packetlib

--- a/doc/userguide/lua/libs/packetlib.rst
+++ b/doc/userguide/lua/libs/packetlib.rst
@@ -1,0 +1,177 @@
+Packet
+------
+
+Packets are exposed to Lua scripts with ``suricata.packet``
+library. For example::
+
+    local packet = require("suricata.packet")
+
+Initialization
+~~~~~~~~~~~~~~
+
+``get``
+^^^^^^^
+
+Init the packet for use in the script. The packet is the current packet the engine is processing.
+
+::
+
+    p = packet.get()
+
+
+Time
+~~~~
+
+``timestamp``
+^^^^^^^^^^^^^
+
+Get packet timestamp as 2 numbers: seconds & microseconds elapsed since
+1970-01-01 00:00:00 UTC.
+
+::
+
+    p = packet.get()
+    local sec, usec = p:timestamp()
+
+
+``timestring_legacy``
+^^^^^^^^^^^^^^^^^^^^^
+
+Get packet timestamp as a string in the format: `11/24/2009-18:57:25.179869`.
+This is the format used by `fast.log`, `http.log` and other legacy outputs.
+
+::
+
+    p = packet.get()
+    print p:timestring_legacy()
+
+
+``timestring_iso8601``
+^^^^^^^^^^^^^^^^^^^^^^
+
+Get packet timestamp as a string in the format: `2015-10-06T15:16:43.137833+0000`.
+This is the format used by `eve`.
+
+::
+
+    p = packet.get()
+    print p:timestring_iso8601()
+
+
+Ports and Addresses
+~~~~~~~~~~~~~~~~~~~
+
+``tuple``
+^^^^^^^^^
+
+Using the `tuple` method the IP version (4 or 6), src IP and dest IP (as string), IP protocol (int) and ports (ints) are retrieved.
+
+The protocol value comes from the IP header, see further https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+
+::
+
+    p = packet.get()
+    ipver, srcip, dstip, proto, sp, dp = p:tuple()
+
+
+If the protocol is ICMPv4 or ICMPv6, so when `proto == 1` or `proto == 58`, then the final two results are `icmp type` and `icmp code`.
+
+::
+
+    p = packet.get()
+    ipver, srcip, dstip, proto, itype, icode = p:tuple()
+    if ipver == 6 and proto == 1 then
+        -- weird, ICMPv4 on IPv6
+        return 1
+    end
+
+
+``sp``
+^^^^^^
+
+Get the packets TCP, UDP or SCTP source port as an int. Returns `nil` for other protocols.
+
+::
+
+    p = packet.get()
+    source_port = p:sp()
+    if source_port == 31337 then
+        return 1
+    end
+
+
+``dp``
+^^^^^^
+
+Get the packets TCP, UDP or SCTP destination port as an int. Returns `nil` for other protocols.
+
+::
+
+    p = packet.get()
+    dest_port = p:dp()
+    -- not port 443
+    if dest_port ~= 443 then
+        return 1
+    end
+
+
+Data
+~~~~
+
+``payload``
+^^^^^^^^^^^
+
+Packet payload.
+
+::
+
+    payload = p:payload()
+
+
+``packet``
+^^^^^^^^^^
+
+Entire packet, including headers for protocols like TCP, Ethernet, VLAN, etc.
+
+::
+
+    raw_packet = p:packet()
+
+
+Misc
+~~~~
+
+``pcap_cnt``
+^^^^^^^^^^^^
+
+The packet number when reading from a pcap file.
+
+::
+
+    p = packet.get()
+    print p:pcap_cnt()
+
+
+Example
+~~~~~~~
+
+Example `match` function that takes a packet, inspect the payload line by line and checks if it finds the HTTP request line.
+If it is found, issue a notice log with packet details.
+
+::
+
+    function match (args)
+        p = packet.get()
+        payload = p:payload()
+        ts = p:timestring()
+
+        for line in payload:gmatch("([^\r\n]*)[\r\n]+") do
+            if line == "GET /index.html HTTP/1.0" then
+                ipver, srcip, dstip, proto, sp, dp = p:tuple()
+                SCLogNotice(string.format("%s %s->%s %d->%d (pcap_cnt:%d) match! %s", ts, srcip, dstip, sp, dp, p:pcap_cnt(), line));
+                return 1
+            end
+        end
+
+        return 0
+    end

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -45,42 +45,6 @@ Initialize with:
       return needs
   end
 
-SCPacketTimestamp
-~~~~~~~~~~~~~~~~~
-
-Get packets timestamp as 2 numbers: seconds & microseconds elapsed since
-1970-01-01 00:00:00 UTC.
-
-::
-
-  function log(args)
-      local sec, usec = SCPacketTimestamp()
-  end
-
-SCPacketTimeString
-~~~~~~~~~~~~~~~~~~
-
-Use ``SCPacketTimeString`` to get the packet's time string in the format:
-11/24/2009-18:57:25.179869
-
-::
-
-  function log(args)
-      ts = SCPacketTimeString()
-
-SCPacketTuple
-~~~~~~~~~~~~~
-
-::
-
-  ipver, srcip, dstip, proto, sp, dp = SCPacketTuple()
-
-SCPacketPayload
-~~~~~~~~~~~~~~~
-
-::
-
-  p = SCPacketPayload()
 
 flow
 ----

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -521,6 +521,7 @@ noinst_HEADERS = \
 	util-lua-hassh.h \
 	util-lua-http.h \
 	util-lua-ja3.h \
+	util-lua-packetlib.h \
 	util-lua-sandbox.h \
 	util-lua-smtp.h \
 	util-lua-ssh.h \
@@ -1075,6 +1076,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-hassh.c \
 	util-lua-http.c \
 	util-lua-ja3.c \
+	util-lua-packetlib.c \
 	util-lua-sandbox.c \
 	util-lua-smtp.c \
 	util-lua-ssh.c \

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -57,6 +57,7 @@
 #include "util-var-name.h"
 
 #include "util-lua.h"
+#include "util-lua-builtins.h"
 #include "util-lua-sandbox.h"
 
 static int DetectLuaMatch (DetectEngineThreadCtx *,
@@ -474,6 +475,7 @@ static void *DetectLuaThreadInit(void *data)
 
     if (lua->allow_restricted_functions) {
         luaL_openlibs(t->luastate);
+        SCLuaRequirefBuiltIns(t->luastate);
     } else {
         SCLuaSbLoadLibs(t->luastate);
     }
@@ -589,6 +591,7 @@ static int DetectLuaSetupPrime(DetectEngineCtx *de_ctx, DetectLuaData *ld, const
         return -1;
     if (ld->allow_restricted_functions) {
         luaL_openlibs(luastate);
+        SCLuaRequirefBuiltIns(luastate);
     } else {
         SCLuaSbLoadLibs(luastate);
     }

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -353,16 +353,6 @@ static int DetectLuaMatch (DetectEngineThreadCtx *det_ctx,
     lua_getglobal(tlua->luastate, "match");
     lua_newtable(tlua->luastate); /* stack at -1 */
 
-    if ((tlua->flags & FLAG_DATATYPE_PAYLOAD) && p->payload_len) {
-        lua_pushliteral(tlua->luastate, "payload"); /* stack at -2 */
-        LuaPushStringBuffer (tlua->luastate, (const uint8_t *)p->payload, (size_t)p->payload_len); /* stack at -3 */
-        lua_settable(tlua->luastate, -3);
-    }
-    if ((tlua->flags & FLAG_DATATYPE_PACKET) && GET_PKT_LEN(p)) {
-        lua_pushliteral(tlua->luastate, "packet"); /* stack at -2 */
-        LuaPushStringBuffer (tlua->luastate, (const uint8_t *)GET_PKT_DATA(p), (size_t)GET_PKT_LEN(p)); /* stack at -3 */
-        lua_settable(tlua->luastate, -3);
-    }
     if (tlua->alproto == ALPROTO_HTTP1) {
         HtpState *htp_state = p->flow->alstate;
         if (htp_state != NULL && htp_state->connp != NULL) {

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -898,20 +898,18 @@ error:
  */
 static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    DetectLuaData *lua = NULL;
-
     /* First check if Lua rules are enabled, by default Lua in rules
      * is disabled. */
     int enabled = 0;
     (void)ConfGetBool("security.lua.allow-rules", &enabled);
     if (!enabled) {
         SCLogError("Lua rules disabled by security configuration: security.lua.allow-rules");
-        goto error;
+        return -1;
     }
 
-    lua = DetectLuaParse(de_ctx, str);
+    DetectLuaData *lua = DetectLuaParse(de_ctx, str);
     if (lua == NULL)
-        goto error;
+        return -1;
 
     /* Load lua sandbox configurations */
     intmax_t lua_alloc_limit = DEFAULT_LUA_ALLOC_LIMIT;

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -116,7 +116,6 @@ void DetectLuaRegister(void)
 #define FLAG_DATATYPE_DNS_RRNAME                BIT_U32(15)
 #define FLAG_DATATYPE_DNS_REQUEST               BIT_U32(16)
 #define FLAG_DATATYPE_DNS_RESPONSE              BIT_U32(17)
-#define FLAG_DATATYPE_TLS                       BIT_U32(18)
 #define FLAG_DATATYPE_SSH                       BIT_U32(19)
 #define FLAG_DATATYPE_SMTP                      BIT_U32(20)
 #define FLAG_DATATYPE_DNP3                      BIT_U32(21)
@@ -852,8 +851,6 @@ static int DetectLuaSetupPrime(DetectEngineCtx *de_ctx, DetectLuaData *ld, const
         } else if (strncmp(k, "tls", 3) == 0 && strcmp(v, "true") == 0) {
 
             ld->alproto = ALPROTO_TLS;
-
-            ld->flags |= FLAG_DATATYPE_TLS;
 
         } else if (strncmp(k, "ssh", 3) == 0 && strcmp(v, "true") == 0) {
 

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -19,12 +19,14 @@
 #include "util-lua-builtins.h"
 #include "util-lua-hashlib.h"
 #include "util-lua-dataset.h"
+#include "util-lua-packetlib.h"
 
 #include "lauxlib.h"
 
 static const luaL_Reg builtins[] = {
     { "suricata.hashlib", SCLuaLoadHashlib },
     { "suricata.dataset", LuaLoadDatasetLib },
+    { "suricata.packet", LuaLoadPacketLib },
     { NULL, NULL },
 };
 

--- a/src/util-lua-packetlib.c
+++ b/src/util-lua-packetlib.c
@@ -1,0 +1,282 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * Packet API for Lua.
+ *
+ * local packet = require("suricata.packet")
+ */
+
+#include "suricata-common.h"
+
+#include "util-lua-packetlib.h"
+
+#include "app-layer-protos.h" /* Required by util-lua-common. */
+#include "util-lua-common.h"
+#include "util-lua.h"
+#include "util-debug.h"
+#include "util-print.h"
+
+/* key for p (packet) pointer */
+extern const char lua_ext_key_p[];
+static const char suricata_packet[] = "suricata:packet";
+
+struct LuaPacket {
+    Packet *p;
+};
+
+static int LuaPacketGC(lua_State *luastate)
+{
+    SCLogDebug("gc:start");
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    SCLogDebug("packet %p", s->p);
+    s->p = NULL;
+    SCLogDebug("gc:done");
+    return 0;
+}
+
+static int LuaPacketPayload(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    LuaPushStringBuffer(luastate, (const uint8_t *)s->p->payload, (size_t)s->p->payload_len);
+    return 1;
+}
+
+static int LuaPacketPacket(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    LuaPushStringBuffer(luastate, (const uint8_t *)GET_PKT_DATA(s->p), (size_t)GET_PKT_LEN(s->p));
+    return 1;
+}
+
+static int LuaPacketPcapCnt(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    lua_pushinteger(luastate, s->p->pcap_cnt);
+    return 1;
+}
+
+/** \internal
+ *  \brief legacy format as used by fast.log, http.log, etc.
+ */
+static int LuaPacketTimestringLegacy(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    char timebuf[64];
+    CreateTimeString(s->p->ts, timebuf, sizeof(timebuf));
+    lua_pushstring(luastate, timebuf);
+    return 1;
+}
+
+static int LuaPacketTimestringIso8601(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    char timebuf[64];
+    CreateIsoTimeString(s->p->ts, timebuf, sizeof(timebuf));
+    lua_pushstring(luastate, timebuf);
+    return 1;
+}
+
+static int LuaPacketTimestamp(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    lua_pushnumber(luastate, (double)SCTIME_SECS(s->p->ts));
+    lua_pushnumber(luastate, (double)SCTIME_USECS(s->p->ts));
+    return 2;
+}
+
+/** \internal
+ *  \brief fill lua stack with header info
+ *  \param luastate the lua state
+ *  \retval cnt number of data items placed on the stack
+ *
+ *  Places: ipver (number), src ip (string), dst ip (string), protocol (number),
+ *          sp or icmp type (number), dp or icmp code (number).
+ */
+static int LuaPacketTuple(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+    Packet *p = s->p;
+
+    int ipver = 0;
+    if (PacketIsIPv4(p)) {
+        ipver = 4;
+    } else if (PacketIsIPv6(p)) {
+        ipver = 6;
+    }
+    lua_pushinteger(luastate, ipver);
+    if (ipver == 0)
+        return 1;
+
+    char srcip[46] = "", dstip[46] = "";
+    if (PacketIsIPv4(p)) {
+        PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
+        PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
+    } else if (PacketIsIPv6(p)) {
+        PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
+        PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
+    }
+
+    lua_pushstring(luastate, srcip);
+    lua_pushstring(luastate, dstip);
+
+    /* proto and ports (or type/code) */
+    lua_pushinteger(luastate, p->proto);
+    if (p->proto == IPPROTO_TCP || p->proto == IPPROTO_UDP) {
+        lua_pushinteger(luastate, p->sp);
+        lua_pushinteger(luastate, p->dp);
+
+    } else if (p->proto == IPPROTO_ICMP || p->proto == IPPROTO_ICMPV6) {
+        lua_pushinteger(luastate, p->icmp_s.type);
+        lua_pushinteger(luastate, p->icmp_s.code);
+    } else {
+        lua_pushinteger(luastate, 0);
+        lua_pushinteger(luastate, 0);
+    }
+
+    return 6;
+}
+
+/** \internal
+ *  \brief get tcp/udp/sctp source port
+ *  \param luastate the lua state
+ */
+static int LuaPacketSport(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+    Packet *p = s->p;
+
+    switch (p->proto) {
+        case IPPROTO_TCP:
+        case IPPROTO_UDP:
+        case IPPROTO_SCTP:
+            lua_pushinteger(luastate, p->sp);
+            break;
+        default:
+            LUA_ERROR("sp only available for tcp, udp and sctp");
+    }
+
+    return 1;
+}
+
+/** \internal
+ *  \brief get tcp/udp/sctp dest port
+ *  \param luastate the lua state
+ */
+static int LuaPacketDport(lua_State *luastate)
+{
+    struct LuaPacket *s = (struct LuaPacket *)lua_touserdata(luastate, 1);
+    if (s == NULL || s->p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+    Packet *p = s->p;
+
+    switch (p->proto) {
+        case IPPROTO_TCP:
+        case IPPROTO_UDP:
+        case IPPROTO_SCTP:
+            lua_pushinteger(luastate, p->dp);
+            break;
+        default:
+            LUA_ERROR("dp only available for tcp, udp and sctp");
+    }
+
+    return 1;
+}
+
+static int LuaPacketGet(lua_State *luastate)
+{
+    Packet *p = LuaStateGetPacket(luastate);
+    if (p == NULL) {
+        LUA_ERROR("failed to get packet");
+    }
+
+    struct LuaPacket *s = (struct LuaPacket *)lua_newuserdata(luastate, sizeof(*s));
+    if (s == NULL) {
+        LUA_ERROR("failed to get userdata");
+    }
+    s->p = p;
+    luaL_getmetatable(luastate, suricata_packet);
+    lua_setmetatable(luastate, -2);
+    return 1;
+}
+
+static const luaL_Reg packetlib[] = {
+    // clang-format off
+    { "get", LuaPacketGet },
+    { NULL, NULL }
+    // clang-format on
+};
+
+static const luaL_Reg packetlib_meta[] = {
+    // clang-format off
+    { "packet", LuaPacketPacket },
+    { "payload", LuaPacketPayload },
+    { "pcap_cnt", LuaPacketPcapCnt },
+    { "timestring_legacy", LuaPacketTimestringLegacy },
+    { "timestring_iso8601", LuaPacketTimestringIso8601 },
+    { "timestamp", LuaPacketTimestamp },
+    { "tuple", LuaPacketTuple },
+    { "sp", LuaPacketSport },
+    { "dp", LuaPacketDport },
+    { "__gc", LuaPacketGC },
+    { NULL, NULL }
+    // clang-format on
+};
+
+int LuaLoadPacketLib(lua_State *luastate)
+{
+    luaL_newmetatable(luastate, suricata_packet);
+    lua_pushvalue(luastate, -1);
+    lua_setfield(luastate, -2, "__index");
+    luaL_setfuncs(luastate, packetlib_meta, 0);
+
+    luaL_newlib(luastate, packetlib);
+    return 1;
+}

--- a/src/util-lua-packetlib.h
+++ b/src/util-lua-packetlib.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_UTIL_LUA_PACKET_H
+#define SURICATA_UTIL_LUA_PACKET_H
+
+#include "lua.h"
+
+int LuaLoadPacketLib(lua_State *luastate);
+
+#endif /* SURICATA_UTIL_LUA_DATASET_H */


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2285

Rebased #12551 

Replaces `timestring` with `timestring_legacy` (fastlog) and `timestring_iso8601` (eve). Went with these as I realized eve has iso 8601 output as mentioned here 6c3c234ca5583f420371bc706716e8ae1b0c5a61

https://redmine.openinfosecfoundation.org/issues/7488
