### PR TITLE
tls: more permissive empty data eof check

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -2681,7 +2681,7 @@ static AppLayerResult SSLDecode(Flow *f, uint8_t direction, void *alstate,
     const uint8_t *init_input = input;
     int32_t input_len = (int32_t)StreamSliceGetDataLen(&stream_slice);
 
-    if (input == NULL &&
+    if ((input == NULL || input_len == 0) &&
             ((direction == 0 && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TS)) ||
                     (direction == 1 &&
                             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF_TC)))) {


### PR DESCRIPTION
If not all data is ACK'd during the FIN session shutdown, the last calls to the parser can be with a non-NULL data pointer, but a input length of 0. This wasn't considered by the EOF check, which then lead to it being seen as an error. No event was raised, but the tls error stats were incremented.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2289

https://redmine.openinfosecfoundation.org/issues/7554