### PR TITLE
configure: require minimum version of cbindgen to be 0.26.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2273,7 +2273,7 @@ fi
     AC_PATH_PROG(CBINDGEN, cbindgen, "no")
     if test "x$CBINDGEN" != "xno"; then
       cbindgen_version=$(cbindgen --version 2>&1 | cut -d' ' -f2-)
-      min_cbindgen_version="0.10.0"
+      min_cbindgen_version="0.20.0"
       AS_VERSION_COMPARE([$cbindgen_version], [$min_cbindgen_version],
           [cbindgen_ok="no"],
           [cbindgen_ok="yes"],


### PR DESCRIPTION
I'm not sure why, but 0.20.0 works on Fedora with Rust 1.75.0
installed via Rustup, but it does not work on Ubuntu 22.04 with Rust
installed by system packages.

However, cbindgen 0.26.0 works in both scenarios.
