### PR TITLE
doc: Update bypass docs to use new keyword format 7143 v1

### DIFF
--- a/doc/userguide/rules/bypass-keyword.rst
+++ b/doc/userguide/rules/bypass-keyword.rst
@@ -1,19 +1,26 @@
 Bypass Keyword
 ==============
 
-Suricata has a ``bypass`` keyword that can be used in signatures to exclude traffic from further evaluation.
+.. role:: example-rule-action
+.. role:: example-rule-header
+.. role:: example-rule-options
+.. role:: example-rule-emphasis
 
-The ``bypass`` keyword is useful in cases where there is a large flow expected (e.g. Netflix, Spotify, YouTube).
+Suricata has a ``bypass`` keyword that can be used in signatures to exclude
+traffic from further evaluation.
+
+The ``bypass`` keyword is useful in cases where there is a large flow expected
+(e.g. Netflix, Spotify, YouTube).
 
 The ``bypass`` keyword is considered a post-match keyword.
-
 
 bypass
 ------
 
 Bypass a flow on matching http traffic.
 
-Example::
+.. container:: example-rule
 
-  alert http any any -> any any (content:"suricata.io"; \
-      http_host; bypass; sid:10001; rev:1;)
+  alert http any any -> any any (http.host; \
+  content:"suricata.io"; :example-rule-options:`bypass;` \
+  sid:10001; rev:1;)


### PR DESCRIPTION
Ticket: #7143

Update documentation to reflect new sticky buffer keyword format

(cherry picked from commit db543870624a98d1fbd3bc6137e259931f423cad)

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7143

Describe changes:
- Update bypass keyword example to use sticky buffer keyword(s)
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
