### PR TITLE
misc: Remove comparisons with boolean values

### DIFF
--- a/plugins/napatech/util-napatech.c
+++ b/plugins/napatech/util-napatech.c
@@ -317,7 +317,7 @@ static uint32_t UpdateStreamStats(ThreadVars *tv, NtInfoStream_t hInfo, NtStatSt
 
             for (uint32_t hbCount = 0; hbCount < hStat.u.usageData_v0.data.numHostBufferUsed;
                     hbCount++) {
-                if (unlikely(stream_config[inst_id].initialized == false)) {
+                if (unlikely(!stream_config[inst_id].initialized)) {
                     rxPktsStart[stream_id] += hStat.u.usageData_v0.data.hb[hbCount].stat.rx.frames;
                     rxByteStart[stream_id] += hStat.u.usageData_v0.data.hb[hbCount].stat.rx.bytes;
                     dropPktStart[stream_id] +=

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1144,7 +1144,7 @@ uint64_t AppLayerParserGetTransactionActive(const Flow *f,
     uint64_t active_id;
     uint64_t log_id = pstate->log_id;
     uint64_t inspect_id = pstate->inspect_id[(direction & STREAM_TOSERVER) ? 0 : 1];
-    if (alp_ctx.ctxs[f->alproto][f->protomap].logger == true) {
+    if (alp_ctx.ctxs[f->alproto][f->protomap].logger) {
         active_id = MIN(log_id, inspect_id);
     } else {
         active_id = inspect_id;
@@ -1525,7 +1525,7 @@ int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto)
 {
     SCEnter();
     int ipproto_map = FlowGetProtoMapping(ipproto);
-    int r = (alp_ctx.ctxs[alproto][ipproto_map].logger == false) ? 0 : 1;
+    int r = (!alp_ctx.ctxs[alproto][ipproto_map].logger) ? 0 : 1;
     SCReturnInt(r);
 }
 

--- a/src/counters.c
+++ b/src/counters.c
@@ -448,7 +448,7 @@ void StatsSyncCounters(ThreadVars *tv)
 
 void StatsSyncCountersIfSignalled(ThreadVars *tv)
 {
-    if (SC_ATOMIC_GET(tv->perf_public_ctx.sync_now) == true) {
+    if (SC_ATOMIC_GET(tv->perf_public_ctx.sync_now)) {
         StatsUpdateCounterArray(&tv->perf_private_ctx, &tv->perf_public_ctx);
     }
 }

--- a/src/datasets.c
+++ b/src/datasets.c
@@ -82,7 +82,7 @@ static Dataset *DatasetSearchByName(const char *name)
 {
     Dataset *set = sets;
     while (set) {
-        if (strcasecmp(name, set->name) == 0 && set->hidden == false) {
+        if (strcasecmp(name, set->name) == 0 && !set->hidden) {
             return set;
         }
         set = set->next;
@@ -488,7 +488,7 @@ void DatasetReload(void)
     SCMutexLock(&sets_lock);
     Dataset *set = sets;
     while (set) {
-        if (!DatasetIsStatic(set->save, set->load) || set->from_yaml == true) {
+        if (!DatasetIsStatic(set->save, set->load) || set->from_yaml) {
             SCLogDebug("Not a static set, skipping %s", set->name);
             set = set->next;
             continue;
@@ -508,7 +508,7 @@ void DatasetPostReloadCleanup(void)
     Dataset *prev = NULL;
     while (cur) {
         Dataset *next = cur->next;
-        if (cur->hidden == false) {
+        if (!cur->hidden) {
             prev = cur;
             cur = next;
             continue;

--- a/src/decode-vlan.c
+++ b/src/decode-vlan.c
@@ -87,8 +87,7 @@ int DecodeVLAN(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
 
     p->vlan_id[p->vlan_idx++] = (uint16_t)GET_VLAN_ID(vlan_hdr);
 
-    if (DecodeNetworkLayer(tv, dtv, proto, p,
-                pkt + VLAN_HEADER_LEN, len - VLAN_HEADER_LEN) == false) {
+    if (!DecodeNetworkLayer(tv, dtv, proto, p, pkt + VLAN_HEADER_LEN, len - VLAN_HEADER_LEN)) {
         ENGINE_SET_INVALID_EVENT(p, VLAN_UNKNOWN_TYPE);
         return TM_ECODE_FAILED;
     }

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -330,7 +330,7 @@ int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, const char *conten
     DetectContentData *cd = DetectContentParse(de_ctx->spm_global_thread_ctx, contentstr);
     if (cd == NULL)
         goto error;
-    if (s->init_data->negated == true) {
+    if (s->init_data->negated) {
         cd->flags |= DETECT_CONTENT_NEGATED;
     }
 
@@ -824,7 +824,7 @@ static bool TestLastContent(const Signature *s, uint16_t o, uint16_t d)
         FAIL_IF_NULL(s);                                                                           \
         SigPrepareStage1(de_ctx);                                                                  \
         bool res = TestLastContent(s, (o), (d));                                                   \
-        FAIL_IF(res == false);                                                                     \
+        FAIL_IF_NOT(res);                                                                          \
         DetectEngineCtxFree(de_ctx);                                                               \
     }
 

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -187,7 +187,7 @@ static void PrefilterMpmFrame(DetectEngineThreadCtx *det_ctx, const void *pectx,
         fsd.mpm_ctx = mpm_ctx;
 
         if (SetupStreamCallbackData(&fsd, ssn, stream, det_ctx, ctx->transforms, frames, frame,
-                    ctx->list_id, eof) == true) {
+                    ctx->list_id, eof)) {
             StreamReassembleForFrame(ssn, stream, FrameStreamDataPrefilterFunc, &fsd,
                     fsd.requested_stream_offset, eof);
         }
@@ -238,7 +238,7 @@ bool DetectRunFrameInspectRule(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, c
 
             // TODO there should be only one inspect engine for this frame, ever?
 
-            if (e->v1.Callback(det_ctx, e, s, p, frames, frame) == true) {
+            if (e->v1.Callback(det_ctx, e, s, p, frames, frame)) {
                 SCLogDebug("sid %u: e %p Callback returned true", s->id, e);
                 return true;
             }
@@ -591,8 +591,8 @@ int DetectEngineInspectFrameBufferGeneric(DetectEngineThreadCtx *det_ctx,
     fsd.inspect_result = DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     fsd.p = p;
 
-    if (SetupStreamCallbackData(
-                &fsd, ssn, stream, det_ctx, transforms, frames, frame, list_id, eof) == false) {
+    if (!SetupStreamCallbackData(
+                &fsd, ssn, stream, det_ctx, transforms, frames, frame, list_id, eof)) {
         return DETECT_ENGINE_INSPECT_SIG_NO_MATCH;
     }
     StreamReassembleForFrame(

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -379,7 +379,7 @@ static DetectGeoipData *DetectGeoipDataParse (DetectEngineCtx *de_ctx, const cha
     /* init geo engine, but not when running as unittests */
     if (!(RunmodeIsUnittests())) {
         /* Initialize the geolocation engine */
-        if (InitGeolocationEngine(geoipdata) == false)
+        if (!InitGeolocationEngine(geoipdata))
             goto error;
     }
 

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -314,7 +314,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
         case DETECT_IPPROTO_OP_LT:
             if (eq_set || lt_set) {
                 SCLogError("can't use a eq or lt "
-                           "ipproto along with a less than ipproto in the "
+                           "ipproto with a less than ipproto in the "
                            "same sig ");
                 goto error;
             }
@@ -334,7 +334,7 @@ static int DetectIPProtoSetup(DetectEngineCtx *de_ctx, Signature *s, const char 
                 if (temp_sm != NULL) {
                   DetectIPProtoData *data_temp = (DetectIPProtoData *)temp_sm->ctx;
                     if (data_temp->proto >= data->proto) {
-                        SCLogError("can't use a have "
+                        SCLogError("can't have "
                                    "both gt and lt ipprotos, with the lt being "
                                    "lower than gt value");
                         goto error;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1049,7 +1049,7 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
 
         /* handle 'silent' error case */
         if (setup_ret == -2) {
-            if (de_ctx->sm_types_silent_error[idx] == false) {
+            if (!de_ctx->sm_types_silent_error[idx]) {
                 de_ctx->sm_types_silent_error[idx] = true;
                 return -1;
             }
@@ -2037,10 +2037,10 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
         }
 
         has_frame |= bt->frame;
-        has_app |= (bt->frame == false && bt->packet == false);
+        has_app |= (!bt->frame && !bt->packet);
         has_pkt |= bt->packet;
 
-        if ((s->flags & SIG_FLAG_REQUIRE_PACKET) && bt->packet == false) {
+        if ((s->flags & SIG_FLAG_REQUIRE_PACKET) && !bt->packet) {
             SCLogError("Signature combines packet "
                        "specific matches (like dsize, flags, ttl) with stream / "
                        "state matching by matching on app layer proto (like using "

--- a/src/detect.c
+++ b/src/detect.c
@@ -595,7 +595,7 @@ static inline bool DetectRunInspectRuleHeader(const Packet *p, const Flow *f, co
 
         /* no flowvars? skip this sig */
         const bool fv = f->flowvar != NULL;
-        if (fv == false) {
+        if (!fv) {
             SCLogDebug("skipping sig as the flow has no flowvars and sig "
                     "has SIG_FLAG_REQUIRE_FLOWVAR flag set.");
             return false;
@@ -824,11 +824,11 @@ static inline void DetectRulePacketRules(
             }
         }
 
-        if (DetectRunInspectRuleHeader(p, pflow, s, sflags, s_proto_flags) == false) {
+        if (!DetectRunInspectRuleHeader(p, pflow, s, sflags, s_proto_flags)) {
             goto next;
         }
 
-        if (DetectEnginePktInspectionRun(tv, det_ctx, s, pflow, p, &alert_flags) == false) {
+        if (!DetectEnginePktInspectionRun(tv, det_ctx, s, pflow, p, &alert_flags)) {
             goto next;
         }
 
@@ -1147,11 +1147,11 @@ static bool DetectRunTxInspectRule(ThreadVars *tv,
     /* for a new inspection we inspect pkt header and packet matches */
     if (likely(stored_flags == NULL)) {
         TRACE_SID_TXS(s->id, tx, "first inspect, run packet matches");
-        if (DetectRunInspectRuleHeader(p, f, s, s->flags, s->proto.flags) == false) {
+        if (!DetectRunInspectRuleHeader(p, f, s, s->flags, s->proto.flags)) {
             TRACE_SID_TXS(s->id, tx, "DetectRunInspectRuleHeader() no match");
             return false;
         }
-        if (DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL) == false) {
+        if (!DetectEnginePktInspectionRun(tv, det_ctx, s, f, p, NULL)) {
             TRACE_SID_TXS(s->id, tx, "DetectEnginePktInspectionRun no match");
             return false;
         }
@@ -1787,9 +1787,9 @@ static void DetectRunFrames(ThreadVars *tv, DetectEngineCtx *de_ctx, DetectEngin
             /* call individual rule inspection */
             RULE_PROFILING_START(p);
             bool r = DetectRunInspectRuleHeader(p, f, s, s->flags, s->proto.flags);
-            if (r == true) {
+            if (r) {
                 r = DetectRunFrameInspectRule(tv, det_ctx, s, f, p, frames, frame);
-                if (r == true) {
+                if (r) {
                     /* match */
                     DetectRunPostMatch(tv, det_ctx, p, s);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -356,7 +356,7 @@ static void FlowManagerHashRowTimeout(FlowManagerTimeoutThread *td, Flow *f, SCT
          * be modified when we have both the flow and hash row lock */
 
         /* timeout logic goes here */
-        if (FlowManagerFlowTimeout(f, ts, next_ts, emergency) == false) {
+        if (!FlowManagerFlowTimeout(f, ts, next_ts, emergency)) {
             FLOWLOCK_UNLOCK(f);
             counters->flows_notimeout++;
 
@@ -898,7 +898,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
 
             FlowCountersUpdate(th_v, ftd, &counters);
 
-            if (emerg == true) {
+            if (emerg) {
                 SCLogDebug("flow_sparse_q.len = %" PRIu32 " prealloc: %" PRIu32
                            "flow_spare_q status: %" PRIu32 "%% flows at the queue",
                         spare_pool_len, flow_config.prealloc,
@@ -1162,7 +1162,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
                 if (SC_ATOMIC_GET(flow_flags) & FLOW_EMERGENCY) {
                     break;
                 }
-                if (SC_ATOMIC_GET(flow_recycle_q.non_empty) == true) {
+                if (SC_ATOMIC_GET(flow_recycle_q.non_empty)) {
                     break;
                 }
             }
@@ -1242,7 +1242,7 @@ void FlowDisableFlowRecyclerThread(void)
     do {
         FlowWakeupFlowRecyclerThread();
         usleep(10);
-    } while (FlowRecyclerReadyToShutdown() == false);
+    } while (!FlowRecyclerReadyToShutdown());
 
     SCMutexLock(&tv_root_lock);
     /* flow recycler thread(s) is/are a part of mgmt threads */

--- a/src/flow-queue.c
+++ b/src/flow-queue.c
@@ -105,13 +105,13 @@ void FlowQueuePrivateAppendPrivate(FlowQueuePrivate *dest, FlowQueuePrivate *src
 
 static inline void FlowQueueAtomicSetNonEmpty(FlowQueue *fq)
 {
-    if (SC_ATOMIC_GET(fq->non_empty) == false) {
+    if (!SC_ATOMIC_GET(fq->non_empty)) {
         SC_ATOMIC_SET(fq->non_empty, true);
     }
 }
 static inline void FlowQueueAtomicSetEmpty(FlowQueue *fq)
 {
-    if (SC_ATOMIC_GET(fq->non_empty) == true) {
+    if (SC_ATOMIC_GET(fq->non_empty)) {
         SC_ATOMIC_SET(fq->non_empty, false);
     }
 }

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -470,7 +470,7 @@ static inline void FlowWorkerProcessInjectedFlows(
     /* take injected flows and append to our work queue */
     FLOWWORKER_PROFILING_START(p, PROFILE_FLOWWORKER_FLOW_INJECTED);
     FlowQueuePrivate injected = { NULL, NULL, 0 };
-    if (SC_ATOMIC_GET(tv->flow_queue->non_empty) == true)
+    if (SC_ATOMIC_GET(tv->flow_queue->non_empty))
         injected = FlowQueueExtractPrivate(tv->flow_queue);
     if (injected.len > 0) {
         StatsAddUI64(tv, fw->cnt.flows_injected, (uint64_t)injected.len);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -542,7 +542,7 @@ static void *ParseAFPConfig(const char *iface)
         boolval = true;
         if (ConfGetChildValueBoolWithDefault(if_root, if_default, "use-percpu-hash", &boolval) ==
                 1) {
-            if (boolval == false) {
+            if (!boolval) {
                 SCLogConfig("%s: not using percpu hash", aconf->iface);
                 aconf->ebpf_t_config.cpus_count = 1;
             }

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2548,7 +2548,7 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, const void *initdata, void **data)
     if (ptv->flags & (AFP_BYPASS|AFP_XDPBYPASS)) {
         ptv->v4_map_fd = EBPFGetMapFDByName(ptv->iface, "flow_table_v4");
         if (ptv->v4_map_fd == -1) {
-            if (g_flowv4_ok == false) {
+            if (!g_flowv4_ok) {
                 SCLogError("Can't find eBPF map fd for '%s'", "flow_table_v4");
                 g_flowv4_ok = true;
             }

--- a/src/source-af-xdp.c
+++ b/src/source-af-xdp.c
@@ -284,7 +284,7 @@ TmEcode AFXDPQueueProtectionInit(void)
 
 static TmEcode AFXDPAssignQueueID(AFXDPThreadVars *ptv)
 {
-    if (ptv->xsk.queue.assigned == false) {
+    if (!ptv->xsk.queue.assigned) {
         ptv->xsk.queue.queue_num = SC_ATOMIC_GET(xsk_protect.queue_num);
         SC_ATOMIC_ADD(xsk_protect.queue_num, 1);
 

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -619,7 +619,7 @@ TmEcode VerdictIPFW(ThreadVars *tv, Packet *p, void *data)
         bool verdict = VerdictTunnelPacket(p);
 
         /* don't verdict if we are not ready */
-        if (verdict == true) {
+        if (verdict) {
             SCLogDebug("Setting verdict on tunnel");
             retval = IPFWSetVerdict(tv, ptv, p->root ? p->root : p);
         }

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -1217,7 +1217,7 @@ TmEcode VerdictNFQ(ThreadVars *tv, Packet *p, void *data)
         root_p->nfq_v.verdicted = do_verdict;
         SCSpinUnlock(lock);
         /* don't verdict if we are not ready */
-        if (do_verdict == true) {
+        if (do_verdict) {
             int ret = NFQSetVerdict(root_p, mark_value, mark_modified);
             if (ret != TM_ECODE_OK) {
                 return ret;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -334,7 +334,7 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, const void *initdata, void **d
             pv->should_loop = (should_loop == 1);
         }
 
-        if (pv->should_recurse == true && pv->should_loop == true) {
+        if (pv->should_recurse && pv->should_loop) {
             SCLogError("Error, --pcap-file-continuous and --pcap-file-recursive "
                        "cannot be used together.");
             closedir(directory);

--- a/src/stream-tcp-list.c
+++ b/src/stream-tcp-list.c
@@ -191,7 +191,7 @@ static int DoInsertSegment (TcpStream *stream, TcpSegment *seg, TcpSegment **dup
             stream->segs_right_edge = SEG_SEQ_RIGHT_EDGE(seg);
 
         /* insert succeeded, now check if we overlap with someone */
-        if (CheckOverlap(&stream->seg_tree, seg) == true) {
+        if (CheckOverlap(&stream->seg_tree, seg)) {
             SCLogDebug("seg %u has overlap in the tree", seg->seq);
             return 1;
         }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -2133,7 +2133,7 @@ static int StreamTcpPacketStateSynSent(
     }
 
     /* check for bad responses */
-    if (StateSynSentValidateTimestamp(ssn, p) == false) {
+    if (!StateSynSentValidateTimestamp(ssn, p)) {
         StreamTcpSetEvent(p, STREAM_PKT_INVALID_TIMESTAMP);
         return -1;
     }
@@ -5625,7 +5625,7 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
             goto skip;
         }
 
-        if (StreamTcpPacketIsDupAck(ssn, p) == true) {
+        if (StreamTcpPacketIsDupAck(ssn, p)) {
             STREAM_PKT_FLAG_SET(p, STREAM_PKT_FLAG_DUP_ACK);
             // TODO see if we can skip work on these
         }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2600,14 +2600,14 @@ static void PostConfLoadedSetupHostMode(void)
 static void SetupUserMode(SCInstance *suri)
 {
     /* apply 'user mode' config updates here */
-    if (suri->system == false) {
-        if (suri->set_logdir == false) {
+    if (!suri->system) {
+        if (!suri->set_logdir) {
             /* override log dir to current work dir" */
             if (ConfigSetLogDirectory((char *)".") != TM_ECODE_OK) {
                 FatalError("could not set USER mode logdir");
             }
         }
-        if (suri->set_datadir == false) {
+        if (!suri->set_datadir) {
             /* override data dir to current work dir" */
             if (ConfigSetDataDirectory((char *)".") != TM_ECODE_OK) {
                 FatalError("could not set USER mode datadir");

--- a/src/tm-queues.c
+++ b/src/tm-queues.c
@@ -116,7 +116,7 @@ void TmValidateQueueState(void)
         }
         SCMutexUnlock(&tmq->pq->mutex_q);
 
-        if (err == true)
+        if (err)
             goto error;
     }
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -464,7 +464,7 @@ static void *TmThreadsSlotVar(void *td)
 
         /* if we didn't get a packet see if we need to do some housekeeping */
         if (unlikely(p == NULL)) {
-            if (tv->flow_queue && SC_ATOMIC_GET(tv->flow_queue->non_empty) == true) {
+            if (tv->flow_queue && SC_ATOMIC_GET(tv->flow_queue->non_empty)) {
                 p = PacketGetFromQueueOrAlloc();
                 if (p != NULL) {
                     p->flags |= PKT_PSEUDO_STREAM_END;

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -243,9 +243,9 @@ static inline void TmThreadsCaptureHandleTimeout(ThreadVars *tv, Packet *p)
         return;
 
     } else {
-        if (TmThreadsHandleInjectedPackets(tv) == false) {
+        if (!TmThreadsHandleInjectedPackets(tv)) {
             /* see if we have to do some house keeping */
-            if (tv->flow_queue && SC_ATOMIC_GET(tv->flow_queue->non_empty) == true) {
+            if (tv->flow_queue && SC_ATOMIC_GET(tv->flow_queue->non_empty)) {
                 TmThreadsCaptureInjectPacket(tv, p); /* consumes 'p' */
                 return;
             }

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -398,7 +398,7 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
             (p->action & ACTION_DROP) ? "DROP" : "no drop");
 
     /* we're done with the tunnel root now as well */
-    if (proot == true) {
+    if (proot) {
         SCLogDebug("getting rid of root pkt... alloc'd %s", BOOL2STR(p->root->pool == NULL));
 
         PacketReleaseRefs(p->root);

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -380,7 +380,7 @@ int EBPFLoadFile(const char *iface, const char *path, const char * section,
         }
     }
 
-    if (found == false) {
+    if (!found) {
         SCLogError("No section '%s' in '%s' file. Will not be able to use the file", section, path);
         return -1;
     }

--- a/src/util-radix-tree-common.h
+++ b/src/util-radix-tree-common.h
@@ -377,7 +377,7 @@ static RADIX_NODE_TYPE *AddKey(RADIX_TREE_TYPE *tree, const RADIX_CONFIG_TYPE *c
      * being the incoming prefix is shorter than the differ bit of the current
      * node.  In case we fail in this aspect, we walk down to the tree, till we
      * arrive at a node that ends in a prefix */
-    while (node->bit < NETMASK_MAX || node->has_prefix == false) {
+    while (node->bit < NETMASK_MAX || !node->has_prefix) {
         /* if the bitlen isn't long enough to handle the bit test, we just walk
          * down along one of the paths, since either paths should end up with a
          * node that has a common prefix whose differ bit is greater than the
@@ -614,7 +614,7 @@ static void RemoveKey(RADIX_TREE_TYPE *tree, const RADIX_CONFIG_TYPE *config,
         }
     }
 
-    if (node->bit != NETMASK_MAX || node->has_prefix == false) {
+    if (node->bit != NETMASK_MAX || !node->has_prefix) {
         SCLogDebug("node %p bit %d != %d, or not has_prefix %s", node, node->bit, NETMASK_MAX,
                 node->has_prefix ? "true" : "false");
         return;
@@ -751,7 +751,7 @@ static inline RADIX_NODE_TYPE *FindKeyIPNetblock(const uint8_t *key_stream, RADI
                 return NULL;
         }
 
-        if (node->bit != NETMASK_MAX || node->has_prefix == false)
+        if (node->bit != NETMASK_MAX || !node->has_prefix)
             return NULL;
 
         if (SCMemcmp(node->prefix_stream, tmp_stream, sizeof(tmp_stream)) == 0) {
@@ -795,7 +795,7 @@ static RADIX_NODE_TYPE *FindKey(const RADIX_TREE_TYPE *tree, const uint8_t *key_
         }
     }
 
-    if (node->bit != NETMASK_MAX || node->has_prefix == false) {
+    if (node->bit != NETMASK_MAX || !node->has_prefix) {
         return NULL;
     }
 
@@ -937,7 +937,7 @@ static bool CompareTreesSub(
             return false;
 
         if (Callback != NULL) {
-            if (Callback(u1->user, u2->user) == false)
+            if (!Callback(u1->user, u2->user))
                 return false;
         }
 
@@ -946,10 +946,10 @@ static bool CompareTreesSub(
     }
 
     if (n1->left && n2->left)
-        if (CompareTreesSub(n1->left, n2->left, Callback) == false)
+        if (!CompareTreesSub(n1->left, n2->left, Callback))
             return false;
     if (n1->right && n2->right)
-        if (CompareTreesSub(n1->right, n2->right, Callback) == false)
+        if (!CompareTreesSub(n1->right, n2->right, Callback))
             return false;
 
     return true;

--- a/src/util-streaming-buffer.c
+++ b/src/util-streaming-buffer.c
@@ -159,7 +159,7 @@ static StreamingBufferRegion *FindFirstRegionForOffset(const StreamingBufferConf
 
     StreamingBufferRegion *p = NULL;
     for (; r != NULL; r = r->next) {
-        if (RegionsIntersect(cfg, r, offset, data_re) == true) {
+        if (RegionsIntersect(cfg, r, offset, data_re)) {
             *prev = p;
             return r;
         }

--- a/src/util-thash.c
+++ b/src/util-thash.c
@@ -417,7 +417,7 @@ int THashWalk(THashTableContext *ctx, THashFormatFunc FormatterFunc, THashOutput
             h = h->next;
         }
         HRLOCK_UNLOCK(hb);
-        if (err == true)
+        if (err)
             return -1;
     }
     return 0;


### PR DESCRIPTION
Continuation of #12602 

Misc. readability improvements.

Describe changes:
- Remove comparisons with bool values `true` and `false`
- Grammar improvement with ipproto keyword.

Updates:
- Rebase

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
