### PR TITLE
7.0.x: handful of clippy cleanups - v1

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -288,6 +288,7 @@ impl From<Err<der_parser::error::BerError>> for Asn1DecodeError {
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_unit)]
 mod tests {
     use super::*;
     use test_case::test_case;

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -209,6 +209,7 @@ pub(super) fn asn1_parse_rule(input: &str) -> IResult<&str, DetectAsn1Data> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_unit)]
 mod tests {
     use super::*;
     use test_case::test_case;

--- a/rust/src/bittorrent_dht/parser.rs
+++ b/rust/src/bittorrent_dht/parser.rs
@@ -444,6 +444,7 @@ pub fn parse_bittorrent_dht_packet(
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_unit)]
 mod tests {
     use super::*;
     use crate::core::Direction;

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -410,9 +410,7 @@ mod tests {
             0x1c, 0x7d, 0xcf, 0x11,
         ];
 
-        if let Ok((_rem, _header)) = parser::parse_dcerpc_udp_header(request) {
-            { assert!(false); }
-        }
+        assert!(parser::parse_dcerpc_udp_header(request).is_err());
     }
 
     #[test]
@@ -425,13 +423,9 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-            }
-            _ => { assert!(false); }
-        }
+        let (rem, header) = parser::parse_dcerpc_udp_header(request).unwrap();
+        assert_eq!(4, header.rpc_vers);
+        assert_eq!(80, request.len() - rem.len());
     }
 
     #[test]
@@ -444,14 +438,10 @@ mod tests {
             0x79, 0xbe, 0x01, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0xff, 0xff, 0xff, 0xff, 0x68, 0x00, 0x00, 0x00, 0x0a, 0x00,
         ];
-        match parser::parse_dcerpc_udp_header(request) {
-            Ok((rem, header)) => {
-                assert_eq!(4, header.rpc_vers);
-                assert_eq!(80, request.len() - rem.len());
-                assert_eq!(0, rem.len());
-            }
-            _ => { assert!(false); }
-        }
+        let (rem, header) = parser::parse_dcerpc_udp_header(request).unwrap();
+        assert_eq!(4, header.rpc_vers);
+        assert_eq!(80, request.len() - rem.len());
+        assert_eq!(0, rem.len());
     }
 
     #[test]

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -517,14 +517,8 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(args) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath(args).unwrap();
+        assert_eq!(val, bmd);
     }
 
     #[test]
@@ -623,52 +617,26 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string dec",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
         bmd.base = BASE_DEFAULT;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
 
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR | DETECT_BYTEMATH_FLAG_STRING;
         bmd.base = ByteMathBase::BaseHex;
-        match parse_bytemath(
-            "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string hex").unwrap();
+        assert_eq!(val, bmd);
 
         bmd.base = ByteMathBase::BaseOct;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, string oct",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
     }
 
     #[test]
@@ -774,40 +742,25 @@ mod tests {
         };
 
         bmd.bitmask_val = 0x12345678;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0x12345678",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask ffff1234",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.bitmask_val = 0xffff1234;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, bitmask 0Xffff1234",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
     }
     #[test]
     fn test_parser_endian_valid() {
@@ -824,49 +777,29 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian big",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = ByteMathEndian::LittleEndian;
-        match parse_bytemath(
+        let (_, val) = parse_bytemath(
             "bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, endian little",
-        ) {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        ).unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = ByteMathEndian::EndianDCE;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo, dce").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.endian = DETECT_BYTEMATH_ENDIAN_DEFAULT;
         bmd.flags = DETECT_BYTEMATH_FLAG_RVALUE_VAR;
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -920,61 +853,31 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper +, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.oper = ByteMathOperator::Subtraction;
-        match parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper -, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.oper = ByteMathOperator::Multiplication;
-        match parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::Division;
-        match parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper /, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::RightShift;
-        match parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper >>, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.oper = ByteMathOperator::LeftShift;
-        match parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 3933, oper <<, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -1013,33 +916,18 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 4294967295      , result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.rvalue = 1;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 1, result foo").unwrap();
+        assert_eq!(val, bmd);
+
         bmd.rvalue = 0;
-        match parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 47303, oper *, rvalue 0, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]
@@ -1064,24 +952,14 @@ mod tests {
             ..Default::default()
         };
 
-        match parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset -65535, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
 
         bmd.offset = 65535;
-        match parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo") {
-            Ok((_, val)) => {
-                assert_eq!(val, bmd);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = parse_bytemath("bytes 4, offset 65535, oper *, rvalue myrvalue, result foo").unwrap();
+        assert_eq!(val, bmd);
+
     }
 
     #[test]

--- a/rust/src/detect/uint.rs
+++ b/rust/src/detect/uint.rs
@@ -409,24 +409,12 @@ mod tests {
 
     #[test]
     fn test_parse_uint_unit() {
-        match detect_parse_uint::<u64>(" 2kb") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 2048);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
-        if let Ok((_, _val)) = detect_parse_uint::<u8>("2kb") {
-            assert!(false);
-        }
-        match detect_parse_uint::<u32>("3MB") {
-            Ok((_, val)) => {
-                assert_eq!(val.arg1, 3 * 1024 * 1024);
-            }
-            Err(_) => {
-                assert!(false);
-            }
-        }
+        let (_, val) = detect_parse_uint::<u64>(" 2kb").unwrap();
+        assert_eq!(val.arg1, 2048);
+
+        assert!(detect_parse_uint::<u8>("2kb").is_err());
+
+        let (_, val) = detect_parse_uint::<u32>("3MB").unwrap();
+        assert_eq!(val.arg1, 3 * 1024 * 1024);
     }
 }

--- a/rust/src/dhcp/parser.rs
+++ b/rust/src/dhcp/parser.rs
@@ -242,42 +242,36 @@ mod tests {
         let pcap = include_bytes!("discover.pcap");
         let payload = &pcap[24 + 16 + 42..];
 
-        match dhcp_parse(payload) {
-            Ok((_rem, message)) => {
-                let header = message.header;
-                assert_eq!(header.opcode, BOOTP_REQUEST);
-                assert_eq!(header.htype, 1);
-                assert_eq!(header.hlen, 6);
-                assert_eq!(header.hops, 0);
-                assert_eq!(header.txid, 0x00003d1d);
-                assert_eq!(header.seconds, 0);
-                assert_eq!(header.flags, 0);
-                assert_eq!(header.clientip, &[0, 0, 0, 0]);
-                assert_eq!(header.yourip, &[0, 0, 0, 0]);
-                assert_eq!(header.serverip, &[0, 0, 0, 0]);
-                assert_eq!(header.giaddr, &[0, 0, 0, 0]);
-                assert_eq!(
-                    &header.clienthw[..(header.hlen as usize)],
-                    &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
-                );
-                assert!(header.servername.iter().all(|&x| x == 0));
-                assert!(header.bootfilename.iter().all(|&x| x == 0));
-                assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
+        let (_rem, message) = dhcp_parse(payload).unwrap();
+        let header = message.header;
+        assert_eq!(header.opcode, BOOTP_REQUEST);
+        assert_eq!(header.htype, 1);
+        assert_eq!(header.hlen, 6);
+        assert_eq!(header.hops, 0);
+        assert_eq!(header.txid, 0x00003d1d);
+        assert_eq!(header.seconds, 0);
+        assert_eq!(header.flags, 0);
+        assert_eq!(header.clientip, &[0, 0, 0, 0]);
+        assert_eq!(header.yourip, &[0, 0, 0, 0]);
+        assert_eq!(header.serverip, &[0, 0, 0, 0]);
+        assert_eq!(header.giaddr, &[0, 0, 0, 0]);
+        assert_eq!(
+            &header.clienthw[..(header.hlen as usize)],
+            &[0x00, 0x0b, 0x82, 0x01, 0xfc, 0x42]
+        );
+        assert!(header.servername.iter().all(|&x| x == 0));
+        assert!(header.bootfilename.iter().all(|&x| x == 0));
+        assert_eq!(header.magic, &[0x63, 0x82, 0x53, 0x63]);
 
-                assert!(!message.malformed_options);
-                assert!(!message.truncated_options);
+        assert!(!message.malformed_options);
+        assert!(!message.truncated_options);
 
-                assert_eq!(message.options.len(), 5);
-                assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
-                assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
-                assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
-                assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
-                assert_eq!(message.options[4].code, DHCP_OPT_END);
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        assert_eq!(message.options.len(), 5);
+        assert_eq!(message.options[0].code, DHCP_OPT_TYPE);
+        assert_eq!(message.options[1].code, DHCP_OPT_CLIENT_ID);
+        assert_eq!(message.options[2].code, DHCP_OPT_REQUESTED_IP);
+        assert_eq!(message.options[3].code, DHCP_OPT_PARAMETER_LIST);
+        assert_eq!(message.options[4].code, DHCP_OPT_END);
     }
 
     #[test]

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -995,11 +995,10 @@ mod tests {
     fn test_dns_parse_name_truncated() {
         // Generate a non-compressed hostname over our maximum of 1024.
         let mut buf: Vec<u8> = vec![];
-        for _ in 0..17 {
+
+        for i in 1..18 {
             buf.push(0b0011_1111);
-            for _ in 0..63 {
-                buf.push(b'a');
-            }
+            buf.resize(i * 64, b'a');
         }
 
         let mut flags = DNSNameFlags::default();
@@ -1026,20 +1025,21 @@ mod tests {
 
     #[test]
     fn test_dns_parse_name_truncated_max_segments_with_pointer() {
-        let mut buf: Vec<u8> = vec![];
+        #[rustfmt::skip]
+        let buf: Vec<u8> = vec![
+            // "a" at the beginning of the buffer.
+            0b0000_0001,
+            b'a',
 
-        // "a" at the beginning of the buffer.
-        buf.push(0b0000_0001);
-        buf.push(b'a');
+            // Followed by a pointer back to the beginning.
+            0b1100_0000,
+            0b0000_0000,
 
-        // Followed by a pointer back to the beginning.
-        buf.push(0b1100_0000);
-        buf.push(0b0000_0000);
-
-        // The start of the name, which is pointer to the beginning of
-        // the buffer.
-        buf.push(0b1100_0000);
-        buf.push(0b000_0000);
+            // The start of the name, which is pointer to the beginning of
+            // the buffer.
+            0b1100_0000,
+            0b000_0000
+        ];
 
         let mut flags = DNSNameFlags::default();
         let (_rem, name) = dns_parse_name(&buf[4..], &buf, &mut flags).unwrap();
@@ -1049,9 +1049,7 @@ mod tests {
 
     #[test]
     fn test_dns_parse_name_self_reference() {
-        let mut buf = vec![];
-        buf.push(0b1100_0000);
-        buf.push(0b0000_0000);
+        let buf = vec![0b1100_0000, 0b0000_0000];
         let mut flags = DNSNameFlags::default();
         assert!(dns_parse_name(&buf, &buf, &mut flags).is_err());
     }

--- a/rust/src/dns/parser.rs
+++ b/rust/src/dns/parser.rs
@@ -617,36 +617,28 @@ mod tests {
             0x00, 0x00, 0x00, /* ... */
         ];
 
-        let res = dns_parse_request(pkt);
-        match res {
-            Ok((rem, (request, _flags))) => {
-                // For now we have some remainder data as there is an
-                // additional record type we don't parse yet.
-                assert!(!rem.is_empty());
+        let (rem, (request, _flags)) = dns_parse_request(pkt).unwrap();
+        // For now we have some remainder data as there is an
+        // additional record type we don't parse yet.
+        assert!(!rem.is_empty());
 
-                assert_eq!(
-                    request.header,
-                    DNSHeader {
-                        tx_id: 0x8d32,
-                        flags: 0x0120,
-                        questions: 1,
-                        answer_rr: 0,
-                        authority_rr: 0,
-                        additional_rr: 1,
-                    }
-                );
-
-                assert_eq!(request.queries.len(), 1);
-
-                let query = &request.queries[0];
-                assert_eq!(query.name.value, "www.suricata-ids.org".as_bytes().to_vec());
-                assert_eq!(query.rrtype, 1);
-                assert_eq!(query.rrclass, 1);
+        assert_eq!(
+            request.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x0120,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 0,
+                additional_rr: 1,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(request.queries.len(), 1);
+        let query = &request.queries[0];
+        assert_eq!(query.name.value, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(query.rrtype, 1);
+        assert_eq!(query.rrclass, 1);
     }
 
     /// Parse a DNS response.
@@ -675,73 +667,66 @@ mod tests {
             0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, /* ....N. */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, (response, _flags))) => {
-                // The response should be full parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, (response, _flags)) = dns_parse_response(pkt).unwrap();
+        // The response should be full parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x8d32,
-                        flags: 0x81a0,
-                        questions: 1,
-                        answer_rr: 3,
-                        authority_rr: 0,
-                        additional_rr: 0,
-                    }
-                );
-
-                assert_eq!(response.answers.len(), 3);
-
-                let answer1 = &response.answers[0];
-                assert_eq!(answer1.name.value, "www.suricata-ids.org".as_bytes().to_vec());
-                assert_eq!(answer1.rrtype, 5);
-                assert_eq!(answer1.rrclass, 1);
-                assert_eq!(answer1.ttl, 3544);
-                assert_eq!(
-                    answer1.data,
-                    DNSRData::CNAME(DNSName {
-                        value: "suricata-ids.org".as_bytes().to_vec(),
-                        flags: Default::default(),
-                    })
-                );
-
-                let answer2 = &response.answers[1];
-                assert_eq!(
-                    answer2,
-                    &DNSAnswerEntry {
-                        name: DNSName {
-                            value: "suricata-ids.org".as_bytes().to_vec(),
-                            flags: Default::default(),
-                        },
-                        rrtype: 1,
-                        rrclass: 1,
-                        ttl: 244,
-                        data: DNSRData::A([192, 0, 78, 24].to_vec()),
-                    }
-                );
-
-                let answer3 = &response.answers[2];
-                assert_eq!(
-                    answer3,
-                    &DNSAnswerEntry {
-                        name: DNSName {
-                            value: "suricata-ids.org".as_bytes().to_vec(),
-                            flags: Default::default(),
-                        },
-                        rrtype: 1,
-                        rrclass: 1,
-                        ttl: 244,
-                        data: DNSRData::A([192, 0, 78, 25].to_vec()),
-                    }
-                )
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x8d32,
+                flags: 0x81a0,
+                questions: 1,
+                answer_rr: 3,
+                authority_rr: 0,
+                additional_rr: 0,
             }
-            _ => {
-                assert!(false);
+        );
+
+        assert_eq!(response.answers.len(), 3);
+
+        let answer1 = &response.answers[0];
+        assert_eq!(answer1.name.value, "www.suricata-ids.org".as_bytes().to_vec());
+        assert_eq!(answer1.rrtype, 5);
+        assert_eq!(answer1.rrclass, 1);
+        assert_eq!(answer1.ttl, 3544);
+        assert_eq!(
+            answer1.data,
+            DNSRData::CNAME(DNSName {
+                value: "suricata-ids.org".as_bytes().to_vec(),
+                flags: Default::default(),
+            })
+        );
+
+        let answer2 = &response.answers[1];
+        assert_eq!(
+            answer2,
+            &DNSAnswerEntry {
+                name: DNSName {
+                    value: "suricata-ids.org".as_bytes().to_vec(),
+                    flags: Default::default(),
+                },
+                rrtype: 1,
+                rrclass: 1,
+                ttl: 244,
+                data: DNSRData::A([192, 0, 78, 24].to_vec()),
             }
-        }
+        );
+
+        let answer3 = &response.answers[2];
+        assert_eq!(
+            answer3,
+            &DNSAnswerEntry {
+                name: DNSName {
+                    value: "suricata-ids.org".as_bytes().to_vec(),
+                    flags: Default::default(),
+                },
+                rrtype: 1,
+                rrclass: 1,
+                ttl: 244,
+                data: DNSRData::A([192, 0, 78, 25].to_vec()),
+            }
+        )
     }
 
     #[test]
@@ -767,55 +752,48 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, /* .... */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, (response, _flags))) => {
-                // For now we have some remainder data as there is an
-                // additional record type we don't parse yet.
-                assert!(!rem.is_empty());
+        let (rem, (response, _flags)) = dns_parse_response(pkt).unwrap();
+        // For now we have some remainder data as there is an
+        // additional record type we don't parse yet.
+        assert!(!rem.is_empty());
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x8295,
-                        flags: 0x8183,
-                        questions: 1,
-                        answer_rr: 0,
-                        authority_rr: 1,
-                        additional_rr: 1,
-                    }
-                );
-
-                assert_eq!(response.authorities.len(), 1);
-
-                let authority = &response.authorities[0];
-                assert_eq!(authority.name.value, "oisf.net".as_bytes().to_vec());
-                assert_eq!(authority.rrtype, 6);
-                assert_eq!(authority.rrclass, 1);
-                assert_eq!(authority.ttl, 899);
-                assert_eq!(
-                    authority.data,
-                    DNSRData::SOA(DNSRDataSOA {
-                        mname: DNSName {
-                            value: "ns-110.awsdns-13.com".as_bytes().to_vec(),
-                            flags: DNSNameFlags::default()
-                        },
-                        rname: DNSName {
-                            value: "awsdns-hostmaster.amazon.com".as_bytes().to_vec(),
-                            flags: DNSNameFlags::default()
-                        },
-                        serial: 1,
-                        refresh: 7200,
-                        retry: 900,
-                        expire: 1209600,
-                        minimum: 86400,
-                    })
-                );
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x8295,
+                flags: 0x8183,
+                questions: 1,
+                answer_rr: 0,
+                authority_rr: 1,
+                additional_rr: 1,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(response.authorities.len(), 1);
+
+        let authority = &response.authorities[0];
+        assert_eq!(authority.name.value, "oisf.net".as_bytes().to_vec());
+        assert_eq!(authority.rrtype, 6);
+        assert_eq!(authority.rrclass, 1);
+        assert_eq!(authority.ttl, 899);
+        assert_eq!(
+            authority.data,
+            DNSRData::SOA(DNSRDataSOA {
+                mname: DNSName {
+                    value: "ns-110.awsdns-13.com".as_bytes().to_vec(),
+                    flags: DNSNameFlags::default()
+                },
+                rname: DNSName {
+                    value: "awsdns-hostmaster.amazon.com".as_bytes().to_vec(),
+                    flags: DNSNameFlags::default()
+                },
+                serial: 1,
+                refresh: 7200,
+                retry: 900,
+                expire: 1209600,
+                minimum: 86400,
+            })
+        );
     }
 
     #[test]
@@ -834,49 +812,42 @@ mod tests {
             0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, (response, _flags))) => {
-                // The response should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, (response, _flags)) = dns_parse_response(pkt).unwrap();
+        // The response should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(
-                    response.header,
-                    DNSHeader {
-                        tx_id: 0x12b0,
-                        flags: 0x8400,
-                        questions: 1,
-                        answer_rr: 1,
-                        authority_rr: 0,
-                        additional_rr: 0,
-                    }
-                );
-
-                assert_eq!(response.queries.len(), 1);
-                let query = &response.queries[0];
-                assert_eq!(query.name.value, "vaaaakardli.pirate.sea".as_bytes().to_vec());
-                assert_eq!(query.rrtype, DNS_RECORD_TYPE_NULL);
-                assert_eq!(query.rrclass, 1);
-
-                assert_eq!(response.answers.len(), 1);
-
-                let answer = &response.answers[0];
-                assert_eq!(answer.name.value, "vaaaakardli.pirate.sea".as_bytes().to_vec());
-                assert_eq!(answer.rrtype, DNS_RECORD_TYPE_NULL);
-                assert_eq!(answer.rrclass, 1);
-                assert_eq!(answer.ttl, 0);
-                assert_eq!(
-                    answer.data,
-                    DNSRData::NULL(vec![
-                        0x56, 0x41, 0x43, 0x4b, /* VACK */
-                        0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
-                    ])
-                );
+        assert_eq!(
+            response.header,
+            DNSHeader {
+                tx_id: 0x12b0,
+                flags: 0x8400,
+                questions: 1,
+                answer_rr: 1,
+                authority_rr: 0,
+                additional_rr: 0,
             }
-            _ => {
-                assert!(false);
-            }
-        }
+        );
+
+        assert_eq!(response.queries.len(), 1);
+        let query = &response.queries[0];
+        assert_eq!(query.name.value, "vaaaakardli.pirate.sea".as_bytes().to_vec());
+        assert_eq!(query.rrtype, DNS_RECORD_TYPE_NULL);
+        assert_eq!(query.rrclass, 1);
+
+        assert_eq!(response.answers.len(), 1);
+
+        let answer = &response.answers[0];
+        assert_eq!(answer.name.value, "vaaaakardli.pirate.sea".as_bytes().to_vec());
+        assert_eq!(answer.rrtype, DNS_RECORD_TYPE_NULL);
+        assert_eq!(answer.rrclass, 1);
+        assert_eq!(answer.ttl, 0);
+        assert_eq!(
+            answer.data,
+            DNSRData::NULL(vec![
+                0x56, 0x41, 0x43, 0x4b, /* VACK */
+                0x44, 0x03, 0xc5, 0xe9, 0x01, /* D.... */
+            ])
+        );
     }
 
     #[test]
@@ -890,25 +861,18 @@ mod tests {
             0x9a, 0xbc, 0xde, 0xf6, 0x78, 0x90,
         ];
 
-        let res = dns_parse_rdata_sshfp(data);
-        match res {
-            Ok((rem, rdata)) => {
-                // The data should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, rdata) = dns_parse_rdata_sshfp(data).unwrap();
+        // The data should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                match rdata {
-                    DNSRData::SSHFP(sshfp) => {
-                        assert_eq!(sshfp.algo, 2);
-                        assert_eq!(sshfp.fp_type, 1);
-                        assert_eq!(sshfp.fingerprint, &data[2..]);
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
+        match rdata {
+            DNSRData::SSHFP(sshfp) => {
+                assert_eq!(sshfp.algo, 2);
+                assert_eq!(sshfp.fp_type, 1);
+                assert_eq!(sshfp.fingerprint, &data[2..]);
             }
             _ => {
-                assert!(false);
+                panic!("Expected DNSRData::SSHFP");
             }
         }
     }
@@ -946,47 +910,40 @@ mod tests {
             0x67, 0x6c, 0x65, 0x03, 0x63, 0x6f, 0x6d, 0x00,
         ];
 
-        let res = dns_parse_response(pkt);
-        match res {
-            Ok((rem, (response, _flags))) => {
-                // The data should be fully parsed.
-                assert_eq!(rem.len(), 0);
+        let (rem, (response, _flags)) = dns_parse_response(pkt).unwrap();
+        // The data should be fully parsed.
+        assert_eq!(rem.len(), 0);
 
-                assert_eq!(response.answers.len(), 2);
+        assert_eq!(response.answers.len(), 2);
 
-                let answer1 = &response.answers[0];
-                match &answer1.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 20);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target.value,
-                            "sip-anycast-2.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
-                let answer2 = &response.answers[1];
-                match &answer2.data {
-                    DNSRData::SRV(srv) => {
-                        assert_eq!(srv.priority, 10);
-                        assert_eq!(srv.weight, 1);
-                        assert_eq!(srv.port, 5060);
-                        assert_eq!(
-                            srv.target.value,
-                            "sip-anycast-1.voice.google.com".as_bytes().to_vec()
-                        );
-                    }
-                    _ => {
-                        assert!(false);
-                    }
-                }
+        let answer1 = &response.answers[0];
+        match &answer1.data {
+            DNSRData::SRV(srv) => {
+                assert_eq!(srv.priority, 20);
+                assert_eq!(srv.weight, 1);
+                assert_eq!(srv.port, 5060);
+                assert_eq!(
+                    srv.target.value,
+                    "sip-anycast-2.voice.google.com".as_bytes().to_vec()
+                );
             }
             _ => {
-                assert!(false);
+                panic!("Expected DNSRData::SRV");
+            }
+        }
+        let answer2 = &response.answers[1];
+        match &answer2.data {
+            DNSRData::SRV(srv) => {
+                assert_eq!(srv.priority, 10);
+                assert_eq!(srv.weight, 1);
+                assert_eq!(srv.port, 5060);
+                assert_eq!(
+                    srv.target.value,
+                    "sip-anycast-1.voice.google.com".as_bytes().to_vec()
+                );
+            }
+            _ => {
+                panic!("Expected DNSRData::SRV");
             }
         }
     }

--- a/rust/src/mqtt/parser.rs
+++ b/rust/src/mqtt/parser.rs
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn test_parse_publish() {
         let buf = [
-            0x00, 06, /* Topic Length: 6 */
+            0x00, 0x06, /* Topic Length: 6 */
             0x74, 0x6f, 0x70, 0x69, 0x63, 0x58, /* Topic: topicX */
             0x00, 0x01, /* Message Identifier: 1 */
             0x00, /* Properties 6 */
@@ -914,7 +914,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v3() {
         let buf = [
-            0x00, 01, /* Message Identifier: 1 */
+            0x00, 0x01, /* Message Identifier: 1 */
             0x74, 0x6f, 0x70, 0x69, 0x63, 0x58, 0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34,
             0x33, 0x45, 0x38, 0x30,
         ];
@@ -939,7 +939,7 @@ mod tests {
     #[test]
     fn test_parse_msgidonly_v5() {
         let buf = [
-            0x00, 01,   /* Message Identifier: 1 */
+            0x00, 0x01,   /* Message Identifier: 1 */
             0x00, /* Reason Code: 0 */
             0x00, /* Properties */
             0x00, 0x61, 0x75, 0x74, 0x6f, 0x2d, 0x42, 0x34, 0x33, 0x45, 0x38, 0x30,

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -113,13 +113,9 @@ mod tests {
             0x00, 0x00, 0xb2, 0x5a, 0x00, 0x00, 0x00, 0x29
         ];
 
-        let result = parse_nfs2_handle(buf).unwrap();
-        match result {
-            (r, res) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(res.value, buf);
-            }
-        }
+        let (r, res) = parse_nfs2_handle(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(res.value, buf);
     }
 
     #[test]
@@ -136,14 +132,10 @@ mod tests {
         let (_, handle) = parse_nfs2_handle(buf).unwrap();
         assert_eq!(handle.value, &buf[..32]);
 
-        let result = parse_nfs2_request_lookup(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, handle);
-                assert_eq!(request.name_vec, b"am".to_vec());
-            }
-        }
+        let (r, request) = parse_nfs2_request_lookup(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, handle);
+        assert_eq!(request.name_vec, b"am".to_vec());
     }
 
     #[test]
@@ -162,14 +154,10 @@ mod tests {
         let (_, handle) = parse_nfs2_handle(buf).unwrap();
         assert_eq!(handle.value, &buf[..32]);
 
-        let result = parse_nfs2_request_read(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 4);
-                assert_eq!(request.handle, handle);
-                assert_eq!(request.offset, 0);
-            }
-        }
+        let (r, request) = parse_nfs2_request_read(buf).unwrap();
+        assert_eq!(r.len(), 4);
+        assert_eq!(request.handle, handle);
+        assert_eq!(request.offset, 0);
     }
 
     #[test]
@@ -192,19 +180,15 @@ mod tests {
             0x00, /*_data_padding*/
         ];
 
-        let result = parse_nfs2_reply_read(buf).unwrap();
-        match result {
-            (r, response) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(response.status, 0);
-                assert_eq!(response.attr_follows, 1);
-                assert_eq!(response.attr_blob.len(), 68);
-                assert_eq!(response.count, response.data_len);
-                assert!(!response.eof);
-                assert_eq!(response.data_len, 11);
-                assert_eq!(response.data, &buf[76..87]);
-            }
-        }
+        let (r, response) = parse_nfs2_reply_read(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(response.status, 0);
+        assert_eq!(response.attr_follows, 1);
+        assert_eq!(response.attr_blob.len(), 68);
+        assert_eq!(response.count, response.data_len);
+        assert!(!response.eof);
+        assert_eq!(response.data_len, 11);
+        assert_eq!(response.data, &buf[76..87]);
     }
 
     #[test]
@@ -223,13 +207,9 @@ mod tests {
             0x00, 0x08, 0x16, 0x50
         ];
 
-        let result = parse_nfs2_attribs(buf).unwrap();
-        match result {
-            (r, res) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(res.atype, 1);
-                assert_eq!(res.asize, 0);
-            }
-        }
+        let (r, res) = parse_nfs2_attribs(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(res.atype, 1);
+        assert_eq!(res.asize, 0);
     }
 }

--- a/rust/src/nfs/nfs3_records.rs
+++ b/rust/src/nfs/nfs3_records.rs
@@ -480,17 +480,13 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_create(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_len, 1);
-                assert_eq!(request.create_mode, 0);
-                assert_eq!(request.verifier.len(), 44);
-                assert_eq!(request.name_vec, br#"h"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_create(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_len, 1);
+        assert_eq!(request.create_mode, 0);
+        assert_eq!(request.verifier.len(), 44);
+        assert_eq!(request.name_vec, br#"h"#.to_vec());
     }
 
     #[test]
@@ -511,15 +507,11 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_remove(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_len, 1);
-                assert_eq!(request.name_vec, br#"h"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_remove(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_len, 1);
+        assert_eq!(request.name_vec, br#"h"#.to_vec());
     }
 
     #[test]
@@ -540,14 +532,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_rmdir(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"d"#.to_vec());
-            }
-        }
+        let (r, request) = parse_nfs3_request_rmdir(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"d"#.to_vec());
     }
 
     #[test]
@@ -573,13 +561,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_mkdir(buf).unwrap();
-        match result {
-            (_r, request) => {
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"d"#.to_vec());
-            }
-        }
+        let (_r, request) = parse_nfs3_request_mkdir(buf).unwrap();
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"d"#.to_vec());
     }
 
     #[test]
@@ -611,18 +595,14 @@ mod tests {
         let (_, expected_from_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
         let (_, expected_to_handle) = parse_nfs3_handle(&buf[44..80]).unwrap();
 
-        let result = parse_nfs3_request_rename(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
+        let (r, request) = parse_nfs3_request_rename(buf).unwrap();
+        assert_eq!(r.len(), 0);
 
-                assert_eq!(request.from_handle, expected_from_handle);
-                assert_eq!(request.from_name_vec, br#"a"#.to_vec());
+        assert_eq!(request.from_handle, expected_from_handle);
+        assert_eq!(request.from_name_vec, br#"a"#.to_vec());
 
-                assert_eq!(request.to_handle, expected_to_handle);
-                assert_eq!(request.to_name_vec, br#"am"#.to_vec());
-            }
-        }
+        assert_eq!(request.to_handle, expected_to_handle);
+        assert_eq!(request.to_name_vec, br#"am"#.to_vec());
     }
 
     #[test]
@@ -638,13 +618,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(buf).unwrap();
 
-        let result = parse_nfs3_request_getattr(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-            }
-        }
+        let (r, request) = parse_nfs3_request_getattr(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
     }
 
     #[test]
@@ -662,14 +638,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_access(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.check_access, 12);
-            }
-        }
+        let (r, request) = parse_nfs3_request_access(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.check_access, 12);
     }
 
     #[test]
@@ -689,13 +661,9 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_commit(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-            }
-        }
+        let (r, request) = parse_nfs3_request_commit(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
     }
 
     #[test]
@@ -714,14 +682,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_read(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.offset, 0);
-            }
-        }
+        let (r, request) = parse_nfs3_request_read(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.offset, 0);
     }
 
     #[test]
@@ -743,14 +707,10 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_lookup(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.name_vec, br#"bln"#);
-            }
-        }
+        let (r, request) = parse_nfs3_request_lookup(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.name_vec, br#"bln"#);
     }
 
     #[test]
@@ -831,14 +791,10 @@ mod tests {
         let (_, entry0) = parse_nfs3_response_readdirplus_entry(entry0_buf).unwrap();
         let (_, entry1) = parse_nfs3_response_readdirplus_entry(entry1_buf).unwrap();
 
-        let response = many0_nfs3_response_readdirplus_entries(data_buf).unwrap();
-        match response {
-            (r, entries) => {
-                assert_eq!(r.len(), 4);
-                assert_eq!(entries[0], Nfs3ResponseReaddirplusEntry { entry: Some(entry0) });
-                assert_eq!(entries[1], Nfs3ResponseReaddirplusEntry { entry: Some(entry1) });
-            }
-        }
+        let (r, entries) = many0_nfs3_response_readdirplus_entries(data_buf).unwrap();
+        assert_eq!(r.len(), 4);
+        assert_eq!(entries[0], Nfs3ResponseReaddirplusEntry { entry: Some(entry0) });
+        assert_eq!(entries[1], Nfs3ResponseReaddirplusEntry { entry: Some(entry1) });
     }
 
     #[test]
@@ -904,18 +860,14 @@ mod tests {
         assert_eq!(expected_handle.len, 36);
         assert_eq!(expected_handle.value, &buf[4..40]);
 
-        let result = parse_nfs3_request_readdirplus(buf).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.cookie, 0);
-                assert_eq!(request.verifier, "\0\0\0\0\0\0\0\0".as_bytes());
-                assert_eq!(request.verifier.len(), 8);
-                assert_eq!(request.dircount, 512);
-                assert_eq!(request.maxcount, 4096);
-            }
-        }
+        let (r, request) = parse_nfs3_request_readdirplus(buf).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.cookie, 0);
+        assert_eq!(request.verifier, "\0\0\0\0\0\0\0\0".as_bytes());
+        assert_eq!(request.verifier.len(), 8);
+        assert_eq!(request.dircount, 512);
+        assert_eq!(request.maxcount, 4096);
     }
 
     #[test]
@@ -942,18 +894,14 @@ mod tests {
 
         let (_, expected_handle) = parse_nfs3_handle(&buf[..36]).unwrap();
 
-        let result = parse_nfs3_request_write(buf, true).unwrap();
-        match result {
-            (r, request) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(request.handle, expected_handle);
-                assert_eq!(request.offset, 0);
-                assert_eq!(request.count, 17);
-                assert_eq!(request.stable, 1);
-                assert_eq!(request.file_len, 17);
-                assert_eq!(request.file_data, "hallo\nthe b file\n".as_bytes());
-            }
-        }
+        let (r, request) = parse_nfs3_request_write(buf, true).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(request.handle, expected_handle);
+        assert_eq!(request.offset, 0);
+        assert_eq!(request.count, 17);
+        assert_eq!(request.stable, 1);
+        assert_eq!(request.file_len, 17);
+        assert_eq!(request.file_data, "hallo\nthe b file\n".as_bytes());
     }
 
     #[test]
@@ -983,18 +931,14 @@ mod tests {
             0x00, /*_data_padding*/
         ];
 
-        let result = parse_nfs3_reply_read(buf, true).unwrap();
-        match result {
-            (r, reply) => {
-                assert_eq!(r.len(), 0);
-                assert_eq!(reply.status, 0);
-                assert_eq!(reply.attr_follows, 1);
-                assert_eq!(reply.attr_blob.len(), 84);
-                assert_eq!(reply.count, 11);
-                assert!(reply.eof);
-                assert_eq!(reply.data_len, 11);
-                assert_eq!(reply.data, "the b file\n".as_bytes());
-            }
-        }
+        let (r, reply) = parse_nfs3_reply_read(buf, true).unwrap();
+        assert_eq!(r.len(), 0);
+        assert_eq!(reply.status, 0);
+        assert_eq!(reply.attr_follows, 1);
+        assert_eq!(reply.attr_blob.len(), 84);
+        assert_eq!(reply.count, 11);
+        assert!(reply.eof);
+        assert_eq!(reply.data_len, 11);
+        assert_eq!(reply.data, "the b file\n".as_bytes());
     }
 }

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -1094,6 +1094,7 @@ pub fn pgsql_parse_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage> {
 }
 
 #[cfg(test)]
+#[allow(clippy::vec_init_then_push)]
 mod tests {
 
     use super::*;

--- a/rust/src/quic/cyu.rs
+++ b/rust/src/quic/cyu.rs
@@ -78,6 +78,7 @@ impl Cyu {
 }
 
 #[cfg(test)]
+#[allow(clippy::unused_unit)]
 mod tests {
     use super::*;
     use crate::quic::frames::{Frame, Stream, StreamTag};

--- a/rust/src/rdp/parser.rs
+++ b/rust/src/rdp/parser.rs
@@ -1103,6 +1103,7 @@ mod tests_negotiate_49350 {
 }
 
 #[cfg(test)]
+#[allow(clippy::vec_init_then_push)]
 mod tests_core_49350 {
     use crate::rdp::parser::*;
 

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -281,17 +281,11 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_request(buf) {
-            Ok((_, req)) => {
-                assert_eq!(req.method, "REGISTER");
-                assert_eq!(req.path, "sip:sip.cybercity.dk");
-                assert_eq!(req.version, "SIP/2.0");
-                assert_eq!(req.headers["Content-Length"], "0");
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        let (_, req) = sip_parse_request(buf).unwrap();
+        assert_eq!(req.method, "REGISTER");
+        assert_eq!(req.path, "sip:sip.cybercity.dk");
+        assert_eq!(req.version, "SIP/2.0");
+        assert_eq!(req.headers["Content-Length"], "0");
     }
 
     #[test]
@@ -317,16 +311,10 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        match sip_parse_response(buf) {
-            Ok((_, resp)) => {
-                assert_eq!(resp.version, "SIP/2.0");
-                assert_eq!(resp.code, "401");
-                assert_eq!(resp.reason, "Unauthorized");
-            }
-            _ => {
-                assert!(false);
-            }
-        }
+        let (_, resp) = sip_parse_response(buf).unwrap();
+        assert_eq!(resp.version, "SIP/2.0");
+        assert_eq!(resp.code, "401");
+        assert_eq!(resp.reason, "Unauthorized");
     }
 
     #[test]

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -225,14 +225,8 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&READ_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true);
-            }
-        }
+        let txp = parse_tftp_request(&READ_REQUEST[..]).unwrap();
+        assert_eq!(tx, txp);
     }
 
     #[test]
@@ -245,14 +239,8 @@ mod test {
             tx_data: AppLayerTxData::new(),
         };
 
-        match parse_tftp_request(&WRITE_REQUEST[..]) {
-            Some(txp) => {
-                assert_eq!(tx, txp);
-            }
-            None => {
-                assert!(true, "fadfasd");
-            }
-        }
+        let txp = parse_tftp_request(&WRITE_REQUEST[..]).unwrap();
+        assert_eq!(tx, txp);
     }
 
     // Invalid request: filename not terminated


### PR DESCRIPTION
- **mqtt: always use 0x notation for hex in tests**
- **rust: allow vec_init_then_push in tests**
- **rust: fix assertions_on_constants for assert!(false)**
- **rust: fix single_binding**
- **rust: fix assertions_on_constants for assert!(true)**
- **dns: fix clippy lint warnings**
- **rust: allow clippy::unused_unit for tests that use the test macro**
- **dns: refactor tests to avoid assert!(false)**
