### PR TITLE
dcerpc: add iface to dcerpc request output

### DIFF
--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -20,6 +20,24 @@ use crate::dcerpc::dcerpc::*;
 use crate::dcerpc::dcerpc_udp::*;
 use crate::jsonbuilder::{JsonBuilder, JsonError};
 
+fn log_bind_interfaces(jsb: &mut JsonBuilder, state: &DCERPCState) -> Result<(), JsonError> {
+    if let Some(bind) = &state.bind {
+        jsb.open_array("interfaces")?;
+        for uuid in &bind.uuid_list {
+            jsb.start_object()?;
+            let ifstr = Uuid::from_slice(uuid.uuid.as_slice());
+            let ifstr = ifstr.map(|uuid| uuid.to_hyphenated().to_string()).unwrap();
+            jsb.set_string("uuid", &ifstr)?;
+            let vstr = format!("{}.{}", uuid.version, uuid.versionminor);
+            jsb.set_string("version", &vstr)?;
+            jsb.set_uint("ack_result", uuid.result as u64)?;
+            jsb.close()?;
+        }
+        jsb.close()?;
+    }
+    return Ok(());
+}
+
 fn log_dcerpc_header_tcp(
     jsb: &mut JsonBuilder, state: &DCERPCState, tx: &DCERPCTransaction,
 ) -> Result<(), JsonError> {
@@ -32,21 +50,9 @@ fn log_dcerpc_header_tcp(
                 jsb.set_uint("frag_cnt", tx.frag_cnt_ts as u64)?;
                 jsb.set_uint("stub_data_size", tx.stub_data_buffer_ts.len() as u64)?;
                 jsb.close()?;
+                log_bind_interfaces(jsb, state)?;
             }
-            DCERPC_TYPE_BIND => if let Some(bind) = &state.bind {
-                jsb.open_array("interfaces")?;
-                for uuid in &bind.uuid_list {
-                    jsb.start_object()?;
-                    let ifstr = Uuid::from_slice(uuid.uuid.as_slice());
-                    let ifstr = ifstr.map(|uuid| uuid.to_hyphenated().to_string()).unwrap();
-                    jsb.set_string("uuid", &ifstr)?;
-                    let vstr = format!("{}.{}", uuid.version, uuid.versionminor);
-                    jsb.set_string("version", &vstr)?;
-                    jsb.set_uint("ack_result", uuid.result as u64)?;
-                    jsb.close()?;
-                }
-                jsb.close()?;
-            },
+            DCERPC_TYPE_BIND => log_bind_interfaces(jsb, state)?,
             _ => {}
         }
     } else {


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2304

This was asked for in the Discord support.
SMB already seems to do this and this was trivial to add.