### PR TITLE
detect: add keywords for LDAPDN - v5

### DIFF
--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -52,7 +52,7 @@ Syntax::
 
 ldap.request.operation uses :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
-This keyword maps to the eve field  ``ldap.request.operation``
+This keyword maps to the EVE field  ``ldap.request.operation``
 
 Examples
 ^^^^^^^^
@@ -79,7 +79,7 @@ Syntax::
 
 ldap.responses.operation uses :ref:`unsigned 8-bit integer <rules-integer-keywords>`.
 
-This keyword maps to the eve field ``ldap.responses[].operation``
+This keyword maps to the EVE field ``ldap.responses[].operation``
 
 An LDAP request operation can receive multiple responses. By default, the ldap.responses.operation
 keyword matches all indices, but it is possible to specify a particular index for matching
@@ -147,7 +147,7 @@ It can be matched exactly, or compared using the ``op`` setting::
 
 ldap.responses.count uses :ref:`unsigned 32-bit integer <rules-integer-keywords>`.
 
-This keyword maps to the eve field ``len(ldap.responses[])``
+This keyword maps to the EVE field ``len(ldap.responses[])``
 
 Examples
 ^^^^^^^^

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -163,3 +163,45 @@ Example of a signature that would alert if a packet has more than 2 LDAP respons
 .. container:: example-rule
 
   alert ldap any any -> any any (msg:"Packet has more than 2 LDAP responses"; :example-rule-emphasis:`ldap.responses.count:>2;` sid:1;)
+
+ldap.request.dn
+---------------
+
+Matches on LDAP distinguished names from request operations.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ ldap.request.dn; content:dc=example,dc=com;
+
+``ldap.request.dn`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE fields:
+``ldap.request.bind_request.name``
+``ldap.request.add_request.entry``
+``ldap.request.search_request.base_object``
+``ldap.request.modify_request.object``
+``ldap.request.del_request.dn``
+``ldap.request.mod_dn_request.entry``
+``ldap.request.compare_request.entry``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet has the LDAP distinguished name ``uid=jdoe,ou=People,dc=example,dc=com``:
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test LDAPDN"; :example-rule-emphasis:`ldap.request.dn; content:"uid=jdoe,ou=People,dc=example,dc=com";` sid:1;)
+
+It is possible to use the keyword ``ldap.request.operation`` in the same rule to
+specify the operation to match.
+
+Here is an example of a signature that would alert if a packet has an LDAP
+search request operation and contains the LDAP distinguished name
+``dc=example,dc=com``.
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test LDAPDN and operation"; :example-rule-emphasis:`ldap.request.operation:search_request; ldap.request.dn; content:"dc=example,dc=com";` sid:1;)

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -205,3 +205,49 @@ search request operation and contains the LDAP distinguished name
 .. container:: example-rule
 
   alert ldap any any -> any any (msg:"Test LDAPDN and operation"; :example-rule-emphasis:`ldap.request.operation:search_request; ldap.request.dn; content:"dc=example,dc=com";` sid:1;)
+
+ldap.responses.dn
+-----------------
+
+Matches on LDAP distinguished names from response operations.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ ldap.responses.dn; content:dc=example,dc=com;
+
+``ldap.responses.dn`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+``ldap.responses.dn`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+This keyword maps to the EVE fields:
+``ldap.responses[].search_result_entry.base_object``
+``ldap.responses[].bind_response.matched_dn``
+``ldap.responses[].search_result_done.matched_dn``
+``ldap.responses[].modify_response.matched_dn``
+``ldap.responses[].add_response.matched_dn``
+``ldap.responses[].del_response.matched_dn``
+``ldap.responses[].mod_dn_response.matched_dn``
+``ldap.responses[].compare_response.matched_dn``
+``ldap.responses[].extended_response.matched_dn``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet has the LDAP distinguished name ``dc=example,dc=com``:
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test LDAPDN"; :example-rule-emphasis:`ldap.responses.dn; content:"dc=example,dc=com";` sid:1;)
+
+It is possible to use the keyword ``ldap.responses.operation`` in the same rule to
+specify the operation to match.
+
+Here is an example of a signature that would alert if a packet has an LDAP
+search result entry operation at index 1 on the responses array,
+and contains the LDAP distinguished name ``dc=example,dc=com``.
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test LDAPDN and operation"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,1; ldap.responses.dn; content:"dc=example,dc=com";` sid:1;)

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -61,11 +61,11 @@ Example of a signatures that would alert if the packet has an LDAP bind request 
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP bind request"; :example-rule-emphasis:`ldap.request.operation:0;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP bind request"; :example-rule-emphasis:`ldap.request.operation:0;` sid:1;)
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP bind request"; :example-rule-emphasis:`ldap.request.operation:bind_request;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP bind request"; :example-rule-emphasis:`ldap.request.operation:bind_request;` sid:1;)
 
 ldap.responses.operation
 ------------------------
@@ -104,23 +104,23 @@ Example of a signatures that would alert if the packet has an LDAP bind response
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP bind response"; :example-rule-emphasis:`ldap.responses.operation:1;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP bind response"; :example-rule-emphasis:`ldap.responses.operation:1;` sid:1;)
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP bind response"; :example-rule-emphasis:`ldap.responses.operation:bind_response;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP bind response"; :example-rule-emphasis:`ldap.responses.operation:bind_response;` sid:1;)
 
 Example of a signature that would alert if the packet has an LDAP search_result_done response operation at index 1:
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_done,1;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_done,1;` sid:1;)
 
 Example of a signature that would alert if all the responses are of type search_result_entry:
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,all;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,all;` sid:1;)
 
 The keyword ldap.responses.operation supports back to front indexing with negative numbers,
 this means that -1 will represent the last index, -2 the second to last index, and so on.
@@ -128,7 +128,7 @@ This is an example of a signature that would alert if a search_result_entry resp
 
 .. container:: example-rule
 
-  alert tcp any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,-1;` sid:1;)
+  alert ldap any any -> any any (msg:"Test LDAP search response"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,-1;` sid:1;)
 
 ldap.responses.count
 --------------------
@@ -156,10 +156,10 @@ Example of a signature that would alert if a packet has 0 LDAP responses:
 
 .. container:: example-rule
 
-  alert ip any any -> any any (msg:"Packet has 0 LDAP responses"; :example-rule-emphasis:`ldap.responses.count:0;` sid:1;)
+  alert ldap any any -> any any (msg:"Packet has 0 LDAP responses"; :example-rule-emphasis:`ldap.responses.count:0;` sid:1;)
 
 Example of a signature that would alert if a packet has more than 2 LDAP responses:
 
 .. container:: example-rule
 
-  alert ip any any -> any any (msg:"Packet has more than 2 LDAP responses"; :example-rule-emphasis:`ldap.responses.count:>2;` sid:1;)
+  alert ldap any any -> any any (msg:"Packet has more than 2 LDAP responses"; :example-rule-emphasis:`ldap.responses.count:>2;` sid:1;)

--- a/rust/src/applayertemplate/detect.rs
+++ b/rust/src/applayertemplate/detect.rs
@@ -76,7 +76,7 @@ unsafe extern "C" fn template_buffer_get(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectTemplateRegister() {
+pub unsafe extern "C" fn SCDetectTemplateRegister() {
     /* TEMPLATE_START_REMOVE */
     if conf_get_node("app-layer.protocols.template").is_none() {
         return;

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -1330,7 +1330,7 @@ unsafe extern "C" fn service_name_get_data(
     );
 }
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectEnipRegister() {
+pub unsafe extern "C" fn SCDetectEnipRegister() {
     let kw = SCSigTableElmt {
         name: b"cip_service\0".as_ptr() as *const libc::c_char,
         desc: b"match on CIP Service, and optionnally class and attribute\0".as_ptr()

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -21,10 +21,11 @@ use crate::detect::uint::{
     rs_detect_u8_free, rs_detect_u8_match, DetectUintData,
 };
 use crate::detect::{
-    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
-    SCSigTableElmt, SigMatchAppendSMToList,
+    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
+    DetectHelperGetData, DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt,
+    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
 };
-use crate::ldap::types::{LdapMessage, ProtocolOpCode};
+use crate::ldap::types::{LdapMessage, ProtocolOp, ProtocolOpCode};
 
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
@@ -53,6 +54,7 @@ static mut G_LDAP_RESPONSES_OPERATION_KW_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_OPERATION_BUFFER_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_COUNT_KW_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_COUNT_BUFFER_ID: c_int = 0;
+static mut G_LDAP_REQUEST_DN_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn ldap_parse_protocol_req_op(
     ustr: *const std::os::raw::c_char,
@@ -263,6 +265,59 @@ unsafe extern "C" fn ldap_detect_responses_count_free(_de: *mut c_void, ctx: *mu
     rs_detect_u32_free(ctx);
 }
 
+unsafe extern "C" fn ldap_detect_request_dn_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_LDAP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_LDAP_REQUEST_DN_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ldap_detect_request_dn_get_data(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        ldap_tx_get_request_dn,
+    );
+}
+
+unsafe extern "C" fn ldap_tx_get_request_dn(
+    tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, LdapTransaction);
+
+    *buffer = std::ptr::null();
+    *buffer_len = 0;
+
+    if let Some(request) = &tx.request {
+        let str_buffer: &str = match &request.protocol_op {
+            ProtocolOp::BindRequest(req) => req.name.0.as_str(),
+            ProtocolOp::AddRequest(req) => req.entry.0.as_str(),
+            ProtocolOp::SearchRequest(req) => req.base_object.0.as_str(),
+            ProtocolOp::ModifyRequest(req) => req.object.0.as_str(),
+            ProtocolOp::DelRequest(req) => req.0.as_str(),
+            ProtocolOp::ModDnRequest(req) => req.entry.0.as_str(),
+            ProtocolOp::CompareRequest(req) => req.entry.0.as_str(),
+            _ => return false,
+        };
+        *buffer = str_buffer.as_ptr();
+        *buffer_len = str_buffer.len() as u32;
+        return true;
+    }
+    return false;
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectLdapRegister() {
     let kw = SCSigTableElmt {
@@ -313,5 +368,23 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
+    );
+    let kw = SCSigTableElmt {
+        name: b"ldap.request.dn\0".as_ptr() as *const libc::c_char,
+        desc: b"match request LDAPDN\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ldap-keywords.html#ldap.request.dn\0".as_ptr() as *const libc::c_char,
+        Setup: ldap_detect_request_dn_setup,
+        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _g_ldap_request_dn_kw_id = DetectHelperKeywordRegister(&kw);
+    G_LDAP_REQUEST_DN_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"ldap.request.dn\0".as_ptr() as *const libc::c_char,
+        b"LDAP REQUEST DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
+        ALPROTO_LDAP,
+        false, //to client
+        true,  //to server
+        ldap_detect_request_dn_get_data,
     );
 }

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -264,7 +264,7 @@ unsafe extern "C" fn ldap_detect_responses_count_free(_de: *mut c_void, ctx: *mu
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectLdapRegister() {
+pub unsafe extern "C" fn SCDetectLdapRegister() {
     let kw = SCSigTableElmt {
         name: b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
         desc: b"match LDAP request operation\0".as_ptr() as *const libc::c_char,

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -1099,7 +1099,7 @@ unsafe extern "C" fn mqtt_conn_clientid_get_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectMqttRegister() {
+pub unsafe extern "C" fn SCDetectMqttRegister() {
     let keyword_name = b"mqtt.unsubscribe.topic\0".as_ptr() as *const libc::c_char;
     let kw = SCSigTableElmt {
         name: keyword_name,

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -187,7 +187,7 @@ unsafe extern "C" fn rfb_sec_result_free(_de: *mut c_void, ctx: *mut c_void) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectRfbRegister() {
+pub unsafe extern "C" fn SCDetectRfbRegister() {
     let kw = SCSigTableElmt {
         name: b"rfb.name\0".as_ptr() as *const libc::c_char,
         desc: b"sticky buffer to match on the RFB desktop name\0".as_ptr() as *const libc::c_char,

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -578,7 +578,7 @@ unsafe extern "C" fn sip_content_length_hdr_get_data(
     return false;
 }
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectSipRegister() {
+pub unsafe extern "C" fn SCDetectSipRegister() {
     let kw = SCSigTableElmt {
         name: b"sip.protocol\0".as_ptr() as *const libc::c_char,
         desc: b"sticky buffer to match on the SIP protocol\0".as_ptr() as *const libc::c_char,

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn snmp_detect_community_get_data(
     );
 }
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectSNMPRegister() {
+pub unsafe extern "C" fn SCDetectSNMPRegister() {
     let kw = SCSigTableElmt {
         name: b"snmp.version\0".as_ptr() as *const libc::c_char,
         desc: b"match SNMP version\0".as_ptr() as *const libc::c_char,

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn websocket_detect_payload_get_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ScDetectWebsocketRegister() {
+pub unsafe extern "C" fn SCDetectWebsocketRegister() {
     let kw = SCSigTableElmt {
         name: b"websocket.opcode\0".as_ptr() as *const libc::c_char,
         desc: b"match WebSocket opcode\0".as_ptr() as *const libc::c_char,

--- a/scripts/setup-app-layer.py
+++ b/scripts/setup-app-layer.py
@@ -255,10 +255,10 @@ def detect_patch_detect_engine_register_c(protoname):
     output = io.StringIO()
     with open(filename) as infile:
         for line in infile:
-            if line.find("ScDetect%sRegister" % protoname) > -1:
+            if line.find("SCDetect%sRegister" % protoname) > -1:
                 # patch already applied
                 return
-            if line.find("ScDetectTemplateRegister") > -1:
+            if line.find("SCDetectTemplateRegister") > -1:
                 new = line.replace("Template", "%s" % protoname)
                 output.write(new)
             output.write(line)

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -734,15 +734,15 @@ void SigTableSetup(void)
     DetectVlanLayersRegister();
 
     SCDetectSMTPRegister();
-    ScDetectSNMPRegister();
+    SCDetectSNMPRegister();
     SCDetectDHCPRegister();
-    ScDetectWebsocketRegister();
-    ScDetectEnipRegister();
-    ScDetectMqttRegister();
-    ScDetectRfbRegister();
-    ScDetectSipRegister();
-    ScDetectTemplateRegister();
-    ScDetectLdapRegister();
+    SCDetectWebsocketRegister();
+    SCDetectEnipRegister();
+    SCDetectMqttRegister();
+    SCDetectRfbRegister();
+    SCDetectSipRegister();
+    SCDetectTemplateRegister();
+    SCDetectLdapRegister();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {
         PreregisteredCallbacks[i]();


### PR DESCRIPTION
Ticket: [#7471](https://redmine.openinfosecfoundation.org/issues/7471)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues7471

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7471

### Description:
- Implement keywords ``ldap.request.dn`` and ``ldap.responses.dn``

### Changes:
- Change ``nit:`` commits to ``doc:``
- Remove unwanted files

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2303
Previous PR: https://github.com/OISF/suricata/pull/12620