### PR TITLE
rust: fix clippy 1.85 precedence warnings

### DIFF
--- a/rust/src/ja4.rs
+++ b/rust/src/ja4.rs
@@ -143,7 +143,7 @@ impl JA4 {
             // If the first ALPN value is only a single character, then that character is treated as both the first and last character.
             if alpn.len() == 2 {
                 // GREASE values are 2 bytes, so this could be one -- check
-                let v: u16 = (alpn[0] as u16) << 8 | alpn[alpn.len() - 1] as u16;
+                let v: u16 = ((alpn[0] as u16) << 8) | alpn[alpn.len() - 1] as u16;
                 if JA4::is_grease(v) {
                     return;
                 }
@@ -288,12 +288,12 @@ mod tests {
     fn test_is_grease() {
         let mut alpn = "foobar".as_bytes();
         let mut len = alpn.len();
-        let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
+        let v: u16 = ((alpn[0] as u16) << 8) | alpn[len - 1] as u16;
         assert!(!JA4::is_grease(v));
 
         alpn = &[0x0a, 0x0a];
         len = alpn.len();
-        let v: u16 = (alpn[0] as u16) << 8 | alpn[len - 1] as u16;
+        let v: u16 = ((alpn[0] as u16) << 8) | alpn[len - 1] as u16;
         assert!(JA4::is_grease(v));
     }
 

--- a/rust/src/jsonbuilder.rs
+++ b/rust/src/jsonbuilder.rs
@@ -778,7 +778,7 @@ impl JsonBuilder {
                 offset += 1;
                 buf[offset] = b'0';
                 offset += 1;
-                buf[offset] = HEX[(x >> 4 & 0xf) as usize];
+                buf[offset] = HEX[((x >> 4) & 0xf) as usize];
                 offset += 1;
                 buf[offset] = HEX[(x & 0xf) as usize];
                 offset += 1;

--- a/rust/src/rdp/util.rs
+++ b/rust/src/rdp/util.rs
@@ -70,7 +70,7 @@ pub fn parse_per_length_determinant(input: &[u8]) -> IResult<&[u8], u32, RdpErro
                 Ok((&input[1..], length))
             }
             _ => {
-                let bit6 = input[0] >> 6 & 0x1;
+                let bit6 = (input[0] >> 6) & 0x1;
                 match bit6 {
                     0b0 => {
                         // byte starts with 0b10.  Length stored in the remaining 6 bits and the next byte

--- a/rust/src/smb/smb1_records.rs
+++ b/rust/src/smb/smb1_records.rs
@@ -520,7 +520,7 @@ pub fn parse_smb_read_andx_request_record(i: &[u8]) -> IResult<&[u8], SmbRequest
     let record = SmbRequestReadAndXRecord {
         fid,
         size: (((max_count_high as u64) << 16)|max_count_low as u64),
-        offset: high_offset.map(|ho| (ho as u64) << 32 | offset as u64).unwrap_or(0),
+        offset: high_offset.map(|ho| ((ho as u64) << 32) | offset as u64).unwrap_or(0),
     };
     Ok((i, record))
 }
@@ -858,7 +858,7 @@ pub fn parse_smb_record(i: &[u8]) -> IResult<&[u8], SmbRecord> {
         user_id,
         multiplex_id,
 
-        process_id: (process_id_high as u32) << 16 | process_id as u32,
+        process_id: ((process_id_high as u32) << 16) | process_id as u32,
         //ssn_id: (((process_id as u32)<< 16)|(user_id as u32)),
         ssn_id: user_id as u32,
         data,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just clippy fixes

Describe changes:
- fix new clippy warning about precedence
