### PR TITLE
Decouple stream bypass from TLS encrypted bypass v9.2

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1827,21 +1827,23 @@ Encrypted traffic
 
 There is no decryption of encrypted traffic, so once the handshake is complete
 continued tracking of the session is of limited use. The ``encryption-handling``
-option controls the behavior after the handshake.
+option in ``app-layer.protocols.tls`` and ``app-layer.protocols.ssh`` controls
+the behavior after the handshake.
 
-If ``encryption-handling`` is set to ``default`` (or if the option is not set),
-Suricata will continue to track the SSL/TLS session. Inspection will be limited,
-as raw ``content`` inspection will still be disabled. There is no point in doing
-pattern matching on traffic known to be encrypted. Inspection for (encrypted)
-Heartbleed and other protocol anomalies still happens.
+If ``encryption-handling`` in TLS protocol is set to ``default``
+(or if the option is not set), Suricata will continue to track the SSL/TLS
+session. Inspection will be limited, as raw ``content`` inspection will still
+be disabled. There is no point in doing pattern matching on traffic known to
+be encrypted. Inspection for (encrypted) Heartbleed and other protocol
+anomalies still happens.
 
-When ``encryption-handling`` is set to ``bypass``, all processing of this session is
-stopped. No further parsing and inspection happens. If ``stream.bypass`` is enabled
-this will lead to the flow being bypassed, either inside Suricata or by the
-capture method if it supports it and is configured for it.
+When ``encryption-handling`` is set to ``bypass``, all processing of this
+session is stopped. No further parsing and inspection happens. This will also
+lead to the flow being bypassed, either inside Suricata or by the capture method
+if it supports it and is configured for it.
 
-Finally, if ``encryption-handling`` is set to ``full``, Suricata will process the
-flow as normal, without inspection limitations or bypass.
+Finally, if ``encryption-handling`` is set to ``full``, Suricata will process
+the flow as normal, without inspection limitations or bypass.
 
 The option has replaced the ``no-reassemble`` option. If ``no-reassemble`` is
 present, and ``encryption-handling`` is not, ``false`` is interpreted as
@@ -2870,7 +2872,7 @@ The Teredo decoder can be disabled. It is enabled by default.
         ports: $TEREDO_PORTS # syntax: '[3544, 1234]'
 
 Using this default configuration, Teredo detection will run on UDP port
-3544. If the `ports` parameter is missing, or set to `any`, all ports will be
+1.    If the `ports` parameter is missing, or set to `any`, all ports will be
 inspected for possible presence of Teredo.
 
 Recursion Level

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -2171,12 +2171,12 @@ are typically provided through the command line, are contained in the node
 parameters. There are two ways to specify arguments: lengthy and short.
 Dashes are omitted when describing the arguments. This setup node can be
 used to set up the memory configuration, accessible NICs, and other EAL-related
-parameters, among other things. The node `dpdk.eal-params` also supports 
-multiple arguments of the same type. This can be useful for EAL arguments 
-such as `--vdev`, `--allow`, or `--block`. Values for these EAL arguments 
-are specified as a comma-separated list. 
-An example of such usage can be found in the example above where the `allow` 
-argument only makes `0000:3b:00.0` and `0000:3b:00.1` accessible to Suricata. 
+parameters, among other things. The node `dpdk.eal-params` also supports
+multiple arguments of the same type. This can be useful for EAL arguments
+such as `--vdev`, `--allow`, or `--block`. Values for these EAL arguments
+are specified as a comma-separated list.
+An example of such usage can be found in the example above where the `allow`
+argument only makes `0000:3b:00.0` and `0000:3b:00.1` accessible to Suricata.
 arguments with list node. such as --vdev, --allow, --block eal options.
 The definition of lcore affinity as an EAL
 parameter is a standard practice. However, lcore parameters like `-l`, `-c`,

--- a/doc/userguide/performance/ignoring-traffic.rst
+++ b/doc/userguide/performance/ignoring-traffic.rst
@@ -73,10 +73,14 @@ Example::
 encrypted traffic
 -----------------
 
-The TLS app layer parser has the ability to stop processing encrypted traffic
-after the initial handshake. By setting the `app-layer.protocols.tls.encryption-handling`
-option to `bypass` the rest of this flow is ignored. If flow bypass is enabled,
-the bypass is done in the kernel or in hardware.
+The TLS and SSH app layer parsers have the ability to stop processing
+encrypted traffic after the initial handshake. By setting the
+`app-layer.protocols.tls.encryption-handling` and
+`app-layer.protocols.ssh.encryption-handling` options to `bypass` Suricata
+bypasses flows once the handshake is completed and encrypted traffic is
+detected. The rest of these flow is ignored.
+The bypass is done in the kernel or in hardware, similar to how flow bypass
+is done.
 
 .. _bypass:
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -95,6 +95,17 @@ Major changes
   will need to be set before external modules can be loaded. See the
   new default configuration file or :ref:`lua-output-yaml` for more
   details.
+- Encrypted traffic bypass has been decoupled from stream.bypass setting.
+  This means that encrypted traffic can be bypassed while tracking/fully
+  inspecting other traffic as well.
+- Encrypted SSH traffic bypass is now independently controlled through
+  `app-layer.protocols.ssh.encryption-handling` setting. The setting can either
+  be `bypass`, `default` or `full`. 
+  To retain the previous behavior of encrypted traffic bypass
+  combined with stream depth bypass, set
+  `app-layer.protocols.ssh.encryption-handling` to `bypass` (while also
+  setting `app-layer.protocols.tls.encryption-handling` to `bypass` and
+  `stream.bypass` to `true`).
 
 Removals
 ~~~~~~~~

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -24,13 +24,34 @@ use crate::frames::Frame;
 use nom7::Err;
 use suricata_sys::sys::AppProto;
 use std::ffi::CString;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering, AtomicU8};
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum SshEncryptionHandling {
+    SSH_HANDLE_ENCRYPTION_DEFAULT = 0, // Disable raw content, continue tracking
+    SSH_HANDLE_ENCRYPTION_BYPASS = 1,  // Skip processing of flow, bypass if possible
+    SSH_HANDLE_ENCRYPTION_FULL = 2,    // Handle fully like any other protocol
+}
 
 static mut ALPROTO_SSH: AppProto = ALPROTO_UNKNOWN;
 static HASSH_ENABLED: AtomicBool = AtomicBool::new(false);
 
+static ENCRYPTION_BYPASS_ENABLED: AtomicU8 = AtomicU8::new(SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_DEFAULT as u8);
+
 fn hassh_is_enabled() -> bool {
     HASSH_ENABLED.load(Ordering::Relaxed)
+}
+
+fn encryption_bypass_mode() -> SshEncryptionHandling {
+    let mode_val = ENCRYPTION_BYPASS_ENABLED.load(Ordering::Relaxed);
+    match mode_val {
+        0 => SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_DEFAULT,
+        1 => SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_BYPASS,
+        2 => SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_FULL,
+        _ => SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_DEFAULT,
+    }
 }
 
 #[derive(AppLayerFrameType)]
@@ -203,13 +224,24 @@ impl SSHState {
                         parser::MessageCode::NewKeys => {
                             hdr.flags = SSHConnectionState::SshStateFinished;
                             if ohdr.flags >= SSHConnectionState::SshStateFinished {
-                                unsafe {
-                                    AppLayerParserStateSetFlag(
-                                        pstate,
-                                        APP_LAYER_PARSER_NO_INSPECTION
+                                let mut flags = 0;
+
+                                match encryption_bypass_mode() {
+                                    SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_BYPASS => {
+                                        flags |= APP_LAYER_PARSER_NO_INSPECTION
                                             | APP_LAYER_PARSER_NO_REASSEMBLY
-                                            | APP_LAYER_PARSER_BYPASS_READY,
-                                    );
+                                            | APP_LAYER_PARSER_BYPASS_READY;
+                                    }
+                                    SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_DEFAULT => {
+                                        flags |= APP_LAYER_PARSER_NO_INSPECTION;
+                                    }
+                                    _ => {}
+                                }
+
+                                if flags != 0 {
+                                    unsafe {
+                                        AppLayerParserStateSetFlag(pstate, flags);
+                                    }
                                 }
                             }
                         }
@@ -551,6 +583,16 @@ pub extern "C" fn SCSshEnableHassh() {
 #[no_mangle]
 pub extern "C" fn SCSshHasshIsEnabled() -> bool {
     hassh_is_enabled()
+}
+
+#[no_mangle]
+pub extern "C" fn SCSshEnableBypass(mode: SshEncryptionHandling) {
+    ENCRYPTION_BYPASS_ENABLED.store(mode as u8, Ordering::Relaxed);
+}
+
+#[no_mangle]
+pub extern "C" fn SCSshEncryptionBypassMode() -> SshEncryptionHandling {
+    encryption_bypass_mode()
 }
 
 #[no_mangle]

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -55,6 +55,8 @@
 
 /* HASSH fingerprints are disabled by default */
 #define SSH_CONFIG_DEFAULT_HASSH false
+/* Bypassing the encrypted part of the connections */
+#define SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS SSH_HANDLE_ENCRYPTION_DEFAULT
 
 static int SSHRegisterPatternsForProtocolDetection(void)
 {
@@ -102,6 +104,25 @@ void RegisterSSHParsers(void)
 
         if (RunmodeIsUnittests() || enable_hassh) {
             SCSshEnableHassh();
+        }
+
+        SshEncryptionHandling encryption_bypass = SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS;
+        ConfNode *encryption_node = ConfGetNode("app-layer.protocols.ssh.encryption-handling");
+        if (encryption_node != NULL && encryption_node->val != NULL) {
+            if (strcmp(encryption_node->val, "full") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_FULL;
+            } else if (strcmp(encryption_node->val, "default") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_DEFAULT;
+            } else if (strcmp(encryption_node->val, "bypass") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_BYPASS;
+            } else {
+                encryption_bypass = SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS;
+            }
+        }
+
+        if (encryption_bypass) {
+            SCLogConfig("ssh: bypass on the start of encryption enabled");
+            SCSshEnableBypass(encryption_bypass);
         }
     }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5692,17 +5692,13 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         }
 
         if (ssn->flags & STREAMTCP_FLAG_BYPASS) {
-            /* we can call bypass callback, if enabled */
-            if (StreamTcpBypassEnabled()) {
-                PacketBypassCallback(p);
-            }
-
-        /* if stream is dead and we have no detect engine at all, bypass. */
+            PacketBypassCallback(p);
         } else if (g_detect_disabled &&
                 (ssn->client.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) &&
                 (ssn->server.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) &&
                 StreamTcpBypassEnabled())
         {
+            /* if stream is dead and we have no detect engine at all, bypass. */
             SCLogDebug("bypass as stream is dead and we have no rules");
             PacketBypassCallback(p);
         }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -952,7 +952,7 @@ app-layer:
       #enabled: yes
     ssh:
       enabled: yes
-      #hassh: yes
+      # hassh: no
 
       # What to do when the encrypted communications start:
       # - default: keep tracking but stop inspection

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -953,6 +953,14 @@ app-layer:
     ssh:
       enabled: yes
       #hassh: yes
+
+      # What to do when the encrypted communications start:
+      # - default: keep tracking but stop inspection
+      # - full:    keep tracking and inspect as normal
+      # - bypass:  stop processing this flow as much as possible.
+      #            Offload flow bypass to kernel or hardware if possible.
+      #
+      # encryption-handling: default
     doh2:
       enabled: yes
     http2:


### PR DESCRIPTION
Following up on https://github.com/OISF/suricata/pull/12573

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6788

Describe changes:
v9.2:
- rebased

v9.1:
- separated mixed changes into their respective commits

v9:
- changed mutex to atomicu8 for SSH encryption handling choice
- rebased 

v8.1:
- specify the correct SV test

v8:
- rebased
- re: QA results: Expected behavior change, the QA needs to set ssh encryption handling to bypass to reproduce the same results. There is no middle-ground solution to have the defaults set exactly as before. See comments in #12249 

v7
- Style guide changes as suggested in the prev PR
- Encryption Handling has now three states, similar to TLS
- rebased

v6
- rebased 

v5
- rebased
- added upgrade section
- fixed docs - Thanks Juliana
- SV tests should pass now

v4
- rebased
- changed SSH bypass defaults to hopefully be in sync with the previous settings

v3
- added SSH app-layer option `encryption-handling` allowing to choose whether to continue inspection on SSH once it turns encrypted
- added SV tests
- minor docs updates


SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2315
