### PR TITLE
rust: avoid static mut - v1

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,9 +57,6 @@
 // example static_mut_refs.
 #![allow(unknown_lints)]
 
-// Allow for now, but need to be fixed.
-#![allow(static_mut_refs)]
-
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;


### PR DESCRIPTION
- **rust: remove allow of static mutables**
- **smtp: use rwlock instead of global static mut**
- **smb: use atomics instead of static mutables**

I believe our usage is OK, and we could have gone the pointer route as
discussed in
https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html,
but this is the safe approach.

Ticket: https://redmine.openinfosecfoundation.org/issues/7417
