### PR TITLE
flow: remove unused definition

### DIFF
--- a/src/flow.h
+++ b/src/flow.h
@@ -551,7 +551,6 @@ void FlowHandlePacket (ThreadVars *, FlowLookupStruct *, Packet *);
 void FlowInitConfig(bool);
 void FlowReset(void);
 void FlowShutdown(void);
-void FlowSetIPOnlyFlag(Flow *, int);
 void FlowSetHasAlertsFlag(Flow *);
 int FlowHasAlerts(const Flow *);
 void FlowSetChangeProtoFlag(Flow *);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None simple cleanup

Describe changes:
- Fixes: 3f3964555e4e ("detect/iponly: use flow first flags")
