### PR TITLE
detect/iponly: use flow first flags (backport7)

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -214,17 +214,14 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
                              p->flow->todstpktcnt, p->flow->tosrcpktcnt,
                              p->flow->todstbytecnt + p->flow->tosrcbytecnt);
         MemBufferWriteString(aft->buffer,
-                             "FLOW IPONLY SET:   TOSERVER: %s, TOCLIENT: %s\n"
-                             "FLOW ACTION:       DROP: %s\n"
-                             "FLOW NOINSPECTION: PACKET: %s, PAYLOAD: %s, APP_LAYER: %s\n"
-                             "FLOW APP_LAYER:    DETECTED: %s, PROTO %"PRIu16"\n",
-                             p->flow->flags & FLOW_TOSERVER_IPONLY_SET ? "TRUE" : "FALSE",
-                             p->flow->flags & FLOW_TOCLIENT_IPONLY_SET ? "TRUE" : "FALSE",
-                             p->flow->flags & FLOW_ACTION_DROP ? "TRUE" : "FALSE",
-                             p->flow->flags & FLOW_NOPACKET_INSPECTION ? "TRUE" : "FALSE",
-                             p->flow->flags & FLOW_NOPAYLOAD_INSPECTION ? "TRUE" : "FALSE",
-                             applayer ? "TRUE" : "FALSE",
-                             (p->flow->alproto != ALPROTO_UNKNOWN) ? "TRUE" : "FALSE", p->flow->alproto);
+                "FLOW ACTION:       DROP: %s\n"
+                "FLOW NOINSPECTION: PACKET: %s, PAYLOAD: %s, APP_LAYER: %s\n"
+                "FLOW APP_LAYER:    DETECTED: %s, PROTO %" PRIu16 "\n",
+                p->flow->flags & FLOW_ACTION_DROP ? "TRUE" : "FALSE",
+                p->flow->flags & FLOW_NOPACKET_INSPECTION ? "TRUE" : "FALSE",
+                p->flow->flags & FLOW_NOPAYLOAD_INSPECTION ? "TRUE" : "FALSE",
+                applayer ? "TRUE" : "FALSE",
+                (p->flow->alproto != ALPROTO_UNKNOWN) ? "TRUE" : "FALSE", p->flow->alproto);
         AlertDebugLogFlowVars(aft, p);
     }
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -2251,7 +2251,7 @@ static int IPOnlyTestSig15(void)
     p[0]->flow = &f;
     p[0]->flow->flowvar = &flowvar;
     p[0]->flags |= PKT_HAS_FLOW;
-    p[0]->flowflags |= FLOW_PKT_TOSERVER;
+    p[0]->flowflags |= (FLOW_PKT_TOSERVER | FLOW_PKT_TOSERVER_FIRST);
 
     const char *sigs[numsigs];
     sigs[0]= "alert tcp 192.168.1.5 any -> any any (msg:\"Testing src ip (sid 1)\"; "

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -977,7 +977,7 @@ static int FlowBitsTestSig06(void)
     p->payload_len = buflen;
     p->proto = IPPROTO_TCP;
     p->flags |= PKT_HAS_FLOW;
-    p->flowflags |= FLOW_PKT_TOSERVER;
+    p->flowflags |= (FLOW_PKT_TOSERVER | FLOW_PKT_TOSERVER_FIRST);
 
     de_ctx = DetectEngineCtxInit();
     FAIL_IF_NULL(de_ctx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -561,23 +561,12 @@ static void DetectRunInspectIPOnly(ThreadVars *tv, const DetectEngineCtx *de_ctx
         Flow * const pflow, Packet * const p)
 {
     if (pflow) {
-        /* set the iponly stuff */
-        if (pflow->flags & FLOW_TOCLIENT_IPONLY_SET)
-            p->flowflags |= FLOW_PKT_TOCLIENT_IPONLY_SET;
-        if (pflow->flags & FLOW_TOSERVER_IPONLY_SET)
-            p->flowflags |= FLOW_PKT_TOSERVER_IPONLY_SET;
-
-        if (((p->flowflags & FLOW_PKT_TOSERVER) && !(p->flowflags & FLOW_PKT_TOSERVER_IPONLY_SET)) ||
-            ((p->flowflags & FLOW_PKT_TOCLIENT) && !(p->flowflags & FLOW_PKT_TOCLIENT_IPONLY_SET)))
-        {
+        if (p->flowflags & (FLOW_PKT_TOSERVER_FIRST | FLOW_PKT_TOCLIENT_FIRST)) {
             SCLogDebug("testing against \"ip-only\" signatures");
 
             PACKET_PROFILING_DETECT_START(p, PROF_DETECT_IPONLY);
             IPOnlyMatchPacket(tv, de_ctx, det_ctx, &de_ctx->io_ctx, p);
             PACKET_PROFILING_DETECT_END(p, PROF_DETECT_IPONLY);
-
-            /* save in the flow that we scanned this direction... */
-            FlowSetIPOnlyFlag(pflow, p->flowflags & FLOW_PKT_TOSERVER ? 1 : 0);
         }
     } else { /* p->flags & PKT_HAS_FLOW */
         /* no flow */

--- a/src/flow.c
+++ b/src/flow.c
@@ -154,18 +154,6 @@ void FlowCleanupAppLayer(Flow *f)
     return;
 }
 
-/** \brief Set the IPOnly scanned flag for 'direction'.
-  *
-  * \param f Flow to set the flag in
-  * \param direction direction to set the flag in
-  */
-void FlowSetIPOnlyFlag(Flow *f, int direction)
-{
-    direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) :
-        (f->flags |= FLOW_TOCLIENT_IPONLY_SET);
-    return;
-}
-
 /** \brief Set flag to indicate that flow has alerts
  *
  * \param f flow
@@ -242,7 +230,6 @@ int FlowChangeProto(Flow *f)
 static inline void FlowSwapFlags(Flow *f)
 {
     SWAP_FLAGS(f->flags, FLOW_TO_SRC_SEEN, FLOW_TO_DST_SEEN);
-    SWAP_FLAGS(f->flags, FLOW_TOSERVER_IPONLY_SET, FLOW_TOCLIENT_IPONLY_SET);
     SWAP_FLAGS(f->flags, FLOW_SGH_TOSERVER, FLOW_SGH_TOCLIENT);
 
     SWAP_FLAGS(f->flags, FLOW_TOSERVER_DROP_LOGGED, FLOW_TOCLIENT_DROP_LOGGED);

--- a/src/flow.h
+++ b/src/flow.h
@@ -52,10 +52,9 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 
 // vacancy
 
-/** Flow was inspected against IP-Only sigs in the toserver direction */
-#define FLOW_TOSERVER_IPONLY_SET        BIT_U32(3)
-/** Flow was inspected against IP-Only sigs in the toclient direction */
-#define FLOW_TOCLIENT_IPONLY_SET        BIT_U32(4)
+// vacancy bit 3
+
+// vacancy bit 4
 
 /** Packet belonging to this flow should not be inspected at all */
 #define FLOW_NOPACKET_INSPECTION        BIT_U32(5)
@@ -222,13 +221,11 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_PKT_TOSERVER               0x01
 #define FLOW_PKT_TOCLIENT               0x02
 #define FLOW_PKT_ESTABLISHED            0x04
-#define FLOW_PKT_TOSERVER_IPONLY_SET    0x08
-#define FLOW_PKT_TOCLIENT_IPONLY_SET    0x10
-#define FLOW_PKT_TOSERVER_FIRST         0x20
-#define FLOW_PKT_TOCLIENT_FIRST         0x40
+#define FLOW_PKT_TOSERVER_FIRST         0x08
+#define FLOW_PKT_TOCLIENT_FIRST         0x10
 /** last pseudo packet in the flow. Can be used to trigger final clean,
  *  logging, etc. */
-#define FLOW_PKT_LAST_PSEUDO            0x80
+#define FLOW_PKT_LAST_PSEUDO 0x20
 
 #define FLOW_END_FLAG_STATE_NEW         0x01
 #define FLOW_END_FLAG_STATE_ESTABLISHED 0x02
@@ -548,7 +545,6 @@ void FlowHandlePacket (ThreadVars *, FlowLookupStruct *, Packet *);
 void FlowInitConfig(bool);
 void FlowReset(void);
 void FlowShutdown(void);
-void FlowSetIPOnlyFlag(Flow *, int);
 void FlowSetHasAlertsFlag(Flow *);
 int FlowHasAlerts(const Flow *);
 bool FlowHasGaps(const Flow *, uint8_t way);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7522
Describe changes:
- Backport of https://github.com/OISF/suricata/pull/12499

Cherry-pick had conflicts in flow.c (removal of FlowSetIPOnlyFlag)
And I also did the removal in flow.h cf https://github.com/OISF/suricata/pull/12668

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2319
