### PR TITLE
Detect revflow 7552 v3

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -5628,6 +5628,7 @@ static int HTPParserTest25(void)
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_HTTP1;
+    f->flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     const char *str = "GET / HTTP/1.1\r\nHost: www.google.com\r\nUser-Agent: Suricata/1.0\r\n\r\n";
     int r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER | STREAM_START,

--- a/src/app-layer-ike.c
+++ b/src/app-layer-ike.c
@@ -66,6 +66,7 @@ static int IkeParserTest(void)
     f.proto = IPPROTO_UDP;
     f.protomap = FlowGetProtoMapping(f.proto);
     f.alproto = ALPROTO_IKE;
+    f.flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     StreamTcpInitConfig(true);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -957,7 +957,8 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
         }
 
         if (txd && has_tx_detect_flags) {
-            if (!IS_DISRUPTED(ts_disrupt_flags) && f->sgh_toserver != NULL) {
+            if (!IS_DISRUPTED(ts_disrupt_flags) &&
+                    (f->sgh_toserver != NULL || (f->flags & FLOW_SGH_TOSERVER) == 0)) {
                 uint64_t detect_flags_ts = AppLayerParserGetTxDetectFlags(txd, STREAM_TOSERVER);
                 if (!(detect_flags_ts &
                             (APP_LAYER_TX_INSPECTED_FLAG | APP_LAYER_TX_SKIP_INSPECT_FLAG))) {
@@ -966,7 +967,8 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
                     tx_skipped = true;
                 }
             }
-            if (!IS_DISRUPTED(tc_disrupt_flags) && f->sgh_toclient != NULL) {
+            if (!IS_DISRUPTED(tc_disrupt_flags) &&
+                    (f->sgh_toclient != NULL || (f->flags & FLOW_SGH_TOCLIENT) == 0)) {
                 uint64_t detect_flags_tc = AppLayerParserGetTxDetectFlags(txd, STREAM_TOCLIENT);
                 if (!(detect_flags_tc &
                             (APP_LAYER_TX_INSPECTED_FLAG | APP_LAYER_TX_SKIP_INSPECT_FLAG))) {

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -72,6 +72,7 @@ static int SMBParserTxCleanupTest(void)
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_SMB;
+    f->flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     char req_str[] ="\x00\x00\x00\x79\xfe\x53\x4d\x42\x40\x00\x01\x00\x00\x00\x00\x00" \
                      "\x05\x00\xe0\x1e\x10\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00" \

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -460,6 +460,8 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 SCLogDebug("reversing flow after proto detect told us so");
                 PacketSwap(p);
                 FlowSwap(f);
+                // Will reset signature groups in DetectRunSetup
+                f->de_ctx_version = UINT32_MAX;
                 SWAP_FLAGS(flags, STREAM_TOSERVER, STREAM_TOCLIENT);
                 if (*stream == &ssn->client) {
                     *stream = &ssn->server;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7552

Describe changes:
- Fix detection when reversing flow

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2320

#12672 with review taken into account, using Flow::de_ctx_version to have only one code doing the flow/detect reset