### PR TITLE
rust: don't suppress static_mut_refs globally - v3


### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,9 +57,6 @@
 // example static_mut_refs.
 #![allow(unknown_lints)]
 
-// Allow for now, but need to be fixed.
-#![allow(static_mut_refs)]
-
 #[macro_use]
 extern crate bitflags;
 extern crate byteorder;

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -291,6 +291,7 @@ fn mime_smtp_finish_url(input: &[u8]) -> &[u8] {
     return input;
 }
 
+#[allow(static_mut_refs)]
 fn mime_smtp_extract_urls(urls: &mut Vec<Vec<u8>>, input_start: &[u8]) {
     //TODO optimize later : use mpm
     for s in unsafe { MIME_SMTP_CONFIG_EXTRACT_URL_SCHEMES.iter() } {
@@ -743,6 +744,7 @@ pub unsafe extern "C" fn SCMimeSmtpConfigHeaderValueDepth(val: u32) {
 }
 
 #[no_mangle]
+#[allow(static_mut_refs)]
 pub unsafe extern "C" fn SCMimeSmtpConfigExtractUrlsSchemeAdd(
     str: *const std::os::raw::c_char,
 ) -> std::os::raw::c_int {

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -743,11 +743,6 @@ pub unsafe extern "C" fn SCMimeSmtpConfigHeaderValueDepth(val: u32) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn SCMimeSmtpConfigExtractUrlsSchemeReset() {
-    MIME_SMTP_CONFIG_EXTRACT_URL_SCHEMES.clear();
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn SCMimeSmtpConfigExtractUrlsSchemeAdd(
     str: *const std::os::raw::c_char,
 ) -> std::os::raw::c_int {

--- a/rust/src/smb/smb.rs
+++ b/rust/src/smb/smb.rs
@@ -2525,11 +2525,60 @@ pub unsafe extern "C" fn rs_smb_register_parser() {
             }
         }
         SCLogConfig!("read: max record size: {}, max queued chunks {}, max queued size {}",
-                SMB_CFG_MAX_READ_SIZE, SMB_CFG_MAX_READ_QUEUE_CNT, SMB_CFG_MAX_READ_QUEUE_SIZE);
+                cfg_max_read_size(), cfg_max_read_queue_cnt(), cfg_max_read_queue_size());
         SCLogConfig!("write: max record size: {}, max queued chunks {}, max queued size {}",
-                SMB_CFG_MAX_WRITE_SIZE, SMB_CFG_MAX_WRITE_QUEUE_CNT, SMB_CFG_MAX_WRITE_QUEUE_SIZE);
-        SCLogConfig!("guid: max cache size: {}", SMB_CFG_MAX_GUID_CACHE_SIZE);
+                cfg_max_write_size(), cfg_max_write_queue_cnt(), cfg_max_write_queue_size());
+        SCLogConfig!("guid: max cache size: {}", cfg_max_guid_cache_size());
     } else {
         SCLogDebug!("Protocol detector and parser disabled for SMB.");
     }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_read_size() -> u32 {
+    unsafe { SMB_CFG_MAX_READ_SIZE }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_read_queue_cnt() -> u32 {
+    unsafe { SMB_CFG_MAX_READ_QUEUE_CNT }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_read_queue_size() -> u32 {
+    unsafe { SMB_CFG_MAX_READ_QUEUE_SIZE }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_write_size() -> u32 {
+    unsafe { SMB_CFG_MAX_WRITE_SIZE }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_write_queue_cnt() -> u32 {
+    unsafe { SMB_CFG_MAX_WRITE_QUEUE_CNT }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_write_queue_size() -> u32 {
+    unsafe { SMB_CFG_MAX_WRITE_QUEUE_SIZE }
+}
+
+// Wrapper function around static mutable to prevent refs to static
+// mutables.
+#[inline(always)]
+fn cfg_max_guid_cache_size() -> usize {
+    unsafe { SMB_CFG_MAX_GUID_CACHE_SIZE }
 }

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -356,7 +356,6 @@ static void SMTPConfigure(void) {
         if (extract_urls_schemes) {
             ConfNode *scheme = NULL;
 
-            SCMimeSmtpConfigExtractUrlsSchemeReset();
             TAILQ_FOREACH (scheme, &extract_urls_schemes->head, next) {
                 size_t scheme_len = strlen(scheme->val);
                 if (scheme_len > UINT16_MAX - SCHEME_SUFFIX_LEN) {
@@ -383,7 +382,6 @@ static void SMTPConfigure(void) {
         } else {
             /* Add default extract url scheme 'http' since
              * extract-urls-schemes wasn't found in the config */
-            SCMimeSmtpConfigExtractUrlsSchemeReset();
             SCMimeSmtpConfigExtractUrlsSchemeAdd("http://");
         }
 


### PR DESCRIPTION
As its use is now a default compiler warning, and eventually will become an
error, remove the global suppression of it. Instead suppress as needed, or
refactor to get rid of the warning.

For reference:
https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html,

Ticket: https://redmine.openinfosecfoundation.org/issues/7417
