### PR TITLE
applayer/ftp: Post-merge fixups

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -18,6 +18,7 @@
 //! This module exposes items from the core "C" code to Rust.
 
 use std;
+use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{AppProto, AppProtoEnum};
 
 use crate::filecontainer::*;
@@ -71,6 +72,15 @@ macro_rules!BIT_U64 {
 extern {
     pub fn StringToAppProto(proto_name: *const u8) -> AppProto;
 }
+
+/// cbindgen:ignore
+extern "C" {
+    pub fn MpmAddPatternCI(
+        ctx: *const c_void, pat: *const libc::c_char, pat_len: c_int, _offset: c_int,
+        _depth: c_int, id: c_int, rule_id: c_int, _flags: c_int,
+    ) -> c_void;
+}
+
 
 //
 // Function types for calls into C.

--- a/rust/src/ftp/constant.rs
+++ b/rust/src/ftp/constant.rs
@@ -28,8 +28,8 @@ pub enum FtpStateValues {
 #[repr(u8)]
 #[allow(non_camel_case_types)]
 pub enum FtpDataStateValues {
-    FTPDATA_STATE_IN_PROGRESS = 1,
-    FTPDATA_STATE_FINISHED = 2,
+    FTPDATA_STATE_IN_PROGRESS,
+    FTPDATA_STATE_FINISHED,
 }
 
 // FTP request command values

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -19,6 +19,7 @@ use std;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int, c_void};
 
+use crate::core::*;
 use crate::conf::{conf_get, get_memval};
 use crate::ftp::constant::*;
 use lazy_static::lazy_static;
@@ -95,14 +96,6 @@ lazy_static! {
         FtpCommand::new("USER", FtpRequestCommand::FTP_COMMAND_USER),
         FtpCommand::new("UNKNOWN", FtpRequestCommand::FTP_COMMAND_UNKNOWN),
     ];
-}
-
-/// cbindgen:ignore
-extern "C" {
-    pub fn MpmAddPatternCI(
-        ctx: *const c_void, pat: *const libc::c_char, pat_len: c_int, _offset: c_int,
-        _depth: c_int, id: c_int, rule_id: c_int, _flags: c_int,
-    ) -> c_void;
 }
 
 #[allow(non_snake_case)]

--- a/rust/src/ftp/ftp.rs
+++ b/rust/src/ftp/ftp.rs
@@ -143,7 +143,6 @@ pub unsafe extern "C" fn SCFTPSetMpmState(ctx: *const c_void) {
 }
 
 #[repr(C)]
-#[allow(dead_code)]
 pub struct FtpTransferCmd {
     // Must be first -- required by app-layer expectation logic
     data_free: unsafe extern "C" fn(*mut c_void),
@@ -161,7 +160,7 @@ impl Default for FtpTransferCmd {
             file_name: std::ptr::null_mut(),
             file_len: 0,
             direction: 0,
-            cmd: FtpStateValues::FTP_STATE_NONE as u8,
+            cmd: 0,
             data_free: default_free_fn,
         }
     }


### PR DESCRIPTION
Post merge fixups of FTP to Rust conversion

Link to ticket: https://redmine.openinfosecfoundation.org/issues/4082

Describe changes:
- Use correct values for enums tracking FTP Data state
- Move MPM declaration to centralized location for use by other Rust modules
- Minor fixups to remove dead_code directive, proper value for init.

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
