### PR TITLE
misc cleanups: cbindgen; rust name; visibility; re-enable rpm builds - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -401,7 +401,7 @@ jobs:
           - almalinux:9
           - fedora:40
     env:
-      skip: true
+      skip: false
     steps:
       - name: Cache cargo registry
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
@@ -456,13 +456,13 @@ jobs:
       # We need a step for each RPM upload as we can't use the
       # container name directly in an artifact, as artifacts can't
       # have ':' in the name.
-      - if: matrix.container == 'fedora:40' && ${{ env.skip != 'true' }}
+      - if: ${{ matrix.container == 'fedora:40' &&  env.skip != 'true' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         name: Uploading RPMs
         with:
           name: rpms-fedora-40
           path: suricata-rpms/devel/rpms
-      - if: matrix.container == 'almalinux:9' && ${{ env.skip != 'true' }}
+      - if: ${{ matrix.container == 'almalinux:9' && env.skip != 'true' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         name: Uploading RPMs
         with:

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -144,7 +144,7 @@ endif
 if HAVE_CBINDGEN
 gen/rust-bindings.h: $(RUST_SURICATA_LIB) cbindgen.toml
 	cd $(abs_top_srcdir)/rust && \
-		cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
+		$(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --verify --output $(abs_top_builddir)/rust/gen/rust-bindings.h || true
 else
 gen/rust-bindings.h:
@@ -155,7 +155,7 @@ doc:
 
 if HAVE_CBINDGEN
 dist/rust-bindings.h:
-	cbindgen --config $(abs_top_srcdir)/rust/cbindgen.toml \
+	$(CBINDGEN) --config $(abs_top_srcdir)/rust/cbindgen.toml \
 		--quiet --output $(abs_top_builddir)/rust/dist/rust-bindings.h
 else
 dist/rust-bindings.h:

--- a/rust/src/bittorrent_dht/logger.rs
+++ b/rust/src/bittorrent_dht/logger.rs
@@ -131,7 +131,7 @@ fn log_bittorrent_dht(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_bittorrent_dht_logger_log(
+pub unsafe extern "C" fn SCBittorrentDhtLogger(
     tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, BitTorrentDHTTransaction);

--- a/rust/src/dcerpc/detect.rs
+++ b/rust/src/dcerpc/detect.rs
@@ -203,7 +203,7 @@ fn parse_opnum_data(arg: &str) -> Result<DCEOpnumData, ()> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dcerpc_iface_match(
+pub extern "C" fn SCDcerpcIfaceMatch(
     tx: &DCERPCTransaction, state: &mut DCERPCState, if_data: &mut DCEIfaceData,
 ) -> u8 {
     let first_req_seen = tx.get_first_req_seen();
@@ -219,7 +219,7 @@ pub extern "C" fn rs_dcerpc_iface_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_iface_parse(carg: *const c_char) -> *mut c_void {
+pub unsafe extern "C" fn SCDcerpcIfaceParse(carg: *const c_char) -> *mut c_void {
     if carg.is_null() {
         return std::ptr::null_mut();
     }
@@ -237,14 +237,14 @@ pub unsafe extern "C" fn rs_dcerpc_iface_parse(carg: *const c_char) -> *mut c_vo
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_iface_free(ptr: *mut c_void) {
+pub unsafe extern "C" fn SCDcerpcIfaceFree(ptr: *mut c_void) {
     if !ptr.is_null() {
         std::mem::drop(Box::from_raw(ptr as *mut DCEIfaceData));
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_opnum_match(
+pub unsafe extern "C" fn SCDcerpcOpnumMatch(
     tx: &DCERPCTransaction, opnum_data: &mut DCEOpnumData,
 ) -> u8 {
     let first_req_seen = tx.get_first_req_seen();
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn rs_dcerpc_opnum_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_opnum_parse(carg: *const c_char) -> *mut c_void {
+pub unsafe extern "C" fn SCDcerpcOpnumParse(carg: *const c_char) -> *mut c_void {
     if carg.is_null() {
         return std::ptr::null_mut();
     }
@@ -284,7 +284,7 @@ pub unsafe extern "C" fn rs_dcerpc_opnum_parse(carg: *const c_char) -> *mut c_vo
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_dcerpc_opnum_free(ptr: *mut c_void) {
+pub unsafe extern "C" fn SCDcerpcOpnumFree(ptr: *mut c_void) {
     if !ptr.is_null() {
         std::mem::drop(Box::from_raw(ptr as *mut DCEOpnumData));
     }

--- a/rust/src/dcerpc/log.rs
+++ b/rust/src/dcerpc/log.rs
@@ -126,14 +126,14 @@ fn log_dcerpc_header_udp(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dcerpc_log_json_record_tcp(
+pub extern "C" fn SCDcerpcLogJsonRecordTcp(
     state: &DCERPCState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
 ) -> bool {
     log_dcerpc_header_tcp(jsb, state, tx).is_ok()
 }
 
 #[no_mangle]
-pub extern "C" fn rs_dcerpc_log_json_record_udp(
+pub extern "C" fn SCDcerpcLogJsonRecordUdp(
     state: &DCERPCUDPState, tx: &DCERPCTransaction, jsb: &mut JsonBuilder,
 ) -> bool {
     log_dcerpc_header_udp(jsb, state, tx).is_ok()

--- a/rust/src/dcerpc/parser.rs
+++ b/rust/src/dcerpc/parser.rs
@@ -53,7 +53,7 @@ fn assemble_uuid(uuid: Uuid) -> Vec<u8> {
     vect
 }
 
-pub fn parse_uuid(i: &[u8]) -> IResult<&[u8], Uuid> {
+fn parse_uuid(i: &[u8]) -> IResult<&[u8], Uuid> {
     let (i, time_low) = take(4_usize)(i)?;
     let (i, time_mid) = take(2_usize)(i)?;
     let (i, time_hi_and_version) = take(2_usize)(i)?;
@@ -71,7 +71,7 @@ pub fn parse_uuid(i: &[u8]) -> IResult<&[u8], Uuid> {
     Ok((i, uuid))
 }
 
-pub fn parse_dcerpc_udp_header(i: &[u8]) -> IResult<&[u8], DCERPCHdrUdp> {
+pub(super) fn parse_dcerpc_udp_header(i: &[u8]) -> IResult<&[u8], DCERPCHdrUdp> {
     let (i, rpc_vers) = le_u8(i)?;
     let (i, pkt_type) = le_u8(i)?;
     let (i, flags1) = le_u8(i)?;
@@ -134,7 +134,7 @@ pub fn parse_dcerpc_udp_header(i: &[u8]) -> IResult<&[u8], DCERPCHdrUdp> {
     Ok((i, header))
 }
 
-pub fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DCERPCBindAckResult> {
+pub(super) fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DCERPCBindAckResult> {
     let (i, ack_result) = le_u16(i)?;
     let (i,  ack_reason) = le_u16(i)?;
     let (i,  transfer_syntax) = take(16_usize)(i)?;
@@ -148,7 +148,7 @@ pub fn parse_dcerpc_bindack_result(i: &[u8]) -> IResult<&[u8], DCERPCBindAckResu
     Ok((i, result))
 }
 
-pub fn parse_dcerpc_bindack(i: &[u8]) -> IResult<&[u8], DCERPCBindAck> {
+pub(super) fn parse_dcerpc_bindack(i: &[u8]) -> IResult<&[u8], DCERPCBindAck> {
     let (i, _max_xmit_frag) = le_u16(i)?;
     let (i, _max_recv_frag) = le_u16(i)?;
     let (i, _assoc_group) = take(4_usize)(i)?;
@@ -167,7 +167,7 @@ pub fn parse_dcerpc_bindack(i: &[u8]) -> IResult<&[u8], DCERPCBindAck> {
     Ok((i, result))
 }
 
-pub fn parse_bindctx_item(i: &[u8], endianness: Endianness) -> IResult<&[u8], BindCtxItem> {
+pub(super) fn parse_bindctx_item(i: &[u8], endianness: Endianness) -> IResult<&[u8], BindCtxItem> {
     let (i, ctxid) = u16(endianness)(i)?;
     let (i, _num_trans_items) = le_u8(i)?;
     let (i, _) = take(1_usize)(i)?; // Reserved bit
@@ -192,7 +192,7 @@ pub fn parse_bindctx_item(i: &[u8], endianness: Endianness) -> IResult<&[u8], Bi
     Ok((i, result))
 }
 
-pub fn parse_dcerpc_bind(i: &[u8]) -> IResult<&[u8], DCERPCBind> {
+pub(super) fn parse_dcerpc_bind(i: &[u8]) -> IResult<&[u8], DCERPCBind> {
     let (i, _max_xmit_frag) = le_u16(i)?;
     let (i, _max_recv_frag) = le_u16(i)?;
     let (i, _assoc_group_id) = le_u32(i)?;
@@ -205,7 +205,7 @@ pub fn parse_dcerpc_bind(i: &[u8]) -> IResult<&[u8], DCERPCBind> {
     Ok((i, result))
 }
 
-pub fn parse_dcerpc_header(i: &[u8]) -> IResult<&[u8], DCERPCHdr> {
+pub(super) fn parse_dcerpc_header(i: &[u8]) -> IResult<&[u8], DCERPCHdr> {
     let (i, rpc_vers) = le_u8(i)?;
     let (i, rpc_vers_minor) = le_u8(i)?;
     let (i, hdrtype) = le_u8(i)?;
@@ -228,7 +228,7 @@ pub fn parse_dcerpc_header(i: &[u8]) -> IResult<&[u8], DCERPCHdr> {
     Ok((i, header))
 }
 
-pub fn parse_dcerpc_request(i: &[u8], endianness: Endianness) -> IResult<&[u8], DCERPCRequest> {
+pub(super) fn parse_dcerpc_request(i: &[u8], endianness: Endianness) -> IResult<&[u8], DCERPCRequest> {
     let (i, _pad) = take(4_usize)(i)?;
     let (i, ctxid) = u16(endianness)(i)?;
     let (i, opnum) = u16(endianness)(i)?;

--- a/rust/src/enip/enip.rs
+++ b/rust/src/enip/enip.rs
@@ -468,7 +468,7 @@ unsafe extern "C" fn enip_probing_parser_tcp(
     return ALPROTO_FAILED;
 }
 
-extern "C" fn rs_enip_state_new(_orig_state: *mut c_void, _orig_proto: AppProto) -> *mut c_void {
+extern "C" fn enip_state_new(_orig_state: *mut c_void, _orig_proto: AppProto) -> *mut c_void {
     let state = EnipState::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut c_void;
@@ -537,7 +537,7 @@ unsafe extern "C" fn enip_parse_response_tcp(
     }
 }
 
-unsafe extern "C" fn rs_enip_state_get_tx(state: *mut c_void, tx_id: u64) -> *mut c_void {
+unsafe extern "C" fn enip_state_get_tx(state: *mut c_void, tx_id: u64) -> *mut c_void {
     let state = cast_pointer!(state, EnipState);
     match state.get_tx(tx_id) {
         Some(tx) => {
@@ -549,12 +549,12 @@ unsafe extern "C" fn rs_enip_state_get_tx(state: *mut c_void, tx_id: u64) -> *mu
     }
 }
 
-unsafe extern "C" fn rs_enip_state_get_tx_count(state: *mut c_void) -> u64 {
+unsafe extern "C" fn enip_state_get_tx_count(state: *mut c_void) -> u64 {
     let state = cast_pointer!(state, EnipState);
     return state.tx_id;
 }
 
-unsafe extern "C" fn rs_enip_tx_get_alstate_progress(tx: *mut c_void, direction: u8) -> c_int {
+unsafe extern "C" fn enip_tx_get_alstate_progress(tx: *mut c_void, direction: u8) -> c_int {
     let tx = cast_pointer!(tx, EnipTransaction);
 
     // Transaction is done if we have a response.
@@ -598,16 +598,16 @@ pub unsafe extern "C" fn SCEnipRegisterParsers() {
         probe_tc: Some(enip_probing_parser_udp),
         min_depth: 0,
         max_depth: 16,
-        state_new: rs_enip_state_new,
+        state_new: enip_state_new,
         state_free: enip_state_free,
         tx_free: enip_state_tx_free,
         parse_ts: enip_parse_request_udp,
         parse_tc: enip_parse_response_udp,
-        get_tx_count: rs_enip_state_get_tx_count,
-        get_tx: rs_enip_state_get_tx,
+        get_tx_count: enip_state_get_tx_count,
+        get_tx: enip_state_get_tx,
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
-        tx_get_progress: rs_enip_tx_get_alstate_progress,
+        tx_get_progress: enip_tx_get_alstate_progress,
         get_eventinfo: Some(EnipEvent::get_event_info),
         get_eventinfo_byid: Some(EnipEvent::get_event_info_by_id),
         localstorage_new: None,

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -911,7 +911,7 @@ unsafe extern "C" fn mqtt_conn_flags_setup(
     return 0;
 }
 
-fn rs_mqtt_tx_has_conn_flags(tx: &MQTTTransaction, ctx: &DetectUintData<u8>) -> c_int {
+fn mqtt_tx_has_conn_flags(tx: &MQTTTransaction, ctx: &DetectUintData<u8>) -> c_int {
     for msg in tx.msg.iter() {
         if let MQTTOperation::CONNECT(ref cv) = msg.op {
             if detect_match_uint(ctx, cv.rawflags) {
@@ -928,7 +928,7 @@ unsafe extern "C" fn mqtt_conn_flags_match(
 ) -> c_int {
     let tx = cast_pointer!(tx, MQTTTransaction);
     let ctx = cast_pointer!(ctx, DetectUintData<u8>);
-    return rs_mqtt_tx_has_conn_flags(tx, ctx);
+    return mqtt_tx_has_conn_flags(tx, ctx);
 }
 
 unsafe extern "C" fn mqtt_conn_flags_free(_de: *mut c_void, ctx: *mut c_void) {

--- a/rust/src/mqtt/logger.rs
+++ b/rust/src/mqtt/logger.rs
@@ -317,7 +317,7 @@ fn log_mqtt(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_mqtt_logger_log(
+pub unsafe extern "C" fn SCMqttLoggerLog(
     tx: *mut std::os::raw::c_void, flags: u32, max_log_len: u32, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1730,8 +1730,8 @@ void AppLayerParserRegisterProtocolParsers(void)
 
     RegisterHTPParsers();
     RegisterSSLParsers();
-    rs_dcerpc_register_parser();
-    rs_dcerpc_udp_register_parser();
+    SCRegisterDcerpcParser();
+    SCRegisterDcerpcUdpParser();
     RegisterSMBParsers();
     RegisterFTPParsers();
     RegisterSSHParsers();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1738,7 +1738,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterSMTPParsers();
     SCRegisterDnsUdpParser();
     SCRegisterDnsTcpParser();
-    rs_bittorrent_dht_udp_register_parser();
+    SCRegisterBittorrentDhtUdpParser();
     RegisterModbusParsers();
     SCEnipRegisterParsers();
     RegisterDNP3Parsers();

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -113,7 +113,7 @@ static int DetectDceIfaceMatchRust(DetectEngineThreadCtx *det_ctx,
 
     if (f->alproto == ALPROTO_DCERPC) {
         // TODO check if state is NULL
-        return rs_dcerpc_iface_match(txv, state, (void *)m);
+        return SCDcerpcIfaceMatch(txv, state, (void *)m);
     }
 
     int ret = 0;
@@ -147,7 +147,7 @@ static int DetectDceIfaceSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
         return -1;
 
-    void *did = rs_dcerpc_iface_parse(arg);
+    void *did = SCDcerpcIfaceParse(arg);
     if (did == NULL) {
         SCLogError("Error parsing dce_iface option in "
                    "signature");
@@ -165,7 +165,7 @@ static void DetectDceIfaceFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     if (ptr != NULL) {
-        rs_dcerpc_iface_free(ptr);
+        SCDcerpcIfaceFree(ptr);
     }
     SCReturn;
 }

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -103,7 +103,7 @@ static int DetectDceOpnumMatchRust(DetectEngineThreadCtx *det_ctx,
     SCEnter();
 
     if (f->alproto == ALPROTO_DCERPC) {
-        return rs_dcerpc_opnum_match(txv, (void *)m);
+        return SCDcerpcOpnumMatch(txv, (void *)m);
     }
 
     if (rs_smb_tx_match_dce_opnum(txv, (void *)m) != 1)
@@ -114,7 +114,7 @@ static int DetectDceOpnumMatchRust(DetectEngineThreadCtx *det_ctx,
 
 /**
  * \brief Creates a SigMatch for the "dce_opnum" keyword being sent as argument,
- *        and appends it to the rs_dcerpc_opnum_matchSignature(s).
+ *        and appends it to the SCDcerpcOpnumMatchSignature(s).
  *
  * \param de_ctx Pointer to the detection engine context.
  * \param s      Pointer to signature for the current Signature being parsed
@@ -135,7 +135,7 @@ static int DetectDceOpnumSetup(DetectEngineCtx *de_ctx, Signature *s, const char
     if (DetectSignatureSetAppProto(s, ALPROTO_DCERPC) < 0)
         return -1;
 
-    void *dod = rs_dcerpc_opnum_parse(arg);
+    void *dod = SCDcerpcOpnumParse(arg);
     if (dod == NULL) {
         SCLogError("Error parsing dce_opnum option in "
                    "signature");
@@ -154,7 +154,7 @@ static void DetectDceOpnumFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     SCEnter();
     if (ptr != NULL) {
-        rs_dcerpc_opnum_free(ptr);
+        SCDcerpcOpnumFree(ptr);
     }
     SCReturn;
 }

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -96,7 +96,7 @@ static InspectionBuffer *GetDCEData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *data = NULL;
         uint8_t endianness;
 
-        rs_dcerpc_get_stub_data(txv, &data, &data_len, &endianness, flow_flags);
+        SCDcerpcGetStubData(txv, &data, &data_len, &endianness, flow_flags);
         if (data == NULL || data_len == 0)
             return NULL;
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -416,11 +416,11 @@ static void AlertAddAppLayer(const Packet *p, JsonBuilder *jb,
                     jb_get_mark(jb, &mark);
                     jb_open_object(jb, "dcerpc");
                     if (p->proto == IPPROTO_TCP) {
-                        if (!rs_dcerpc_log_json_record_tcp(state, tx, jb)) {
+                        if (!SCDcerpcLogJsonRecordTcp(state, tx, jb)) {
                             jb_restore_mark(jb, &mark);
                         }
                     } else {
-                        if (!rs_dcerpc_log_json_record_udp(state, tx, jb)) {
+                        if (!SCDcerpcLogJsonRecordUdp(state, tx, jb)) {
                             jb_restore_mark(jb, &mark);
                         }
                     }

--- a/src/output-json-dcerpc.c
+++ b/src/output-json-dcerpc.c
@@ -36,11 +36,11 @@ static int JsonDCERPCLogger(ThreadVars *tv, void *thread_data,
 
     jb_open_object(jb, "dcerpc");
     if (p->proto == IPPROTO_TCP) {
-        if (!rs_dcerpc_log_json_record_tcp(state, tx, jb)) {
+        if (!SCDcerpcLogJsonRecordTcp(state, tx, jb)) {
             goto error;
         }
     } else {
-        if (!rs_dcerpc_log_json_record_udp(state, tx, jb)) {
+        if (!SCDcerpcLogJsonRecordUdp(state, tx, jb)) {
             goto error;
         }
     }

--- a/src/output-json-mqtt.c
+++ b/src/output-json-mqtt.c
@@ -62,7 +62,7 @@ typedef struct LogMQTTLogThread_ {
 
 bool JsonMQTTAddMetadata(void *vtx, JsonBuilder *js)
 {
-    return rs_mqtt_logger_log(vtx, MQTT_DEFAULT_FLAGS, MQTT_DEFAULT_MAXLOGLEN, js);
+    return SCMqttLoggerLog(vtx, MQTT_DEFAULT_FLAGS, MQTT_DEFAULT_MAXLOGLEN, js);
 }
 
 static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
@@ -71,7 +71,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
     LogMQTTLogThread *thread = thread_data;
     enum OutputJsonLogDirection dir;
 
-    if (rs_mqtt_tx_is_toclient((MQTTTransaction*) tx)) {
+    if (SCMqttTxIsToClient((MQTTTransaction *)tx)) {
         dir = LOG_DIR_FLOW_TOCLIENT;
     } else {
         dir = LOG_DIR_FLOW_TOSERVER;
@@ -82,7 +82,7 @@ static int JsonMQTTLogger(ThreadVars *tv, void *thread_data,
         return TM_ECODE_FAILED;
     }
 
-    if (!rs_mqtt_logger_log(tx, thread->mqttlog_ctx->flags, thread->mqttlog_ctx->max_log_len, js))
+    if (!SCMqttLoggerLog(tx, thread->mqttlog_ctx->flags, thread->mqttlog_ctx->max_log_len, js))
         goto error;
 
     OutputJsonBuilderBuffer(tv, p, p->flow, js, thread->ctx);

--- a/src/output.c
+++ b/src/output.c
@@ -918,7 +918,7 @@ void OutputRegisterRootLoggers(void)
     RegisterSimpleJsonApplayerLogger(ALPROTO_HTTP2, rs_http2_log_json, "http");
     // underscore instead of dash for bittorrent_dht
     RegisterSimpleJsonApplayerLogger(
-            ALPROTO_BITTORRENT_DHT, rs_bittorrent_dht_logger_log, "bittorrent_dht");
+            ALPROTO_BITTORRENT_DHT, SCBittorrentDhtLogger, "bittorrent_dht");
 
     OutputPacketLoggerRegister();
     OutputFiledataLoggerRegister();


### PR DESCRIPTION
- **github-ci: re-enable RPM builds**
- **rust: use CBINDGEN variable and not "cbindgen"**
- **bittorrent: no_mangle, pub and naming cleanups**
- **dcerpc: visibility and naming cleanups**
- **enip: remove rs_ prefix**
- **mqtt: naming and visibility cleanups**
