### PR TITLE
output/buffer: Change buffer-size default value

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -533,6 +533,7 @@ SCConfLogOpenGeneric(ConfNode *conf,
 
     /* Determine the buffering for this output device; a value of 0 means to not buffer;
      * any other value must be a multiple of 4096
+     * The default value is 0 (no buffering)
      */
     uint32_t buffer_size = LOGFILE_EVE_BUFFER_SIZE;
     const char *buffer_size_value = ConfNodeLookupChildValue(conf, "buffer-size");

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -172,7 +172,7 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_ROTATE_INTERVAL 0x04
 
 /* Default EVE output buffering size */
-#define LOGFILE_EVE_BUFFER_SIZE (8 * 1024)
+#define LOGFILE_EVE_BUFFER_SIZE 0
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -104,7 +104,7 @@ outputs:
       # Specify the amount of buffering, in bytes, for
       # this output type. The default value 0 means "no
       # buffering".
-      buffer-size: 0
+      #buffer-size: 0
       #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"


### PR DESCRIPTION
The buffer-size value that controls file output buffering defaults to 8k. To be consistent with previous logic, the default is being changed to 0 (e.g., needed if there are old config files that don't specifically enable the new value).


Link to ticket: https://redmine.openinfosecfoundation.org/issues/3449

Describe changes:
- Ensure default value for `buffer-size` is 0, even with old config files.
-
-

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
