### PR TITLE
flow/output: log triggered exception policies - v2

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -59,6 +59,10 @@ It is possible to disable this default, by setting the exception policies'
 **In IDS mode**, setting ``auto`` mode actually means disabling the
 ``master-switch``, or ignoring the exception policies.
 
+.. note::
+
+    If no exception policy is enabled, Suricata will not log exception policy stats.
+
 .. _eps_settings:
 
 Specific settings
@@ -259,7 +263,8 @@ to Suricata applying the behavior that had been configured for such scenario:
 Available Stats
 ~~~~~~~~~~~~~~~
 
-There are stats counters for each supported exception policy scenario:
+There are stats counters for each supported exception policy scenario that will
+be logged when exception policies are enabled:
 
 .. list-table:: **Exception Policy Stats Counters**
    :widths: 50 50
@@ -288,7 +293,7 @@ Stats for application layer errors are available in summarized form or per
 application layer protocol. As the latter is extremely verbose, by default
 Suricata logs only the summary. If any further investigation is needed, it
 is recommended to enable per-app-proto exception policy error counters
-temporarily (for :ref:`stats configuration<suricata_yaml_outputs>`).
+temporarily (for more, read :ref:`stats configuration<suricata_yaml_outputs>`).
 
 
 Command-line Options for Simulating Exceptions

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -59,6 +59,8 @@ It is possible to disable this default, by setting the exception policies'
 **In IDS mode**, setting ``auto`` mode actually means disabling the
 ``master-switch``, or ignoring the exception policies.
 
+.. _eps_settings:
+
 Specific settings
 ~~~~~~~~~~~~~~~~~
 
@@ -210,10 +212,52 @@ Notes:
    * Not valid means that Suricata will error out and won't start.
    * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender of the matching packet.
 
+.. _eps_output:
+
+Log Output
+----------
+
+.. _eps_flow_event:
+
+Flow Event
+~~~~~~~~~~
+
+When an Exception Policy is triggered, this will be indicated in the flow log
+event for the associated flow, also indicating which target triggered that, and
+what policy was applied. If no exception policy is triggered, that field won't
+be present in the logs.
+
+Note that this is true even if the policy is applied only to certain packets from
+a flow.
+
+In the log sample below, the flow triggered the ``midstream policy``, leading
+to Suricata applying the behavior that had been configured for such scenario:
+*to pass the flow* (``pass_flow``)::
+
+  "flow": {
+    "pkts_toserver": 4,
+    "pkts_toclient": 5,
+    "bytes_toserver": 495,
+    "bytes_toclient": 351,
+    "start": "2016-07-13T22:42:07.199672+0000",
+    "end": "2016-07-13T22:42:07.573174+0000",
+    "age": 0,
+    "state": "new",
+    "reason": "shutdown",
+    "alerted": false,
+    "action": "pass",
+    "exception_policy_triggered": [
+      {
+        "target": "stream_midstream",
+        "policy": "pass_flow"
+      }
+    ]
+  },
+
 .. _eps_stats:
 
 Available Stats
----------------
+~~~~~~~~~~~~~~~
 
 There are stats counters for each supported exception policy scenario:
 

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -1669,6 +1669,12 @@ Fields
 * "state": display state of the flow (include "new", "established", "closed", "bypassed")
 * "reason": mechanism that did trigger the end of the flow (include "timeout", "forced" and "shutdown")
 * "alerted": "true" or "false" depending if an alert has been seen on flow
+* "action": "pass" or "drop" depending if flow was PASS'ed or DROP'ed (no present if none)
+* "exception_policy_triggered.target": if an exception policy was triggered,
+  what setting exception led to this (cf. :ref:`Exception Policy - Specific
+  Settings<eps_settings>`).
+* "exception_policy_triggered.policy": if an exception policy was triggered,
+  what policy was applied (to the flow or to any packet(s) from it)
 
 Example ::
 
@@ -1689,7 +1695,14 @@ Example ::
     "bypass": "capture",
     "state": "bypassed",
     "reason": "timeout",
-    "alerted": false
+    "alerted": false,
+    "action": "pass",
+    "exception_policy_triggered": [
+      {
+        "target": "stream_midstream",
+        "policy": "pass_flow"
+      }
+    ]
   }
 
 Event type: RDP

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1872,6 +1872,20 @@
                 "end": {
                     "type": "string"
                 },
+                "exception_policy_triggered": {
+                    "description": "The exception policy(ies) triggered by the flow. Not logged if none was triggered",
+                    "type": "array",
+                    "properties": {
+                        "target": {
+                            "description": "What triggered the exception",
+                            "type": "string"
+                        },
+                        "policy": {
+                            "description": "Which exception policy was applied",
+                            "type": "string"
+                        }
+                    }
+                },
                 "pkts_toclient": {
                     "type": "integer"
                 },

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2021 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -151,6 +151,11 @@ enum ExceptionPolicy g_applayerparser_error_policy = EXCEPTION_POLICY_NOT_SET;
 static void AppLayerConfig(void)
 {
     g_applayerparser_error_policy = ExceptionPolicyParse("app-layer.error-policy", true);
+}
+
+enum ExceptionPolicy AppLayerErrorGetExceptionPolicy(void)
+{
+    return g_applayerparser_error_policy;
 }
 
 static void AppLayerParserFramesFreeContainer(FramesContainer *frames)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -135,6 +135,8 @@ void AppLayerParserThreadCtxFree(AppLayerParserThreadCtx *tctx);
  */
 int AppLayerParserConfParserEnabled(const char *ipproto,
                                     const char *alproto_name);
+
+enum ExceptionPolicy AppLayerErrorGetExceptionPolicy(void);
 
 /** \brief Prototype for parsing functions */
 typedef AppLayerResult (*AppLayerParserFPtr)(Flow *f, void *protocol_state,

--- a/src/flow.h
+++ b/src/flow.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -55,7 +55,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /** next packet in toclient direction will act on updated app-layer state */
 #define FLOW_TC_APP_UPDATE_NEXT BIT_U32(2)
 
-// vacancy bit 3
+/** if an exception policy was triggered, use this to log about that */
+#define FLOW_TRIGGERED_EXCEPTION_POLICY BIT_U32(3)
 
 // vacancy bit 4
 
@@ -491,6 +492,9 @@ typedef struct Flow_
     uint32_t tosrcpktcnt;
     uint64_t todstbytecnt;
     uint64_t tosrcbytecnt;
+
+    /** which exception policies were applied, if any */
+    ExceptionTargets applied_exception_policy;
 
     Storage storage[];
 } Flow;

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2020 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -50,6 +50,7 @@
 #include "stream-tcp.h"
 #include "stream-tcp-private.h"
 #include "flow-storage.h"
+#include "util-exception-policy.h"
 
 static JsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
 {
@@ -279,6 +280,23 @@ static void EveFlowLogJSON(OutputJsonThreadCtx *aft, JsonBuilder *jb, Flow *f)
         JB_SET_STRING(jb, "action", "drop");
     } else if (f->flags & FLOW_ACTION_PASS) {
         JB_SET_STRING(jb, "action", "pass");
+    }
+    if (f->flags & FLOW_TRIGGERED_EXCEPTION_POLICY) {
+        jb_open_array(jb, "exception_policy_triggered");
+        for (uint i; i < EXCEPTION_POLICY_TARGETS_MAX; i++) {
+            if (f->applied_exception_policy.eps_targets[i]) {
+                JsonBuilder *jb_policy = jb_new_object();
+                if (jb_policy != NULL) {
+                    jb_set_string(jb_policy, "target", ExceptionPolicyTargetFlagToString(i));
+                    jb_set_string(jb_policy, "policy",
+                            ExceptionPolicyEnumToString(ExceptionPolicyTargetPolicy(i), true));
+                }
+                jb_close(jb_policy);
+                jb_append_object(jb, jb_policy);
+                jb_free(jb_policy);
+            }
+        }
+        jb_close(jb); /* close array */
     }
 
     /* Close flow. */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -894,6 +894,21 @@ static void StreamTcpSsnMemcapExceptionPolicyStatsIncr(
     if (likely(tv && id > 0)) {
         StatsIncr(tv, id);
     }
+}
+
+enum ExceptionPolicy StreamTcpSsnMemcapGetExceptionPolicy(void)
+{
+    return stream_config.ssn_memcap_policy;
+}
+
+enum ExceptionPolicy StreamTcpReassemblyMemcapGetExceptionPolicy(void)
+{
+    return stream_config.reassembly_memcap_policy;
+}
+
+enum ExceptionPolicy StreamMidstreamGetExceptionPolicy(void)
+{
+    return stream_config.midstream_policy;
 }
 
 /** \internal

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2024 Open Information Security Foundation
+/* Copyright (C) 2007-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -157,6 +157,10 @@ void StreamTcpDetectLogFlush(ThreadVars *tv, StreamTcpThread *stt, Flow *f, Pack
 
 const char *StreamTcpStateAsString(const enum TcpState);
 const char *StreamTcpSsnStateAsString(const TcpSession *ssn);
+
+enum ExceptionPolicy StreamTcpSsnMemcapGetExceptionPolicy(void);
+enum ExceptionPolicy StreamTcpReassemblyMemcapGetExceptionPolicy(void);
+enum ExceptionPolicy StreamMidstreamGetExceptionPolicy(void);
 
 /** ------- Inline functions: ------ */
 

--- a/src/util-exception-policy-types.h
+++ b/src/util-exception-policy-types.h
@@ -40,6 +40,24 @@ enum ExceptionPolicy {
  * "tcp.reassembly_exception_policy.drop_packet" + 1 */
 #define EXCEPTION_POLICY_COUNTER_MAX_LEN 45
 
+/** Possible scenario/ config settings for exception policies */
+enum ExceptionPolicyTargets {
+    EXCEPTION_TARGET_NONE = 0,
+    EXCEPTION_TARGET_DEFRAG_MEMCAP,
+    EXCEPTION_TARGET_SESSION_MEMCAP,
+    EXCEPTION_TARGET_REASSEMBLY_MEMCAP,
+    EXCEPTION_TARGET_FLOW_MEMCAP,
+    EXCEPTION_TARGET_MIDSTREAM,
+    EXCEPTION_TARGET_APPLAYER_ERROR,
+};
+
+#define EXCEPTION_POLICY_TARGETS_MAX (EXCEPTION_TARGET_APPLAYER_ERROR + 1)
+
+typedef struct ExceptionTargets_ {
+    /* Follows enum order */
+    bool eps_targets[EXCEPTION_POLICY_TARGETS_MAX];
+} ExceptionTargets;
+
 typedef struct ExceptionPolicyCounters_ {
     /* Follows enum order */
     uint16_t eps_id[EXCEPTION_POLICY_MAX];

--- a/src/util-exception-policy.c
+++ b/src/util-exception-policy.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2024 Open Information Security Foundation
+/* Copyright (C) 2022-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -19,14 +19,18 @@
  * \file
  */
 
+#include "util-exception-policy.h"
 #include "suricata-common.h"
 #include "suricata.h"
 #include "packet.h"
-#include "util-exception-policy.h"
 #include "util-misc.h"
 #include "stream-tcp-reassemble.h"
 #include "action-globals.h"
 #include "conf.h"
+#include "flow.h"
+#include "stream-tcp.h"
+#include "defrag-hash.h"
+#include "app-layer-parser.h"
 
 enum ExceptionPolicy g_eps_master_switch = EXCEPTION_POLICY_NOT_SET;
 /** true if exception policy was defined in config */
@@ -61,14 +65,82 @@ void SetMasterExceptionPolicy(void)
     g_eps_master_switch = ExceptionPolicyParse("exception-policy", true);
 }
 
-static enum ExceptionPolicy GetMasterExceptionPolicy(void)
+enum ExceptionPolicy GetMasterExceptionPolicy(void)
 {
     return g_eps_master_switch;
+}
+
+static enum ExceptionPolicyTargets ExceptionPolicyFlag(enum PacketDropReason drop_reason)
+{
+    switch (drop_reason) {
+        case PKT_DROP_REASON_DEFRAG_MEMCAP:
+            return EXCEPTION_TARGET_DEFRAG_MEMCAP;
+        case PKT_DROP_REASON_STREAM_MEMCAP:
+            return EXCEPTION_TARGET_SESSION_MEMCAP;
+        case PKT_DROP_REASON_STREAM_REASSEMBLY:
+            return EXCEPTION_TARGET_REASSEMBLY_MEMCAP;
+        case PKT_DROP_REASON_FLOW_MEMCAP:
+            return EXCEPTION_TARGET_FLOW_MEMCAP;
+        case PKT_DROP_REASON_STREAM_MIDSTREAM:
+            return EXCEPTION_TARGET_MIDSTREAM;
+        case PKT_DROP_REASON_APPLAYER_ERROR:
+            return EXCEPTION_TARGET_APPLAYER_ERROR;
+        default:
+            return EXCEPTION_TARGET_NONE;
+    }
+
+    return EXCEPTION_TARGET_NONE;
+}
+
+const char *ExceptionPolicyTargetFlagToString(enum ExceptionPolicyTargets target_flag)
+{
+    switch (target_flag) {
+        case EXCEPTION_TARGET_DEFRAG_MEMCAP:
+            return "defrag_memcap";
+        case EXCEPTION_TARGET_SESSION_MEMCAP:
+            return "stream_memcap";
+        case EXCEPTION_TARGET_REASSEMBLY_MEMCAP:
+            return "stream_reassembly_memcap";
+        case EXCEPTION_TARGET_FLOW_MEMCAP:
+            return "flow_memcap";
+        case EXCEPTION_TARGET_MIDSTREAM:
+            return "stream_midstream";
+        case EXCEPTION_TARGET_APPLAYER_ERROR:
+            return "app_layer_error";
+        default:
+            return "ignore";
+    }
+    return "ignore";
+}
+
+enum ExceptionPolicy ExceptionPolicyTargetPolicy(enum ExceptionPolicyTargets target_flag)
+{
+    switch (target_flag) {
+        case EXCEPTION_TARGET_DEFRAG_MEMCAP:
+            return DefragGetMemcapExceptionPolicy();
+        case EXCEPTION_TARGET_SESSION_MEMCAP:
+            return StreamTcpSsnMemcapGetExceptionPolicy();
+        case EXCEPTION_TARGET_REASSEMBLY_MEMCAP:
+            return StreamTcpReassemblyMemcapGetExceptionPolicy();
+        case EXCEPTION_TARGET_FLOW_MEMCAP:
+            return FlowGetMemcapExceptionPolicy();
+        case EXCEPTION_TARGET_MIDSTREAM:
+            return StreamMidstreamGetExceptionPolicy();
+        case EXCEPTION_TARGET_APPLAYER_ERROR:
+            return AppLayerErrorGetExceptionPolicy();
+        default:
+            return EXCEPTION_POLICY_NOT_SET;
+    }
+    return EXCEPTION_POLICY_NOT_SET;
 }
 
 void ExceptionPolicyApply(Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason)
 {
     SCLogDebug("start: pcap_cnt %" PRIu64 ", policy %u", p->pcap_cnt, policy);
+    if (p->flow) {
+        p->flow->flags |= FLOW_TRIGGERED_EXCEPTION_POLICY;
+        p->flow->applied_exception_policy.eps_targets[ExceptionPolicyFlag(drop_reason)] = true;
+    }
     switch (policy) {
         case EXCEPTION_POLICY_AUTO:
             break;

--- a/src/util-exception-policy.h
+++ b/src/util-exception-policy.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2024 Open Information Security Foundation
+/* Copyright (C) 2022-2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -26,7 +26,10 @@
 #include "util-exception-policy-types.h"
 
 const char *ExceptionPolicyEnumToString(enum ExceptionPolicy policy, bool is_json);
+const char *ExceptionPolicyTargetFlagToString(enum ExceptionPolicyTargets target_flag);
+enum ExceptionPolicy ExceptionPolicyTargetPolicy(enum ExceptionPolicyTargets target_flag);
 void SetMasterExceptionPolicy(void);
+enum ExceptionPolicy GetMasterExceptionPolicy(void);
 void ExceptionPolicyApply(
         Packet *p, enum ExceptionPolicy policy, enum PacketDropReason drop_reason);
 enum ExceptionPolicy ExceptionPolicyParse(const char *option, const bool support_flow);


### PR DESCRIPTION
## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/6215

Previous PR: https://github.com/OISF/suricata/pull/12683

Output sample:
```json
"flow": {
    "pkts_toserver": 4,
    "pkts_toclient": 5,
    "bytes_toserver": 495,
    "bytes_toclient": 351,
    "start": "2016-07-13T22:42:07.199672+0000",
    "end": "2016-07-13T22:42:07.573174+0000",
    "age": 0,
    "state": "new",
    "reason": "shutdown",
    "alerted": false,
    "action": "pass",
    "exception_policy_triggered": [
      {
        "target": "stream_midstream",
        "policy": "pass_flow"
      }
    ]
  },
```

Describe changes:
- change approach for logging exception policies to the flow event, now allowing for more than one triggered policy to be logged for the same flow
-- this includes some implementation changes to accommodate that
- incorporate feedback from previous PR
-- this includes an attempt at rearranging the Flow struct -- used `pahole` to check for holes and struct size. Size remains the same as before the change, from what I could compare

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2329
