### PR TITLE
detect: add keywords for LDAP attributes - v1

### DIFF
--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -291,3 +291,40 @@ add request operation and contains the LDAP attribute type
 .. container:: example-rule
 
   alert ldap any any -> any any (msg:"Test attribute type and operation"; :example-rule-emphasis:`ldap.request.operation:add_request; ldap.request.attribute_type; content:"objectClass";` sid:1;)
+
+ldap.responses.attribute_type
+-----------------------------
+
+Matches on LDAP attribute type from response operations.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ ldap.responses.attribute_type; content:"<content to match against>";
+
+``ldap.responses.attribute_type`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+``ldap.responses.attribute_type`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+This keyword maps to the EVE field ``ldap.responses[].search_result_entry.attributes[].type``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet has the LDAP attribute type ``dc``:
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test responses attribute type"; :example-rule-emphasis:`ldap.responses.attribute_type; content:"dc";` sid:1;)
+
+It is possible to use the keyword ``ldap.responses.operation`` in the same rule to
+specify the operation to match.
+
+Here is an example of a signature that would alert if a packet has an LDAP
+search result entry operation at index 1 on the responses array,
+and contains the LDAP attribute type ``dc``.
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test attribute type and operation"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,1; ldap.responses.attribute_type; content:"dc";` sid:1;)

--- a/doc/userguide/rules/ldap-keywords.rst
+++ b/doc/userguide/rules/ldap-keywords.rst
@@ -251,3 +251,43 @@ and contains the LDAP distinguished name ``dc=example,dc=com``.
 .. container:: example-rule
 
   alert ldap any any -> any any (msg:"Test LDAPDN and operation"; :example-rule-emphasis:`ldap.responses.operation:search_result_entry,1; ldap.responses.dn; content:"dc=example,dc=com";` sid:1;)
+
+ldap.request.attribute_type
+---------------------------
+
+Matches on LDAP attribute type from request operations.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ ldap.request.attribute_type; content:"<content to match against>";
+
+``ldap.request.attribute_type`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE fields:
+
+   - ``ldap.request.search_request.attributes[]``
+   - ``ldap.request.modify_request.changes[].modification.attribute_type``
+   - ``ldap.request.add_request.attributes[].name``
+   - ``ldap.request.compare_request.attribute_value_assertion.description``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet has the LDAP attribute type ``objectClass``:
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test attribute type"; :example-rule-emphasis:`ldap.request.attribute_type; content:"objectClass";` sid:1;)
+
+It is possible to use the keyword ``ldap.request.operation`` in the same rule to
+specify the operation to match.
+
+Here is an example of a signature that would alert if a packet has an LDAP
+add request operation and contains the LDAP attribute type
+``objectClass``.
+
+.. container:: example-rule
+
+  alert ldap any any -> any any (msg:"Test attribute type and operation"; :example-rule-emphasis:`ldap.request.operation:add_request; ldap.request.attribute_type; content:"objectClass";` sid:1;)

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -58,6 +58,7 @@ static mut G_LDAP_RESPONSES_COUNT_BUFFER_ID: c_int = 0;
 static mut G_LDAP_REQUEST_DN_BUFFER_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_DN_BUFFER_ID: c_int = 0;
 static mut G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID: c_int = 0;
+static mut G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn ldap_parse_protocol_req_op(
     ustr: *const std::os::raw::c_char,
@@ -454,6 +455,59 @@ unsafe extern "C" fn ldap_tx_get_req_attribute_type(
     return false;
 }
 
+unsafe extern "C" fn ldap_detect_responses_attibute_type_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_LDAP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ldap_detect_responses_attribute_type_get_data(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        ldap_tx_get_resp_attribute_type,
+    );
+}
+
+unsafe extern "C" fn ldap_tx_get_resp_attribute_type(
+    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, LdapTransaction);
+
+    let mut pos = 0_u32;
+    for i in 0..tx.responses.len() {
+        let response = &tx.responses[i];
+        match &response.protocol_op {
+            ProtocolOp::SearchResultEntry(resp) => {
+                if local_id < pos + resp.attributes.len() as u32 {
+                    let value = &resp.attributes[(local_id - pos) as usize].attr_type.0;
+                    *buffer = value.as_ptr(); //unsafe
+                    *buffer_len = value.len() as u32;
+                    return true;
+                } else {
+                    pos += resp.attributes.len() as u32;
+                }
+            }
+            _ => continue,
+        }
+    }
+    return false;
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectLdapRegister() {
     let kw = SCSigTableElmt {
@@ -559,5 +613,24 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         false, //to client
         true,  //to server
         ldap_detect_request_attribute_type_get_data,
+    );
+    let kw = SCSigTableElmt {
+        name: b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
+        desc: b"match LDAP responses attribute type\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ldap-keywords.html#ldap.responses.attribute_type\0".as_ptr()
+            as *const libc::c_char,
+        Setup: ldap_detect_responses_attibute_type_setup,
+        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _g_ldap_responses_attribute_type_kw_id = DetectHelperKeywordRegister(&kw);
+    G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
+        b"LDAP RESPONSES ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
+        ALPROTO_LDAP,
+        true,  //to client
+        false, //to server
+        ldap_detect_responses_attribute_type_get_data,
     );
 }

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -57,6 +57,7 @@ static mut G_LDAP_RESPONSES_COUNT_KW_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_COUNT_BUFFER_ID: c_int = 0;
 static mut G_LDAP_REQUEST_DN_BUFFER_ID: c_int = 0;
 static mut G_LDAP_RESPONSES_DN_BUFFER_ID: c_int = 0;
+static mut G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID: c_int = 0;
 
 unsafe extern "C" fn ldap_parse_protocol_req_op(
     ustr: *const std::os::raw::c_char,
@@ -379,6 +380,80 @@ unsafe extern "C" fn ldap_tx_get_responses_dn(
     return true;
 }
 
+unsafe extern "C" fn ldap_detect_request_attibute_type_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_LDAP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn ldap_detect_request_attribute_type_get_data(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int, local_id: u32,
+) -> *mut c_void {
+    return DetectHelperGetMultiData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        local_id,
+        ldap_tx_get_req_attribute_type,
+    );
+}
+
+unsafe extern "C" fn ldap_tx_get_req_attribute_type(
+    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, LdapTransaction);
+
+    *buffer = std::ptr::null();
+    *buffer_len = 0;
+    if let Some(request) = &tx.request {
+        let str_buffer: &str = match &request.protocol_op {
+            ProtocolOp::SearchRequest(req) => {
+                if local_id as usize >= req.attributes.len() {
+                    return false;
+                }
+                req.attributes[local_id as usize].0.as_str()
+            }
+            ProtocolOp::ModifyRequest(req) => {
+                if local_id as usize >= req.changes.len() {
+                    return false;
+                }
+                req.changes[local_id as usize]
+                    .modification
+                    .attr_type
+                    .0
+                    .as_str()
+            }
+            ProtocolOp::AddRequest(req) => {
+                if local_id as usize >= req.attributes.len() {
+                    return false;
+                }
+                req.attributes[local_id as usize].attr_type.0.as_str()
+            }
+            ProtocolOp::CompareRequest(req) => {
+                if local_id > 0 {
+                    return false;
+                }
+                req.ava.attribute_desc.0.as_str()
+            }
+            _ => return false,
+        };
+        *buffer = str_buffer.as_ptr();
+        *buffer_len = str_buffer.len() as u32;
+        return true;
+    }
+    return false;
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectLdapRegister() {
     let kw = SCSigTableElmt {
@@ -465,5 +540,24 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         true,  //to client
         false, //to server
         ldap_detect_responses_dn_get_data,
+    );
+    let kw = SCSigTableElmt {
+        name: b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
+        desc: b"match request LDAP attribute type\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/ldap-keywords.html#ldap.request.attribute_type\0".as_ptr()
+            as *const libc::c_char,
+        Setup: ldap_detect_request_attibute_type_setup,
+        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _g_ldap_request_attribute_type_kw_id = DetectHelperKeywordRegister(&kw);
+    G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+        b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
+        b"LDAP REQUEST ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
+        ALPROTO_LDAP,
+        false, //to client
+        true,  //to server
+        ldap_detect_request_attribute_type_get_data,
     );
 }


### PR DESCRIPTION
Ticket: [#7533](https://redmine.openinfosecfoundation.org/issues/7533)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
     https://redmine.openinfosecfoundation.org/issues/7533

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7533

### Description:
- Implement keywords ``ldap.request.attribute_type`` and ``ldap.responses.attribute_type``

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2331

