### PR TITLE
ci: fix clusterfuzzlite build

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -11,6 +11,7 @@ RUN git clone --depth 1 -b develop https://github.com/madler/zlib.git
 RUN git clone --depth=1 https://github.com/catenacyber/fuzzpcap
 
 ENV RUSTUP_TOOLCHAIN nightly
+RUN rustup toolchain install nightly-x86_64-unknown-linux-gnu
 RUN cargo install --force cbindgen
 
 RUN git clone --depth 1 https://github.com/OISF/libhtp.git libhtp


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None, just fix CI

Describe changes:
- ci: fix clusterfuzzlite build

We had
> cargo install cbindgen
```
error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install nightly-x86_64-unknown-linux-gnu` to install it
```