### PR TITLE
detect/files: append data on closing even with FILE_NOSTORE for file.data keyword usage

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1019,11 +1019,10 @@ int FileCloseFilePtr(File *ff, const StreamingBufferConfig *sbcfg, const uint8_t
                 SCLogDebug("file %p data %p data_len %u", ff, data, data_len);
                 SCSha256Update(ff->sha256_ctx, data, data_len);
             }
-        } else {
-            if (AppendData(sbcfg, ff, data, data_len) != 0) {
-                ff->state = FILE_STATE_ERROR;
-                SCReturnInt(-1);
-            }
+        }
+        if (AppendData(sbcfg, ff, data, data_len) != 0) {
+            ff->state = FILE_STATE_ERROR;
+            SCReturnInt(-1);
         }
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7577

Describe changes:
- detect/files: append data on closing even with FILE_NOSTORE, useful on HTTP1 multipart small files where we close the file with the whole data

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2333
