### PR TITLE
files: append data on closing even with FILE_NOSTORE (backport7)

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1018,11 +1018,10 @@ int FileCloseFilePtr(File *ff, const StreamingBufferConfig *sbcfg, const uint8_t
                 SCLogDebug("file %p data %p data_len %u", ff, data, data_len);
                 SCSha256Update(ff->sha256_ctx, data, data_len);
             }
-        } else {
-            if (AppendData(sbcfg, ff, data, data_len) != 0) {
-                ff->state = FILE_STATE_ERROR;
-                SCReturnInt(-1);
-            }
+        }
+        if (AppendData(sbcfg, ff, data, data_len) != 0) {
+            ff->state = FILE_STATE_ERROR;
+            SCReturnInt(-1);
         }
     }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7581

Describe changes:
- backport of https://github.com/OISF/suricata/pull/12713 clean cherry-pick

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2338
