### PR TITLE
Detect revflow 7552 backport7 v2

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -6829,6 +6829,7 @@ static int HTPParserTest25(void)
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_HTTP1;
+    f->flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     const char *str = "GET / HTTP/1.1\r\nHost: www.google.com\r\nUser-Agent: Suricata/1.0\r\n\r\n";
     int r = AppLayerParserParse(NULL, alp_tctx, f, ALPROTO_HTTP1, STREAM_TOSERVER | STREAM_START,

--- a/src/app-layer-ike.c
+++ b/src/app-layer-ike.c
@@ -66,6 +66,7 @@ static int IkeParserTest(void)
     f.proto = IPPROTO_UDP;
     f.protomap = FlowGetProtoMapping(f.proto);
     f.alproto = ALPROTO_IKE;
+    f.flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     StreamTcpInitConfig(true);
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -999,7 +999,8 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
         }
 
         if (txd && has_tx_detect_flags) {
-            if (!IS_DISRUPTED(ts_disrupt_flags) && f->sgh_toserver != NULL) {
+            if (!IS_DISRUPTED(ts_disrupt_flags) &&
+                    (f->sgh_toserver != NULL || (f->flags & FLOW_SGH_TOSERVER) == 0)) {
                 uint64_t detect_flags_ts = AppLayerParserGetTxDetectFlags(txd, STREAM_TOSERVER);
                 if (!(detect_flags_ts &
                             (APP_LAYER_TX_INSPECTED_FLAG | APP_LAYER_TX_SKIP_INSPECT_FLAG))) {
@@ -1008,7 +1009,8 @@ void AppLayerParserTransactionsCleanup(Flow *f, const uint8_t pkt_dir)
                     tx_skipped = true;
                 }
             }
-            if (!IS_DISRUPTED(tc_disrupt_flags) && f->sgh_toclient != NULL) {
+            if (!IS_DISRUPTED(tc_disrupt_flags) &&
+                    (f->sgh_toclient != NULL || (f->flags & FLOW_SGH_TOCLIENT) == 0)) {
                 uint64_t detect_flags_tc = AppLayerParserGetTxDetectFlags(txd, STREAM_TOCLIENT);
                 if (!(detect_flags_tc &
                             (APP_LAYER_TX_INSPECTED_FLAG | APP_LAYER_TX_SKIP_INSPECT_FLAG))) {

--- a/src/app-layer-rfb.c
+++ b/src/app-layer-rfb.c
@@ -83,6 +83,7 @@ static int RFBParserTest(void)
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_RFB;
+    f->flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     static const unsigned char rfb_version_str[12] = {
             0x52, 0x46, 0x42, 0x20, 0x30, 0x30, 0x33, 0x2e, 0x30, 0x30, 0x37, 0x0a

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -74,6 +74,7 @@ static int SMBParserTxCleanupTest(void)
     f->protoctx = &ssn;
     f->proto = IPPROTO_TCP;
     f->alproto = ALPROTO_SMB;
+    f->flags |= FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
 
     char req_str[] ="\x00\x00\x00\x79\xfe\x53\x4d\x42\x40\x00\x01\x00\x00\x00\x00\x00" \
                      "\x05\x00\xe0\x1e\x10\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00" \

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -410,6 +410,8 @@ static int TCPProtoDetect(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 SCLogDebug("reversing flow after proto detect told us so");
                 PacketSwap(p);
                 FlowSwap(f);
+                // Will reset signature groups in DetectRunSetup
+                f->de_ctx_version = UINT32_MAX;
                 SWAP_FLAGS(flags, STREAM_TOSERVER, STREAM_TOCLIENT);
                 if (*stream == &ssn->client) {
                     *stream = &ssn->server;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7552

Describe changes:
- Backport of #12716 clean cherry-pick + additional line change in RFB unit test in second commit

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2342

https://github.com/OISF/suricata/pull/12741 with additional fix in RFB unit test that got moved to SV in Suricata 8