### PR TITLE
rust: pin once_cell to work with Rust 1.67.1

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1361,6 +1361,7 @@ name = "suricatactl"
 version = "8.0.0-dev"
 dependencies = [
  "clap",
+ "once_cell",
  "regex",
  "tracing",
  "tracing-subscriber",
@@ -1371,6 +1372,7 @@ name = "suricatasc"
 version = "8.0.0-dev"
 dependencies = [
  "clap",
+ "once_cell",
  "rustyline",
  "rustyline-derive",
  "serde",

--- a/rust/suricatactl/Cargo.toml.in
+++ b/rust/suricatactl/Cargo.toml.in
@@ -14,3 +14,6 @@ tracing-subscriber = "0.3"
 
 # 4.0 is the newest version that builds with Rust 1.67.1.
 clap = { version = "=4.2.0", default-features = false, features = ["std", "derive", "help", "usage"] }
+
+# Pin once_cell otherwise clap will pull in v1.21.0 which requires Rust 1.70+.
+once_cell = { version = "=1.20.3" }

--- a/rust/suricatasc/Cargo.toml.in
+++ b/rust/suricatasc/Cargo.toml.in
@@ -13,6 +13,9 @@ name = "suricatasc"
 # 4.0 is the newest version that builds with Rust 1.67.1.
 clap = { version = "=4.2.0", default-features = false, features = ["std", "derive", "help", "usage"] }
 
+# Pin once_cell otherwise clap will pull in v1.21.0 which requires Rust 1.70+.
+once_cell = { version = "=1.20.3" }
+
 # Need to pin back for Rust 1.67.1
 rustyline = { version = "=11.0.0" }
 rustyline-derive = { version = "0.9.0" }


### PR DESCRIPTION
Clap uses once_cell which recently released v1.21 which updated its
MSRV to 1.70. Locally pin once_cell to 1.20.3 to maintain our MSRV.
