### PR TITLE
detect: add mime email.from keyword - v1

### DIFF
--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -1,0 +1,101 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::mime;
+use super::smtp::{MimeStateSMTP, ALPROTO_SMTP};
+use crate::detect::{
+    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableElmt,
+    SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+};
+
+use std::os::raw::{c_int, c_void};
+
+static mut G_MIME_EMAIL_FROM_BUFFER_ID: c_int = 0;
+
+unsafe extern "C" fn mime_detect_email_from_setup(
+    de: *mut c_void, s: *mut c_void, _raw: *const std::os::raw::c_char,
+) -> c_int {
+    if DetectSignatureSetAppProto(s, ALPROTO_SMTP) != 0 {
+        return -1;
+    }
+    if DetectBufferSetActiveList(de, s, G_MIME_EMAIL_FROM_BUFFER_ID) < 0 {
+        return -1;
+    }
+    return 0;
+}
+
+unsafe extern "C" fn mime_detect_email_from_get_data(
+    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
+    tx: *const c_void, list_id: c_int,
+) -> *mut c_void {
+    return DetectHelperGetData(
+        de,
+        transforms,
+        flow,
+        flow_flags,
+        tx,
+        list_id,
+        mime_tx_get_email_from,
+    );
+}
+
+unsafe extern "C" fn mime_tx_get_email_from(
+    tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, MimeStateSMTP);
+
+    *buffer = std::ptr::null();
+    *buffer_len = 0;
+
+    let hname: &str = "from";
+    for header in &tx.headers[..tx.main_headers_nb] {
+        if mime::slice_equals_lowercase(&header.name, hname.as_bytes()) {
+            SCLogInfo!(
+                "detect: value=[{}]\n",
+                &String::from_utf8_lossy(&header.value)
+            );
+            let str_buffer: &str = &String::from_utf8_lossy(&header.value);
+            *buffer = str_buffer.as_ptr();
+            *buffer_len = str_buffer.len() as u32;
+            return true;
+        }
+    }
+    return false;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeRegister() {
+    let kw = SCSigTableElmt {
+        name: b"email.from\0".as_ptr() as *const libc::c_char,
+        desc: b"match MIME email from\0".as_ptr() as *const libc::c_char,
+        url: b"/rules/mime-keywords.html#email.from\0".as_ptr() as *const libc::c_char,
+        Setup: mime_detect_email_from_setup,
+        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
+        AppLayerTxMatch: None,
+        Free: None,
+    };
+    let _g_mime_email_from_kw_id = DetectHelperKeywordRegister(&kw);
+    G_MIME_EMAIL_FROM_BUFFER_ID = DetectHelperBufferMpmRegister(
+        b"email.from\0".as_ptr() as *const libc::c_char,
+        b"MIME EMAIL FROM\0".as_ptr() as *const libc::c_char,
+        ALPROTO_SMTP,
+        true, //to client
+        true, //to server
+        mime_detect_email_from_get_data,
+    );
+}

--- a/rust/src/mime/mod.rs
+++ b/rust/src/mime/mod.rs
@@ -17,6 +17,7 @@
 
 //! MIME protocol parser module.
 
+pub mod detect;
 pub mod mime;
 pub mod smtp;
 pub mod smtp_log;

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -16,9 +16,9 @@
  */
 
 use super::mime;
-use crate::utils::base64;
 use crate::core::StreamingBufferConfig;
 use crate::filecontainer::FileContainer;
+use crate::utils::base64;
 use digest::generic_array::{typenum::U16, GenericArray};
 use digest::Digest;
 use digest::Update;
@@ -457,17 +457,16 @@ fn mime_smtp_parse_line(
                                 for _i in 0..4 - decoder.nb {
                                     v.push(b'=');
                                 }
-                                let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + v.len()) as u32);
+                                let dec_size = base64::get_decoded_buffer_size(
+                                    (decoder.nb as usize + v.len()) as u32,
+                                );
                                 let mut dec = vec![0; dec_size as usize];
                                 let mut dec_len = 0;
-                                if base64::decode_rfc2045(decoder, &v, &mut dec, &mut dec_len).is_ok() {
+                                if base64::decode_rfc2045(decoder, &v, &mut dec, &mut dec_len)
+                                    .is_ok()
+                                {
                                     unsafe {
-                                        FileAppendData(
-                                            ctx.files,
-                                            ctx.sbcfg,
-                                            dec.as_ptr(),
-                                            dec_len,
-                                        );
+                                        FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
                                     }
                                 }
                             }
@@ -505,10 +504,14 @@ fn mime_smtp_parse_line(
                                     if i.len() > MAX_ENC_LINE_LEN {
                                         warnings |= MIME_ANOM_LONG_ENC_LINE;
                                     }
-                                    let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + i.len()) as u32);
+                                    let dec_size = base64::get_decoded_buffer_size(
+                                        (decoder.nb as usize + i.len()) as u32,
+                                    );
                                     let mut dec = vec![0; dec_size as usize];
                                     let mut dec_len = 0; // unnecessary but required by fn args
-                                    if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len).is_ok() {
+                                    if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len)
+                                        .is_ok()
+                                    {
                                         mime_smtp_find_url_strings(ctx, &dec);
                                     } else {
                                         warnings |= MIME_ANOM_INVALID_BASE64;
@@ -547,18 +550,15 @@ fn mime_smtp_parse_line(
                             if i.len() > MAX_ENC_LINE_LEN {
                                 warnings |= MIME_ANOM_LONG_ENC_LINE;
                             }
-                            let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + i.len()) as u32);
+                            let dec_size = base64::get_decoded_buffer_size(
+                                (decoder.nb as usize + i.len()) as u32,
+                            );
                             let mut dec = vec![0; dec_size as usize];
                             let mut dec_len = 0;
                             if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len).is_ok() {
                                 mime_smtp_find_url_strings(ctx, &dec);
                                 unsafe {
-                                    FileAppendData(
-                                        ctx.files,
-                                        ctx.sbcfg,
-                                        dec.as_ptr(),
-                                        dec_len,
-                                    );
+                                    FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
                                 }
                             } else {
                                 warnings |= MIME_ANOM_INVALID_BASE64;

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -25,6 +25,9 @@ use digest::Update;
 use md5::Md5;
 use std::ffi::CStr;
 use std::os::raw::c_uchar;
+use suricata_sys::sys::AppProto;
+
+pub(super) static mut ALPROTO_SMTP: AppProto = 4;
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Eq)]

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -743,6 +743,7 @@ void SigTableSetup(void)
     SCDetectSipRegister();
     SCDetectTemplateRegister();
     SCDetectLdapRegister();
+    SCDetectMimeRegister();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {
         PreregisteredCallbacks[i]();


### PR DESCRIPTION
Ticket: [#7592](https://redmine.openinfosecfoundation.org/issues/7592)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7592

### Description:
- Implement ``email.from``  keyword.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2349
