### PR TITLE
output: Add linktype name

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3558,6 +3558,10 @@
             "properties": {
                 "linktype": {
                     "type": "integer"
+                },
+                "linktype_name": {
+                    "type": "string",
+                    "description": "the descriptive name of the linktype"
                 }
             },
             "additionalProperties": false

--- a/rust/src/utils/datalink.rs
+++ b/rust/src/utils/datalink.rs
@@ -1,0 +1,77 @@
+/* Copyright (C) 2024 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// Author: Jeff Lucovsky <jlucovsky@oisf.net>
+
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+use std::ptr;
+
+fn get_datalink_value(map: &HashMap<i32, CString>, key: i32) -> Option<&CString> {
+    map.get(&key)
+}
+
+fn add_datalink_value(map: &mut HashMap<i32, CString>, key: i32, value: &CStr) {
+    if let Ok(str_value) = value.to_str() {
+        if let Ok(cstring_value) = CString::new(str_value) {
+            map.insert(key, cstring_value);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn SCDatalinkInit() -> *mut HashMap<i32, CString> {
+    let map: HashMap<i32, CString> = HashMap::new();
+    Box::into_raw(Box::new(map))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDatalinkValueNameInsert(
+    map: *mut HashMap<i32, CString>, key: i32, value: *const c_char,
+) {
+    if map.is_null() || value.is_null() {
+        return;
+    }
+
+    let map = &mut *map;
+    let c_str = CStr::from_ptr(value);
+
+    add_datalink_value(map, key, c_str);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDatalinkValueToName(
+    map: *mut HashMap<i32, CString>, key: i32,
+) -> *const c_char {
+    if map.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let map = &*map;
+    match get_datalink_value(map, key) {
+        Some(value) => value.as_ptr(),
+        None => ptr::null(),
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDatalinkDeInit(map: *mut HashMap<i32, CString>) {
+    if !map.is_null() {
+        let _ = Box::from_raw(map); // Automatically dropped at end of scope
+    }
+}

--- a/rust/src/utils/mod.rs
+++ b/rust/src/utils/mod.rs
@@ -16,3 +16,4 @@
  */
 
 pub mod base64;
+pub mod datalink;

--- a/src/decode.h
+++ b/src/decode.h
@@ -33,6 +33,7 @@
 #include "util-debug.h"
 #include "decode-events.h"
 #include "util-exception-policy-types.h"
+#include "util-datalink.h"
 #ifdef PROFILING
 #include "flow-worker.h"
 #include "app-layer-protos.h"
@@ -1204,45 +1205,6 @@ void DecodeUnregisterCounters(void);
 #ifndef IPPROTO_SHIM6
 #define IPPROTO_SHIM6 140
 #endif
-
-/* pcap provides this, but we don't want to depend on libpcap */
-#ifndef DLT_EN10MB
-#define DLT_EN10MB 1
-#endif
-
-#ifndef DLT_C_HDLC
-#define DLT_C_HDLC 104
-#endif
-
-/* taken from pcap's bpf.h */
-#ifndef DLT_RAW
-#ifdef __OpenBSD__
-#define DLT_RAW     14  /* raw IP */
-#else
-#define DLT_RAW     12  /* raw IP */
-#endif
-#endif
-
-#ifndef DLT_NULL
-#define DLT_NULL 0
-#endif
-
-/** libpcap shows us the way to linktype codes
- * \todo we need more & maybe put them in a separate file? */
-#define LINKTYPE_NULL        DLT_NULL
-#define LINKTYPE_ETHERNET    DLT_EN10MB
-#define LINKTYPE_LINUX_SLL   113
-#define LINKTYPE_PPP         9
-#define LINKTYPE_RAW         DLT_RAW
-/* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.
- * Libpcap on at least OpenBSD returns 101 as datalink type for RAW pcaps though. */
-#define LINKTYPE_RAW2        101
-#define LINKTYPE_IPV4        228
-#define LINKTYPE_IPV6        229
-#define LINKTYPE_GRE_OVER_IP 778
-#define LINKTYPE_CISCO_HDLC  DLT_C_HDLC
-#define PPP_OVER_GRE         11
-#define VLAN_OVER_GRE        13
 
 /* Packet Flags */
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -428,8 +428,16 @@ void EvePacket(const Packet *p, JsonBuilder *js, uint32_t max_length)
         return;
     }
     if (!jb_set_uint(js, "linktype", p->datalink)) {
+        jb_close(js);
         return;
     }
+
+    const char *dl_name = DatalinkValueToName(p->datalink);
+
+    // Intentionally ignore the return value from jb_set_string and proceed
+    // so the jb object is closed
+    (void)jb_set_string(js, "linktype_name", dl_name == NULL ? "n/a" : dl_name);
+
     jb_close(js);
 }
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -400,6 +400,7 @@ void GlobalsDestroy(void)
     TmqhCleanup();
     TmModuleRunDeInit();
     ParseSizeDeinit();
+    DatalinkTableDeinit();
 
 #ifdef HAVE_DPDK
     DPDKCleanupEAL();
@@ -2880,6 +2881,7 @@ int InitGlobal(void)
 
     /* Initialize the configuration module. */
     ConfInit();
+    DatalinkTableInit();
 
     VarNameStoreInit();
 

--- a/src/util-datalink.c
+++ b/src/util-datalink.c
@@ -17,6 +17,7 @@
 
 #include "suricata-common.h"
 #include "util-datalink.h"
+#include "rust.h"
 #include "decode.h"
 
 int g_datalink_value = LINKTYPE_NULL;
@@ -41,4 +42,32 @@ inline int DatalinkGetGlobalType(void)
 bool DatalinkHasMultipleValues(void)
 {
     return g_datalink_is_multiple == 1;
+}
+
+static void *datalink_value_map;
+
+void DatalinkTableInit(void)
+{
+    datalink_value_map = SCDatalinkInit();
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_NULL, "NULL");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_ETHERNET, "EN10MB");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_LINUX_SLL, "LINUX_SLL");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_PPP, "PPP");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_RAW, "RAW");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_RAW2, "RAW2");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_GRE_OVER_IP, "GRE_RAW");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_NULL, "NULL");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_CISCO_HDLC, "C_HDLC");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_IPV4, "IPv4");
+    SCDatalinkValueNameInsert(datalink_value_map, LINKTYPE_IPV6, "IPv6");
+}
+
+void DatalinkTableDeinit(void)
+{
+    SCDatalinkDeInit(datalink_value_map);
+}
+
+const char *DatalinkValueToName(int datalink_value)
+{
+    return SCDatalinkValueToName(datalink_value_map, datalink_value);
 }

--- a/src/util-datalink.h
+++ b/src/util-datalink.h
@@ -18,8 +18,50 @@
 #ifndef SURICATA_UTIL_DATALINK_H
 #define SURICATA_UTIL_DATALINK_H
 
+#include "util-debug.h"
+
+/* pcap provides this, but we don't want to depend on libpcap */
+#ifndef DLT_EN10MB
+#define DLT_EN10MB 1
+#endif
+
+#ifndef DLT_C_HDLC
+#define DLT_C_HDLC 104
+#endif
+
+/* taken from pcap's bpf.h */
+#ifndef DLT_RAW
+#ifdef __OpenBSD__
+#define DLT_RAW 14 /* raw IP */
+#else
+#define DLT_RAW 12 /* raw IP */
+#endif
+#endif
+
+#ifndef DLT_NULL
+#define DLT_NULL 0
+#endif
+
+/** libpcap shows us the way to linktype codes
+ * \todo we need more & maybe put them in a separate file? */
+#define LINKTYPE_NULL      DLT_NULL
+#define LINKTYPE_ETHERNET  DLT_EN10MB
+#define LINKTYPE_LINUX_SLL 113
+#define LINKTYPE_PPP       9
+#define LINKTYPE_RAW       DLT_RAW
+/* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.
+ * Libpcap on at least OpenBSD returns 101 as datalink type for RAW pcaps though. */
+#define LINKTYPE_RAW2        101
+#define LINKTYPE_IPV4        228
+#define LINKTYPE_IPV6        229
+#define LINKTYPE_GRE_OVER_IP 778
+#define LINKTYPE_CISCO_HDLC  DLT_C_HDLC
+
 void DatalinkSetGlobalType(int datalink);
 int DatalinkGetGlobalType(void);
 bool DatalinkHasMultipleValues(void);
+void DatalinkTableInit(void);
+void DatalinkTableDeinit(void);
+const char *DatalinkValueToName(int datalink_value);
 
 #endif /* SURICATA_UTIL_DATALINK_H */


### PR DESCRIPTION
Continuation of #12497   

Issue: 6954

This commit adds the linktype name to the output stream. The name is determined from a Rust linktype-to-name function.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/6954

Describe changes:
- Include the linktype name alongside linktype
- Update the schema with linktype_name
- Custom linktype to name function in Rust.

Updates:
- Rebase
- Address review comments (from #12497)

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2023
