### PR TITLE
5486 missing ethernet v4

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -15,7 +15,9 @@ Each alert, http log, etc will go into this one file: 'eve.json'. This file
 can then be processed by 3rd party tools like Logstash (ELK) or jq.
 
 If ``ethernet`` is set to yes, then ethernet headers will be added to events
-if available.
+if available. If the ``pkt_src`` value is ``stream (flow timeout)``, then the
+``ethernet`` value will be populated with mac addresses from the flow's first
+packet with ethernet header.
 
 Output Buffering
 ~~~~~~~~~~~~~~~~

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -767,6 +767,22 @@ static int CreateJSONEther(
             JSONFormatAndAddMACAddr(js, "src_mac", src, false);
             JSONFormatAndAddMACAddr(js, "dest_mac", dst, false);
             jb_close(js);
+        } else if (f != NULL) {
+            /* When pseudopackets do not have associated ethernet metadata,
+               use the first set of mac addresses stored with their flow.
+               The first set of macs should come from the flow's first packet,
+               providing the most fitting representation of the event's ethernet. */
+            MacSet *ms = FlowGetStorageById(f, MacSetGetFlowStorageID());
+            if (ms != NULL && MacSetSize(ms) > 0) {
+                uint8_t *src = MacSetGetFirst(ms, MAC_SET_SRC);
+                uint8_t *dst = MacSetGetFirst(ms, MAC_SET_DST);
+                if (dst != NULL && src != NULL) {
+                    jb_open_object(js, "ether");
+                    JSONFormatAndAddMACAddr(js, "src_mac", src, false);
+                    JSONFormatAndAddMACAddr(js, "dest_mac", dst, false);
+                    jb_close(js);
+                }
+            }
         }
     } else if (f != NULL) {
         /* we are creating an ether object in a flow context, so we need to

--- a/src/util-macset.h
+++ b/src/util-macset.h
@@ -37,6 +37,7 @@ void MacSetAdd(MacSet *, const uint8_t *src_addr, const uint8_t *dst_addr);
 void MacSetAddWithCtr(MacSet *, const uint8_t *src_addr, const uint8_t *dst_addr, ThreadVars *tv,
         uint16_t ctr_src, uint16_t ctr_dst);
 int     MacSetForEach(const MacSet*, MacSetIteratorFunc, void*);
+uint8_t *MacSetGetFirst(const MacSet *, MacSetSide);
 int     MacSetSize(const MacSet*);
 void    MacSetReset(MacSet*);
 void    MacSetFree(MacSet*);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/5486

Describe changes:

Ethernet metadata is missing for events triggered on flow timeout pseudopackets. These changes use the first set of mac addresses stored with the flow to fill in the ether field.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2350

Previous PR: https://github.com/OISF/suricata/pull/12775

Changes since previous PR:
- expand unit test coverage