### PR TITLE
datasets: work around scan-build warning

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -477,8 +477,11 @@ Dataset *DatasetGet(const char *name, enum DatasetTypes type, const char *save, 
                 goto out_err;
             break;
     }
+    if (set->hash == NULL) {
+        goto out_err;
+    }
 
-    if (set->hash && SC_ATOMIC_GET(set->hash->memcap_reached)) {
+    if (SC_ATOMIC_GET(set->hash->memcap_reached)) {
         SCLogError("dataset too large for set memcap");
         goto out_err;
     }


### PR DESCRIPTION
datasets.c:493:27: warning: Dereference of null pointer [core.NullDereference]
  493 |     DEBUG_VALIDATE_BUG_ON(set->hash->config.hash_size != hashsize);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
./util-validate.h:95:44: note: expanded from macro 'DEBUG_VALIDATE_BUG_ON'
   95 | #define DEBUG_VALIDATE_BUG_ON(exp) BUG_ON((exp))
      |                                            ^~~
./suricata-common.h:307:36: note: expanded from macro 'BUG_ON'
  307 |         #define BUG_ON(x) assert(!(x))
      |                                    ^
/usr/include/assert.h:109:7: note: expanded from macro 'assert'
  109 |     ((expr)                                                             \
      |       ^~~~
1 warning generated.
