### PR TITLE
detect: add mime email.from keyword - v4

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -1,0 +1,28 @@
+Email Keywords
+==============
+
+.. role:: example-rule-emphasis
+
+email.from
+----------
+
+Matches the MIME ``From`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.from; content:"<content to match against>";
+
+``email.from`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.from``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``from`` with the value ``toto <toto@gmail.com>``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email from"; :example-rule-emphasis:`email.from; content:"toto <toto@gmail.com>";` sid:1;)

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -53,3 +53,4 @@ Suricata Rules
    vlan-keywords
    ldap-keywords
    rule-types
+   email-keywords

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -1,0 +1,43 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use super::mime;
+use super::smtp::MimeStateSMTP;
+use std::ffi::CStr;
+use std::ptr;
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetData(
+    ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
+    hname: *const std::os::raw::c_char,
+) -> u8 {
+    let c_str = CStr::from_ptr(hname); //unsafe
+    let str = c_str.to_str().unwrap_or("");
+
+    for h in &ctx.headers[..ctx.main_headers_nb] {
+        if mime::slice_equals_lowercase(&h.name, str.as_bytes()) {
+            *buffer = h.value.as_ptr();
+            *buffer_len = h.value.len() as u32;
+            return 1;
+        }
+    }
+
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
+    return 0;
+}

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -16,9 +16,9 @@
  */
 
 use super::mime;
-use crate::utils::base64;
 use crate::core::StreamingBufferConfig;
 use crate::filecontainer::FileContainer;
+use crate::utils::base64;
 use digest::generic_array::{typenum::U16, GenericArray};
 use digest::Digest;
 use digest::Update;
@@ -457,17 +457,16 @@ fn mime_smtp_parse_line(
                                 for _i in 0..4 - decoder.nb {
                                     v.push(b'=');
                                 }
-                                let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + v.len()) as u32);
+                                let dec_size = base64::get_decoded_buffer_size(
+                                    (decoder.nb as usize + v.len()) as u32,
+                                );
                                 let mut dec = vec![0; dec_size as usize];
                                 let mut dec_len = 0;
-                                if base64::decode_rfc2045(decoder, &v, &mut dec, &mut dec_len).is_ok() {
+                                if base64::decode_rfc2045(decoder, &v, &mut dec, &mut dec_len)
+                                    .is_ok()
+                                {
                                     unsafe {
-                                        FileAppendData(
-                                            ctx.files,
-                                            ctx.sbcfg,
-                                            dec.as_ptr(),
-                                            dec_len,
-                                        );
+                                        FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
                                     }
                                 }
                             }
@@ -505,10 +504,14 @@ fn mime_smtp_parse_line(
                                     if i.len() > MAX_ENC_LINE_LEN {
                                         warnings |= MIME_ANOM_LONG_ENC_LINE;
                                     }
-                                    let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + i.len()) as u32);
+                                    let dec_size = base64::get_decoded_buffer_size(
+                                        (decoder.nb as usize + i.len()) as u32,
+                                    );
                                     let mut dec = vec![0; dec_size as usize];
                                     let mut dec_len = 0; // unnecessary but required by fn args
-                                    if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len).is_ok() {
+                                    if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len)
+                                        .is_ok()
+                                    {
                                         mime_smtp_find_url_strings(ctx, &dec);
                                     } else {
                                         warnings |= MIME_ANOM_INVALID_BASE64;
@@ -547,18 +550,15 @@ fn mime_smtp_parse_line(
                             if i.len() > MAX_ENC_LINE_LEN {
                                 warnings |= MIME_ANOM_LONG_ENC_LINE;
                             }
-                            let dec_size = base64::get_decoded_buffer_size((decoder.nb as usize + i.len()) as u32);
+                            let dec_size = base64::get_decoded_buffer_size(
+                                (decoder.nb as usize + i.len()) as u32,
+                            );
                             let mut dec = vec![0; dec_size as usize];
                             let mut dec_len = 0;
                             if base64::decode_rfc2045(decoder, i, &mut dec, &mut dec_len).is_ok() {
                                 mime_smtp_find_url_strings(ctx, &dec);
                                 unsafe {
-                                    FileAppendData(
-                                        ctx.files,
-                                        ctx.sbcfg,
-                                        dec.as_ptr(),
-                                        dec_len,
-                                    );
+                                    FileAppendData(ctx.files, ctx.sbcfg, dec.as_ptr(), dec_len);
                                 }
                             } else {
                                 warnings |= MIME_ANOM_INVALID_BASE64;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -317,6 +317,7 @@ noinst_HEADERS = \
 	detect-within.h \
 	detect-xbits.h \
 	detect-vlan.h \
+	detect-email.h \
 	device-storage.h \
 	feature.h \
 	flow-bit.h \
@@ -891,6 +892,7 @@ libsuricata_c_a_SOURCES = \
 	detect-within.c \
 	detect-xbits.c \
 	detect-vlan.c \
+	detect-email.c \
 	device-storage.c \
 	feature.c \
 	flow-bit.c \

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "detect-engine.h"
+#include "detect-engine-helper.h"
+#include "detect-parse.h"
+#include "app-layer-smtp.h"
+#include "detect-email.h"
+#include "rust.h"
+
+static int g_mime_email_from_buffer_id = 0;
+
+static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_from_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailFromData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_from = NULL;
+        uint32_t b_email_from_len = 0;
+
+        if ((tx->mime_state != NULL)) {
+            if (SCDetectMimeEmailGetData(
+                        tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
+                return NULL;
+        }
+
+        if (b_email_from == NULL || b_email_from_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_from, b_email_from_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
+void DetectEmailRegister(void)
+{
+    SCSigTableElmt kw = { 0 };
+
+    kw.name = "email.from";
+    kw.desc = "'From' field from an email";
+    kw.url = "/rules/email-keywords.html#email.from";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailFromSetup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_from_buffer_id =
+            DetectHelperBufferMpmRegister("email.from", "MIME EMAIL FROM", ALPROTO_SMTP, false,
+                    true, // to server
+                    GetMimeEmailFromData);
+}

--- a/src/detect-email.h
+++ b/src/detect-email.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2021-2024 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-//! MIME protocol parser module.
+#ifndef SURICATA_DETECT_EMAIL_H
+#define SURICATA_DETECT_EMAIL_H
 
-pub mod detect;
-pub mod mime;
-pub mod smtp;
-pub mod smtp_log;
+void DetectEmailRegister(void);
+
+#endif /* SURICATA_DETECT_EMAIL_H */

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -252,6 +252,7 @@
 #include "detect-ike-nonce-payload.h"
 #include "detect-ike-key-exchange-payload.h"
 #include "detect-vlan.h"
+#include "detect-email.h"
 
 #include "action-globals.h"
 #include "tm-threads.h"
@@ -732,6 +733,8 @@ void SigTableSetup(void)
 
     DetectVlanIdRegister();
     DetectVlanLayersRegister();
+
+    DetectEmailRegister();
 
     SCDetectSMTPRegister();
     SCDetectSNMPRegister();


### PR DESCRIPTION
Ticket: [#7592](https://redmine.openinfosecfoundation.org/issues/7592)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7592

### Description:
- Implement ``email.from``  keyword.

### Changes:
- Change ``email.from`` keyword description to 'From' field from an email
- Rename ``DetectMimeRegister();`` to ``DetectEmailRegister();``
- Rename ``detect-mime.c`` and ``detect-mime.h`` to ``detect-email.c`` and ``detect-email.h``

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2351
Previous PR: https://github.com/OISF/suricata/pull/12784
