### PR TITLE
detect: add padding to suppress scan-build warning

### DIFF
--- a/src/detect.h
+++ b/src/detect.h
@@ -887,6 +887,7 @@ typedef struct DetectEngineCtx_ {
 
     /* force app-layer tx finding for alerts with signatures not having app-layer keywords */
     bool guess_applayer;
+    bool pad0[3];
 
     /* registration id for per thread ctx for the filemagic/file.magic keywords */
     int filemagic_thread_ctx_id;
@@ -928,6 +929,7 @@ typedef struct DetectEngineCtx_ {
 
     /* Maximum size of the buffer for decoded base64 data. */
     uint16_t base64_decode_max_len;
+    uint16_t pad1;
 
     /** Store rule file and line so that parsers can use them in errors. */
     int rule_line;
@@ -943,6 +945,7 @@ typedef struct DetectEngineCtx_ {
 
     /* specify the configuration for mpm context factory */
     uint8_t sgh_mpm_ctx_cnf;
+    uint8_t pad2[3];
 
     int keyword_id;
     /** hash list of keywords that need thread local ctxs */


### PR DESCRIPTION
Add to DetectEngineCtx to avoid:

./detect.h:840:16: warning: Excessive padding in 'struct DetectEngineCtx_' (32 padding bytes, where 0 is optimal). Optimal fields order: sig_list, srepCIDR_ctx, sig_array, sc_sig_order_funcs, sgh_hash_table, mpm_hash_table, pattern_hash_table, dup_sig_hash_table, spm_global_thread_ctx, mpm_ctx_factory_container, sgh_array, decoder_event_sgh, rule_file, sigerror, keyword_hash, next, dport_hash_table, tcp_whitelist, udp_whitelist, address_table, metadata_table, buffer_type_hash_name, buffer_type_hash_id, app_mpms_list, app_inspect_engines, pkt_inspect_engines, pkt_mpms_list, frame_inspect_engines, frame_mpms_list, prefilter_hash_table, fp_support_smlist_list, class_conf_ht, class_conf_regex, class_conf_regex_match, reference_conf_ht, reference_conf_regex, reference_conf_regex_match, ea, tenant_path, requirements, last_reload, sig_stat, ths_ctx, io_ctx, flow_gh, tenant_id, sig_cnt, srep_version, sig_array_size, sig_array_len, signum, non_pf_store_cnt_max, inspection_recursion_limit, filemagic_thread_ctx_id, max_fb_id, sgh_array_cnt, sgh_array_size, sgh_mpm_context_proto_tcp_packet, sgh_mpm_context_proto_udp_packet, sgh_mpm_context_proto_other_packet, sgh_mpm_context_stream, byte_extract_max_local_id, version, rule_line, keyword_id, type, ref_cnt, loader_id, prefilter_setting, buffer_type_id, app_mpms_list_cnt, pkt_mpms_list_cnt, frame_mpms_list_cnt, prefilter_id, filedata_config, max_uniq_toclient_groups, max_uniq_toserver_groups, base64_decode_max_len, filestore_cnt, failure_fatal, flags, mpm_matcher, spm_matcher, guess_applayer, sigerror_silent, sigerror_ok, sigerror_requires, filedata_config_initialized, sgh_mpm_ctx_cnf, config_prefix, sm_types_prefilter, sm_types_silent_error, consider reordering the fields or adding explicit padding members [optin.performance.Padding]
  840 | typedef struct DetectEngineCtx_ {
      |         ~~~~~~~^~~~~~~~~~~~~~~~~~
  841 |     bool failure_fatal;
      |     ~~~~~~~~~~~~~~~~~~~
  842 |     uint8_t flags;       /**< only DE_QUIET */
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  843 |     uint8_t mpm_matcher; /**< mpm matcher this ctx uses */
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  844 |     uint8_t spm_matcher; /**< spm matcher this ctx uses */
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  845 |
  846 |     uint32_t tenant_id;
      |     ~~~~~~~~~~~~~~~~~~~
  847 |
  848 |     Signature *sig_list;
      |     ~~~~~~~~~~~~~~~~~~~~
  849 |     uint32_t sig_cnt;
      |     ~~~~~~~~~~~~~~~~~
  850 |
  851 |     /* version of the srep data */
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  852 |     uint32_t srep_version;
      |     ~~~~~~~~~~~~~~~~~~~~~~
  853 |
  854 |     /* reputation for netblocks */
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  855 |     SRepCIDRTree *srepCIDR_ctx;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.

Replaces #12788