### PR TITLE
afpacket/v3: fix socket ref count v1

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -719,6 +719,7 @@ static void AFPReleasePacketV3(Packet *p)
     if (p->afp_v.copy_mode != AFP_COPY_MODE_NONE) {
         AFPWritePacket(p, TPACKET_V3);
     }
+    (void)AFPDerefSocket(p->afp_v.mpeer);
     PacketFreeOrRelease(p);
 }
 #endif


### PR DESCRIPTION
When using AFPacket V3, we can use
the packet data right from the ring (i.e.,
zero-copy).
The socket ref count is incremented to
ensure the socket isn't closed while
there are still references to the rx-queue.
However, we don't ever decrement those
references.
This add a ref decrement upon freeing
the packet.

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:  https://redmine.openinfosecfoundation.org/issues/7622

Describe changes:
- Add call to decrement reference count (see comit description)

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
