### PR TITLE
detect: add mime email.subject keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -26,3 +26,27 @@ Example of a signature that would alert if a packet contains the MIME field ``fr
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email from"; :example-rule-emphasis:`email.from; content:"toto <toto@gmail.com>";` sid:1;)
+
+email.subject
+-------------
+
+Matches the MIME ``Subject`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.subject; content:"<content to match against>";
+
+``email.subject`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.subject``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``subject`` with the value ``This is a test email``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email subject"; :example-rule-emphasis:`email.subject; content:"This is a test email";` sid:1;)


### PR DESCRIPTION
Ticket: [#7595](https://redmine.openinfosecfoundation.org/issues/7595)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7595

### Description:
- Implement ``email.subject``  keyword.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2360

