### PR TITLE
applayer: fix alp_ctx indexing in tests

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1813,7 +1813,7 @@ void AppLayerParserRegisterProtocolUnittests(uint8_t ipproto, AppProto alproto,
                                   void (*RegisterUnittests)(void))
 {
     SCEnter();
-    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+    alp_ctx.ctxs[alproto][FlowGetProtoMapping(ipproto)].
         RegisterUnittests = RegisterUnittests;
     SCReturn;
 }


### PR DESCRIPTION
Fix problem that some app-layer unittests regist failed.

Describe bug:
Some unittests in applayer never be called.
Describe changes:
Exchange row and colunm in AppLayerParserRegisterProtocolUnittests when regist app-layer unittests register.

