### PR TITLE
fuzz: set flow flags as in Suricata

### DIFF
--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -104,7 +104,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (f == NULL) {
         return 0;
     }
-    f->flags |= FLOW_IPV4;
+    f->flags |= FLOW_IPV4 | FLOW_SGH_TOCLIENT | FLOW_SGH_TOSERVER;
     f->src.addr_data32[0] = 0x01020304;
     f->dst.addr_data32[0] = 0x05060708;
     f->sp = (uint16_t)((data[2] << 8) | data[3]);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None but https://issues.oss-fuzz.com/u/1/issues/402587674

Describe changes:
- fuzz: set flow flags as in Suricata to be correct with d8ddef4c1485