### PR TITLE
detect: add email.cc keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -50,3 +50,29 @@ Example of a signature that would alert if a packet contains the MIME field ``su
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email subject"; :example-rule-emphasis:`email.subject; content:"This is a test email";` sid:1;)
+
+email.cc
+--------
+
+Matches the MIME ``Cc`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.cc; content:"<content to match against>";
+
+``email.cc`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+``email.cc`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+This keyword maps to the EVE field ``email.cc[]``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if any of the values in the MIME field ``cc`` contain ``toto <toto@gmail.com>``.
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email cc"; :example-rule-emphasis:`email.cc; content:"toto <toto@gmail.com>";` sid:1;)

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -74,6 +74,8 @@ not be met.
 Multiple buffer matching is currently enabled for use with the
 following keywords:
 
+* ``dns.answer.name``
+* ``dns.query.name``
 * ``dns.query``
 * ``file.data``
 * ``file.magic``
@@ -84,10 +86,20 @@ following keywords:
 * ``ike.vendor``
 * ``krb5_cname``
 * ``krb5_sname``
+* ``ldap.responses.dn``
+* ``ldap.responses.message``
 * ``mqtt.subscribe.topic``
 * ``mqtt.unsubscribe.topic``
 * ``quic.cyu.hash``
 * ``quic.cyu.string``
-* ``tls.certs``
+* ``sip.content_length``
+* ``sip.content_type``
+* ``sip.from``
+* ``sip.to``
+* ``sip.ua``
+* ``sip.via``
+* ``smtp.rcpt_to``
+* ``tls.alpn``
 * ``tls.cert_subject``
+* ``tls.certs``
 * ``tls.subjectaltname``

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -77,6 +77,7 @@ following keywords:
 * ``dns.answer.name``
 * ``dns.query.name``
 * ``dns.query``
+* ``email.cc``
 * ``file.data``
 * ``file.magic``
 * ``file.name``

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn SCMimeSmtpLogFieldArray(
     return false;
 }
 
-enum FieldCommaState {
+pub enum FieldCommaState {
     Start = 0, // skip leading spaces
     Field = 1,
     Quoted = 2, // do not take comma for split in quote

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -47,13 +47,10 @@ static InspectionBuffer *GetMimeEmailFromData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b_email_from = NULL;
         uint32_t b_email_from_len = 0;
 
-        if ((tx->mime_state != NULL)) {
-            if (SCDetectMimeEmailGetData(
-                        tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
-                return NULL;
-        }
+        if (tx->mime_state == NULL)
+            return NULL;
 
-        if (b_email_from == NULL || b_email_from_len == 0)
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b_email_from, b_email_from_len);
@@ -84,13 +81,11 @@ static InspectionBuffer *GetMimeEmailSubjectData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b_email_sub = NULL;
         uint32_t b_email_sub_len = 0;
 
-        if ((tx->mime_state != NULL)) {
-            if (SCDetectMimeEmailGetData(
-                        tx->mime_state, &b_email_sub, &b_email_sub_len, "subject") != 1)
-                return NULL;
-        }
+        if (tx->mime_state == NULL)
+            return NULL;
 
-        if (b_email_sub == NULL || b_email_sub_len == 0)
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_sub, &b_email_sub_len, "subject") !=
+                1)
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b_email_sub, b_email_sub_len);


### PR DESCRIPTION
Ticket: [#7588](https://redmine.openinfosecfoundation.org/issues/7588)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7588

### Description:
- Implement ``email.cc`  keyword.
- Fix https://github.com/OISF/suricata/pull/12815#pullrequestreview-2710509710
- Add missing keywords to the multi-buffer-matching list

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2363
