### PR TITLE
rust: fixes for breaking change on deranged crate

### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -1525,15 +1525,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -77,7 +77,7 @@ asn1-rs = { version = "~0.6.1" }
 ldap-parser = { version = "~0.4.1" }
 hex = "~0.4.3"
 
-time = "~0.3.36"
+time = "~0.3.41"
 
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -1113,10 +1113,10 @@ unsafe extern "C" fn get_tx_cnt(vtx: *mut std::os::raw::c_void) -> u64 {
 pub(super) unsafe extern "C" fn get_alstate_progress(tx: *mut std::os::raw::c_void, direction: u8
                                                  )-> std::os::raw::c_int {
     let tx = cast_pointer!(tx, DCERPCTransaction);
-    if direction == Direction::ToServer.into() && tx.req_done {
+    if Direction::from(direction) == Direction::ToServer && tx.req_done {
         SCLogDebug!("tx {} TOSERVER progress 1 => {:?}", tx.call_id, tx);
         return 1;
-    } else if direction == Direction::ToClient.into() && tx.resp_done {
+    } else if Direction::from(direction) == Direction::ToClient && tx.resp_done {
         SCLogDebug!("tx {} TOCLIENT progress 1 => {:?}", tx.call_id, tx);
         return 1;
     }

--- a/rust/src/detect/byte_extract.rs
+++ b/rust/src/detect/byte_extract.rs
@@ -205,7 +205,7 @@ fn parse_byteextract(input: &str) -> IResult<&str, SCDetectByteExtractData, Rule
                 let mult = val
                     .parse::<u32>()
                     .map_err(|_| make_error(format!("invalid multiplier value: {}", val)))?;
-                if mult == 0 || mult > u16::MAX.into() {
+                if mult == 0 || mult > u16::MAX as u32 {
                     return Err(make_error(format!(
                         "invalid multiplier value: must be between 0 and {}: {}",
                         u16::MAX,

--- a/rust/src/detect/byte_math.rs
+++ b/rust/src/detect/byte_math.rs
@@ -213,7 +213,7 @@ fn parse_bytemath(input: &str) -> IResult<&str, DetectByteMathData, RuleParseErr
                 let (_, res) = parse_var(val)?;
                 match res {
                     ResultValue::Numeric(val) => {
-                        if val >= u32::MIN.into() && val <= u32::MAX.into() {
+                        if val >= u32::MIN as u64 && val <= u32::MAX as u64 {
                             byte_math.rvalue = val as u32
                         } else {
                             return Err(make_error(format!(

--- a/rust/src/detect/transform_base64.rs
+++ b/rust/src/detect/transform_base64.rs
@@ -142,7 +142,7 @@ fn parse_transform_base64(
                 let (_, res) = parse_var(val)?;
                 match res {
                     ResultValue::Numeric(val) => {
-                        if val <= u16::MAX.into() {
+                        if val <= u16::MAX as u64 {
                             transform_base64.offset = val as u32
                         } else {
                             return Err(make_error(format!(
@@ -174,7 +174,7 @@ fn parse_transform_base64(
                 let (_, res) = parse_var(val)?;
                 match res {
                     ResultValue::Numeric(val) => {
-                        if val as u32 <= u16::MAX.into() {
+                        if val as u32 <= u16::MAX as u32 {
                             transform_base64.nbytes = val as u32
                         } else {
                             return Err(make_error(format!(

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -36,7 +36,7 @@ fn xor_parse_do(i: &str) -> Option<DetectTransformXorData> {
         SCLogError!("XOR transform key's length must be an even number");
         return None;
     }
-    if i.len() / 2 > u8::MAX.into() {
+    if i.len() / 2 > u8::MAX as usize {
         SCLogError!("Key length too big for XOR transform");
         return None;
     }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -1187,7 +1187,7 @@ unsafe extern "C" fn c_probe_tcp(
         } else {
             Direction::ToClient
         };
-        if (direction & DIR_BOTH) != dir.into() {
+        if Direction::from(direction & DIR_BOTH) != dir {
             *rdir = dir as u8;
         }
         return ALPROTO_DNS;

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -124,14 +124,14 @@ fn enip_cip_has_attribute(cipdir: &CipDir, attr: u32) -> std::os::raw::c_int {
         match &req.payload {
             EnipCipRequestPayload::GetAttributeList(ga) => {
                 for attrg in ga.attr_list.iter() {
-                    if attr == (*attrg).into() {
+                    if attr == *attrg as u32 {
                         return 1;
                     }
                 }
             }
             EnipCipRequestPayload::SetAttributeList(sa) => {
                 if let Some(val) = sa.first_attr {
-                    if attr == val.into() {
+                    if attr == val as u32 {
                         return 1;
                     }
                 }

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -697,7 +697,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_status(
 pub unsafe extern "C" fn rs_http2_tx_get_cookie(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
-    if direction == Direction::ToServer.into() {
+    if Direction::from(direction) == Direction::ToServer {
         if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, "cookie") {
             *buffer = value.as_ptr(); //unsafe
             *buffer_len = value.len() as u32;

--- a/rust/src/ike/parser.rs
+++ b/rust/src/ike/parser.rs
@@ -304,7 +304,7 @@ pub fn parse_proposal(i: &[u8]) -> IResult<&[u8], ProposalPayload> {
     let (i, spi_size) = be_u8(i)?;
     let (i, number_transforms) = be_u8(i)?;
     let (i, spi) = take(spi_size as usize)(i)?;
-    let (i, payload_data) = cond((start_i.len() - 4) >= spi_size.into(), |b| {
+    let (i, payload_data) = cond((start_i.len() - 4) >= spi_size as usize, |b| {
         take((start_i.len() - 4) - spi_size as usize)(b)
     })(i)?;
     let payload = ProposalPayload {

--- a/rust/src/mime/mime.rs
+++ b/rust/src/mime/mime.rs
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn SCMimeStateGetFilename(
 ) {
     if !ctx.filename.is_empty() {
         *buffer = ctx.filename.as_ptr();
-        if ctx.filename.len() < u16::MAX.into() {
+        if ctx.filename.len() < u16::MAX as usize {
             *filename_len = ctx.filename.len() as u16;
         } else {
             *filename_len = u16::MAX;

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -660,7 +660,7 @@ pub unsafe extern "C" fn SCMimeSmtpGetFilename(
 ) {
     if !ctx.filename.is_empty() {
         *buffer = ctx.filename.as_ptr();
-        if ctx.filename.len() < u16::MAX.into() {
+        if ctx.filename.len() < u16::MAX as usize {
             *filename_len = ctx.filename.len() as u16;
         } else {
             *filename_len = u16::MAX;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -1687,10 +1687,10 @@ pub unsafe extern "C" fn rs_nfs_tx_get_alstate_progress(tx: *mut std::os::raw::c
                                                   -> std::os::raw::c_int
 {
     let tx = cast_pointer!(tx, NFSTransaction);
-    if direction == Direction::ToServer.into() && tx.request_done {
+    if Direction::from(direction) == Direction::ToServer && tx.request_done {
         SCLogDebug!("TOSERVER progress 1");
         return 1;
-    } else if direction == Direction::ToClient.into() && tx.response_done {
+    } else if Direction::from(direction) == Direction::ToClient && tx.response_done {
         SCLogDebug!("TOCLIENT progress 1");
         return 1;
     } else {
@@ -1879,7 +1879,7 @@ pub unsafe extern "C" fn rs_nfs_probe_ms(
     let mut adirection : u8 = 0;
     match nfs_probe_dir(slice, &mut adirection) {
         1 => {
-            if adirection == Direction::ToServer.into() {
+            if Direction::from(adirection) == Direction::ToServer {
                 SCLogDebug!("nfs_probe_dir said Direction::ToServer");
             } else {
                 SCLogDebug!("nfs_probe_dir said Direction::ToClient");

--- a/rust/src/smb/smb2.rs
+++ b/rust/src/smb/smb2.rs
@@ -169,7 +169,7 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     if offset < tdf.file_tracker.tracked {
                         set_event_fileoverlap = true;
                     }
-                    if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size.into() {
+                    if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size as u64 {
                         state.set_event(SMBEvent::ReadQueueSizeExceeded);
                         state.set_skip(Direction::ToClient, nbss_remaining);
                     } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
@@ -242,7 +242,7 @@ pub fn smb2_read_response_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                         if offset < tdf.file_tracker.tracked {
                             set_event_fileoverlap = true;
                         }
-                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size.into() {
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + rd.len as u64 > max_queue_size as u64 {
                             state.set_event(SMBEvent::ReadQueueSizeExceeded);
                             state.set_skip(Direction::ToClient, nbss_remaining);
                         } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
@@ -313,7 +313,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                     if wr.wr_offset < tdf.file_tracker.tracked {
                         set_event_fileoverlap = true;
                     }
-                    if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size.into() {
+                    if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size as u64 {
                         state.set_event(SMBEvent::WriteQueueSizeExceeded);
                         state.set_skip(Direction::ToServer, nbss_remaining);
                     } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {
@@ -381,7 +381,7 @@ pub fn smb2_write_request_record(state: &mut SMBState, r: &Smb2Record, nbss_rema
                             set_event_fileoverlap = true;
                         }
 
-                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size.into() {
+                        if max_queue_size != 0 && tdf.file_tracker.get_inflight_size() + wr.wr_len as u64 > max_queue_size as u64 {
                             state.set_event(SMBEvent::WriteQueueSizeExceeded);
                             state.set_skip(Direction::ToServer, nbss_remaining);
                         } else if max_queue_cnt != 0 && tdf.file_tracker.get_inflight_cnt() >= max_queue_cnt as usize {

--- a/rust/src/smb/smb2_records.rs
+++ b/rust/src/smb/smb2_records.rs
@@ -695,7 +695,7 @@ mod tests {
         let record: Smb2CreateRequestRecord = result.1;
         assert_eq!(record.disposition, 2); // FILE_CREATE: 2
         assert_eq!(record.create_options, 0x200021);
-        assert_eq!(record.data, &[]);
+        assert_eq!(record.data, &[] as &[u8]);
         let del = record.create_options & 0x0000_1000 != 0;
         let dir = record.create_options & 0x0000_0001 != 0;
         assert!(!del);
@@ -893,6 +893,6 @@ mod tests {
         );
         assert!(!record.is_pipe);
         assert_eq!(record.function, 0x1401fc);
-        assert_eq!(record.data, &[]);
+        assert_eq!(record.data, &[] as &[u8]);
     }
 }

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -460,7 +460,7 @@ pub unsafe extern "C" fn SCSshTxGetFlags(
     tx: *mut std::os::raw::c_void, direction: u8,
 ) -> SSHConnectionState {
     let tx = cast_pointer!(tx, SSHTransaction);
-    if direction == Direction::ToServer.into() {
+    if Direction::from(direction) == Direction::ToServer {
         return tx.cli_hdr.flags;
     } else {
         return tx.srv_hdr.flags;
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn SCSshTxGetAlStateProgress(
         return SSHConnectionState::SshStateFinished as i32;
     }
 
-    if direction == Direction::ToServer.into() {
+    if Direction::from(direction) == Direction::ToServer {
         if tx.cli_hdr.flags >= SSHConnectionState::SshStateBannerDone {
             return SSHConnectionState::SshStateBannerDone as i32;
         }

--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -70,7 +70,7 @@ pub fn parse_message(i: &[u8], max_pl_size: u32) -> IResult<&[u8], WebSocketPdu>
     };
     // we limit payload_len to u32, so as to build on 32-bit system
     // where we cannot take(usize) with a u64
-    let (to_skip, payload_len) = if payload_len < max_pl_size.into() {
+    let (to_skip, payload_len) = if payload_len < max_pl_size as u64 {
         (0, payload_len as u32)
     } else {
         (payload_len - (max_pl_size as u64), max_pl_size)

--- a/rust/src/x509/mod.rs
+++ b/rust/src/x509/mod.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn rs_x509_get_subjectaltname_len(ptr: *const X509) -> u16
     if let Ok(Some(sans)) = san_list {
         // SAN length in a certificate is kept u16 following discussions at
         // https://community.letsencrypt.org/t/why-sans-are-limited-to-100-domains-only
-        debug_validate_bug_on!(sans.value.general_names.len() == u16::MAX.into());
+        debug_validate_bug_on!(sans.value.general_names.len() == u16::MAX as usize);
         return sans.value.general_names.len() as u16;
     }
     return 0;


### PR DESCRIPTION
Deranged v0.4.1 (a dependency of the time crate) has implemented PartialOrd for some integer types that conflict with the implementation in the standard library creating an ambiguity as such implementation are global. For more info see
https://github.com/jhpratt/deranged/issues/18.

To fix, use "as <type>" when we are comparing a one integer type to another, to be fair the .into() here does seem odd.

And for our Direction type, use "from" instead of into.

