### PR TITLE
detect: add email.cc keyword - v2

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -50,3 +50,27 @@ Example of a signature that would alert if a packet contains the MIME field ``su
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email subject"; :example-rule-emphasis:`email.subject; content:"This is a test email";` sid:1;)
+
+email.cc
+--------
+
+Matches the MIME ``Cc`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.cc; content:"<content to match against>";
+
+``email.cc`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.cc[]``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``cc`` with the value ``Emily <emily.roberts@example.com>, Ava <ava.johnson@example.com>, Sophia Wilson <sophia.wilson@example.com>``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email cc"; :example-rule-emphasis:`email.cc; content:"Emily <emily.roberts@example.com>, Ava <ava.johnson@example.com>, Sophia Wilson <sophia.wilson@example.com>";` sid:1;)

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -47,7 +47,7 @@ Example rule:
 
 The above rule will alert on a single dns query containing
 "example.net" or "example.domain.net" since the rule content
-matches are within a single ``dns.query`` buffer and all 
+matches are within a single ``dns.query`` buffer and all
 content match requirements of the rule are met.
 
 
@@ -65,7 +65,7 @@ Using our example from above, the first query is for example.net
 which matches content:"example"; but does not match content:".com";
 
 The second query is for something.com which would match on the
-content:".com"; but not the content:"example"; 
+content:".com"; but not the content:"example";
 
 So with the Suricata behavior prior to Suricata 7, the signature
 would not fire in this case since both content conditions will

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -74,6 +74,8 @@ not be met.
 Multiple buffer matching is currently enabled for use with the
 following keywords:
 
+* ``dns.answer.name``
+* ``dns.query.name``
 * ``dns.query``
 * ``file.data``
 * ``file.magic``
@@ -84,10 +86,20 @@ following keywords:
 * ``ike.vendor``
 * ``krb5_cname``
 * ``krb5_sname``
+* ``ldap.responses.dn``
+* ``ldap.responses.message``
 * ``mqtt.subscribe.topic``
 * ``mqtt.unsubscribe.topic``
 * ``quic.cyu.hash``
 * ``quic.cyu.string``
-* ``tls.certs``
+* ``sip.content_length``
+* ``sip.content_type``
+* ``sip.from``
+* ``sip.to``
+* ``sip.ua``
+* ``sip.via``
+* ``smtp.rcpt_to``
+* ``tls.alpn``
 * ``tls.cert_subject``
+* ``tls.certs``
 * ``tls.subjectaltname``

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -20,6 +20,8 @@ use super::smtp::MimeStateSMTP;
 use std::ffi::CStr;
 use std::ptr;
 
+/// Intermediary function used in detect-email.c to access data from the MimeStateSMTP structure.
+/// The hname parameter determines which data will be returned.
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectMimeEmailGetData(
     ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -24,6 +24,7 @@
 
 static int g_mime_email_from_buffer_id = 0;
 static int g_mime_email_subject_buffer_id = 0;
+static int g_mime_email_cc_buffer_id = 0;
 
 static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
@@ -94,6 +95,40 @@ static InspectionBuffer *GetMimeEmailSubjectData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
+static int DetectMimeEmailCcSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_cc_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailCcData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_cc = NULL;
+        uint32_t b_email_cc_len = 0;
+
+        if (tx->mime_state == NULL)
+            return NULL;
+
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_cc, &b_email_cc_len, "cc") != 1)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_cc, b_email_cc_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
 void DetectEmailRegister(void)
 {
     SCSigTableElmt kw = { 0 };
@@ -119,4 +154,15 @@ void DetectEmailRegister(void)
             "MIME EMAIL SUBJECT", ALPROTO_SMTP, false,
             true, // to server
             GetMimeEmailSubjectData);
+
+    kw.name = "email.cc";
+    kw.desc = "'Cc' field from an email";
+    kw.url = "/rules/email-keywords.html#email.cc";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailCcSetup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_cc_buffer_id =
+            DetectHelperBufferMpmRegister("email.cc", "MIME EMAIL CC", ALPROTO_SMTP, false,
+                    true, // to server
+                    GetMimeEmailCcData);
 }

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -47,13 +47,10 @@ static InspectionBuffer *GetMimeEmailFromData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b_email_from = NULL;
         uint32_t b_email_from_len = 0;
 
-        if ((tx->mime_state != NULL)) {
-            if (SCDetectMimeEmailGetData(
-                        tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
-                return NULL;
-        }
+        if (tx->mime_state == NULL)
+            return NULL;
 
-        if (b_email_from == NULL || b_email_from_len == 0)
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b_email_from, b_email_from_len);
@@ -84,13 +81,11 @@ static InspectionBuffer *GetMimeEmailSubjectData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b_email_sub = NULL;
         uint32_t b_email_sub_len = 0;
 
-        if ((tx->mime_state != NULL)) {
-            if (SCDetectMimeEmailGetData(
-                        tx->mime_state, &b_email_sub, &b_email_sub_len, "subject") != 1)
-                return NULL;
-        }
+        if (tx->mime_state == NULL)
+            return NULL;
 
-        if (b_email_sub == NULL || b_email_sub_len == 0)
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_sub, &b_email_sub_len, "subject") !=
+                1)
             return NULL;
 
         InspectionBufferSetup(det_ctx, list_id, buffer, b_email_sub, b_email_sub_len);


### PR DESCRIPTION
Ticket: [#7588](https://redmine.openinfosecfoundation.org/issues/7588)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7588

### Description:
- Implement ``email.cc`  keyword.
- Fix https://github.com/OISF/suricata/pull/12815#pullrequestreview-2710509710
- Add missing keywords to the multi-buffer-matching list

### Changes
- ``email.cc`` is not multi buffer
- add comment for func ``SCDetectMimeEmailGetData``

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2367
Previous PR: https://github.com/OISF/suricata/pull/12822 
