### PR TITLE
detect: add email.to keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -50,3 +50,27 @@ Example of a signature that would alert if a packet contains the MIME field ``su
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email subject"; :example-rule-emphasis:`email.subject; content:"This is a test email";` sid:1;)
+
+email.to
+--------
+
+Matches the MIME ``To`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.to; content:"<content to match against>";
+
+``email.to`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.to``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``to`` with the value ``172.16.92.2@linuxbox``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email to"; :example-rule-emphasis:`email.to; content:"172.16.92.2@linuxbox";` sid:1;)

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -24,6 +24,7 @@
 
 static int g_mime_email_from_buffer_id = 0;
 static int g_mime_email_subject_buffer_id = 0;
+static int g_mime_email_to_buffer_id = 0;
 
 static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
@@ -99,6 +100,42 @@ static InspectionBuffer *GetMimeEmailSubjectData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
+static int DetectMimeEmailToSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_to_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailToData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_to = NULL;
+        uint32_t b_email_to_len = 0;
+
+        if ((tx->mime_state != NULL)) {
+            if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_to, &b_email_to_len, "to") != 1)
+                return NULL;
+        }
+
+        if (b_email_to == NULL || b_email_to_len == 0)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_to, b_email_to_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
 void DetectEmailRegister(void)
 {
     SCSigTableElmt kw = { 0 };
@@ -124,4 +161,15 @@ void DetectEmailRegister(void)
             "MIME EMAIL SUBJECT", ALPROTO_SMTP, false,
             true, // to server
             GetMimeEmailSubjectData);
+
+    kw.name = "email.to";
+    kw.desc = "'To' field from an email";
+    kw.url = "/rules/email-keywords.html#email.to";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailToSetup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_to_buffer_id =
+            DetectHelperBufferMpmRegister("email.to", "MIME EMAIL TO", ALPROTO_SMTP, false,
+                    true, // to server
+                    GetMimeEmailToData);
 }


### PR DESCRIPTION
Ticket: [#7596](https://redmine.openinfosecfoundation.org/issues/7596)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7596

### Description:
- Implement ``email.to`  keyword.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2368
