### PR TITLE
Warnint 64to32 6186 v23

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1373,7 +1373,7 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
 
     switch (set->type) {
         case DATASET_TYPE_STRING: {
-            uint32_t decoded_size = SCBase64DecodeBufferSize(strlen(string));
+            uint32_t decoded_size = SCBase64DecodeBufferSize((uint32_t)strlen(string));
             uint8_t decoded[decoded_size];
             uint32_t num_decoded = SCBase64Decode(
                     (const uint8_t *)string, strlen(string), SCBase64ModeStrict, decoded);

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -40,37 +40,38 @@
 /*prototypes*/
 static int DetectBsizeSetup (DetectEngineCtx *, Signature *, const char *);
 static void DetectBsizeFree (DetectEngineCtx *, void *);
-static int SigParseGetMaxBsize(const DetectU64Data *bsz);
+static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize);
 #ifdef UNITTESTS
 static void DetectBsizeRegisterTests (void);
 #endif
 
 bool DetectBsizeValidateContentCallback(Signature *s, const SignatureInitDataBuffer *b)
 {
-    int bsize = -1;
+    uint64_t bsize;
+    int max_bsize = 0;
     const DetectU64Data *bsz;
     for (const SigMatch *sm = b->head; sm != NULL; sm = sm->next) {
         if (sm->type == DETECT_BSIZE) {
             bsz = (const DetectU64Data *)sm->ctx;
-            bsize = SigParseGetMaxBsize(bsz);
+            max_bsize = SigParseGetMaxBsize(bsz, &bsize);
             break;
         }
     }
 
-    if (bsize == -1) {
+    if (max_bsize == -1) {
         return true;
     }
 
     uint64_t needed;
-    if (bsize >= 0) {
+    if (max_bsize == 0 && bsize >= 0) {
         int len, offset;
         SigParseRequiredContentSize(s, bsize, b->head, &len, &offset);
         SCLogDebug("bsize: %d; len: %d; offset: %d [%s]", bsize, len, offset, s->sig_str);
         needed = len;
-        if (len > bsize) {
+        if ((uint64_t)len > bsize) {
             goto value_error;
         }
-        if ((len + offset) > bsize) {
+        if ((uint64_t)(len + offset) > bsize) {
             needed += offset;
             goto value_error;
         }
@@ -157,14 +158,16 @@ int DetectBsizeMatch(const SigMatchCtx *ctx, const uint64_t buffer_size, bool eo
     return 0;
 }
 
-static int SigParseGetMaxBsize(const DetectU64Data *bsz)
+static int SigParseGetMaxBsize(const DetectU64Data *bsz, uint64_t *bsize)
 {
     switch (bsz->mode) {
         case DETECT_UINT_LT:
         case DETECT_UINT_EQ:
-            return bsz->arg1;
+            *bsize = bsz->arg1;
+            SCReturnInt(0);
         case DETECT_UINT_RA:
-            return bsz->arg2;
+            *bsize = bsz->arg2;
+            SCReturnInt(0);
         case DETECT_UINT_GT:
         default:
             SCReturnInt(-2);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -159,7 +159,7 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
 
     ptr += extbytes;
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     *value = val;
     SCLogDebug("extracted value is %"PRIu64, val);

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -253,7 +253,7 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
     /* Adjust the detection context to the jump location. */
     DEBUG_VALIDATE_BUG_ON(jumpptr < payload);
-    det_ctx->buffer_offset = jumpptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(jumpptr - payload);
 
     SCReturnBool(true);
 }

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -191,7 +191,7 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const DetectByteMathDa
             break;
     }
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     if (data->flags & DETECT_BYTEMATH_FLAG_BITMASK) {
         val &= data->bitmask_val;

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -401,7 +401,7 @@ static DetectBytetestData *DetectBytetestParse(
             data->neg_op = true;
             op_ptr = &args[1][1];
             while (isspace((char)*op_ptr) || (*op_ptr == ',')) op_ptr++;
-            op_offset = op_ptr - &args[1][0];
+            op_offset = (uint32_t)(op_ptr - &args[1][0]);
         } else {
             data->neg_op = false;
         }

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -406,7 +406,7 @@ void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
  *  - Negated content values are checked but not accumulated for the required size.
  */
 void SigParseRequiredContentSize(
-        const Signature *s, const int max_size, const SigMatch *sm, int *len, int *offset)
+        const Signature *s, const uint64_t max_size, const SigMatch *sm, int *len, int *offset)
 {
     int max_offset = 0, total_len = 0;
     bool first = true;
@@ -428,7 +428,7 @@ void SigParseRequiredContentSize(
             if (cd->flags & DETECT_CONTENT_NEGATED) {
                 /* Check if distance/within cause max to be exceeded */
                 int check = total_len + cd->distance + cd->within;
-                if (max_size < check) {
+                if (max_size < (uint64_t)check) {
                     *len = check;
                     return;
                 }
@@ -457,12 +457,11 @@ bool DetectContentPMATCHValidateCallback(const Signature *s)
         return true;
     }
 
-    int max_right_edge_i = SigParseGetMaxDsize(s);
-    if (max_right_edge_i < 0) {
+    uint16_t max_right_edge_i;
+    if (SigParseGetMaxDsize(s, &max_right_edge_i) < 0) {
         return true;
     }
-
-    uint32_t max_right_edge = (uint32_t)max_right_edge_i;
+    uint32_t max_right_edge = max_right_edge_i;
 
     int min_dsize_required = SigParseMaxRequiredDsize(s);
     if (min_dsize_required >= 0) {

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -131,7 +131,7 @@ void DetectContentPropagateLimits(Signature *s);
 
 void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
 void SigParseRequiredContentSize(
-        const Signature *s, const int max, const SigMatch *sm, int *len, int *offset);
+        const Signature *s, const uint64_t max, const SigMatch *sm, int *len, int *offset);
 int DetectContentConvertToNocase(DetectEngineCtx *de_ctx, DetectContentData *cd);
 
 #endif /* SURICATA_DETECT_CONTENT_H */

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -208,7 +208,7 @@ static bool PrefilterDsizeIsPrefilterable(const Signature *s)
  *  \param s signature to get dsize value from
  *  \retval depth or negative value
  */
-int SigParseGetMaxDsize(const Signature *s)
+int SigParseGetMaxDsize(const Signature *s, uint16_t *dsize)
 {
     if (s->flags & SIG_FLAG_DSIZE && s->init_data->dsize_sm != NULL) {
         const DetectU16Data *dd = (const DetectU16Data *)s->init_data->dsize_sm->ctx;
@@ -217,9 +217,11 @@ int SigParseGetMaxDsize(const Signature *s)
             case DETECT_UINT_LT:
             case DETECT_UINT_EQ:
             case DETECT_UINT_NE:
-                return dd->arg1;
+                *dsize = dd->arg1;
+                SCReturnInt(0);
             case DETECT_UINT_RA:
-                return dd->arg2;
+                *dsize = dd->arg2;
+                SCReturnInt(0);
             case DETECT_UINT_GT:
             default:
                 SCReturnInt(-2);
@@ -293,8 +295,8 @@ int SigParseMaxRequiredDsize(const Signature *s)
         SCReturnInt(-1);
     }
 
-    const int dsize = SigParseGetMaxDsize(s);
-    if (dsize < 0) {
+    uint16_t dsize;
+    if (SigParseGetMaxDsize(s, &dsize) < 0) {
         /* nothing to do */
         SCReturnInt(-1);
     }
@@ -328,8 +330,8 @@ void SigParseApplyDsizeToContent(Signature *s)
     if (s->flags & SIG_FLAG_DSIZE) {
         SigParseSetDsizePair(s);
 
-        int dsize = SigParseGetMaxDsize(s);
-        if (dsize < 0) {
+        uint16_t dsize;
+        if (SigParseGetMaxDsize(s, &dsize) < 0) {
             /* nothing to do */
             return;
         }

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -30,7 +30,7 @@
 void DetectDsizeRegister (void);
 
 int SigParseMaxRequiredDsize(const Signature *s);
-int SigParseGetMaxDsize(const Signature *s);
+int SigParseGetMaxDsize(const Signature *s, uint16_t *dsize);
 void SigParseSetDsizePair(Signature *s);
 void SigParseApplyDsizeToContent(Signature *s);
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -483,7 +483,7 @@ void SetupEngineAnalysis(DetectEngineCtx *de_ctx, bool *fp_analysis, bool *rule_
     }
 
     ea->file_prefix = NULL;
-    int cfg_prefix_len = strlen(de_ctx->config_prefix);
+    size_t cfg_prefix_len = strlen(de_ctx->config_prefix);
     if (cfg_prefix_len > 0) {
         /* length of prefix + NULL + "." */
         ea->file_prefix = SCCalloc(1, cfg_prefix_len + 1 + 1);

--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -257,12 +257,12 @@ static void BufferSetupUdp(InspectionBuffer *buffer, const Frame *frame, const P
     uint8_t ci_flags = DETECT_CI_FLAGS_START;
     uint32_t frame_len;
     if (frame->len == -1) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = p->payload_len - (uint32_t)frame->offset;
     } else {
         frame_len = (uint32_t)frame->len;
     }
     if (frame->offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = p->payload_len - (uint32_t)frame->offset;
     } else {
         ci_flags |= DETECT_CI_FLAGS_END;
     }
@@ -340,7 +340,7 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
         SCLogDebug("have frame data start");
 
         if (frame->len >= 0) {
-            data_len = MIN(input_len, frame->len);
+            data_len = (uint32_t)MIN(input_len, frame->len);
             if (data_len == frame->len) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
@@ -367,20 +367,23 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
 
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
 
             uint32_t in_data_excess = 0;
             if (so_input_re >= so_frame_re) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
-                in_data_excess = so_input_re - so_frame_re;
+                DEBUG_VALIDATE_BUG_ON(so_input_re - so_frame_re > UINT32_MAX);
+                in_data_excess = (uint32_t)(so_input_re - so_frame_re);
             }
             data_len = input_len - in_data_offset - in_data_excess;
         } else {
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            DEBUG_VALIDATE_BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
             data_len = input_len - in_data_offset;
         }
@@ -473,8 +476,12 @@ static int FrameStreamDataInspectFunc(
 #endif
     BUG_ON(fsd->frame->len > 0 && (int64_t)data_len > fsd->frame->len);
 
+    if (data_offset > UINT32_MAX) {
+        SCLogDebug("DETECT_ENGINE_INSPECT_SIG_NO_MATCH data_offset > UINT32_MAX");
+        return more_chunks;
+    }
     const bool match = DetectEngineContentInspection(det_ctx->de_ctx, det_ctx, s, engine->smd, p,
-            p->flow, data, data_len, data_offset, buffer->flags,
+            p->flow, data, data_len, (uint32_t)data_offset, buffer->flags,
             DETECT_ENGINE_CONTENT_INSPECTION_MODE_FRAME);
     if (match) {
         SCLogDebug("DETECT_ENGINE_INSPECT_SIG_MATCH");

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -130,7 +130,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, const char *sig_file, int 
         return -1;
     }
 
-    while(fgets(line + offset, (int)sizeof(line) - offset, fp) != NULL) {
+    while (fgets(line + offset, (int)(sizeof(line) - offset), fp) != NULL) {
         lineno++;
         size_t len = strlen(line);
 

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -33,7 +33,7 @@ static uint32_t PrefilterPacketHeaderHashFunc(HashListTable *ht, void *data, uin
     PrefilterPacketHeaderCtx *ctx = data;
     uint64_t hash = ctx->v1.u64[0] + ctx->v1.u64[1] + ctx->type + ctx->value;
     hash %= ht->array_size;
-    return hash;
+    return (uint32_t)hash;
 }
 
 static char PrefilterPacketHeaderCompareFunc(void *data1, uint16_t len1,

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -83,8 +83,8 @@ static inline void QuickSortSigIntId(SigIntId *sids, uint32_t n)
             r--;
         }
     }
-    QuickSortSigIntId(sids, r - sids + 1);
-    QuickSortSigIntId(l, sids + n - l);
+    QuickSortSigIntId(sids, (uint32_t)(r - sids) + 1);
+    QuickSortSigIntId(l, (uint32_t)(sids + n - l));
 }
 
 /**
@@ -597,7 +597,7 @@ static uint32_t PrefilterStoreHashFunc(HashListTable *ht, void *data, uint16_t d
 {
     PrefilterStore *ctx = data;
 
-    uint32_t hash = strlen(ctx->name);
+    uint32_t hash = (uint32_t)strlen(ctx->name);
 
     for (size_t u = 0; u < strlen(ctx->name); u++) {
         hash += ctx->name[u];

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -335,7 +335,7 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
     }
 }
 
-static void SigMultilinePrint(int i, const char *prefix)
+static void SigMultilinePrint(size_t i, const char *prefix)
 {
     if (sigmatch_table[i].desc) {
         printf("%sDescription: %s\n", prefix, sigmatch_table[i].desc);

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -82,7 +82,7 @@ void ThresholdDestroy(void)
 typedef struct ThresholdEntry_ {
     uint32_t key[5];
 
-    uint32_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
+    uint64_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
                                  its not "seconds", that define the time interval */
     uint32_t seconds;       /**< Event seconds */
     uint32_t current_count; /**< Var for count control */

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2230,8 +2230,11 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
 
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
+    if (offset > UINT32_MAX) {
+        return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
+    }
     const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, data,
-            data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+            data_len, (uint32_t)offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
     if (match) {
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
@@ -3683,9 +3686,10 @@ static uint32_t DetectKeywordCtxHashFunc(HashListTable *ht, void *data, uint16_t
 {
     DetectEngineThreadKeywordCtxItem *ctx = data;
     const char *name = ctx->name;
-    uint64_t hash = StringHashDjb2((const uint8_t *)name, strlen(name)) + (ptrdiff_t)ctx->data;
+    uint64_t hash =
+            StringHashDjb2((const uint8_t *)name, (uint32_t)strlen(name)) + (ptrdiff_t)ctx->data;
     hash %= ht->array_size;
-    return hash;
+    return (uint32_t)hash;
 }
 
 static char DetectKeywordCtxCompareFunc(void *data1, uint16_t len1, void *data2, uint16_t len2)

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -425,8 +425,12 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
         if (buffer->inspect_offset == 0)
             ciflags |= DETECT_CI_FLAGS_START;
 
+        if (buffer->inspect_offset > UINT32_MAX) {
+            local_file_id++;
+            continue;
+        }
         const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                buffer->inspect, buffer->inspect_len, buffer->inspect_offset, ciflags,
+                buffer->inspect, buffer->inspect_len, (uint32_t)buffer->inspect_offset, ciflags,
                 DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -264,8 +264,12 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
         if (buffer == NULL)
             continue;
 
+        if (buffer->inspect_offset > UINT32_MAX) {
+            local_file_id++;
+            continue;
+        }
         const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-                buffer->inspect, buffer->inspect_len, buffer->inspect_offset,
+                buffer->inspect, buffer->inspect_len, (uint32_t)buffer->inspect_offset,
                 DETECT_CI_FLAGS_SINGLE, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
         if (match) {
             return DETECT_ENGINE_INSPECT_SIG_MATCH;

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -29,10 +29,13 @@ static int DetectFlowAgeMatch(
     if (p->flow == NULL) {
         return 0;
     }
-    uint32_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
+    uint64_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
+    if (age > UINT32_MAX) {
+        age = UINT32_MAX;
+    }
 
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
-    return DetectU32Match(age, du32);
+    return DetectU32Match((uint32_t)age, du32);
 }
 
 static void DetectFlowAgeFree(DetectEngineCtx *de_ctx, void *ptr)

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -329,10 +329,13 @@ static uint8_t DetectEngineInspectBufferHttpBody(DetectEngineCtx *de_ctx,
 
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
-    const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f, data,
-            data_len, offset, ci_flags, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
-    if (match) {
-        return DETECT_ENGINE_INSPECT_SIG_MATCH;
+    if (offset <= UINT32_MAX) {
+        const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                data, data_len, (uint32_t)offset, ci_flags,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        if (match) {
+            return DETECT_ENGINE_INSPECT_SIG_MATCH;
+        }
     }
 
     if (flags & STREAM_TOSERVER) {

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -187,7 +187,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -214,7 +214,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-header-common.c
+++ b/src/detect-http-header-common.c
@@ -78,8 +78,7 @@ void HttpHeaderThreadDataFree(void *data)
     SCFree(hdrnames);
 }
 
-int HttpHeaderExpandBuffer(HttpHeaderThreadData *td,
-        HttpHeaderBuffer *buf, uint32_t size)
+int HttpHeaderExpandBuffer(HttpHeaderThreadData *td, HttpHeaderBuffer *buf, size_t size)
 {
     size_t extra = td->size_step;
     while ((buf->size + extra) < (size + buf->len)) {

--- a/src/detect-http-header-common.h
+++ b/src/detect-http-header-common.h
@@ -45,7 +45,6 @@ void HttpHeaderThreadDataFree(void *data);
 HttpHeaderBuffer *HttpHeaderGetBufferSpace(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags,
         const int keyword_id, HttpHeaderThreadData **ret_hdr_td);
 
-int HttpHeaderExpandBuffer(HttpHeaderThreadData *td,
-        HttpHeaderBuffer *buf, uint32_t size);
+int HttpHeaderExpandBuffer(HttpHeaderThreadData *td, HttpHeaderBuffer *buf, size_t size);
 
 #endif /* SURICATA_DETECT_HTTP_HEADER_COMMON_H */

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -204,11 +204,13 @@ static uint8_t DetectEngineInspectBufferHttpHeader(DetectEngineCtx *de_ctx,
 
     /* Inspect all the uricontents fetched on each
      * transaction at the app layer */
-    const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
-            (uint8_t *)data, data_len, offset, DETECT_CI_FLAGS_SINGLE,
-            DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
-    if (match) {
-        return DETECT_ENGINE_INSPECT_SIG_MATCH;
+    if (offset <= UINT32_MAX) {
+        const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
+                (uint8_t *)data, data_len, (uint32_t)offset, DETECT_CI_FLAGS_SINGLE,
+                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE);
+        if (match) {
+            return DETECT_ENGINE_INSPECT_SIG_MATCH;
+        }
     }
 end:
     if (eof) {
@@ -599,8 +601,8 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     // hdr_td->len is the number of header buffers
     if (local_id < hdr_td->len) {
         // we have one valid header buffer
-        InspectionBufferSetupMulti(
-                buffer, transforms, hdr_td->items[local_id].buffer, hdr_td->items[local_id].len);
+        InspectionBufferSetupMulti(buffer, transforms, hdr_td->items[local_id].buffer,
+                (uint32_t)hdr_td->items[local_id].len);
         buffer->flags = DETECT_CI_FLAGS_SINGLE;
         SCReturnPtr(buffer, "InspectionBuffer");
     } // else there are no more header buffer to get

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -64,7 +64,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -118,7 +118,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -248,7 +248,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_hostname(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_request_hostname(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_hostname(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_hostname(tx));
 
         InspectionBufferSetupAndApplyTransforms(
@@ -355,10 +355,10 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
                 return NULL;
 
             data = (const uint8_t *)htp_header_value_ptr(h);
-            data_len = htp_header_value_len(h);
+            data_len = (uint32_t)htp_header_value_len(h);
         } else {
             data = (const uint8_t *)bstr_ptr(tx->parsed_uri->hostname);
-            data_len = bstr_len(tx->parsed_uri->hostname);
+            data_len = (uint32_t)bstr_len(tx->parsed_uri->hostname);
         }
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -207,7 +207,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_method(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_request_method(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_method(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_method(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -100,7 +100,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        uint32_t data_len = bstr_size(str);
+        uint32_t data_len = (uint32_t)bstr_size(str);
         uint8_t *data = bstr_ptr(str);
         if (data == NULL || data_len == 0) {
             SCLogDebug("HTTP protocol not present");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -161,7 +161,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_request_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_request_line(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_line(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_line(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -160,7 +160,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_response_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_response_line(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_line(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_line(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -166,7 +166,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_status(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_response_status(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_status(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_status(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -175,7 +175,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_message(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_response_message(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_message(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_message(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -171,7 +171,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -234,7 +234,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = bstr_len(tx_ud->request_uri_normalized);
+        const uint32_t data_len = (uint32_t)bstr_len(tx_ud->request_uri_normalized);
         const uint8_t *data = bstr_ptr(tx_ud->request_uri_normalized);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -324,7 +324,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_request_uri(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_request_uri(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_uri(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_uri(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -113,7 +113,7 @@ void DetectPcreRegister (void)
         SCLogDebug("Using PCRE match-limit setting of: %i", pcre_match_limit);
     }
     else    {
-        pcre_match_limit = val;
+        pcre_match_limit = (int)val;
         if (pcre_match_limit != SC_MATCH_LIMIT_DEFAULT) {
             SCLogInfo("Using PCRE match-limit setting of: %i", pcre_match_limit);
         } else {
@@ -128,7 +128,7 @@ void DetectPcreRegister (void)
         SCLogDebug("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
     }
     else    {
-        pcre_match_limit_recursion = val;
+        pcre_match_limit_recursion = (int)val;
         if (pcre_match_limit_recursion != SC_MATCH_LIMIT_RECURSION_DEFAULT) {
             SCLogInfo("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
         } else {
@@ -192,7 +192,7 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
     int start_offset = 0;
     if (det_ctx->pcre_match_start_offset != 0) {
-        start_offset = (payload + det_ctx->pcre_match_start_offset - ptr);
+        start_offset = (uint32_t)(payload - ptr) + det_ctx->pcre_match_start_offset;
     }
 
     /* run the actual pcre detection */
@@ -289,8 +289,8 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
             PCRE2_SIZE *ov = pcre2_get_ovector_pointer(match);
             /* update offset for pcre RELATIVE */
-            det_ctx->buffer_offset = (ptr + ov[1]) - payload;
-            det_ctx->pcre_match_start_offset = (ptr + ov[0] + 1) - payload;
+            det_ctx->buffer_offset = (uint32_t)((ptr + ov[1]) - payload);
+            det_ctx->pcre_match_start_offset = (uint32_t)((ptr + ov[0] + 1) - payload);
 
             ret = 1;
         }
@@ -370,13 +370,13 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         SCLogDebug("regexstr %s", regexstr);
 
         if (fcap && !pcap)
-            cut_capture = fcap - regexstr;
+            cut_capture = (int)(fcap - regexstr);
         else if (pcap && !fcap)
-            cut_capture = pcap - regexstr;
+            cut_capture = (int)(pcap - regexstr);
         else {
             BUG_ON(pcap == NULL); // added to assist cppcheck
             BUG_ON(fcap == NULL);
-            cut_capture = MIN((pcap - regexstr), (fcap - regexstr));
+            cut_capture = (int)MIN((pcap - regexstr), (fcap - regexstr));
         }
 
         SCLogDebug("cut_capture %d", cut_capture);

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -84,7 +84,7 @@ static int DetectPrioritySetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
     pcre2_match_data_free(match);
     char *endptr = NULL;
-    long prio = strtol(copy_str, &endptr, 10);
+    int prio = (int)strtol(copy_str, &endptr, 10);
     if (endptr == NULL || *endptr != '\0') {
         SCLogError("Saw an invalid character as arg "
                    "to priority keyword");

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -145,7 +145,7 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         goto error;
     }
 
-    int ref_len = strlen(uri);
+    size_t ref_len = strlen(uri);
     /* no key, reference -- return an error */
     if (strlen(key) == 0 || ref_len == 0)
         goto error;

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -79,8 +79,8 @@ typedef struct DetectTagDataEntry_ {
         uint32_t packets;               /**< number of packets (metric packets) */
         uint32_t bytes;                 /**< number of bytes (metric bytes) */
     };
-    uint32_t first_ts;                  /**< First time seen (for metric = seconds) */
-    uint32_t last_ts;                   /**< Last time seen (to prune old sessions) */
+    uint64_t first_ts; /**< First time seen (for metric = seconds) */
+    uint64_t last_ts;  /**< Last time seen (to prune old sessions) */
 #if __WORDSIZE == 64
     uint32_t pad1;
 #endif

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -149,7 +149,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_fingerprint);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_fingerprint);
         const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -137,7 +137,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_issuerdn);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_issuerdn);
         const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -147,7 +147,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_serial);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_serial);
         const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -139,7 +139,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_subject);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_subject);
         const uint8_t *data = (uint8_t *)connp->cert0_subject;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -168,7 +168,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_hash;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -158,7 +158,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_str->data;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -166,7 +166,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_hash;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -157,7 +157,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_str->data;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -119,7 +119,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.sni);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.sni);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.sni;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-subjectaltname.c
+++ b/src/detect-tls-subjectaltname.c
@@ -121,7 +121,7 @@ static InspectionBuffer *TlsSubjectAltNameGetData(DetectEngineThreadCtx *det_ctx
     }
 
     InspectionBufferSetupMulti(buffer, transforms, (const uint8_t *)connp->cert0_sans[idx],
-            strlen(connp->cert0_sans[idx]));
+            (uint32_t)strlen(connp->cert0_sans[idx]));
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect.c
+++ b/src/detect.c
@@ -382,7 +382,7 @@ static inline void DetectPrefilterMergeSort(DetectEngineCtx *de_ctx,
         }
     }
 
-    det_ctx->match_array_cnt = match_array - det_ctx->match_array;
+    det_ctx->match_array_cnt = (uint32_t)(match_array - det_ctx->match_array);
     DEBUG_VALIDATE_BUG_ON((det_ctx->pmq.rule_id_array_cnt + det_ctx->non_pf_id_cnt) < det_ctx->match_array_cnt);
     PMQ_RESET(&det_ctx->pmq);
 }

--- a/src/host-bit.c
+++ b/src/host-bit.c
@@ -70,7 +70,7 @@ int HostBitsTimedoutCheck(Host *h, SCTime_t ts)
     for ( ; gv != NULL; gv = gv->next) {
         if (gv->type == DETECT_XBITS) {
             XBit *xb = (XBit *)gv;
-            if (xb->expire > (uint32_t)SCTIME_SECS(ts))
+            if (xb->expire > SCTIME_SECS(ts))
                 return 0;
         }
     }
@@ -91,7 +91,7 @@ static XBit *HostBitGet(Host *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void HostBitAdd(Host *h, uint32_t idx, uint32_t expire)
+static void HostBitAdd(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void HostBitRemove(Host *h, uint32_t idx)
     }
 }
 
-void HostBitSet(Host *h, uint32_t idx, uint32_t expire)
+void HostBitSet(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void HostBitUnset(Host *h, uint32_t idx)
     }
 }
 
-void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
+void HostBitToggle(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
@@ -154,7 +154,7 @@ void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsset(Host *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
@@ -167,7 +167,7 @@ int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int HostBitIsnotset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsnotset(Host *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {

--- a/src/host-bit.h
+++ b/src/host-bit.h
@@ -33,11 +33,11 @@ void HostBitRegisterTests(void);
 int HostHasHostBits(Host *host);
 int HostBitsTimedoutCheck(Host *h, SCTime_t ts);
 
-void HostBitSet(Host *, uint32_t, uint32_t);
+void HostBitSet(Host *, uint32_t, uint64_t);
 void HostBitUnset(Host *, uint32_t);
-void HostBitToggle(Host *, uint32_t, uint32_t);
-int HostBitIsset(Host *, uint32_t, uint32_t);
-int HostBitIsnotset(Host *, uint32_t, uint32_t);
+void HostBitToggle(Host *, uint32_t, uint64_t);
+int HostBitIsset(Host *, uint32_t, uint64_t);
+int HostBitIsnotset(Host *, uint32_t, uint64_t);
 int HostBitList(Host *, XBit **);
 
 #endif /* SURICATA_HOST_BIT_H */

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -91,7 +91,7 @@ static XBit *IPPairBitGet(IPPair *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void IPPairBitAdd(IPPair *h, uint32_t idx, uint32_t expire)
+static void IPPairBitAdd(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void IPPairBitRemove(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitSet(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitSet(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void IPPairBitUnset(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitToggle(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
@@ -154,7 +154,7 @@ void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsset(IPPair *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
@@ -168,7 +168,7 @@ int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int IPPairBitIsnotset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsnotset(IPPair *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {

--- a/src/ippair-bit.h
+++ b/src/ippair-bit.h
@@ -32,10 +32,10 @@ void IPPairBitRegisterTests(void);
 int IPPairHasBits(IPPair *host);
 int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts);
 
-void IPPairBitSet(IPPair *, uint32_t, uint32_t);
+void IPPairBitSet(IPPair *, uint32_t, uint64_t);
 void IPPairBitUnset(IPPair *, uint32_t);
-void IPPairBitToggle(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsset(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsnotset(IPPair *, uint32_t, uint32_t);
+void IPPairBitToggle(IPPair *, uint32_t, uint64_t);
+int IPPairBitIsset(IPPair *, uint32_t, uint64_t);
+int IPPairBitIsnotset(IPPair *, uint32_t, uint64_t);
 
 #endif /* SURICATA_IPPAIR_BIT_H */

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -1428,7 +1428,7 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data_unused)
 
     struct Bit {
         uint32_t id;
-        uint32_t expire;
+        uint64_t expire;
     } bits[256];
     memset(&bits, 0, sizeof(bits));
     int i = 0, use = 0;
@@ -1463,7 +1463,7 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data_unused)
         json_t *bitobject = json_object();
         if (bitobject == NULL)
             continue;
-        uint32_t expire = 0;
+        uint64_t expire = 0;
         if ((uint32_t)SCTIME_SECS(ts) < bits[i].expire)
             expire = bits[i].expire - (uint32_t)SCTIME_SECS(ts);
 

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -58,7 +58,7 @@ typedef struct XBit_ {
     uint8_t pad[2];
     uint32_t idx;       /* name idx */
     GenericVar *next;
-    uint32_t expire;
+    uint64_t expire;
 } XBit;
 
 void XBitFree(XBit *);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix `-Wshorten-64-to-32` warnings for remaining files : detect

Last commit of #9840 after https://github.com/OISF/suricata/pull/12633 merge

Still to do afterwards :
- CI check
