### PR TITLE
ci: make a build with ja disabled

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -901,7 +901,9 @@ jobs:
   # This job builds and tests Suricata as a non-root user as some
   # issues only show up when not running as root, and by default all
   # jobs in GitHub actions are run as root inside the container.
-  fedora-non-root:
+  # Also ja3 and ja4 are disabled to run SV tests that require
+  # the absence of these features
+  fedora-non-root-disable-ja:
     name: Fedora (non-root, debug, clang, asan, wshadow, rust-strict)
     runs-on: ubuntu-latest
     container: fedora:41
@@ -963,7 +965,10 @@ jobs:
       - run: sudo -u suricata -s ./autogen.sh
         working-directory: /home/suricata/suricata
 
-      - run: sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis --enable-nfqueue
+      - run: >-
+          sudo -u suricata -s env PATH="/home/suricata/.cargo/bin:$PATH" ./configure --enable-warnings
+          --enable-debug --enable-unittests --disable-shared --enable-rust-strict --enable-hiredis
+          --enable-nfqueue --disable-ja3 --disable-ja4
         working-directory: /home/suricata/suricata
         env:
           ac_cv_func_realloc_0_nonnull: "yes"


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7461

Describe changes:
- ci: make a build with ja3 and ja4 disabled
