### PR TITLE
detect: add email.date keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -98,3 +98,27 @@ Example of a signature that would alert if a packet contains the MIME field ``cc
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email cc"; :example-rule-emphasis:`email.cc; content:"Emily <emily.roberts@example.com>, Ava <ava.johnson@example.com>, Sophia Wilson <sophia.wilson@example.com>";` sid:1;)
+
+email.date
+----------
+
+Matches the MIME ``Date`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.date; content:"<content to match against>";
+
+``email.date`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.date``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``date`` with the value ``Fri, 21 Apr 2023 05:10:36 +0000``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email date"; :example-rule-emphasis:`email.date; content:"Fri, 21 Apr 2023 05:10:36 +0000";` sid:1;)

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -210,6 +210,8 @@ fn log_data_header(
 
 fn log_data(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> {
     log_data_header(js, ctx, "from")?;
+    log_data_header(js, ctx, "date")?;
+    log_data_header(js, ctx, "subject")?;
     log_field_comma(js, ctx, "to", "to")?;
     log_field_comma(js, ctx, "cc", "cc")?;
 

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -26,6 +26,7 @@ static int g_mime_email_from_buffer_id = 0;
 static int g_mime_email_subject_buffer_id = 0;
 static int g_mime_email_to_buffer_id = 0;
 static int g_mime_email_cc_buffer_id = 0;
+static int g_mime_email_date_buffer_id = 0;
 
 static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
@@ -166,6 +167,40 @@ static InspectionBuffer *GetMimeEmailCcData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
+static int DetectMimeEmailDateSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_date_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailDateData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_date = NULL;
+        uint32_t b_email_date_len = 0;
+
+        if (tx->mime_state == NULL)
+            return NULL;
+
+        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_date, &b_email_date_len, "date") != 1)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_date, b_email_date_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
 void DetectEmailRegister(void)
 {
     SCSigTableElmt kw = { 0 };
@@ -213,4 +248,15 @@ void DetectEmailRegister(void)
             DetectHelperBufferMpmRegister("email.cc", "MIME EMAIL CC", ALPROTO_SMTP, false,
                     true, // to server
                     GetMimeEmailCcData);
+
+    kw.name = "email.date";
+    kw.desc = "'Date' field from an email";
+    kw.url = "/rules/email-keywords.html#email.date";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailDateSetup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_date_buffer_id =
+            DetectHelperBufferMpmRegister("email.date", "MIME EMAIL DATE", ALPROTO_SMTP, false,
+                    true, // to server
+                    GetMimeEmailDateData);
 }


### PR DESCRIPTION
Ticket: [#7591](https://redmine.openinfosecfoundation.org/issues/7591)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7591

### Description:
- Implement ``email.date``  keyword.
- Log fields ``date`` and ``subject``.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2382
