### PR TITLE
exceptions: move stats counters to dedicated object - v3

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -277,19 +277,20 @@ be logged when exception policies are enabled:
    :stub-columns: 1
 
    * - Setting
-     - Counter
+     - Counters
    * - stream.memcap
-     - tcp.ssn_memcap_exception_policy
+     - exception_policy.tcp.ssn_memcap
    * - stream.reassembly.memcap
-     - tcp.reassembly_memcap_exception_policy
+     - exception_policy.tcp.reassembly.memcap
    * - stream.midstream
-     - tcp.midstream_exception_policy
+     - exception_policy.tcp.midstream
    * - defrag.memcap
-     - defrag.memcap_exception_policy
+     - exception_policy.defrag.memcap
    * - flow.memcap
-     - flow.memcap_exception_policy
+     - exception_policy.flow.memcap
    * - app-layer.error
-     - app_layer.error.exception_policy
+     - * exception_policy.app_layer.error
+       * app_layer.error.exception_policy
 
 If a given exception policy does not apply for a setting, no related counter
 is logged.

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6176,6 +6176,11 @@
                                 "description":
                                         "How many times session memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
+                            },
+                            "reassembly": {
+                                "description":
+                                        "How many times reassembly memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
                             }
                         }
                     }
@@ -6630,11 +6635,6 @@
                         },
                         "pseudo": {
                             "type": "integer"
-                        },
-                        "reassembly_exception_policy": {
-                            "description":
-                                    "How many times reassembly memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "reassembly_gap": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -4672,11 +4672,6 @@
                         "error": {
                             "type": "object",
                             "properties": {
-                                "exception_policy": {
-                                    "description":
-                                            "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
-                                    "$ref": "#/$defs/exceptionPolicy"
-                                },
                                 "bittorrent-dht": {
                                     "description":
                                             "Errors encountered parsing BitTorrent DHT protocol",
@@ -6152,6 +6147,19 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "exception_policy": {
+                    "type": "object",
+                    "properties": {
+                        "app_layer": {
+                            "type": "object",
+                            "error": {
+                                "description":
+                                    "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
+                        }
+                    }
                 },
                 "file_store": {
                     "type": "object",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6172,6 +6172,11 @@
                         },
                         "tcp": {
                             "type": "object",
+                            "midstream": {
+                                "description":
+                                        "How many times midstream exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            },
                             "ssn_memcap": {
                                 "description":
                                         "How many times session memcap exception policy was applied, and which one",
@@ -6615,11 +6620,6 @@
                         },
                         "midstream_pickups": {
                             "type": "integer"
-                        },
-                        "midstream_exception_policy": {
-                            "description":
-                                    "How many times midstream exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "no_flow": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6161,6 +6161,14 @@
                                         "How many times defrag memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
+                        },
+                        "flow": {
+                            "type": "object",
+                            "memcap": {
+                                "description":
+                                        "How many times flow memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
                         }
                     }
                 },
@@ -6230,11 +6238,6 @@
                         "memcap": {
                             "description": "Number of times memcap was reached for flows",
                             "type": "integer"
-                        },
-                        "memcap_exception_policy": {
-                            "description":
-                                    "How many times flow memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "memuse": {
                             "description": "Memory currently in use by the flows",

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6169,6 +6169,14 @@
                                         "How many times flow memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
+                        },
+                        "tcp": {
+                            "type": "object",
+                            "ssn_memcap": {
+                                "description":
+                                        "How many times session memcap exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
                         }
                     }
                 },
@@ -6657,11 +6665,6 @@
                         },
                         "ssn_memcap_drop": {
                             "type": "integer"
-                        },
-                        "ssn_memcap_exception_policy": {
-                            "description":
-                                    "How many times session memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
                         },
                         "stream_depth_reached": {
                             "type": "integer"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6016,11 +6016,6 @@
                             "type": "integer",
                             "description": "Current memory use."
                         },
-                        "memcap_exception_policy": {
-                            "description":
-                                    "How many times defrag memcap exception policy was applied, and which one",
-                            "$ref": "#/$defs/exceptionPolicy"
-                        },
                         "ipv4": {
                             "type": "object",
                             "properties": {
@@ -6156,6 +6151,14 @@
                             "error": {
                                 "description":
                                     "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                "$ref": "#/$defs/exceptionPolicy"
+                            }
+                        },
+                        "defrag": {
+                            "type": "object",
+                            "memcap": {
+                                "description":
+                                        "How many times defrag memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         }

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -1213,7 +1213,7 @@ void AppLayerSetupCounters(void)
     /* We don't log stats counters if exception policy is `ignore`/`not set` */
     if (g_applayerparser_error_policy != EXCEPTION_POLICY_NOT_SET) {
         /* Register global counters for app layer error exception policy summary */
-        const char *eps_default_str = "app_layer.error.exception_policy.";
+        const char *eps_default_str = "exception_policy.app_layer.error.";
         for (enum ExceptionPolicy i = EXCEPTION_POLICY_NOT_SET + 1; i < EXCEPTION_POLICY_MAX; i++) {
             if (IsAppLayerErrorExceptionPolicyStatsValid(i)) {
                 snprintf(app_layer_error_eps_stats.eps_name[i],

--- a/src/decode.c
+++ b/src/decode.c
@@ -683,7 +683,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_defrag_tracker_timeout = StatsRegisterCounter("defrag.wrk.tracker_timeout", tv);
 
     ExceptionPolicySetStatsCounters(tv, &dtv->counter_defrag_memcap_eps, &defrag_memcap_eps_stats,
-            DefragGetMemcapExceptionPolicy(), "defrag.memcap_exception_policy.",
+            DefragGetMemcapExceptionPolicy(), "exception_policy.defrag.memcap.",
             IsDefragMemcapExceptionPolicyStatsValid);
 
     for (int i = 0; i < DECODE_EVENT_MAX; i++) {

--- a/src/decode.c
+++ b/src/decode.c
@@ -648,7 +648,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_nsh = StatsRegisterMaxCounter("decoder.nsh", tv);
     dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
     ExceptionPolicySetStatsCounters(tv, &dtv->counter_flow_memcap_eps, &flow_memcap_eps_stats,
-            FlowGetMemcapExceptionPolicy(), "flow.memcap_exception_policy.",
+            FlowGetMemcapExceptionPolicy(), "exception_policy.flow.memcap.",
             IsFlowMemcapExceptionPolicyStatsValid);
 
     dtv->counter_tcp_active_sessions = StatsRegisterCounter("tcp.active_sessions", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5999,7 +5999,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_ssn_from_cache = StatsRegisterCounter("tcp.ssn_from_cache", tv);
     stt->counter_tcp_ssn_from_pool = StatsRegisterCounter("tcp.ssn_from_pool", tv);
     ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_ssn_memcap_eps, &stream_memcap_eps_stats,
-            stream_config.ssn_memcap_policy, "tcp.ssn_memcap_exception_policy.",
+            stream_config.ssn_memcap_policy, "exception_policy.tcp.ssn_memcap.",
             IsStreamTcpSessionMemcapExceptionPolicyStatsValid);
 
     stt->counter_tcp_pseudo = StatsRegisterCounter("tcp.pseudo", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6027,7 +6027,7 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ExceptionPolicySetStatsCounters(tv, &stt->ra_ctx->counter_tcp_reas_eps,
             &stream_reassembly_memcap_eps_stats, stream_config.reassembly_memcap_policy,
-            "tcp.reassembly_exception_policy.", IsReassemblyMemcapExceptionPolicyStatsValid);
+            "exception_policy.tcp.reassembly.", IsReassemblyMemcapExceptionPolicyStatsValid);
 
     stt->ra_ctx->counter_tcp_segment_from_cache =
             StatsRegisterCounter("tcp.segment_from_cache", tv);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -6008,11 +6008,11 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     if (stream_config.midstream) {
         ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
                 &stream_midstream_enabled_eps_stats, stream_config.midstream_policy,
-                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+                "exception_policy.tcp.midstream.", IsMidstreamExceptionPolicyStatsValid);
     } else {
         ExceptionPolicySetStatsCounters(tv, &stt->counter_tcp_midstream_eps,
                 &stream_midstream_disabled_eps_stats, stream_config.midstream_policy,
-                "tcp.midstream_exception_policy.", IsMidstreamExceptionPolicyStatsValid);
+                "exception_policy.tcp.midstream.", IsMidstreamExceptionPolicyStatsValid);
     }
 
     stt->counter_tcp_wrong_thread = StatsRegisterCounter("tcp.pkt_on_wrong_thread", tv);


### PR DESCRIPTION
## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7185

Previous PR: https://github.com/OISF/suricata/pull/12852

Describe changes: #12852 with cleaned up commit messages. 
- rebase to see if now the cargo audit checks aren't failing anymore
- bring `exception_policy` stats counters into one object. (See output sample)
- kept counters for individual app-layer proto error stats as part of `stats.app_layer.error`, to avoid making the `exception_policy` object even way more verbose. The reasoning is that one can see the summary under `exception_policy` and if one wants to further investigate, they can search for the key under `app_layer.error` protos.

Output sample:
Null-values: true
```json
"stats": {
  "exception_policy": {
  "flow": {
    "memcap": {
      "pass_packet": 0,
      "bypass": 0,
      "drop_packet": 0,
      "reject": 0
    }
  },
  "defrag": {
    "memcap": {
      "pass_packet": 0,
      "bypass": 0,
      "drop_packet": 0,
      "reject": 0
    }
  },
  "tcp": {
    "ssn_memcap": {
      "pass_packet": 0,
      "pass_flow": 0,
      "bypass": 0,
      "drop_packet": 0,
      "drop_flow": 0,
      "reject": 0
    },
    "midstream": {
      "pass_flow": 0,
      "bypass": 0,
      "drop_flow": 1,
      "reject": 0
    },
    "reassembly": {
      "pass_packet": 0,
      "pass_flow": 0,
      "bypass": 0,
      "drop_packet": 0,
      "drop_flow": 0,
      "reject": 0
    }
  },
  "app_layer": {
    "error": {
      "pass_packet": 0,
      "pass_flow": 0,
      "bypass": 0,
      "drop_packet": 0,
      "drop_flow": 0,
      "reject": 0
    }
  }
 }
}
```

Null-values: false
```json
"stats":   {
   "exception_policy": {
    "tcp": {
      "midstream": {
        "drop_flow": 1
      }
    }
  }
},
```

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2377