### PR TITLE
detect: add email.message_id email.x_mailer keywords - v4

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -122,3 +122,27 @@ Example of a signature that would alert if a packet contains the MIME field ``da
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email date"; :example-rule-emphasis:`email.date; content:"Fri, 21 Apr 2023 05:10:36 +0000";` sid:1;)
+
+email.message_id
+----------------
+
+Matches the MIME ``Message-Id`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.message_id; content:"<content to match against>";
+
+``email.message_id`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.message_id``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``message id`` with the value ``<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email message id"; :example-rule-emphasis:`email.message_id; content:"<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>";` sid:1;)

--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -146,3 +146,27 @@ Example of a signature that would alert if a packet contains the MIME field ``me
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email message id"; :example-rule-emphasis:`email.message_id; content:"<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>";` sid:1;)
+
+email.x_mailer
+--------------
+
+Matches the MIME ``X-Mailer`` field of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.x_mailer; content:"<content to match against>";
+
+``email.x_mailer`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.x_mailer``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if a packet contains the MIME field ``x-mailer`` with the value ``Microsoft Office Outlook, Build 11.0.5510``
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email x-mailer"; :example-rule-emphasis:`email.x_mailer; content:"Microsoft Office Outlook, Build 11.0.5510";` sid:1;)

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -210,8 +210,6 @@ fn log_data_header(
 
 fn log_data(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> {
     log_data_header(js, ctx, "from")?;
-    log_data_header(js, ctx, "date")?;
-    log_data_header(js, ctx, "subject")?;
     log_field_comma(js, ctx, "to", "to")?;
     log_field_comma(js, ctx, "cc", "cc")?;
 

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -27,6 +27,7 @@ static int g_mime_email_subject_buffer_id = 0;
 static int g_mime_email_to_buffer_id = 0;
 static int g_mime_email_cc_buffer_id = 0;
 static int g_mime_email_date_buffer_id = 0;
+static int g_mime_email_message_id_buffer_id = 0;
 
 static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
@@ -201,6 +202,41 @@ static InspectionBuffer *GetMimeEmailDateData(DetectEngineThreadCtx *det_ctx,
     return buffer;
 }
 
+static int DetectMimeEmailMessageIdSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_message_id_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailMessageIdData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_msg_id = NULL;
+        uint32_t b_email_msg_id_len = 0;
+
+        if (tx->mime_state == NULL)
+            return NULL;
+
+        if (SCDetectMimeEmailGetData(
+                    tx->mime_state, &b_email_msg_id, &b_email_msg_id_len, "message-id") != 1)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_msg_id, b_email_msg_id_len);
+        InspectionBufferApplyTransforms(buffer, transforms);
+    }
+    return buffer;
+}
+
 void DetectEmailRegister(void)
 {
     SCSigTableElmt kw = { 0 };
@@ -259,4 +295,15 @@ void DetectEmailRegister(void)
             DetectHelperBufferMpmRegister("email.date", "MIME EMAIL DATE", ALPROTO_SMTP, false,
                     true, // to server
                     GetMimeEmailDateData);
+
+    kw.name = "email.message_id";
+    kw.desc = "'Message-Id' field from an email";
+    kw.url = "/rules/email-keywords.html#email.message_id";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailMessageIdSetup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_message_id_buffer_id = DetectHelperBufferMpmRegister("email.message_id",
+            "MIME EMAIL Message-Id", ALPROTO_SMTP, false,
+            true, // to server
+            GetMimeEmailMessageIdData);
 }


### PR DESCRIPTION
Ticket: [#7593](https://redmine.openinfosecfoundation.org/issues/7593) [#7598](https://redmine.openinfosecfoundation.org/issues/7598)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:
https://redmine.openinfosecfoundation.org/issues/7593
https://redmine.openinfosecfoundation.org/issues/7598

### Description:
- Implement ``email.message_id``  keyword.
- Implement ``email.x_mailer`  keyword.

### Changes:
- Remove unnecessary log for fields ``date``, ``subject``, ``message_id``
- Include ``email.x_mailer`` work

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2406
Prevous PR: https://github.com/OISF/suricata/pull/12919