### PR TITLE
Websocket compression 7285 v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2844,13 +2844,13 @@ jobs:
       - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure  --enable-warnings --enable-unittests --prefix="$HOME/.local/"
       - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make -j2
       # somehow it gets included by some C++ stdlib header (case unsensitive)
-      - run: rm libhtp/VERSION && make check
+      - run: rm libhtp/VERSION && CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
         run: |
           . ./testenv/bin/activate
           python3 ./suricata-verify/run.py -q --debug-failed
-      - run: make install
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make install
       - name: Check Suricata-Update
         run: |
           . ./testenv/bin/activate

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -188,6 +188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -605,6 +615,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -946,6 +967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1274,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -1676,6 +1709,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -47,7 +47,7 @@ num = "~0.2.1"
 num-derive = "~0.4.2"
 num-traits = "~0.2.14"
 widestring = "~0.4.3"
-flate2 = "~1.0.19"
+flate2 = { version = "~1.0.19", features = ["zlib"] }
 brotli = "~3.4.0"
 hkdf = "~0.12.3"
 aes = "~0.7.5"

--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -19,6 +19,12 @@ use nom7::bytes::streaming::take;
 use nom7::combinator::cond;
 use nom7::number::streaming::{be_u16, be_u32, be_u64, be_u8};
 use nom7::IResult;
+
+use nom7::bytes::complete::tag;
+use nom7::character::complete::space0;
+use nom7::character::complete::u8 as nomu8;
+use nom7::combinator::verify;
+
 use suricata_derive::EnumStringU8;
 
 #[derive(Clone, Debug, Default, EnumStringU8)]
@@ -94,4 +100,10 @@ pub fn parse_message(i: &[u8], max_pl_size: u32) -> IResult<&[u8], WebSocketPdu>
             to_skip,
         },
     ))
+}
+
+pub(super) fn parse_max_win(i: &[u8]) -> IResult<&[u8], u8> {
+    let (i, _space) = space0(i)?;
+    let (i, _name) = tag("client_max_window_bits=")(i)?;
+    verify(nomu8, |&v| (9..=15).contains(&v))(i)
 }

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -200,6 +200,7 @@ impl WebSocketState {
                     } else {
                         &mut self.c2s_buf
                     };
+                    let mut compress = pdu.compress;
                     if !buf.data.is_empty() || !pdu.fin {
                         if buf.data.is_empty() {
                             buf.compress = pdu.compress;
@@ -216,10 +217,11 @@ impl WebSocketState {
                     tx.pdu = pdu;
                     if tx.pdu.fin && !buf.data.is_empty() {
                         // the final PDU gets the full reassembled payload
+                        compress = buf.compress;
                         std::mem::swap(&mut tx.pdu.payload, &mut buf.data);
                         buf.data.clear();
                     }
-                    if buf.compress && tx.pdu.fin {
+                    if compress && tx.pdu.fin {
                         buf.compress = false;
                         // cf RFC 7692 section-7.2.2
                         tx.pdu.payload.extend_from_slice(&[0, 0, 0xFF, 0xFF]);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2702,6 +2702,20 @@ void *HtpGetTxForH2(void *alstate)
     return NULL;
 }
 
+void Http1GetDataForWebsocket(void *alstate_orig, void *wss)
+{
+    // get last transaction
+    htp_tx_t *h1tx = HtpGetTxForH2(alstate_orig);
+    if (wss == NULL || h1tx == NULL) {
+        return;
+    }
+    const htp_header_t *h = htp_tx_response_header(h1tx, "Sec-WebSocket-Extensions");
+    if (h == NULL) {
+        return;
+    }
+    SCWebSocketUseExtension(wss, htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
+}
+
 static int HTPStateGetEventInfo(
         const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -959,6 +959,7 @@ app-layer:
     websocket:
       #enabled: yes
       # Maximum used payload size, the rest is skipped
+      # Also applies as a maximum for uncompressed data
       # max-payload-size: 64 KiB
     rdp:
       #enabled: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7285

Describe changes:
- better handle websocket decompression
  - handle single-frame decompression
  - handle HTTP1 Header `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=15`, especially the `max_window_bits=15` for the decompressor 

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2387

#12874 with a dedicated commit for flate2 use of zlib

Draft as I think Windows CI failures are still unaccounted for