### PR TITLE
Clippy fixes 186 v1

### DIFF
--- a/rust/src/applayer.rs
+++ b/rust/src/applayer.rs
@@ -494,7 +494,7 @@ pub type GetFrameNameById = unsafe extern "C" fn(u8) -> *const c_char;
 
 // Defined in app-layer-register.h
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn AppLayerRegisterProtocolDetection(parser: *const RustParser, enable_default: c_int) -> AppProto;
     pub fn AppLayerRegisterParserAlias(parser_name: *const c_char, alias_name: *const c_char);
     pub fn AppLayerRegisterParser(parser: *const RustParser, alproto: AppProto) -> c_int;
@@ -503,7 +503,7 @@ extern {
 
 // Defined in app-layer-detect-proto.h
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn AppLayerForceProtocolChange(f: *const Flow, new_proto: AppProto);
     pub fn AppLayerProtoDetectPPRegister(ipproto: u8, portstr: *const c_char, alproto: AppProto,
                                          min_depth: u16, max_depth: u16, dir: u8,
@@ -543,7 +543,7 @@ pub const _APP_LAYER_TX_INSPECTED_TS: u8 = BIT_U8!(2);
 pub const _APP_LAYER_TX_INSPECTED_TC: u8 = BIT_U8!(3);
 
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn AppLayerParserStateSetFlag(state: *mut c_void, flag: u16);
     pub fn AppLayerParserStateIssetFlag(state: *mut c_void, flag: u16) -> u16;
     pub fn AppLayerParserSetStreamDepth(ipproto: u8, alproto: AppProto, stream_depth: u32);

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -69,7 +69,7 @@ macro_rules!BIT_U64 {
 
 // Defined in app-layer-protos.h
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn StringToAppProto(proto_name: *const u8) -> AppProto;
 }
 
@@ -181,7 +181,7 @@ pub struct SuricataFileContext {
 }
 
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn SCGetContext() -> &'static mut SuricataContext;
 }
 

--- a/rust/src/dcerpc/dcerpc.rs
+++ b/rust/src/dcerpc/dcerpc.rs
@@ -454,9 +454,7 @@ impl DCERPCState {
     /// parser in C. This requires an internal transaction ID to be maintained.
     ///
     /// Arguments:
-    /// * `tx_id`:
-    ///           type: unsigned 32 bit integer
-    ///    description: internal transaction ID to track transactions
+    /// * `tx_id`: internal transaction ID to track transactions
     ///
     /// Return value:
     /// Option mutable reference to DCERPCTransaction
@@ -474,12 +472,8 @@ impl DCERPCState {
     /// found, create one.
     ///
     /// Arguments:
-    /// * `call_id`:
-    ///             type: unsigned 32 bit integer
-    ///      description: call_id param derived from TCP Header
-    /// * `dir`:
-    ///         type: enum Direction
-    ///   description: direction of the flow
+    /// * `call_id`: call_id param derived from TCP Header
+    /// * `dir`: direction of the flow
     ///
     /// Return value:
     /// Option mutable reference to DCERPCTransaction
@@ -567,15 +561,14 @@ impl DCERPCState {
     /// Makes a call to the nom parser for parsing DCERPC Header.
     ///
     /// Arguments:
-    /// * `input`:
-    ///           type: u8 vector slice.
-    ///    description: bytes from the beginning of the buffer.
+    /// * `input`: bytes from the beginning of the buffer.
     ///
     /// Return value:
     /// * Success: Number of bytes successfully parsed.
-    /// * Failure: -1 in case of Incomplete data or Eof.
-    ///            -2 in case of Error while parsing.
-    ///            -3 in case of invalid DCERPC header.
+    /// * Failure:
+    //    -1 in case of Incomplete data or Eof.
+    ///   -2 in case of Error while parsing.
+    ///   -3 in case of invalid DCERPC header.
     pub fn process_header(&mut self, input: &[u8]) -> i32 {
         match parser::parse_dcerpc_header(input) {
             Ok((leftover_bytes, header)) => {
@@ -782,15 +775,9 @@ impl DCERPCState {
     /// Handles stub data for both request and response.
     ///
     /// Arguments:
-    /// * `input`:
-    ///           type: u8 vector slice.
-    ///    description: bytes left *after* parsing header.
-    /// * `bytes_consumed`:
-    ///           type: 16 bit unsigned integer.
-    ///    description: bytes consumed *after* parsing header.
-    /// * `dir`:
-    ///           type: enum Direction.
-    ///    description: direction whose stub is supposed to be handled.
+    /// * `input`: bytes left *after* parsing header.
+    /// * `bytes_consumed`: bytes consumed *after* parsing header.
+    /// * `dir`: direction whose stub is supposed to be handled.
     ///
     /// Return value:
     /// * Success: Number of bytes successfully parsed.

--- a/rust/src/dcerpc/dcerpc_udp.rs
+++ b/rust/src/dcerpc/dcerpc_udp.rs
@@ -130,8 +130,7 @@ impl DCERPCUDPState {
     /// parser in C. This requires an internal transaction ID to be maintained.
     ///
     /// Arguments:
-    /// * `tx_id`:
-    ///    description: internal transaction ID to track transactions
+    /// * `tx_id`: internal transaction ID to track transactions
     ///
     /// Return value:
     /// Option mutable reference to DCERPCTransaction

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -86,7 +86,7 @@ pub(crate) const SIGMATCH_QUOTES_MANDATORY: u16 = 0x40; // BIT_U16(6) in detect.
 pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
 
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn DetectBufferSetActiveList(de: *mut c_void, s: *mut c_void, bufid: c_int) -> c_int;
     pub fn DetectHelperGetData(
         de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,

--- a/rust/src/detect/requires.rs
+++ b/rust/src/detect/requires.rs
@@ -465,8 +465,8 @@ pub unsafe extern "C" fn SCDetectRequiresStatusLog(
 ///   *  0 - OK, rule should continue loading
 ///   * -1 - Error parsing the requires content
 ///   * -4 - Requirements not met, don't continue loading the rule, this
-///          value is chosen so it can be passed back to the options parser
-///          as its treated as a non-fatal silent error.
+///     value is chosen so it can be passed back to the options parser
+///     as its treated as a non-fatal silent error.
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectCheckRequires(
     requires: *const c_char, suricata_version_string: *const c_char, errstr: *mut *const c_char,

--- a/rust/src/filecontainer.rs
+++ b/rust/src/filecontainer.rs
@@ -24,7 +24,7 @@ use crate::core::*;
 
 // Defined in util-file.h
 /// cbindgen:ignore
-extern {
+extern "C" {
     pub fn FileFlowFlagsToFlags(flow_file_flags: u16, flags: u8) -> u16;
 }
 

--- a/rust/src/frames.rs
+++ b/rust/src/frames.rs
@@ -31,7 +31,7 @@ struct CFrame {
 
 // Defined in app-layer-register.h
 /// cbindgen:ignore
-extern {
+extern "C" {
     #[cfg(not(test))]
     fn AppLayerFrameNewByRelativeOffset(
         flow: *const Flow, stream_slice: *const StreamSlice, frame_start_rel: u32, len: i64,

--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -264,7 +264,7 @@ impl HTTP2Transaction {
                 path = Some(&block.value);
             } else if block.name.eq_ignore_ascii_case(b":authority") {
                 authority = Some(&block.value);
-                if block.value.iter().any(|&x| x == b'@') {
+                if block.value.contains(&b'@') {
                     // it is forbidden by RFC 9113 to have userinfo in this field
                     // when in HTTP1 we can have user:password@domain.com
                     self.set_event(HTTP2Event::UserinfoInUri);

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -25,7 +25,7 @@ use std::os::raw::c_long;
 pub enum CLuaState {}
 
 /// cbindgen:ignore
-extern {
+extern "C" {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
     fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);

--- a/rust/src/nfs/rpc_records.rs
+++ b/rust/src/nfs/rpc_records.rs
@@ -215,9 +215,7 @@ pub struct RpcPacket<'a> {
 ///  2. we have partial data (large records) -> allow partial prog_data parsing
 ///
 /// Arguments:
-/// * `complete`:
-///           type: bool
-///    description: do full parsing, including of `prog_data`
+/// * `complete`: do full parsing, including of `prog_data`
 ///
 pub fn parse_rpc(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcPacket> {
     let (i, hdr) = parse_rpc_packet_header(start_i)?;
@@ -282,9 +280,7 @@ pub fn parse_rpc(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcPacket> {
 ///  2. we have partial data (large records) -> allow partial prog_data parsing
 ///
 /// Arguments:
-/// * `complete`:
-///           type: bool
-///    description: do full parsing, including of `prog_data`
+/// * `complete`: do full parsing, including of `prog_data`
 ///
 pub fn parse_rpc_reply(start_i: &[u8], complete: bool) -> IResult<&[u8], RpcReplyPacket> {
     let (i, hdr) = parse_rpc_packet_header(start_i)?;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None

Describe changes:
- Fixes clippy 1.86 warnings (and one nightly warning as well)

Let CI check MSRV
