### PR TITLE
output: option to add suricata version in eve logs

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -19,6 +19,9 @@ if available. If the ``pkt_src`` value is ``stream (flow timeout)``, then the
 ``ethernet`` value will be populated with mac addresses from the flow's first
 packet with ethernet header.
 
+If ``suricata-version`` is set to yes, then Suricata version, with its git
+revision if available, will be added to events as ``suricata_version``.
+
 Output Buffering
 ~~~~~~~~~~~~~~~~
 
@@ -69,6 +72,7 @@ Output types::
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
       #ethernet: no # log ethernet header in events when available
+      #suricata-version: no # include suricata version. Default no.
       #redis:
       #  server: 127.0.0.1
       #  port: 6379

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -99,6 +99,9 @@
         "src_port": {
             "type": "integer"
         },
+        "suricata_version": {
+            "type": "string"
+        },
         "stream": {
             "type": "integer"
         },

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -398,6 +398,13 @@ void EveAddMetadata(const Packet *p, const Flow *f, JsonBuilder *js)
 void EveAddCommonOptions(const OutputJsonCommonSettings *cfg, const Packet *p, const Flow *f,
         JsonBuilder *js, enum OutputJsonLogDirection dir)
 {
+    if (cfg->include_suricata_version) {
+#ifdef REVISION
+        jb_set_string(js, "suricata_version", PROG_VER " (" xstr(REVISION) ")");
+#else
+        jb_set_string(js, "suricata_version", PROG_VER);
+#endif
+    }
     if (cfg->include_metadata) {
         EveAddMetadata(p, f, js);
     }
@@ -1224,6 +1231,14 @@ OutputInitResult OutputJsonInitCtx(SCConfNode *conf)
             json_ctx->cfg.include_ethernet = true;
         } else {
             json_ctx->cfg.include_ethernet = false;
+        }
+
+        const SCConfNode *suriver = SCConfNodeLookupChild(conf, "suricata-version");
+        if (suriver && suriver->val && SCConfValIsTrue(suriver->val)) {
+            SCLogConfig("Enabling Suricata version logging.");
+            json_ctx->cfg.include_suricata_version = true;
+        } else {
+            json_ctx->cfg.include_suricata_version = false;
         }
 
         /* See if we want to enable the community id */

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -72,6 +72,7 @@ typedef struct OutputJsonCommonSettings_ {
     bool include_metadata;
     bool include_community_id;
     bool include_ethernet;
+    bool include_suricata_version;
     uint16_t community_id_seed;
 } OutputJsonCommonSettings;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -139,6 +139,8 @@ outputs:
 
       # Include top level metadata. Default yes.
       #metadata: no
+      # Include suricata version. Default no.
+      #suricata-version: yes
 
       # include the name of the input pcap file in pcap file processing mode
       pcap-file: false


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4853

Describe changes:
- output: option to add suricata version in eve logs

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2412
