### PR TITLE
pgsql: add initial support to copy-out subproto - v1

### DIFF
--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -121,6 +121,9 @@ pub enum PgsqlStateProgress {
     CancelRequestReceived,
     ConnectionTerminated,
     // Related to Backend-received messages //
+    CopyOutResponseReceived,
+    CopyDataOutReceived, // TODO -- Should we differentiate if from FE or BE?
+    CopyDoneReceived,
     SSLRejectedReceived,
     // SSPIAuthenticationReceived, // TODO implement
     SASLAuthenticationReceived,
@@ -481,16 +484,24 @@ impl PgsqlState {
             }
             PgsqlBEMessage::ReadyForQuery(_) => Some(PgsqlStateProgress::ReadyForQueryReceived),
             // TODO should we store any Parameter Status in PgsqlState?
+            // -- For CopyBoth mode, parameterstatus may be important (replication parameter)
             PgsqlBEMessage::AuthenticationMD5Password(_)
             | PgsqlBEMessage::AuthenticationCleartextPassword(_) => {
                 Some(PgsqlStateProgress::SimpleAuthenticationReceived)
             }
             PgsqlBEMessage::RowDescription(_) => Some(PgsqlStateProgress::RowDescriptionReceived),
+            PgsqlBEMessage::CopyOutResponse(_) => Some(PgsqlStateProgress::CopyOutResponseReceived),
             PgsqlBEMessage::ConsolidatedDataRow(msg) => {
                 // Increment tx.data_size here, since we know msg type, so that we can later on log that info
                 self.transactions.back_mut()?.sum_data_size(msg.data_size);
                 Some(PgsqlStateProgress::DataRowReceived)
             }
+            PgsqlBEMessage::ConsolidatedCopyDataOut(msg) => {
+                // Increment tx.data_size here, since we know msg type, so that we can later on log that info
+                self.transactions.back_mut()?.sum_data_size(msg.data_size);
+                Some(PgsqlStateProgress::CopyDataOutReceived)
+            }
+            PgsqlBEMessage::CopyDone(_) => Some(PgsqlStateProgress::CopyDoneReceived),
             PgsqlBEMessage::CommandComplete(_) => {
                 // TODO Do we want to compare the command that was stored when
                 // query was sent with what we received here?
@@ -504,6 +515,7 @@ impl PgsqlState {
             PgsqlBEMessage::ErrorResponse(_) => Some(PgsqlStateProgress::ErrorMessageReceived),
             _ => {
                 // We don't always have to change current state when we see a response...
+                // NotificationResponse and NoticeResponse fall here
                 None
             }
         }
@@ -582,6 +594,25 @@ impl PgsqlState {
                                 );
                                 tx.responses.push(dummy_resp);
                                 tx.responses.push(response);
+                                // reset values
+                                tx.data_row_cnt = 0;
+                                tx.data_size = 0;
+                            } else if state == PgsqlStateProgress::CopyDataOutReceived {
+                                tx.incr_row_cnt();
+                            } else if state == PgsqlStateProgress::CopyDoneReceived && tx.get_row_cnt() > 0 {
+                                // let's summarize the info from the data_rows in one response
+                                let dummy_resp = PgsqlBEMessage::ConsolidatedCopyDataOut(
+                                    ConsolidatedDataRowPacket {
+                                        identifier: b'd',
+                                        row_cnt: tx.get_row_cnt(),
+                                        data_size: tx.data_size, // total byte count of all data_row messages combined
+                                    },
+                                );
+                                tx.responses.push(dummy_resp);
+                                tx.responses.push(response);
+                                // reset values
+                                tx.data_row_cnt = 0;
+                                tx.data_size = 0;
                             } else {
                                 tx.responses.push(response);
                                 if Self::response_is_complete(state) {


### PR DESCRIPTION
This sub-protocol inspects messages exchanged between the postgresql backend and frontend after a 'COPY TO STDOUT' has been processed.

Parses new messages:
- CopyOutResponse -- initiates copy-out mode/ sub-protocol
- CopyData -- data transfer messages -- TODO decide whether to differentiate those between BE and FE
- CopyDone -- signals that no more CopyData messages will be seen from the BE for this transaction

Task #4854

As draft as there are TODOs
- update schema (once names are settled)
- update docs
- remove TODO comments

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4854

Describe changes:
- add initial support to PGSQL's [CopyOut mode](https://www.postgresql.org/docs/13/protocol-flow.html#PROTOCOL-COPY), which handles COPY TO STDOUT messages from the backend to the frontend
- parse new messages  (from Backend to Frontend): CopyData, CopyOutResponse, CopyDone
-- these new messages can happen as part of a SimpleQuery transaction, as per this implementation (as responses to a SimpleQuery with a COPY (select statement) TO STDOUT statement
- as with DataRow messages, we don't actually nor store the CopyData values, just consolidate rows (same as messages, when it's from the backend) and bytes sent
- log  new messages CopyOutReponse, Copy done, and ConsolidatedCopyDataOut

Log output sample:
```json
{
  "timestamp": "2025-04-02T17:09:20.080739+0000",
  "flow_id": 2135466975904183,
  "pcap_cnt": 18,
  "event_type": "pgsql",
  "src_ip": "10.16.1.11",
  "src_port": 47808,
  "dest_ip": "10.16.1.10",
  "dest_port": 5432,
  "proto": "TCP",
  "pkt_src": "wire/pcap",
  "pgsql": {
    "tx_id": 4,
    "request": {
      "simple_query": "COPY (SELECT * FROM rules WHERE source = 'tgreen/hunting' LIMIT 5) TO STDOUT"
    },
    "response": {
      "message": "copy_done",
      "row_count": 5,
      "data_size": 2779,
      "command_completed": "COPY 5"
    }
  }
}
```

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2416