### PR TITLE
pgsql/logger: encapsulate complex msgs w/ objects - v1

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2542,7 +2542,8 @@ pgsql flow. Some of the possible request messages are:
 * "notification_response"
 * "authentication_md5_password": a string with the ``md5`` salt value
 * "parameter_status": logged as an array
-* "backend_key_data"
+* "backend_key_data": object containing ``secret key`` and ``process id`` data
+  about the sender
 * "data_rows": integer. When one or many ``DataRow`` messages are parsed, the
   total returned rows
 * "data_size": in bytes. When one or many ``DataRow`` messages are parsed, the

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3591,6 +3591,17 @@
                 "request": {
                     "type": "object",
                     "properties": {
+                        "cancel_request": {
+                            "type": "object",
+                            "properties": {
+                                "process_id": {
+                                    "type": "integer"
+                                },
+                                "secret_key": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
                         "message": {
                             "type": "string"
                         },
@@ -3599,9 +3610,6 @@
                         },
                         "password_message": {
                             "type": "string"
-                        },
-                        "process_id": {
-                            "type": "integer"
                         },
                         "protocol_version": {
                             "type": "string"
@@ -3615,11 +3623,13 @@
                         "sasl_response": {
                             "type": "string"
                         },
-                        "secret_key": {
-                            "type": "integer"
-                        },
                         "simple_query": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "statement": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "startup_parameters": {
                             "type": "object",
@@ -3673,29 +3683,67 @@
                         "authentication_sasl_final": {
                             "type": "string"
                         },
-                        "code": {
-                            "type": "string"
+                        "backend_key_data": {
+                            "type": "object",
+                            "properties": {
+                                "process_id": {
+                                    "type": "integer"
+                                },
+                                "secret_key": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "command_completed": {
                             "type": "string"
                         },
-                        "data_rows": {
-                            "type": "integer"
+                        "consolidated_data_rows": {
+                            "type": "object",
+                            "properties": {
+                                "data_rows": {
+                                    "type": "integer"
+                                },
+                                "data_size": {
+                                    "type": "integer"
+                                }
+                            }
                         },
-                        "data_size": {
-                            "type": "integer"
-                        },
-                        "field_count": {
-                            "type": "integer"
-                        },
-                        "file": {
-                            "type": "string"
-                        },
-                        "line": {
-                            "type": "string"
+                        "error_response": {
+                            "type": "object",
+                            "properties": {
+                                "code": {
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "type": "string"
+                                },
+                                "line": {
+                                    "type": "string"
+                                },
+                                "message": {
+                                    "type": "string"
+                                },
+                                "routine": {
+                                    "type": "string"
+                                },
+                                "severity_localizable": {
+                                    "type": "string"
+                                },
+                                "severity_non_localizable": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "message": {
                             "type": "string"
+                        },
+                        "row_description": {
+                            "type": "object",
+                            "properties": {
+                                "field_count": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "parameter_status": {
                             "type": "array",
@@ -3739,21 +3787,6 @@
                                 },
                                 "additionalProperties": true
                             }
-                        },
-                        "process_id": {
-                            "type": "integer"
-                        },
-                        "routine": {
-                            "type": "string"
-                        },
-                        "secret_key": {
-                            "type": "integer"
-                        },
-                        "severity_localizable": {
-                            "type": "string"
-                        },
-                        "severity_non_localizable": {
-                            "type": "string"
                         },
                         "ssl_accepted": {
                             "type": "boolean"

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -94,12 +94,16 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
             length: _,
             payload,
         }) => {
-            js.set_string_from_bytes(req.to_str(), payload)?;
+            js.open_object(req.to_str())?;
+            // TODO should this be an array?
+            js.set_string_from_bytes("statement", payload)?;
+            js.close()?;
         }
         PgsqlFEMessage::CancelRequest(CancelRequestMessage { pid, backend_key }) => {
-            js.set_string("message", "cancel_request")?;
+            js.open_object(req.to_str())?;
             js.set_uint("process_id", *pid)?;
             js.set_uint("secret_key", *backend_key)?;
+            js.close()?;
         }
         PgsqlFEMessage::Terminate(TerminationMessage {
             identifier: _,
@@ -160,7 +164,9 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             length: _,
             message_body,
         }) => {
+            jb.open_object(res.to_str())?;
             log_error_notice_field_types(message_body, jb)?;
+            jb.close()?;
         }
         PgsqlBEMessage::AuthenticationMD5Password(AuthenticationMessage {
             identifier: _,
@@ -213,8 +219,10 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             backend_pid,
             secret_key,
         }) => {
+            jb.open_object(res.to_str())?;
             jb.set_uint("process_id", *backend_pid)?;
             jb.set_uint("secret_key", *secret_key)?;
+            jb.close()?;
         }
         PgsqlBEMessage::ReadyForQuery(ReadyForQueryMessage {
             identifier: _,
@@ -229,15 +237,19 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             field_count,
             fields: _,
         }) => {
+            jb.open_object(res.to_str())?;
             jb.set_uint("field_count", *field_count)?;
+            jb.close()?;
         }
         PgsqlBEMessage::ConsolidatedDataRow(ConsolidatedDataRowPacket {
             identifier: _,
             row_cnt,
             data_size,
         }) => {
+            jb.open_object(res.to_str())?;
             jb.set_uint("data_rows", *row_cnt)?;
             jb.set_uint("data_size", *data_size)?;
+            jb.close()?;
         }
         PgsqlBEMessage::NotificationResponse(NotificationResponse {
             identifier: _,
@@ -246,9 +258,11 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             channel_name,
             payload,
         }) => {
+            jb.open_object(res.to_str())?;
             jb.set_uint("pid", *pid)?;
             jb.set_string_from_bytes("channel_name", channel_name)?;
             jb.set_string_from_bytes("payload", payload)?;
+            jb.close()?;
         }
     }
     Ok(())

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -314,7 +314,7 @@ impl PgsqlBEMessage {
             PgsqlBEMessage::SSLResponse(SSLResponseMessage::InvalidResponse) => {
                 "invalid_be_message"
             }
-            PgsqlBEMessage::ConsolidatedDataRow(_) => "data_row",
+            PgsqlBEMessage::ConsolidatedDataRow(_) => "consolidated_data_rows",
             PgsqlBEMessage::NotificationResponse(_) => "notification_response",
             PgsqlBEMessage::UnknownMessageType(_) => "unknown_message_type",
         }


### PR DESCRIPTION
Describe changes:
- encapsulate pgsql log messages to add more context

---

**This proposes a new log style for PGSQL for Suricata 8**

Several PGSQL messages that contain more than one field or that don't make much sense if their type isn't clear were logged as independent fields, likely making log output interpretation not easy.

Encapsulate them into objects that refer to the PostgreSQL message type, as much as possible. (One exception being the DataRow messages that we consolidate into a single message, so more different than the original protocol).

Example of change: two data fields that only come together in the `backend key data` backend message were being logged as independent fields. While this is probably not severe, makes more sense to have them together.

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none yet, but probably should?

Sample outputs:
**before**
```json
  "pgsql": {
    "tx_id": 14,
    "request": {
      "simple_query": "SELECT 1/0;"
    },
    "response": {
      "severity_localizable": "ERROR",
      "severity_non_localizable": "ERROR",
      "code": "22012",
      "message": "division by zero",
      "file": "d:\\pginstaller_13.auto\\postgres.windows-x64\\src\\backend\\utils\\adt\\int.c",
      "line": "824",
      "routine": "int4div"
    }
  }
```

**with this change**
```json
  "pgsql": {
    "tx_id": 14,
    "request": {
      "simple_query": {
        "statement": "SELECT 1/0;"
      }
    },
    "response": {
      "error_response": {
        "severity_localizable": "ERROR",
        "severity_non_localizable": "ERROR",
        "code": "22012",
        "message": "division by zero",
        "file": "d:\\pginstaller_13.auto\\postgres.windows-x64\\src\\backend\\utils\\adt\\int.c",
        "line": "824",
        "routine": "int4div"
      }
    }
  }
 ```

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2417
