### PR TITLE
pgsql: add initial support for CopyOut mode - v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2548,6 +2548,12 @@ pgsql flow. Some of the possible request messages are:
 * "data_size": in bytes. When one or many ``DataRow`` messages are parsed, the
   total size in bytes of the data returned
 * "command_completed": string. Informs the command just completed by the backend
+* "copy_out_response": object. Indicates the beginning of a CopyTo mode, shows
+  how many columns will be copied to STDOUT (``copy_column_cnt`` field)
+* "copy_data_out": object. Consolidated data on the CopyData sent by the backend
+  in a CopyOut transaction
+* "copy_done": string. Similar to ``command_completed`` but sent after the
+  backend finishes sending a batch of ``CopyData`` messages
 * "ssl_accepted": bool. With this event, the initial PGSQL SSL Handshake
   negotiation is complete in terms of tracking and logging. The session will be
   upgraded to use TLS encryption

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3676,6 +3676,17 @@
                         "code": {
                             "type": "string"
                         },
+                        "copy_data_out": {
+                            "type": "object",
+                            "properties": {
+                                "row_count": {
+                                    "type": "integer"
+                                },
+                                "data_size": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
                         "command_completed": {
                             "type": "string"
                         },
@@ -3754,6 +3765,14 @@
                         },
                         "severity_non_localizable": {
                             "type": "string"
+                        },
+                        "copy_out_response": {
+                            "type": "object",
+                            "properties": {
+                                "copy_column_count": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "ssl_accepted": {
                             "type": "boolean"

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -102,7 +102,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
             js.set_uint("process_id", *pid)?;
             js.set_uint("secret_key", *backend_key)?;
         }
-        PgsqlFEMessage::Terminate(TerminationMessage {
+        PgsqlFEMessage::Terminate(NoPayloadMessage {
             identifier: _,
             length: _,
         }) => {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -29,7 +29,7 @@ use nom7::multi::{many1, many_m_n, many_till};
 use nom7::number::streaming::{be_i16, be_i32};
 use nom7::number::streaming::{be_u16, be_u32, be_u8};
 use nom7::sequence::terminated;
-use nom7::{Err, IResult};
+use nom7::{Err, IResult, ToUsize};
 
 pub const PGSQL_LENGTH_FIELD: u32 = 4;
 
@@ -247,7 +247,7 @@ pub struct BackendKeyDataMessage {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConsolidatedDataRowPacket {
     pub identifier: u8,
-    pub row_cnt: u64,
+    pub row_cnt: u64, // row or msg cnt
     pub data_size: u64,
 }
 
@@ -269,6 +269,21 @@ pub struct NotificationResponse {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct CopyOutResponse {
+    pub identifier: u8,
+    pub length: u32,
+    pub column_cnt: u16,
+    // for each column, there are column_cnt u16 format codes received
+    // for now, we're not storing those
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TerminationMessage {
+    pub identifier: u8,
+    pub length: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum PgsqlBEMessage {
     SSLResponse(SSLResponseMessage),
     ErrorResponse(ErrorNoticeMessage),
@@ -283,6 +298,9 @@ pub enum PgsqlBEMessage {
     ParameterStatus(ParameterStatusMessage),
     BackendKeyData(BackendKeyDataMessage),
     CommandComplete(RegularPacket),
+    CopyOutResponse(CopyOutResponse),
+    ConsolidatedCopyDataOut(ConsolidatedDataRowPacket),
+    CopyDone(TerminationMessage),
     ReadyForQuery(ReadyForQueryMessage),
     RowDescription(RowDescriptionMessage),
     ConsolidatedDataRow(ConsolidatedDataRowPacket),
@@ -309,6 +327,9 @@ impl PgsqlBEMessage {
             PgsqlBEMessage::ParameterStatus(_) => "parameter_status",
             PgsqlBEMessage::BackendKeyData(_) => "backend_key_data",
             PgsqlBEMessage::CommandComplete(_) => "command_completed",
+            PgsqlBEMessage::CopyOutResponse(_) => "copy_out_response",
+            PgsqlBEMessage::ConsolidatedCopyDataOut(_) => "copy_data_out",
+            PgsqlBEMessage::CopyDone(_) => "copy_done",
             PgsqlBEMessage::ReadyForQuery(_) => "ready_for_query",
             PgsqlBEMessage::RowDescription(_) => "row_description",
             PgsqlBEMessage::SSLResponse(SSLResponseMessage::InvalidResponse) => {
@@ -347,12 +368,6 @@ impl SASLAuthenticationMechanism {
 }
 
 type SASLInitialResponse = (SASLAuthenticationMechanism, u32, Vec<u8>);
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct TerminationMessage {
-    pub identifier: u8,
-    pub length: u32,
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct CancelRequestMessage {
@@ -1017,6 +1032,47 @@ fn add_up_data_size(columns: Vec<ColumnFieldValue>) -> u64 {
     data_size
 }
 
+pub fn parse_copy_out_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, PgsqlParseError<&[u8]>> {
+    let (i, identifier) = verify(be_u8, |&x| x == b'H')(i)?;
+    // copy out message : identifier (u8), length (u32), format (u8), cols (u16), formats (u16*cols)
+    let (i, length) = parse_gte_length(i, 8)?;
+    let (i, _format) = be_u8(i)?;
+    let (i, columns) = be_u16(i)?;
+    let (i, _formats) = many_m_n(0, columns.to_usize(), be_u16)(i)?;
+    Ok((
+        i,
+        PgsqlBEMessage::CopyOutResponse(CopyOutResponse {
+            identifier,
+            length,
+            column_cnt: columns,
+        })
+    ))
+}
+
+pub fn parse_consolidated_copy_data_out(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, PgsqlParseError<&[u8]>> {
+    let (i, identifier) = verify(be_u8, |&x| x == b'd')(i)?;
+    let (i, length) = parse_gte_length(i, 5)?;
+    let (i, _data) = take(length - PGSQL_LENGTH_FIELD)(i)?;
+    SCLogDebug!("data_size is {:?}", _data);
+    Ok((
+        i, PgsqlBEMessage::ConsolidatedCopyDataOut(ConsolidatedDataRowPacket {
+            identifier,
+            row_cnt: 1,
+            data_size: (length - PGSQL_LENGTH_FIELD) as u64 })
+    ))
+}
+
+fn parse_copy_done(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, PgsqlParseError<&[u8]>> {
+    let (i, identifier) = verify(be_u8, |&x| x == b'c')(i)?;
+    let (i, length) = parse_exact_length(i, PGSQL_LENGTH_FIELD)?;
+    Ok((
+        i, PgsqlBEMessage::CopyDone(TerminationMessage {
+            identifier,
+            length
+        })
+    ))
+}
+
 // Currently, we don't store the actual DataRow messages, as those could easily become a burden, memory-wise
 // We use ConsolidatedDataRow to store info we still want to log: message size.
 // Later on, we calculate the number of lines the command actually returned by counting ConsolidatedDataRow messages
@@ -1211,10 +1267,13 @@ pub fn pgsql_parse_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, PgsqlPar
         b'R' => pgsql_parse_authentication_message(i)?,
         b'S' => parse_parameter_status_message(i)?,
         b'C' => parse_command_complete(i)?,
+        b'c' => parse_copy_done(i)?,
         b'Z' => parse_ready_for_query(i)?,
         b'T' => parse_row_description(i)?,
         b'A' => parse_notification_response(i)?,
         b'D' => parse_consolidated_data_row(i)?,
+        b'd' => parse_consolidated_copy_data_out(i)?,
+        b'H' => parse_copy_out_response(i)?,
         _ => {
             let (i, identifier) = be_u8(i)?;
             let (i, length) = parse_gte_length(i, PGSQL_LENGTH_FIELD)?;

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -278,7 +278,7 @@ pub struct CopyOutResponse {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct TerminationMessage {
+pub struct NoPayloadMessage {
     pub identifier: u8,
     pub length: u32,
 }
@@ -300,7 +300,7 @@ pub enum PgsqlBEMessage {
     CommandComplete(RegularPacket),
     CopyOutResponse(CopyOutResponse),
     ConsolidatedCopyDataOut(ConsolidatedDataRowPacket),
-    CopyDone(TerminationMessage),
+    CopyDone(NoPayloadMessage),
     ReadyForQuery(ReadyForQueryMessage),
     RowDescription(RowDescriptionMessage),
     ConsolidatedDataRow(ConsolidatedDataRowPacket),
@@ -384,7 +384,7 @@ pub enum PgsqlFEMessage {
     SASLResponse(RegularPacket),
     SimpleQuery(RegularPacket),
     CancelRequest(CancelRequestMessage),
-    Terminate(TerminationMessage),
+    Terminate(NoPayloadMessage),
     UnknownMessageType(RegularPacket),
 }
 
@@ -776,7 +776,7 @@ fn parse_terminate_message(i: &[u8]) -> IResult<&[u8], PgsqlFEMessage, PgsqlPars
     let (i, length) = parse_exact_length(i, PGSQL_LENGTH_FIELD)?;
     Ok((
         i,
-        PgsqlFEMessage::Terminate(TerminationMessage { identifier, length }),
+        PgsqlFEMessage::Terminate(NoPayloadMessage { identifier, length }),
     ))
 }
 
@@ -1066,7 +1066,7 @@ fn parse_copy_done(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, PgsqlParseError<&
     let (i, identifier) = verify(be_u8, |&x| x == b'c')(i)?;
     let (i, length) = parse_exact_length(i, PGSQL_LENGTH_FIELD)?;
     Ok((
-        i, PgsqlBEMessage::CopyDone(TerminationMessage {
+        i, PgsqlBEMessage::CopyDone(NoPayloadMessage {
             identifier,
             length
         })


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata/pull/12941

This sub-protocol inspects messages exchanged between the postgresql backend and frontend after a 'COPY TO STDOUT' has been processed.

Parses new messages:
- CopyOutResponse -- initiates copy-out mode/ sub-protocol
- CopyData -- data transfer messages -- TODO decide whether to differentiate those between BE and FE
- CopyDone -- signals that no more CopyData messages will be seen from the BE for this transaction

Task https://github.com/OISF/suricata/pull/4854

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/4854

Sample output
```json
"pgsql": {
    "tx_id": 4,
    "request": {
      "simple_query": "COPY (SELECT * FROM rules WHERE source = 'tgreen/hunting' LIMIT 5) TO STDOUT"
    },
    "response": {
      "copy_out_response": {
        "copy_column_count": 13
      },
      "copy_data_out": {
        "row_count": 5,
        "data_size": 2779
      },
      "message": "copy_done",
      "command_completed": "COPY 5"
    }
  }
```

Describe changes:
- add initial support to PGSQL's [CopyOut mode](https://www.postgresql.org/docs/13/protocol-flow.html#PROTOCOL-COPY), which handles COPY TO STDOUT messages from the backend to the frontend
- parse new messages (from Backend to Frontend): CopyData, CopyOutResponse, CopyDone
-- these new messages can happen as part of a SimpleQuery transaction, as per this implementation (as responses to a SimpleQuery with a COPY (select statement) TO STDOUT statement
- as with DataRow messages, we don't actually nor store the CopyData values, just consolidate rows (same as messages, when it's from the backend) and bytes sent
- log new messages CopyOutReponse, Copy done, and ConsolidatedCopyDataOut

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2418
