### PR TITLE
lua/detect: remove rule sid, rev and gid globals

### DIFF
--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -481,13 +481,6 @@ static void *DetectLuaThreadInit(void *data)
 
     LuaRegisterExtensions(t->luastate);
 
-    lua_pushinteger(t->luastate, (lua_Integer)(lua->sid));
-    lua_setglobal(t->luastate, "SCRuleSid");
-    lua_pushinteger(t->luastate, (lua_Integer)(lua->rev));
-    lua_setglobal(t->luastate, "SCRuleRev");
-    lua_pushinteger(t->luastate, (lua_Integer)(lua->gid));
-    lua_setglobal(t->luastate, "SCRuleGid");
-
     /* hackish, needed to allow unittests to pass buffers as scripts instead of files */
 #ifdef UNITTESTS
     if (ut_script != NULL) {
@@ -996,27 +989,6 @@ error:
     if (lua != NULL)
         DetectLuaFree(de_ctx, lua);
     return -1;
-}
-
-/** \brief post-sig parse function to set the sid,rev,gid into the
- *         ctx, as this isn't available yet during parsing.
- */
-void DetectLuaPostSetup(Signature *s)
-{
-    int i;
-    SigMatch *sm;
-
-    for (i = 0; i < DETECT_SM_LIST_MAX; i++) {
-        for (sm = s->init_data->smlists[i]; sm != NULL; sm = sm->next) {
-            if (sm->type != DETECT_LUA)
-                continue;
-
-            DetectLuaData *ld = (DetectLuaData *)sm->ctx;
-            ld->sid = s->id;
-            ld->rev = s->rev;
-            ld->gid = s->gid;
-        }
-    }
 }
 
 /**

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -50,9 +50,6 @@ typedef struct DetectLuaData {
     uint32_t flowvar[DETECT_LUA_MAX_FLOWVARS];
     uint16_t bytevars;
     uint32_t bytevar[DETECT_LUA_MAX_BYTEVARS];
-    uint32_t sid;
-    uint32_t rev;
-    uint32_t gid;
     uint64_t alloc_limit;
     uint64_t instruction_limit;
     int allow_restricted_functions;
@@ -65,7 +62,6 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx,
         const uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
         Flow *f);
 
-void DetectLuaPostSetup(Signature *s);
 void LuaDumpStack(lua_State *state, const char *prefix);
 
 #endif /* SURICATA_DETECT_LUA_H */

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -2308,7 +2308,6 @@ static int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
             }
         }
     }
-    DetectLuaPostSetup(s);
 
     if ((s->flags & SIG_FLAG_FILESTORE) || s->file_flags != 0 ||
         (s->init_data->init_flags & SIG_FLAG_INIT_FILEDATA)) {


### PR DESCRIPTION
Pretty trivial...  Removing as its scheduled to be replaced anyways.

For some rules the values are always 0, for others they get set, so not
consistent. Also not documented and not tested and should be replaced by
a "suricata.rule" lib.

For example, these globals would be set for this rule:

alert tcp any any -> any any (flow:to_server;
flowbits:isnotset,dataset_added; lua:dataset.lua;
flowbits:set,dataset_added;sid:1;rev:99;)

But not this rule:

alert dns any any -> any any (msg:"TEST DNS LUA dns.rrname"; \
      content:"org"; lua:test-rrname.lua; sid:1; rev:1;)

Related to ticket
https://redmine.openinfosecfoundation.org/issues/7490 (but not a fix)

This does not affect the functions with similar names for getting rule
details in output context.
