### PR TITLE
detect/transform: add serialized data from a transform into the detect buffer's hash 

### DIFF
--- a/rust/src/detect/transform_base64.rs
+++ b/rust/src/detect/transform_base64.rs
@@ -20,7 +20,7 @@
 use crate::detect::error::RuleParseError;
 use crate::detect::parser::{parse_var, take_until_whitespace, ResultValue};
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_int, c_void, c_char};
 use crate::ffi::base64::SCBase64Mode;
 
 use nom7::bytes::complete::tag;
@@ -47,6 +47,8 @@ pub struct SCDetectTransformFromBase64Data {
     offset: u32,
     offset_str: *const c_char,
     mode: SCBase64Mode,
+    serialized_data: *mut c_void,
+    serialized_data_len:  c_int,
 }
 
 impl Drop for SCDetectTransformFromBase64Data {
@@ -70,6 +72,8 @@ impl Default for SCDetectTransformFromBase64Data {
             offset: 0,
             offset_str: std::ptr::null_mut(),
             mode: TRANSFORM_FROM_BASE64_MODE_DEFAULT,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         }
     }
 }
@@ -287,6 +291,8 @@ mod tests {
                 std::ptr::null_mut()
             },
             mode,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         };
 
         let (_, val) = parse_transform_base64(args).unwrap();

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -957,8 +957,27 @@ static uint32_t DetectBufferTypeHashNameFunc(HashListTable *ht, void *data, uint
 {
     const DetectBufferType *map = (DetectBufferType *)data;
     uint32_t hash = hashlittle_safe(map->name, strlen(map->name), 0);
-    hash += hashlittle_safe((uint8_t *)&map->transforms, sizeof(map->transforms), 0);
+
+    // Add the transform data
+    // - Collect transform id and position
+    // - Collect serialized data, if any
+    for (int i = 0; i < map->transforms.cnt; i++) {
+        const TransformData *t = &map->transforms.transforms[i];
+        uint8_t tval = t->transform + i;
+        hash += hashlittle_safe((uint8_t *)&tval, sizeof(tval), 0);
+        if (sigmatch_table[t->transform].TransformSerialize) {
+            sigmatch_table[t->transform].TransformSerialize(
+                    (TransformSerializedData *)&map->xform_serialized[i], t->options);
+            hash += hashlittle_safe(map->xform_serialized[i].serialized_data,
+                    map->xform_serialized[i].serialized_data_len, 0);
+            SCLogDebug("serialized data: [%p] \"%s\" [%d]",
+                    map->xform_serialized[i].serialized_data,
+                    (char *)map->xform_serialized[i].serialized_data,
+                    map->xform_serialized[i].serialized_data_len);
+        }
+    }
     hash %= ht->array_size;
+    SCLogDebug("map->name %s, hash %d", map->name, hash);
     return hash;
 }
 
@@ -976,7 +995,52 @@ static char DetectBufferTypeCompareNameFunc(void *data1, uint16_t len1, void *da
     DetectBufferType *map2 = (DetectBufferType *)data2;
 
     char r = (strcmp(map1->name, map2->name) == 0);
-    r &= (memcmp((uint8_t *)&map1->transforms, (uint8_t *)&map2->transforms, sizeof(map2->transforms)) == 0);
+
+    // Compare the transforms
+    // the transform supports serialization, that data will also be added.
+    if (r && map1->transforms.cnt && (map1->transforms.cnt == map2->transforms.cnt)) {
+        for (int i = 0; i < map1->transforms.cnt; i++) {
+            if (map1->transforms.transforms[i].transform !=
+                    map2->transforms.transforms[i].transform) {
+                r = 0;
+                break;
+            }
+
+            SCLogDebug("%s: transform ids match; checking specialized data", map1->name);
+            // Checks
+            // - Both NULL: --> ok, continue
+            // - One NULL: --> no match, break?
+            // - Serialized data lengths match: --> ok, continue
+            // - Serialized data matches: ok
+
+            // Stop if only one is NULL
+            if ((map1->xform_serialized[i].serialized_data == NULL) ^
+                    (map2->xform_serialized[i].serialized_data == NULL)) {
+                SCLogDebug("serialized data: only one is null");
+                r = 0;
+                break;
+            } else if (map1->xform_serialized[i].serialized_data ==
+                       NULL) { /* continue when both are null */
+                SCLogDebug("serialized data: both null");
+                r = 1;
+                continue;
+            } else if (map1->xform_serialized[i].serialized_data_len !=
+                       map2->xform_serialized[i].serialized_data_len) {
+                // Stop when serialized data lengths aren't equal
+                SCLogDebug("serialized data: unequal lengths");
+                r = 0;
+                break;
+            }
+
+            // stop if the serialized data is different
+            r &= memcmp(map1->xform_serialized[i].serialized_data,
+                         map2->xform_serialized[i].serialized_data,
+                         map1->xform_serialized[i].serialized_data_len) == 0;
+            if (r == 0)
+                break;
+            SCLogDebug("serialized data: data matches");
+        }
+    }
     return r;
 }
 
@@ -999,6 +1063,7 @@ static void DetectBufferTypeFreeFunc(void *data)
     for (int i = 0; i < map->transforms.cnt; i++) {
         if (map->transforms.transforms[i].options == NULL)
             continue;
+
         if (sigmatch_table[map->transforms.transforms[i].transform].Free == NULL) {
             SCLogError("%s allocates transform option memory but has no free routine",
                     sigmatch_table[map->transforms.transforms[i].transform].name);
@@ -1478,8 +1543,9 @@ int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s)
             SCReturnInt(-1);
         }
 
-        SCLogDebug("buffer %d has transform(s) registered: %d",
-                s->init_data->list, s->init_data->transforms.cnt);
+        SCLogDebug("buffer %d has transform(s) registered: %d", s->init_data->list,
+                s->init_data->transforms.cnt);
+
         int new_list = DetectEngineBufferTypeGetByIdTransforms(de_ctx, s->init_data->list,
                 s->init_data->transforms.transforms, s->init_data->transforms.cnt);
         if (new_list == -1) {

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -31,9 +31,11 @@
 #include "detect-transform-pcrexform.h"
 #include "detect-pcre.h"
 
+#define PCRE_SERIALIZED_DATA_LEN 32
 typedef struct DetectTransformPcrexformData {
     pcre2_code *regex;
     pcre2_match_context *context;
+    uint8_t serialized_data[PCRE_SERIALIZED_DATA_LEN];
 } DetectTransformPcrexformData;
 
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
@@ -44,6 +46,16 @@ static void DetectTransformPcrexform(
 void DetectTransformPcrexformRegisterTests (void);
 #endif
 
+static void DetectTransformPcrexformSerialize(
+        TransformSerializedData *serialized_data, void *options)
+{
+    if (options) {
+        DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *)options;
+        serialized_data->serialized_data = pxd->serialized_data;
+        serialized_data->serialized_data_len = PCRE_SERIALIZED_DATA_LEN;
+    }
+}
+
 void DetectTransformPcrexformRegister(void)
 {
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].name = "pcrexform";
@@ -52,6 +64,8 @@ void DetectTransformPcrexformRegister(void)
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].url = "/rules/transforms.html#pcre-xform";
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Transform =
         DetectTransformPcrexform;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].TransformSerialize =
+            DetectTransformPcrexformSerialize;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Free =
         DetectTransformPcrexformFree;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Setup =
@@ -124,6 +138,9 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         DetectTransformPcrexformFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
+
+    memcpy(pxd->serialized_data, regexstr, PCRE_SERIALIZED_DATA_LEN);
+    pxd->serialized_data[PCRE_SERIALIZED_DATA_LEN - 1] = '\0';
 
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
     if (r != 0) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -462,9 +462,15 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct DetectEngineAppInspectionEngine_ *next;
 } DetectEngineAppInspectionEngine;
 
+typedef struct TransformSerializedData_ {
+    uint8_t *serialized_data;
+    uint32_t serialized_data_len;
+} TransformSerializedData;
+
 typedef struct DetectBufferType_ {
     char name[32];
     char description[128];
+    TransformSerializedData xform_serialized[DETECT_TRANSFORMS_MAX];
     int id;
     int parent_id;
     bool mpm;
@@ -1339,6 +1345,9 @@ typedef struct SigTableElmt_ {
     /** InspectionBuffer transformation callback */
     void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
     bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
+
+    /** Transform serialization callback */
+    void (*TransformSerialize)(TransformSerializedData *serialized_data, void *options);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Continuation of #12953 

This PR improves transform support by including transform options, when available, into the hashing logic to better support prefiltering.

There are 2 transforms that support options -- both have been modified to use serialization data
- pcrexform -- pcre pattern
- from_base64 -- stringified version of the mode, offset/bytes.

Changes:
- When computing a hash, include serialized data from the transform
- Omitting the "options" ptr from the transform hash (instead, use the transform id and position)
- pcrexform/from_base64 create serialized data
- Incorporate serialized data into hash compare function.
