### PR TITLE
Warnint 64to32 6186 v24.1

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1370,7 +1370,11 @@ static int DatasetOpSerialized(Dataset *set, const char *string, DatasetOpFunc D
 
     switch (set->type) {
         case DATASET_TYPE_STRING: {
-            uint32_t decoded_size = SCBase64DecodeBufferSize(strlen(string));
+            if (strlen(string) > UINT16_MAX) {
+                // size check before cast and stack allocation
+                return -1;
+            }
+            uint32_t decoded_size = SCBase64DecodeBufferSize((uint32_t)strlen(string));
             uint8_t decoded[decoded_size];
             uint32_t num_decoded = SCBase64Decode(
                     (const uint8_t *)string, strlen(string), SCBase64ModeStrict, decoded);

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -159,7 +159,7 @@ int DetectByteExtractDoMatch(DetectEngineThreadCtx *det_ctx, const SigMatchData 
 
     ptr += extbytes;
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     *value = val;
     SCLogDebug("extracted value is %"PRIu64, val);

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -253,7 +253,7 @@ bool DetectBytejumpDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
     /* Adjust the detection context to the jump location. */
     DEBUG_VALIDATE_BUG_ON(jumpptr < payload);
-    det_ctx->buffer_offset = jumpptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(jumpptr - payload);
 
     SCReturnBool(true);
 }

--- a/src/detect-bytemath.c
+++ b/src/detect-bytemath.c
@@ -191,7 +191,7 @@ int DetectByteMathDoMatch(DetectEngineThreadCtx *det_ctx, const DetectByteMathDa
             break;
     }
 
-    det_ctx->buffer_offset = ptr - payload;
+    det_ctx->buffer_offset = (uint32_t)(ptr - payload);
 
     if (data->flags & DETECT_BYTEMATH_FLAG_BITMASK) {
         val &= data->bitmask_val;

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -401,7 +401,7 @@ static DetectBytetestData *DetectBytetestParse(
             data->neg_op = true;
             op_ptr = &args[1][1];
             while (isspace((char)*op_ptr) || (*op_ptr == ',')) op_ptr++;
-            op_offset = op_ptr - &args[1][0];
+            op_offset = (uint32_t)(op_ptr - &args[1][0]);
         } else {
             data->neg_op = false;
         }

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -406,7 +406,7 @@ void DetectContentFree(DetectEngineCtx *de_ctx, void *ptr)
  *  - Negated content values are checked but not accumulated for the required size.
  */
 void SigParseRequiredContentSize(
-        const Signature *s, const int max_size, const SigMatch *sm, int *len, int *offset)
+        const Signature *s, const uint64_t max_size, const SigMatch *sm, int *len, int *offset)
 {
     int max_offset = 0, total_len = 0;
     bool first = true;
@@ -428,7 +428,7 @@ void SigParseRequiredContentSize(
             if (cd->flags & DETECT_CONTENT_NEGATED) {
                 /* Check if distance/within cause max to be exceeded */
                 int check = total_len + cd->distance + cd->within;
-                if (max_size < check) {
+                if (max_size < (uint64_t)check) {
                     *len = check;
                     return;
                 }
@@ -457,12 +457,11 @@ bool DetectContentPMATCHValidateCallback(const Signature *s)
         return true;
     }
 
-    int max_right_edge_i = SigParseGetMaxDsize(s);
-    if (max_right_edge_i < 0) {
+    uint16_t max_right_edge_i;
+    if (SigParseGetMaxDsize(s, &max_right_edge_i) < 0) {
         return true;
     }
-
-    uint32_t max_right_edge = (uint32_t)max_right_edge_i;
+    uint32_t max_right_edge = max_right_edge_i;
 
     int min_dsize_required = SigParseMaxRequiredDsize(s);
     if (min_dsize_required >= 0) {

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -131,7 +131,7 @@ void DetectContentPropagateLimits(Signature *s);
 
 void DetectContentPatternPrettyPrint(const DetectContentData *cd, char *str, size_t str_len);
 void SigParseRequiredContentSize(
-        const Signature *s, const int max, const SigMatch *sm, int *len, int *offset);
+        const Signature *s, const uint64_t max, const SigMatch *sm, int *len, int *offset);
 int DetectContentConvertToNocase(DetectEngineCtx *de_ctx, DetectContentData *cd);
 
 #endif /* SURICATA_DETECT_CONTENT_H */

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -208,7 +208,7 @@ static bool PrefilterDsizeIsPrefilterable(const Signature *s)
  *  \param s signature to get dsize value from
  *  \retval depth or negative value
  */
-int SigParseGetMaxDsize(const Signature *s)
+int SigParseGetMaxDsize(const Signature *s, uint16_t *dsize)
 {
     if (s->flags & SIG_FLAG_DSIZE && s->init_data->dsize_sm != NULL) {
         const DetectU16Data *dd = (const DetectU16Data *)s->init_data->dsize_sm->ctx;
@@ -217,9 +217,11 @@ int SigParseGetMaxDsize(const Signature *s)
             case DETECT_UINT_LT:
             case DETECT_UINT_EQ:
             case DETECT_UINT_NE:
-                return dd->arg1;
+                *dsize = dd->arg1;
+                SCReturnInt(0);
             case DETECT_UINT_RA:
-                return dd->arg2;
+                *dsize = dd->arg2;
+                SCReturnInt(0);
             case DETECT_UINT_GT:
             default:
                 SCReturnInt(-2);
@@ -293,8 +295,8 @@ int SigParseMaxRequiredDsize(const Signature *s)
         SCReturnInt(-1);
     }
 
-    const int dsize = SigParseGetMaxDsize(s);
-    if (dsize < 0) {
+    uint16_t dsize;
+    if (SigParseGetMaxDsize(s, &dsize) < 0) {
         /* nothing to do */
         SCReturnInt(-1);
     }
@@ -328,8 +330,8 @@ void SigParseApplyDsizeToContent(Signature *s)
     if (s->flags & SIG_FLAG_DSIZE) {
         SigParseSetDsizePair(s);
 
-        int dsize = SigParseGetMaxDsize(s);
-        if (dsize < 0) {
+        uint16_t dsize;
+        if (SigParseGetMaxDsize(s, &dsize) < 0) {
             /* nothing to do */
             return;
         }

--- a/src/detect-dsize.h
+++ b/src/detect-dsize.h
@@ -30,7 +30,7 @@
 void DetectDsizeRegister (void);
 
 int SigParseMaxRequiredDsize(const Signature *s);
-int SigParseGetMaxDsize(const Signature *s);
+int SigParseGetMaxDsize(const Signature *s, uint16_t *dsize);
 void SigParseSetDsizePair(Signature *s);
 void SigParseApplyDsizeToContent(Signature *s);
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -482,7 +482,7 @@ void SetupEngineAnalysis(DetectEngineCtx *de_ctx, bool *fp_analysis, bool *rule_
     }
 
     ea->file_prefix = NULL;
-    int cfg_prefix_len = strlen(de_ctx->config_prefix);
+    size_t cfg_prefix_len = strlen(de_ctx->config_prefix);
     if (cfg_prefix_len > 0) {
         /* length of prefix + NULL + "." */
         ea->file_prefix = SCCalloc(1, cfg_prefix_len + 1 + 1);

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -131,7 +131,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, const char *sig_file, int 
         return -1;
     }
 
-    while(fgets(line + offset, (int)sizeof(line) - offset, fp) != NULL) {
+    while (fgets(line + offset, (int)(sizeof(line) - offset), fp) != NULL) {
         lineno++;
         size_t len = strlen(line);
 

--- a/src/detect-engine-prefilter-common.c
+++ b/src/detect-engine-prefilter-common.c
@@ -33,7 +33,7 @@ static uint32_t PrefilterPacketHeaderHashFunc(HashListTable *ht, void *data, uin
     PrefilterPacketHeaderCtx *ctx = data;
     uint64_t hash = ctx->v1.u64[0] + ctx->v1.u64[1] + ctx->type + ctx->value;
     hash %= ht->array_size;
-    return hash;
+    return (uint32_t)hash;
 }
 
 static char PrefilterPacketHeaderCompareFunc(void *data1, uint16_t len1,

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -83,8 +83,8 @@ static inline void QuickSortSigIntId(SigIntId *sids, uint32_t n)
             r--;
         }
     }
-    QuickSortSigIntId(sids, r - sids + 1);
-    QuickSortSigIntId(l, sids + n - l);
+    QuickSortSigIntId(sids, (uint32_t)(r - sids) + 1);
+    QuickSortSigIntId(l, (uint32_t)(sids + n - l));
 }
 
 /**
@@ -698,7 +698,7 @@ static uint32_t PrefilterStoreHashFunc(HashListTable *ht, void *data, uint16_t d
 {
     PrefilterStore *ctx = data;
 
-    uint32_t hash = strlen(ctx->name);
+    uint32_t hash = (uint32_t)strlen(ctx->name);
 
     for (size_t u = 0; u < strlen(ctx->name); u++) {
         hash += ctx->name[u];

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -337,7 +337,7 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
     }
 }
 
-static void SigMultilinePrint(int i, const char *prefix)
+static void SigMultilinePrint(size_t i, const char *prefix)
 {
     if (sigmatch_table[i].desc) {
         printf("%sDescription: %s\n", prefix, sigmatch_table[i].desc);

--- a/src/detect-flow-age.c
+++ b/src/detect-flow-age.c
@@ -29,10 +29,13 @@ static int DetectFlowAgeMatch(
     if (p->flow == NULL) {
         return 0;
     }
-    uint32_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
+    uint64_t age = SCTIME_SECS(p->flow->lastts) - SCTIME_SECS(p->flow->startts);
+    if (age > UINT32_MAX) {
+        age = UINT32_MAX;
+    }
 
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
-    return DetectU32Match(age, du32);
+    return DetectU32Match((uint32_t)age, du32);
 }
 
 static void DetectFlowAgeFree(DetectEngineCtx *de_ctx, void *ptr)

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -187,7 +187,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -214,7 +214,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-header-common.c
+++ b/src/detect-http-header-common.c
@@ -78,8 +78,7 @@ void HttpHeaderThreadDataFree(void *data)
     SCFree(hdrnames);
 }
 
-int HttpHeaderExpandBuffer(HttpHeaderThreadData *td,
-        HttpHeaderBuffer *buf, uint32_t size)
+int HttpHeaderExpandBuffer(HttpHeaderThreadData *td, HttpHeaderBuffer *buf, size_t size)
 {
     size_t extra = td->size_step;
     while ((buf->size + extra) < (size + buf->len)) {

--- a/src/detect-http-header-common.h
+++ b/src/detect-http-header-common.h
@@ -45,7 +45,6 @@ void HttpHeaderThreadDataFree(void *data);
 HttpHeaderBuffer *HttpHeaderGetBufferSpace(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags,
         const int keyword_id, HttpHeaderThreadData **ret_hdr_td);
 
-int HttpHeaderExpandBuffer(HttpHeaderThreadData *td,
-        HttpHeaderBuffer *buf, uint32_t size);
+int HttpHeaderExpandBuffer(HttpHeaderThreadData *td, HttpHeaderBuffer *buf, size_t size);
 
 #endif /* SURICATA_DETECT_HTTP_HEADER_COMMON_H */

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -63,7 +63,7 @@ static InspectionBuffer *GetRequestData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -117,7 +117,7 @@ static InspectionBuffer *GetResponseData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -250,7 +250,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_hostname(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_request_hostname(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_hostname(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_hostname(tx));
 
         InspectionBufferSetupAndApplyTransforms(
@@ -357,10 +357,10 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
                 return NULL;
 
             data = htp_header_value_ptr(h);
-            data_len = htp_header_value_len(h);
+            data_len = (uint32_t)htp_header_value_len(h);
         } else {
             data = (const uint8_t *)bstr_ptr(htp_uri_hostname(htp_tx_parsed_uri(tx)));
-            data_len = bstr_len(htp_uri_hostname(htp_tx_parsed_uri(tx)));
+            data_len = (uint32_t)bstr_len(htp_uri_hostname(htp_tx_parsed_uri(tx)));
         }
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -209,7 +209,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_request_method(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_request_method(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_method(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_method(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-protocol.c
+++ b/src/detect-http-protocol.c
@@ -100,7 +100,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        uint32_t data_len = bstr_size(str);
+        uint32_t data_len = (uint32_t)bstr_size(str);
         uint8_t *data = bstr_ptr(str);
         if (data == NULL || data_len == 0) {
             SCLogDebug("HTTP protocol not present");

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -161,7 +161,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_request_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_request_line(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_line(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_line(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -160,7 +160,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_response_line(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_response_line(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_line(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_line(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -166,7 +166,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_status(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_response_status(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_status(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_status(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -175,7 +175,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (htp_tx_response_message(tx) == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(htp_tx_response_message(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_response_message(tx));
         const uint8_t *data = bstr_ptr(htp_tx_response_message(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -171,7 +171,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = htp_header_value_len(h);
+        const uint32_t data_len = (uint32_t)htp_header_value_len(h);
         const uint8_t *data = htp_header_value_ptr(h);
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -220,7 +220,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         if (request_uri_normalized == NULL)
             return NULL;
 
-        const uint32_t data_len = bstr_len(request_uri_normalized);
+        const uint32_t data_len = (uint32_t)bstr_len(request_uri_normalized);
         const uint8_t *data = bstr_ptr(request_uri_normalized);
 
         InspectionBufferSetupAndApplyTransforms(
@@ -305,7 +305,7 @@ static InspectionBuffer *GetRawData(DetectEngineThreadCtx *det_ctx,
         if (unlikely(htp_tx_request_uri(tx) == NULL)) {
             return NULL;
         }
-        const uint32_t data_len = bstr_len(htp_tx_request_uri(tx));
+        const uint32_t data_len = (uint32_t)bstr_len(htp_tx_request_uri(tx));
         const uint8_t *data = bstr_ptr(htp_tx_request_uri(tx));
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -112,7 +112,7 @@ void DetectPcreRegister (void)
         pcre_match_limit = SC_MATCH_LIMIT_DEFAULT;
         SCLogDebug("Using PCRE match-limit setting of: %i", pcre_match_limit);
     } else {
-        pcre_match_limit = val;
+        pcre_match_limit = (int)val;
         if (pcre_match_limit != SC_MATCH_LIMIT_DEFAULT) {
             SCLogInfo("Using PCRE match-limit setting of: %i", pcre_match_limit);
         } else {
@@ -126,7 +126,7 @@ void DetectPcreRegister (void)
         pcre_match_limit_recursion = SC_MATCH_LIMIT_RECURSION_DEFAULT;
         SCLogDebug("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
     } else {
-        pcre_match_limit_recursion = val;
+        pcre_match_limit_recursion = (int)val;
         if (pcre_match_limit_recursion != SC_MATCH_LIMIT_RECURSION_DEFAULT) {
             SCLogInfo("Using PCRE match-limit-recursion setting of: %i", pcre_match_limit_recursion);
         } else {
@@ -190,7 +190,7 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
     int start_offset = 0;
     if (det_ctx->pcre_match_start_offset != 0) {
-        start_offset = (payload + det_ctx->pcre_match_start_offset - ptr);
+        start_offset = (uint32_t)(payload - ptr) + det_ctx->pcre_match_start_offset;
     }
 
     /* run the actual pcre detection */
@@ -287,8 +287,8 @@ int DetectPcrePayloadMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
             PCRE2_SIZE *ov = pcre2_get_ovector_pointer(match);
             /* update offset for pcre RELATIVE */
-            det_ctx->buffer_offset = (ptr + ov[1]) - payload;
-            det_ctx->pcre_match_start_offset = (ptr + ov[0] + 1) - payload;
+            det_ctx->buffer_offset = (uint32_t)((ptr + ov[1]) - payload);
+            det_ctx->pcre_match_start_offset = (uint32_t)((ptr + ov[0] + 1) - payload);
 
             ret = 1;
         }
@@ -368,13 +368,13 @@ static DetectPcreData *DetectPcreParse (DetectEngineCtx *de_ctx,
         SCLogDebug("regexstr %s", regexstr);
 
         if (fcap && !pcap)
-            cut_capture = fcap - regexstr;
+            cut_capture = (int)(fcap - regexstr);
         else if (pcap && !fcap)
-            cut_capture = pcap - regexstr;
+            cut_capture = (int)(pcap - regexstr);
         else {
             BUG_ON(pcap == NULL); // added to assist cppcheck
             BUG_ON(fcap == NULL);
-            cut_capture = MIN((pcap - regexstr), (fcap - regexstr));
+            cut_capture = (int)MIN((pcap - regexstr), (fcap - regexstr));
         }
 
         SCLogDebug("cut_capture %d", cut_capture);

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -84,7 +84,7 @@ static int DetectPrioritySetup (DetectEngineCtx *de_ctx, Signature *s, const cha
 
     pcre2_match_data_free(match);
     char *endptr = NULL;
-    long prio = strtol(copy_str, &endptr, 10);
+    int prio = (int)strtol(copy_str, &endptr, 10);
     if (endptr == NULL || *endptr != '\0') {
         SCLogError("Saw an invalid character as arg "
                    "to priority keyword");

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -145,7 +145,7 @@ static DetectReference *DetectReferenceParse(const char *rawstr, DetectEngineCtx
         goto error;
     }
 
-    int ref_len = strlen(uri);
+    size_t ref_len = strlen(uri);
     /* no key, reference -- return an error */
     if (strlen(key) == 0 || ref_len == 0)
         goto error;

--- a/src/detect-tls-cert-fingerprint.c
+++ b/src/detect-tls-cert-fingerprint.c
@@ -149,7 +149,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_fingerprint);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_fingerprint);
         const uint8_t *data = (uint8_t *)connp->cert0_fingerprint;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -137,7 +137,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_issuerdn);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_issuerdn);
         const uint8_t *data = (uint8_t *)connp->cert0_issuerdn;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-serial.c
+++ b/src/detect-tls-cert-serial.c
@@ -147,7 +147,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_serial);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_serial);
         const uint8_t *data = (uint8_t *)connp->cert0_serial;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -139,7 +139,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(connp->cert0_subject);
+        const uint32_t data_len = (uint32_t)strlen(connp->cert0_subject);
         const uint8_t *data = (uint8_t *)connp->cert0_subject;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3-hash.c
+++ b/src/detect-tls-ja3-hash.c
@@ -164,7 +164,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_hash;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3-string.c
+++ b/src/detect-tls-ja3-string.c
@@ -158,7 +158,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.ja3_str->data;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3s-hash.c
+++ b/src/detect-tls-ja3s-hash.c
@@ -162,7 +162,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_hash);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_hash);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_hash;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-ja3s-string.c
+++ b/src/detect-tls-ja3s-string.c
@@ -157,7 +157,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->server_connp.ja3_str->data);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->server_connp.ja3_str->data);
         const uint8_t *data = (uint8_t *)ssl_state->server_connp.ja3_str->data;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -119,7 +119,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
             return NULL;
         }
 
-        const uint32_t data_len = strlen(ssl_state->client_connp.sni);
+        const uint32_t data_len = (uint32_t)strlen(ssl_state->client_connp.sni);
         const uint8_t *data = (uint8_t *)ssl_state->client_connp.sni;
 
         InspectionBufferSetupAndApplyTransforms(

--- a/src/detect-tls-subjectaltname.c
+++ b/src/detect-tls-subjectaltname.c
@@ -121,7 +121,7 @@ static InspectionBuffer *TlsSubjectAltNameGetData(DetectEngineThreadCtx *det_ctx
     }
 
     InspectionBufferSetupMulti(det_ctx, buffer, transforms, (const uint8_t *)connp->cert0_sans[idx],
-            strlen(connp->cert0_sans[idx]));
+            (uint32_t)strlen(connp->cert0_sans[idx]));
     buffer->flags = DETECT_CI_FLAGS_SINGLE;
 
     SCReturnPtr(buffer, "InspectionBuffer");

--- a/src/detect.c
+++ b/src/detect.c
@@ -382,7 +382,7 @@ static inline void DetectPrefilterMergeSort(DetectEngineCtx *de_ctx,
         }
     }
 
-    det_ctx->match_array_cnt = match_array - det_ctx->match_array;
+    det_ctx->match_array_cnt = (uint32_t)(match_array - det_ctx->match_array);
     DEBUG_VALIDATE_BUG_ON((det_ctx->pmq.rule_id_array_cnt + det_ctx->non_pf_id_cnt) < det_ctx->match_array_cnt);
     PMQ_RESET(&det_ctx->pmq);
 }


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix some `-Wshorten-64-to-32` warnings for remaining files : detect

#12843 with only easy fixes

Still to do afterwards :
- fix other detect warnings
- CI check
