### PR TITLE
Decouple stream bypass from TLS encrypted bypass v10.5

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1842,7 +1842,7 @@ port independent.
         dp: 443
 
       # What to do when the encrypted communications start:
-      # - default: keep tracking TLS session, check for protocol anomalies,
+      # - track-only: keep tracking TLS session, check for protocol anomalies,
       #            inspect tls_* keywords. Disables inspection of unmodified
       #            'content' signatures.
       # - bypass:  stop processing this flow as much as possible. No further
@@ -1853,7 +1853,7 @@ port independent.
       #
       # For best performance, select 'bypass'.
       #
-      #encryption-handling: default
+      #encryption-handling: track-only
 
 
 Encrypted traffic
@@ -1879,7 +1879,7 @@ flow as normal, without inspection limitations or bypass.
 
 The option has replaced the ``no-reassemble`` option. If ``no-reassemble`` is
 present, and ``encryption-handling`` is not, ``false`` is interpreted as
-``encryption-handling: default`` and ``true`` is interpreted as
+``encryption-handling: track-only`` and ``true`` is interpreted as
 ``encryption-handling: bypass``.
 
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1851,7 +1851,7 @@ port independent.
       # - full:    keep tracking and inspection as normal. Unmodified content
       #            keyword signatures are inspected as well.
       #
-      # For best performance, select 'bypass'.
+      # For the best performance, select 'bypass'.
       #
       #encryption-handling: track-only
 

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -1861,21 +1861,21 @@ Encrypted traffic
 
 There is no decryption of encrypted traffic, so once the handshake is complete
 continued tracking of the session is of limited use. The ``encryption-handling``
-option controls the behavior after the handshake.
+option in ``app-layer.protocols.tls`` and ``app-layer.protocols.ssh`` controls
+the behavior after the handshake.
 
-If ``encryption-handling`` is set to ``default`` (or if the option is not set),
-Suricata will continue to track the SSL/TLS session. Inspection will be limited,
-as raw ``content`` inspection will still be disabled. There is no point in doing
-pattern matching on traffic known to be encrypted. Inspection for (encrypted)
-Heartbleed and other protocol anomalies still happens.
+If the ``encryption-handling`` property of the TLS/SSH configuration nodes are set to ``track-only`` (or are not set), Suricata will continue to track the respective SSL/TLS or SSH session. Inspection will be limited, as raw ``content`` inspection will still
+be disabled. There is no point in doing pattern matching on traffic known to
+be encrypted. Inspection for (encrypted) Heartbleed and other protocol
+anomalies still happens.
 
-When ``encryption-handling`` is set to ``bypass``, all processing of this session is
-stopped. No further parsing and inspection happens. If ``stream.bypass`` is enabled
-this will lead to the flow being bypassed, either inside Suricata or by the
-capture method if it supports it and is configured for it.
+When ``encryption-handling`` is set to ``bypass``, all processing of this
+session is stopped. No further parsing and inspection happens. This will also
+lead to the flow being bypassed, either inside Suricata or by the capture method
+if it supports it and is configured for it.
 
-Finally, if ``encryption-handling`` is set to ``full``, Suricata will process the
-flow as normal, without inspection limitations or bypass.
+Finally, if ``encryption-handling`` is set to ``full``, Suricata will process
+the flow as normal, without inspection limitations or bypass.
 
 The option has replaced the ``no-reassemble`` option. If ``no-reassemble`` is
 present, and ``encryption-handling`` is not, ``false`` is interpreted as

--- a/doc/userguide/performance/ignoring-traffic.rst
+++ b/doc/userguide/performance/ignoring-traffic.rst
@@ -4,7 +4,7 @@ Ignoring Traffic
 In some cases there are reasons to ignore certain traffic. Certain hosts
 may be trusted, or perhaps a backup stream should be ignored.
 
-capture filters (BPF)
+Capture Filters (BPF)
 ---------------------
 
 Through BPFs the capture methods pcap, af-packet, netmap  and pf_ring can be
@@ -70,7 +70,7 @@ Example::
   suppress gen_id 0, sig_id 0, track by_src, ip 1.2.3.4
 
 
-encrypted traffic
+Encrypted Traffic
 -----------------
 
 The TLS and SSH app layer parsers have the ability to stop processing
@@ -84,7 +84,7 @@ is done.
 
 .. _bypass:
 
-bypassing traffic
+Bypassing Traffic
 -----------------
 
 Aside from using the ``bypass`` keyword in rules, there are three other ways

--- a/doc/userguide/performance/ignoring-traffic.rst
+++ b/doc/userguide/performance/ignoring-traffic.rst
@@ -73,10 +73,14 @@ Example::
 encrypted traffic
 -----------------
 
-The TLS app layer parser has the ability to stop processing encrypted traffic
-after the initial handshake. By setting the `app-layer.protocols.tls.encryption-handling`
-option to `bypass` the rest of this flow is ignored. If flow bypass is enabled,
-the bypass is done in the kernel or in hardware.
+The TLS and SSH app layer parsers have the ability to stop processing
+encrypted traffic after the initial handshake. By setting the
+`app-layer.protocols.tls.encryption-handling` and
+`app-layer.protocols.ssh.encryption-handling` options to `bypass` Suricata
+bypasses flows once the handshake is completed and encrypted traffic is
+detected. The rest of the flow is ignored.
+The bypass is done in the kernel or in hardware, similar to how flow bypass
+is done.
 
 .. _bypass:
 

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -141,6 +141,17 @@ Major changes
   after the previously mentioned interval. Other cards were not observed to have
   this issue. This feature is disabled by default.
   See :ref:`dpdk-link-state-change-timeout`.
+- Encrypted traffic bypass has been decoupled from stream.bypass setting.
+  This means that encrypted traffic can be bypassed while tracking/fully
+  inspecting other traffic as well.
+- Encrypted SSH traffic bypass is now independently controlled through
+  ``app-layer.protocols.ssh.encryption-handling`` setting. The setting can either
+  be ``bypass``, ``track-only`` or ``full``.
+  To retain the previous behavior of encrypted traffic bypass
+  combined with stream depth bypass, set
+  ``app-layer.protocols.ssh.encryption-handling`` to ``bypass`` (while also
+  setting ``app-layer.protocols.tls.encryption-handling`` to ``bypass`` and
+  ``stream.bypass`` to ``true``).
 
 Removals
 ~~~~~~~~

--- a/doc/userguide/upgrade.rst
+++ b/doc/userguide/upgrade.rst
@@ -153,6 +153,9 @@ Deprecations
 - The ``syslog`` output is now deprecated and will be removed in
   Suricata 9.0. Note that this is the standalone ``syslog`` output and
   does affect the ``eve`` outputs ability to send to syslog.
+- The ``default`` option in ``app-layer.protocols.tls.encryption-handling`` is
+  now deprecated and will be removed in Suricata 9.0. The ``track-only`` option
+  should be used instead.
 
 Keyword changes
 ~~~~~~~~~~~~~~~

--- a/rust/src/ssh/ssh.rs
+++ b/rust/src/ssh/ssh.rs
@@ -26,11 +26,26 @@ use suricata_sys::sys::AppProto;
 use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum SshEncryptionHandling {
+    SSH_HANDLE_ENCRYPTION_TRACK_ONLY = 0, // Disable raw content inspection, continue tracking
+    SSH_HANDLE_ENCRYPTION_BYPASS = 1,  // Skip processing of flow, bypass if possible
+    SSH_HANDLE_ENCRYPTION_FULL = 2,    // Handle fully like any other protocol
+}
+
 static mut ALPROTO_SSH: AppProto = ALPROTO_UNKNOWN;
 static HASSH_ENABLED: AtomicBool = AtomicBool::new(false);
 
+static mut ENCRYPTION_BYPASS_ENABLED: SshEncryptionHandling = SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_TRACK_ONLY;
+
 fn hassh_is_enabled() -> bool {
     HASSH_ENABLED.load(Ordering::Relaxed)
+}
+
+fn encryption_bypass_mode() -> SshEncryptionHandling {
+    unsafe { ENCRYPTION_BYPASS_ENABLED }
 }
 
 #[derive(AppLayerFrameType)]
@@ -203,13 +218,24 @@ impl SSHState {
                         parser::MessageCode::NewKeys => {
                             hdr.flags = SSHConnectionState::SshStateFinished;
                             if ohdr.flags >= SSHConnectionState::SshStateFinished {
-                                unsafe {
-                                    AppLayerParserStateSetFlag(
-                                        pstate,
-                                        APP_LAYER_PARSER_NO_INSPECTION
+                                let mut flags = 0;
+
+                                match encryption_bypass_mode() {
+                                    SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_BYPASS => {
+                                        flags |= APP_LAYER_PARSER_NO_INSPECTION
                                             | APP_LAYER_PARSER_NO_REASSEMBLY
-                                            | APP_LAYER_PARSER_BYPASS_READY,
-                                    );
+                                            | APP_LAYER_PARSER_BYPASS_READY;
+                                    }
+                                    SshEncryptionHandling::SSH_HANDLE_ENCRYPTION_TRACK_ONLY => {
+                                        flags |= APP_LAYER_PARSER_NO_INSPECTION;
+                                    }
+                                    _ => {}
+                                }
+
+                                if flags != 0 {
+                                    unsafe {
+                                        AppLayerParserStateSetFlag(pstate, flags);
+                                    }
                                 }
                             }
                         }
@@ -551,6 +577,13 @@ pub extern "C" fn SCSshEnableHassh() {
 #[no_mangle]
 pub extern "C" fn SCSshHasshIsEnabled() -> bool {
     hassh_is_enabled()
+}
+
+#[no_mangle]
+pub extern "C" fn SCSshEnableBypass(mode: SshEncryptionHandling) {
+    unsafe {
+        ENCRYPTION_BYPASS_ENABLED = mode;
+    }
 }
 
 #[no_mangle]

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -55,6 +55,8 @@
 
 /* HASSH fingerprints are disabled by default */
 #define SSH_CONFIG_DEFAULT_HASSH false
+/* Bypassing the encrypted part of the connections */
+#define SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS SSH_HANDLE_ENCRYPTION_TRACK_ONLY
 
 static int SSHRegisterPatternsForProtocolDetection(void)
 {
@@ -102,6 +104,25 @@ void RegisterSSHParsers(void)
 
         if (RunmodeIsUnittests() || enable_hassh) {
             SCSshEnableHassh();
+        }
+
+        SshEncryptionHandling encryption_bypass = SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS;
+        SCConfNode *encryption_node = SCConfGetNode("app-layer.protocols.ssh.encryption-handling");
+        if (encryption_node != NULL && encryption_node->val != NULL) {
+            if (strcmp(encryption_node->val, "full") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_FULL;
+            } else if (strcmp(encryption_node->val, "track-only") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_TRACK_ONLY;
+            } else if (strcmp(encryption_node->val, "bypass") == 0) {
+                encryption_bypass = SSH_HANDLE_ENCRYPTION_BYPASS;
+            } else {
+                encryption_bypass = SSH_CONFIG_DEFAULT_ENCRYPTION_BYPASS;
+            }
+        }
+
+        if (encryption_bypass) {
+            SCLogConfig("ssh: bypass on the start of encryption enabled");
+            SCSshEnableBypass(encryption_bypass);
         }
     }
 

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -137,9 +137,9 @@ enum {
 #define SSL_CONFIG_DEFAULT_JA4 0
 
 enum SslConfigEncryptHandling {
-    SSL_CNF_ENC_HANDLE_DEFAULT = 0, /**< disable raw content, continue tracking */
-    SSL_CNF_ENC_HANDLE_BYPASS = 1,  /**< skip processing of flow, bypass if possible */
-    SSL_CNF_ENC_HANDLE_FULL = 2,    /**< handle fully like any other proto */
+    SSL_CNF_ENC_HANDLE_TRACK_ONLY = 0, /**< disable raw content, continue tracking */
+    SSL_CNF_ENC_HANDLE_BYPASS = 1,     /**< skip processing of flow, bypass if possible */
+    SSL_CNF_ENC_HANDLE_FULL = 2,       /**< handle fully like any other proto */
 };
 
 typedef struct SslConfig_ {
@@ -3316,10 +3316,15 @@ void RegisterSSLParsers(void)
                 ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_FULL;
             } else if (strcmp(enc_handle->val, "bypass") == 0) {
                 ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_BYPASS;
+            } else if (strcmp(enc_handle->val, "track-only") == 0) {
+                ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_TRACK_ONLY;
             } else if (strcmp(enc_handle->val, "default") == 0) {
-                ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_DEFAULT;
+                SCLogWarning("app-layer.protocols.tls.encryption-handling = default is deprecated "
+                             "and will be removed in Suricata 9, use \"track-only\" instead, "
+                             "(see ticket #7642)");
+                ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_TRACK_ONLY;
             } else {
-                ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_DEFAULT;
+                ssl_config.encrypt_mode = SSL_CNF_ENC_HANDLE_TRACK_ONLY;
             }
         } else {
             /* Get the value of no reassembly option from the config file */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5707,17 +5707,13 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         }
 
         if (ssn->flags & STREAMTCP_FLAG_BYPASS) {
-            /* we can call bypass callback, if enabled */
-            if (StreamTcpBypassEnabled()) {
-                PacketBypassCallback(p);
-            }
-
-        /* if stream is dead and we have no detect engine at all, bypass. */
+            PacketBypassCallback(p);
         } else if (g_detect_disabled &&
                 (ssn->client.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) &&
                 (ssn->server.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) &&
                 StreamTcpBypassEnabled())
         {
+            /* if stream is dead and we have no detect engine at all, bypass. */
             SCLogDebug("bypass as stream is dead and we have no rules");
             PacketBypassCallback(p);
         }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -964,7 +964,7 @@ app-layer:
       #enabled: yes
     ssh:
       enabled: yes
-      #hassh: yes
+      # hassh: no
 
       # What to do when the encrypted communications start:
       # - track-only: keep tracking but stop inspection (default)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -965,6 +965,15 @@ app-layer:
     ssh:
       enabled: yes
       #hassh: yes
+
+      # What to do when the encrypted communications start:
+      # - track-only: keep tracking but stop inspection (default)
+      # - full:    keep tracking and inspect as normal
+      # - bypass:  stop processing this flow as much as possible.
+      #            Offload flow bypass to kernel or hardware if possible.
+      # For the best performance, select 'bypass'.
+      #
+      # encryption-handling: track-only
     doh2:
       enabled: yes
     http2:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -930,9 +930,9 @@ app-layer:
       #ja4-fingerprints: auto
 
       # What to do when the encrypted communications start:
-      # - default: keep tracking TLS session, check for protocol anomalies,
+      # - track-only: keep tracking TLS session, check for protocol anomalies,
       #            inspect tls_* keywords. Disables inspection of unmodified
-      #            'content' signatures.
+      #            'content' signatures. (default)
       # - bypass:  stop processing this flow as much as possible. No further
       #            TLS parsing and inspection. Offload flow bypass to kernel
       #            or hardware if possible.
@@ -941,7 +941,7 @@ app-layer:
       #
       # For best performance, select 'bypass'.
       #
-      #encryption-handling: default
+      #encryption-handling: track-only
 
     pgsql:
       enabled: no


### PR DESCRIPTION
Following up on https://github.com/OISF/suricata/pull/12935

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6788
The deprecation tracking ticket created  - https://redmine.openinfosecfoundation.org/issues/7642

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2422


## FAQ:

- This PR changes the behavior; why not set the defaults in a way to keep it?
  - the defaults are actually set to keep the behavior the same (considering the unchanged suricata.yaml file) but Suricata QA lab uses a modified suricata.yaml, and that's where the behavior change happens
  - this PR decouples SSH bypass from stream.bypass setting. Previously, SSH, TLS could be bypassed only when stream.bypass was enabled. This also forced bypass on the depth level which either bypassed the flow after reaching certain depth or the depth had to be set to 0, which introduced unlimited depth.
  - a new rebaseline is needed
  - more comments in https://github.com/OISF/suricata/pull/12249
- The current PR inspects SSH even if stream.bypass is set to true. Why not set the default behavior to bypass? We don't need to rebaseline QA and people upgrading won't notice a difference. 
  - in general deployments - where stream.bypass is enabled - people with bypass as a default wouldn't notice the difference. However, people who do not want to bypass any traffic will now miss the SSH traffic. In my view, it is better to inspect extra traffic and then figure out why I am seeing the extra traffic than not seeing the traffic from start.

Describe changes:
v10.5:
- rebased
- tracking ticket created for deprecation - https://redmine.openinfosecfoundation.org/issues/7642
- doc updates per Juliana's comments

v10.4:
- rebased

v10.3.rev2:
- changed SV PR

v10.3:
- rebased
- fixed the rust warning

v10.1:
- Option "default" changed to "track-only", and the default is now deprecated, to be removed in Suri 9
- adjust the Rust implementation as per #12655  (made it static mut)
- removed unused function
- rebased

v9.2:
- rebased

v9.1:
- separated mixed changes into their respective commits

v9:
- changed mutex to atomicu8 for SSH encryption handling choice
- rebased 

v8.1:
- specify the correct SV test

v8:
- rebased
- re: QA results: Expected behavior change, the QA needs to set ssh encryption handling to bypass to reproduce the same results. There is no middle-ground solution to have the defaults set exactly as before. See comments in #12249 

v7
- Style guide changes as suggested in the prev PR
- Encryption Handling has now three states, similar to TLS
- rebased

v6
- rebased 

v5
- rebased
- added upgrade section
- fixed docs - Thanks Juliana
- SV tests should pass now

v4
- rebased
- changed SSH bypass defaults to hopefully be in sync with the previous settings

v3
- added SSH app-layer option `encryption-handling` allowing to choose whether to continue inspection on SSH once it turns encrypted
- added SV tests
- minor docs updates
