### PR TITLE
detect/transform: add serialized data from a transform into the detect buffer's hash

### DIFF
--- a/rust/src/detect/transform_base64.rs
+++ b/rust/src/detect/transform_base64.rs
@@ -20,7 +20,7 @@
 use crate::detect::error::RuleParseError;
 use crate::detect::parser::{parse_var, take_until_whitespace, ResultValue};
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_int, c_void, c_char};
 use crate::ffi::base64::SCBase64Mode;
 
 use nom7::bytes::complete::tag;
@@ -47,6 +47,8 @@ pub struct SCDetectTransformFromBase64Data {
     offset: u32,
     offset_str: *const c_char,
     mode: SCBase64Mode,
+    serialized_data: *mut c_void,
+    serialized_data_len:  c_int,
 }
 
 impl Drop for SCDetectTransformFromBase64Data {
@@ -70,6 +72,8 @@ impl Default for SCDetectTransformFromBase64Data {
             offset: 0,
             offset_str: std::ptr::null_mut(),
             mode: TRANSFORM_FROM_BASE64_MODE_DEFAULT,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         }
     }
 }
@@ -287,6 +291,8 @@ mod tests {
                 std::ptr::null_mut()
             },
             mode,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         };
 
         let (_, val) = parse_transform_base64(args).unwrap();

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -37,33 +37,48 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
-static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 #define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) SCBase64ModeRFC4648
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
-static void TransformFromBase64Decode(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
+#define B64D_SERIALIZED_DATA_LEN 128
 
-void DetectTransformFromBase64DecodeRegister(void)
+static const char *serialization_format = "{"
+                                          "\"flags\" : %d, "
+                                          "\"bytes\" : { \"str\": \"%s\", \"cnt\": %d}, "
+                                          "\"offset\" : { \"str\": \"%s\", \"cnt\": %d}, "
+                                          "\"mode\" : %d"
+                                          "}";
+
+static inline uint8_t *DetectTransformFromBase64SerializeData(SCDetectTransformFromBase64Data *b64d, int *len)
 {
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
-#ifdef UNITTESTS
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
-            DetectTransformFromBase64DecodeRegisterTests;
-#endif
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
+    void *ptr = SCCalloc(1, B64D_SERIALIZED_DATA_LEN);
+    if (ptr) {
+        int rc = snprintf(ptr, B64D_SERIALIZED_DATA_LEN, serialization_format, b64d->flags,
+                b64d->nbytes_str ? b64d->nbytes_str : "n/a", b64d->nbytes,
+                b64d->offset_str ? b64d->offset_str : "n/a", b64d->offset, b64d->mode);
+        *len = rc;
+    }
+    return ptr;
+}
+
+static void DetectTransformFromBase64Serialize(
+        TransformSerializedData *serialized_data, void *options)
+{
+    if (options) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)options;
+        serialized_data->serialized_data = b64d->serialized_data;
+        serialized_data->serialized_data_len = b64d->serialized_data_len;
+    }
 }
 
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCTransformBase64Free(ptr);
+    if (ptr) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)ptr;
+        SCFree(b64d->serialized_data);
+        SCTransformBase64Free(ptr);
+    }
 }
 
 static SCDetectTransformFromBase64Data *DetectTransformFromBase64DecodeParse(const char *str)
@@ -104,6 +119,14 @@ static int DetectTransformFromBase64DecodeSetup(
         SCLogError("byte value must be a value, not a variable name");
         goto exit_path;
     }
+
+    int len;
+    b64d->serialized_data = DetectTransformFromBase64SerializeData(b64d, &len);
+    if (!b64d->serialized_data) {
+        SCLogError("Unable to allocate memory for serialized representation");
+        goto exit_path;
+    }
+    b64d->serialized_data_len = len;
 
     r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_FROM_BASE64, b64d);
 
@@ -153,6 +176,23 @@ static void TransformFromBase64Decode(
         //            PrintRawDataFp(stdout, output, b64data->decoded_len);
         InspectionBufferCopy(buffer, decoded, num_decoded);
     }
+}
+
+void DetectTransformFromBase64DecodeRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].TransformSerialize =
+            DetectTransformFromBase64Serialize;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
+            DetectTransformFromBase64DecodeRegisterTests;
+#endif
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
 }
 
 #ifdef UNITTESTS

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -31,9 +31,11 @@
 #include "detect-transform-pcrexform.h"
 #include "detect-pcre.h"
 
+#define PCRE_SERIALIZED_DATA_LEN 32
 typedef struct DetectTransformPcrexformData {
     pcre2_code *regex;
     pcre2_match_context *context;
+    uint8_t serialized_data[PCRE_SERIALIZED_DATA_LEN];
 } DetectTransformPcrexformData;
 
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
@@ -44,6 +46,16 @@ static void DetectTransformPcrexform(
 void DetectTransformPcrexformRegisterTests (void);
 #endif
 
+static void DetectTransformPcrexformSerialize(
+        TransformSerializedData *serialized_data, void *options)
+{
+    if (options) {
+        DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *)options;
+        serialized_data->serialized_data = pxd->serialized_data;
+        serialized_data->serialized_data_len = PCRE_SERIALIZED_DATA_LEN;
+    }
+}
+
 void DetectTransformPcrexformRegister(void)
 {
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].name = "pcrexform";
@@ -52,6 +64,8 @@ void DetectTransformPcrexformRegister(void)
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].url = "/rules/transforms.html#pcre-xform";
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Transform =
         DetectTransformPcrexform;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].TransformSerialize =
+            DetectTransformPcrexformSerialize;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Free =
         DetectTransformPcrexformFree;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Setup =
@@ -124,6 +138,9 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         DetectTransformPcrexformFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
+
+    memcpy(pxd->serialized_data, regexstr, PCRE_SERIALIZED_DATA_LEN);
+    pxd->serialized_data[PCRE_SERIALIZED_DATA_LEN - 1] = '\0';
 
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
     if (r != 0) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -462,9 +462,15 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct DetectEngineAppInspectionEngine_ *next;
 } DetectEngineAppInspectionEngine;
 
+typedef struct TransformSerializedData_ {
+    uint8_t *serialized_data;
+    uint32_t serialized_data_len;
+} TransformSerializedData;
+
 typedef struct DetectBufferType_ {
     char name[32];
     char description[128];
+    TransformSerializedData xform_serialized[DETECT_TRANSFORMS_MAX];
     int id;
     int parent_id;
     bool mpm;
@@ -1339,6 +1345,9 @@ typedef struct SigTableElmt_ {
     /** InspectionBuffer transformation callback */
     void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
     bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
+
+    /** Transform serialization callback */
+    void (*TransformSerialize)(TransformSerializedData *serialized_data, void *options);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Continuation of #12971 

Transforms that support optional strings, like from_base64 and pcrexform, should also support serialization to treat transforms with like transform options as the same.

This commit demonstrates
- When computing a hash, include serialized data from the transform
- When comparing, include the serialized data from the transforms
- Omitting the "options" ptr from the transform hash/compare
- Modify pcrexform and from_base64 to supply serialization data for disambiguation in the compare/hash logic.

Updates
- Fix compiler warning when computing hash value for transforms (see #12971)
- Check memory allocation values
- Move serialized data collection to hash table user (from hash computation function)


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
