### PR TITLE
lua: enable lua rules by default

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -3000,8 +3000,8 @@ can be completely disabled the same as the Suricata 7.0 default:
 
    security:
      lua:
-       # Allow Lua rules. Disabled by default.
-       #allow-rules: false
+       # Allow Lua rules. Enabled by default.
+       #allow-rules: true
 
        # Upper bound of allocations by a Lua rule before it will fail
        #max-bytes: 500000 

--- a/doc/userguide/rules/lua-detection.rst
+++ b/doc/userguide/rules/lua-detection.rst
@@ -3,10 +3,6 @@
 Lua Scripting for Detection
 ===========================
 
-.. note:: Lua is disabled by default for use in rules, it must be
-          enabled in the configuration file. See the ``security.lua``
-          section of ``suricata.yaml`` and enable ``allow-rules``.
-
 Syntax:
 
 ::

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -706,8 +706,7 @@ static int DetectLuaSetup (DetectEngineCtx *de_ctx, Signature *s, const char *st
     /* First check if Lua rules are enabled, by default Lua in rules
      * is disabled. */
     int enabled = 0;
-    (void)SCConfGetBool("security.lua.allow-rules", &enabled);
-    if (!enabled) {
+    if (SCConfGetBool("security.lua.allow-rules", &enabled) == 1 && !enabled) {
         SCLogError("Lua rules disabled by security configuration: security.lua.allow-rules");
         return -1;
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1306,8 +1306,8 @@ security:
         - @e_sysconfdir@
 
   lua:
-    # Allow Lua rules. Disabled by default.
-    #allow-rules: false
+    # Allow Lua rules. Enabled by default.
+    #allow-rules: true
 
 # Some logging modules will use that name in event as identifier. The default
 # value is the hostname


### PR DESCRIPTION
Now that sandboxing is in place, lua rule support is enabled by default.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2433
