### PR TITLE
detect/transform: add serialized data from a transform into the detect buffer hash value

### DIFF
--- a/rust/src/detect/transform_base64.rs
+++ b/rust/src/detect/transform_base64.rs
@@ -20,7 +20,7 @@
 use crate::detect::error::RuleParseError;
 use crate::detect::parser::{parse_var, take_until_whitespace, ResultValue};
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
+use std::os::raw::{c_int, c_void, c_char};
 use crate::ffi::base64::SCBase64Mode;
 
 use nom7::bytes::complete::tag;
@@ -47,6 +47,8 @@ pub struct SCDetectTransformFromBase64Data {
     offset: u32,
     offset_str: *const c_char,
     mode: SCBase64Mode,
+    serialized_data: *mut c_void,
+    serialized_data_len:  c_int,
 }
 
 impl Drop for SCDetectTransformFromBase64Data {
@@ -70,6 +72,8 @@ impl Default for SCDetectTransformFromBase64Data {
             offset: 0,
             offset_str: std::ptr::null_mut(),
             mode: TRANSFORM_FROM_BASE64_MODE_DEFAULT,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         }
     }
 }
@@ -287,6 +291,8 @@ mod tests {
                 std::ptr::null_mut()
             },
             mode,
+            serialized_data: std::ptr::null_mut(),
+            serialized_data_len: 0,
         };
 
         let (_, val) = parse_transform_base64(args).unwrap();

--- a/rust/src/detect/transforms/casechange.rs
+++ b/rust/src/detect/transforms/casechange.rs
@@ -80,6 +80,7 @@ pub unsafe extern "C" fn DetectTransformToLowerRegister() {
         Transform: tolower_transform,
         Free: None,
         TransformValidate: Some(tolower_validate),
+        TransformSerialize: None,
     };
     G_TRANSFORM_TOLOWER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_TOLOWER_ID < 0 {
@@ -140,6 +141,7 @@ pub unsafe extern "C" fn DetectTransformToUpperRegister() {
         Transform: toupper_transform,
         Free: None,
         TransformValidate: Some(toupper_validate),
+        TransformSerialize: None,
     };
     G_TRANSFORM_TOUPPER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_TOUPPER_ID < 0 {

--- a/rust/src/detect/transforms/compress_whitespace.rs
+++ b/rust/src/detect/transforms/compress_whitespace.rs
@@ -49,7 +49,9 @@ fn compress_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn compress_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn compress_whitespace_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -103,6 +105,7 @@ pub unsafe extern "C" fn DetectTransformCompressWhitespaceRegister() {
         Transform: compress_whitespace_transform,
         Free: None,
         TransformValidate: Some(compress_whitespace_validate),
+        TransformSerialize: None,
     };
     G_TRANSFORM_COMPRESS_WHITESPACE_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_COMPRESS_WHITESPACE_ID < 0 {

--- a/rust/src/detect/transforms/dotprefix.rs
+++ b/rust/src/detect/transforms/dotprefix.rs
@@ -41,7 +41,9 @@ fn dot_prefix_transform_do(input: &[u8], output: &mut [u8]) {
     output[0] = b'.';
 }
 
-unsafe extern "C" fn dot_prefix_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn dot_prefix_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input_len = InspectionBufferLength(buffer);
     if input_len == 0 {
         return;
@@ -76,6 +78,7 @@ pub unsafe extern "C" fn DetectTransformDotPrefixRegister() {
         Transform: dot_prefix_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     unsafe {
         G_TRANSFORM_DOT_PREFIX_ID = DetectHelperTransformRegister(&kw);

--- a/rust/src/detect/transforms/hash.rs
+++ b/rust/src/detect/transforms/hash.rs
@@ -80,6 +80,7 @@ pub unsafe extern "C" fn DetectTransformMd5Register() {
         Transform: md5_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_MD5_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_MD5_ID < 0 {
@@ -132,6 +133,7 @@ pub unsafe extern "C" fn DetectTransformSha1Register() {
         Transform: sha1_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_SHA1_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_SHA1_ID < 0 {
@@ -184,6 +186,7 @@ pub unsafe extern "C" fn DetectTransformSha256Register() {
         Transform: sha256_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_SHA256_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_SHA256_ID < 0 {

--- a/rust/src/detect/transforms/http_headers.rs
+++ b/rust/src/detect/transforms/http_headers.rs
@@ -52,7 +52,9 @@ fn header_lowertransform_do(input: &[u8], output: &mut [u8]) {
     }
 }
 
-unsafe extern "C" fn header_lowertransform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn header_lowertransform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -83,6 +85,7 @@ pub unsafe extern "C" fn DetectTransformHeaderLowercaseRegister() {
         Transform: header_lowertransform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_HEADER_LOWER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_HEADER_LOWER_ID < 0 {
@@ -114,7 +117,9 @@ fn strip_pseudo_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn strip_pseudo_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_pseudo_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -145,6 +150,7 @@ pub unsafe extern "C" fn DetectTransformStripPseudoHeadersRegister() {
         Transform: strip_pseudo_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_STRIP_PSEUDO_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_STRIP_PSEUDO_ID < 0 {

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -37,9 +37,13 @@ pub struct SCTransformTableElmt {
     pub flags: u16,
     pub Setup: unsafe extern "C" fn(de: *mut c_void, s: *mut c_void, raw: *const c_char) -> c_int,
     pub Free: Option<unsafe extern "C" fn(de: *mut c_void, ptr: *mut c_void)>,
-    pub Transform: unsafe extern "C" fn(_det: *mut c_void, inspect_buf: *mut c_void, options: *mut c_void),
+    pub Transform:
+        unsafe extern "C" fn(_det: *mut c_void, inspect_buf: *mut c_void, options: *mut c_void),
     pub TransformValidate:
         Option<unsafe extern "C" fn(content: *const u8, len: u16, context: *mut c_void) -> bool>,
+    pub TransformSerialize: Option<
+        unsafe extern "C" fn(data: *mut *const u8, length: *mut u32, ctx: *mut *const c_void),
+    >,
 }
 
 /// cbindgen:ignore

--- a/rust/src/detect/transforms/strip_whitespace.rs
+++ b/rust/src/detect/transforms/strip_whitespace.rs
@@ -46,7 +46,9 @@ fn strip_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn strip_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_whitespace_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -90,6 +92,7 @@ pub unsafe extern "C" fn DetectTransformStripWhitespaceRegister() {
         Transform: strip_whitespace_transform,
         Free: None,
         TransformValidate: Some(strip_whitespace_validate),
+        TransformSerialize: None,
     };
     unsafe {
         G_TRANSFORM_STRIP_WHITESPACE_ID = DetectHelperTransformRegister(&kw);

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -86,7 +86,9 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn url_decode_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn url_decode_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -118,6 +120,7 @@ pub unsafe extern "C" fn DetectTransformUrlDecodeRegister() {
         Transform: url_decode_transform,
         Free: None,
         TransformValidate: None,
+        TransformSerialize: None,
     };
     G_TRANSFORM_URL_DECODE_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_URL_DECODE_ID < 0 {

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -101,6 +101,18 @@ unsafe extern "C" fn xor_transform(_det: *mut c_void, buffer: *mut c_void, ctx: 
     InspectionBufferTruncate(buffer, input_len);
 }
 
+unsafe extern "C" fn xor_serialize(
+    data: *mut *const u8, length: *mut u32, ctx: *mut *const c_void,
+) {
+    if data.is_null() || length.is_null() || ctx.is_null() {
+        return;
+    }
+
+    let ctx = cast_pointer!(ctx, DetectTransformXorData);
+    *data = ctx.key.as_ptr();
+    *length = ctx.key.len() as u32;
+}
+
 unsafe extern "C" fn xor_free(_de: *mut c_void, ctx: *mut c_void) {
     std::mem::drop(Box::from_raw(ctx as *mut DetectTransformXorData));
 }
@@ -116,11 +128,12 @@ pub unsafe extern "C" fn DetectTransformXorRegister() {
         Transform: xor_transform,
         Free: Some(xor_free),
         TransformValidate: None,
+        TransformSerialize: Some(xor_serialize),
     };
     unsafe {
         G_TRANSFORM_XOR_ID = DetectHelperTransformRegister(&kw);
         if G_TRANSFORM_XOR_ID < 0 {
-            SCLogWarning!("Failed registering transform dot_prefix");
+            SCLogWarning!("Failed registering transform xor");
         }
     }
 }
@@ -137,6 +150,32 @@ mod tests {
             xor_parse_do("0a0DC8ff"),
             Some(DetectTransformXorData { key: key.to_vec() })
         );
+    }
+
+    #[test]
+    fn test_xor_serialize() {
+        let ctx = Box::new(DetectTransformXorData {
+            key: vec![1, 2, 3, 4, 5],
+        });
+
+        let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
+
+        let mut data_ptr: *const u8 = std::ptr::null();
+        let mut length: u32 = 0;
+
+        unsafe {
+            xor_serialize(
+                &mut data_ptr as *mut _,
+                &mut length as *mut _,
+                ctx_ptr as *mut _,
+            );
+
+            assert!(!data_ptr.is_null(), "data_ptr should not be null");
+            assert_eq!(length, 5);
+
+            let actual = std::slice::from_raw_parts(data_ptr, length as usize);
+            assert_eq!(actual, &[1, 2, 3, 4, 5]);
+        }
     }
 
     #[test]

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -151,6 +151,9 @@ int DetectHelperTransformRegister(const SCTransformTableElmt *kw)
     sigmatch_table[transform_id].Setup =
             (int (*)(DetectEngineCtx * de, Signature * s, const char *raw)) kw->Setup;
     sigmatch_table[transform_id].Free = (void (*)(DetectEngineCtx * de, void *ptr)) kw->Free;
+    sigmatch_table[transform_id].TransformSerialize =
+            (void (*)(uint8_t * *serialized_data, uint32_t * length, const void *context))
+                    kw->TransformSerialize;
 
     return transform_id;
 }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -987,12 +987,41 @@ int DetectBufferTypeMaxId(void)
     return g_buffer_type_id;
 }
 
+static void DetectBufferAddTransformData(DetectBufferType *map)
+{
+    for (int i = 0; i < map->transforms.cnt; i++) {
+        const TransformData *t = &map->transforms.transforms[i];
+        if (sigmatch_table[t->transform].TransformSerialize) {
+            sigmatch_table[t->transform].TransformSerialize(
+                    &map->xform_serialized[i].serialized_data,
+                    &map->xform_serialized[i].serialized_data_len, t->options);
+            SCLogDebug("serialized data: [%p] \"%s\" [%d]",
+                    map->xform_serialized[i].serialized_data,
+                    (char *)map->xform_serialized[i].serialized_data,
+                    map->xform_serialized[i].serialized_data_len);
+        }
+    }
+}
+
 static uint32_t DetectBufferTypeHashNameFunc(HashListTable *ht, void *data, uint16_t datalen)
 {
     const DetectBufferType *map = (DetectBufferType *)data;
     uint32_t hash = hashlittle_safe(map->name, strlen(map->name), 0);
-    hash += hashlittle_safe((uint8_t *)&map->transforms, sizeof(map->transforms), 0);
+
+    // Add the transform data
+    // - Collect transform id and position
+    // - Collect serialized data, if any
+    for (int i = 0; i < map->transforms.cnt; i++) {
+        const TransformData *t = &map->transforms.transforms[i];
+        int tval = t->transform + i;
+        hash += hashlittle_safe((uint8_t *)&tval, sizeof(tval), 0);
+        if (map->xform_serialized[i].serialized_data) {
+            hash += hashlittle_safe(map->xform_serialized[i].serialized_data,
+                    map->xform_serialized[i].serialized_data_len, 0);
+        }
+    }
     hash %= ht->array_size;
+    SCLogDebug("map->name %s, hash %d", map->name, hash);
     return hash;
 }
 
@@ -1010,7 +1039,52 @@ static char DetectBufferTypeCompareNameFunc(void *data1, uint16_t len1, void *da
     DetectBufferType *map2 = (DetectBufferType *)data2;
 
     char r = (strcmp(map1->name, map2->name) == 0);
-    r &= (memcmp((uint8_t *)&map1->transforms, (uint8_t *)&map2->transforms, sizeof(map2->transforms)) == 0);
+
+    // Compare the transforms
+    // the transform supports serialization, that data will also be added.
+    if (r && map1->transforms.cnt && (map1->transforms.cnt == map2->transforms.cnt)) {
+        for (int i = 0; i < map1->transforms.cnt; i++) {
+            if (map1->transforms.transforms[i].transform !=
+                    map2->transforms.transforms[i].transform) {
+                r = 0;
+                break;
+            }
+
+            SCLogDebug("%s: transform ids match; checking specialized data", map1->name);
+            // Checks
+            // - Both NULL: --> ok, continue
+            // - One NULL: --> no match, break?
+            // - Serialized data lengths match: --> ok, continue
+            // - Serialized data matches: ok
+
+            // Stop if only one is NULL
+            if ((map1->xform_serialized[i].serialized_data == NULL) ^
+                    (map2->xform_serialized[i].serialized_data == NULL)) {
+                SCLogDebug("serialized data: only one is null");
+                r = 0;
+                break;
+            } else if (map1->xform_serialized[i].serialized_data ==
+                       NULL) { /* continue when both are null */
+                SCLogDebug("serialized data: both null");
+                r = 1;
+                continue;
+            } else if (map1->xform_serialized[i].serialized_data_len !=
+                       map2->xform_serialized[i].serialized_data_len) {
+                // Stop when serialized data lengths aren't equal
+                SCLogDebug("serialized data: unequal lengths");
+                r = 0;
+                break;
+            }
+
+            // stop if the serialized data is different
+            r &= memcmp(map1->xform_serialized[i].serialized_data,
+                         map2->xform_serialized[i].serialized_data,
+                         map1->xform_serialized[i].serialized_data_len) == 0;
+            if (r == 0)
+                break;
+            SCLogDebug("serialized data: data matches");
+        }
+    }
     return r;
 }
 
@@ -1033,6 +1107,7 @@ static void DetectBufferTypeFreeFunc(void *data)
     for (int i = 0; i < map->transforms.cnt; i++) {
         if (map->transforms.transforms[i].options == NULL)
             continue;
+
         if (sigmatch_table[map->transforms.transforms[i].transform].Free == NULL) {
             SCLogError("%s allocates transform option memory but has no free routine",
                     sigmatch_table[map->transforms.transforms[i].transform].name);
@@ -1512,8 +1587,9 @@ int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s)
             SCReturnInt(-1);
         }
 
-        SCLogDebug("buffer %d has transform(s) registered: %d",
-                s->init_data->list, s->init_data->transforms.cnt);
+        SCLogDebug("buffer %d has transform(s) registered: %d", s->init_data->list,
+                s->init_data->transforms.cnt);
+
         int new_list = DetectEngineBufferTypeGetByIdTransforms(de_ctx, s->init_data->list,
                 s->init_data->transforms.transforms, s->init_data->transforms.cnt);
         if (new_list == -1) {
@@ -1944,6 +2020,11 @@ int DetectEngineBufferTypeGetByIdTransforms(
     memset(&lookup_map, 0, sizeof(lookup_map));
     strlcpy(lookup_map.name, base_map->name, sizeof(lookup_map.name));
     lookup_map.transforms = t;
+
+    /* Add serialized data from transforms */
+    if (t.cnt) {
+        DetectBufferAddTransformData(&lookup_map);
+    }
     DetectBufferType *res = HashListTableLookup(de_ctx->buffer_type_hash_name, &lookup_map, 0);
 
     SCLogDebug("res %p", res);

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -37,33 +37,49 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
-static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 #define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) SCBase64ModeRFC4648
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
-static void TransformFromBase64Decode(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
+#define B64D_SERIALIZED_DATA_LEN 128
 
-void DetectTransformFromBase64DecodeRegister(void)
+static const char *serialization_format = "{"
+                                          "\"flags\" : %d, "
+                                          "\"bytes\" : { \"str\": \"%s\", \"cnt\": %d}, "
+                                          "\"offset\" : { \"str\": \"%s\", \"cnt\": %d}, "
+                                          "\"mode\" : %d"
+                                          "}";
+
+static inline uint8_t *DetectTransformFromBase64SerializeData(
+        SCDetectTransformFromBase64Data *b64d, int *len)
 {
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
-#ifdef UNITTESTS
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
-            DetectTransformFromBase64DecodeRegisterTests;
-#endif
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
+    void *ptr = SCCalloc(1, B64D_SERIALIZED_DATA_LEN);
+    if (ptr) {
+        int rc = snprintf(ptr, B64D_SERIALIZED_DATA_LEN, serialization_format, b64d->flags,
+                b64d->nbytes_str ? b64d->nbytes_str : "n/a", b64d->nbytes,
+                b64d->offset_str ? b64d->offset_str : "n/a", b64d->offset, b64d->mode);
+        *len = rc;
+    }
+    return ptr;
+}
+
+static void DetectTransformFromBase64Serialize(
+        uint8_t **data, uint32_t *length, const void *context)
+{
+    if (context) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)context;
+        *data = b64d->serialized_data;
+        *length = b64d->serialized_data_len;
+    }
 }
 
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCTransformBase64Free(ptr);
+    if (ptr) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)ptr;
+        SCFree(b64d->serialized_data);
+        SCTransformBase64Free(ptr);
+    }
 }
 
 static SCDetectTransformFromBase64Data *DetectTransformFromBase64DecodeParse(const char *str)
@@ -104,6 +120,14 @@ static int DetectTransformFromBase64DecodeSetup(
         SCLogError("byte value must be a value, not a variable name");
         goto exit_path;
     }
+
+    int len;
+    b64d->serialized_data = DetectTransformFromBase64SerializeData(b64d, &len);
+    if (!b64d->serialized_data) {
+        SCLogError("Unable to allocate memory for serialized representation");
+        goto exit_path;
+    }
+    b64d->serialized_data_len = len;
 
     r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_FROM_BASE64, b64d);
 
@@ -153,6 +177,23 @@ static void TransformFromBase64Decode(
         //            PrintRawDataFp(stdout, output, b64data->decoded_len);
         InspectionBufferCopy(buffer, decoded, num_decoded);
     }
+}
+
+void DetectTransformFromBase64DecodeRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].TransformSerialize =
+            DetectTransformFromBase64Serialize;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
+            DetectTransformFromBase64DecodeRegisterTests;
+#endif
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
 }
 
 #ifdef UNITTESTS

--- a/src/detect.h
+++ b/src/detect.h
@@ -460,9 +460,15 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct DetectEngineAppInspectionEngine_ *next;
 } DetectEngineAppInspectionEngine;
 
+typedef struct TransformSerializedData_ {
+    uint8_t *serialized_data;
+    uint32_t serialized_data_len;
+} TransformSerializedData;
+
 typedef struct DetectBufferType_ {
     char name[64];
     char description[128];
+    TransformSerializedData xform_serialized[DETECT_TRANSFORMS_MAX];
     int id;
     int parent_id;
     bool mpm;
@@ -1372,6 +1378,9 @@ typedef struct SigTableElmt_ {
     /** InspectionBuffer transformation callback */
     void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
     bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
+
+    /** Transform serialization callback */
+    void (*TransformSerialize)(uint8_t **serialized_data, uint32_t *length, const void *context);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Continuation of #12994  

Transforms that support optional strings, like from_base64 and pcrexform, should also support serialization to treat transforms with like transform options as the same.

This commit demonstrates
- When computing a hash, include serialized data from the transform
- When comparing, include the serialized data from the transforms
- Omitting the "options" ptr from the transform hash/compare
- Modify xor, pcrexform, and from_base64 to supply serialization data for disambiguation in the compare/hash logic.

Updates:
- Modify serialization function to better support rust; now uses pointer, nbytes instead of a structure
- Update rust transforms with transform serialization function
- Add serialization to xor transform.
- Fix compiler warning when computing hash value for transforms (see https://github.com/OISF/suricata/pull/12971)
- Check memory allocation values
- Move serialized data collection to hash table user (from hash computation function)
- Formatting fixup (again :-( )
- Rust clippy fixup

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
