### PR TITLE
configure: pickup pre-release versions from changelog

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2360,7 +2360,7 @@ return 0;
     if test "x$LAST_COMMIT_DATE" != "x"; then
 	RELEASE_DATE=$LAST_COMMIT_DATE
     else
-        RELEASE_DATE=`awk '/^[[0-9\.]]+ -- [[0-9]][[0-9]][[0-9]][[0-9]]-[[0-9]][[0-9]]-[[0-9]][[0-9]]/ { print $3; exit }' $srcdir/ChangeLog`
+        RELEASE_DATE=`awk '/^[[0-9\.]].+ -- [[0-9]][[0-9]][[0-9]][[0-9]]-[[0-9]][[0-9]]-[[0-9]][[0-9]]/ { print $3; exit }' $srcdir/ChangeLog`
         if test "x$RELEASE_DATE" = "x"; then
             AC_MSG_ERROR([Failed to determine release date])
         fi


### PR DESCRIPTION
Pickup release versions like 8.0.0-beta1 and 8.0.0-rc1 from the
ChangeLog. This version is used in the generated documentation.

This one should work on busybox.
