### PR TITLE
crates.io/v1

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -87,7 +87,7 @@ suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { version = "0.1.0-alpha.6" }
 
-htp = { path = "./htp", version = "2.0.0" }
+htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "htp"
+name = "suricata-htp"
 authors = ["ivanr = Ivan Ristic <ivanr@webkreator.com>", "cccs = Canadian Centre for Cyber Security"]
 version = "2.0.0"
-publish = false
+publish = true
 edition = "2021"
 autobins = false
 license-file = "LICENSE"

--- a/rust/suricatactl/Cargo.toml.in
+++ b/rust/suricatactl/Cargo.toml.in
@@ -3,6 +3,7 @@ name = "suricatactl"
 version = "@PACKAGE_VERSION@"
 edition = "2021"
 license = "GPL-2.0-only"
+description = "Suricata control tools"
 
 [[bin]]
 name = "suricatactl"


### PR DESCRIPTION
- **suricatactl: add description to Cargo.toml**
  For publishing to crates.io.
  

- **htp: rename to suricata-htp; allow publishing to crates.io**
  As the "suricata" crate depends on htp, we need to publish htp to
  crates.io first, however "htp" name is already taken. So rename "htp" to
  "suricata-htp".
  