### PR TITLE
detect: add email.url keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -170,3 +170,29 @@ Example of a signature that would alert if a packet contains the MIME field ``x-
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email x-mailer"; :example-rule-emphasis:`email.x_mailer; content:"Microsoft Office Outlook, Build 11.0.5510";` sid:1;)
+
+email.url
+---------
+
+Matches ``URL`` extracted of an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.url; content:"<content to match against>";
+
+``email.url`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+``email.url`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+This keyword maps to the EVE field ``email.url[]``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if en email contains the ``url`` ``test-site.org/blah/123/``.
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email url"; :example-rule-emphasis:`email.url; content:"test-site.org/blah/123/";` sid:1;)

--- a/doc/userguide/rules/multi-buffer-matching.rst
+++ b/doc/userguide/rules/multi-buffer-matching.rst
@@ -77,6 +77,7 @@ following keywords:
 * ``dns.answer.name``
 * ``dns.query.name``
 * ``dns.query``
+* ``email.url``
 * ``file.data``
 * ``file.magic``
 * ``file.name``

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -43,3 +43,20 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetData(
 
     return 0;
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetUrl(
+    ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32, idx: u32,
+) -> u8 {
+    if !ctx.urls.is_empty() && idx < ctx.urls.len() as u32 {
+        let url = &ctx.urls[idx as usize];
+        *buffer = url.as_ptr();
+        *buffer_len = url.len() as u32;
+        return 1;
+    }
+
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
+    return 0;
+}


### PR DESCRIPTION
Ticket: [#7597](https://redmine.openinfosecfoundation.org/issues/7597)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7597

### Description:
- Implement ``email.url`  keyword.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2436