### PR TITLE
rust: fixups for publishing to crates.io - v2


### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -87,7 +87,7 @@ suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { version = "0.1.0-alpha.6" }
 
-htp = { path = "./htp", version = "2.0.0" }
+htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name = "htp"
+name = "suricata-htp"
 authors = ["ivanr = Ivan Ristic <ivanr@webkreator.com>", "cccs = Canadian Centre for Cyber Security"]
 version = "2.0.0"
-publish = false
 edition = "2021"
 autobins = false
 license-file = "LICENSE"

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "suricata-htp"
-authors = ["ivanr = Ivan Ristic <ivanr@webkreator.com>", "cccs = Canadian Centre for Cyber Security"]
 version = "2.0.0"
 edition = "2021"
 autobins = false
 license-file = "LICENSE"
 description = "Security Aware HTP Protocol parsing library"
 readme = "README.md"
-repository = "https://github.com/CybercentreCanada/libhtp-rs-internal"
-homepage = "https://github.com/CybercentreCanada/libhtp-rs-internal"
+repository = "https://github.com/OISF/suricata"
 keywords = ["parser", "HTTP", "protocol", "network", "api"]
 categories = ["parsing", "network-programming"]
 include = [

--- a/rust/suricatactl/Cargo.toml.in
+++ b/rust/suricatactl/Cargo.toml.in
@@ -3,6 +3,7 @@ name = "suricatactl"
 version = "@PACKAGE_VERSION@"
 edition = "2021"
 license = "GPL-2.0-only"
+description = "Suricata control tools"
 
 [[bin]]
 name = "suricatactl"


### PR DESCRIPTION
- suricatactl: add description to Cargo.toml
- htp: rename to suricata-htp, htp already taken
- htp: remove authors field (deprecated)
- htp: fix repository URL
