### PR TITLE
rust: fixups for publishing to crates.io - v3


### DIFF
--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -660,22 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "htp"
-version = "2.0.0"
-dependencies = [
- "base64",
- "bstr",
- "cdylib-link-lines",
- "flate2",
- "lazy_static",
- "libc",
- "lzma-rs",
- "nom",
- "rstest",
- "time",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,7 +1536,6 @@ dependencies = [
  "flate2",
  "hex",
  "hkdf",
- "htp",
  "ipsec-parser",
  "kerberos-parser",
  "lazy_static",
@@ -1576,6 +1559,7 @@ dependencies = [
  "sha2",
  "snmp-parser",
  "suricata-derive",
+ "suricata-htp",
  "suricata-lua-sys",
  "suricata-sys",
  "test-case",
@@ -1594,6 +1578,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "suricata-htp"
+version = "2.0.0"
+dependencies = [
+ "base64",
+ "bstr",
+ "cdylib-link-lines",
+ "flate2",
+ "lazy_static",
+ "libc",
+ "lzma-rs",
+ "nom",
+ "rstest",
+ "time",
 ]
 
 [[package]]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -87,7 +87,7 @@ suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
 suricata-lua-sys = { version = "0.1.0-alpha.6" }
 
-htp = { path = "./htp", version = "2.0.0" }
+htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 
 [dev-dependencies]
 test-case = "~3.3.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -74,6 +74,9 @@ all-local: Cargo.toml
 	fi
 	$(MAKE) gen/rust-bindings.h
 	$(MAKE) gen/htp/htp_rs.h
+	if test -e Cargo.lock.in; then \
+		cp Cargo.lock Cargo.lock.in; \
+	fi
 
 install-exec-local:
 	install -d -m 0755 "$(DESTDIR)$(bindir)"

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-name = "htp"
+name = "suricata-htp"
 authors = ["ivanr = Ivan Ristic <ivanr@webkreator.com>", "cccs = Canadian Centre for Cyber Security"]
 version = "2.0.0"
-publish = false
 edition = "2021"
 autobins = false
 license-file = "LICENSE"

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "suricata-htp"
-authors = ["ivanr = Ivan Ristic <ivanr@webkreator.com>", "cccs = Canadian Centre for Cyber Security"]
 version = "2.0.0"
 edition = "2021"
 autobins = false
 license-file = "LICENSE"
 description = "Security Aware HTP Protocol parsing library"
 readme = "README.md"
-repository = "https://github.com/CybercentreCanada/libhtp-rs-internal"
-homepage = "https://github.com/CybercentreCanada/libhtp-rs-internal"
+repository = "https://github.com/OISF/suricata"
 keywords = ["parser", "HTTP", "protocol", "network", "api"]
 categories = ["parsing", "network-programming"]
 include = [

--- a/rust/suricatactl/Cargo.toml.in
+++ b/rust/suricatactl/Cargo.toml.in
@@ -3,6 +3,7 @@ name = "suricatactl"
 version = "@PACKAGE_VERSION@"
 edition = "2021"
 license = "GPL-2.0-only"
+description = "Suricata control tools"
 
 [[bin]]
 name = "suricatactl"


### PR DESCRIPTION
- suricatactl: add description to Cargo.toml
- htp: rename to suricata-htp, htp already taken
- htp: remove authors field (deprecated)
- htp: fix repository URL
- Copy Cargo.lock to Cargo.lock.in

The version updates the Cargo.lock.

Additionally, always update the Cargo.lock.in to keep it in sync with
Cargo.lock. This will always make us aware when it has changed and needs to be
committed.

