### PR TITLE
Fw ips cleanups/v2

### DIFF
--- a/doc/userguide/rules/app-layer.rst
+++ b/doc/userguide/rules/app-layer.rst
@@ -18,10 +18,14 @@ Examples::
     app-layer-protocol:!http,final;
     app-layer-protocol:http,to_server; app-layer-protocol:tls,to_client;
     app-layer-protocol:http2,final; app-layer-protocol:http1,original;
+    app-layer-protocol:unknown;
 
 A special value 'failed' can be used for matching on flows in which
 protocol detection failed. This can happen if Suricata doesn't know
 the protocol or when certain 'bail out' conditions happen.
+
+A special value 'unknown' can be used to match on a protocol being
+not yet known. It can not be negated.
 
 The different modes are
 * direction : protocol recognized on the direction of the current packet
@@ -32,6 +36,9 @@ The different modes are
 * original : original protocol (in case of protocol change)
 
 By default, (if no mode is specified), the mode is ``direction``.
+
+.. note:: when negation is used, like ``!http``, it will not match on the
+   "unknown" state in the flow.
 
 Here is an example of a rule matching non-http traffic on port 80:
 

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -357,7 +357,7 @@ void DetectAppLayerProtocolRegister(void)
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].RegisterTests = DetectAppLayerProtocolRegisterTests;
 #endif
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].flags =
-            (SIGMATCH_QUOTES_OPTIONAL | SIGMATCH_HANDLE_NEGATION);
+            (SIGMATCH_QUOTES_OPTIONAL | SIGMATCH_HANDLE_NEGATION | SIGMATCH_SUPPORT_FIREWALL);
 
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].SetupPrefilter = PrefilterSetupAppProto;
     sigmatch_table[DETECT_APP_LAYER_PROTOCOL].SupportsPrefilter = PrefilterAppProtoIsPrefilterable;

--- a/src/detect-bsize.c
+++ b/src/detect-bsize.c
@@ -103,6 +103,7 @@ void DetectBsizeRegister(void)
     sigmatch_table[DETECT_BSIZE].Match = NULL;
     sigmatch_table[DETECT_BSIZE].Setup = DetectBsizeSetup;
     sigmatch_table[DETECT_BSIZE].Free = DetectBsizeFree;
+    sigmatch_table[DETECT_BSIZE].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_BSIZE].RegisterTests = DetectBsizeRegisterTests;
 #endif

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -66,7 +66,8 @@ void DetectContentRegister (void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_CONTENT].RegisterTests = DetectContentRegisterTests;
 #endif
-    sigmatch_table[DETECT_CONTENT].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
+    sigmatch_table[DETECT_CONTENT].flags =
+            (SIGMATCH_QUOTES_MANDATORY | SIGMATCH_HANDLE_NEGATION | SIGMATCH_SUPPORT_FIREWALL);
 }
 
 /**

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -66,6 +66,7 @@ void DetectDsizeRegister (void)
     sigmatch_table[DETECT_DSIZE].Match = DetectDsizeMatch;
     sigmatch_table[DETECT_DSIZE].Setup = DetectDsizeSetup;
     sigmatch_table[DETECT_DSIZE].Free  = DetectDsizeFree;
+    sigmatch_table[DETECT_DSIZE].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_DSIZE].RegisterTests = DsizeRegisterTests;
 #endif

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -394,6 +394,9 @@ static inline void PacketAlertFinalizeProcessQueue(
     for (uint16_t i = 0; i < det_ctx->alert_queue_size; i++) {
         PacketAlert *pa = &det_ctx->alert_queue[i];
         const Signature *s = pa->s;
+
+        /* if a firewall rule told us to skip, we don't count the skipped
+         * alerts. */
         if (have_fw_rules && skip_td && (s->flags & SIG_FLAG_FIREWALL) == 0) {
             continue;
         }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -393,7 +393,7 @@ static inline void PacketAlertFinalizeProcessQueue(
     bool skip_td = false;
     for (uint16_t i = 0; i < det_ctx->alert_queue_size; i++) {
         PacketAlert *pa = &det_ctx->alert_queue[i];
-        const Signature *s = pa->s; // de_ctx->sig_array[pa->num];
+        const Signature *s = pa->s;
         if (have_fw_rules && skip_td && (s->flags & SIG_FLAG_FIREWALL) == 0) {
             continue;
         }

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -330,15 +330,19 @@ static int AlertQueueSortHelper(const void *a, const void *b)
 {
     const PacketAlert *pa0 = a;
     const PacketAlert *pa1 = b;
-    if (pa1->num == pa0->num) {
-        if (pa1->tx_id == PACKET_ALERT_NOTX) {
-            return -1;
-        } else if (pa0->tx_id == PACKET_ALERT_NOTX) {
-            return 1;
+    if (pa0->s->firewall_table == pa1->s->firewall_table) {
+        if (pa1->num == pa0->num) {
+            if (pa1->tx_id == PACKET_ALERT_NOTX) {
+                return -1;
+            } else if (pa0->tx_id == PACKET_ALERT_NOTX) {
+                return 1;
+            }
+            return pa0->tx_id < pa1->tx_id ? 1 : -1;
+        } else {
+            return pa0->num < pa1->num ? -1 : 1;
         }
-        return pa0->tx_id < pa1->tx_id ? 1 : -1;
     }
-    return pa0->num > pa1->num ? 1 : -1;
+    return pa0->s->firewall_table < pa1->s->firewall_table ? -1 : 1;
 }
 
 /** \internal

--- a/src/detect-engine-loader.c
+++ b/src/detect-engine-loader.c
@@ -293,6 +293,7 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
         int32_t skipped_sigs = 0;
 
         SCLogNotice("fw: rule file full path \"%s\"", de_ctx->firewall_rule_file_exclusive);
+        de_ctx->flags |= DE_HAS_FIREWALL;
 
         int ret = DetectLoadSigFile(de_ctx, de_ctx->firewall_rule_file_exclusive, &good_sigs,
                 &bad_sigs, &skipped_sigs, true);
@@ -303,8 +304,6 @@ static int LoadFirewallRuleFiles(DetectEngineCtx *de_ctx)
              * errors would have already been logged. */
             exit(EXIT_FAILURE);
         }
-
-        de_ctx->flags |= DE_HAS_FIREWALL;
 
         if (good_sigs == 0) {
             SCLogNotice("fw: No rules loaded from %s.", de_ctx->firewall_rule_file_exclusive);

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -322,6 +322,12 @@ static void PrintFeatureList(const SigTableElmt *e, char sep)
         printf("sticky buffer");
         prev = 1;
     }
+    if (flags & SIGMATCH_SUPPORT_FIREWALL) {
+        if (prev == 1)
+            printf("%c", sep);
+        printf("supports firewall");
+        prev = 1;
+    }
     if (e->Transform) {
         if (prev == 1)
             printf("%c", sep);

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -70,6 +70,7 @@ void DetectFlowRegister (void)
     sigmatch_table[DETECT_FLOW].Match = DetectFlowMatch;
     sigmatch_table[DETECT_FLOW].Setup = DetectFlowSetup;
     sigmatch_table[DETECT_FLOW].Free  = DetectFlowFree;
+    sigmatch_table[DETECT_FLOW].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FLOW].RegisterTests = DetectFlowRegisterTests;
 #endif

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -79,7 +79,7 @@ void DetectFlowbitsRegister (void)
     sigmatch_table[DETECT_FLOWBITS].RegisterTests = FlowBitsRegisterTests;
 #endif
     /* this is compatible to ip-only signatures */
-    sigmatch_table[DETECT_FLOWBITS].flags |= SIGMATCH_IPONLY_COMPAT;
+    sigmatch_table[DETECT_FLOWBITS].flags |= (SIGMATCH_IPONLY_COMPAT | SIGMATCH_SUPPORT_FIREWALL);
 
     sigmatch_table[DETECT_FLOWBITS].SupportsPrefilter = PrefilterFlowbitIsPrefilterable;
     sigmatch_table[DETECT_FLOWBITS].SetupPrefilter = PrefilterSetupFlowbits;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -62,6 +62,7 @@ void DetectITypeRegister (void)
     sigmatch_table[DETECT_ITYPE].Match = DetectITypeMatch;
     sigmatch_table[DETECT_ITYPE].Setup = DetectITypeSetup;
     sigmatch_table[DETECT_ITYPE].Free = DetectITypeFree;
+    sigmatch_table[DETECT_ITYPE].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_ITYPE].RegisterTests = DetectITypeRegisterTests;
 #endif

--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -50,7 +50,7 @@ void DetectMsgRegister (void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_MSG].RegisterTests = DetectMsgRegisterTests;
 #endif
-    sigmatch_table[DETECT_MSG].flags = SIGMATCH_QUOTES_MANDATORY;
+    sigmatch_table[DETECT_MSG].flags = (SIGMATCH_QUOTES_MANDATORY | SIGMATCH_SUPPORT_FIREWALL);
 }
 
 static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, const char *msgstr)

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -978,6 +978,10 @@ static int SigParseOptions(DetectEngineCtx *de_ctx, Signature *s, char *optstr, 
             goto error;
         }
 
+        if (s->init_data->firewall_rule && (st->flags & SIGMATCH_SUPPORT_FIREWALL) == 0) {
+            SCLogWarning("keyword \'%s\' has not been tested for firewall rules", optname);
+        }
+
         /* see if value is negated */
         if ((st->flags & SIGMATCH_HANDLE_NEGATION) && *ptr == '!') {
             s->init_data->negated = true;

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -44,6 +44,7 @@ void DetectSidRegister (void)
     sigmatch_table[DETECT_SID].url = "/rules/meta.html#sid-signature-id";
     sigmatch_table[DETECT_SID].Match = NULL;
     sigmatch_table[DETECT_SID].Setup = DetectSidSetup;
+    sigmatch_table[DETECT_SID].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_SID].RegisterTests = DetectSidRegisterTests;
 #endif

--- a/src/detect-tcp-flags.c
+++ b/src/detect-tcp-flags.c
@@ -82,6 +82,7 @@ void DetectFlagsRegister (void)
     sigmatch_table[DETECT_FLAGS].Match = DetectFlagsMatch;
     sigmatch_table[DETECT_FLAGS].Setup = DetectFlagsSetup;
     sigmatch_table[DETECT_FLAGS].Free  = DetectFlagsFree;
+    sigmatch_table[DETECT_FLAGS].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FLAGS].RegisterTests = FlagsRegisterTests;
 #endif

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -78,6 +78,7 @@ void DetectTlsVersionRegister (void)
     sigmatch_table[DETECT_TLS_VERSION].AppLayerTxMatch = DetectTlsVersionMatch;
     sigmatch_table[DETECT_TLS_VERSION].Setup = DetectTlsVersionSetup;
     sigmatch_table[DETECT_TLS_VERSION].Free = DetectTlsVersionFree;
+    sigmatch_table[DETECT_TLS_VERSION].flags = SIGMATCH_SUPPORT_FIREWALL;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_TLS_VERSION].RegisterTests = DetectTlsVersionRegisterTests;
 #endif

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -83,7 +83,7 @@ void DetectXbitsRegister (void)
     sigmatch_table[DETECT_XBITS].RegisterTests = XBitsRegisterTests;
 #endif
     /* this is compatible to ip-only signatures */
-    sigmatch_table[DETECT_XBITS].flags |= SIGMATCH_IPONLY_COMPAT;
+    sigmatch_table[DETECT_XBITS].flags |= (SIGMATCH_IPONLY_COMPAT | SIGMATCH_SUPPORT_FIREWALL);
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex);
 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -1618,6 +1618,8 @@ typedef struct SigGroupHead_ {
 #define SIGMATCH_INFO_DEPRECATED        BIT_U16(10)
 /** strict parsing is enabled */
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
+/** keyword supported by firewall rules */
+#define SIGMATCH_SUPPORT_FIREWALL BIT_U16(12)
 
 enum DetectEngineTenantSelectors
 {

--- a/src/detect.h
+++ b/src/detect.h
@@ -560,6 +560,13 @@ enum SignatureHookType {
     SIGNATURE_HOOK_TYPE_APP,
 };
 
+enum FirewallTable {
+    FIREWALL_TABLE_PACKET_FILTER,
+    FIREWALL_TABLE_PACKET_TD,
+    FIREWALL_TABLE_APP_FILTER,
+    FIREWALL_TABLE_APP_TD,
+};
+
 // dns:request_complete should add DetectBufferTypeGetByName("dns:request_complete");
 // TODO to json
 typedef struct SignatureHook_ {
@@ -691,6 +698,9 @@ typedef struct Signature_ {
 
     /** classification id **/
     uint16_t class_id;
+
+    /** firewall: pseudo table this rule is part of (enum FirewallTable) */
+    uint8_t firewall_table;
 
     /** firewall: progress value for this signature */
     uint8_t app_progress_hook;


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2440

Fix IPS handling of conflicting drop and pass:flow sigs matching for the same packet.
https://redmine.openinfosecfoundation.org/issues/7653

Add flag for keywords confirmed to work with firewall mode. It gives a warning for now, but when more are tested/evaluated, it could turn into an error to limit things to a known to work set.

Add `unknown` matching to `app-layer-protocol` to allow firewall rules to match on packets during this state.

Fix order of actions applied. A `drop` in `packet:td` should take precedence over a `accept` in `app:filter`.