### PR TITLE
rust: fix clippy warning manual_contains

### DIFF
--- a/rust/src/http2/http2.rs
+++ b/rust/src/http2/http2.rs
@@ -212,7 +212,7 @@ impl HTTP2Transaction {
                 self.decoder.http2_encoding_fromvec(&block.value, dir);
             } else if block.name.eq_ignore_ascii_case(b":authority") {
                 authority = Some(&block.value);
-                if block.value.iter().any(|&x| x == b'@') {
+                if block.value.contains(&b'@') {
                     // it is forbidden by RFC 9113 to have userinfo in this field
                     // when in HTTP1 we can have user:password@domain.com
                     self.set_event(HTTP2Event::UserinfoInUri);


### PR DESCRIPTION
Remaining commit of https://github.com/OISF/suricata/pull/12932/commits to backport

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- rust: fix clippy warning manual_contains

@jasonish any reason you did not `git cherry-pick -x` my PR ?