### PR TITLE
Websocket compression 7285 v3

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -48,7 +48,7 @@ num = "~0.2.1"
 num-derive = "~0.4.2"
 num-traits = "~0.2.14"
 widestring = "~0.4.3"
-flate2 = "~1.0.19"
+flate2 = { version = "~1.0.19", features = ["zlib"] }
 brotli = "~3.4.0"
 hkdf = "~0.12.3"
 aes = "~0.7.5"

--- a/rust/src/websocket/parser.rs
+++ b/rust/src/websocket/parser.rs
@@ -19,6 +19,12 @@ use nom7::bytes::streaming::take;
 use nom7::combinator::cond;
 use nom7::number::streaming::{be_u16, be_u32, be_u64, be_u8};
 use nom7::IResult;
+
+use nom7::bytes::complete::tag;
+use nom7::character::complete::space0;
+use nom7::character::complete::u8 as nomu8;
+use nom7::combinator::verify;
+
 use suricata_derive::EnumStringU8;
 
 #[derive(Clone, Debug, Default, EnumStringU8)]
@@ -94,4 +100,16 @@ pub fn parse_message(i: &[u8], max_pl_size: u32) -> IResult<&[u8], WebSocketPdu>
             to_skip,
         },
     ))
+}
+
+pub(super) fn parse_cli_max_win(i: &[u8]) -> IResult<&[u8], u8> {
+    let (i, _space) = space0(i)?;
+    let (i, _name) = tag("client_max_window_bits=")(i)?;
+    verify(nomu8, |&v| (9..=15).contains(&v))(i)
+}
+
+pub(super) fn parse_srv_max_win(i: &[u8]) -> IResult<&[u8], u8> {
+    let (i, _space) = space0(i)?;
+    let (i, _name) = tag("server_max_window_bits=")(i)?;
+    verify(nomu8, |&v| (9..=15).contains(&v))(i)
 }

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -200,6 +200,7 @@ impl WebSocketState {
                     } else {
                         &mut self.c2s_buf
                     };
+                    let mut compress = pdu.compress;
                     if !buf.data.is_empty() || !pdu.fin {
                         if buf.data.is_empty() {
                             buf.compress = pdu.compress;
@@ -216,10 +217,11 @@ impl WebSocketState {
                     tx.pdu = pdu;
                     if tx.pdu.fin && !buf.data.is_empty() {
                         // the final PDU gets the full reassembled payload
+                        compress = buf.compress;
                         std::mem::swap(&mut tx.pdu.payload, &mut buf.data);
                         buf.data.clear();
                     }
-                    if buf.compress && tx.pdu.fin {
+                    if compress && tx.pdu.fin {
                         buf.compress = false;
                         // cf RFC 7692 section-7.2.2
                         tx.pdu.payload.extend_from_slice(&[0, 0, 0xFF, 0xFF]);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2552,6 +2552,20 @@ void *HtpGetTxForH2(void *alstate)
     return NULL;
 }
 
+void Http1GetDataForWebsocket(void *alstate_orig, void *wss)
+{
+    // get last transaction
+    htp_tx_t *h1tx = HtpGetTxForH2(alstate_orig);
+    if (wss == NULL || h1tx == NULL) {
+        return;
+    }
+    const htp_header_t *h = htp_tx_response_header(h1tx, "Sec-WebSocket-Extensions");
+    if (h == NULL) {
+        return;
+    }
+    SCWebSocketUseExtension(wss, htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
+}
+
 static int HTPStateGetEventInfo(
         const char *event_name, uint8_t *event_id, AppLayerEventType *event_type)
 {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -970,6 +970,7 @@ app-layer:
     websocket:
       #enabled: yes
       # Maximum used payload size, the rest is skipped
+      # Also applies as a maximum for uncompressed data
       # max-payload-size: 64 KiB
     rdp:
       #enabled: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7285

Describe changes:
- better handle websocket decompression
  - handle single-frame decompression
  - use max window bits of 15, and keep the context of decompression
  - handle HTTP1 Header `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=15`, especially the `max_window_bits=15` for the decompressor 

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2387

#12930 rebased and more detailed commit history

I am not sure we need and want the last commit (too much complexity for some small optimization)
