### PR TITLE
Websocket compression 7285 v4

### DIFF
--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -48,7 +48,7 @@ num = "~0.2.1"
 num-derive = "~0.4.2"
 num-traits = "~0.2.14"
 widestring = "~0.4.3"
-flate2 = "~1.0.19"
+flate2 = { version = "~1.0.19", features = ["zlib"] }
 brotli = "~3.4.0"
 hkdf = "~0.12.3"
 aes = "~0.7.5"

--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -200,6 +200,7 @@ impl WebSocketState {
                     } else {
                         &mut self.c2s_buf
                     };
+                    let mut compress = pdu.compress;
                     if !buf.data.is_empty() || !pdu.fin {
                         if buf.data.is_empty() {
                             buf.compress = pdu.compress;
@@ -216,10 +217,11 @@ impl WebSocketState {
                     tx.pdu = pdu;
                     if tx.pdu.fin && !buf.data.is_empty() {
                         // the final PDU gets the full reassembled payload
+                        compress = buf.compress;
                         std::mem::swap(&mut tx.pdu.payload, &mut buf.data);
                         buf.data.clear();
                     }
-                    if buf.compress && tx.pdu.fin {
+                    if compress && tx.pdu.fin {
                         buf.compress = false;
                         // cf RFC 7692 section-7.2.2
                         tx.pdu.payload.extend_from_slice(&[0, 0, 0xFF, 0xFF]);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -970,6 +970,7 @@ app-layer:
     websocket:
       #enabled: yes
       # Maximum used payload size, the rest is skipped
+      # Also applies as a maximum for uncompressed data
       # max-payload-size: 64 KiB
     rdp:
       #enabled: yes


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7285

Describe changes:
- better handle websocket decompression
  - handle single-frame decompression
  - use max window bits of 15, and keep the context of decompression

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2387

#13018 with clean history and without last commit
