### PR TITLE
output/rotate: Remove multiple registrations/races in log output rotation

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -1068,7 +1068,6 @@ static int LogFileTypePrepare(
         if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
             return -1;
         }
-        OutputRegisterFileRotationFlag(&json_ctx->file_ctx->rotation_flag);
     }
 #ifdef HAVE_LIBHIREDIS
     else if (log_filetype == LOGFILE_TYPE_REDIS) {


### PR DESCRIPTION
Under continuous log rotation (see bug for python script that demonstrates), Suricata can crash due to
- Multiple log rotate registrations for the EVE output, usually `eve.json`
- Concurrent access to log rotation flag list

By serializing access to the file rotation flags and removing the duplicate registration, the python script and Suricata run w/out crashes.

Without serialization, Suricata will crash as the queue containing file rotation flags becomes inconsistent.

With duplicate registrations of the EVE rotation flag, an orphaned flag pointer is left in the queue and eventually causes access to a freed memory area (detected with ASAN).

Link to ticket: https://redmine.openinfosecfoundation.org/issues/3436

Describe changes:
- Serialize output_file_rotation_flags handling with a mutex
- Remove duplicate log registration for EVE output


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
