### PR TITLE
Http1 brotli 5692 v3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -645,15 +645,15 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - run: ./autogen.sh
-      - run: ./configure --enable-warnings --disable-shared
+      - run: RUSTC_WRAPPER="$(pwd)/scripts/rustc.py" ./configure --enable-warnings --disable-shared
         env:
           CC: "clang"
-          RUSTFLAGS: "-C instrument-coverage"
+          RUSTFLAGS: "-Cinstrument-coverage"
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0"
-      - run: make -j ${{ env.CPUS }}
+      - run: RUSTC_WRAPPER="$(pwd)/scripts/rustc.py" make -j ${{ env.CPUS }}
         env:
           CC: "clang"
-          RUSTFLAGS: "-C instrument-coverage"
+          RUSTFLAGS: "-Cinstrument-coverage"
           CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0"
       - name: Extracting suricata-verify
         run: tar xf prep/suricata-verify.tar.gz

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1585,6 +1585,7 @@ name = "suricata-htp"
 version = "2.0.0"
 dependencies = [
  "base64",
+ "brotli",
  "bstr",
  "cdylib-link-lines",
  "flate2",

--- a/rust/htp/Cargo.toml
+++ b/rust/htp/Cargo.toml
@@ -27,6 +27,7 @@ libc = "0.2"
 nom = "7.1.1"
 lzma-rs = { version = "0.2.0", features = ["stream"] }
 flate2 = { version = "~1.0.35", features = ["zlib-default"], default-features = false }
+brotli = "~3.4.0"
 lazy_static = "1.4.0"
 time = "=0.3.36"
 

--- a/rust/htp/src/request.rs
+++ b/rust/htp/src/request.rs
@@ -1043,6 +1043,7 @@ impl ConnectionParser {
             HtpContentEncoding::Gzip
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
+            | HtpContentEncoding::Brotli
             | HtpContentEncoding::Lzma => {
                 // Send data buffer to the decompressor if it exists
                 if req.request_decompressor.is_none() && data.is_none() {
@@ -1125,6 +1126,8 @@ impl ConnectionParser {
                 HtpContentEncoding::Gzip
             } else if ce.cmp_nocase_nozero(b"deflate") || ce.cmp_nocase_nozero(b"x-deflate") {
                 HtpContentEncoding::Deflate
+            } else if ce.cmp_nocase_nozero(b"br") {
+                HtpContentEncoding::Brotli
             } else if ce.cmp_nocase_nozero(b"lzma") {
                 HtpContentEncoding::Lzma
             } else if ce.cmp_nocase_nozero(b"inflate") || ce.cmp_nocase_nozero(b"none") {
@@ -1154,6 +1157,7 @@ impl ConnectionParser {
             HtpContentEncoding::Gzip
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
+            | HtpContentEncoding::Brotli
             | HtpContentEncoding::Lzma => {
                 self.request_prepend_decompressor(request_content_encoding_processing)?;
             }

--- a/rust/htp/src/response.rs
+++ b/rust/htp/src/response.rs
@@ -1062,6 +1062,7 @@ impl ConnectionParser {
             HtpContentEncoding::Gzip
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
+            | HtpContentEncoding::Brotli
             | HtpContentEncoding::Lzma => {
                 // Send data buffer to the decompressor if it exists
                 if resp.response_decompressor.is_none() && data.is_none() {
@@ -1141,6 +1142,8 @@ impl ConnectionParser {
                 HtpContentEncoding::Deflate
             } else if ce.cmp_nocase_nozero(b"lzma") {
                 HtpContentEncoding::Lzma
+            } else if ce.cmp_nocase_nozero(b"br") {
+                HtpContentEncoding::Brotli
             } else if ce.cmp_nocase_nozero(b"inflate") || ce.cmp_nocase_nozero(b"none") {
                 HtpContentEncoding::None
             } else {
@@ -1160,6 +1163,7 @@ impl ConnectionParser {
             HtpContentEncoding::Gzip
             | HtpContentEncoding::Deflate
             | HtpContentEncoding::Zlib
+            | HtpContentEncoding::Brotli
             | HtpContentEncoding::Lzma => {
                 self.response_prepend_decompressor(response_content_encoding_processing)?;
             }

--- a/scripts/rustc.py
+++ b/scripts/rustc.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+# RUSTC_WRAPPER to disable coverage for external crates
+# and so save disk space when running suricata-verify with many profraw files
+if len(sys.argv) > 4 and sys.argv[2] == '--crate-name' and not sys.argv[3].startswith("suricata"):
+    try:
+        sys.argv.remove("-Cinstrument-coverage")
+    except:
+        pass
+result = subprocess.run(sys.argv[1:])
+sys.exit(result.returncode)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5692

Describe changes:
- http1: support brotli decompression

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2441

https://github.com/OISF/suricata/pull/13025 with clean commit to keep code coverage profraw smaller and CI green for suricata verify codecov (locally profraw files go down from 4.2M to 1.7M)

Looks like `zstd` is another algorithm we miss cf https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding