### PR TITLE
detect: add email.body_md5 keyword - v3

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -222,3 +222,27 @@ Example of a signature that would alert if a packet contains the MIME field ``re
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email received"; :example-rule-emphasis:`email.received; content:"from [65.201.218.30] (helo=COZOXORY.club)by 173-66-46-112.wash.fios.verizon.net with esmtpa (Exim 4.86)(envelope-from )id 71cF63a9for mirjam@abrakadabra.ch\; Mon, 29 Jul 2019 17:01:45 +0000";` sid:1;)
+
+email.body_md5
+--------------
+
+Matches the ``md5`` hash generated from an email body.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.body_md5; content:"<content to match against>";
+
+``email.body_md5`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+This keyword maps to the EVE field ``email.body_md5``
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if the hash ``ed00c81b85fa455d60e19f1230977134`` is generated from an email body.
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email body_md5"; :example-rule-emphasis:`email.body_md5; content:"ed00c81b85fa455d60e19f1230977134";` sid:1;)

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -17,6 +17,7 @@
 
 use super::mime;
 use super::smtp::MimeStateSMTP;
+use crate::mime::smtp::MimeSmtpMd5State;
 use std::ffi::CStr;
 use std::ptr;
 
@@ -82,6 +83,23 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
             }
             i += 1;
         }
+    }
+
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
+    return 0;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetBodyMd5(
+    ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32,
+) -> u8 {
+    if ctx.md5_state == MimeSmtpMd5State::MimeSmtpMd5Completed {
+        let hash = &ctx.md5_result;
+        *buffer = hash.as_ptr();
+        *buffer_len = hash.len() as u32;
+        return 1;
     }
 
     *buffer = ptr::null();

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetData(
     hname: *const std::os::raw::c_char,
 ) -> u8 {
     let c_str = CStr::from_ptr(hname); //unsafe
-    let str = c_str.to_str().unwrap_or("");
+    let str = c_str.to_str().unwrap();
 
     for h in &ctx.headers[..ctx.main_headers_nb] {
         if mime::slice_equals_lowercase(&h.name, str.as_bytes()) {
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
     hname: *const std::os::raw::c_char, idx: u32,
 ) -> u8 {
     let c_str = CStr::from_ptr(hname); //unsafe
-    let str = c_str.to_str().unwrap_or("");
+    let str = c_str.to_str().unwrap();
 
     let mut i = 0;
     for h in &ctx.headers[..ctx.main_headers_nb] {

--- a/rust/src/mime/smtp.rs
+++ b/rust/src/mime/smtp.rs
@@ -19,7 +19,6 @@ use super::mime;
 use crate::core::StreamingBufferConfig;
 use crate::filecontainer::FileContainer;
 use crate::utils::base64;
-use digest::generic_array::{typenum::U16, GenericArray};
 use digest::Digest;
 use digest::Update;
 use md5::Md5;
@@ -92,7 +91,7 @@ pub struct MimeStateSMTP<'a> {
     sbcfg: *const StreamingBufferConfig,
     md5: md5::Md5,
     pub(crate) md5_state: MimeSmtpMd5State,
-    pub(crate) md5_result: GenericArray<u8, U16>,
+    pub(crate) md5_result: String,
 }
 
 pub fn mime_smtp_state_init(
@@ -116,7 +115,9 @@ pub fn mime_smtp_state_init(
         sbcfg,
         md5: Md5::new(),
         md5_state: MimeSmtpMd5State::MimeSmtpMd5Disabled,
-        md5_result: [0; 16].into(),
+        // md5_result: [0; 16].into(),
+        // body_md5: String::new(),
+        md5_result: String::new(),
     };
     return Some(r);
 }
@@ -638,7 +639,8 @@ pub unsafe extern "C" fn SCSmtpMimeParseLine(
 fn mime_smtp_complete(ctx: &mut MimeStateSMTP) {
     if ctx.md5_state == MimeSmtpMd5State::MimeSmtpMd5Started {
         ctx.md5_state = MimeSmtpMd5State::MimeSmtpMd5Completed;
-        ctx.md5_result = ctx.md5.finalize_reset();
+        let hash = ctx.md5.finalize_reset();
+        ctx.md5_result = format!("{:x}", hash);
     }
     // look for url in the last unfinished line
     mime_smtp_find_url_strings(ctx, b"\n");

--- a/rust/src/mime/smtp_log.rs
+++ b/rust/src/mime/smtp_log.rs
@@ -43,8 +43,7 @@ pub unsafe extern "C" fn SCMimeSmtpLogSubjectMd5(
 
 fn log_body_md5(js: &mut JsonBuilder, ctx: &MimeStateSMTP) -> Result<(), JsonError> {
     if ctx.md5_state == MimeSmtpMd5State::MimeSmtpMd5Completed {
-        let hash = format!("{:x}", ctx.md5_result);
-        js.set_string("body_md5", &hash)?;
+        js.set_string("body_md5", &ctx.md5_result)?;
     }
     return Ok(());
 }

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -32,6 +32,7 @@ static int g_mime_email_message_id_buffer_id = 0;
 static int g_mime_email_x_mailer_buffer_id = 0;
 static int g_mime_email_url_buffer_id = 0;
 static int g_mime_email_received_buffer_id = 0;
+static int g_mime_email_body_md5_buffer_id = 0;
 
 static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
 {
@@ -355,6 +356,41 @@ static InspectionBuffer *GetMimeEmailReceivedData(DetectEngineThreadCtx *det_ctx
     return buffer;
 }
 
+static int DetectMimeEmailBodyMd5Setup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
+{
+    if (DetectBufferSetActiveList(de_ctx, s, g_mime_email_body_md5_buffer_id) < 0)
+        return -1;
+
+    if (DetectSignatureSetAppProto(s, ALPROTO_SMTP) < 0)
+        return -1;
+
+    return 0;
+}
+
+static InspectionBuffer *GetMimeEmailBodyMd5Data(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
+        const int list_id)
+{
+    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
+    if (buffer->inspect == NULL) {
+        SMTPTransaction *tx = (SMTPTransaction *)txv;
+
+        const uint8_t *b_email_body_md5 = NULL;
+        uint32_t b_email_body_md5_len = 0;
+
+        if (tx->mime_state == NULL)
+            return NULL;
+
+        if (SCDetectMimeEmailGetBodyMd5(tx->mime_state, &b_email_body_md5, &b_email_body_md5_len) !=
+                1)
+            return NULL;
+
+        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_body_md5, b_email_body_md5_len);
+        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
+    }
+    return buffer;
+}
+
 void DetectEmailRegister(void)
 {
     SCSigTableElmt kw = { 0 };
@@ -457,4 +493,15 @@ void DetectEmailRegister(void)
             "MIME EMAIL RECEIVED", ALPROTO_SMTP, false,
             true, // to server
             GetMimeEmailReceivedData);
+
+    kw.name = "email.body_md5";
+    kw.desc = "'md5' hash generated from an email body";
+    kw.url = "/rules/email-keywords.html#email.body_md5";
+    kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailBodyMd5Setup;
+    kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
+    DetectHelperKeywordRegister(&kw);
+    g_mime_email_body_md5_buffer_id = DetectHelperBufferMpmRegister("email.body_md5",
+            "MIME EMAIL BODY MD5", ALPROTO_SMTP, false,
+            true, // to server
+            GetMimeEmailBodyMd5Data);
 }


### PR DESCRIPTION
Ticket: [#7587](https://redmine.openinfosecfoundation.org/issues/7587)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [ ] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket:
https://redmine.openinfosecfoundation.org/issues/7587

### Description:
- Implement ``email.body_md5``  keyword.

### Changes:
- Fix nits

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2450
Previous PR: https://github.com/OISF/suricata/pull/13034
