### PR TITLE
detect: factorize code for DetectSetupDirection (transactional rules)

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -78,7 +78,7 @@ void DetectFiledataRegister(void)
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FILE_DATA].RegisterTests = DetectFiledataRegisterTests;
 #endif
-    sigmatch_table[DETECT_FILE_DATA].flags = SIGMATCH_OPTIONAL_OPT;
+    sigmatch_table[DETECT_FILE_DATA].flags = SIGMATCH_OPTIONAL_OPT | SIGMATCH_SUPPORT_DIR;
 
     filehandler_table[DETECT_FILE_DATA].name = "file_data";
     filehandler_table[DETECT_FILE_DATA].priority = 2;
@@ -140,11 +140,6 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
         return -1;
     }
 
-    if (DetectSetupDirection(s, str) < 0) {
-        SCLogError("file.data failed to setup direction");
-        return -1;
-    }
-
     if (s->alproto == ALPROTO_SMTP && (s->init_data->init_flags & SIG_FLAG_INIT_FLOW) &&
         !(s->flags & SIG_FLAG_TOSERVER) && (s->flags & SIG_FLAG_TOCLIENT)) {
         SCLogError("The 'file-data' keyword cannot be used with SMTP flow:to_client or "
@@ -166,8 +161,6 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
         }
         s->init_data->init_flags |= SIG_FLAG_INIT_TXDIR_STREAMING_TOSERVER;
     }
-    s->init_data->init_flags &= ~SIG_FLAG_INIT_FORCE_TOSERVER;
-    s->init_data->init_flags &= ~SIG_FLAG_INIT_FORCE_TOCLIENT;
 
     SetupDetectEngineConfig(de_ctx);
     return 0;

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -113,7 +113,8 @@ void DetectFilemagicRegister(void)
     sigmatch_table[DETECT_FILE_MAGIC].desc = "sticky buffer to match on the file magic";
     sigmatch_table[DETECT_FILE_MAGIC].url = "/rules/file-keywords.html#filemagic";
     sigmatch_table[DETECT_FILE_MAGIC].Setup = DetectFilemagicSetupSticky;
-    sigmatch_table[DETECT_FILE_MAGIC].flags = SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER;
+    sigmatch_table[DETECT_FILE_MAGIC].flags =
+            SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_SUPPORT_DIR;
 
     filehandler_table[DETECT_FILE_MAGIC].name = "file.magic",
     filehandler_table[DETECT_FILE_MAGIC].priority = 2;
@@ -249,10 +250,6 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, const ch
  */
 static int DetectFilemagicSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    if (DetectSetupDirection(s, str) < 0) {
-        SCLogError("file.magic failed to setup direction");
-        return -1;
-    }
     if (DetectBufferSetActiveList(de_ctx, s, g_file_magic_buffer_id) < 0)
         return -1;
 

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -99,7 +99,8 @@ void DetectFilenameRegister(void)
     sigmatch_table[DETECT_FILE_NAME].desc = "sticky buffer to match on the file name";
     sigmatch_table[DETECT_FILE_NAME].url = "/rules/file-keywords.html#filename";
     sigmatch_table[DETECT_FILE_NAME].Setup = DetectFilenameSetupSticky;
-    sigmatch_table[DETECT_FILE_NAME].flags = SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER;
+    sigmatch_table[DETECT_FILE_NAME].flags =
+            SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_SUPPORT_DIR;
 
     DetectBufferTypeSetDescriptionByName("file.name", "file name");
 
@@ -207,10 +208,6 @@ static int DetectFilenameSetup (DetectEngineCtx *de_ctx, Signature *s, const cha
  */
 static int DetectFilenameSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    if (DetectSetupDirection(s, str) < 0) {
-        SCLogError("file.name failed to setup direction");
-        return -1;
-    }
     if (DetectBufferSetActiveList(de_ctx, s, g_file_name_buffer_id) < 0)
         return -1;
     s->file_flags |= (FILE_SIG_NEED_FILE | FILE_SIG_NEED_FILENAME);

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -66,6 +66,7 @@ void DetectFilesizeRegister(void)
     sigmatch_table[DETECT_FILESIZE].FileMatch = DetectFilesizeMatch;
     sigmatch_table[DETECT_FILESIZE].Setup = DetectFilesizeSetup;
     sigmatch_table[DETECT_FILESIZE].Free = DetectFilesizeFree;
+    sigmatch_table[DETECT_FILESIZE].flags = SIGMATCH_SUPPORT_DIR;
 #ifdef UNITTESTS
     sigmatch_table[DETECT_FILESIZE].RegisterTests = DetectFilesizeRegisterTests;
 #endif

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -161,16 +161,8 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
  */
 static int DetectHttpHeadersSetupSticky(DetectEngineCtx *de_ctx, Signature *s, const char *str)
 {
-    if (DetectSetupDirection(s, str) < 0) {
-        SCLogError(KEYWORD_NAME " failed to setup direction");
-        return -1;
-    }
-
     if (DetectBufferSetActiveList(de_ctx, s, g_buffer_id) < 0)
         return -1;
-
-    s->init_data->init_flags &= ~SIG_FLAG_INIT_FORCE_TOSERVER;
-    s->init_data->init_flags &= ~SIG_FLAG_INIT_FORCE_TOCLIENT;
 
     if (DetectSignatureSetAppProto(s, ALPROTO_HTTP) < 0)
         return -1;
@@ -188,7 +180,8 @@ static void DetectHttpHeadersRegisterStub(void)
     sigmatch_table[KEYWORD_ID].url = "/rules/" KEYWORD_DOC;
     sigmatch_table[KEYWORD_ID].Setup = DetectHttpHeadersSetupSticky;
 #if defined(KEYWORD_TOSERVER) && defined(KEYWORD_TOSERVER)
-    sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER;
+    sigmatch_table[KEYWORD_ID].flags |=
+            SIGMATCH_OPTIONAL_OPT | SIGMATCH_INFO_STICKY_BUFFER | SIGMATCH_SUPPORT_DIR;
 #else
     sigmatch_table[KEYWORD_ID].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 #endif

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -122,7 +122,6 @@ int SC_Pcre2SubstringCopy(
 int SC_Pcre2SubstringGet(pcre2_match_data *match_data, uint32_t number, PCRE2_UCHAR **bufferptr,
         PCRE2_SIZE *bufflen);
 
-int DetectSetupDirection(Signature *s, const char *str);
 void DetectRegisterAppLayerHookLists(void);
 
 #endif /* SURICATA_DETECT_PARSE_H */

--- a/src/detect.h
+++ b/src/detect.h
@@ -1620,6 +1620,8 @@ typedef struct SigGroupHead_ {
 #define SIGMATCH_STRICT_PARSING         BIT_U16(11)
 /** keyword supported by firewall rules */
 #define SIGMATCH_SUPPORT_FIREWALL BIT_U16(12)
+/** keyword supporting setting an optional direction */
+#define SIGMATCH_SUPPORT_DIR BIT_U16(13)
 
 enum DetectEngineTenantSelectors
 {


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7665

Describe changes:
- detect: transactional rules allow filesize keyword

This means adding facility to allow non-sticky buffer keywords
- Moving `DetectSetupDirection` call site to `SigParseOptions` instead of in each keyword and use a new flag `SIGMATCH_SUPPORT_DIR`
- `DetectSetupDirection` now takes a pointer to a string, and may move the string forward to allow `filesize: to_client, >100;` so that `DetectFilesizeSetup` gets called with ">100"
- `SigMatchAppendSMToList` now sets `only_tc` and `only_ts` as `DetectBufferSetActiveList` already does

(3 commits may be better but debugging, I ended up squashing everything)

Now making transactional rules support other direction-ambiguous keywords should be one-liner like adding `SIGMATCH_SUPPORT_DIR` to `sigmatch_table[DETECT_KEYWORD].flags`

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2453

#13045 clean