### PR TITLE
Http1 updatetx 7668 v1

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -898,6 +898,7 @@ static void DNP3HandleUserDataRequest(DNP3State *dnp3, const uint8_t *input,
         if (unlikely(tx == NULL)) {
             return;
         }
+        tx->tx_data.updated_ts = true;
         tx->lh = *lh;
         tx->th = th;
         tx->ah = *ah;
@@ -971,6 +972,7 @@ static void DNP3HandleUserDataResponse(DNP3State *dnp3, const uint8_t *input,
         if (unlikely(tx == NULL)) {
             return;
         }
+        tx->tx_data.updated_tc = true;
         tx->lh = *lh;
         tx->th = th;
         tx->ah = *ah;

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -450,6 +450,7 @@ static AppLayerResult FTPParseRequest(Flow *f, void *ftp_state, AppLayerParserSt
         FTPTransaction *tx = FTPTransactionCreate(state);
         if (unlikely(tx == NULL))
             SCReturnStruct(APP_LAYER_ERROR);
+        tx->tx_data.updated_ts = true;
         state->curr_tx = tx;
 
         tx->command_descriptor = cmd_descriptor;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1703,9 +1703,8 @@ static int HTPCallbackRequestStart(const htp_connp_t *connp, htp_tx_t *tx)
         }
         tx_ud->tx_data.file_tx = STREAM_TOSERVER | STREAM_TOCLIENT; // each http tx may xfer files
         htp_tx_set_user_data(tx, tx_ud);
-    } else {
-        tx_ud->tx_data.updated_ts = true;
     }
+    tx_ud->tx_data.updated_ts = true;
     SCReturnInt(HTP_STATUS_OK);
 }
 
@@ -1745,9 +1744,8 @@ static int HTPCallbackResponseStart(const htp_connp_t *connp, htp_tx_t *tx)
         tx_ud->tx_data.file_tx =
                 STREAM_TOCLIENT; // each http tx may xfer files. Toserver already missed.
         htp_tx_set_user_data(tx, tx_ud);
-    } else {
-        tx_ud->tx_data.updated_tc = true;
     }
+    tx_ud->tx_data.updated_tc = true;
     SCReturnInt(HTP_STATUS_OK);
 }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7668

Describe changes:
- http1, ftp, dnp3 : mark tx as updated on allocating transaction (as done as `AppLayerTxData::new()` in rust)

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2456
