### PR TITLE
detect/transform: add identity data from a transform into the detect buffer hash value 

### DIFF
--- a/rust/src/detect/transforms/casechange.rs
+++ b/rust/src/detect/transforms/casechange.rs
@@ -80,6 +80,7 @@ pub unsafe extern "C" fn DetectTransformToLowerRegister() {
         Transform: tolower_transform,
         Free: None,
         TransformValidate: Some(tolower_validate),
+        TransformId: None,
     };
     G_TRANSFORM_TOLOWER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_TOLOWER_ID < 0 {
@@ -140,6 +141,7 @@ pub unsafe extern "C" fn DetectTransformToUpperRegister() {
         Transform: toupper_transform,
         Free: None,
         TransformValidate: Some(toupper_validate),
+        TransformId: None,
     };
     G_TRANSFORM_TOUPPER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_TOUPPER_ID < 0 {

--- a/rust/src/detect/transforms/compress_whitespace.rs
+++ b/rust/src/detect/transforms/compress_whitespace.rs
@@ -49,7 +49,9 @@ fn compress_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn compress_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn compress_whitespace_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -103,6 +105,7 @@ pub unsafe extern "C" fn DetectTransformCompressWhitespaceRegister() {
         Transform: compress_whitespace_transform,
         Free: None,
         TransformValidate: Some(compress_whitespace_validate),
+        TransformId: None,
     };
     G_TRANSFORM_COMPRESS_WHITESPACE_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_COMPRESS_WHITESPACE_ID < 0 {

--- a/rust/src/detect/transforms/domain.rs
+++ b/rust/src/detect/transforms/domain.rs
@@ -110,6 +110,7 @@ pub unsafe extern "C" fn SCDetectTransformDomainRegister() {
         Transform: domain_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     unsafe {
         G_TRANSFORM_DOMAIN_ID = DetectHelperTransformRegister(&kw);
@@ -127,6 +128,7 @@ pub unsafe extern "C" fn SCDetectTransformDomainRegister() {
         Transform: tld_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     unsafe {
         G_TRANSFORM_TLD_ID = DetectHelperTransformRegister(&kw);

--- a/rust/src/detect/transforms/dotprefix.rs
+++ b/rust/src/detect/transforms/dotprefix.rs
@@ -41,7 +41,9 @@ fn dot_prefix_transform_do(input: &[u8], output: &mut [u8]) {
     output[0] = b'.';
 }
 
-unsafe extern "C" fn dot_prefix_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn dot_prefix_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input_len = InspectionBufferLength(buffer);
     if input_len == 0 {
         return;
@@ -76,6 +78,7 @@ pub unsafe extern "C" fn DetectTransformDotPrefixRegister() {
         Transform: dot_prefix_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     unsafe {
         G_TRANSFORM_DOT_PREFIX_ID = DetectHelperTransformRegister(&kw);

--- a/rust/src/detect/transforms/hash.rs
+++ b/rust/src/detect/transforms/hash.rs
@@ -80,6 +80,7 @@ pub unsafe extern "C" fn DetectTransformMd5Register() {
         Transform: md5_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_MD5_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_MD5_ID < 0 {
@@ -132,6 +133,7 @@ pub unsafe extern "C" fn DetectTransformSha1Register() {
         Transform: sha1_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_SHA1_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_SHA1_ID < 0 {
@@ -184,6 +186,7 @@ pub unsafe extern "C" fn DetectTransformSha256Register() {
         Transform: sha256_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_SHA256_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_SHA256_ID < 0 {

--- a/rust/src/detect/transforms/http_headers.rs
+++ b/rust/src/detect/transforms/http_headers.rs
@@ -52,7 +52,9 @@ fn header_lowertransform_do(input: &[u8], output: &mut [u8]) {
     }
 }
 
-unsafe extern "C" fn header_lowertransform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn header_lowertransform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -83,6 +85,7 @@ pub unsafe extern "C" fn DetectTransformHeaderLowercaseRegister() {
         Transform: header_lowertransform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_HEADER_LOWER_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_HEADER_LOWER_ID < 0 {
@@ -114,7 +117,9 @@ fn strip_pseudo_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn strip_pseudo_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_pseudo_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -145,6 +150,7 @@ pub unsafe extern "C" fn DetectTransformStripPseudoHeadersRegister() {
         Transform: strip_pseudo_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_STRIP_PSEUDO_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_STRIP_PSEUDO_ID < 0 {

--- a/rust/src/detect/transforms/mod.rs
+++ b/rust/src/detect/transforms/mod.rs
@@ -38,9 +38,13 @@ pub struct SCTransformTableElmt {
     pub flags: u16,
     pub Setup: unsafe extern "C" fn(de: *mut c_void, s: *mut c_void, raw: *const c_char) -> c_int,
     pub Free: Option<unsafe extern "C" fn(de: *mut c_void, ptr: *mut c_void)>,
-    pub Transform: unsafe extern "C" fn(_det: *mut c_void, inspect_buf: *mut c_void, options: *mut c_void),
+    pub Transform:
+        unsafe extern "C" fn(_det: *mut c_void, inspect_buf: *mut c_void, options: *mut c_void),
     pub TransformValidate:
         Option<unsafe extern "C" fn(content: *const u8, len: u16, context: *mut c_void) -> bool>,
+    pub TransformId: Option<
+        unsafe extern "C" fn(data: *mut *const u8, length: *mut u32, ctx: *mut *const c_void),
+    >,
 }
 
 /// cbindgen:ignore

--- a/rust/src/detect/transforms/strip_whitespace.rs
+++ b/rust/src/detect/transforms/strip_whitespace.rs
@@ -46,7 +46,9 @@ fn strip_whitespace_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn strip_whitespace_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn strip_whitespace_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -90,6 +92,7 @@ pub unsafe extern "C" fn DetectTransformStripWhitespaceRegister() {
         Transform: strip_whitespace_transform,
         Free: None,
         TransformValidate: Some(strip_whitespace_validate),
+        TransformId: None,
     };
     unsafe {
         G_TRANSFORM_STRIP_WHITESPACE_ID = DetectHelperTransformRegister(&kw);

--- a/rust/src/detect/transforms/urldecode.rs
+++ b/rust/src/detect/transforms/urldecode.rs
@@ -86,7 +86,9 @@ fn url_decode_transform_do(input: &[u8], output: &mut [u8]) -> u32 {
     return nb as u32;
 }
 
-unsafe extern "C" fn url_decode_transform(_det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void) {
+unsafe extern "C" fn url_decode_transform(
+    _det: *mut c_void, buffer: *mut c_void, _ctx: *mut c_void,
+) {
     let input = InspectionBufferPtr(buffer);
     let input_len = InspectionBufferLength(buffer);
     if input.is_null() || input_len == 0 {
@@ -118,6 +120,7 @@ pub unsafe extern "C" fn DetectTransformUrlDecodeRegister() {
         Transform: url_decode_transform,
         Free: None,
         TransformValidate: None,
+        TransformId: None,
     };
     G_TRANSFORM_URL_DECODE_ID = DetectHelperTransformRegister(&kw);
     if G_TRANSFORM_URL_DECODE_ID < 0 {

--- a/rust/src/detect/transforms/xor.rs
+++ b/rust/src/detect/transforms/xor.rs
@@ -101,6 +101,16 @@ unsafe extern "C" fn xor_transform(_det: *mut c_void, buffer: *mut c_void, ctx: 
     InspectionBufferTruncate(buffer, input_len);
 }
 
+unsafe extern "C" fn xor_id(data: *mut *const u8, length: *mut u32, ctx: *mut *const c_void) {
+    if data.is_null() || length.is_null() || ctx.is_null() {
+        return;
+    }
+
+    let ctx = cast_pointer!(ctx, DetectTransformXorData);
+    *data = ctx.key.as_ptr();
+    *length = ctx.key.len() as u32;
+}
+
 unsafe extern "C" fn xor_free(_de: *mut c_void, ctx: *mut c_void) {
     std::mem::drop(Box::from_raw(ctx as *mut DetectTransformXorData));
 }
@@ -116,11 +126,12 @@ pub unsafe extern "C" fn DetectTransformXorRegister() {
         Transform: xor_transform,
         Free: Some(xor_free),
         TransformValidate: None,
+        TransformId: Some(xor_id),
     };
     unsafe {
         G_TRANSFORM_XOR_ID = DetectHelperTransformRegister(&kw);
         if G_TRANSFORM_XOR_ID < 0 {
-            SCLogWarning!("Failed registering transform dot_prefix");
+            SCLogWarning!("Failed registering transform xor");
         }
     }
 }
@@ -137,6 +148,32 @@ mod tests {
             xor_parse_do("0a0DC8ff"),
             Some(DetectTransformXorData { key: key.to_vec() })
         );
+    }
+
+    #[test]
+    fn test_xor_id() {
+        let ctx = Box::new(DetectTransformXorData {
+            key: vec![1, 2, 3, 4, 5],
+        });
+
+        let ctx_ptr: *const c_void = &*ctx as *const _ as *const c_void;
+
+        let mut data_ptr: *const u8 = std::ptr::null();
+        let mut length: u32 = 0;
+
+        unsafe {
+            xor_id(
+                &mut data_ptr as *mut _,
+                &mut length as *mut _,
+                ctx_ptr as *mut _,
+            );
+
+            assert!(!data_ptr.is_null(), "data_ptr should not be null");
+            assert_eq!(length, 5);
+
+            let actual = std::slice::from_raw_parts(data_ptr, length as usize);
+            assert_eq!(actual, &[1, 2, 3, 4, 5]);
+        }
     }
 
     #[test]

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -165,6 +165,8 @@ int DetectHelperTransformRegister(const SCTransformTableElmt *kw)
     sigmatch_table[transform_id].Setup =
             (int (*)(DetectEngineCtx * de, Signature * s, const char *raw)) kw->Setup;
     sigmatch_table[transform_id].Free = (void (*)(DetectEngineCtx * de, void *ptr)) kw->Free;
+    sigmatch_table[transform_id].TransformId =
+            (void (*)(uint8_t * *id_data, uint32_t * length, const void *context)) kw->TransformId;
 
     return transform_id;
 }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -987,12 +987,37 @@ int DetectBufferTypeMaxId(void)
     return g_buffer_type_id;
 }
 
+static void DetectBufferAddTransformData(DetectBufferType *map)
+{
+    for (int i = 0; i < map->transforms.cnt; i++) {
+        const TransformData *t = &map->transforms.transforms[i];
+        if (sigmatch_table[t->transform].TransformId) {
+            sigmatch_table[t->transform].TransformId(
+                    &map->xform_id[i].id_data, &map->xform_id[i].id_data_len, t->options);
+            SCLogDebug("transform identity data: [%p] \"%s\" [%d]", map->xform_id[i].id_data,
+                    (char *)map->xform_id[i].id_data, map->xform_id[i].id_data_len);
+        }
+    }
+}
+
 static uint32_t DetectBufferTypeHashNameFunc(HashListTable *ht, void *data, uint16_t datalen)
 {
     const DetectBufferType *map = (DetectBufferType *)data;
     uint32_t hash = hashlittle_safe(map->name, strlen(map->name), 0);
-    hash += hashlittle_safe((uint8_t *)&map->transforms, sizeof(map->transforms), 0);
+
+    // Add the transform data
+    // - Collect transform id and position
+    // - Collect identity data, if any
+    for (int i = 0; i < map->transforms.cnt; i++) {
+        const TransformData *t = &map->transforms.transforms[i];
+        int tval = t->transform + i;
+        hash += hashlittle_safe((uint8_t *)&tval, sizeof(tval), 0);
+        if (map->xform_id[i].id_data) {
+            hash += hashlittle_safe(map->xform_id[i].id_data, map->xform_id[i].id_data_len, 0);
+        }
+    }
     hash %= ht->array_size;
+    SCLogDebug("map->name %s, hash %d", map->name, hash);
     return hash;
 }
 
@@ -1010,7 +1035,48 @@ static char DetectBufferTypeCompareNameFunc(void *data1, uint16_t len1, void *da
     DetectBufferType *map2 = (DetectBufferType *)data2;
 
     char r = (strcmp(map1->name, map2->name) == 0);
-    r &= (memcmp((uint8_t *)&map1->transforms, (uint8_t *)&map2->transforms, sizeof(map2->transforms)) == 0);
+
+    // Compare the transforms
+    // the transform supports identity, that data will also be added.
+    if (r && map1->transforms.cnt && (map1->transforms.cnt == map2->transforms.cnt)) {
+        for (int i = 0; i < map1->transforms.cnt; i++) {
+            if (map1->transforms.transforms[i].transform !=
+                    map2->transforms.transforms[i].transform) {
+                r = 0;
+                break;
+            }
+
+            SCLogDebug("%s: transform ids match; checking specialized data", map1->name);
+            // Checks
+            // - Both NULL: --> ok, continue
+            // - One NULL: --> no match, break?
+            // - identity data lengths match: --> ok, continue
+            // - identity data matches: ok
+
+            // Stop if only one is NULL
+            if ((map1->xform_id[i].id_data == NULL) ^ (map2->xform_id[i].id_data == NULL)) {
+                SCLogDebug("identity data: only one is null");
+                r = 0;
+                break;
+            } else if (map1->xform_id[i].id_data == NULL) { /* continue when both are null */
+                SCLogDebug("identity data: both null");
+                r = 1;
+                continue;
+            } else if (map1->xform_id[i].id_data_len != map2->xform_id[i].id_data_len) {
+                // Stop when id data lengths aren't equal
+                SCLogDebug("id data: unequal lengths");
+                r = 0;
+                break;
+            }
+
+            // stop if the identity data is different
+            r &= memcmp(map1->xform_id[i].id_data, map2->xform_id[i].id_data,
+                         map1->xform_id[i].id_data_len) == 0;
+            if (r == 0)
+                break;
+            SCLogDebug("identity data: data matches");
+        }
+    }
     return r;
 }
 
@@ -1033,6 +1099,7 @@ static void DetectBufferTypeFreeFunc(void *data)
     for (int i = 0; i < map->transforms.cnt; i++) {
         if (map->transforms.transforms[i].options == NULL)
             continue;
+
         if (sigmatch_table[map->transforms.transforms[i].transform].Free == NULL) {
             SCLogError("%s allocates transform option memory but has no free routine",
                     sigmatch_table[map->transforms.transforms[i].transform].name);
@@ -1512,8 +1579,9 @@ int DetectBufferGetActiveList(DetectEngineCtx *de_ctx, Signature *s)
             SCReturnInt(-1);
         }
 
-        SCLogDebug("buffer %d has transform(s) registered: %d",
-                s->init_data->list, s->init_data->transforms.cnt);
+        SCLogDebug("buffer %d has transform(s) registered: %d", s->init_data->list,
+                s->init_data->transforms.cnt);
+
         int new_list = DetectEngineBufferTypeGetByIdTransforms(de_ctx, s->init_data->list,
                 s->init_data->transforms.transforms, s->init_data->transforms.cnt);
         if (new_list == -1) {
@@ -1944,6 +2012,11 @@ int DetectEngineBufferTypeGetByIdTransforms(
     memset(&lookup_map, 0, sizeof(lookup_map));
     strlcpy(lookup_map.name, base_map->name, sizeof(lookup_map.name));
     lookup_map.transforms = t;
+
+    /* Add transform identity data from transforms */
+    if (t.cnt) {
+        DetectBufferAddTransformData(&lookup_map);
+    }
     DetectBufferType *res = HashListTableLookup(de_ctx->buffer_type_hash_name, &lookup_map, 0);
 
     SCLogDebug("res %p", res);

--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -37,33 +37,48 @@
 #include "util-unittest.h"
 #include "util-print.h"
 
-static int DetectTransformFromBase64DecodeSetup(DetectEngineCtx *, Signature *, const char *);
-static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *, void *);
 #ifdef UNITTESTS
 #define DETECT_TRANSFORM_FROM_BASE64_MODE_DEFAULT (uint8_t) SCBase64ModeRFC4648
 static void DetectTransformFromBase64DecodeRegisterTests(void);
 #endif
-static void TransformFromBase64Decode(
-        DetectEngineThreadCtx *det_ctx, InspectionBuffer *buffer, void *options);
+#define B64D_ID_DATA_LEN 128
 
-void DetectTransformFromBase64DecodeRegister(void)
+static const char *id_format = "{"
+                               "\"flags\" : %d, "
+                               "\"bytes\" : { \"str\": \"%s\", \"val\": %d}, "
+                               "\"offset\" : { \"str\": \"%s\", \"val\": %d}, "
+                               "\"mode\" : %d"
+                               "}";
+
+static inline uint8_t *DetectTransformFromBase64IdData(
+        SCDetectTransformFromBase64Data *b64d, int *len)
 {
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
-#ifdef UNITTESTS
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
-            DetectTransformFromBase64DecodeRegisterTests;
-#endif
-    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
+    void *ptr = SCCalloc(1, B64D_ID_DATA_LEN);
+    if (ptr) {
+        int rc = snprintf(ptr, B64D_ID_DATA_LEN, id_format, b64d->flags,
+                b64d->nbytes_str ? b64d->nbytes_str : "n/a", b64d->nbytes,
+                b64d->offset_str ? b64d->offset_str : "n/a", b64d->offset, b64d->mode);
+        *len = rc;
+    }
+    return ptr;
+}
+
+static void DetectTransformFromBase64Id(uint8_t **data, uint32_t *length, const void *context)
+{
+    if (context) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)context;
+        *data = b64d->id_data;
+        *length = b64d->id_data_len;
+    }
 }
 
 static void DetectTransformFromBase64DecodeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCTransformBase64Free(ptr);
+    if (ptr) {
+        SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)ptr;
+        SCFree(b64d->id_data);
+        SCTransformBase64Free(ptr);
+    }
 }
 
 static SCDetectTransformFromBase64Data *DetectTransformFromBase64DecodeParse(const char *str)
@@ -104,6 +119,14 @@ static int DetectTransformFromBase64DecodeSetup(
         SCLogError("byte value must be a value, not a variable name");
         goto exit_path;
     }
+
+    int len;
+    b64d->id_data = DetectTransformFromBase64IdData(b64d, &len);
+    if (!b64d->id_data) {
+        SCLogError("Unable to allocate memory for identity representation");
+        goto exit_path;
+    }
+    b64d->id_data_len = len;
 
     r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_FROM_BASE64, b64d);
 
@@ -153,6 +176,22 @@ static void TransformFromBase64Decode(
         //            PrintRawDataFp(stdout, output, b64data->decoded_len);
         InspectionBufferCopy(buffer, decoded, num_decoded);
     }
+}
+
+void DetectTransformFromBase64DecodeRegister(void)
+{
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].name = "from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].desc = "convert the base64 decode of the buffer";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].url = "/rules/transforms.html#from_base64";
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Setup = DetectTransformFromBase64DecodeSetup;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Transform = TransformFromBase64Decode;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].TransformId = DetectTransformFromBase64Id;
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].Free = DetectTransformFromBase64DecodeFree;
+#ifdef UNITTESTS
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].RegisterTests =
+            DetectTransformFromBase64DecodeRegisterTests;
+#endif
+    sigmatch_table[DETECT_TRANSFORM_FROM_BASE64].flags |= SIGMATCH_OPTIONAL_OPT;
 }
 
 #ifdef UNITTESTS

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -31,9 +31,12 @@
 #include "detect-transform-pcrexform.h"
 #include "detect-pcre.h"
 
+#define PCRE_ID_MAX_DATA_LEN 1024
 typedef struct DetectTransformPcrexformData {
     pcre2_code *regex;
     pcre2_match_context *context;
+    uint8_t *id_data;
+    int id_data_len;
 } DetectTransformPcrexformData;
 
 static int DetectTransformPcrexformSetup (DetectEngineCtx *, Signature *, const char *);
@@ -44,6 +47,15 @@ static void DetectTransformPcrexform(
 void DetectTransformPcrexformRegisterTests (void);
 #endif
 
+static void DetectTransformPcrexformId(uint8_t **data, uint32_t *length, const void *context)
+{
+    if (context) {
+        DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *)context;
+        *data = pxd->id_data;
+        *length = pxd->id_data_len;
+    }
+}
+
 void DetectTransformPcrexformRegister(void)
 {
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].name = "pcrexform";
@@ -52,6 +64,7 @@ void DetectTransformPcrexformRegister(void)
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].url = "/rules/transforms.html#pcre-xform";
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Transform =
         DetectTransformPcrexform;
+    sigmatch_table[DETECT_TRANSFORM_PCREXFORM].TransformId = DetectTransformPcrexformId;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Free =
         DetectTransformPcrexformFree;
     sigmatch_table[DETECT_TRANSFORM_PCREXFORM].Setup =
@@ -66,8 +79,11 @@ static void DetectTransformPcrexformFree(DetectEngineCtx *de_ctx, void *ptr)
 {
     if (ptr != NULL) {
         DetectTransformPcrexformData *pxd = (DetectTransformPcrexformData *) ptr;
+
         pcre2_match_context_free(pxd->context);
         pcre2_code_free(pxd->regex);
+
+        SCFree(pxd->id_data);
         SCFree(pxd);
     }
 }
@@ -112,6 +128,7 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         SCFree(pxd);
         SCReturnInt(-1);
     }
+
     // check pcd->regex has exactly one capture expression
     uint32_t nb;
     if (pcre2_pattern_info(pxd->regex, PCRE2_INFO_CAPTURECOUNT, &nb) < 0) {
@@ -124,6 +141,15 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         DetectTransformPcrexformFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
+
+    size_t regexstr_len = MIN(PCRE_ID_MAX_DATA_LEN, strlen(regexstr));
+    pxd->id_data = (uint8_t *)SCCalloc(1, regexstr_len);
+    if (pxd->id_data == NULL) {
+        DetectTransformPcrexformFree(de_ctx, pxd);
+        SCReturnInt(-1);
+    }
+    pxd->id_data_len = regexstr_len;
+    memcpy(pxd->id_data, regexstr, regexstr_len);
 
     int r = DetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
     if (r != 0) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -460,9 +460,15 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct DetectEngineAppInspectionEngine_ *next;
 } DetectEngineAppInspectionEngine;
 
+typedef struct TransformIdData_ {
+    uint8_t *id_data;
+    uint32_t id_data_len;
+} TransformIdData;
+
 typedef struct DetectBufferType_ {
     char name[64];
     char description[128];
+    TransformIdData xform_id[DETECT_TRANSFORMS_MAX];
     int id;
     int parent_id;
     bool mpm;
@@ -1382,6 +1388,9 @@ typedef struct SigTableElmt_ {
     /** InspectionBuffer transformation callback */
     void (*Transform)(DetectEngineThreadCtx *, InspectionBuffer *, void *context);
     bool (*TransformValidate)(const uint8_t *content, uint16_t content_len, void *context);
+
+    /** Transform identity callback */
+    void (*TransformId)(uint8_t **data, uint32_t *length, const void *context);
 
     /** keyword setup function pointer */
     int (*Setup)(DetectEngineCtx *, Signature *, const char *);


### PR DESCRIPTION
Continuation of #13058  

Transforms that support optional strings, like from_base64 and pcrexform, should also support identity-data to treat transforms with like transform options as the same.

This commit demonstrates
- When computing a hash, include identity data from the transform
- When comparing, include the identity data from the transforms
- Omitting the "options" ptr from the transform hash/compare
- Modify xor, pcrexform, and from_base64 to supply identity data for disambiguation in the compare/hash logic.

Updates:
- Modify identity function to support rust better; now uses pointer, nbytes instead of a structure
- Update rust transforms with transform identity function
- Add identity to xor transform.
- Fix compiler warning when computing hash value for transforms (see https://github.com/OISF/suricata/pull/12971)
- Check memory allocation values
- Move identity data collection to hash table user (from hash computation function)
- Formatting fixup (again :-( )
- Rust clippy fixup
- Change term from "serialization" to "identity"
- Formatting fixup (see #13041 )
- Increase PCRE ID string len (see #1051) to 1024 bytes or the actual length, whichever is shorter.
- Rename fields in base64-identity string -- `cnt` -> `val`
- Remove extraneous line from pcrexform (line with only `;` )

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
