### PR TITLE
websocket: fixes substraction

### DIFF
--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -261,7 +261,7 @@ impl WebSocketState {
                                     let end = if v.len() + (dec.total_out() - before) as usize
                                         > max_pl_size as usize
                                     {
-                                        v.len() - max_pl_size as usize
+                                        max_pl_size as usize - v.len()
                                     } else {
                                         (dec.total_out() - before) as usize
                                     };


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7285
Found by oss-fuzz: https://issues.oss-fuzz.com/u/1/issues/411998246

Describe changes:
- websocket: fixes substraction

Follow-up on https://github.com/OISF/suricata/pull/13022
Fixes: 16f74c68aaa9 ("websocket: use max window bits of 15")

