### PR TITLE
http: fail tx creation if we cannot allocate user data

### DIFF
--- a/rust/htp/src/c_api/config.rs
+++ b/rust/htp/src/c_api/config.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 use crate::{
     config::{Config, HtpServerPersonality, HtpUrlEncodingHandling},
-    hook::{DataExternalCallbackFn, TxExternalCallbackFn},
+    hook::{DataExternalCallbackFn, TxCreateCallbackFn, TxDestroyCallbackFn, TxExternalCallbackFn},
     HtpStatus,
 };
 use std::convert::TryInto;
@@ -71,6 +71,31 @@ pub unsafe extern "C" fn htp_config_register_request_line(
 ) {
     if let Some(cfg) = cfg.as_mut() {
         cfg.hook_request_line.register_extern(cbk_fn)
+    }
+}
+
+/// Registers a tx create callback, which is invoked every time a new
+/// request begins and before any parsing is done.
+/// # Safety
+/// When calling this method, you have to ensure that cfg is either properly initialized or NULL
+#[no_mangle]
+pub unsafe extern "C" fn htp_config_register_tx_create(
+    cfg: *mut Config, cbk_fn: TxCreateCallbackFn,
+) {
+    if let Some(cfg) = cfg.as_mut() {
+        cfg.hook_tx_create = Some(cbk_fn);
+    }
+}
+
+/// Registers a tx destroy callback, which is invoked every time a tx is dropped
+/// # Safety
+/// When calling this method, you have to ensure that cfg is either properly initialized or NULL
+#[no_mangle]
+pub unsafe extern "C" fn htp_config_register_tx_destroy(
+    cfg: *mut Config, cbk_fn: TxDestroyCallbackFn,
+) {
+    if let Some(cfg) = cfg.as_mut() {
+        cfg.hook_tx_destroy = Some(cbk_fn);
     }
 }
 

--- a/rust/htp/src/c_api/transaction.rs
+++ b/rust/htp/src/c_api/transaction.rs
@@ -45,16 +45,6 @@ pub unsafe extern "C" fn htp_tx_get_user_data(tx: *const Transaction) -> *mut li
         .unwrap_or(std::ptr::null_mut())
 }
 
-/// Associates user data with this transaction.
-/// # Safety
-/// When calling this method, you have to ensure that tx is either properly initialized or NULL
-#[no_mangle]
-pub unsafe extern "C" fn htp_tx_set_user_data(tx: *mut Transaction, user_data: *mut libc::c_void) {
-    if let Some(tx) = tx.as_mut() {
-        tx.set_user_data(Box::new(user_data))
-    }
-}
-
 /// Get a transaction's request line.
 ///
 /// tx: Transaction pointer.

--- a/rust/htp/src/config.rs
+++ b/rust/htp/src/config.rs
@@ -6,6 +6,8 @@ use crate::{
     HtpStatus,
 };
 
+use crate::hook::{TxCreateCallbackFn, TxDestroyCallbackFn};
+
 #[cfg(test)]
 use crate::hook::{DataNativeCallbackFn, TxNativeCallbackFn};
 
@@ -20,6 +22,14 @@ pub struct Config {
     pub(crate) server_personality: HtpServerPersonality,
     /// Decoder configuration for url path.
     pub(crate) decoder_cfg: DecoderConfig,
+    /// Transaction creation hook.
+    /// Used by suricata to allocate its transaction (user data)
+    /// And make libhtp.rs tx creation fail (return None) if suricata failed
+    /// to do the C allocation.
+    pub(crate) hook_tx_create: Option<TxCreateCallbackFn>,
+    /// Transaction destroy hook.
+    /// Used by suricata to free its transaction (user data)
+    pub(crate) hook_tx_destroy: Option<TxDestroyCallbackFn>,
     /// Request start hook, invoked when the parser receives the first byte of a new
     /// request. Because an HTTP transaction always starts with a request, this hook
     /// doubles as a transaction start hook.
@@ -104,6 +114,8 @@ impl Default for Config {
             field_limit: 18000,
             server_personality: HtpServerPersonality::MINIMAL,
             decoder_cfg: Default::default(),
+            hook_tx_create: None,
+            hook_tx_destroy: None,
             hook_request_start: TxHook::default(),
             hook_request_line: TxHook::default(),
             hook_request_header_data: DataHook::default(),

--- a/rust/htp/src/hook.rs
+++ b/rust/htp/src/hook.rs
@@ -16,6 +16,12 @@ pub(crate) type TxNativeCallbackFn = fn(tx: &mut Transaction) -> Result<()>;
 pub(crate) type TxHook = Hook<TxExternalCallbackFn, TxNativeCallbackFn>;
 
 /// External (C) callback function prototype
+pub(crate) type TxCreateCallbackFn = unsafe extern "C" fn(req: bool) -> *mut libc::c_void;
+
+/// External (C) callback function prototype
+pub(crate) type TxDestroyCallbackFn = unsafe extern "C" fn(tx_ud: *mut libc::c_void);
+
+/// External (C) callback function prototype
 pub(crate) type DataExternalCallbackFn =
     unsafe extern "C" fn(connp: *const ConnectionParser, data: *mut Data) -> HtpStatus;
 

--- a/rust/htp/src/transactions.rs
+++ b/rust/htp/src/transactions.rs
@@ -67,7 +67,11 @@ impl Transactions {
                 if nbtx >= cfg.max_tx as usize {
                     return None;
                 }
-                Some(entry.insert(Transaction::new(cfg, logger, request)))
+                let tx = Transaction::new(cfg, logger, request, true);
+                if let Some(tx) = tx {
+                    return Some(entry.insert(tx));
+                }
+                None
             }
         }
     }
@@ -97,7 +101,11 @@ impl Transactions {
                 if nbtx >= cfg.max_tx as usize {
                     return None;
                 }
-                Some(entry.insert(Transaction::new(cfg, logger, response)))
+                let tx = Transaction::new(cfg, logger, response, false);
+                if let Some(tx) = tx {
+                    return Some(entry.insert(tx));
+                }
+                None
             }
         }
     }

--- a/src/detect-config.c
+++ b/src/detect-config.c
@@ -94,23 +94,18 @@ static void ConfigApplyTx(Flow *f,
     void *tx = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, tx_id);
     if (tx) {
         AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, tx);
-        if (txd) {
-            SCLogDebug("tx %p txd %p: log_flags %x", tx, txd, txd->config.log_flags);
-            txd->config.log_flags |= BIT_U8(config->type);
+        SCLogDebug("tx %p txd %p: log_flags %x", tx, txd, txd->config.log_flags);
+        txd->config.log_flags |= BIT_U8(config->type);
 
-            const bool unidir =
-                    (txd->flags & (APP_LAYER_TX_SKIP_INSPECT_TS | APP_LAYER_TX_SKIP_INSPECT_TC)) !=
-                    0;
-            if (unidir) {
-                SCLogDebug("handle unidir tx");
-                AppLayerTxConfig req;
-                memset(&req, 0, sizeof(req));
-                req.log_flags = BIT_U8(config->type);
-                AppLayerParserApplyTxConfig(
-                        f->proto, f->alproto, f->alstate, tx, CONFIG_ACTION_SET, req);
-            }
-        } else {
-            SCLogDebug("no tx data");
+        const bool unidir =
+                (txd->flags & (APP_LAYER_TX_SKIP_INSPECT_TS | APP_LAYER_TX_SKIP_INSPECT_TC)) != 0;
+        if (unidir) {
+            SCLogDebug("handle unidir tx");
+            AppLayerTxConfig req;
+            memset(&req, 0, sizeof(req));
+            req.log_flags = BIT_U8(config->type);
+            AppLayerParserApplyTxConfig(
+                    f->proto, f->alproto, f->alstate, tx, CONFIG_ACTION_SET, req);
         }
     } else {
         SCLogDebug("no tx");

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -219,11 +219,6 @@ void DetectRunStoreStateTx(
         const uint16_t file_no_match)
 {
     AppLayerTxData *tx_data = AppLayerParserGetTxData(f->proto, f->alproto, tx);
-    BUG_ON(tx_data == NULL);
-    if (tx_data == NULL) {
-        SCLogDebug("No TX data for %" PRIu64, tx_id);
-        return;
-    }
     if (tx_data->de_state == NULL) {
         tx_data->de_state = DetectEngineStateAlloc();
         if (tx_data->de_state == NULL)

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -159,15 +159,12 @@ static int FilestorePostMatchWithOptions(Packet *p, Flow *f, const DetectFilesto
         DEBUG_VALIDATE_BUG_ON(txv == NULL);
         if (txv != NULL) {
             AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
-            DEBUG_VALIDATE_BUG_ON(txd == NULL);
-            if (txd != NULL) {
-                if (toclient_dir) {
-                    txd->file_flags |= FLOWFILE_STORE_TC;
-                }
+            if (toclient_dir) {
+                txd->file_flags |= FLOWFILE_STORE_TC;
+            }
                 if (toserver_dir) {
                     txd->file_flags |= FLOWFILE_STORE_TS;
                 }
-            }
         }
     } else if (this_flow) {
         /* set in flow and AppLayerStateData */

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -182,11 +182,6 @@ static int DetectHttpClientBodySetupSticky(DetectEngineCtx *de_ctx, Signature *s
 static inline HtpBody *GetRequestBody(htp_tx_t *tx)
 {
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
-    if (htud == NULL) {
-        SCLogDebug("no htud");
-        return NULL;
-    }
-
     return &htud->request_body;
 }
 

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -274,9 +274,8 @@ static void PrefilterMpmHttpTrailer(DetectEngineThreadCtx *det_ctx, const void *
     htp_tx_t *tx = txv;
     const HtpTxUserData *htud = (const HtpTxUserData *)htp_tx_get_user_data(tx);
     /* if the request wasn't flagged as having a trailer, we skip */
-    if (htud && (
-            ((flags & STREAM_TOSERVER) && !htud->request_has_trailers) ||
-            ((flags & STREAM_TOCLIENT) && !htud->response_has_trailers))) {
+    if (((flags & STREAM_TOSERVER) && !htud->request_has_trailers) ||
+            ((flags & STREAM_TOCLIENT) && !htud->response_has_trailers)) {
         SCReturn;
     }
     PrefilterMpmHttpHeader(det_ctx, pectx, p, f, txv, idx, _txd, flags);

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -191,8 +191,6 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         htp_tx_t *tx = (htp_tx_t *)txv;
 
         HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
-        if (tx_ud == NULL)
-            return NULL;
 
         const bool ts = ((flow_flags & STREAM_TOSERVER) != 0);
         const uint8_t *data = ts ?
@@ -280,9 +278,8 @@ static void PrefilterMpmHttpTrailerRaw(DetectEngineThreadCtx *det_ctx, const voi
     htp_tx_t *tx = txv;
     const HtpTxUserData *htud = (const HtpTxUserData *)htp_tx_get_user_data(tx);
     /* if the request wasn't flagged as having a trailer, we skip */
-    if (htud && (
-            ((flags & STREAM_TOSERVER) && !htud->request_has_trailers) ||
-            ((flags & STREAM_TOCLIENT) && !htud->response_has_trailers))) {
+    if (((flags & STREAM_TOSERVER) && !htud->request_has_trailers) ||
+            ((flags & STREAM_TOCLIENT) && !htud->response_has_trailers)) {
         SCReturn;
     }
     PrefilterMpmHttpHeaderRaw(det_ctx, pectx, p, f, txv, idx, _txd, flags);

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -224,9 +224,6 @@ static int DetectXbitTxMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t fl
     BUG_ON(xd == NULL);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
-    if (txd == NULL) {
-        return 0;
-    }
 
     SCLogDebug("sid:%u: tx:%" PRIu64 ", txd->txbits:%p", s->id, det_ctx->tx_id, txd->txbits);
     int r = TxBitIsset(txd, xd->idx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -590,9 +590,8 @@ static bool IsOnlyTxInDirection(Flow *f, uint64_t txid, uint8_t dir)
         if (tx) {
             AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, tx);
             // test if the other tx is unidirectional in the other way
-            if (txd && ((dir == STREAM_TOSERVER && (txd->flags & APP_LAYER_TX_SKIP_INSPECT_TS)) ||
-                               (dir == STREAM_TOCLIENT &&
-                                       (txd->flags & APP_LAYER_TX_SKIP_INSPECT_TC)))) {
+            if ((dir == STREAM_TOSERVER && (txd->flags & APP_LAYER_TX_SKIP_INSPECT_TS)) ||
+                    (dir == STREAM_TOCLIENT && (txd->flags & APP_LAYER_TX_SKIP_INSPECT_TC))) {
                 return true;
             }
         }
@@ -1358,10 +1357,6 @@ static DetectTransaction GetDetectTx(const uint8_t ipproto, const AppProto alpro
         const uint64_t tx_id, void *tx_ptr, const int tx_end_state, const uint8_t flow_flags)
 {
     AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx_ptr);
-    if (unlikely(txd == NULL)) {
-        DetectTransaction no_tx = NO_TX;
-        return no_tx;
-    }
     const int tx_progress = AppLayerParserGetStateProgress(ipproto, alproto, tx_ptr, flow_flags);
     bool updated = (flow_flags & STREAM_TOSERVER) ? txd->updated_ts : txd->updated_tc;
     if (!updated && tx_progress < tx_end_state && ((flow_flags & STREAM_EOF) == 0)) {

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -114,10 +114,8 @@ static void CloseFile(const Packet *p, Flow *f, File *file, void *txv)
     DEBUG_VALIDATE_BUG_ON((file->flags & FILE_STORED) != 0);
 
     AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
-    if (txd) {
-        BUG_ON(f->alproto == ALPROTO_SMB && txd->files_logged != 0);
-        txd->files_stored++;
-    }
+    BUG_ON(f->alproto == ALPROTO_SMB && txd->files_logged != 0);
+    txd->files_stored++;
     file->flags |= FILE_STORED;
 }
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -395,10 +395,8 @@ void EveHttpLogJSONBodyPrintable(SCJsonBuilder *js, Flow *f, uint64_t tx_id)
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, tx_id);
         if (tx) {
             HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
-            if (htud != NULL) {
-                BodyPrintableBuffer(js, &htud->request_body, "http_request_body_printable");
-                BodyPrintableBuffer(js, &htud->response_body, "http_response_body_printable");
-            }
+            BodyPrintableBuffer(js, &htud->request_body, "http_request_body_printable");
+            BodyPrintableBuffer(js, &htud->response_body, "http_response_body_printable");
         }
     }
 }
@@ -426,10 +424,8 @@ void EveHttpLogJSONBodyBase64(SCJsonBuilder *js, Flow *f, uint64_t tx_id)
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP1, htp_state, tx_id);
         if (tx) {
             HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
-            if (htud != NULL) {
-                BodyBase64Buffer(js, &htud->request_body, "http_request_body");
-                BodyBase64Buffer(js, &htud->response_body, "http_response_body");
-            }
+            BodyBase64Buffer(js, &htud->request_body, "http_request_body");
+            BodyBase64Buffer(js, &htud->response_body, "http_response_body");
         }
     }
 }

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -178,19 +178,18 @@ static int HttpBodyIterator(Flow *f, int close, void *cbdata, uint8_t iflags)
         }
 
         SCLogDebug("tx %p", tx);
-        HtpTxUserData *htud = (HtpTxUserData *) htp_tx_get_user_data(tx);
-        if (htud != NULL) {
-            SCLogDebug("htud %p", htud);
-            HtpBody *body = NULL;
-            if (iflags & OUTPUT_STREAMING_FLAG_TOSERVER)
-                body = &htud->request_body;
-            else if (iflags & OUTPUT_STREAMING_FLAG_TOCLIENT)
-                body = &htud->response_body;
+        HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
+        SCLogDebug("htud %p", htud);
+        HtpBody *body = NULL;
+        if (iflags & OUTPUT_STREAMING_FLAG_TOSERVER)
+            body = &htud->request_body;
+        else if (iflags & OUTPUT_STREAMING_FLAG_TOCLIENT)
+            body = &htud->response_body;
 
-            if (body == NULL) {
-                SCLogDebug("no body");
-                goto next;
-            }
+        if (body == NULL) {
+            SCLogDebug("no body");
+            goto next;
+        }
             if (body->first == NULL) {
                 SCLogDebug("no body chunks");
                 goto next;
@@ -236,7 +235,6 @@ static int HttpBodyIterator(Flow *f, int close, void *cbdata, uint8_t iflags)
                 Streamer(cbdata, f, NULL, 0, tx_id,
                          iflags|OUTPUT_STREAMING_FLAG_CLOSE|OUTPUT_STREAMING_FLAG_TRANSACTION);
             }
-        }
     }
     return 0;
 }

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -416,13 +416,6 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
         SCLogDebug("STARTING tx_id %" PRIu64 ", tx %p", tx_id, tx);
 
         AppLayerTxData *txd = AppLayerParserGetTxData(ipproto, alproto, tx);
-        if (unlikely(txd == NULL)) {
-            SCLogDebug("NO TXD");
-            /* make sure this tx, which can't be properly logged is skipped */
-            logged = 1;
-            max_id = tx_id;
-            goto next_tx;
-        }
 
         const int tx_progress_ts =
                 AppLayerParserGetStateProgress(ipproto, alproto, tx, ts_disrupt_flags);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1157,12 +1157,10 @@ void FileDisableStoringForTransaction(Flow *f, const uint8_t direction, void *tx
 {
     if (g_file_force_filestore == 0) {
         AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, tx);
-        if (txd != NULL) {
-            if (direction & STREAM_TOSERVER) {
-                txd->file_flags |= FLOWFILE_NO_STORE_TS;
-            } else {
-                txd->file_flags |= FLOWFILE_NO_STORE_TC;
-            }
+        if (direction & STREAM_TOSERVER) {
+            txd->file_flags |= FLOWFILE_NO_STORE_TS;
+        } else {
+            txd->file_flags |= FLOWFILE_NO_STORE_TC;
         }
     }
 }

--- a/src/util-lua-http.c
+++ b/src/util-lua-http.c
@@ -169,8 +169,6 @@ static int LuaHttpGetRawHeaders(lua_State *luastate, int dir)
         return 1;
     }
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx->tx);
-    if (htud == NULL)
-        return LuaCallbackError(luastate, "no htud in tx");
 
     uint8_t *raw = htud->request_headers_raw;
     uint32_t raw_len = htud->request_headers_raw_len;
@@ -245,8 +243,6 @@ static int LuaHttpGetBody(lua_State *luastate, int dir)
     }
 
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx->tx);
-    if (htud == NULL)
-        return LuaCallbackError(luastate, "no htud in tx");
 
     HtpBody *body = NULL;
     if (dir == 0)


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/5739

Describe changes:
- Introduce a new callback in htp.rs called from `Transaction::new` to allocate `HtpTxUserData`. If allocation of HtpTxUserData fails, `Transaction::new` returns None (as can already be the case with max tx)
- Thus a htp_tx_t can no longer have `htp_tx_get_user_data` return NULL
- And thus `AppLayerParserGetTxData` can no longer return NULL
- And introduce another new callback in htp.rs so that Transaction::drop does call `HtpTxUserDataFree` and we do not leak in any case

https://github.com/OISF/suricata/pull/13067 with also `impl Drop for Transaction` and its hook `hook_tx_destroy`