### PR TITLE
detect/multibuf: harmonize/unify wrapper

### DIFF
--- a/examples/plugins/altemplate/src/detect.rs
+++ b/examples/plugins/altemplate/src/detect.rs
@@ -24,9 +24,9 @@ use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
 use std::os::raw::{c_int, c_void};
 use suricata::cast_pointer;
 use suricata::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectSignatureSetAppProto,
+    SigTableElmtStickyBuffer,
 };
 use suricata::direction::Direction;
 
@@ -81,18 +81,14 @@ unsafe extern "C" fn template_buffer_get(
 pub(super) unsafe extern "C" fn detect_template_register() {
     // TODO create a suricata-verify test
     // Setup a keyword structure and register it
-    let kw = SCSigTableAppLiteElmt {
-        name: b"altemplate.buffer\0".as_ptr() as *const libc::c_char,
-        desc: b"Template content modifier to match on the template buffer\0".as_ptr()
-            as *const libc::c_char,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("altemplate.buffer"),
+        desc: String::from("Template content modifier to match on the template buffer"),
         // TODO use the right anchor for url and write doc
-        url: b"/rules/template-keywords.html#buffer\0".as_ptr() as *const libc::c_char,
-        Setup: template_buffer_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+        url: String::from("/rules/template-keywords.html#buffer"),
+        setup: template_buffer_setup,
     };
-    let _g_template_buffer_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_template_buffer_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_TEMPLATE_BUFFER_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"altemplate.buffer\0".as_ptr() as *const libc::c_char,
         b"template.buffer intern description\0".as_ptr() as *const libc::c_char,

--- a/examples/plugins/altemplate/src/log.rs
+++ b/examples/plugins/altemplate/src/log.rs
@@ -24,7 +24,6 @@
 use super::template::TemplateTransaction;
 use std::ffi::CString;
 use suricata::cast_pointer;
-use suricata::jsonbuilder::JsonError;
 use suricata_sys::jsonbuilder::{SCJbClose, SCJbOpenObject, SCJbSetString, SCJsonBuilder};
 
 use std;
@@ -35,30 +34,30 @@ pub struct SCJsonBuilderWrapper {
 }
 
 impl SCJsonBuilderWrapper {
-    fn close(&mut self) -> Result<(), JsonError> {
+    fn close(&mut self) -> Result<(), ()> {
         if unsafe { !SCJbClose(self.inner) } {
-            return Err(JsonError::Memory);
+            return Err(());
         }
         Ok(())
     }
-    fn open_object(&mut self, key: &str) -> Result<(), JsonError> {
+    fn open_object(&mut self, key: &str) -> Result<(), ()> {
         let keyc = CString::new(key).unwrap();
         if unsafe { !SCJbOpenObject(self.inner, keyc.as_ptr()) } {
-            return Err(JsonError::Memory);
+            return Err(());
         }
         Ok(())
     }
-    fn set_string(&mut self, key: &str, val: &str) -> Result<(), JsonError> {
+    fn set_string(&mut self, key: &str, val: &str) -> Result<(), ()> {
         let keyc = CString::new(key).unwrap();
         let valc = CString::new(val.escape_default().to_string()).unwrap();
         if unsafe { !SCJbSetString(self.inner, keyc.as_ptr(), valc.as_ptr()) } {
-            return Err(JsonError::Memory);
+            return Err(());
         }
         Ok(())
     }
 }
 
-fn log_template(tx: &TemplateTransaction, js: &mut SCJsonBuilderWrapper) -> Result<(), JsonError> {
+fn log_template(tx: &TemplateTransaction, js: &mut SCJsonBuilderWrapper) -> Result<(), ()> {
     js.open_object("altemplate")?;
     if let Some(ref request) = tx.request {
         js.set_string("request", request)?;

--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -98,6 +98,7 @@ exclude = [
     "AppLayerParserState",
     "CLuaState",
     "DetectEngineState",
+    "DetectEngineThreadCtx",
     "GenericVar",
     "Flow",
     "StreamingBufferConfig",

--- a/rust/src/applayertemplate/detect.rs
+++ b/rust/src/applayertemplate/detect.rs
@@ -20,9 +20,9 @@ use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
 use crate::conf::conf_get_node;
 /* TEMPLATE_END_REMOVE */
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectSignatureSetAppProto,
+    SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use std::os::raw::{c_int, c_void};
@@ -84,18 +84,14 @@ pub unsafe extern "C" fn SCDetectTemplateRegister() {
     /* TEMPLATE_END_REMOVE */
     // TODO create a suricata-verify test
     // Setup a keyword structure and register it
-    let kw = SCSigTableAppLiteElmt {
-        name: b"template.buffer\0".as_ptr() as *const libc::c_char,
-        desc: b"Template content modifier to match on the template buffer\0".as_ptr()
-            as *const libc::c_char,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("template.buffer"),
+        desc: String::from("Template content modifier to match on the template buffer"),
         // TODO use the right anchor for url and write doc
-        url: b"/rules/template-keywords.html#buffer\0".as_ptr() as *const libc::c_char,
-        Setup: template_buffer_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+        url: String::from("/rules/template-keywords.html#buffer"),
+        setup: template_buffer_setup,
     };
-    let _g_template_buffer_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_template_buffer_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_TEMPLATE_BUFFER_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"template.buffer\0".as_ptr() as *const libc::c_char,
         b"template.buffer intern description\0".as_ptr() as *const libc::c_char,

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -28,6 +28,10 @@ use crate::flow::Flow;
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 pub enum GenericVar {}
+#[repr(C)]
+pub struct DetectEngineThreadCtx {
+    _unused: [u8; 0],
+}
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -38,6 +38,7 @@ pub mod datasets;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CString;
 
+use crate::core::DetectEngineThreadCtx;
 use suricata_sys::sys::AppProto;
 
 /// EnumString trait that will be implemented on enums that
@@ -180,41 +181,29 @@ extern "C" {
         de: *mut c_void, s: *mut c_void, kwid: c_int, ctx: *const c_void, bufid: c_int,
     ) -> *mut c_void;
     // in detect-engine-helper.h
-    pub fn DetectHelperGetMultiData(
-        de: *mut c_void,
-        transforms: *const c_void,
-        flow: *const c_void,
-        flow_flags: u8,
-        tx: *const c_void,
-        list_id: c_int,
-        local_id: u32,
-        get_buf: unsafe extern "C" fn(*const c_void, u8, u32, *mut *const u8, *mut u32) -> bool,
-    ) -> *mut c_void;
     pub fn DetectHelperMultiBufferMpmRegister(
         name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
         toserver: bool,
         get_multi_data: unsafe extern "C" fn(
-            *mut c_void,
-            *const c_void,
+            *mut DetectEngineThreadCtx,
             *const c_void,
             u8,
-            *const c_void,
-            i32,
             u32,
-        ) -> *mut c_void,
+            *mut *const u8,
+            *mut u32,
+        ) -> bool,
     ) -> c_int;
     pub fn DetectHelperMultiBufferProgressMpmRegister(
         name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
         toserver: bool,
         get_multi_data: unsafe extern "C" fn(
-            *mut c_void,
-            *const c_void,
+            *mut DetectEngineThreadCtx,
             *const c_void,
             u8,
-            *const c_void,
-            i32,
             u32,
-        ) -> *mut c_void,
+            *mut *const u8,
+            *mut u32,
+        ) -> bool,
         progress: c_int,
     ) -> c_int;
 }

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -30,14 +30,15 @@ use super::parser::{
 };
 
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, SCDetectU16Free, SCDetectU16Match,
-    SCDetectU16Parse, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse,
-    SCDetectU8Free, SCDetectU8Match, SCDetectU8Parse, DetectUintData,
+    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU16Match,
+    SCDetectU16Parse, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free,
+    SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 
 use crate::direction::Direction;
@@ -1605,16 +1606,13 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         true,
         true,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"enip.product_name\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match EtherNet/IP product name\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/enip-keyword.html#enip-product-name\0".as_ptr() as *const libc::c_char,
-        Setup: product_name_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("enip.product_name"),
+        desc: String::from("sticky buffer to match EtherNet/IP product name"),
+        url: String::from("/rules/enip-keyword.html#enip-product-name"),
+        setup: product_name_setup,
     };
-    let _g_enip_product_name_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_enip_product_name_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_ENIP_PRODUCT_NAME_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"enip.product_name\0".as_ptr() as *const libc::c_char,
         b"ENIP product name\0".as_ptr() as *const libc::c_char,
@@ -1623,16 +1621,13 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         true,
         product_name_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"enip.service_name\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match EtherNet/IP service name\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/enip-keyword.html#enip-service-name\0".as_ptr() as *const libc::c_char,
-        Setup: service_name_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("enip.service_name"),
+        desc: String::from("sticky buffer to match EtherNet/IP service name"),
+        url: String::from("/rules/enip-keyword.html#enip-service-name"),
+        setup: service_name_setup,
     };
-    let _g_enip_service_name_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_enip_service_name_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_ENIP_SERVICE_NAME_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"enip.service_name\0".as_ptr() as *const libc::c_char,
         b"ENIP service name\0".as_ptr() as *const libc::c_char,

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -17,6 +17,7 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::krb::krb5::{test_weak_encryption, KRB5Transaction};
 
 use kerberos_parser::krb5::EncryptionType;
@@ -29,6 +30,7 @@ use nom7::multi::many1;
 use nom7::IResult;
 
 use std::ffi::CStr;
+use std::os::raw::c_void;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx: &KRB5Transaction, ptr: *mut u32) {
@@ -50,32 +52,36 @@ pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut 
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_cname(
-    tx: &KRB5Transaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, KRB5Transaction);
     if let Some(ref s) = tx.cname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];
             *buffer = value.as_ptr();
             *buffer_len = value.len() as u32;
-            return 1;
+            return true;
         }
     }
-    0
+    false
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_sname(
-    tx: &KRB5Transaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, KRB5Transaction);
     if let Some(ref s) = tx.sname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];
             *buffer = value.as_ptr();
             *buffer_len = value.len() as u32;
-            return 1;
+            return true;
         }
     }
-    0
+    false
 }
 
 const KRB_TICKET_FASTARRAY_SIZE: usize = 256;

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -21,10 +21,11 @@ use crate::detect::uint::{
     SCDetectU8Free,
 };
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperGetMultiData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
 
@@ -740,16 +741,13 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         true,  //to client
         false, //to server
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"ldap.request.dn\0".as_ptr() as *const libc::c_char,
-        desc: b"match request LDAPDN\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/ldap-keywords.html#ldap.request.dn\0".as_ptr() as *const libc::c_char,
-        Setup: ldap_detect_request_dn_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ldap.request.dn"),
+        desc: String::from("match request LDAPDN"),
+        url: String::from("/rules/ldap-keywords.html#ldap.request.dn"),
+        setup: ldap_detect_request_dn_setup,
     };
-    let _g_ldap_request_dn_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ldap_request_dn_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_LDAP_REQUEST_DN_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"ldap.request.dn\0".as_ptr() as *const libc::c_char,
         b"LDAP REQUEST DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
@@ -758,16 +756,13 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         true,  //to server
         ldap_detect_request_dn_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"ldap.responses.dn\0".as_ptr() as *const libc::c_char,
-        desc: b"match responses LDAPDN\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/ldap-keywords.html#ldap.responses.dn\0".as_ptr() as *const libc::c_char,
-        Setup: ldap_detect_responses_dn_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ldap.responses.dn"),
+        desc: String::from("match responses LDAPDN"),
+        url: String::from("/rules/ldap-keywords.html#ldap.responses.dn"),
+        setup: ldap_detect_responses_dn_setup,
     };
-    let _g_ldap_responses_dn_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ldap_responses_dn_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_LDAP_RESPONSES_DN_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"ldap.responses.dn\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
@@ -793,16 +788,13 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         true,  //to client
         false, //to server
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"ldap.responses.message\0".as_ptr() as *const libc::c_char,
-        desc: b"match LDAPResult message for responses\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/ldap-keywords.html#ldap.responses.message\0".as_ptr() as *const libc::c_char,
-        Setup: ldap_detect_responses_msg_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ldap.responses.message"),
+        desc: String::from("match LDAPResult message for responses"),
+        url: String::from("/rules/ldap-keywords.html#ldap.responses.message"),
+        setup: ldap_detect_responses_msg_setup,
     };
-    let _g_ldap_responses_dn_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ldap_responses_dn_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_LDAP_RESPONSES_MSG_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"ldap.responses.message\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
@@ -811,17 +803,13 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         false, //to server
         ldap_detect_responses_msg_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
-        desc: b"match request LDAP attribute type\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/ldap-keywords.html#ldap.request.attribute_type\0".as_ptr()
-            as *const libc::c_char,
-        Setup: ldap_detect_request_attibute_type_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ldap.request.attribute_type"),
+        desc: String::from("match request LDAP attribute type"),
+        url: String::from("/rules/ldap-keywords.html#ldap.request.attribute_type"),
+        setup: ldap_detect_request_attibute_type_setup,
     };
-    let _g_ldap_request_attribute_type_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ldap_request_attribute_type_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP REQUEST ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
@@ -830,17 +818,13 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         true,  //to server
         ldap_detect_request_attribute_type_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
-        desc: b"match LDAP responses attribute type\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/ldap-keywords.html#ldap.responses.attribute_type\0".as_ptr()
-            as *const libc::c_char,
-        Setup: ldap_detect_responses_attibute_type_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("ldap.responses.attribute_type"),
+        desc: String::from("match LDAP responses attribute type"),
+        url: String::from("/rules/ldap-keywords.html#ldap.responses.attribute_type"),
+        setup: ldap_detect_responses_attibute_type_setup,
     };
-    let _g_ldap_responses_attribute_type_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ldap_responses_attribute_type_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -16,6 +16,7 @@
  */
 
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
     SCDetectU8Free,
@@ -23,9 +24,8 @@ use crate::detect::uint::{
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
     DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
-    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
 
@@ -368,24 +368,9 @@ unsafe extern "C" fn ldap_detect_responses_dn_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_dn_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_responses_dn,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_responses_dn(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -515,24 +500,9 @@ unsafe extern "C" fn ldap_detect_responses_msg_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_msg_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_responses_msg,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_responses_msg(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -575,24 +545,9 @@ unsafe extern "C" fn ldap_detect_request_attibute_type_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_request_attribute_type_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_req_attribute_type,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_req_attribute_type(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -649,24 +604,9 @@ unsafe extern "C" fn ldap_detect_responses_attibute_type_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_attribute_type_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_resp_attribute_type,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_resp_attribute_type(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -769,7 +709,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_dn_get_data,
+        ldap_tx_get_responses_dn,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
@@ -801,7 +741,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_msg_get_data,
+        ldap_tx_get_responses_msg,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.request.attribute_type"),
@@ -816,7 +756,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         false, //to client
         true,  //to server
-        ldap_detect_request_attribute_type_get_data,
+        ldap_tx_get_req_attribute_type,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.responses.attribute_type"),
@@ -831,6 +771,6 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_attribute_type_get_data,
+        ldap_tx_get_resp_attribute_type,
     );
 }

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -18,14 +18,15 @@
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint, detect_parse_uint_enum, SCDetectU8Free,
-    SCDetectU8Parse, DetectUintData, DetectUintMode,
+    detect_match_uint, detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode,
+    SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperGetMultiData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
 
 use nom7::branch::alt;
@@ -1101,14 +1102,11 @@ unsafe extern "C" fn mqtt_conn_clientid_get_data(
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectMqttRegister() {
     let keyword_name = b"mqtt.unsubscribe.topic\0".as_ptr() as *const libc::c_char;
-    let kw = SCSigTableAppLiteElmt {
-        name: keyword_name,
-        desc: b"sticky buffer to match MQTT UNSUBSCRIBE topic\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/mqtt-keywords.html#mqtt-unsubscribe-topic\0".as_ptr() as *const libc::c_char,
-        Setup: unsub_topic_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.unsubscribe.topic"),
+        desc: String::from("sticky buffer to match MQTT UNSUBSCRIBE topic"),
+        url: String::from("/rules/mqtt-keywords.html#mqtt-unsubscribe-topic"),
+        setup: unsub_topic_setup,
     };
     if let Some(val) = conf_get("app-layer.protocols.mqtt.unsubscribe-topic-match-limit") {
         if let Ok(v) = val.parse::<isize>() {
@@ -1117,7 +1115,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
             SCLogError!("Invalid value for app-layer.protocols.mqtt.unsubscribe-topic-match-limit");
         }
     }
-    let _g_mqtt_unsub_topic_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_unsub_topic_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_UNSUB_TOPIC_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         keyword_name,
         b"unsubscribe topic query\0".as_ptr() as *const libc::c_char,
@@ -1145,14 +1143,11 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     );
 
     let keyword_name = b"mqtt.subscribe.topic\0".as_ptr() as *const libc::c_char;
-    let kw = SCSigTableAppLiteElmt {
-        name: keyword_name,
-        desc: b"sticky buffer to match MQTT SUBSCRIBE topic\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/mqtt-keywords.html#mqtt-subscribe-topic\0".as_ptr() as *const libc::c_char,
-        Setup: sub_topic_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.subscribe.topic"),
+        desc: String::from("sticky buffer to match MQTT SUBSCRIBE topic"),
+        url: String::from("/rules/mqtt-keywords.html#mqtt-subscribe-topic"),
+        setup: sub_topic_setup,
     };
     if let Some(val) = conf_get("app-layer.protocols.mqtt.subscribe-topic-match-limit") {
         if let Ok(v) = val.parse::<isize>() {
@@ -1161,7 +1156,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
             SCLogError!("Invalid value for app-layer.protocols.mqtt.subscribe-topic-match-limit");
         }
     }
-    let _g_mqtt_sub_topic_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_sub_topic_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_SUB_TOPIC_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         keyword_name,
         b"subscribe topic query\0".as_ptr() as *const libc::c_char,
@@ -1222,16 +1217,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         false, // only to server
         true,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.publish.topic\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT PUBLISH topic\0".as_ptr() as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-publish-topic\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_pub_topic_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.publish.topic"),
+        desc: String::from("sticky buffer to match on the MQTT PUBLISH topic"),
+        url: String::from("mqtt-keywords.html#mqtt-publish-topic"),
+        setup: mqtt_pub_topic_setup,
     };
-    let _g_mqtt_pub_topic_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_pub_topic_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_PUB_TOPIC_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.publish.topic\0".as_ptr() as *const libc::c_char,
         b"MQTT PUBLISH topic\0".as_ptr() as *const libc::c_char,
@@ -1240,17 +1232,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_pub_topic_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.publish.message\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT PUBLISH message\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-publish-message\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_pub_msg_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.publish.message"),
+        desc: String::from("sticky buffer to match on the MQTT PUBLISH message"),
+        url: String::from("mqtt-keywords.html#mqtt-publish-message"),
+        setup: mqtt_pub_msg_setup,
     };
-    let _g_mqtt_pub_msg_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_pub_msg_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_PUB_MSG_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.publish.message\0".as_ptr() as *const libc::c_char,
         b"MQTT PUBLISH message\0".as_ptr() as *const libc::c_char,
@@ -1307,17 +1295,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         false, // only to server
         true,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.willtopic\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT will topic\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-willtopic\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_willtopic_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.willtopic"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT will topic"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-willtopic"),
+        setup: mqtt_conn_willtopic_setup,
     };
-    let _g_mqtt_conn_willtopic_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_willtopic_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_WILLTOPIC_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.willtopic\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT will topic\0".as_ptr() as *const libc::c_char,
@@ -1326,17 +1310,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_conn_willtopic_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.willmessage\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT will message\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-willmessage\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_willmsg_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.willmessage"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT will message"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-willmessage"),
+        setup: mqtt_conn_willmsg_setup,
     };
-    let _g_mqtt_conn_willmsg_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_willmsg_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_WILLMSG_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.willmessage\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT will message\0".as_ptr() as *const libc::c_char,
@@ -1345,17 +1325,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_conn_willmsg_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.username\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT username\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-username\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_username_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.username"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT username"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-username"),
+        setup: mqtt_conn_username_setup,
     };
-    let _g_mqtt_conn_username_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_username_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_USERNAME_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.username\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT username\0".as_ptr() as *const libc::c_char,
@@ -1364,17 +1340,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_conn_username_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.protocol_string\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT protocol string\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-protocol_string\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_protocolstring_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.protocol_string"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT protocol string"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-protocol_string"),
+        setup: mqtt_conn_protocolstring_setup,
     };
-    let _g_mqtt_conn_protostr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_protostr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_PROTOCOLSTRING_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.protocol_string\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT protocol string\0".as_ptr() as *const libc::c_char,
@@ -1383,17 +1355,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_conn_protocolstring_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.password\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT password\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-password\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_password_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.password"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT password"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-password"),
+        setup: mqtt_conn_password_setup,
     };
-    let _g_mqtt_conn_password_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_password_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_PASSWORD_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.password\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT password\0".as_ptr() as *const libc::c_char,
@@ -1402,17 +1370,13 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         true,
         mqtt_conn_password_get_data,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"mqtt.connect.clientid\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the MQTT CONNECT clientid\0".as_ptr()
-            as *const libc::c_char,
-        url: b"mqtt-keywords.html#mqtt-connect-clientid\0".as_ptr() as *const libc::c_char,
-        Setup: mqtt_conn_clientid_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("mqtt.connect.clientid"),
+        desc: String::from("sticky buffer to match on the MQTT CONNECT clientid"),
+        url: String::from("mqtt-keywords.html#mqtt-connect-clientid"),
+        setup: mqtt_conn_clientid_setup,
     };
-    let _g_mqtt_conn_password_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_mqtt_conn_password_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_MQTT_CONN_CLIENTID_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"mqtt.connect.clientid\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT clientid\0".as_ptr() as *const libc::c_char,
@@ -1426,8 +1390,8 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::direction::Direction;
     use crate::detect::uint::DetectUintMode;
+    use crate::direction::Direction;
     use crate::mqtt::mqtt::MQTTTransaction;
     use crate::mqtt::mqtt_message::*;
     use crate::mqtt::parser::FixedHeader;

--- a/rust/src/quic/detect.rs
+++ b/rust/src/quic/detect.rs
@@ -15,7 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::core::DetectEngineThreadCtx;
 use crate::quic::quic::QuicTransaction;
+use std::os::raw::c_void;
 use std::ptr;
 
 #[no_mangle]
@@ -96,8 +98,10 @@ pub unsafe extern "C" fn rs_quic_tx_get_version(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
-    tx: &QuicTransaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, QuicTransaction);
     if (i as usize) < tx.cyu.len() {
         let cyu = &tx.cyu[i as usize];
 
@@ -106,19 +110,21 @@ pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
         *buffer = p.as_ptr();
         *buffer_len = p.len() as u32;
 
-        1
+        true
     } else {
         *buffer = ptr::null();
         *buffer_len = 0;
 
-        0
+        false
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_tx_get_cyu_string(
-    tx: &QuicTransaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, QuicTransaction);
     if (i as usize) < tx.cyu.len() {
         let cyu = &tx.cyu[i as usize];
 
@@ -126,11 +132,11 @@ pub unsafe extern "C" fn rs_quic_tx_get_cyu_string(
 
         *buffer = p.as_ptr();
         *buffer_len = p.len() as u32;
-        1
+        true
     } else {
         *buffer = ptr::null();
         *buffer_len = 0;
 
-        0
+        false
     }
 }

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -20,13 +20,13 @@
 use super::parser::RFBSecurityResultStatus;
 use super::rfb::{RFBTransaction, ALPROTO_RFB};
 use crate::detect::uint::{
-    detect_match_uint, detect_parse_uint_enum, SCDetectU32Free, SCDetectU32Parse,
-    DetectUintData,
+    detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
 };
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
@@ -188,16 +188,13 @@ unsafe extern "C" fn rfb_sec_result_free(_de: *mut c_void, ctx: *mut c_void) {
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectRfbRegister() {
-    let kw = SCSigTableAppLiteElmt {
-        name: b"rfb.name\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the RFB desktop name\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/rfb-keywords.html#rfb-name\0".as_ptr() as *const libc::c_char,
-        Setup: rfb_name_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("rfb.name"),
+        desc: String::from("sticky buffer to match on the RFB desktop name"),
+        url: String::from("/rules/rfb-keywords.html#rfb-name"),
+        setup: rfb_name_setup,
     };
-    let _g_rfb_name_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_rfb_name_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_RFB_NAME_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"rfb.name\0".as_ptr() as *const libc::c_char,
         b"rfb name\0".as_ptr() as *const libc::c_char,

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -17,10 +17,11 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
-    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
@@ -388,24 +389,9 @@ unsafe extern "C" fn sdp_bandwidth_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_bandwidth_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_bandwidth_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_bandwidth_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -440,24 +426,9 @@ unsafe extern "C" fn sdp_time_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_time_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sdp_time_get_data,
-    );
-}
-
 unsafe extern "C" fn sdp_time_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -490,24 +461,9 @@ unsafe extern "C" fn sdp_repeat_time_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_repeat_time_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sdp_repeat_time_get_data,
-    );
-}
-
 unsafe extern "C" fn sdp_repeat_time_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -636,24 +592,9 @@ unsafe extern "C" fn sdp_attribute_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_attribute_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_attribute_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_attribute_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -688,24 +629,9 @@ unsafe extern "C" fn sdp_media_desc_media_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_media_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_media_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_media_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -740,24 +666,9 @@ unsafe extern "C" fn sdp_media_desc_session_info_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_session_info_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_session_info_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_session_info_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -793,24 +704,9 @@ unsafe extern "C" fn sdp_media_desc_connection_data_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_connection_data_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_connection_data_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_connection_data_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -846,24 +742,9 @@ unsafe extern "C" fn sdp_media_desc_encryption_key_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_encryption_key_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_encryption_key_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_encryption_key_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -1007,7 +888,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_bandwidth_get,
+        sip_bandwidth_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.time"),
@@ -1022,7 +903,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_time_get,
+        sdp_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.repeat_time"),
@@ -1037,7 +918,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_repeat_time_get,
+        sdp_repeat_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.timezone"),
@@ -1082,7 +963,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_attribute_get,
+        sip_attribute_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media"),
@@ -1099,7 +980,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_media_get,
+        sip_media_desc_media_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media_info"),
@@ -1114,7 +995,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_session_info_get,
+        sip_media_desc_session_info_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.connection_data"),
@@ -1129,7 +1010,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_connection_data_get,
+        sip_media_desc_connection_data_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.encryption_key"),
@@ -1144,6 +1025,6 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_encryption_key_get,
+        sip_media_desc_encryption_key_get_data,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -18,9 +18,9 @@
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
+    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
@@ -889,17 +889,13 @@ unsafe extern "C" fn sip_media_desc_encryption_key_get_data(
 
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectSdpRegister() {
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.session_name\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP session name field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-session-name\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_session_name_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.session_name"),
+        desc: String::from("sticky buffer to match on the SDP session name field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-session-name"),
+        setup: sdp_session_name_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_SESSION_NAME_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.session_name\0".as_ptr() as *const libc::c_char,
         b"sdp.session_name\0".as_ptr() as *const libc::c_char,
@@ -908,17 +904,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_session_name_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.session_info\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP session info field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-session-info\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_session_info_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.session_info"),
+        desc: String::from("sticky buffer to match on the SDP session info field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-session-info"),
+        setup: sdp_session_info_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_SESSION_INFO_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.session_info\0".as_ptr() as *const libc::c_char,
         b"sdp.session_info\0".as_ptr() as *const libc::c_char,
@@ -927,16 +919,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_session_info_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.origin\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP origin field\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-origin\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_origin_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.origin"),
+        desc: String::from("sticky buffer to match on the SDP origin field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-origin"),
+        setup: sdp_origin_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_ORIGIN_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.origin\0".as_ptr() as *const libc::c_char,
         b"sdp.origin\0".as_ptr() as *const libc::c_char,
@@ -945,16 +934,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_origin_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.uri\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP uri field\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-uri\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_uri_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.uri"),
+        desc: String::from("sticky buffer to match on the SDP uri field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-uri"),
+        setup: sdp_uri_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_URI_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.uri\0".as_ptr() as *const libc::c_char,
         b"sdp.uri\0".as_ptr() as *const libc::c_char,
@@ -963,16 +949,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_uri_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.email\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP email field\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-email\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_email_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.email"),
+        desc: String::from("sticky buffer to match on the SDP email field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-email"),
+        setup: sdp_email_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_EMAIL_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.email\0".as_ptr() as *const libc::c_char,
         b"sdp.email\0".as_ptr() as *const libc::c_char,
@@ -981,17 +964,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_email_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP phone number field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-phone-number\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_phone_number_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.phone_number"),
+        desc: String::from("sticky buffer to match on the SDP phone number field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-phone-number"),
+        setup: sdp_phone_number_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_PHONE_NUMBER_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
         b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
@@ -1000,17 +979,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_phone_number_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP connection data field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-connection-data\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_conn_data_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.connection_data"),
+        desc: String::from("sticky buffer to match on the SDP connection data field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-connection-data"),
+        setup: sdp_conn_data_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_CONNECTION_DATA_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
@@ -1019,17 +994,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_conn_data_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP bandwidth field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-bandwidth\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_bandwidth_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.bandwidth"),
+        desc: String::from("sticky buffer to match on the SDP bandwidth field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-bandwidth"),
+        setup: sdp_bandwidth_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_BANDWIDTH_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
@@ -1038,16 +1009,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_bandwidth_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.time\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP time field\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#time\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_time_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.time"),
+        desc: String::from("sticky buffer to match on the SDP time field"),
+        url: String::from("/rules/sdp-keywords.html#time"),
+        setup: sdp_time_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_TIME_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         b"sdp.time\0".as_ptr() as *const libc::c_char,
@@ -1056,17 +1024,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_time_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP repeat time field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#repeat-time\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_repeat_time_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.repeat_time"),
+        desc: String::from("sticky buffer to match on the SDP repeat time field"),
+        url: String::from("/rules/sdp-keywords.html#repeat-time"),
+        setup: sdp_repeat_time_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_REPEAT_TIME_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
@@ -1075,16 +1039,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_repeat_time_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.timezone\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP timezone field\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#timezone\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_timezone_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.timezone"),
+        desc: String::from("sticky buffer to match on the SDP timezone field"),
+        url: String::from("/rules/sdp-keywords.html#timezone"),
+        setup: sdp_timezone_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_TIMEZONE_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.timezone\0".as_ptr() as *const libc::c_char,
         b"sdp.timezone\0".as_ptr() as *const libc::c_char,
@@ -1093,17 +1054,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_timezone_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.encryption_key\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP encryption key field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#encryption-key\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_encryption_key_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.encryption_key"),
+        desc: String::from("sticky buffer to match on the SDP encryption key field"),
+        url: String::from("/rules/sdp-keywords.html#encryption-key"),
+        setup: sdp_encryption_key_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_ENCRYPTION_KEY_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sdp.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.encription_key\0".as_ptr() as *const libc::c_char,
@@ -1112,17 +1069,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_encryption_key_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.attribute\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP attribute field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-attribute\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_attribute_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.attribute"),
+        desc: String::from("sticky buffer to match on the SDP attribute field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-attribute"),
+        setup: sdp_attribute_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_ATTRIBUTE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
@@ -1131,17 +1084,15 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_attribute_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.media.media\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP media subfield of the media_description field\0"
-            .as_ptr() as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#media-description-media\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_media_desc_media_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.media.media"),
+        desc: String::from(
+            "sticky buffer to match on the SDP media subfield of the media_description field",
+        ),
+        url: String::from("/rules/sdp-keywords.html#media-description-media"),
+        setup: sdp_media_desc_media_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
@@ -1150,17 +1101,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_media_desc_media_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP session info subfield of the media_description field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-media-description-session-info\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_media_desc_session_info_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.media.media_info"),
+        desc: String::from("sticky buffer to match on the SDP session info subfield of the media_description field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-media-description-session-info"),
+        setup: sdp_media_desc_session_info_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
@@ -1169,17 +1116,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_media_desc_session_info_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP connection data subfield of the media_description field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-media-description-connection-data\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_media_desc_connection_data_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.media.connection_data"),
+        desc: String::from("sticky buffer to match on the SDP connection data subfield of the media_description field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-media-description-connection-data"),
+        setup: sdp_media_desc_connection_data_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
@@ -1188,17 +1131,13 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         true,
         sdp_media_desc_connection_data_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SDP encryption key subfield of the media_description field\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sdp-keywords.html#sdp-media-description-encryption-key\0".as_ptr() as *const libc::c_char,
-        Setup: sdp_media_desc_encryption_key_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sdp.media.encryption_key"),
+        desc: String::from("sticky buffer to match on the SDP encryption key subfield of the media_description field"),
+        url: String::from("/rules/sdp-keywords.html#sdp-media-description-encryption-key"),
+        setup: sdp_media_desc_encryption_key_setup,
     };
-    let _ = DetectHelperKeywordRegister(&kw);
+    let _ = helper_keyword_register_sticky_buffer(&kw);
     G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,10 +17,11 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
-    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
@@ -338,24 +339,9 @@ unsafe extern "C" fn sip_from_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_from_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_from_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_from_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "From") {
@@ -380,24 +366,9 @@ unsafe extern "C" fn sip_to_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_to_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_to_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_to_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "To") {
@@ -422,24 +393,9 @@ unsafe extern "C" fn sip_via_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_via_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_via_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_via_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Via") {
@@ -464,24 +420,9 @@ unsafe extern "C" fn sip_ua_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_ua_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_ua_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_ua_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "User-Agent") {
@@ -506,24 +447,9 @@ unsafe extern "C" fn sip_content_type_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_content_type_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_content_type_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_content_type_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Content-Type") {
@@ -548,24 +474,9 @@ unsafe extern "C" fn sip_content_length_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_content_length_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_content_length_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_content_length_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Content-Length") {
@@ -667,7 +578,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_from_hdr_get,
+        sip_from_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.to"),
@@ -682,7 +593,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_to_hdr_get,
+        sip_to_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.via"),
@@ -697,7 +608,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_via_hdr_get,
+        sip_via_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.user_agent"),
@@ -712,7 +623,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_ua_hdr_get,
+        sip_ua_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_type"),
@@ -727,7 +638,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_content_type_hdr_get,
+        sip_content_type_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_length"),
@@ -742,6 +653,6 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_content_length_hdr_get,
+        sip_content_length_hdr_get_data,
     );
 }

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,12 +17,12 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::direction::Direction;
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
+    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
+use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
@@ -579,16 +579,13 @@ unsafe extern "C" fn sip_content_length_hdr_get_data(
 }
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectSipRegister() {
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.protocol\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP protocol\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-protocol\0".as_ptr() as *const libc::c_char,
-        Setup: sip_protocol_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.protocol"),
+        desc: String::from("sticky buffer to match on the SIP protocol"),
+        url: String::from("/rules/sip-keywords.html#sip-protocol"),
+        setup: sip_protocol_setup,
     };
-    let _g_sip_protocol_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_protocol_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_PROTOCOL_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sip.protocol\0".as_ptr() as *const libc::c_char,
         b"sip.protocol\0".as_ptr() as *const libc::c_char,
@@ -597,16 +594,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_protocol_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.stat_code\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP status code\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-stat-code\0".as_ptr() as *const libc::c_char,
-        Setup: sip_stat_code_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.stat_code"),
+        desc: String::from("sticky buffer to match on the SIP status code"),
+        url: String::from("/rules/sip-keywords.html#sip-stat-code"),
+        setup: sip_stat_code_setup,
     };
-    let _g_sip_stat_code_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_stat_code_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_STAT_CODE_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sip.stat_code\0".as_ptr() as *const libc::c_char,
         b"sip.stat_code\0".as_ptr() as *const libc::c_char,
@@ -615,16 +609,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         false,
         sip_stat_code_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.stat_msg\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP status message\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-stat-msg\0".as_ptr() as *const libc::c_char,
-        Setup: sip_stat_msg_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.stat_msg"),
+        desc: String::from("sticky buffer to match on the SIP status message"),
+        url: String::from("/rules/sip-keywords.html#sip-stat-msg"),
+        setup: sip_stat_msg_setup,
     };
-    let _g_sip_stat_msg_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_stat_msg_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_STAT_MSG_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sip.stat_msg\0".as_ptr() as *const libc::c_char,
         b"sip.stat_msg\0".as_ptr() as *const libc::c_char,
@@ -633,16 +624,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         false,
         sip_stat_msg_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.request_line\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP request line\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-request-line\0".as_ptr() as *const libc::c_char,
-        Setup: sip_request_line_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.request_line"),
+        desc: String::from("sticky buffer to match on the SIP request line"),
+        url: String::from("/rules/sip-keywords.html#sip-request-line"),
+        setup: sip_request_line_setup,
     };
-    let _g_sip_request_line_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_request_line_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_REQUEST_LINE_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sip.request_line\0".as_ptr() as *const libc::c_char,
         b"sip.request_line\0".as_ptr() as *const libc::c_char,
@@ -651,16 +639,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_request_line_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.response_line\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP response line\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-response-line\0".as_ptr() as *const libc::c_char,
-        Setup: sip_response_line_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.response_line"),
+        desc: String::from("sticky buffer to match on the SIP response line"),
+        url: String::from("/rules/sip-keywords.html#sip-response-line"),
+        setup: sip_response_line_setup,
     };
-    let _g_sip_response_line_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_response_line_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_RESPONSE_LINE_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"sip.response_line\0".as_ptr() as *const libc::c_char,
         b"sip.response_line\0".as_ptr() as *const libc::c_char,
@@ -669,16 +654,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         false,
         sip_response_line_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.from\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP From header\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-from\0".as_ptr() as *const libc::c_char,
-        Setup: sip_from_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.from"),
+        desc: String::from("sticky buffer to match on the SIP From header"),
+        url: String::from("/rules/sip-keywords.html#sip-from"),
+        setup: sip_from_hdr_setup,
     };
-    let _g_sip_from_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_from_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_FROM_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.from\0".as_ptr() as *const libc::c_char,
         b"sip.from\0".as_ptr() as *const libc::c_char,
@@ -687,16 +669,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_from_hdr_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.to\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP To header\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-to\0".as_ptr() as *const libc::c_char,
-        Setup: sip_to_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.to"),
+        desc: String::from("sticky buffer to match on the SIP To header"),
+        url: String::from("/rules/sip-keywords.html#sip-to"),
+        setup: sip_to_hdr_setup,
     };
-    let _g_sip_to_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_to_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_TO_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.to\0".as_ptr() as *const libc::c_char,
         b"sip.to\0".as_ptr() as *const libc::c_char,
@@ -705,16 +684,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_to_hdr_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.via\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP Via header\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-via\0".as_ptr() as *const libc::c_char,
-        Setup: sip_via_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.via"),
+        desc: String::from("sticky buffer to match on the SIP Via header"),
+        url: String::from("/rules/sip-keywords.html#sip-via"),
+        setup: sip_via_hdr_setup,
     };
-    let _g_sip_via_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_via_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_VIA_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.via\0".as_ptr() as *const libc::c_char,
         b"sip.via\0".as_ptr() as *const libc::c_char,
@@ -723,17 +699,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_via_hdr_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.user_agent\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP User-Agent header\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-user-agent\0".as_ptr() as *const libc::c_char,
-        Setup: sip_ua_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.user_agent"),
+        desc: String::from("sticky buffer to match on the SIP User-Agent header"),
+        url: String::from("/rules/sip-keywords.html#sip-user-agent"),
+        setup: sip_ua_hdr_setup,
     };
-    let _g_sip_ua_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_ua_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_UA_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.ua\0".as_ptr() as *const libc::c_char,
         b"sip.ua\0".as_ptr() as *const libc::c_char,
@@ -742,17 +714,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_ua_hdr_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.content_type\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP Content-Type header\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-content-type\0".as_ptr() as *const libc::c_char,
-        Setup: sip_content_type_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.content_type"),
+        desc: String::from("sticky buffer to match on the SIP Content-Type header"),
+        url: String::from("/rules/sip-keywords.html#sip-content-type"),
+        setup: sip_content_type_hdr_setup,
     };
-    let _g_sip_content_type_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_content_type_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_CONTENT_TYPE_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
@@ -761,17 +729,13 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         true,
         sip_content_type_hdr_get,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"sip.content_length\0".as_ptr() as *const libc::c_char,
-        desc: b"sticky buffer to match on the SIP Content-Length header\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/sip-keywords.html#sip-content-length\0".as_ptr() as *const libc::c_char,
-        Setup: sip_content_length_hdr_setup,
-        flags: SIGMATCH_NOOPT,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("sip.content_length"),
+        desc: String::from("sticky buffer to match on the SIP Content-Length header"),
+        url: String::from("/rules/sip-keywords.html#sip-content-length"),
+        setup: sip_content_length_hdr_setup,
     };
-    let _g_sip_content_length_hdr_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_sip_content_length_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SIP_CONTENT_LENGTH_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
         b"sip.content_length\0".as_ptr() as *const libc::c_char,
         b"sip.content_length\0".as_ptr() as *const libc::c_char,

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -18,13 +18,12 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use super::snmp::{SNMPTransaction, ALPROTO_SNMP};
-use crate::detect::uint::{
-    SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, DetectUintData,
-};
+use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::os::raw::{c_int, c_void};
 
@@ -218,16 +217,13 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         true,
     );
 
-    let kw = SCSigTableAppLiteElmt {
-        name: b"snmp.usm\0".as_ptr() as *const libc::c_char,
-        desc: b"SNMP content modifier to match on the SNMP usm\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/snmp-keywords.html#snmp-usm\0".as_ptr() as *const libc::c_char,
-        Setup: snmp_detect_usm_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("snmp.usm"),
+        desc: String::from("SNMP content modifier to match on the SNMP usm"),
+        url: String::from("/rules/snmp-keywords.html#snmp-usm"),
+        setup: snmp_detect_usm_setup,
     };
-    let _g_snmp_usm_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_snmp_usm_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SNMP_USM_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"snmp.usm\0".as_ptr() as *const libc::c_char,
         b"SNMP USM\0".as_ptr() as *const libc::c_char,
@@ -237,17 +233,13 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         snmp_detect_usm_get_data,
     );
 
-    let kw = SCSigTableAppLiteElmt {
-        name: b"snmp.community\0".as_ptr() as *const libc::c_char,
-        desc: b"SNMP content modifier to match on the SNMP community\0".as_ptr()
-            as *const libc::c_char,
-        url: b"/rules/snmp-keywords.html#snmp-community\0".as_ptr() as *const libc::c_char,
-        Setup: snmp_detect_community_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("snmp.community"),
+        desc: String::from("SNMP content modifier to match on the SNMP community"),
+        url: String::from("/rules/snmp-keywords.html#snmp-community"),
+        setup: snmp_detect_community_setup,
     };
-    let _g_snmp_community_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_snmp_community_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_SNMP_COMMUNITY_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"snmp.community\0".as_ptr() as *const libc::c_char,
         b"SNMP Community identifier\0".as_ptr() as *const libc::c_char,

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -17,13 +17,14 @@
 
 use super::websocket::{WebSocketTransaction, ALPROTO_WEBSOCKET};
 use crate::detect::uint::{
-    detect_parse_uint, detect_parse_uint_enum, SCDetectU32Free, SCDetectU32Match,
-    SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match, DetectUintData, DetectUintMode,
+    detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode, SCDetectU32Free,
+    SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match,
 };
 use crate::detect::{
-    DetectBufferSetActiveList, DetectHelperBufferMpmRegister, DetectHelperBufferRegister,
-    DetectHelperGetData, DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SIGMATCH_INFO_STICKY_BUFFER, SIGMATCH_NOOPT,
+    helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
+    DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::websocket::parser::WebSocketOpcode;
 
@@ -326,16 +327,13 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         true,
         true,
     );
-    let kw = SCSigTableAppLiteElmt {
-        name: b"websocket.payload\0".as_ptr() as *const libc::c_char,
-        desc: b"match WebSocket payload\0".as_ptr() as *const libc::c_char,
-        url: b"/rules/websocket-keywords.html#websocket-payload\0".as_ptr() as *const libc::c_char,
-        Setup: websocket_detect_payload_setup,
-        flags: SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER,
-        AppLayerTxMatch: None,
-        Free: None,
+    let kw = SigTableElmtStickyBuffer {
+        name: String::from("websocket.payload"),
+        desc: String::from("match WebSocket payload"),
+        url: String::from("/rules/websocket-keywords.html#websocket-payload"),
+        setup: websocket_detect_payload_setup,
     };
-    let _g_ws_payload_kw_id = DetectHelperKeywordRegister(&kw);
+    let _g_ws_payload_kw_id = helper_keyword_register_sticky_buffer(&kw);
     G_WEBSOCKET_PAYLOAD_BUFFER_ID = DetectHelperBufferMpmRegister(
         b"websocket.payload\0".as_ptr() as *const libc::c_char,
         b"WebSocket payload\0".as_ptr() as *const libc::c_char,

--- a/src/detect-dns-response.c
+++ b/src/detect-dns-response.c
@@ -110,25 +110,29 @@ static InspectionBuffer *GetBuffer(DetectEngineThreadCtx *det_ctx, uint8_t flags
         /* Get name values. */
         switch (cbdata->response_section) {
             case DNS_RESPONSE_QUERY:
-                if (!SCDnsTxGetQueryName(txv, true, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetQueryName(
+                            det_ctx, txv, STREAM_TOCLIENT, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_ANSWER:
-                if (!SCDnsTxGetAnswerName(txv, true, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAnswerName(
+                            det_ctx, txv, STREAM_TOCLIENT, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_AUTHORITY:
-                if (!SCDnsTxGetAuthorityName(txv, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAuthorityName(
+                            det_ctx, txv, 0, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_ADDITIONAL:
-                if (!SCDnsTxGetAdditionalName(txv, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAdditionalName(
+                            det_ctx, txv, 0, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -169,30 +169,6 @@ int DetectHelperTransformRegister(const SCTransformTableElmt *kw)
     return transform_id;
 }
 
-InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf)
-{
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, index);
-    if (buffer == NULL) {
-        return NULL;
-    }
-    if (buffer->initialized) {
-        return buffer;
-    }
-
-    const uint8_t *data = NULL;
-    uint32_t data_len = 0;
-
-    if (!GetBuf(txv, flow_flags, index, &data, &data_len)) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-    return buffer;
-}
-
 const uint8_t *InspectionBufferPtr(InspectionBuffer *buf)
 {
     return buf->inspect;

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -35,7 +35,6 @@ void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
 int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
-typedef bool (*MultiGetTxBuffer)(void *, uint8_t, uint32_t, const uint8_t **, uint32_t *);
 
 InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
@@ -46,10 +45,6 @@ int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppPr
         bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData);
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData, int progress);
-
-InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf);
 
 int DetectHelperTransformRegister(const SCTransformTableElmt *kw);
 const uint8_t *InspectionBufferPtr(InspectionBuffer *buf);

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -52,6 +52,7 @@
 #include "detect-engine-mpm.h"
 #include "detect-engine-frame.h"
 #include "detect-engine-uint.h"
+#include "detect-engine-content-inspection.h"
 
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
@@ -1583,8 +1584,8 @@ static void PrefilterMultiMpm(DetectEngineThreadCtx *det_ctx, const void *pectx,
 
     do {
         // loop until we get a NULL
-        InspectionBuffer *buffer =
-                ctx->GetData(det_ctx, ctx->transforms, f, flags, txv, ctx->list_id, local_id);
+        InspectionBuffer *buffer = DetectGetMultiData(
+                det_ctx, ctx->transforms, f, flags, txv, ctx->list_id, local_id, ctx->GetData);
         if (buffer == NULL)
             break;
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -151,6 +151,9 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id);
 
+InspectionBuffer *DetectGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id, uint32_t index, InspectionMultiBufferGetDataPtr GetBuf);
 uint8_t DetectEngineInspectMultiBufferGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);

--- a/src/detect-ftp-reply.c
+++ b/src/detect-ftp-reply.c
@@ -59,8 +59,8 @@ static int DetectFtpReplySetup(DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 }
 
-static bool DetectFTPReplyGetData(void *txv, uint8_t _flow_flags, uint32_t index,
-        const uint8_t **buffer, uint32_t *buffer_len)
+static bool DetectFTPReplyGetData(DetectEngineThreadCtx *_det_ctx, const void *txv,
+        uint8_t _flow_flags, uint32_t index, const uint8_t **buffer, uint32_t *buffer_len)
 {
     FTPTransaction *tx = (FTPTransaction *)txv;
 
@@ -86,14 +86,6 @@ static bool DetectFTPReplyGetData(void *txv, uint8_t _flow_flags, uint32_t index
     return false;
 }
 
-static InspectionBuffer *GetDataWrapper(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id, uint32_t index)
-{
-    return DetectHelperGetMultiData(
-            det_ctx, transforms, _f, _flow_flags, txv, list_id, index, DetectFTPReplyGetData);
-}
-
 void DetectFtpReplyRegister(void)
 {
     /* ftp.reply sticky buffer */
@@ -104,7 +96,7 @@ void DetectFtpReplyRegister(void)
     sigmatch_table[DETECT_FTP_REPLY].flags |= SIGMATCH_NOOPT;
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, GetDataWrapper, 2, 1);
+            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, DetectFTPReplyGetData, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -99,14 +99,6 @@ static int g_http2_header_name_buffer_id = 0;
  * \brief Registration function for HTTP2 keywords
  */
 
-static InspectionBuffer *GetHttp2HNameData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    return DetectHelperGetMultiData(det_ctx, transforms, _f, flags, txv, list_id, local_id,
-            (MultiGetTxBuffer)rs_http2_tx_get_header_name);
-}
-
 void DetectHttp2Register(void)
 {
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].name = "http2.frametype";
@@ -182,9 +174,10 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, GetHttp2HNameData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, GetHttp2HNameData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
+
     DetectBufferTypeSupportsMultiInstance("http2_header_name");
     DetectBufferTypeSetDescriptionByName("http2_header_name",
                                          "HTTP2 header name");

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -49,36 +49,6 @@ static int DetectKrb5CNameSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 }
 
-static InspectionBuffer *GetKrb5CNameData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    uint32_t b_len = 0;
-    const uint8_t *b = NULL;
-
-    if (rs_krb5_tx_get_cname(txv, local_id, &b, &b_len) != 1) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    if (b == NULL || b_len == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectKrb5CNameRegister(void)
 {
     sigmatch_table[DETECT_KRB5_CNAME].name = "krb5.cname";
@@ -89,7 +59,7 @@ void DetectKrb5CNameRegister(void)
     sigmatch_table[DETECT_KRB5_CNAME].desc = "sticky buffer to match on Kerberos 5 client name";
 
     DetectAppLayerMultiRegister(
-            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, GetKrb5CNameData, 2, 1);
+            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, rs_krb5_tx_get_cname, 2, 1);
 
     DetectBufferTypeSetDescriptionByName("krb5_cname",
             "Kerberos 5 ticket client name");

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -55,33 +55,6 @@ static int DetectQuicCyuHashSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     return 0;
 }
 
-static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    if (local_id > UINT16_MAX)
-        return NULL;
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    const uint8_t *data;
-    uint32_t data_len;
-    if (rs_quic_tx_get_cyu_hash(txv, local_id, &data, &data_len) == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectQuicCyuHashRegister(void)
 {
     /* quic.cyu.hash sticky buffer */
@@ -95,7 +68,7 @@ void DetectQuicCyuHashRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, QuicHashGetData, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_hash, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -53,31 +53,6 @@ static int DetectQuicCyuStringSetup(DetectEngineCtx *de_ctx, Signature *s, const
     return 0;
 }
 
-static InspectionBuffer *QuicStringGetData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    const uint8_t *data;
-    uint32_t data_len;
-    if (rs_quic_tx_get_cyu_string(txv, local_id, &data, &data_len) == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectQuicCyuStringRegister(void)
 {
     /* quic.cyu.string sticky buffer */
@@ -91,7 +66,7 @@ void DetectQuicCyuStringRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, QuicStringGetData, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_string, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -423,9 +423,10 @@ typedef InspectionBuffer *(*InspectionBufferGetDataPtr)(
         const DetectEngineTransforms *transforms,
         Flow *f, const uint8_t flow_flags,
         void *txv, const int list_id);
-typedef InspectionBuffer *(*InspectionMultiBufferGetDataPtr)(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, const uint32_t local_id);
+
+typedef bool (*InspectionMultiBufferGetDataPtr)(struct DetectEngineThreadCtx_ *det_ctx,
+        const void *txv, const uint8_t flow_flags, uint32_t local_id, const uint8_t **buf,
+        uint32_t *buf_len);
 struct DetectEngineAppInspectionEngine_;
 
 typedef uint8_t (*InspectEngineFuncPtr)(struct DetectEngineCtx_ *de_ctx,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, cleanup

Describe changes:
- Move wrapper code for multi-buffer getter to a unique function `DetectGetMultiData` and removes boilerplate duplicate code (changing `InspectionMultiBufferGetDataPtr` prototype)

Draft on top of approved https://github.com/OISF/suricata/pull/13068
