### PR TITLE
Detect multibuf v2

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -98,6 +98,7 @@ exclude = [
     "AppLayerParserState",
     "CLuaState",
     "DetectEngineState",
+    "DetectEngineThreadCtx",
     "GenericVar",
     "Flow",
     "StreamingBufferConfig",

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -28,6 +28,10 @@ use crate::flow::Flow;
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 pub enum GenericVar {}
+#[repr(C)]
+pub struct DetectEngineThreadCtx {
+    _unused: [u8; 0],
+}
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -38,6 +38,7 @@ pub mod datasets;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CString;
 
+use crate::core::DetectEngineThreadCtx;
 use suricata_sys::sys::AppProto;
 
 /// EnumString trait that will be implemented on enums that
@@ -180,41 +181,29 @@ extern "C" {
         de: *mut c_void, s: *mut c_void, kwid: c_int, ctx: *const c_void, bufid: c_int,
     ) -> *mut c_void;
     // in detect-engine-helper.h
-    pub fn DetectHelperGetMultiData(
-        de: *mut c_void,
-        transforms: *const c_void,
-        flow: *const c_void,
-        flow_flags: u8,
-        tx: *const c_void,
-        list_id: c_int,
-        local_id: u32,
-        get_buf: unsafe extern "C" fn(*const c_void, u8, u32, *mut *const u8, *mut u32) -> bool,
-    ) -> *mut c_void;
     pub fn DetectHelperMultiBufferMpmRegister(
         name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
         toserver: bool,
         get_multi_data: unsafe extern "C" fn(
-            *mut c_void,
-            *const c_void,
+            *mut DetectEngineThreadCtx,
             *const c_void,
             u8,
-            *const c_void,
-            i32,
             u32,
-        ) -> *mut c_void,
+            *mut *const u8,
+            *mut u32,
+        ) -> bool,
     ) -> c_int;
     pub fn DetectHelperMultiBufferProgressMpmRegister(
         name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
         toserver: bool,
         get_multi_data: unsafe extern "C" fn(
-            *mut c_void,
-            *const c_void,
+            *mut DetectEngineThreadCtx,
             *const c_void,
             u8,
-            *const c_void,
-            i32,
             u32,
-        ) -> *mut c_void,
+            *mut *const u8,
+            *mut u32,
+        ) -> bool,
         progress: c_int,
     ) -> c_int;
 }

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -182,8 +182,7 @@ extern "C" {
     ) -> *mut c_void;
     // in detect-engine-helper.h
     pub fn DetectHelperMultiBufferMpmRegister(
-        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
-        toserver: bool,
+        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
         get_multi_data: unsafe extern "C" fn(
             *mut DetectEngineThreadCtx,
             *const c_void,
@@ -194,8 +193,7 @@ extern "C" {
         ) -> bool,
     ) -> c_int;
     pub fn DetectHelperMultiBufferProgressMpmRegister(
-        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
-        toserver: bool,
+        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
         get_multi_data: unsafe extern "C" fn(
             *mut DetectEngineThreadCtx,
             *const c_void,

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::dns::{DNSRcode, DNSRecordType, DNSTransaction, ALPROTO_DNS};
-use crate::core::DetectEngineThreadCtx;
+use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU8Free,
     SCDetectU8Parse,
@@ -333,10 +333,9 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         b"dns.answer.name\0".as_ptr() as *const libc::c_char,
         b"dns answer name\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         /* Register also in the TO_SERVER direction, even though this is not
         normal, it could be provided as part of a request. */
-        true,
         dns_tx_get_answer_name,
         1, // response complete
     );
@@ -367,10 +366,9 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         b"dns.query.name\0".as_ptr() as *const libc::c_char,
         b"dns query name\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         /* Register in both directions as the query is usually echoed back
         in the response. */
-        true,
         dns_tx_get_query_name,
         1, // request or response complete
     );
@@ -421,8 +419,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         b"dns_query\0".as_ptr() as *const libc::c_char,
         b"dns request query\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        false, // only toserver
-        true,
+        STREAM_TOSERVER,
         dns_tx_get_query, // reuse, will be called only toserver
         1,                // request complete
     );

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -17,6 +17,7 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::krb::krb5::{test_weak_encryption, KRB5Transaction};
 
 use kerberos_parser::krb5::EncryptionType;
@@ -29,6 +30,7 @@ use nom7::multi::many1;
 use nom7::IResult;
 
 use std::ffi::CStr;
+use std::os::raw::c_void;
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx: &KRB5Transaction, ptr: *mut u32) {
@@ -50,32 +52,36 @@ pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut 
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_cname(
-    tx: &KRB5Transaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, KRB5Transaction);
     if let Some(ref s) = tx.cname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];
             *buffer = value.as_ptr();
             *buffer_len = value.len() as u32;
-            return 1;
+            return true;
         }
     }
-    0
+    false
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_krb5_tx_get_sname(
-    tx: &KRB5Transaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, KRB5Transaction);
     if let Some(ref s) = tx.sname {
         if (i as usize) < s.name_string.len() {
             let value = &s.name_string[i as usize];
             *buffer = value.as_ptr();
             *buffer_len = value.len() as u32;
-            return 1;
+            return true;
         }
     }
-    0
+    false
 }
 
 const KRB_TICKET_FASTARRAY_SIZE: usize = 256;

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
-use crate::core::DetectEngineThreadCtx;
+use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
     SCDetectU8Free,
@@ -707,8 +707,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         b"ldap.responses.dn\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
         ldap_tx_get_responses_dn,
     );
     let kw = SCSigTableAppLiteElmt {
@@ -739,8 +738,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         b"ldap.responses.message\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
         ldap_tx_get_responses_msg,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -754,8 +752,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP REQUEST ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        false, //to client
-        true,  //to server
+        STREAM_TOSERVER,
         ldap_tx_get_req_attribute_type,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -769,8 +766,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
         ldap_tx_get_resp_attribute_type,
     );
 }

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -16,6 +16,7 @@
  */
 
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
     SCDetectU8Free,
@@ -23,9 +24,8 @@ use crate::detect::uint::{
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
     DetectHelperBufferMpmRegister, DetectHelperBufferRegister, DetectHelperGetData,
-    DetectHelperGetMultiData, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
 
@@ -368,24 +368,9 @@ unsafe extern "C" fn ldap_detect_responses_dn_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_dn_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_responses_dn,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_responses_dn(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -515,24 +500,9 @@ unsafe extern "C" fn ldap_detect_responses_msg_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_msg_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_responses_msg,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_responses_msg(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -575,24 +545,9 @@ unsafe extern "C" fn ldap_detect_request_attibute_type_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_request_attribute_type_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_req_attribute_type,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_req_attribute_type(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -649,24 +604,9 @@ unsafe extern "C" fn ldap_detect_responses_attibute_type_setup(
     return 0;
 }
 
-unsafe extern "C" fn ldap_detect_responses_attribute_type_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        ldap_tx_get_resp_attribute_type,
-    );
-}
-
 unsafe extern "C" fn ldap_tx_get_resp_attribute_type(
-    tx: *const c_void, _flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);
 
@@ -769,7 +709,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_dn_get_data,
+        ldap_tx_get_responses_dn,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
@@ -801,7 +741,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_msg_get_data,
+        ldap_tx_get_responses_msg,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.request.attribute_type"),
@@ -816,7 +756,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         false, //to client
         true,  //to server
-        ldap_detect_request_attribute_type_get_data,
+        ldap_tx_get_req_attribute_type,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.responses.attribute_type"),
@@ -831,6 +771,6 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         ALPROTO_LDAP,
         true,  //to client
         false, //to server
-        ldap_detect_responses_attribute_type_get_data,
+        ldap_tx_get_resp_attribute_type,
     );
 }

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
-use crate::core::DetectEngineThreadCtx;
+use crate::core::{DetectEngineThreadCtx, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode,
     SCDetectU8Free, SCDetectU8Parse,
@@ -1090,8 +1090,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         keyword_name,
         b"unsubscribe topic query\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         unsub_topic_get_data,
     );
 
@@ -1131,8 +1130,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         keyword_name,
         b"subscribe topic query\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         sub_topic_get_data,
     );
 

--- a/rust/src/quic/detect.rs
+++ b/rust/src/quic/detect.rs
@@ -15,7 +15,9 @@
  * 02110-1301, USA.
  */
 
+use crate::core::DetectEngineThreadCtx;
 use crate::quic::quic::QuicTransaction;
+use std::os::raw::c_void;
 use std::ptr;
 
 #[no_mangle]
@@ -96,8 +98,10 @@ pub unsafe extern "C" fn rs_quic_tx_get_version(
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
-    tx: &QuicTransaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, QuicTransaction);
     if (i as usize) < tx.cyu.len() {
         let cyu = &tx.cyu[i as usize];
 
@@ -106,19 +110,21 @@ pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
         *buffer = p.as_ptr();
         *buffer_len = p.len() as u32;
 
-        1
+        true
     } else {
         *buffer = ptr::null();
         *buffer_len = 0;
 
-        0
+        false
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_quic_tx_get_cyu_string(
-    tx: &QuicTransaction, i: u32, buffer: *mut *const u8, buffer_len: *mut u32,
-) -> u8 {
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
+    buffer_len: *mut u32,
+) -> bool {
+    let tx = cast_pointer!(tx, QuicTransaction);
     if (i as usize) < tx.cyu.len() {
         let cyu = &tx.cyu[i as usize];
 
@@ -126,11 +132,11 @@ pub unsafe extern "C" fn rs_quic_tx_get_cyu_string(
 
         *buffer = p.as_ptr();
         *buffer_len = p.len() as u32;
-        1
+        true
     } else {
         *buffer = ptr::null();
         *buffer_len = 0;
 
-        0
+        false
     }
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -17,10 +17,11 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
-    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
@@ -388,24 +389,9 @@ unsafe extern "C" fn sdp_bandwidth_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_bandwidth_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_bandwidth_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_bandwidth_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -440,24 +426,9 @@ unsafe extern "C" fn sdp_time_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_time_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sdp_time_get_data,
-    );
-}
-
 unsafe extern "C" fn sdp_time_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -490,24 +461,9 @@ unsafe extern "C" fn sdp_repeat_time_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_repeat_time_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sdp_repeat_time_get_data,
-    );
-}
-
 unsafe extern "C" fn sdp_repeat_time_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -636,24 +592,9 @@ unsafe extern "C" fn sdp_attribute_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_attribute_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_attribute_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_attribute_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -688,24 +629,9 @@ unsafe extern "C" fn sdp_media_desc_media_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_media_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_media_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_media_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -740,24 +666,9 @@ unsafe extern "C" fn sdp_media_desc_session_info_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_session_info_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_session_info_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_session_info_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -793,24 +704,9 @@ unsafe extern "C" fn sdp_media_desc_connection_data_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_connection_data_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_connection_data_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_connection_data_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -846,24 +742,9 @@ unsafe extern "C" fn sdp_media_desc_encryption_key_setup(
     return 0;
 }
 
-unsafe extern "C" fn sdp_media_desc_encryption_key_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_media_desc_encryption_key_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_media_desc_encryption_key_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     let direction = flow_flags.into();
@@ -1007,7 +888,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_bandwidth_get,
+        sip_bandwidth_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.time"),
@@ -1022,7 +903,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_time_get,
+        sdp_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.repeat_time"),
@@ -1037,7 +918,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_repeat_time_get,
+        sdp_repeat_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.timezone"),
@@ -1082,7 +963,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_attribute_get,
+        sip_attribute_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media"),
@@ -1099,7 +980,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_media_get,
+        sip_media_desc_media_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media_info"),
@@ -1114,7 +995,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_session_info_get,
+        sip_media_desc_session_info_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.connection_data"),
@@ -1129,7 +1010,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_connection_data_get,
+        sip_media_desc_connection_data_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.encryption_key"),
@@ -1144,6 +1025,6 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sdp_media_desc_encryption_key_get,
+        sip_media_desc_encryption_key_get_data,
     );
 }

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::core::DetectEngineThreadCtx;
+use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
     DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
@@ -886,8 +886,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_bandwidth_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -901,8 +900,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -916,8 +914,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_repeat_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -961,8 +958,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_attribute_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -978,8 +974,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_media_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -993,8 +988,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_session_info_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1008,8 +1002,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_connection_data_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1023,8 +1016,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_encryption_key_get_data,
     );
 }

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::core::DetectEngineThreadCtx;
+use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
     DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
@@ -576,8 +576,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.from\0".as_ptr() as *const libc::c_char,
         b"sip.from\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_from_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -591,8 +590,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.to\0".as_ptr() as *const libc::c_char,
         b"sip.to\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_to_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -606,8 +604,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.via\0".as_ptr() as *const libc::c_char,
         b"sip.via\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_via_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -621,8 +618,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.ua\0".as_ptr() as *const libc::c_char,
         b"sip.ua\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_ua_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -636,8 +632,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_content_type_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -651,8 +646,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.content_length\0".as_ptr() as *const libc::c_char,
         b"sip.content_length\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_content_length_hdr_get_data,
     );
 }

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,10 +17,11 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
+use crate::core::DetectEngineThreadCtx;
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
-    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperGetMultiData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectHelperBufferMpmRegister, DetectHelperGetData, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
@@ -338,24 +339,9 @@ unsafe extern "C" fn sip_from_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_from_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_from_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_from_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "From") {
@@ -380,24 +366,9 @@ unsafe extern "C" fn sip_to_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_to_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_to_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_to_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "To") {
@@ -422,24 +393,9 @@ unsafe extern "C" fn sip_via_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_via_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_via_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_via_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Via") {
@@ -464,24 +420,9 @@ unsafe extern "C" fn sip_ua_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_ua_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_ua_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_ua_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "User-Agent") {
@@ -506,24 +447,9 @@ unsafe extern "C" fn sip_content_type_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_content_type_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_content_type_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_content_type_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Content-Type") {
@@ -548,24 +474,9 @@ unsafe extern "C" fn sip_content_length_hdr_setup(
     return 0;
 }
 
-unsafe extern "C" fn sip_content_length_hdr_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int, local_id: u32,
-) -> *mut c_void {
-    return DetectHelperGetMultiData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        local_id,
-        sip_content_length_hdr_get_data,
-    );
-}
-
 unsafe extern "C" fn sip_content_length_hdr_get_data(
-    tx: *const c_void, flow_flags: u8, local_id: u32, buffer: *mut *const u8, buffer_len: *mut u32,
+    _de: *mut DetectEngineThreadCtx, tx: *const c_void, flow_flags: u8, local_id: u32,
+    buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
     if let Some(value) = sip_get_header_value(tx, local_id, flow_flags.into(), "Content-Length") {
@@ -667,7 +578,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_from_hdr_get,
+        sip_from_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.to"),
@@ -682,7 +593,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_to_hdr_get,
+        sip_to_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.via"),
@@ -697,7 +608,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_via_hdr_get,
+        sip_via_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.user_agent"),
@@ -712,7 +623,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_ua_hdr_get,
+        sip_ua_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_type"),
@@ -727,7 +638,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_content_type_hdr_get,
+        sip_content_type_hdr_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_length"),
@@ -742,6 +653,6 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         ALPROTO_SIP,
         true,
         true,
-        sip_content_length_hdr_get,
+        sip_content_length_hdr_get_data,
     );
 }

--- a/src/detect-dns-name.c
+++ b/src/detect-dns-name.c
@@ -89,8 +89,8 @@ static int Register(const char *keyword, const char *desc, const char *doc,
     sigmatch_table[keyword_id].flags |= SIGMATCH_NOOPT;
     sigmatch_table[keyword_id].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerMultiRegister(keyword, ALPROTO_DNS, SIG_FLAG_TOSERVER, 0, GetBufferFn, 2, 1);
-    DetectAppLayerMultiRegister(keyword, ALPROTO_DNS, SIG_FLAG_TOCLIENT, 0, GetBufferFn, 2, 1);
+    DetectAppLayerMultiRegister(keyword, ALPROTO_DNS, SIG_FLAG_TOSERVER, 1, GetBufferFn, 2);
+    DetectAppLayerMultiRegister(keyword, ALPROTO_DNS, SIG_FLAG_TOCLIENT, 1, GetBufferFn, 2);
 
     DetectBufferTypeSetDescriptionByName(keyword, keyword);
     DetectBufferTypeSupportsMultiInstance(keyword);

--- a/src/detect-dns-response.c
+++ b/src/detect-dns-response.c
@@ -110,25 +110,29 @@ static InspectionBuffer *GetBuffer(DetectEngineThreadCtx *det_ctx, uint8_t flags
         /* Get name values. */
         switch (cbdata->response_section) {
             case DNS_RESPONSE_QUERY:
-                if (!SCDnsTxGetQueryName(txv, true, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetQueryName(
+                            det_ctx, txv, STREAM_TOCLIENT, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_ANSWER:
-                if (!SCDnsTxGetAnswerName(txv, true, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAnswerName(
+                            det_ctx, txv, STREAM_TOCLIENT, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_AUTHORITY:
-                if (!SCDnsTxGetAuthorityName(txv, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAuthorityName(
+                            det_ctx, txv, 0, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }
                 break;
             case DNS_RESPONSE_ADDITIONAL:
-                if (!SCDnsTxGetAdditionalName(txv, cbdata->response_id, &data, &data_len)) {
+                if (!SCDnsTxGetAdditionalName(
+                            det_ctx, txv, 0, cbdata->response_id, &data, &data_len)) {
                     InspectionBufferSetupMultiEmpty(buffer);
                     return NULL;
                 }

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -414,10 +414,8 @@ void DetectEmailRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailUrlSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_url_buffer_id =
-            DetectHelperMultiBufferMpmRegister("email.url", "MIME EMAIL URL", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetMimeEmailUrlData);
+    g_mime_email_url_buffer_id = DetectHelperMultiBufferMpmRegister(
+            "email.url", "MIME EMAIL URL", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData);
 
     kw.name = "email.received";
     kw.desc = "'Received' field from an email";
@@ -426,7 +424,5 @@ void DetectEmailRegister(void)
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
     g_mime_email_received_buffer_id = DetectHelperMultiBufferMpmRegister("email.received",
-            "MIME EMAIL RECEIVED", ALPROTO_SMTP, false,
-            true, // to server
-            GetMimeEmailReceivedData);
+            "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -81,12 +81,12 @@ int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto a
 }
 
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData, int progress)
+        uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress)
 {
-    if (toserver) {
+    if (direction & STREAM_TOSERVER) {
         DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOSERVER, progress, GetData, 2);
     }
-    if (toclient) {
+    if (direction & STREAM_TOCLIENT) {
         DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOCLIENT, progress, GetData, 2);
     }
     DetectBufferTypeSupportsMultiInstance(name);
@@ -95,10 +95,9 @@ int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *des
 }
 
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData)
+        uint8_t direction, InspectionMultiBufferGetDataPtr GetData)
 {
-    return DetectHelperMultiBufferProgressMpmRegister(
-            name, desc, alproto, toclient, toserver, GetData, 0);
+    return DetectHelperMultiBufferProgressMpmRegister(name, desc, alproto, direction, GetData, 0);
 }
 
 int SCDetectHelperNewKeywordId(void)

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -169,30 +169,6 @@ int DetectHelperTransformRegister(const SCTransformTableElmt *kw)
     return transform_id;
 }
 
-InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf)
-{
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, index);
-    if (buffer == NULL) {
-        return NULL;
-    }
-    if (buffer->initialized) {
-        return buffer;
-    }
-
-    const uint8_t *data = NULL;
-    uint32_t data_len = 0;
-
-    if (!GetBuf(txv, flow_flags, index, &data, &data_len)) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-    return buffer;
-}
-
 const uint8_t *InspectionBufferPtr(InspectionBuffer *buf)
 {
     return buf->inspect;

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -84,12 +84,10 @@ int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *des
         bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData, int progress)
 {
     if (toserver) {
-        DetectAppLayerMultiRegister(
-                name, alproto, SIG_FLAG_TOSERVER, progress, GetData, 2, progress);
+        DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOSERVER, progress, GetData, 2);
     }
     if (toclient) {
-        DetectAppLayerMultiRegister(
-                name, alproto, SIG_FLAG_TOCLIENT, progress, GetData, 2, progress);
+        DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOCLIENT, progress, GetData, 2);
     }
     DetectBufferTypeSupportsMultiInstance(name);
     DetectBufferTypeSetDescriptionByName(name, desc);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -42,9 +42,9 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         bool toclient, bool toserver, InspectionBufferGetDataPtr GetData);
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData);
+        uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData, int progress);
+        uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress);
 
 int DetectHelperTransformRegister(const SCTransformTableElmt *kw);
 const uint8_t *InspectionBufferPtr(InspectionBuffer *buf);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -35,7 +35,6 @@ void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
 int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
-typedef bool (*MultiGetTxBuffer)(void *, uint8_t, uint32_t, const uint8_t **, uint32_t *);
 
 InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
@@ -46,10 +45,6 @@ int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppPr
         bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData);
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         bool toclient, bool toserver, InspectionMultiBufferGetDataPtr GetData, int progress);
-
-InspectionBuffer *DetectHelperGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, uint32_t index, MultiGetTxBuffer GetBuf);
 
 int DetectHelperTransformRegister(const SCTransformTableElmt *kw);
 const uint8_t *InspectionBufferPtr(InspectionBuffer *buf);

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1583,8 +1583,8 @@ static void PrefilterMultiMpm(DetectEngineThreadCtx *det_ctx, const void *pectx,
 
     do {
         // loop until we get a NULL
-        InspectionBuffer *buffer =
-                ctx->GetData(det_ctx, ctx->transforms, f, flags, txv, ctx->list_id, local_id);
+        InspectionBuffer *buffer = DetectGetMultiData(
+                det_ctx, ctx->transforms, f, flags, txv, ctx->list_id, local_id, ctx->GetData);
         if (buffer == NULL)
             break;
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2300,12 +2300,12 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
 // wrapper for both DetectAppLayerInspectEngineRegister and DetectAppLayerMpmRegister
 // with cast of callback function
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, int progress,
-        InspectionMultiBufferGetDataPtr GetData, int priority, int tx_min_progress)
+        InspectionMultiBufferGetDataPtr GetData, int priority)
 {
     AppLayerInspectEngineRegisterInternal(
             name, alproto, dir, progress, DetectEngineInspectMultiBufferGeneric, NULL, GetData);
-    DetectAppLayerMpmMultiRegister(name, dir, priority, PrefilterMultiGenericMpmRegister, GetData,
-            alproto, tx_min_progress);
+    DetectAppLayerMpmMultiRegister(
+            name, dir, priority, PrefilterMultiGenericMpmRegister, GetData, alproto, progress);
 }
 
 InspectionBuffer *DetectGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -177,7 +177,7 @@ void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uin
         int progress, InspectEngineFuncPtr Callback2, InspectionBufferGetDataPtr GetData);
 
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, int progress,
-        InspectionMultiBufferGetDataPtr GetData, int priority, int tx_min_progress);
+        InspectionMultiBufferGetDataPtr GetData, int priority);
 
 void DetectPktInspectEngineRegister(const char *name,
         InspectionBufferGetPktDataPtr GetPktData,

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -151,6 +151,9 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id);
 
+InspectionBuffer *DetectGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id, uint32_t index, InspectionMultiBufferGetDataPtr GetBuf);
 uint8_t DetectEngineInspectMultiBufferGeneric(DetectEngineCtx *de_ctx,
         DetectEngineThreadCtx *det_ctx, const DetectEngineAppInspectionEngine *engine,
         const Signature *s, Flow *f, uint8_t flags, void *alstate, void *txv, uint64_t tx_id);

--- a/src/detect-ftp-reply.c
+++ b/src/detect-ftp-reply.c
@@ -59,8 +59,8 @@ static int DetectFtpReplySetup(DetectEngineCtx *de_ctx, Signature *s, const char
     return 0;
 }
 
-static bool DetectFTPReplyGetData(void *txv, uint8_t _flow_flags, uint32_t index,
-        const uint8_t **buffer, uint32_t *buffer_len)
+static bool DetectFTPReplyGetData(DetectEngineThreadCtx *_det_ctx, const void *txv,
+        uint8_t _flow_flags, uint32_t index, const uint8_t **buffer, uint32_t *buffer_len)
 {
     FTPTransaction *tx = (FTPTransaction *)txv;
 
@@ -86,14 +86,6 @@ static bool DetectFTPReplyGetData(void *txv, uint8_t _flow_flags, uint32_t index
     return false;
 }
 
-static InspectionBuffer *GetDataWrapper(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id, uint32_t index)
-{
-    return DetectHelperGetMultiData(
-            det_ctx, transforms, _f, _flow_flags, txv, list_id, index, DetectFTPReplyGetData);
-}
-
 void DetectFtpReplyRegister(void)
 {
     /* ftp.reply sticky buffer */
@@ -104,7 +96,7 @@ void DetectFtpReplyRegister(void)
     sigmatch_table[DETECT_FTP_REPLY].flags |= SIGMATCH_NOOPT;
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, GetDataWrapper, 2, 1);
+            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, DetectFTPReplyGetData, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-ftp-reply.c
+++ b/src/detect-ftp-reply.c
@@ -96,7 +96,7 @@ void DetectFtpReplyRegister(void)
     sigmatch_table[DETECT_FTP_REPLY].flags |= SIGMATCH_NOOPT;
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 0, DetectFTPReplyGetData, 2, 1);
+            BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOCLIENT, 1, DetectFTPReplyGetData, 2);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -591,9 +591,9 @@ void DetectHttpRequestHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, rs_http2_tx_get_header, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header, 2);
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
-            HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2, HTP_REQUEST_PROGRESS_HEADERS);
+            HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 
     DetectBufferTypeSetDescriptionByName("http_request_header", "HTTP header name and value");
     g_http_request_header_buffer_id = DetectBufferTypeGetByName("http_request_header");
@@ -624,9 +624,9 @@ void DetectHttpResponseHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, rs_http2_tx_get_header, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header, 2);
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
-            HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2, HTP_RESPONSE_PROGRESS_HEADERS);
+            HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 
     DetectBufferTypeSetDescriptionByName("http_response_header", "HTTP header name and value");
     g_http_response_header_buffer_id = DetectBufferTypeGetByName("http_response_header");

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -496,46 +496,10 @@ static void HttpMultiBufHeaderThreadDataFree(void *data)
     SCFree(td);
 }
 
-static InspectionBuffer *GetHttp2HeaderData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
+static bool GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx, const void *txv, const uint8_t flags,
+        uint32_t local_id, const uint8_t **buf, uint32_t *buf_len)
 {
     SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    uint32_t b_len = 0;
-    const uint8_t *b = NULL;
-
-    if (rs_http2_tx_get_header(txv, flags, local_id, &b, &b_len) != 1) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    if (b == NULL || b_len == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
-static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
 
     int kw_thread_id;
     if (flags & STREAM_TOSERVER) {
@@ -546,7 +510,7 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     HttpMultiBufHeaderThreadData *hdr_td =
             DetectThreadCtxGetGlobalKeywordThreadCtx(det_ctx, kw_thread_id);
     if (unlikely(hdr_td == NULL)) {
-        return NULL;
+        return false;
     }
 
     htp_tx_t *tx = (htp_tx_t *)txv;
@@ -598,13 +562,11 @@ static InspectionBuffer *GetHttp1HeaderData(DetectEngineThreadCtx *det_ctx,
     // hdr_td->len is the number of header buffers
     if (local_id < hdr_td->len) {
         // we have one valid header buffer
-        InspectionBufferSetupMulti(det_ctx, buffer, transforms, hdr_td->items[local_id].buffer,
-                hdr_td->items[local_id].len);
-        buffer->flags = DETECT_CI_FLAGS_SINGLE;
-        SCReturnPtr(buffer, "InspectionBuffer");
+        *buf = hdr_td->items[local_id].buffer;
+        *buf_len = hdr_td->items[local_id].len;
+        return true;
     } // else there are no more header buffer to get
-    InspectionBufferSetupMultiEmpty(buffer);
-    return NULL;
+    return false;
 }
 
 static int DetectHTTPRequestHeaderSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -629,7 +591,7 @@ void DetectHttpRequestHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, GetHttp2HeaderData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header, 2, HTTP2StateOpen);
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2, HTP_REQUEST_PROGRESS_HEADERS);
 
@@ -662,7 +624,7 @@ void DetectHttpResponseHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, GetHttp2HeaderData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header, 2, HTTP2StateOpen);
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2, HTP_RESPONSE_PROGRESS_HEADERS);
 

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -99,14 +99,6 @@ static int g_http2_header_name_buffer_id = 0;
  * \brief Registration function for HTTP2 keywords
  */
 
-static InspectionBuffer *GetHttp2HNameData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    return DetectHelperGetMultiData(det_ctx, transforms, _f, flags, txv, list_id, local_id,
-            (MultiGetTxBuffer)rs_http2_tx_get_header_name);
-}
-
 void DetectHttp2Register(void)
 {
     sigmatch_table[DETECT_HTTP2_FRAMETYPE].name = "http2.frametype";
@@ -182,9 +174,10 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, GetHttp2HNameData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, GetHttp2HNameData, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
+
     DetectBufferTypeSupportsMultiInstance("http2_header_name");
     DetectBufferTypeSetDescriptionByName("http2_header_name",
                                          "HTTP2 header name");

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -174,9 +174,9 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2);
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, rs_http2_tx_get_header_name, 2, HTTP2StateOpen);
+            HTTP2StateOpen, rs_http2_tx_get_header_name, 2);
 
     DetectBufferTypeSupportsMultiInstance("http2_header_name");
     DetectBufferTypeSetDescriptionByName("http2_header_name",

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -52,7 +52,7 @@ void DetectIkeVendorRegister(void)
     sigmatch_table[DETECT_IKE_VENDOR].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister(
-            "ike.vendor", ALPROTO_IKE, SIG_FLAG_TOSERVER, 1, rs_ike_tx_get_vendor, 1, 1);
+            "ike.vendor", ALPROTO_IKE, SIG_FLAG_TOSERVER, 1, rs_ike_tx_get_vendor, 1);
 
     g_ike_vendor_buffer_id = DetectBufferTypeGetByName("ike.vendor");
 

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -59,7 +59,7 @@ void DetectKrb5CNameRegister(void)
     sigmatch_table[DETECT_KRB5_CNAME].desc = "sticky buffer to match on Kerberos 5 client name";
 
     DetectAppLayerMultiRegister(
-            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, rs_krb5_tx_get_cname, 2, 1);
+            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_cname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_cname",
             "Kerberos 5 ticket client name");

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -49,36 +49,6 @@ static int DetectKrb5CNameSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
     return 0;
 }
 
-static InspectionBuffer *GetKrb5CNameData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    uint32_t b_len = 0;
-    const uint8_t *b = NULL;
-
-    if (rs_krb5_tx_get_cname(txv, local_id, &b, &b_len) != 1) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-    if (b == NULL || b_len == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, b, b_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectKrb5CNameRegister(void)
 {
     sigmatch_table[DETECT_KRB5_CNAME].name = "krb5.cname";
@@ -89,7 +59,7 @@ void DetectKrb5CNameRegister(void)
     sigmatch_table[DETECT_KRB5_CNAME].desc = "sticky buffer to match on Kerberos 5 client name";
 
     DetectAppLayerMultiRegister(
-            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, GetKrb5CNameData, 2, 1);
+            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, rs_krb5_tx_get_cname, 2, 1);
 
     DetectBufferTypeSetDescriptionByName("krb5_cname",
             "Kerberos 5 ticket client name");

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -59,7 +59,7 @@ void DetectKrb5SNameRegister(void)
     sigmatch_table[DETECT_KRB5_SNAME].desc = "sticky buffer to match on Kerberos 5 server name";
 
     DetectAppLayerMultiRegister(
-            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 0, rs_krb5_tx_get_sname, 2, 1);
+            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_sname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_sname",
             "Kerberos 5 ticket server name");

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -55,33 +55,6 @@ static int DetectQuicCyuHashSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     return 0;
 }
 
-static InspectionBuffer *QuicHashGetData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    if (local_id > UINT16_MAX)
-        return NULL;
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    const uint8_t *data;
-    uint32_t data_len;
-    if (rs_quic_tx_get_cyu_hash(txv, local_id, &data, &data_len) == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectQuicCyuHashRegister(void)
 {
     /* quic.cyu.hash sticky buffer */
@@ -95,7 +68,7 @@ void DetectQuicCyuHashRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, QuicHashGetData, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_hash, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -68,7 +68,7 @@ void DetectQuicCyuHashRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_hash, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, rs_quic_tx_get_cyu_hash, 2);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -53,31 +53,6 @@ static int DetectQuicCyuStringSetup(DetectEngineCtx *de_ctx, Signature *s, const
     return 0;
 }
 
-static InspectionBuffer *QuicStringGetData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flags, void *txv,
-        int list_id, uint32_t local_id)
-{
-    SCEnter();
-
-    InspectionBuffer *buffer = InspectionBufferMultipleForListGet(det_ctx, list_id, local_id);
-    if (buffer == NULL)
-        return NULL;
-    if (buffer->initialized)
-        return buffer;
-
-    const uint8_t *data;
-    uint32_t data_len;
-    if (rs_quic_tx_get_cyu_string(txv, local_id, &data, &data_len) == 0) {
-        InspectionBufferSetupMultiEmpty(buffer);
-        return NULL;
-    }
-
-    InspectionBufferSetupMulti(det_ctx, buffer, transforms, data, data_len);
-    buffer->flags = DETECT_CI_FLAGS_SINGLE;
-
-    SCReturnPtr(buffer, "InspectionBuffer");
-}
-
 void DetectQuicCyuStringRegister(void)
 {
     /* quic.cyu.string sticky buffer */
@@ -91,7 +66,7 @@ void DetectQuicCyuStringRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, QuicStringGetData, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_string, 2, 1);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -66,7 +66,7 @@ void DetectQuicCyuStringRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 0, rs_quic_tx_get_cyu_string, 2, 1);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, rs_quic_tx_get_cyu_string, 2);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -158,8 +158,6 @@ void SCDetectSMTPRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectSmtpRcptToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_smtp_rcpt_to_buffer_id =
-            DetectHelperMultiBufferMpmRegister("smtp.rcpt_to", "SMTP RCPT TO", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetSmtpRcptToData);
+    g_smtp_rcpt_to_buffer_id = DetectHelperMultiBufferMpmRegister(
+            "smtp.rcpt_to", "SMTP RCPT TO", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpRcptToData);
 }

--- a/src/detect-tls-alpn.c
+++ b/src/detect-tls-alpn.c
@@ -104,9 +104,9 @@ void DetectTlsAlpnRegister(void)
     sigmatch_table[DETECT_TLS_ALPN].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("tls.alpn", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CLIENT_HELLO_DONE, TlsAlpnGetData, 2, TLS_STATE_CLIENT_HELLO_DONE);
-    DetectAppLayerMultiRegister("tls.alpn", ALPROTO_TLS, SIG_FLAG_TOCLIENT, TLS_STATE_SERVER_HELLO,
-            TlsAlpnGetData, 2, TLS_STATE_SERVER_HELLO);
+            TLS_STATE_CLIENT_HELLO_DONE, TlsAlpnGetData, 2);
+    DetectAppLayerMultiRegister(
+            "tls.alpn", ALPROTO_TLS, SIG_FLAG_TOCLIENT, TLS_STATE_SERVER_HELLO, TlsAlpnGetData, 2);
 
     DetectBufferTypeSetDescriptionByName("tls.alpn", "TLS APLN");
 

--- a/src/detect-tls-certs.c
+++ b/src/detect-tls-certs.c
@@ -113,9 +113,9 @@ void DetectTlsCertsRegister(void)
     sigmatch_table[DETECT_TLS_CERTS].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
-            TLS_STATE_SERVER_CERT_DONE, TlsCertsGetData, 2, 1);
+            TLS_STATE_SERVER_CERT_DONE, TlsCertsGetData, 2);
     DetectAppLayerMultiRegister("tls.certs", ALPROTO_TLS, SIG_FLAG_TOSERVER,
-            TLS_STATE_CLIENT_CERT_DONE, TlsCertsGetData, 2, 1);
+            TLS_STATE_CLIENT_CERT_DONE, TlsCertsGetData, 2);
 
     DetectBufferTypeSetDescriptionByName("tls.certs", "TLS certificate");
 

--- a/src/detect-tls-subjectaltname.c
+++ b/src/detect-tls-subjectaltname.c
@@ -84,8 +84,8 @@ void DetectTlsSubjectAltNameRegister(void)
     sigmatch_table[DETECT_TLS_SUBJECTALTNAME].flags |= SIGMATCH_NOOPT;
     sigmatch_table[DETECT_TLS_SUBJECTALTNAME].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
-    DetectAppLayerMultiRegister("tls.subjectaltname", ALPROTO_TLS, SIG_FLAG_TOCLIENT, 0,
-            TlsSubjectAltNameGetData, 2, TLS_STATE_SERVER_CERT_DONE);
+    DetectAppLayerMultiRegister("tls.subjectaltname", ALPROTO_TLS, SIG_FLAG_TOCLIENT,
+            TLS_STATE_SERVER_CERT_DONE, TlsSubjectAltNameGetData, 2);
 
     DetectBufferTypeSetDescriptionByName("tls.subjectaltname", "TLS Subject Alternative Name");
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -423,9 +423,10 @@ typedef InspectionBuffer *(*InspectionBufferGetDataPtr)(
         const DetectEngineTransforms *transforms,
         Flow *f, const uint8_t flow_flags,
         void *txv, const int list_id);
-typedef InspectionBuffer *(*InspectionMultiBufferGetDataPtr)(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, const uint32_t local_id);
+
+typedef bool (*InspectionMultiBufferGetDataPtr)(struct DetectEngineThreadCtx_ *det_ctx,
+        const void *txv, const uint8_t flow_flags, uint32_t local_id, const uint8_t **buf,
+        uint32_t *buf_len);
 struct DetectEngineAppInspectionEngine_;
 
 typedef uint8_t (*InspectEngineFuncPtr)(struct DetectEngineCtx_ *de_ctx,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, cleanup

Describe changes:
- Move wrapper code for multi-buffer getter to a unique function `DetectGetMultiData` and removes boilerplate duplicate code (changing `InspectionMultiBufferGetDataPtr` prototype)
- use only one value of progress for both inspect engine and app-layer mpm for multi-buffers
- change the helper with more explicit direction for multi-buffers

https://github.com/OISF/suricata/pull/13071 with more commits
