### PR TITLE
lua: convert flowvar functions to lib

### DIFF
--- a/doc/userguide/lua/libs/flowvar.rst
+++ b/doc/userguide/lua/libs/flowvar.rst
@@ -1,0 +1,79 @@
+Flowvar
+#######
+
+The ``suricata.flowvar`` library exposes flow variables to Lua
+scripts.
+
+Initialization
+--------------
+
+First, the ``flowvar`` lib must be required::
+
+  local flowvarlib = require("suricata.flow")
+
+Then in the ``init`` method, any flow variables used in the script
+should be registered. This is optional and could be skipped if you
+know for sure the flow variable will be registered by some other
+means.
+
+Example::
+
+  local flowvarlib = require("suricata.flow")
+
+  function init ()
+      flowvarlib.register("count")
+      return {}
+  end
+
+Finally, in the ``thread_init`` function a handle is acquired for the
+flow variables and stored as a global::
+
+  function thread_init ()
+      count_flow_var = flowvarlib.get("count")
+  end
+
+Flow Variable Methods
+---------------------
+
+``value()``
+^^^^^^^^^^^
+
+Get the current value of the flow variable as a string. Note that
+``nil`` may be returned if the flow variable does not have a value.
+
+``set(value, len)``
+^^^^^^^^^^^^^^^^^^^
+
+Set the value of the flow variable to the value provided. The length
+of the value must also be provided.
+
+Example
+-------
+
+::
+
+  local flowvarlib = require("suricata.flowvar")
+
+  function init ()
+      flowvarlib.register("count")
+      return {}
+  end
+
+  function thread_init ()
+      count_var = flowvarlib.get("count")
+  end
+
+  function match ()
+      local value = count_var:value()
+      if value == nil then
+          -- Initialize value to 1.
+          value = tostring(1)
+          count_var:set(value, #value)
+      else
+          value = tostring(tonumber(value) + 1)
+          count_var:set(value, #value)
+      fi
+
+      -- Return 1 or 0 based on your own logic.
+      return 1
+  end

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -11,6 +11,7 @@ environment without access to additional modules.
    base64
    dns
    flowlib
+   flowvar
    hashlib
    http
    packetlib

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -675,38 +675,6 @@ SCFlowintDecr
 
 Decrement Flowint at index given by the first parameter.
 
-SCFlowvarGet
-~~~~~~~~~~~~
-
-Get the Flowvar at index given by the parameter.
-
-SCFlowvarSet
-~~~~~~~~~~~~
-
-Set a Flowvar. First parameter is the index, second is the data
-and third is the length of data.
-
-You can use it to set string 
-
-::
-
- function init (args)
-     local needs = {}
-     needs["http.request_headers"] = tostring(true)
-     needs["flowvar"] = {"cnt"}
-     return needs
- end
- 
- function match(args)
-     a = SCFlowvarGet(0);
-     if a then
-         a = tostring(tonumber(a)+1)
-         SCFlowvarSet(0, a, #a)
-     else
-         a = tostring(1)
-         SCFlowvarSet(0, a, #a)
-     end 
-
 Misc
 ----
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -526,6 +526,7 @@ noinst_HEADERS = \
 	util-lua-dnp3-objects.h \
 	util-lua-dns.h \
 	util-lua-flowlib.h \
+	util-lua-flowvarlib.h \
 	util-lua.h \
 	util-lua-hashlib.h \
 	util-lua-hassh.h \
@@ -1094,6 +1095,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-dnp3-objects.c \
 	util-lua-dns.c \
 	util-lua-flowlib.c \
+	util-lua-flowvarlib.c \
 	util-lua-hashlib.c \
 	util-lua-hassh.c \
 	util-lua-http.c \

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -20,6 +20,7 @@
 #include "util-lua-base64lib.h"
 #include "util-lua-dataset.h"
 #include "util-lua-dnp3.h"
+#include "util-lua-flowvarlib.h"
 #include "util-lua-http.h"
 #include "util-lua-dns.h"
 #include "util-lua-ssh.h"
@@ -36,6 +37,7 @@ static const luaL_Reg builtins[] = {
     { "suricata.dnp3", SCLuaLoadDnp3Lib },
     { "suricata.dns", SCLuaLoadDnsLib },
     { "suricata.flow", LuaLoadFlowLib },
+    { "suricata.flowvar", LuaLoadFlowvarLib },
     { "suricata.hashlib", SCLuaLoadHashlib },
     { "suricata.http", SCLuaLoadHttpLib },
     { "suricata.packet", LuaLoadPacketLib },

--- a/src/util-lua-flowvarlib.c
+++ b/src/util-lua-flowvarlib.c
@@ -1,0 +1,145 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "app-layer-protos.h"
+#include "flow-var.h"
+#include "lauxlib.h"
+#include "util-debug.h"
+#include "util-lua-common.h"
+#include "util-lua-flowvarlib.h"
+#include "util-lua.h"
+#include "util-var-name.h"
+#include "detect-lua.h"
+#include "detect-lua-extensions.h"
+
+static const char suricata_flowvar_mt[] = "suricata:flowvar:mt";
+
+static DetectLuaData *GetLuaData(lua_State *luastate)
+{
+    DetectLuaData *ld;
+    lua_pushlightuserdata(luastate, (void *)&luaext_key_ld);
+    lua_gettable(luastate, LUA_REGISTRYINDEX);
+    ld = lua_touserdata(luastate, -1);
+    return ld;
+}
+
+/**
+ * \brief Register a flowvar.
+ *
+ * Ensures that a flowvar exists for the provided name, will be
+ * created if needed.
+ *
+ * The flowvar ID is returned, however as this is most likely to be
+ * used in the scripts "init" method, this ID is unlikely to be used.
+ */
+static int LuaFlowvarRegister(lua_State *L)
+{
+    DetectLuaData *ld = GetLuaData(L);
+    const char *name = luaL_checkstring(L, 1);
+    uint32_t *flowvar_id = lua_newuserdata(L, sizeof(*flowvar_id));
+    *flowvar_id = VarNameStoreRegister(name, VAR_TYPE_FLOW_VAR);
+    if (*flowvar_id == 0) {
+        return luaL_error(L, "failed to register flowvar");
+    }
+    ld->flowvar[ld->flowvars++] = *flowvar_id;
+
+    luaL_getmetatable(L, suricata_flowvar_mt);
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+
+static int LuaFlowvarGet(lua_State *L)
+{
+    const char *name = luaL_checkstring(L, 1);
+    uint32_t *flowvar_id = lua_newuserdata(L, sizeof(*flowvar_id));
+    *flowvar_id = VarNameStoreLookupByName(name, VAR_TYPE_FLOW_VAR);
+    if (*flowvar_id == 0) {
+        return luaL_error(L, "flowvar does not exist");
+    }
+
+    luaL_getmetatable(L, suricata_flowvar_mt);
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+
+/**
+ * \brief Return the current value of the flowvar.
+ */
+static int LuaFlowvarValue(lua_State *L)
+{
+    uint32_t *flowvar_id = luaL_testudata(L, 1, suricata_flowvar_mt);
+    Flow *f = LuaStateGetFlow(L);
+    if (f == NULL) {
+        return LuaCallbackError(L, "flow is NULL");
+    }
+    FlowVar *fv = FlowVarGet(f, *flowvar_id);
+    if (fv == NULL) {
+        lua_pushnil(L);
+    } else {
+        LuaPushStringBuffer(
+                L, (const uint8_t *)fv->data.fv_str.value, (size_t)fv->data.fv_str.value_len);
+    }
+    return 1;
+}
+
+static int LuaFlowvarSet(lua_State *L)
+{
+    const char *value = luaL_checkstring(L, 2);
+    const int len = luaL_checkinteger(L, 3);
+    uint32_t *flowvar_id = luaL_checkudata(L, 1, suricata_flowvar_mt);
+    Flow *f = LuaStateGetFlow(L);
+    if (f == NULL) {
+        return luaL_error(L, "no flow");
+    }
+
+    uint8_t *buf = SCMalloc(len + 1);
+    memcpy(buf, value, len);
+    buf[len] = '\0';
+    FlowVarAddIdValue(f, *flowvar_id, buf, (uint16_t)len);
+
+    return 1;
+}
+
+static const luaL_Reg flowvarlib[] = {
+    // clang-format off
+  { "register", LuaFlowvarRegister, },
+{ "get", LuaFlowvarGet },
+  { NULL, NULL, },
+    // clang-format on
+};
+
+static const luaL_Reg flowvarmt[] = {
+    // clang-format off
+  { "value", LuaFlowvarValue, },
+  { "set", LuaFlowvarSet, },
+  { NULL, NULL, },
+    // clang-format on
+};
+
+int LuaLoadFlowvarLib(lua_State *L)
+{
+    luaL_newmetatable(L, suricata_flowvar_mt);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, flowvarmt, 0);
+
+    luaL_newlib(L, flowvarlib);
+    return 1;
+}

--- a/src/util-lua-flowvarlib.h
+++ b/src/util-lua-flowvarlib.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,22 +15,11 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Victor Julien <victor@inliniac.net>
- */
+#ifndef SURICATA_UTIL_LUA_FLOWVARLIB_H
+#define SURICATA_UTIL_LUA_FLOWVARLIB_H
 
-#ifndef SURICATA_DETECT_LUA_EXT_H
-#define SURICATA_DETECT_LUA_EXT_H
+#include "lua.h"
 
-extern const char luaext_key_ld[];
+int LuaLoadFlowvarLib(lua_State *L);
 
-int LuaRegisterExtensions(lua_State *);
-
-void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *, DetectEngineThreadCtx *det_ctx,
-        Flow *f, Packet *p, const Signature *s, uint8_t flags);
-
-void LuaLoadDatasetLib(lua_State *luastate);
-
-#endif
+#endif /* SURICATA_UTIL_LUA_FLOWVARLIB_H */


### PR DESCRIPTION
New Lua lib, "suricata.flowvar" for working with flowvars from Lua.

Replaces functions:
- SCFlowvarGet (and ScFlowvarGet)
- SCFlowvarSet (and SCFlowvarSet)

Of note, the DetectLuaData has been made available to the init and
thread_init methods, instead of just the match. This is due to an
issue that if a flow variable is not registered in init, it will not
be logged, registering in thread_init is too late.

Ticket: #7486

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2467
