### PR TITLE
websocket: limit allocation for small sizes

### DIFF
--- a/rust/src/websocket/websocket.rs
+++ b/rust/src/websocket/websocket.rs
@@ -239,7 +239,12 @@ impl WebSocketState {
                         buf.compress = false;
                         // cf RFC 7692 section-7.2.2
                         tx.pdu.payload.extend_from_slice(&[0, 0, 0xFF, 0xFF]);
-                        let mut v = Vec::with_capacity(WEBSOCKET_DECOMPRESS_BUF_SIZE);
+                        let mut v = Vec::with_capacity(std::cmp::min(
+                            WEBSOCKET_DECOMPRESS_BUF_SIZE,
+                            // Do not allocate 8kbytes for a small size.
+                            // Numbers here may be optimized.
+                            256 + 16 * tx.pdu.payload.len(),
+                        ));
                         if let Some(dec) = dec {
                             let expect = dec.total_in() + tx.pdu.payload.len() as u64;
                             let start = dec.total_in();


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
None but https://issues.oss-fuzz.com/u/1/issues/413963383

Describe changes:
- websocket: limit allocation for decompressing small size payloads

Do not allocate a 8bytes if we have only one byte.

Another solution to oss-fuzz could be to add a max-tx config parameter to websocket
