### PR TITLE
detect: do not bug on tx data being NULL

### DIFF
--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -284,7 +284,6 @@ void DetectEngineStateResetTxs(Flow *f)
         void *inspect_tx = AppLayerParserGetTx(f->proto, f->alproto, alstate, inspect_tx_id);
         if (inspect_tx != NULL) {
             AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, inspect_tx);
-            BUG_ON(txd == NULL);
             if (txd) {
                 ResetTxState(txd->de_state);
             }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7610

Describe changes:
- detect: do not bug on tx data being NULL

This is not a cherry-pick, but a simple fix for libhtp.rs in master taking advatnage and doing f301cd370205af7e069680c286252304ab128214 and 833a738dd1429f63c79d95edf25bb86fcc15b51a