### PR TITLE
detect: do not bug on tx data being NULL

### DIFF
--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -228,7 +228,6 @@ void DetectRunStoreStateTx(
         const uint16_t file_no_match)
 {
     AppLayerTxData *tx_data = AppLayerParserGetTxData(f->proto, f->alproto, tx);
-    BUG_ON(tx_data == NULL);
     if (tx_data == NULL) {
         SCLogDebug("No TX data for %" PRIu64, tx_id);
         return;
@@ -284,7 +283,6 @@ void DetectEngineStateResetTxs(Flow *f)
         void *inspect_tx = AppLayerParserGetTx(f->proto, f->alproto, alstate, inspect_tx_id);
         if (inspect_tx != NULL) {
             AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, inspect_tx);
-            BUG_ON(txd == NULL);
             if (txd) {
                 ResetTxState(txd->de_state);
             }

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -159,7 +159,6 @@ static int FilestorePostMatchWithOptions(Packet *p, Flow *f, const DetectFilesto
         DEBUG_VALIDATE_BUG_ON(txv == NULL);
         if (txv != NULL) {
             AppLayerTxData *txd = AppLayerParserGetTxData(f->proto, f->alproto, txv);
-            DEBUG_VALIDATE_BUG_ON(txd == NULL);
             if (txd != NULL) {
                 if (toclient_dir) {
                     txd->file_flags |= FLOWFILE_STORE_TC;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7610

Describe changes:
- detect: do not bug on tx data being NULL

#13101 with more complete inspection of BUG_ON removed in both commits mentioned below : 

This is not a cherry-pick, but a simple fix for libhtp.rs in master taking advantage and doing f301cd370205af7e069680c286252304ab128214 and 833a738dd1429f63c79d95edf25bb86fcc15b51a