### PR TITLE
detect/single-buf: helper with more explicit direction

### DIFF
--- a/examples/plugins/altemplate/src/detect.rs
+++ b/examples/plugins/altemplate/src/detect.rs
@@ -28,6 +28,7 @@ use suricata::detect::{
     DetectHelperBufferMpmRegister, DetectHelperGetData, DetectSignatureSetAppProto,
     SigTableElmtStickyBuffer,
 };
+use suricata::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use suricata::direction::Direction;
 
 static mut G_TEMPLATE_BUFFER_BUFFER_ID: c_int = 0;
@@ -93,8 +94,7 @@ pub(super) unsafe extern "C" fn detect_template_register() {
         b"altemplate.buffer\0".as_ptr() as *const libc::c_char,
         b"template.buffer intern description\0".as_ptr() as *const libc::c_char,
         ALPROTO_TEMPLATE,
-        true, //toclient
-        true, //toserver
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         template_buffer_get,
     );
 }

--- a/rust/src/applayertemplate/detect.rs
+++ b/rust/src/applayertemplate/detect.rs
@@ -19,6 +19,7 @@ use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
 /* TEMPLATE_START_REMOVE */
 use crate::conf::conf_get_node;
 /* TEMPLATE_END_REMOVE */
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
     DetectHelperBufferMpmRegister, DetectHelperGetData, DetectSignatureSetAppProto,
@@ -96,8 +97,7 @@ pub unsafe extern "C" fn SCDetectTemplateRegister() {
         b"template.buffer\0".as_ptr() as *const libc::c_char,
         b"template.buffer intern description\0".as_ptr() as *const libc::c_char,
         ALPROTO_TEMPLATE,
-        true, //toclient
-        true, //toserver
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         template_buffer_get,
     );
 }

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -160,8 +160,7 @@ extern "C" {
         get_buf: unsafe extern "C" fn(*const c_void, u8, *mut *const u8, *mut u32) -> bool,
     ) -> *mut c_void;
     pub fn DetectHelperBufferMpmRegister(
-        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, toclient: bool,
-        toserver: bool,
+        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
         get_data: unsafe extern "C" fn(
             *mut c_void,
             *const c_void,
@@ -174,7 +173,7 @@ extern "C" {
     pub fn DetectHelperKeywordRegister(kw: *const SCSigTableAppLiteElmt) -> c_int;
     pub fn DetectHelperKeywordAliasRegister(kwid: c_int, alias: *const c_char);
     pub fn DetectHelperBufferRegister(
-        name: *const libc::c_char, alproto: AppProto, toclient: bool, toserver: bool,
+        name: *const libc::c_char, alproto: AppProto, dir: u8,
     ) -> c_int;
     pub fn DetectSignatureSetAppProto(s: *mut c_void, alproto: AppProto) -> c_int;
     pub fn SigMatchAppendSMToList(

--- a/rust/src/dhcp/detect.rs
+++ b/rust/src/dhcp/detect.rs
@@ -20,9 +20,8 @@ use super::dhcp::{
     DHCP_OPT_RENEWAL_TIME,
 };
 use super::parser::DHCPOptionWrapper;
-use crate::detect::uint::{
-    SCDetectU64Free, SCDetectU64Match, SCDetectU64Parse, DetectUintData,
-};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::detect::uint::{DetectUintData, SCDetectU64Free, SCDetectU64Match, SCDetectU64Parse};
 use crate::detect::{
     DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
     SCSigTableAppLiteElmt, SigMatchAppendSMToList,
@@ -179,8 +178,7 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
     G_DHCP_LEASE_TIME_BUFFER_ID = DetectHelperBufferRegister(
         b"dhcp.leasetime\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"dhcp.rebinding_time\0".as_ptr() as *const libc::c_char,
@@ -195,8 +193,7 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
     G_DHCP_REBINDING_TIME_BUFFER_ID = DetectHelperBufferRegister(
         b"dhcp.rebinding-time\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"dhcp.renewal_time\0".as_ptr() as *const libc::c_char,
@@ -211,7 +208,6 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
     G_DHCP_RENEWAL_TIME_BUFFER_ID = DetectHelperBufferRegister(
         b"dhcp.renewal-time\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
 }

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -352,8 +352,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
     G_DNS_OPCODE_BUFFER_ID = DetectHelperBufferRegister(
         b"dns.opcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("dns.query.name"),
@@ -385,8 +384,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
     G_DNS_RCODE_BUFFER_ID = DetectHelperBufferRegister(
         b"dns.rcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"dns.rrtype\0".as_ptr() as *const libc::c_char,
@@ -401,8 +399,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
     G_DNS_RRTYPE_BUFFER_ID = DetectHelperBufferRegister(
         b"dns.rrtype\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("dns.query"),

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -29,6 +29,7 @@ use super::parser::{
     CIP_MULTIPLE_SERVICE,
 };
 
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU16Match,
     SCDetectU16Parse, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free,
@@ -1346,8 +1347,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIPSERVICE_BUFFER_ID = DetectHelperBufferRegister(
         b"cip\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.capabilities\0".as_ptr() as *const libc::c_char,
@@ -1362,8 +1362,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CAPABILITIES_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.capabilities\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.cip_attribute\0".as_ptr() as *const libc::c_char,
@@ -1378,8 +1377,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIP_ATTRIBUTE_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.cip_attribute\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.cip_class\0".as_ptr() as *const libc::c_char,
@@ -1394,8 +1392,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIP_CLASS_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.cip_class\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.vendor_id\0".as_ptr() as *const libc::c_char,
@@ -1410,8 +1407,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_VENDOR_ID_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.vendor_id\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.status\0".as_ptr() as *const libc::c_char,
@@ -1426,8 +1422,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_STATUS_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.state\0".as_ptr() as *const libc::c_char,
@@ -1442,8 +1437,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_STATE_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.state\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.serial\0".as_ptr() as *const libc::c_char,
@@ -1458,8 +1452,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_SERIAL_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.serial\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.revision\0".as_ptr() as *const libc::c_char,
@@ -1474,8 +1467,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_REVISION_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.revision\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.protocol_version\0".as_ptr() as *const libc::c_char,
@@ -1490,8 +1482,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_PROTOCOL_VERSION_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.protocol_version\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.product_code\0".as_ptr() as *const libc::c_char,
@@ -1506,8 +1497,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_PRODUCT_CODE_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.product_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip_command\0".as_ptr() as *const libc::c_char,
@@ -1522,8 +1512,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_COMMAND_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.command\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.identity_status\0".as_ptr() as *const libc::c_char,
@@ -1538,8 +1527,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_IDENTITY_STATUS_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.identity_status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.device_type\0".as_ptr() as *const libc::c_char,
@@ -1554,8 +1542,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_DEVICE_TYPE_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.device_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.cip_status\0".as_ptr() as *const libc::c_char,
@@ -1570,8 +1557,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIP_STATUS_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.cip_status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.cip_instance\0".as_ptr() as *const libc::c_char,
@@ -1586,8 +1572,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIP_INSTANCE_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.cip_instance\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"enip.cip_extendedstatus\0".as_ptr() as *const libc::c_char,
@@ -1603,8 +1588,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
     G_ENIP_CIP_EXTENDEDSTATUS_BUFFER_ID = DetectHelperBufferRegister(
         b"enip.cip_extendedstatus\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("enip.product_name"),
@@ -1617,8 +1601,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         b"enip.product_name\0".as_ptr() as *const libc::c_char,
         b"ENIP product name\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         product_name_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1632,8 +1615,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         b"enip.service_name\0".as_ptr() as *const libc::c_char,
         b"ENIP service name\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         service_name_get_data,
     );
 }

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -645,8 +645,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
     G_LDAP_REQUEST_OPERATION_BUFFER_ID = DetectHelperBufferRegister(
         b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        false, //to client
-        true,  //to server
+        STREAM_TOSERVER,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"ldap.responses.operation\0".as_ptr() as *const libc::c_char,
@@ -662,8 +661,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
     G_LDAP_RESPONSES_OPERATION_BUFFER_ID = DetectHelperBufferRegister(
         b"ldap.responses.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"ldap.responses.count\0".as_ptr() as *const libc::c_char,
@@ -678,8 +676,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
     G_LDAP_RESPONSES_COUNT_BUFFER_ID = DetectHelperBufferRegister(
         b"ldap.responses.count\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.request.dn"),
@@ -692,8 +689,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         b"ldap.request.dn\0".as_ptr() as *const libc::c_char,
         b"LDAP REQUEST DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        false, //to client
-        true,  //to server
+        STREAM_TOSERVER,
         ldap_detect_request_dn_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -724,8 +720,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
     G_LDAP_RESPONSES_RESULT_CODE_BUFFER_ID = DetectHelperBufferRegister(
         b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
-        true,  //to client
-        false, //to server
+        STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.responses.message"),

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
-use crate::core::{DetectEngineThreadCtx, STREAM_TOSERVER};
+use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode,
     SCDetectU8Free, SCDetectU8Parse,
@@ -1107,8 +1107,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_TYPE_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.type\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
 
     let keyword_name = b"mqtt.subscribe.topic\0".as_ptr() as *const libc::c_char;
@@ -1148,8 +1147,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_REASON_CODE_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.reason_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"mqtt.connack.session_present\0".as_ptr() as *const libc::c_char,
@@ -1165,8 +1163,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_CONNACK_SESSIONPRESENT_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.connack.session_present\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        true,
-        false, // only to client
+        STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"mqtt.qos\0".as_ptr() as *const libc::c_char,
@@ -1182,8 +1179,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_QOS_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.qos\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("mqtt.publish.topic"),
@@ -1196,8 +1192,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.publish.topic\0".as_ptr() as *const libc::c_char,
         b"MQTT PUBLISH topic\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        true, // PUBLISH goes both ways
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         mqtt_pub_topic_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1211,8 +1206,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.publish.message\0".as_ptr() as *const libc::c_char,
         b"MQTT PUBLISH message\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        true, // PUBLISH goes both ways
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         mqtt_pub_msg_get_data,
     );
     let kw = SCSigTableAppLiteElmt {
@@ -1228,8 +1222,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_PROTOCOL_VERSION_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.protocol_version\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"mqtt.flags\0".as_ptr() as *const libc::c_char,
@@ -1244,8 +1237,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"mqtt.connect.flags\0".as_ptr() as *const libc::c_char,
@@ -1260,8 +1252,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
     G_MQTT_CONN_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
         b"mqtt.connect.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("mqtt.connect.willtopic"),
@@ -1274,8 +1265,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.willtopic\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT will topic\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_willtopic_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1289,8 +1279,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.willmessage\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT will message\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_willmsg_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1304,8 +1293,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.username\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT username\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_username_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1319,8 +1307,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.protocol_string\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT protocol string\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_protocolstring_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1334,8 +1321,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.password\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT password\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_password_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1349,8 +1335,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         b"mqtt.connect.clientid\0".as_ptr() as *const libc::c_char,
         b"MQTT CONNECT clientid\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
         mqtt_conn_clientid_get_data,
     );
 }

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -19,6 +19,7 @@
 
 use super::parser::RFBSecurityResultStatus;
 use super::rfb::{RFBTransaction, ALPROTO_RFB};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
 };
@@ -199,8 +200,7 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
         b"rfb.name\0".as_ptr() as *const libc::c_char,
         b"rfb name\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,
-        true, //toclient
-        false,
+        STREAM_TOCLIENT,
         rfb_name_get,
     );
     let kw = SCSigTableAppLiteElmt {
@@ -216,8 +216,7 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
     G_RFB_SEC_TYPE_BUFFER_ID = DetectHelperBufferRegister(
         b"rfb.sectype\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,
-        false, // only to server
-        true,
+        STREAM_TOSERVER,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"rfb.secresult\0".as_ptr() as *const libc::c_char,
@@ -232,8 +231,7 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
     G_RFB_SEC_RESULT_BUFFER_ID = DetectHelperBufferRegister(
         b"rfb.secresult\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,
-        true, // only to client
-        false,
+        STREAM_TOCLIENT,
     );
 }
 

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -781,8 +781,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.session_name\0".as_ptr() as *const libc::c_char,
         b"sdp.session_name\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_session_name_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -796,8 +795,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.session_info\0".as_ptr() as *const libc::c_char,
         b"sdp.session_info\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_session_info_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -811,8 +809,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.origin\0".as_ptr() as *const libc::c_char,
         b"sdp.origin\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_origin_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -826,8 +823,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.uri\0".as_ptr() as *const libc::c_char,
         b"sdp.uri\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_uri_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -841,8 +837,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.email\0".as_ptr() as *const libc::c_char,
         b"sdp.email\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_email_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -856,8 +851,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
         b"sdp.phone_number\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_phone_number_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -871,8 +865,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.connection_data\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_conn_data_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -886,7 +879,7 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_bandwidth_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -900,7 +893,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -914,7 +907,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_repeat_time_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -928,8 +921,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.timezone\0".as_ptr() as *const libc::c_char,
         b"sdp.timezone\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_timezone_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -943,8 +935,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.encription_key\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sdp_encryption_key_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -958,7 +949,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_attribute_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -974,7 +965,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_media_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -988,7 +979,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_session_info_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1002,7 +993,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_connection_data_get_data,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -1016,7 +1007,7 @@ STREAM_TOSERVER | STREAM_TOCLIENT,
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-STREAM_TOSERVER | STREAM_TOCLIENT,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_media_desc_encryption_key_get_data,
     );
 }

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -501,8 +501,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.protocol\0".as_ptr() as *const libc::c_char,
         b"sip.protocol\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         sip_protocol_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -516,8 +515,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.stat_code\0".as_ptr() as *const libc::c_char,
         b"sip.stat_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        false,
+        STREAM_TOCLIENT,
         sip_stat_code_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -531,8 +529,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.stat_msg\0".as_ptr() as *const libc::c_char,
         b"sip.stat_msg\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        false,
+        STREAM_TOCLIENT,
         sip_stat_msg_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -546,8 +543,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.request_line\0".as_ptr() as *const libc::c_char,
         b"sip.request_line\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        false,
-        true,
+        STREAM_TOSERVER,
         sip_request_line_get,
     );
     let kw = SigTableElmtStickyBuffer {
@@ -561,8 +557,7 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         b"sip.response_line\0".as_ptr() as *const libc::c_char,
         b"sip.response_line\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
-        true,
-        false,
+        STREAM_TOCLIENT,
         sip_response_line_get,
     );
     let kw = SigTableElmtStickyBuffer {

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -18,6 +18,7 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use super::snmp::{SNMPTransaction, ALPROTO_SNMP};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectBufferSetActiveList,
@@ -196,8 +197,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
     G_SNMP_VERSION_BUFFER_ID = DetectHelperBufferRegister(
         b"snmp.version\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
 
     let kw = SCSigTableAppLiteElmt {
@@ -213,8 +213,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
     G_SNMP_PDUTYPE_BUFFER_ID = DetectHelperBufferRegister(
         b"snmp.pdu_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
 
     let kw = SigTableElmtStickyBuffer {
@@ -228,8 +227,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         b"snmp.usm\0".as_ptr() as *const libc::c_char,
         b"SNMP USM\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         snmp_detect_usm_get_data,
     );
 
@@ -244,8 +242,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         b"snmp.community\0".as_ptr() as *const libc::c_char,
         b"SNMP Community identifier\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         snmp_detect_community_get_data,
     );
 }

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -16,6 +16,7 @@
  */
 
 use super::websocket::{WebSocketTransaction, ALPROTO_WEBSOCKET};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode, SCDetectU32Free,
     SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match,
@@ -292,8 +293,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
     G_WEBSOCKET_OPCODE_BUFFER_ID = DetectHelperBufferRegister(
         b"websocket.opcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"websocket.mask\0".as_ptr() as *const libc::c_char,
@@ -308,8 +308,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
     G_WEBSOCKET_MASK_BUFFER_ID = DetectHelperBufferRegister(
         b"websocket.mask\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"websocket.flags\0".as_ptr() as *const libc::c_char,
@@ -324,8 +323,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
     G_WEBSOCKET_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
         b"websocket.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("websocket.payload"),
@@ -338,8 +336,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         b"websocket.payload\0".as_ptr() as *const libc::c_char,
         b"WebSocket payload\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
-        true,
-        true,
+        STREAM_TOSERVER | STREAM_TOCLIENT,
         websocket_detect_payload_get_data,
     );
 }

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -337,10 +337,8 @@ void DetectEmailRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_from_buffer_id =
-            DetectHelperBufferMpmRegister("email.from", "MIME EMAIL FROM", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetMimeEmailFromData);
+    g_mime_email_from_buffer_id = DetectHelperBufferMpmRegister(
+            "email.from", "MIME EMAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailFromData);
 
     kw.name = "email.subject";
     kw.desc = "'Subject' field from an email";
@@ -349,9 +347,7 @@ void DetectEmailRegister(void)
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
     g_mime_email_subject_buffer_id = DetectHelperBufferMpmRegister("email.subject",
-            "MIME EMAIL SUBJECT", ALPROTO_SMTP, false,
-            true, // to server
-            GetMimeEmailSubjectData);
+            "MIME EMAIL SUBJECT", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData);
 
     kw.name = "email.to";
     kw.desc = "'To' field from an email";
@@ -359,10 +355,8 @@ void DetectEmailRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_to_buffer_id =
-            DetectHelperBufferMpmRegister("email.to", "MIME EMAIL TO", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetMimeEmailToData);
+    g_mime_email_to_buffer_id = DetectHelperBufferMpmRegister(
+            "email.to", "MIME EMAIL TO", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData);
 
     kw.name = "email.cc";
     kw.desc = "'Cc' field from an email";
@@ -370,10 +364,8 @@ void DetectEmailRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailCcSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_cc_buffer_id =
-            DetectHelperBufferMpmRegister("email.cc", "MIME EMAIL CC", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetMimeEmailCcData);
+    g_mime_email_cc_buffer_id = DetectHelperBufferMpmRegister(
+            "email.cc", "MIME EMAIL CC", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData);
 
     kw.name = "email.date";
     kw.desc = "'Date' field from an email";
@@ -381,10 +373,8 @@ void DetectEmailRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectMimeEmailDateSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_date_buffer_id =
-            DetectHelperBufferMpmRegister("email.date", "MIME EMAIL DATE", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetMimeEmailDateData);
+    g_mime_email_date_buffer_id = DetectHelperBufferMpmRegister(
+            "email.date", "MIME EMAIL DATE", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailDateData);
 
     kw.name = "email.message_id";
     kw.desc = "'Message-Id' field from an email";
@@ -393,9 +383,7 @@ void DetectEmailRegister(void)
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
     g_mime_email_message_id_buffer_id = DetectHelperBufferMpmRegister("email.message_id",
-            "MIME EMAIL Message-Id", ALPROTO_SMTP, false,
-            true, // to server
-            GetMimeEmailMessageIdData);
+            "MIME EMAIL Message-Id", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData);
 
     kw.name = "email.x_mailer";
     kw.desc = "'X-Mailer' field from an email";
@@ -404,9 +392,7 @@ void DetectEmailRegister(void)
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
     g_mime_email_x_mailer_buffer_id = DetectHelperBufferMpmRegister("email.x_mailer",
-            "MIME EMAIL X-Mailer", ALPROTO_SMTP, false,
-            true, // to server
-            GetMimeEmailXMailerData);
+            "MIME EMAIL X-Mailer", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData);
 
     kw.name = "email.url";
     kw.desc = "'Url' extracted from an email";

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -30,13 +30,13 @@
 #include "detect-parse.h"
 #include "detect-engine-content-inspection.h"
 
-int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver)
+int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction)
 {
-    if (toserver) {
+    if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectGenericList, NULL);
     }
-    if (toclient) {
+    if (direction & STREAM_TOCLIENT) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectGenericList, NULL);
     }
@@ -62,15 +62,15 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
 }
 
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionBufferGetDataPtr GetData)
+        uint8_t direction, InspectionBufferGetDataPtr GetData)
 {
-    if (toserver) {
+    if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectBufferGeneric, GetData);
         DetectAppLayerMpmRegister(
                 name, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData, alproto, 0);
     }
-    if (toclient) {
+    if (direction & STREAM_TOCLIENT) {
         DetectAppLayerInspectEngineRegister(
                 name, alproto, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectBufferGeneric, GetData);
         DetectAppLayerMpmRegister(

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -32,7 +32,7 @@ int SCDetectHelperNewKeywordId(void);
 
 int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
-int DetectHelperBufferRegister(const char *name, AppProto alproto, bool toclient, bool toserver);
+int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
 
@@ -40,7 +40,7 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
         const int list_id, SimpleGetTxBuffer GetBuf);
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        bool toclient, bool toserver, InspectionBufferGetDataPtr GetData);
+        uint8_t direction, InspectionBufferGetDataPtr GetData);
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,

--- a/src/detect-ftp-command-data.c
+++ b/src/detect-ftp-command-data.c
@@ -104,7 +104,7 @@ void DetectFtpCommandDataRegister(void)
     sigmatch_table[DETECT_FTP_COMMAND_DATA].flags |= SIGMATCH_NOOPT;
 
     DetectHelperBufferMpmRegister(
-            BUFFER_NAME, BUFFER_NAME, ALPROTO_FTP, false, true, GetDataWrapper);
+            BUFFER_NAME, BUFFER_NAME, ALPROTO_FTP, STREAM_TOSERVER, GetDataWrapper);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -136,10 +136,8 @@ void SCDetectSMTPRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectSmtpHeloSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_smtp_helo_buffer_id =
-            DetectHelperBufferMpmRegister("smtp.helo", "SMTP helo", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetSmtpHeloData);
+    g_smtp_helo_buffer_id = DetectHelperBufferMpmRegister(
+            "smtp.helo", "SMTP helo", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpHeloData);
 
     kw.name = "smtp.mail_from";
     kw.desc = "SMTP mail from buffer";
@@ -147,10 +145,8 @@ void SCDetectSMTPRegister(void)
     kw.Setup = (int (*)(void *, void *, const char *))DetectSmtpMailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_smtp_mail_from_buffer_id =
-            DetectHelperBufferMpmRegister("smtp.mail_from", "SMTP MAIL FROM", ALPROTO_SMTP, false,
-                    true, // to server
-                    GetSmtpMailFromData);
+    g_smtp_mail_from_buffer_id = DetectHelperBufferMpmRegister(
+            "smtp.mail_from", "SMTP MAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpMailFromData);
 
     kw.name = "smtp.rcpt_to";
     kw.desc = "SMTP rcpt to buffer";


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none, cleanup

Describe changes:
- change the helper with more explicit direction for single-buffers

https://github.com/OISF/suricata/pull/13083 continuation for single buffers

Still to do afterwards :
- [detect/multi-buf: harmonize wrapper](https://github.com/OISF/suricata/pull/13083/commits/d3f9985b51ad2a0d93947216f3badca0b01c6bd8) for single buffer
