### PR TITLE
gen/typo: Correct configure output grammar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1738,7 +1738,7 @@
 
     # Napatech - Using the 3GD API
     AC_ARG_ENABLE(napatech,
-                AS_HELP_STRING([--enable-napatech],[Enabled Napatech Devices]),
+                AS_HELP_STRING([--enable-napatech],[Enable Napatech Devices]),
                 [ enable_napatech=$enableval ],
                 [ enable_napatech=no])
     AS_IF([test "x$enable_napatech" = "xyes"], [


### PR DESCRIPTION
Fixup the grammar for the Napatech option -- was "Enabled Napatech".

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

Describe changes:
- Change message displayed for enabling Napatech.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
