### PR TITLE
lua: misc cleanups for flowvarlib

### DIFF
--- a/src/util-lua-flowvarlib.c
+++ b/src/util-lua-flowvarlib.c
@@ -81,7 +81,7 @@ static int LuaFlowvarGet(lua_State *L)
 
 static int LuaFlowvarValue(lua_State *L)
 {
-    uint32_t *flowvar_id = luaL_testudata(L, 1, suricata_flowvar_mt);
+    uint32_t *flowvar_id = luaL_checkudata(L, 1, suricata_flowvar_mt);
     Flow *f = LuaStateGetFlow(L);
     if (f == NULL) {
         return LuaCallbackError(L, "flow is NULL");

--- a/src/util-lua-flowvarlib.c
+++ b/src/util-lua-flowvarlib.c
@@ -116,17 +116,17 @@ static int LuaFlowvarSet(lua_State *L)
 
 static const luaL_Reg flowvarlib[] = {
     // clang-format off
-  { "register", LuaFlowvarRegister, },
-{ "get", LuaFlowvarGet },
-  { NULL, NULL, },
+    { "register", LuaFlowvarRegister, },
+    { "get", LuaFlowvarGet },
+    { NULL, NULL, },
     // clang-format on
 };
 
 static const luaL_Reg flowvarmt[] = {
     // clang-format off
-  { "value", LuaFlowvarValue, },
-  { "set", LuaFlowvarSet, },
-  { NULL, NULL, },
+    { "value", LuaFlowvarValue, },
+    { "set", LuaFlowvarSet, },
+    { NULL, NULL, },
     // clang-format on
 };
 


### PR DESCRIPTION
- **lua/flowvarlib: fix formatting inside clang-format off**
  

- **lua/flowvarlib: fix unchecked null**
  Use checkudata, instead of testudata which won't return in case of
  NULL, but raise an error in the Lua script.
  
  Fixes:
  
  ** CID 1646748:  Null pointer dereferences  (NULL_RETURNS)
  /src/util-lua-flowvarlib.c: 89 in LuaFlowvarValue()
  