### PR TITLE
libsuricata: add rate_filter callback - v2


### DIFF
--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -16,6 +16,8 @@
  */
 
 #include "suricata.h"
+#include "detect.h"
+#include "detect-engine.h"
 #include "runmodes.h"
 #include "conf.h"
 #include "pcap.h"
@@ -144,6 +146,11 @@ done:
     pthread_exit(NULL);
 }
 
+static void RateFilterCallback(
+        const Signature *s, const Packet *p, uint8_t orig_action, PacketAlert *pa, void *arg)
+{
+}
+
 int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
@@ -207,6 +214,8 @@ int main(int argc, char **argv)
 
     SuricataInit();
 
+    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+
     /* Create and start worker on its own thread, passing the PCAP
      * file as argument. This needs to be done in between SuricataInit
      * and SuricataPostInit. */
@@ -237,6 +246,7 @@ int main(int argc, char **argv)
      * function and SCTmThreadsSlotPktAcqLoopFinish that require them
      * to be run concurrently at this time. */
     SuricataShutdown();
+
     GlobalsDestroy();
 
     return EXIT_SUCCESS;

--- a/src/decode.h
+++ b/src/decode.h
@@ -249,7 +249,14 @@ typedef struct PacketAlert_ {
     int64_t frame_id;
 } PacketAlert;
 
-/* flag to indicate the rule action (drop/pass) needs to be applied to the flow */
+/**
+ * \defgroup PacketAlertFlags
+ *
+ * Available flags for PacketAlert.flags.
+ *
+ * @{
+ */
+/** flag to indicate the rule action (drop/pass) needs to be applied to the flow */
 #define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW BIT_U8(0)
 /** alert was generated based on state */
 #define PACKET_ALERT_FLAG_STATE_MATCH BIT_U8(1)
@@ -265,6 +272,7 @@ typedef struct PacketAlert_ {
 #define PACKET_ALERT_FLAG_TX_GUESSED BIT_U8(6)
 /** accept should be applied to packet */
 #define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET BIT_U8(7)
+/** @} */
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/decode.h
+++ b/src/decode.h
@@ -250,21 +250,21 @@ typedef struct PacketAlert_ {
 } PacketAlert;
 
 /* flag to indicate the rule action (drop/pass) needs to be applied to the flow */
-#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW 0x1
+#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW BIT_U8(0)
 /** alert was generated based on state */
-#define PACKET_ALERT_FLAG_STATE_MATCH   0x02
+#define PACKET_ALERT_FLAG_STATE_MATCH BIT_U8(1)
 /** alert was generated based on stream */
-#define PACKET_ALERT_FLAG_STREAM_MATCH  0x04
+#define PACKET_ALERT_FLAG_STREAM_MATCH BIT_U8(2)
 /** alert is in a tx, tx_id set */
-#define PACKET_ALERT_FLAG_TX            0x08
+#define PACKET_ALERT_FLAG_TX BIT_U8(3)
 /** action was changed by rate_filter */
-#define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
+#define PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED BIT_U8(4)
 /** alert is in a frame, frame_id set */
-#define PACKET_ALERT_FLAG_FRAME 0x20
+#define PACKET_ALERT_FLAG_FRAME BIT_U8(5)
 /** alert in a tx was forced */
-#define PACKET_ALERT_FLAG_TX_GUESSED 0x40
+#define PACKET_ALERT_FLAG_TX_GUESSED BIT_U8(6)
 /** accept should be applied to packet */
-#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET 0x80
+#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET BIT_U8(7)
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -193,8 +193,9 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
     if (pa->action & ACTION_DROP_REJECT) {
         /* PacketDrop will update the packet action, too */
         PacketDrop(p, pa->action,
-                (pa->flags & PACKET_ALERT_RATE_FILTER_MODIFIED) ? PKT_DROP_REASON_RULES_THRESHOLD
-                                                                : PKT_DROP_REASON_RULES);
+                (pa->flags & PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED)
+                        ? PKT_DROP_REASON_RULES_THRESHOLD
+                        : PKT_DROP_REASON_RULES);
         SCLogDebug("[packet %p][DROP sid %u]", p, s->id);
 
         if (p->alerts.drop.action == 0) {

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -952,6 +952,8 @@ int PacketAlertThreshold(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *d
 {
     SCEnter();
 
+    uint8_t action = pa->action;
+
     int ret = 0;
     if (td == NULL) {
         SCReturnInt(0);
@@ -985,6 +987,10 @@ int PacketAlertThreshold(const DetectEngineCtx *de_ctx, DetectEngineThreadCtx *d
         if (p->flow) {
             ret = ThresholdHandlePacketFlow(p->flow, p, td, s->id, s->gid, s->rev, pa);
         }
+    }
+
+    if (de_ctx->RateFilterCallback && action != pa->action) {
+        (*de_ctx->RateFilterCallback)(s, p, action, pa, de_ctx->rate_filter_callback_arg);
     }
 
     SCReturnInt(ret);

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -625,19 +625,19 @@ static inline void RateFilterSetAction(PacketAlert *pa, uint8_t new_action)
 {
     switch (new_action) {
         case TH_ACTION_ALERT:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_ALERT;
             break;
         case TH_ACTION_DROP:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_DROP;
             break;
         case TH_ACTION_REJECT:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = (ACTION_REJECT | ACTION_DROP);
             break;
         case TH_ACTION_PASS:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_PASS;
             break;
         default:

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4869,6 +4869,10 @@ int DetectEngineReload(const SCInstance *suri)
     }
     SCLogDebug("set up new_de_ctx %p", new_de_ctx);
 
+    /* Copy over callbacks. */
+    new_de_ctx->RateFilterCallback = old_de_ctx->RateFilterCallback;
+    new_de_ctx->rate_filter_callback_arg = old_de_ctx->rate_filter_callback_arg;
+
     /* add to master */
     DetectEngineAddToMaster(new_de_ctx);
 
@@ -5067,6 +5071,14 @@ bool DetectMd5ValidateCallback(
         }
     }
     return true;
+}
+
+void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
+{
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    de_ctx->RateFilterCallback = fn;
+    de_ctx->rate_filter_callback_arg = arg;
+    DetectEngineDeReference(&de_ctx);
 }
 
 /*************************************Unittest*********************************/

--- a/src/detect.h
+++ b/src/detect.h
@@ -917,6 +917,10 @@ typedef struct {
     uint32_t content_inspect_min_size;
 } DetectFileDataCfg;
 
+// Type for rate filter callback function.
+typedef void (*SCDetectRateFilterFunc)(
+        const Signature *s, const Packet *p, uint8_t orig_action, PacketAlert *pa, void *arg);
+
 /** \brief main detection engine ctx */
 typedef struct DetectEngineCtx_ {
     bool failure_fatal;
@@ -1131,7 +1135,22 @@ typedef struct DetectEngineCtx_ {
     HashTable *non_pf_engine_names;
 
     const char *firewall_rule_file_exclusive;
+
+    /* user provided rate filter callbacks. */
+    SCDetectRateFilterFunc RateFilterCallback;
+
+    /* use provided data to be passed to rate_filter_callback. */
+    void *rate_filter_callback_arg;
 } DetectEngineCtx;
+
+/**
+ * \brief Register a callback when a rate_filter has been applied to
+ *     an alert.
+ *
+ * This callback is added to the current detection engine and will be
+ * copied to all future detection engines over rule reloads.
+ */
+void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
 
 /* Engine groups profiles (low, medium, high, custom) */
 enum {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -204,7 +204,7 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, SCJsonBuilder *js, 
 {
     const char *action = "allowed";
     /* use packet action if rate_filter modified the action */
-    if (unlikely(pa->flags & PACKET_ALERT_RATE_FILTER_MODIFIED)) {
+    if (unlikely(pa->flags & PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED)) {
         if (PacketCheckAction(p, ACTION_DROP_REJECT)) {
             action = "blocked";
         }


### PR DESCRIPTION
From ticket https://redmine.openinfosecfoundation.org/issues/7673:

> If a ratefilter kicks in, have a callback that allows to customise the action

Previous PR: https://github.com/OISF/suricata/pull/13086

Changes from previous PR:
- Revert flags to uint8_t, the extra bit aren't needed
