### PR TITLE
pgsql: don't log empty request -  v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2526,8 +2526,10 @@ Requests are sent by the frontend (client), which would be the source of a pgsql
 flow. Some of the possible request messages are:
 
 * "startup_message": message sent to start a new PostgreSQL connection
-* "password_message": if password output for PGSQL is enabled in suricata.yaml,
+* "password": if password output for PGSQL is enabled in suricata.yaml,
   carries the password sent during Authentication phase
+* "password_redacted": set to true in case there is a password message, but its
+  logging is disabled
 * "simple_query": issued SQL command during simple query subprotocol. PostgreSQL
   identifies specific sets of commands that change the set of expected messages
   to be exchanged as subprotocols.

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3615,6 +3615,9 @@
                         "password_message": {
                             "type": "string"
                         },
+                        "password_redacted": {
+                            "type": "boolean"
+                        },
                         "process_id": {
                             "type": "integer"
                         },

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -81,6 +81,8 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             if flags & PGSQL_LOG_PASSWORDS != 0 {
                 js.set_string_from_bytes("password", payload)?;
+            } else {
+                js.set_bool("password_redacted", true)?;
             }
         }
         PgsqlFEMessage::SASLResponse(RegularPacket {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -360,6 +360,8 @@ outputs:
         - pgsql:
             enabled: no
             # passwords: yes           # enable output of passwords. Disabled by default
+                                       # If a password message is seen but this setting
+                                       # is disabled, "password_redacted": true is logged
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats


### PR DESCRIPTION
If a password message was seen while logging passwords was disabled for pgsql, this would lead to an empty request being logged. Instead of simply not logging anything when there is a password message and this is disabled, however, log instead that said password is redacted.

Bug #7647

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes 
      
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7647

Describe changes:
- change approach, and now log a boolean `"password_redacted": true` if there is a password message, but logging passwords is disabled
This is following feedback from both Victor and Jason, but trying to make the log less redundant. Not sure if  best solution
- replace `password_message` with `password` in our docs, since that's the actual field name in our logs -- will remove code references in another PR

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2477
