### PR TITLE
  detect: add mime email.attachment keyword - v1

### DIFF
--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -16,12 +16,12 @@ Syntax::
 
 ``email.from`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.from``
+This keyword maps to the EVE field ``email.from``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``from`` with the value ``toto <toto@gmail.com>``
+Example of a signature that would alert if a packet contains the MIME field ``from`` with the value ``toto <toto@gmail.com>``:
 
 .. container:: example-rule
 
@@ -40,12 +40,12 @@ Syntax::
 
 ``email.subject`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.subject``
+This keyword maps to the EVE field ``email.subject``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``subject`` with the value ``This is a test email``
+Example of a signature that would alert if a packet contains the MIME field ``subject`` with the value ``This is a test email``:
 
 .. container:: example-rule
 
@@ -64,12 +64,12 @@ Syntax::
 
 ``email.to`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.to``
+This keyword maps to the EVE field ``email.to``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``to`` with the value ``172.16.92.2@linuxbox``
+Example of a signature that would alert if a packet contains the MIME field ``to`` with the value ``172.16.92.2@linuxbox``:
 
 .. container:: example-rule
 
@@ -88,12 +88,12 @@ Syntax::
 
 ``email.cc`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.cc[]``
+This keyword maps to the EVE field ``email.cc[]``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``cc`` with the value ``Emily <emily.roberts@example.com>, Ava <ava.johnson@example.com>, Sophia Wilson <sophia.wilson@example.com>``
+Example of a signature that would alert if a packet contains the MIME field ``cc`` with the value ``Emily <emily.roberts@example.com>, Ava <ava.johnson@example.com>, Sophia Wilson <sophia.wilson@example.com>``:
 
 .. container:: example-rule
 
@@ -112,12 +112,12 @@ Syntax::
 
 ``email.date`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.date``
+This keyword maps to the EVE field ``email.date``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``date`` with the value ``Fri, 21 Apr 2023 05:10:36 +0000``
+Example of a signature that would alert if a packet contains the MIME field ``date`` with the value ``Fri, 21 Apr 2023 05:10:36 +0000``:
 
 .. container:: example-rule
 
@@ -136,12 +136,12 @@ Syntax::
 
 ``email.message_id`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.message_id``
+This keyword maps to the EVE field ``email.message_id``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``message id`` with the value ``<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>``
+Example of a signature that would alert if a packet contains the MIME field ``message id`` with the value ``<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>``:
 
 .. container:: example-rule
 
@@ -160,12 +160,12 @@ Syntax::
 
 ``email.x_mailer`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
 
-This keyword maps to the EVE field ``email.x_mailer``
+This keyword maps to the EVE field ``email.x_mailer``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``x-mailer`` with the value ``Microsoft Office Outlook, Build 11.0.5510``
+Example of a signature that would alert if a packet contains the MIME field ``x-mailer`` with the value ``Microsoft Office Outlook, Build 11.0.5510``:
 
 .. container:: example-rule
 
@@ -186,12 +186,12 @@ Syntax::
 
 ``email.url`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
-This keyword maps to the EVE field ``email.url[]``
+This keyword maps to the EVE field ``email.url[]``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if an email contains the ``url`` ``test-site.org/blah/123/``.
+Example of a signature that would alert if an email contains the ``url`` ``test-site.org/blah/123/``:
 
 .. container:: example-rule
 
@@ -212,12 +212,12 @@ Syntax::
 
 ``email.received`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
 
-This keyword maps to the EVE field ``email.received[]``
+This keyword maps to the EVE field ``email.received[]``.
 
 Example
 ^^^^^^^
 
-Example of a signature that would alert if a packet contains the MIME field ``received`` with the value ``from [65.201.218.30] (helo=COZOXORY.club)by 173-66-46-112.wash.fios.verizon.net with esmtpa (Exim 4.86)(envelope-from )id 71cF63a9for mirjam@abrakadabra.ch; Mon, 29 Jul 2019 17:01:45 +0000``
+Example of a signature that would alert if a packet contains the MIME field ``received`` with the value ``from [65.201.218.30] (helo=COZOXORY.club)by 173-66-46-112.wash.fios.verizon.net with esmtpa (Exim 4.86)(envelope-from )id 71cF63a9for mirjam@abrakadabra.ch; Mon, 29 Jul 2019 17:01:45 +0000``:
 
 .. container:: example-rule
 

--- a/doc/userguide/rules/email-keywords.rst
+++ b/doc/userguide/rules/email-keywords.rst
@@ -222,3 +222,29 @@ Example of a signature that would alert if a packet contains the MIME field ``re
 .. container:: example-rule
 
   alert smtp any any -> any any (msg:"Test mime email received"; :example-rule-emphasis:`email.received; content:"from [65.201.218.30] (helo=COZOXORY.club)by 173-66-46-112.wash.fios.verizon.net with esmtpa (Exim 4.86)(envelope-from )id 71cF63a9for mirjam@abrakadabra.ch\; Mon, 29 Jul 2019 17:01:45 +0000";` sid:1;)
+
+email.attachment
+----------------
+
+Matches the attached files from an email.
+
+Comparison is case-sensitive.
+
+Syntax::
+
+ email.attachment; content:"<content to match against>";
+
+``email.attachment`` is a 'sticky buffer' and can be used as a ``fast_pattern``.
+
+``email.attachment`` supports multiple buffer matching, see :doc:`multi-buffer-matching`.
+
+This keyword maps to the EVE field ``email.attachment[]``.
+
+Example
+^^^^^^^
+
+Example of a signature that would alert if an email contains the attachment ``file-test.zip``:
+
+.. container:: example-rule
+
+  alert smtp any any -> any any (msg:"Test mime email attachment"; :example-rule-emphasis:`email.attachment; content:"file-test.zip";` sid:1;)

--- a/rust/src/mime/detect.rs
+++ b/rust/src/mime/detect.rs
@@ -89,3 +89,20 @@ pub unsafe extern "C" fn SCDetectMimeEmailGetDataArray(
 
     return 0;
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn SCDetectMimeEmailGetAttachment(
+    ctx: &MimeStateSMTP, buffer: *mut *const u8, buffer_len: *mut u32, idx: u32,
+) -> u8 {
+    if !ctx.attachments.is_empty() && idx < ctx.attachments.len() as u32 {
+        let attachment = &ctx.attachments[idx as usize];
+        *buffer = attachment.as_ptr();
+        *buffer_len = attachment.len() as u32;
+        return 1;
+    }
+
+    *buffer = ptr::null();
+    *buffer_len = 0;
+
+    return 0;
+}


### PR DESCRIPTION
Ticket: [#7683](https://redmine.openinfosecfoundation.org/issues/7683)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues/7683

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7683

### Description:
- Implement ``email.attachment``  keyword.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2478

