### PR TITLE
libsuricata: add rate filter callback - v4

### DIFF
--- a/doc/userguide/devguide/contributing/contribution-process.rst
+++ b/doc/userguide/devguide/contributing/contribution-process.rst
@@ -224,8 +224,16 @@ We have a :ref:`Coding Style` that must be followed.
 Documentation Style
 ===================
 
-For documenting *code*, please follow Rust documentation and/or Doxygen
-guidelines, according to what your contribution is using (Rust or C).
+For documenting *code*, please follow Rust documentation and/or
+Doxygen guidelines, according to what your contribution is using (Rust
+or C). The rest of this section refers to the user and developer
+documentation.
+
+The user and developer guide documentation (what you are reading now)
+is written in *reStructuredText* and rendered with `Sphinx
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_. For
+a primer *reStucturedText* please see the `reStrucutredText Primer
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_.
 
 When writing or updating *documentation pages*, please:
 
@@ -235,6 +243,32 @@ When writing or updating *documentation pages*, please:
 * bear in mind that our documentation is published on `Read the Docs <https:/
   /docs.suricata.io/en/latest/#suricata-user-guide>`_ and can also be
   built to pdf, so it is important that it looks good in such formats.
+
+Headings
+--------
+
+reStructuredText allows for flexible header order, for consistency
+please use the following order:
+
+* ``#``: for h1
+* ``*``: for h2
+* ``=``: for h3
+* ``-``: for h4
+* ``~``: for h5
+* ``^``: for h6
+
+For example, in a new documentation page:
+
+.. code-block:: rst
+
+  Page Title
+  ##########
+
+  Section
+  *******
+
+  Sub-Section
+  ===========
 
 Rule examples
 -------------

--- a/doc/userguide/devguide/extending/detect/index.rst
+++ b/doc/userguide/devguide/extending/detect/index.rst
@@ -1,2 +1,40 @@
 Detection
-=========
+#########
+
+Rate Filter Callback
+********************
+
+A callback can be registered for any signature hit whose action has
+been modified by the rate filter. This allows for the user to modify
+the action, if needed using their own custom logic.
+
+For an example, see ``examples/lib/custom/main.c`` in the Suricata
+source code.
+
+The Callback
+============
+
+The callback function will be called with the packet, signature
+details (sid, gid, rev), original action, the new action, and a user
+provided argument. It will only be called if the Suricata rate filter
+modified the action:
+
+.. literalinclude:: ../../../../../src/detect.h
+   :language: c
+   :start-at:  * \brief Function type for rate filter callback.
+   :end-at: );
+   :prepend: /**
+
+Callback Registration
+=====================
+
+To register the rate filter callback, use the
+``SCDetectEngineRegisterRateFilterCallback`` function with your
+callback and a user provided argument which will be provided to the
+callback.
+
+.. literalinclude:: ../../../../../src/detect.h
+   :language: c
+   :start-at:  * \brief Register a callback when a rate_filter
+   :end-at: );
+   :prepend: /**

--- a/examples/lib/custom/main.c
+++ b/examples/lib/custom/main.c
@@ -16,6 +16,8 @@
  */
 
 #include "suricata.h"
+#include "detect.h"
+#include "detect-engine.h"
 #include "runmodes.h"
 #include "conf.h"
 #include "pcap.h"
@@ -145,6 +147,13 @@ done:
     pthread_exit(NULL);
 }
 
+static uint8_t RateFilterCallback(const Packet *p, const uint32_t sid, const uint32_t gid,
+        const uint32_t rev, uint8_t original_action, uint8_t new_action, void *arg)
+{
+    /* Don't change the action. */
+    return new_action;
+}
+
 int main(int argc, char **argv)
 {
     SuricataPreInit(argv[0]);
@@ -208,6 +217,8 @@ int main(int argc, char **argv)
 
     SuricataInit();
 
+    SCDetectEngineRegisterRateFilterCallback(RateFilterCallback, NULL);
+
     /* Create and start worker on its own thread, passing the PCAP
      * file as argument. This needs to be done in between SuricataInit
      * and SuricataPostInit. */
@@ -238,6 +249,7 @@ int main(int argc, char **argv)
      * function and SCTmThreadsSlotPacketLoopFinish that require them
      * to be run concurrently at this time. */
     SuricataShutdown();
+
     GlobalsDestroy();
 
     return EXIT_SUCCESS;

--- a/src/decode.h
+++ b/src/decode.h
@@ -249,7 +249,14 @@ typedef struct PacketAlert_ {
     int64_t frame_id;
 } PacketAlert;
 
-/* flag to indicate the rule action (drop/pass) needs to be applied to the flow */
+/**
+ * \defgroup PacketAlertFlags
+ *
+ * Available flags for PacketAlert.flags.
+ *
+ * @{
+ */
+/** flag to indicate the rule action (drop/pass) needs to be applied to the flow */
 #define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW BIT_U8(0)
 /** alert was generated based on state */
 #define PACKET_ALERT_FLAG_STATE_MATCH BIT_U8(1)
@@ -265,6 +272,7 @@ typedef struct PacketAlert_ {
 #define PACKET_ALERT_FLAG_TX_GUESSED BIT_U8(6)
 /** accept should be applied to packet */
 #define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET BIT_U8(7)
+/** @} */
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/decode.h
+++ b/src/decode.h
@@ -250,21 +250,21 @@ typedef struct PacketAlert_ {
 } PacketAlert;
 
 /* flag to indicate the rule action (drop/pass) needs to be applied to the flow */
-#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW 0x1
+#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_FLOW BIT_U8(0)
 /** alert was generated based on state */
-#define PACKET_ALERT_FLAG_STATE_MATCH   0x02
+#define PACKET_ALERT_FLAG_STATE_MATCH BIT_U8(1)
 /** alert was generated based on stream */
-#define PACKET_ALERT_FLAG_STREAM_MATCH  0x04
+#define PACKET_ALERT_FLAG_STREAM_MATCH BIT_U8(2)
 /** alert is in a tx, tx_id set */
-#define PACKET_ALERT_FLAG_TX            0x08
+#define PACKET_ALERT_FLAG_TX BIT_U8(3)
 /** action was changed by rate_filter */
-#define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
+#define PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED BIT_U8(4)
 /** alert is in a frame, frame_id set */
-#define PACKET_ALERT_FLAG_FRAME 0x20
+#define PACKET_ALERT_FLAG_FRAME BIT_U8(5)
 /** alert in a tx was forced */
-#define PACKET_ALERT_FLAG_TX_GUESSED 0x40
+#define PACKET_ALERT_FLAG_TX_GUESSED BIT_U8(6)
 /** accept should be applied to packet */
-#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET 0x80
+#define PACKET_ALERT_FLAG_APPLY_ACTION_TO_PACKET BIT_U8(7)
 
 extern uint16_t packet_alert_max;
 #define PACKET_ALERT_MAX 15

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -193,8 +193,9 @@ static void PacketApplySignatureActions(Packet *p, const Signature *s, const Pac
     if (pa->action & ACTION_DROP_REJECT) {
         /* PacketDrop will update the packet action, too */
         PacketDrop(p, pa->action,
-                (pa->flags & PACKET_ALERT_RATE_FILTER_MODIFIED) ? PKT_DROP_REASON_RULES_THRESHOLD
-                                                                : PKT_DROP_REASON_RULES);
+                (pa->flags & PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED)
+                        ? PKT_DROP_REASON_RULES_THRESHOLD
+                        : PKT_DROP_REASON_RULES);
         SCLogDebug("[packet %p][DROP sid %u]", p, s->id);
 
         if (p->alerts.drop.action == 0) {

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -625,19 +625,19 @@ static inline void RateFilterSetAction(PacketAlert *pa, uint8_t new_action)
 {
     switch (new_action) {
         case TH_ACTION_ALERT:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_ALERT;
             break;
         case TH_ACTION_DROP:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_DROP;
             break;
         case TH_ACTION_REJECT:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = (ACTION_REJECT | ACTION_DROP);
             break;
         case TH_ACTION_PASS:
-            pa->flags |= PACKET_ALERT_RATE_FILTER_MODIFIED;
+            pa->flags |= PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED;
             pa->action = ACTION_PASS;
             break;
         default:

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -4869,6 +4869,10 @@ int DetectEngineReload(const SCInstance *suri)
     }
     SCLogDebug("set up new_de_ctx %p", new_de_ctx);
 
+    /* Copy over callbacks. */
+    new_de_ctx->RateFilterCallback = old_de_ctx->RateFilterCallback;
+    new_de_ctx->rate_filter_callback_arg = old_de_ctx->rate_filter_callback_arg;
+
     /* add to master */
     DetectEngineAddToMaster(new_de_ctx);
 
@@ -5067,6 +5071,14 @@ bool DetectMd5ValidateCallback(
         }
     }
     return true;
+}
+
+void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc fn, void *arg)
+{
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    de_ctx->RateFilterCallback = fn;
+    de_ctx->rate_filter_callback_arg = arg;
+    DetectEngineDeReference(&de_ctx);
 }
 
 /*************************************Unittest*********************************/

--- a/src/detect.h
+++ b/src/detect.h
@@ -917,6 +917,16 @@ typedef struct {
     uint32_t content_inspect_min_size;
 } DetectFileDataCfg;
 
+/**
+ * \brief Function type for rate filter callback.
+ *
+ * This function should return the new action to be applied. If no change to the
+ * action is to be made, the callback should return the current action provided
+ * in the new_action parameter.
+ */
+typedef uint8_t (*SCDetectRateFilterFunc)(const Packet *p, uint32_t sid, uint32_t gid, uint32_t rev,
+        uint8_t original_action, uint8_t new_action, void *arg);
+
 /** \brief main detection engine ctx */
 typedef struct DetectEngineCtx_ {
     bool failure_fatal;
@@ -1131,7 +1141,22 @@ typedef struct DetectEngineCtx_ {
     HashTable *non_pf_engine_names;
 
     const char *firewall_rule_file_exclusive;
+
+    /* user provided rate filter callbacks. */
+    SCDetectRateFilterFunc RateFilterCallback;
+
+    /* use provided data to be passed to rate_filter_callback. */
+    void *rate_filter_callback_arg;
 } DetectEngineCtx;
+
+/**
+ * \brief Register a callback when a rate_filter has been applied to
+ *     an alert.
+ *
+ * This callback is added to the current detection engine and will be
+ * copied to all future detection engines over rule reloads.
+ */
+void SCDetectEngineRegisterRateFilterCallback(SCDetectRateFilterFunc cb, void *arg);
 
 /* Engine groups profiles (low, medium, high, custom) */
 enum {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -204,7 +204,7 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, SCJsonBuilder *js, 
 {
     const char *action = "allowed";
     /* use packet action if rate_filter modified the action */
-    if (unlikely(pa->flags & PACKET_ALERT_RATE_FILTER_MODIFIED)) {
+    if (unlikely(pa->flags & PACKET_ALERT_FLAG_RATE_FILTER_MODIFIED)) {
         if (PacketCheckAction(p, ACTION_DROP_REJECT)) {
             action = "blocked";
         }


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/7673.

Previous PR: https://github.com/OISF/suricata/pull/13121

Changes from previous PR:
- move location of callback into rate handling code
- have the callback return the new action, instead of manipulating the `PacketAlert` directly
- provide the signature identifiers, instead of the `Signature` as those are already drilled down through the execution path
- add docs (could be better, but better than nothing)
