### PR TITLE
rust cleanups/20250502

### DIFF
--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -215,9 +215,9 @@ fn asn1_decode<'a>(
 /// # Safety
 ///
 /// input must be a valid buffer of at least input_len bytes
-/// pointer must be freed using `rs_asn1_free`
+/// pointer must be freed using `SCAsn1Free`
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_decode(
+pub unsafe extern "C" fn SCAsn1Decode(
     input: *const u8, input_len: u32, buffer_offset: u32, ad_ptr: *const DetectAsn1Data,
 ) -> *mut Asn1<'static> {
     if input.is_null() || input_len == 0 || ad_ptr.is_null() {
@@ -240,9 +240,9 @@ pub unsafe extern "C" fn rs_asn1_decode(
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_asn1_decode`
+/// ptr must be a valid object obtained using `SCAsn1Decode`
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_free(ptr: *mut Asn1) {
+pub unsafe extern "C" fn SCAsn1Free(ptr: *mut Asn1) {
     if ptr.is_null() {
         return;
     }
@@ -256,12 +256,12 @@ pub unsafe extern "C" fn rs_asn1_free(ptr: *mut Asn1) {
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_asn1_decode`
-/// ad_ptr must be a valid object obtained using `rs_detect_asn1_parse`
+/// ptr must be a valid object obtained using `SCAsn1Decode`
+/// ad_ptr must be a valid object obtained using `SCAsn1DetectParse`
 ///
 /// Returns 1 if any of the options match, 0 if not
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_checks(ptr: *const Asn1, ad_ptr: *const DetectAsn1Data) -> u8 {
+pub unsafe extern "C" fn SCAsn1Checks(ptr: *const Asn1, ad_ptr: *const DetectAsn1Data) -> u8 {
     if ptr.is_null() || ad_ptr.is_null() {
         return 0;
     }

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -32,9 +32,9 @@ const ASN1_DEFAULT_MAX_FRAMES: u16 = 30;
 ///
 /// # Safety
 ///
-/// pointer must be free'd using `rs_detect_asn1_free`
+/// pointer must be free'd using `SCAsn1DetectFree`
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_asn1_parse(input: *const c_char) -> *mut DetectAsn1Data {
+pub unsafe extern "C" fn SCAsn1DetectParse(input: *const c_char) -> *mut DetectAsn1Data {
     if input.is_null() {
         return std::ptr::null_mut();
     }
@@ -73,9 +73,9 @@ pub unsafe extern "C" fn rs_detect_asn1_parse(input: *const c_char) -> *mut Dete
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_detect_asn1_parse`
+/// ptr must be a valid object obtained using `SCAsn1DetectParse`
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_asn1_free(ptr: *mut DetectAsn1Data) {
+pub unsafe extern "C" fn SCAsn1DetectFree(ptr: *mut DetectAsn1Data) {
     if ptr.is_null() {
         return;
     }

--- a/rust/src/detect/float.rs
+++ b/rust/src/detect/float.rs
@@ -229,7 +229,7 @@ fn detect_parse_float_notending<T: DetectFloatType>(i: &str) -> IResult<&str, De
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_parse(
+pub unsafe extern "C" fn SCDetectF64Parse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectFloatData<f64> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn rs_detect_f64_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_match(
+pub unsafe extern "C" fn SCDetectF64Match(
     arg: f64, ctx: &DetectFloatData<f64>,
 ) -> std::os::raw::c_int {
     if detect_match_float::<f64>(ctx, arg) {
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn rs_detect_f64_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_free(ctx: &mut DetectFloatData<f64>) {
+pub unsafe extern "C" fn SCDetectF64Free(ctx: &mut DetectFloatData<f64>) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }
@@ -441,7 +441,7 @@ mod tests {
     fn do_match_test(val: &str, arg1: f64, arg1_cmp: f64, arg2: f64, mode: DetectFloatMode) {
         let c_string = CString::new(val).expect("CString::new failed");
         unsafe {
-            let val = rs_detect_f64_parse(c_string.as_ptr());
+            let val = SCDetectF64Parse(c_string.as_ptr());
             let str_arg_a = format!("{:.3}", (*val).arg1);
             let str_arg_b = format!("{:.3}", arg1);
             assert_eq!(str_arg_a, str_arg_b);
@@ -450,7 +450,7 @@ mod tests {
             assert_eq!(str_arg_a, str_arg_b);
 
             assert_eq!((*val).mode, mode);
-            assert_eq!(1, rs_detect_f64_match(arg1_cmp, &*val));
+            assert_eq!(1, SCDetectF64Match(arg1_cmp, &*val));
         }
     }
 
@@ -461,7 +461,7 @@ mod tests {
     fn do_parse_test(val: &str, arg1: f64, arg2: f64, mode: DetectFloatMode) {
         let c_string = CString::new(val).expect("CString::new failed");
         unsafe {
-            let val = rs_detect_f64_parse(c_string.as_ptr());
+            let val = SCDetectF64Parse(c_string.as_ptr());
             let str_arg_a = format!("{:.3}", (*val).arg1);
             let str_arg_b = format!("{:.3}", arg1);
             assert_eq!(str_arg_a, str_arg_b);
@@ -478,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rs_detect_match_valid() {
+    fn test_ffi_detect_match_valid() {
         do_match_test_arg1("1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeEqual);
         do_match_test_arg1("> 1.0", 1.0, 1.1, DetectFloatMode::DetectFloatModeGt);
         do_match_test_arg1(">= 1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeGte);
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rs_detect_parse_valid() {
+    fn test_ffi_detect_parse_valid() {
         do_parse_test_arg1("1.0", 1.0, DetectFloatMode::DetectFloatModeEqual);
         do_parse_test_arg1("> 1.0", 1.0, DetectFloatMode::DetectFloatModeGt);
         do_parse_test_arg1(">= 1.0", 1.0, DetectFloatMode::DetectFloatModeGte);

--- a/rust/src/detect/stream_size.rs
+++ b/rust/src/detect/stream_size.rs
@@ -78,7 +78,7 @@ pub fn detect_parse_stream_size(i: &str) -> IResult<&str, DetectStreamSizeData> 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_stream_size_parse(
+pub unsafe extern "C" fn SCDetectStreamSizeParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectStreamSizeData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn rs_detect_stream_size_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_stream_size_free(ctx: &mut DetectStreamSizeData) {
+pub unsafe extern "C" fn SCDetectStreamSizeFree(ctx: &mut DetectStreamSizeData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/detect/uri.rs
+++ b/rust/src/detect/uri.rs
@@ -58,7 +58,7 @@ pub fn detect_parse_urilen(i: &str) -> IResult<&str, DetectUrilenData> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_urilen_parse(
+pub unsafe extern "C" fn SCDetectUrilenParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectUrilenData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn rs_detect_urilen_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_urilen_free(ctx: &mut DetectUrilenData) {
+pub unsafe extern "C" fn SCDetectUrilenFree(ctx: &mut DetectUrilenData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -940,13 +940,13 @@ extern "C" fn tx_get_alstate_progress(
 ) -> std::os::raw::c_int {
     // This is a stateless parser, just the existence of a transaction
     // means its complete.
-    SCLogDebug!("rs_dns_tx_get_alstate_progress");
+    SCLogDebug!("tx_get_alstate_progress");
     return 1;
 }
 
 unsafe extern "C" fn state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, DNSState);
-    SCLogDebug!("rs_dns_state_get_tx_count: returning {}", state.tx_id);
+    SCLogDebug!("state_get_tx_count: returning {}", state.tx_id);
     return state.tx_id;
 }
 
@@ -979,7 +979,7 @@ unsafe extern "C" fn state_get_tx_data(tx: *mut std::os::raw::c_void) -> *mut Ap
     return &mut tx.tx_data;
 }
 
-export_state_data_get!(rs_dns_get_state_data, DNSState);
+export_state_data_get!(dns_get_state_data, DNSState);
 
 /// Get the DNS query name at index i.
 #[no_mangle]
@@ -1248,7 +1248,7 @@ pub unsafe extern "C" fn SCRegisterDnsUdpParser() {
         get_tx_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_tx_data: state_get_tx_data,
-        get_state_data: rs_dns_get_state_data,
+        get_state_data: dns_get_state_data,
         apply_tx_config: Some(apply_tx_config),
         flags: 0,
         get_frame_id_by_name: Some(DnsFrameType::ffi_id_from_name),
@@ -1295,7 +1295,7 @@ pub unsafe extern "C" fn SCRegisterDnsTcpParser() {
         get_tx_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_tx_data: state_get_tx_data,
-        get_state_data: rs_dns_get_state_data,
+        get_state_data: dns_get_state_data,
         apply_tx_config: Some(apply_tx_config),
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
         get_frame_id_by_name: Some(DnsFrameType::ffi_id_from_name),

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -33,14 +33,14 @@ use std::ffi::CStr;
 use std::os::raw::c_void;
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx: &KRB5Transaction, ptr: *mut u32) {
+pub unsafe extern "C" fn SCKrb5TxGetMsgType(tx: &KRB5Transaction, ptr: *mut u32) {
     *ptr = tx.msg_type.0;
 }
 
 /// Get error code, if present in transaction
 /// Return 0 if error code was filled, else 1
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut i32) -> u32 {
+pub unsafe extern "C" fn SCKrb5TxGetErrorCode(tx: &KRB5Transaction, ptr: *mut i32) -> u32 {
     match tx.error_code {
         Some(ref e) => {
             *ptr = e.0;
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_cname(
+pub unsafe extern "C" fn SCKrb5TxGetCname(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn rs_krb5_tx_get_cname(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_sname(
+pub unsafe extern "C" fn SCKrb5TxGetSname(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {
@@ -218,7 +218,7 @@ pub fn detect_parse_encryption(i: &str) -> IResult<&str, DetectKrb5TicketEncrypt
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_parse(
+pub unsafe extern "C" fn SCKrb5DetectEncryptionParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectKrb5TicketEncryptionData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn rs_krb5_detect_encryption_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_match(
+pub unsafe extern "C" fn SCKrb5DetectEncryptionMatch(
     tx: &KRB5Transaction, ctx: &DetectKrb5TicketEncryptionData,
 ) -> std::os::raw::c_int {
     if let Some(x) = tx.ticket_etype {
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn rs_krb5_detect_encryption_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_free(ctx: &mut DetectKrb5TicketEncryptionData) {
+pub unsafe extern "C" fn SCKrb5DetectEncryptionFree(ctx: &mut DetectKrb5TicketEncryptionData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -308,8 +308,7 @@ pub fn test_weak_encryption(alg:EncryptionType) -> bool {
 
 
 /// Returns *mut KRB5State
-#[no_mangle]
-pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+extern "C" fn krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = KRB5State::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut _;
@@ -317,14 +316,12 @@ pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _ori
 
 /// Params:
 /// - state: *mut KRB5State as void pointer
-#[no_mangle]
-pub extern "C" fn rs_krb5_state_free(state: *mut std::os::raw::c_void) {
+extern "C" fn krb5_state_free(state: *mut std::os::raw::c_void) {
     let mut state: Box<KRB5State> = unsafe{Box::from_raw(state as _)};
     state.free();
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
+unsafe extern "C" fn krb5_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -335,24 +332,21 @@ pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
+unsafe extern "C" fn krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,KRB5State);
     state.tx_id
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_tx_free(state: *mut std::os::raw::c_void,
+unsafe extern "C" fn krb5_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,KRB5State);
     state.free_tx(tx_id);
 }
 
-#[no_mangle]
-pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
+pub extern "C" fn krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
                                                  _direction: u8)
                                                  -> std::os::raw::c_int
 {
@@ -361,8 +355,7 @@ pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 
 static mut ALPROTO_KRB5 : AppProto = ALPROTO_UNKNOWN;
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
+unsafe extern "C" fn krb5_probing_parser(_flow: *const Flow,
         _direction: u8,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
@@ -403,8 +396,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_probing_parser_tcp(_flow: *const Flow,
         direction: u8,
         input:*const u8, input_len: u32,
         rdir: *mut u8) -> AppProto
@@ -418,7 +410,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         Ok((rem, record_mark)) => {
             // protocol implementations forbid very large requests
             if record_mark > 16384 { return ALPROTO_FAILED; }
-            return rs_krb5_probing_parser(_flow, direction,
+            return krb5_probing_parser(_flow, direction,
                     rem.as_ptr(), rem.len() as u32, rdir);
         },
         Err(Err::Incomplete(_)) => {
@@ -430,8 +422,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const Flow,
+pub unsafe extern "C" fn krb5_parse_request(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -445,8 +436,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_response(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -460,8 +450,7 @@ pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_request_tcp(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -518,8 +507,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_response_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_response_tcp(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -582,26 +570,26 @@ export_state_data_get!(krb5_get_state_data, KRB5State);
 const PARSER_NAME : &[u8] = b"krb5\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_register_krb5_parser() {
+pub unsafe extern "C" fn SCRegisterKrb5Parser() {
     let default_port = CString::new("88").unwrap();
     let mut parser = RustParser {
         name               : PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port       : default_port.as_ptr(),
         ipproto            : core::IPPROTO_UDP,
-        probe_ts           : Some(rs_krb5_probing_parser),
-        probe_tc           : Some(rs_krb5_probing_parser),
+        probe_ts           : Some(krb5_probing_parser),
+        probe_tc           : Some(krb5_probing_parser),
         min_depth          : 0,
         max_depth          : 16,
-        state_new          : rs_krb5_state_new,
-        state_free         : rs_krb5_state_free,
-        tx_free            : rs_krb5_state_tx_free,
-        parse_ts           : rs_krb5_parse_request,
-        parse_tc           : rs_krb5_parse_response,
-        get_tx_count       : rs_krb5_state_get_tx_count,
-        get_tx             : rs_krb5_state_get_tx,
+        state_new          : krb5_state_new,
+        state_free         : krb5_state_free,
+        tx_free            : krb5_state_tx_free,
+        parse_ts           : krb5_parse_request,
+        parse_tc           : krb5_parse_response,
+        get_tx_count       : krb5_state_get_tx_count,
+        get_tx             : krb5_state_get_tx,
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
-        tx_get_progress    : rs_krb5_tx_get_alstate_progress,
+        tx_get_progress    : krb5_tx_get_alstate_progress,
         get_eventinfo      : Some(KRB5Event::get_event_info),
         get_eventinfo_byid : Some(KRB5Event::get_event_info_by_id),
         localstorage_new   : None,
@@ -632,10 +620,10 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
     }
     // register TCP parser
     parser.ipproto = core::IPPROTO_TCP;
-    parser.probe_ts = Some(rs_krb5_probing_parser_tcp);
-    parser.probe_tc = Some(rs_krb5_probing_parser_tcp);
-    parser.parse_ts = rs_krb5_parse_request_tcp;
-    parser.parse_tc = rs_krb5_parse_response_tcp;
+    parser.probe_ts = Some(krb5_probing_parser_tcp);
+    parser.probe_tc = Some(krb5_probing_parser_tcp);
+    parser.parse_ts = krb5_parse_request_tcp;
+    parser.parse_tc = krb5_parse_response_tcp;
     let ip_proto_str = CString::new("tcp").unwrap();
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -18,10 +18,9 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
-use crate::krb::krb5::{KRB5Transaction,test_weak_encryption};
+use crate::krb::krb5::{test_weak_encryption, KRB5Transaction};
 
-fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), JsonError>
-{
+fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), JsonError> {
     jsb.open_object("krb5")?;
     match tx.error_code {
         Some(c) => {
@@ -35,30 +34,35 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
                 jsb.set_string("failed_request", "UNKNOWN")?;
             }
             jsb.set_string("error_code", &format!("{:?}", c))?;
-        },
-        None    => { jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?; },
+        }
+        None => {
+            jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?;
+        }
     }
     let cname = match tx.cname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let realm = match tx.realm {
         Some(ref x) => x.0.to_string(),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let sname = match tx.sname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let encryption = match tx.etype {
         Some(ref x) => format!("{:?}", x),
-        None        => "<none>".to_owned(),
+        None => "<none>".to_owned(),
     };
     jsb.set_string("cname", &cname)?;
     jsb.set_string("realm", &realm)?;
     jsb.set_string("sname", &sname)?;
     jsb.set_string("encryption", &encryption)?;
-    jsb.set_bool("weak_encryption", tx.etype.map_or(false,test_weak_encryption))?;
+    jsb.set_bool(
+        "weak_encryption",
+        tx.etype.map_or(false, test_weak_encryption),
+    )?;
     if let Some(x) = tx.ticket_etype {
         let refs = format!("{:?}", x);
         jsb.set_string("ticket_encryption", &refs)?;
@@ -70,7 +74,6 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
 }
 
 #[no_mangle]
-pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
-{
+pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -70,7 +70,7 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
+pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
 {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/krb/mod.rs
+++ b/rust/src/krb/mod.rs
@@ -19,6 +19,6 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-pub mod krb5;
 pub mod detect;
+pub mod krb5;
 pub mod log;

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -378,8 +378,7 @@ fn probe(input: &[u8]) -> IResult<&[u8], ()> {
 // C exports.
 
 /// C entry point for a probing parser.
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_probing_parser(
+unsafe extern "C" fn telnet_probing_parser(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -397,20 +396,17 @@ pub unsafe extern "C" fn rs_telnet_probing_parser(
     return ALPROTO_UNKNOWN;
 }
 
-#[no_mangle]
-pub extern "C" fn rs_telnet_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+extern "C" fn telnet_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = TelnetState::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut std::os::raw::c_void;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_free(state: *mut std::os::raw::c_void) {
+unsafe extern "C" fn telnet_state_free(state: *mut std::os::raw::c_void) {
     std::mem::drop(Box::from_raw(state as *mut TelnetState));
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_tx_free(
+unsafe extern "C" fn telnet_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) {
@@ -418,8 +414,7 @@ pub unsafe extern "C" fn rs_telnet_state_tx_free(
     state.free_tx(tx_id);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_parse_request(
+unsafe extern "C" fn telnet_parse_request(
     flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -446,8 +441,7 @@ pub unsafe extern "C" fn rs_telnet_parse_request(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_parse_response(
+unsafe extern "C" fn telnet_parse_response(
     flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -468,8 +462,7 @@ pub unsafe extern "C" fn rs_telnet_parse_response(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_get_tx(
+unsafe extern "C" fn telnet_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -484,16 +477,14 @@ pub unsafe extern "C" fn rs_telnet_state_get_tx(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_get_tx_count(
+unsafe extern "C" fn telnet_state_get_tx_count(
     state: *mut std::os::raw::c_void,
 ) -> u64 {
     let state = cast_pointer!(state, TelnetState);
     return state.tx_id;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_tx_get_alstate_progress(
+unsafe extern "C" fn telnet_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void,
     _direction: u8,
 ) -> std::os::raw::c_int {
@@ -509,26 +500,26 @@ export_state_data_get!(telnet_get_state_data, TelnetState);
 const PARSER_NAME: &[u8] = b"telnet\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_telnet_register_parser() {
+pub unsafe extern "C" fn SCRegisterTelnetParser() {
     let default_port = CString::new("[23]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),
         ipproto: IPPROTO_TCP,
-        probe_ts: Some(rs_telnet_probing_parser),
-        probe_tc: Some(rs_telnet_probing_parser),
+        probe_ts: Some(telnet_probing_parser),
+        probe_tc: Some(telnet_probing_parser),
         min_depth: 0,
         max_depth: 16,
-        state_new: rs_telnet_state_new,
-        state_free: rs_telnet_state_free,
-        tx_free: rs_telnet_state_tx_free,
-        parse_ts: rs_telnet_parse_request,
-        parse_tc: rs_telnet_parse_response,
-        get_tx_count: rs_telnet_state_get_tx_count,
-        get_tx: rs_telnet_state_get_tx,
+        state_new: telnet_state_new,
+        state_free: telnet_state_free,
+        tx_free: telnet_state_tx_free,
+        parse_ts: telnet_parse_request,
+        parse_tc: telnet_parse_response,
+        get_tx_count: telnet_state_get_tx_count,
+        get_tx: telnet_state_get_tx,
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
-        tx_get_progress: rs_telnet_tx_get_alstate_progress,
+        tx_get_progress: telnet_tx_get_alstate_progress,
         get_eventinfo: Some(TelnetEvent::get_event_info),
         get_eventinfo_byid : Some(TelnetEvent::get_event_info_by_id),
         localstorage_new: None,

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -34,6 +34,6 @@ fn tftp_log_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> Result<(), Js
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_log_json_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> bool {
+pub extern "C" fn SCTftpLogJsonRequest(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> bool {
     tftp_log_request(tx, jb).is_ok()
 }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -87,25 +87,25 @@ impl TFTPTransaction {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_alloc() -> *mut std::os::raw::c_void {
+pub extern "C" fn SCTftpStateAlloc() -> *mut std::os::raw::c_void {
     let state = TFTPState { state_data: AppLayerStateData::new(), transactions : Vec::new(), tx_id: 0, };
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_free(state: *mut std::os::raw::c_void) {
+pub extern "C" fn SCTftpStateFree(state: *mut std::os::raw::c_void) {
     std::mem::drop(unsafe { Box::from_raw(state as *mut TFTPState) });
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_tx_free(state: &mut TFTPState,
+pub extern "C" fn SCTftpStateTxFree(state: &mut TFTPState,
                                         tx_id: u64) {
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_get_tx(state: &mut TFTPState,
+pub extern "C" fn SCTftpGetTx(state: &mut TFTPState,
                                     tx_id: u64) -> *mut std::os::raw::c_void {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => tx as *const _ as *mut _,
@@ -114,7 +114,7 @@ pub extern "C" fn rs_tftp_get_tx(state: &mut TFTPState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_get_tx_cnt(state: &mut TFTPState) -> u64 {
+pub extern "C" fn SCTftpGetTxCnt(state: &mut TFTPState) -> u64 {
     return state.tx_id;
 }
 
@@ -155,7 +155,7 @@ fn parse_tftp_request(input: &[u8]) -> Option<TFTPTransaction> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_request(state: &mut TFTPState,
+pub unsafe extern "C" fn SCTftpParseRequest(state: &mut TFTPState,
                                   input: *const u8,
                                   len: u32) -> i64 {
     let buf = std::slice::from_raw_parts(input, len as usize);
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn rs_tftp_request(state: &mut TFTPState,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_get_tx_data(
+pub unsafe extern "C" fn SCTftpGetTxData(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
 {
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn rs_tftp_get_tx_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_get_state_data(
+pub unsafe extern "C" fn SCTftpGetStateData(
     state: *mut std::os::raw::c_void)
     -> *mut AppLayerStateData
 {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1790,7 +1790,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_register_ntp_parser();
     RegisterTFTPParsers();
     RegisterIKEParsers();
-    rs_register_krb5_parser();
+    SCRegisterKrb5Parser();
     SCRegisterDhcpParser();
     SCRegisterSnmpParser();
     rs_sip_register_parser();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1805,7 +1805,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     SCRegisterPop3Parser();
     SCRegisterRdpParser();
     RegisterHTTP2Parsers();
-    rs_telnet_register_parser();
+    SCRegisterTelnetParser();
     RegisterIMAPParsers();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -43,12 +43,12 @@
 
 static void *TFTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    return rs_tftp_state_alloc();
+    return SCTftpStateAlloc();
 }
 
 static void TFTPStateFree(void *state)
 {
-    rs_tftp_state_free(state);
+    SCTftpStateFree(state);
 }
 
 /**
@@ -59,7 +59,7 @@ static void TFTPStateFree(void *state)
  */
 static void TFTPStateTxFree(void *state, uint64_t tx_id)
 {
-    rs_tftp_state_tx_free(state, tx_id);
+    SCTftpStateTxFree(state, tx_id);
 }
 
 static int TFTPStateGetEventInfo(
@@ -108,7 +108,7 @@ static AppLayerResult TFTPParseRequest(Flow *f, void *state, AppLayerParserState
         SCReturnStruct(APP_LAYER_OK);
     }
 
-    int64_t res = rs_tftp_request(state, input, input_len);
+    int64_t res = SCTftpParseRequest(state, input, input_len);
     if (res < 0) {
         SCReturnStruct(APP_LAYER_ERROR);
     }
@@ -126,12 +126,12 @@ static AppLayerResult TFTPParseResponse(Flow *f, void *state, AppLayerParserStat
 
 static uint64_t TFTPGetTxCnt(void *state)
 {
-    return rs_tftp_get_tx_cnt(state);
+    return SCTftpGetTxCnt(state);
 }
 
 static void *TFTPGetTx(void *state, uint64_t tx_id)
 {
-    return rs_tftp_get_tx(state, tx_id);
+    return SCTftpGetTx(state, tx_id);
 }
 
 /**
@@ -229,8 +229,8 @@ void RegisterTFTPParsers(void)
                                            TFTPStateGetEventInfo);
 
         AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_TFTP,
-                                         rs_tftp_get_tx_data);
-        AppLayerParserRegisterStateDataFunc(IPPROTO_UDP, ALPROTO_TFTP, rs_tftp_get_state_data);
+                                         SCTftpGetTxData);
+        AppLayerParserRegisterStateDataFunc(IPPROTO_UDP, ALPROTO_TFTP, SCTftpGetStateData);
     }
     else {
         SCLogDebug("TFTP protocol parsing disabled.");

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -59,9 +59,9 @@ bool DetectAsn1Match(const SigMatchData *smd, const uint8_t *buffer, const uint3
         const uint32_t offset)
 {
     const DetectAsn1Data *ad = (const DetectAsn1Data *)smd->ctx;
-    Asn1 *asn1 = rs_asn1_decode(buffer, buffer_len, offset, ad);
-    uint8_t ret = rs_asn1_checks(asn1, ad);
-    rs_asn1_free(asn1);
+    Asn1 *asn1 = SCAsn1Decode(buffer, buffer_len, offset, ad);
+    uint8_t ret = SCAsn1Checks(asn1, ad);
+    SCAsn1Free(asn1);
     return ret == 1;
 }
 
@@ -75,7 +75,7 @@ bool DetectAsn1Match(const SigMatchData *smd, const uint8_t *buffer, const uint3
  */
 static DetectAsn1Data *DetectAsn1Parse(const char *asn1str)
 {
-    DetectAsn1Data *ad = rs_detect_asn1_parse(asn1str);
+    DetectAsn1Data *ad = SCAsn1DetectParse(asn1str);
 
     if (ad == NULL) {
         SCLogError("Malformed asn1 argument: %s", asn1str);
@@ -120,7 +120,7 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
 static void DetectAsn1Free(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectAsn1Data *ad = (DetectAsn1Data *)ptr;
-    rs_detect_asn1_free(ad);
+    SCAsn1DetectFree(ad);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -60,7 +60,7 @@ void DetectKrb5CNameRegister(void)
     sigmatch_table[DETECT_KRB5_CNAME].desc = "sticky buffer to match on Kerberos 5 client name";
 
     DetectAppLayerMultiRegister(
-            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_cname, 2);
+            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, SCKrb5TxGetCname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_cname",
             "Kerberos 5 ticket client name");

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -103,7 +103,7 @@ static int DetectKrb5ErrCodeMatch (DetectEngineThreadCtx *det_ctx,
 
     SCEnter();
 
-    ret = rs_krb5_tx_get_errcode(txv, &err_code);
+    ret = SCKrb5TxGetErrorCode(txv, &err_code);
     if (ret != 0)
         SCReturnInt(0);
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -102,7 +102,7 @@ static int DetectKrb5MsgTypeMatch (DetectEngineThreadCtx *det_ctx,
 
     SCEnter();
 
-    rs_krb5_tx_get_msgtype(txv, &msg_type);
+    SCKrb5TxGetMsgType(txv, &msg_type);
 
     if (dd->msg_type == msg_type)
         SCReturnInt(1);

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -60,7 +60,7 @@ void DetectKrb5SNameRegister(void)
     sigmatch_table[DETECT_KRB5_SNAME].desc = "sticky buffer to match on Kerberos 5 server name";
 
     DetectAppLayerMultiRegister(
-            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_sname, 2);
+            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, SCKrb5TxGetSname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_sname",
             "Kerberos 5 ticket server name");

--- a/src/detect-krb5-ticket-encryption.c
+++ b/src/detect-krb5-ticket-encryption.c
@@ -27,7 +27,7 @@ static int g_krb5_ticket_encryption_list_id = 0;
 
 static void DetectKrb5TicketEncryptionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    rs_krb5_detect_encryption_free(ptr);
+    SCKrb5DetectEncryptionFree(ptr);
 }
 
 static int DetectKrb5TicketEncryptionMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags,
@@ -37,7 +37,7 @@ static int DetectKrb5TicketEncryptionMatch(DetectEngineThreadCtx *det_ctx, Flow 
 
     SCEnter();
 
-    SCReturnInt(rs_krb5_detect_encryption_match(txv, dd));
+    SCReturnInt(SCKrb5DetectEncryptionMatch(txv, dd));
 }
 
 static int DetectKrb5TicketEncryptionSetup(
@@ -48,7 +48,7 @@ static int DetectKrb5TicketEncryptionSetup(
     if (DetectSignatureSetAppProto(s, ALPROTO_KRB5) != 0)
         return -1;
 
-    krb5d = rs_krb5_detect_encryption_parse(krb5str);
+    krb5d = SCKrb5DetectEncryptionParse(krb5str);
     if (krb5d == NULL)
         goto error;
 

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -142,7 +142,7 @@ static int DetectStreamSizeMatch(
  */
 static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *streamstr)
 {
-    DetectStreamSizeData *sd = rs_detect_stream_size_parse(streamstr);
+    DetectStreamSizeData *sd = SCDetectStreamSizeParse(streamstr);
     if (sd == NULL)
         return -1;
 
@@ -161,7 +161,7 @@ static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
  */
 void DetectStreamSizeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    rs_detect_stream_size_free(ptr);
+    SCDetectStreamSizeFree(ptr);
 }
 
 /* prefilter code */
@@ -238,7 +238,7 @@ static int DetectStreamSizeParseTest01 (void)
 {
     int result = 0;
     DetectStreamSizeData *sd = NULL;
-    sd = rs_detect_stream_size_parse("server,<,6");
+    sd = SCDetectStreamSizeParse("server,<,6");
     if (sd != NULL) {
         if (sd->flags & StreamSizeServer && sd->du32.mode == DETECT_UINT_LT && sd->du32.arg1 == 6)
             result = 1;
@@ -257,7 +257,7 @@ static int DetectStreamSizeParseTest02 (void)
 {
     int result = 1;
     DetectStreamSizeData *sd = NULL;
-    sd = rs_detect_stream_size_parse("invalidoption,<,6");
+    sd = SCDetectStreamSizeParse("invalidoption,<,6");
     if (sd != NULL) {
         printf("expected: NULL got 0x%02X %" PRIu32 ": ", sd->flags, sd->du32.arg1);
         result = 0;
@@ -298,7 +298,7 @@ static int DetectStreamSizeParseTest03 (void)
     memset(&f, 0, sizeof(Flow));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    sd = rs_detect_stream_size_parse("client,>,8");
+    sd = SCDetectStreamSizeParse("client,>,8");
     if (sd != NULL) {
         if (!(sd->flags & StreamSizeClient)) {
             printf("sd->flags not STREAM_SIZE_CLIENT: ");
@@ -374,7 +374,7 @@ static int DetectStreamSizeParseTest04 (void)
     memset(&f, 0, sizeof(Flow));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
-    sd = rs_detect_stream_size_parse(" client , > , 8 ");
+    sd = SCDetectStreamSizeParse(" client , > , 8 ");
     if (sd != NULL) {
         if (!(sd->flags & StreamSizeClient) && sd->du32.mode != DETECT_UINT_GT &&
                 sd->du32.arg1 != 8) {

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -85,7 +85,7 @@ void DetectUrilenRegister(void)
 
 static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 {
-    return rs_detect_urilen_parse(urilenstr);
+    return SCDetectUrilenParse(urilenstr);
 }
 
 /**
@@ -140,7 +140,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectUrilenData *urilend = (DetectUrilenData *)ptr;
-    rs_detect_urilen_free(urilend);
+    SCDetectUrilenFree(urilend);
 }
 
 /** \brief set prefilter dsize pair

--- a/src/output.c
+++ b/src/output.c
@@ -910,7 +910,7 @@ void OutputRegisterRootLoggers(void)
     RegisterSimpleJsonApplayerLogger(
             ALPROTO_FTPDATA, (EveJsonSimpleTxLogFunc)EveFTPDataAddMetadata, "ftp_data");
     RegisterSimpleJsonApplayerLogger(
-            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
+            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)SCTftpLogJsonRequest, NULL);
     // ALPROTO_IKE special: uses state
     RegisterSimpleJsonApplayerLogger(
             ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);

--- a/src/output.c
+++ b/src/output.c
@@ -913,7 +913,7 @@ void OutputRegisterRootLoggers(void)
             ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
     // ALPROTO_IKE special: uses state
     RegisterSimpleJsonApplayerLogger(
-            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response, NULL);
+            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, (EveJsonSimpleTxLogFunc)rs_quic_to_json, NULL);
     // ALPROTO_DHCP TODO missing
     RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);


### PR DESCRIPTION
- **rust/dns: rs_ prefix name cleanup**
  

- **rust/krb: remove rs_ prefix; visibility fixes**
  - remove pub/no_mangle where not needed
  - replace rs_ naming with SC naming
  

- **rust/krb: rust format**
  

- **rust/asn1: replace rs_ naming with SC naming**
  

- **rust/detect: replace rs_ naming with SC**
  

- **rust/telnet: replace rs_ naming with SC**
  

- **rust/tftp: replace rs_ naming with SC**
  