### PR TITLE
rust: naming cleanups

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -86,6 +86,7 @@ include = [
     "FtpRequestCommand",
     "FtpStateValues",
     "FtpDataStateValues",
+    "HTTP2TransactionState",
     "SCSigTableAppLiteElmt",
     "SCTransformTableElmt",
     "DataRepType",

--- a/rust/src/asn1/mod.rs
+++ b/rust/src/asn1/mod.rs
@@ -215,9 +215,9 @@ fn asn1_decode<'a>(
 /// # Safety
 ///
 /// input must be a valid buffer of at least input_len bytes
-/// pointer must be freed using `rs_asn1_free`
+/// pointer must be freed using `SCAsn1Free`
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_decode(
+pub unsafe extern "C" fn SCAsn1Decode(
     input: *const u8, input_len: u32, buffer_offset: u32, ad_ptr: *const DetectAsn1Data,
 ) -> *mut Asn1<'static> {
     if input.is_null() || input_len == 0 || ad_ptr.is_null() {
@@ -240,9 +240,9 @@ pub unsafe extern "C" fn rs_asn1_decode(
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_asn1_decode`
+/// ptr must be a valid object obtained using `SCAsn1Decode`
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_free(ptr: *mut Asn1) {
+pub unsafe extern "C" fn SCAsn1Free(ptr: *mut Asn1) {
     if ptr.is_null() {
         return;
     }
@@ -256,12 +256,12 @@ pub unsafe extern "C" fn rs_asn1_free(ptr: *mut Asn1) {
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_asn1_decode`
-/// ad_ptr must be a valid object obtained using `rs_detect_asn1_parse`
+/// ptr must be a valid object obtained using `SCAsn1Decode`
+/// ad_ptr must be a valid object obtained using `SCAsn1DetectParse`
 ///
 /// Returns 1 if any of the options match, 0 if not
 #[no_mangle]
-pub unsafe extern "C" fn rs_asn1_checks(ptr: *const Asn1, ad_ptr: *const DetectAsn1Data) -> u8 {
+pub unsafe extern "C" fn SCAsn1Checks(ptr: *const Asn1, ad_ptr: *const DetectAsn1Data) -> u8 {
     if ptr.is_null() || ad_ptr.is_null() {
         return 0;
     }

--- a/rust/src/asn1/parse_rules.rs
+++ b/rust/src/asn1/parse_rules.rs
@@ -32,9 +32,9 @@ const ASN1_DEFAULT_MAX_FRAMES: u16 = 30;
 ///
 /// # Safety
 ///
-/// pointer must be free'd using `rs_detect_asn1_free`
+/// pointer must be free'd using `SCAsn1DetectFree`
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_asn1_parse(input: *const c_char) -> *mut DetectAsn1Data {
+pub unsafe extern "C" fn SCAsn1DetectParse(input: *const c_char) -> *mut DetectAsn1Data {
     if input.is_null() {
         return std::ptr::null_mut();
     }
@@ -73,9 +73,9 @@ pub unsafe extern "C" fn rs_detect_asn1_parse(input: *const c_char) -> *mut Dete
 ///
 /// # Safety
 ///
-/// ptr must be a valid object obtained using `rs_detect_asn1_parse`
+/// ptr must be a valid object obtained using `SCAsn1DetectParse`
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_asn1_free(ptr: *mut DetectAsn1Data) {
+pub unsafe extern "C" fn SCAsn1DetectFree(ptr: *mut DetectAsn1Data) {
     if ptr.is_null() {
         return;
     }

--- a/rust/src/detect/float.rs
+++ b/rust/src/detect/float.rs
@@ -229,7 +229,7 @@ fn detect_parse_float_notending<T: DetectFloatType>(i: &str) -> IResult<&str, De
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_parse(
+pub unsafe extern "C" fn SCDetectF64Parse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectFloatData<f64> {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn rs_detect_f64_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_match(
+pub unsafe extern "C" fn SCDetectF64Match(
     arg: f64, ctx: &DetectFloatData<f64>,
 ) -> std::os::raw::c_int {
     if detect_match_float::<f64>(ctx, arg) {
@@ -253,7 +253,7 @@ pub unsafe extern "C" fn rs_detect_f64_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_f64_free(ctx: &mut DetectFloatData<f64>) {
+pub unsafe extern "C" fn SCDetectF64Free(ctx: &mut DetectFloatData<f64>) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }
@@ -441,7 +441,7 @@ mod tests {
     fn do_match_test(val: &str, arg1: f64, arg1_cmp: f64, arg2: f64, mode: DetectFloatMode) {
         let c_string = CString::new(val).expect("CString::new failed");
         unsafe {
-            let val = rs_detect_f64_parse(c_string.as_ptr());
+            let val = SCDetectF64Parse(c_string.as_ptr());
             let str_arg_a = format!("{:.3}", (*val).arg1);
             let str_arg_b = format!("{:.3}", arg1);
             assert_eq!(str_arg_a, str_arg_b);
@@ -450,7 +450,7 @@ mod tests {
             assert_eq!(str_arg_a, str_arg_b);
 
             assert_eq!((*val).mode, mode);
-            assert_eq!(1, rs_detect_f64_match(arg1_cmp, &*val));
+            assert_eq!(1, SCDetectF64Match(arg1_cmp, &*val));
         }
     }
 
@@ -461,7 +461,7 @@ mod tests {
     fn do_parse_test(val: &str, arg1: f64, arg2: f64, mode: DetectFloatMode) {
         let c_string = CString::new(val).expect("CString::new failed");
         unsafe {
-            let val = rs_detect_f64_parse(c_string.as_ptr());
+            let val = SCDetectF64Parse(c_string.as_ptr());
             let str_arg_a = format!("{:.3}", (*val).arg1);
             let str_arg_b = format!("{:.3}", arg1);
             assert_eq!(str_arg_a, str_arg_b);
@@ -478,7 +478,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rs_detect_match_valid() {
+    fn test_ffi_detect_match_valid() {
         do_match_test_arg1("1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeEqual);
         do_match_test_arg1("> 1.0", 1.0, 1.1, DetectFloatMode::DetectFloatModeGt);
         do_match_test_arg1(">= 1.0", 1.0, 1.0, DetectFloatMode::DetectFloatModeGte);
@@ -515,7 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rs_detect_parse_valid() {
+    fn test_ffi_detect_parse_valid() {
         do_parse_test_arg1("1.0", 1.0, DetectFloatMode::DetectFloatModeEqual);
         do_parse_test_arg1("> 1.0", 1.0, DetectFloatMode::DetectFloatModeGt);
         do_parse_test_arg1(">= 1.0", 1.0, DetectFloatMode::DetectFloatModeGte);

--- a/rust/src/detect/stream_size.rs
+++ b/rust/src/detect/stream_size.rs
@@ -78,7 +78,7 @@ pub fn detect_parse_stream_size(i: &str) -> IResult<&str, DetectStreamSizeData> 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_stream_size_parse(
+pub unsafe extern "C" fn SCDetectStreamSizeParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectStreamSizeData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -92,7 +92,7 @@ pub unsafe extern "C" fn rs_detect_stream_size_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_stream_size_free(ctx: &mut DetectStreamSizeData) {
+pub unsafe extern "C" fn SCDetectStreamSizeFree(ctx: &mut DetectStreamSizeData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/detect/uri.rs
+++ b/rust/src/detect/uri.rs
@@ -58,7 +58,7 @@ pub fn detect_parse_urilen(i: &str) -> IResult<&str, DetectUrilenData> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_urilen_parse(
+pub unsafe extern "C" fn SCDetectUrilenParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectUrilenData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn rs_detect_urilen_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_detect_urilen_free(ctx: &mut DetectUrilenData) {
+pub unsafe extern "C" fn SCDetectUrilenFree(ctx: &mut DetectUrilenData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -940,13 +940,13 @@ extern "C" fn tx_get_alstate_progress(
 ) -> std::os::raw::c_int {
     // This is a stateless parser, just the existence of a transaction
     // means its complete.
-    SCLogDebug!("rs_dns_tx_get_alstate_progress");
+    SCLogDebug!("tx_get_alstate_progress");
     return 1;
 }
 
 unsafe extern "C" fn state_get_tx_count(state: *mut std::os::raw::c_void) -> u64 {
     let state = cast_pointer!(state, DNSState);
-    SCLogDebug!("rs_dns_state_get_tx_count: returning {}", state.tx_id);
+    SCLogDebug!("state_get_tx_count: returning {}", state.tx_id);
     return state.tx_id;
 }
 
@@ -979,7 +979,7 @@ unsafe extern "C" fn state_get_tx_data(tx: *mut std::os::raw::c_void) -> *mut Ap
     return &mut tx.tx_data;
 }
 
-export_state_data_get!(rs_dns_get_state_data, DNSState);
+export_state_data_get!(dns_get_state_data, DNSState);
 
 /// Get the DNS query name at index i.
 #[no_mangle]
@@ -1248,7 +1248,7 @@ pub unsafe extern "C" fn SCRegisterDnsUdpParser() {
         get_tx_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_tx_data: state_get_tx_data,
-        get_state_data: rs_dns_get_state_data,
+        get_state_data: dns_get_state_data,
         apply_tx_config: Some(apply_tx_config),
         flags: 0,
         get_frame_id_by_name: Some(DnsFrameType::ffi_id_from_name),
@@ -1295,7 +1295,7 @@ pub unsafe extern "C" fn SCRegisterDnsTcpParser() {
         get_tx_files: None,
         get_tx_iterator: Some(crate::applayer::state_get_tx_iterator::<DNSState, DNSTransaction>),
         get_tx_data: state_get_tx_data,
-        get_state_data: rs_dns_get_state_data,
+        get_state_data: dns_get_state_data,
         apply_tx_config: Some(apply_tx_config),
         flags: APP_LAYER_PARSER_OPT_ACCEPT_GAPS,
         get_frame_id_by_name: Some(DnsFrameType::ffi_id_from_name),

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -48,7 +48,7 @@ fn http2_tx_has_frametype(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_has_frametype(
+pub unsafe extern "C" fn SCHttp2TxHasFrametype(
     tx: *mut std::os::raw::c_void, direction: u8, value: u8,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn rs_http2_tx_has_frametype(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_parse_frametype(
+pub unsafe extern "C" fn SCHttp2ParseFrametype(
     str: *const std::os::raw::c_char,
 ) -> std::os::raw::c_int {
     let ft_name: &CStr = CStr::from_ptr(str); //unsafe
@@ -108,7 +108,7 @@ fn http2_tx_has_errorcode(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_has_errorcode(
+pub unsafe extern "C" fn SCHttp2TxHasErrorCode(
     tx: *mut std::os::raw::c_void, direction: u8, code: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn rs_http2_tx_has_errorcode(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_parse_errorcode(
+pub unsafe extern "C" fn SCHttp2ParseErrorCode(
     str: *const std::os::raw::c_char,
 ) -> std::os::raw::c_int {
     let ft_name: &CStr = CStr::from_ptr(str); //unsafe
@@ -181,7 +181,7 @@ fn http2_tx_get_next_priority(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_next_priority(
+pub unsafe extern "C" fn SCHttp2TxGetNextPriority(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -217,7 +217,7 @@ fn http2_tx_get_next_window(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_next_window(
+pub unsafe extern "C" fn SCHttp2TxGetNextWindow(
     tx: *mut std::os::raw::c_void, direction: u8, nb: u32,
 ) -> std::os::raw::c_int {
     let tx = cast_pointer!(tx, HTTP2Transaction);
@@ -225,7 +225,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_next_window(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_detect_settingsctx_parse(
+pub unsafe extern "C" fn SCHttp2DetectSettingsCtxParse(
     str: *const std::os::raw::c_char,
 ) -> *mut std::os::raw::c_void {
     let ft_name: &CStr = CStr::from_ptr(str); //unsafe
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn rs_http2_detect_settingsctx_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_detect_settingsctx_free(ctx: *mut std::os::raw::c_void) {
+pub unsafe extern "C" fn SCHttp2DetectSettingsCtxFree(ctx: *mut std::os::raw::c_void) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx as *mut parser::DetectHTTP2settingsSigCtx));
 }
@@ -288,7 +288,7 @@ fn http2_detect_settingsctx_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_detect_settingsctx_match(
+pub unsafe extern "C" fn SCHttp2DetectSettingsCtxMatch(
     ctx: *const std::os::raw::c_void, tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, parser::DetectHTTP2settingsSigCtx);
@@ -349,7 +349,7 @@ fn http2_detect_sizeupdatectx_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_detect_sizeupdatectx_match(
+pub unsafe extern "C" fn SCHttp2DetectSizeUpdateCtxMatch(
     ctx: *const std::os::raw::c_void, tx: *mut std::os::raw::c_void, direction: u8,
 ) -> std::os::raw::c_int {
     let ctx = cast_pointer!(ctx, DetectUintData<u64>);
@@ -357,10 +357,10 @@ pub unsafe extern "C" fn rs_http2_detect_sizeupdatectx_match(
     return http2_detect_sizeupdatectx_match(ctx, tx, direction.into());
 }
 
-//TODOask better syntax between rs_http2_tx_get_header_name in argument
-// and rs_http2_detect_sizeupdatectx_match explicitly casting
+//TODOask better syntax between SCHttp2TxGetHeaderName in argument
+// and SCHttp2DetectSizeUpdateCtxMatch explicitly casting
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_header_name(
+pub unsafe extern "C" fn SCHttp2TxGetHeaderName(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, direction: u8, nb: u32,
     buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
@@ -530,7 +530,7 @@ fn http2_tx_get_req_line(tx: &mut HTTP2Transaction) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_request_line(
+pub unsafe extern "C" fn SCHttp2TxGetRequestLine(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     http2_tx_get_req_line(tx);
@@ -559,7 +559,7 @@ fn http2_tx_get_resp_line(tx: &mut HTTP2Transaction) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_response_line(
+pub unsafe extern "C" fn SCHttp2TxGetResponseLine(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     http2_tx_get_resp_line(tx);
@@ -569,7 +569,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_response_line(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_uri(
+pub unsafe extern "C" fn SCHttp2TxGetUri(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":path") {
@@ -581,7 +581,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_uri(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_method(
+pub unsafe extern "C" fn SCHttp2TxGetMethod(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToServer, ":method") {
@@ -593,7 +593,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_method(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_host(
+pub unsafe extern "C" fn SCHttp2TxGetHost(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
@@ -645,7 +645,7 @@ fn http2_normalize_host(value: &[u8]) -> &[u8] {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_host_norm(
+pub unsafe extern "C" fn SCHttp2TxGetHostNorm(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, ":authority") {
@@ -674,7 +674,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_host_norm(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_useragent(
+pub unsafe extern "C" fn SCHttp2TxGetUserAgent(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_value(tx, Direction::ToServer, "user-agent") {
@@ -686,7 +686,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_useragent(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_status(
+pub unsafe extern "C" fn SCHttp2TxGetStatus(
     tx: &mut HTTP2Transaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Ok(value) = http2_frames_get_header_firstvalue(tx, Direction::ToClient, ":status") {
@@ -698,7 +698,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_status(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_cookie(
+pub unsafe extern "C" fn SCHttp2TxGetCookie(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if direction == u8::from(Direction::ToServer) {
@@ -716,7 +716,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_cookie(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_header_value(
+pub unsafe extern "C" fn SCHttp2TxGetHeaderValue(
     tx: &mut HTTP2Transaction, direction: u8, strname: *const std::os::raw::c_char,
     buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
@@ -742,7 +742,7 @@ fn http2_escape_header(blocks: &[parser::HTTP2FrameHeaderBlock], i: u32) -> Vec<
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_header_names(
+pub unsafe extern "C" fn SCHttp2TxGetHeaderNames(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = vec![b'\r', b'\n'];
@@ -806,7 +806,7 @@ fn http2_header_trimspaces(value: &[u8]) -> &[u8] {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_headers(
+pub unsafe extern "C" fn SCHttp2TxGetHeaders(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = Vec::new();
@@ -840,7 +840,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_headers_raw(
+pub unsafe extern "C" fn SCHttp2TxGetHeadersRaw(
     tx: &mut HTTP2Transaction, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     let mut vec = Vec::new();
@@ -872,7 +872,7 @@ pub unsafe extern "C" fn rs_http2_tx_get_headers_raw(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_get_header(
+pub unsafe extern "C" fn SCHttp2TxGetHeader(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, direction: u8, nb: u32,
     buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
@@ -951,7 +951,7 @@ fn http2_tx_set_header(state: &mut HTTP2State, name: &[u8], input: &[u8]) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_set_method(
+pub unsafe extern "C" fn SCHttp2TxSetMethod(
     state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
 ) {
     let slice = build_slice!(buffer, buffer_len as usize);
@@ -959,7 +959,7 @@ pub unsafe extern "C" fn rs_http2_tx_set_method(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_set_uri(
+pub unsafe extern "C" fn SCHttp2TxSetUri(
     state: &mut HTTP2State, buffer: *const u8, buffer_len: u32,
 ) {
     let slice = build_slice!(buffer, buffer_len as usize);
@@ -1011,7 +1011,7 @@ fn http2_caseinsensitive_cmp(s1: &[u8], s2: &str) -> bool {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_tx_add_header(
+pub unsafe extern "C" fn SCHttp2TxAddHeader(
     state: &mut HTTP2State, name: *const u8, name_len: u32, value: *const u8, value_len: u32,
 ) {
     let slice_name = build_slice!(name, name_len as usize);

--- a/rust/src/http2/logger.rs
+++ b/rust/src/http2/logger.rs
@@ -285,7 +285,7 @@ fn log_http2(tx: &HTTP2Transaction, js: &mut JsonBuilder) -> Result<bool, JsonEr
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http2_log_json(
+pub unsafe extern "C" fn SCHttp2LogJson(
     tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, HTTP2Transaction);

--- a/rust/src/http2/range.rs
+++ b/rust/src/http2/range.rs
@@ -86,7 +86,7 @@ pub fn http2_parse_check_content_range(input: &[u8]) -> IResult<&[u8], HTTPConte
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_http_parse_content_range(
+pub unsafe extern "C" fn SCHttpParseContentRange(
     cr: &mut HTTPContentRange, buffer: *const u8, buffer_len: u32,
 ) -> std::os::raw::c_int {
     let slice = build_slice!(buffer, buffer_len as usize);

--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -25,7 +25,7 @@ use std::os::raw::c_void;
 use std::ptr;
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_exch_type(tx: &IKETransaction, exch_type: *mut u8) -> u8 {
+pub extern "C" fn SCIkeStateGetExchType(tx: &IKETransaction, exch_type: *mut u8) -> u8 {
     debug_validate_bug_on!(exch_type.is_null());
 
     if tx.ike_version == 1 {
@@ -46,7 +46,7 @@ pub extern "C" fn rs_ike_state_get_exch_type(tx: &IKETransaction, exch_type: *mu
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_spi_initiator(
+pub extern "C" fn SCIkeStateGetSpiInitiator(
     tx: &IKETransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(buffer.is_null() || buffer_len.is_null());
@@ -59,7 +59,7 @@ pub extern "C" fn rs_ike_state_get_spi_initiator(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_spi_responder(
+pub extern "C" fn SCIkeStateGetSpiResponder(
     tx: &IKETransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(buffer.is_null() || buffer_len.is_null());
@@ -72,7 +72,7 @@ pub extern "C" fn rs_ike_state_get_spi_responder(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_nonce(
+pub extern "C" fn SCIkeStateGetNonce(
     tx: &IKETransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(buffer.is_null() || buffer_len.is_null());
@@ -95,7 +95,7 @@ pub extern "C" fn rs_ike_state_get_nonce(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_key_exchange(
+pub extern "C" fn SCIkeStateGetKeyExchange(
     tx: &IKETransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(buffer.is_null() || buffer_len.is_null());
@@ -118,7 +118,7 @@ pub extern "C" fn rs_ike_state_get_key_exchange(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ike_tx_get_vendor(
+pub unsafe extern "C" fn SCIkeTxGetVendor(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buf: *mut *const u8,
     len: *mut u32,
 ) -> bool {
@@ -136,7 +136,7 @@ pub unsafe extern "C" fn rs_ike_tx_get_vendor(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_ike_state_get_sa_attribute(
+pub extern "C" fn SCIkeStateGetSaAttribute(
     tx: &IKETransaction, sa_type: *const std::os::raw::c_char, value: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(value.is_null());
@@ -207,7 +207,7 @@ pub extern "C" fn rs_ike_state_get_sa_attribute(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ike_state_get_key_exchange_payload_length(
+pub unsafe extern "C" fn SCIkeStateGetKeyExchangePayloadLength(
     tx: &IKETransaction, value: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(value.is_null());
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn rs_ike_state_get_key_exchange_payload_length(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ike_state_get_nonce_payload_length(
+pub unsafe extern "C" fn SCIkeStateGetNoncePayloadLength(
     tx: &IKETransaction, value: *mut u32,
 ) -> u8 {
     debug_validate_bug_on!(value.is_null());

--- a/rust/src/ike/logger.rs
+++ b/rust/src/ike/logger.rs
@@ -226,7 +226,7 @@ fn log_ikev2(tx: &IKETransaction, jb: &mut JsonBuilder) -> Result<(), JsonError>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_ike_logger_log(
+pub unsafe extern "C" fn SCIkeLoggerLog(
     state: &mut IKEState, tx: *mut std::os::raw::c_void, flags: u32, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, IKETransaction);

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -33,14 +33,14 @@ use std::ffi::CStr;
 use std::os::raw::c_void;
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_msgtype(tx: &KRB5Transaction, ptr: *mut u32) {
+pub unsafe extern "C" fn SCKrb5TxGetMsgType(tx: &KRB5Transaction, ptr: *mut u32) {
     *ptr = tx.msg_type.0;
 }
 
 /// Get error code, if present in transaction
 /// Return 0 if error code was filled, else 1
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut i32) -> u32 {
+pub unsafe extern "C" fn SCKrb5TxGetErrorCode(tx: &KRB5Transaction, ptr: *mut i32) -> u32 {
     match tx.error_code {
         Some(ref e) => {
             *ptr = e.0;
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn rs_krb5_tx_get_errcode(tx: &KRB5Transaction, ptr: *mut 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_cname(
+pub unsafe extern "C" fn SCKrb5TxGetCname(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {
@@ -68,7 +68,7 @@ pub unsafe extern "C" fn rs_krb5_tx_get_cname(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_tx_get_sname(
+pub unsafe extern "C" fn SCKrb5TxGetSname(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {
@@ -218,7 +218,7 @@ pub fn detect_parse_encryption(i: &str) -> IResult<&str, DetectKrb5TicketEncrypt
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_parse(
+pub unsafe extern "C" fn SCKrb5DetectEncryptionParse(
     ustr: *const std::os::raw::c_char,
 ) -> *mut DetectKrb5TicketEncryptionData {
     let ft_name: &CStr = CStr::from_ptr(ustr); //unsafe
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn rs_krb5_detect_encryption_parse(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_match(
+pub unsafe extern "C" fn SCKrb5DetectEncryptionMatch(
     tx: &KRB5Transaction, ctx: &DetectKrb5TicketEncryptionData,
 ) -> std::os::raw::c_int {
     if let Some(x) = tx.ticket_etype {
@@ -266,7 +266,7 @@ pub unsafe extern "C" fn rs_krb5_detect_encryption_match(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_krb5_detect_encryption_free(ctx: &mut DetectKrb5TicketEncryptionData) {
+pub unsafe extern "C" fn SCKrb5DetectEncryptionFree(ctx: &mut DetectKrb5TicketEncryptionData) {
     // Just unbox...
     std::mem::drop(Box::from_raw(ctx));
 }

--- a/rust/src/krb/krb5.rs
+++ b/rust/src/krb/krb5.rs
@@ -308,8 +308,7 @@ pub fn test_weak_encryption(alg:EncryptionType) -> bool {
 
 
 /// Returns *mut KRB5State
-#[no_mangle]
-pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+extern "C" fn krb5_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = KRB5State::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut _;
@@ -317,14 +316,12 @@ pub extern "C" fn rs_krb5_state_new(_orig_state: *mut std::os::raw::c_void, _ori
 
 /// Params:
 /// - state: *mut KRB5State as void pointer
-#[no_mangle]
-pub extern "C" fn rs_krb5_state_free(state: *mut std::os::raw::c_void) {
+extern "C" fn krb5_state_free(state: *mut std::os::raw::c_void) {
     let mut state: Box<KRB5State> = unsafe{Box::from_raw(state as _)};
     state.free();
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
+unsafe extern "C" fn krb5_state_get_tx(state: *mut std::os::raw::c_void,
                                       tx_id: u64)
                                       -> *mut std::os::raw::c_void
 {
@@ -335,24 +332,21 @@ pub unsafe extern "C" fn rs_krb5_state_get_tx(state: *mut std::os::raw::c_void,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
+unsafe extern "C" fn krb5_state_get_tx_count(state: *mut std::os::raw::c_void)
                                             -> u64
 {
     let state = cast_pointer!(state,KRB5State);
     state.tx_id
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_state_tx_free(state: *mut std::os::raw::c_void,
+unsafe extern "C" fn krb5_state_tx_free(state: *mut std::os::raw::c_void,
                                        tx_id: u64)
 {
     let state = cast_pointer!(state,KRB5State);
     state.free_tx(tx_id);
 }
 
-#[no_mangle]
-pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
+pub extern "C" fn krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void,
                                                  _direction: u8)
                                                  -> std::os::raw::c_int
 {
@@ -361,8 +355,7 @@ pub extern "C" fn rs_krb5_tx_get_alstate_progress(_tx: *mut std::os::raw::c_void
 
 static mut ALPROTO_KRB5 : AppProto = ALPROTO_UNKNOWN;
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
+unsafe extern "C" fn krb5_probing_parser(_flow: *const Flow,
         _direction: u8,
         input:*const u8, input_len: u32,
         _rdir: *mut u8) -> AppProto
@@ -403,8 +396,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser(_flow: *const Flow,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_probing_parser_tcp(_flow: *const Flow,
         direction: u8,
         input:*const u8, input_len: u32,
         rdir: *mut u8) -> AppProto
@@ -418,7 +410,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
         Ok((rem, record_mark)) => {
             // protocol implementations forbid very large requests
             if record_mark > 16384 { return ALPROTO_FAILED; }
-            return rs_krb5_probing_parser(_flow, direction,
+            return krb5_probing_parser(_flow, direction,
                     rem.as_ptr(), rem.len() as u32, rdir);
         },
         Err(Err::Incomplete(_)) => {
@@ -430,8 +422,7 @@ pub unsafe extern "C" fn rs_krb5_probing_parser_tcp(_flow: *const Flow,
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const Flow,
+pub unsafe extern "C" fn krb5_parse_request(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -445,8 +436,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_response(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -460,8 +450,7 @@ pub unsafe extern "C" fn rs_krb5_parse_response(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_request_tcp(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -518,8 +507,7 @@ pub unsafe extern "C" fn rs_krb5_parse_request_tcp(_flow: *const Flow,
     AppLayerResult::ok()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_krb5_parse_response_tcp(_flow: *const Flow,
+unsafe extern "C" fn krb5_parse_response_tcp(_flow: *const Flow,
                                        state: *mut std::os::raw::c_void,
                                        _pstate: *mut std::os::raw::c_void,
                                        stream_slice: StreamSlice,
@@ -582,26 +570,26 @@ export_state_data_get!(krb5_get_state_data, KRB5State);
 const PARSER_NAME : &[u8] = b"krb5\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_register_krb5_parser() {
+pub unsafe extern "C" fn SCRegisterKrb5Parser() {
     let default_port = CString::new("88").unwrap();
     let mut parser = RustParser {
         name               : PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port       : default_port.as_ptr(),
         ipproto            : core::IPPROTO_UDP,
-        probe_ts           : Some(rs_krb5_probing_parser),
-        probe_tc           : Some(rs_krb5_probing_parser),
+        probe_ts           : Some(krb5_probing_parser),
+        probe_tc           : Some(krb5_probing_parser),
         min_depth          : 0,
         max_depth          : 16,
-        state_new          : rs_krb5_state_new,
-        state_free         : rs_krb5_state_free,
-        tx_free            : rs_krb5_state_tx_free,
-        parse_ts           : rs_krb5_parse_request,
-        parse_tc           : rs_krb5_parse_response,
-        get_tx_count       : rs_krb5_state_get_tx_count,
-        get_tx             : rs_krb5_state_get_tx,
+        state_new          : krb5_state_new,
+        state_free         : krb5_state_free,
+        tx_free            : krb5_state_tx_free,
+        parse_ts           : krb5_parse_request,
+        parse_tc           : krb5_parse_response,
+        get_tx_count       : krb5_state_get_tx_count,
+        get_tx             : krb5_state_get_tx,
         tx_comp_st_ts      : 1,
         tx_comp_st_tc      : 1,
-        tx_get_progress    : rs_krb5_tx_get_alstate_progress,
+        tx_get_progress    : krb5_tx_get_alstate_progress,
         get_eventinfo      : Some(KRB5Event::get_event_info),
         get_eventinfo_byid : Some(KRB5Event::get_event_info_by_id),
         localstorage_new   : None,
@@ -632,10 +620,10 @@ pub unsafe extern "C" fn rs_register_krb5_parser() {
     }
     // register TCP parser
     parser.ipproto = core::IPPROTO_TCP;
-    parser.probe_ts = Some(rs_krb5_probing_parser_tcp);
-    parser.probe_tc = Some(rs_krb5_probing_parser_tcp);
-    parser.parse_ts = rs_krb5_parse_request_tcp;
-    parser.parse_tc = rs_krb5_parse_response_tcp;
+    parser.probe_ts = Some(krb5_probing_parser_tcp);
+    parser.probe_tc = Some(krb5_probing_parser_tcp);
+    parser.parse_ts = krb5_parse_request_tcp;
+    parser.parse_tc = krb5_parse_response_tcp;
     let ip_proto_str = CString::new("tcp").unwrap();
     if AppLayerProtoDetectConfProtoDetectionEnabled(ip_proto_str.as_ptr(), parser.name) != 0 {
         let alproto = AppLayerRegisterProtocolDetection(&parser, 1);

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -18,10 +18,9 @@
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
 use crate::jsonbuilder::{JsonBuilder, JsonError};
-use crate::krb::krb5::{KRB5Transaction,test_weak_encryption};
+use crate::krb::krb5::{test_weak_encryption, KRB5Transaction};
 
-fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), JsonError>
-{
+fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), JsonError> {
     jsb.open_object("krb5")?;
     match tx.error_code {
         Some(c) => {
@@ -35,30 +34,35 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
                 jsb.set_string("failed_request", "UNKNOWN")?;
             }
             jsb.set_string("error_code", &format!("{:?}", c))?;
-        },
-        None    => { jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?; },
+        }
+        None => {
+            jsb.set_string("msg_type", &format!("{:?}", tx.msg_type))?;
+        }
     }
     let cname = match tx.cname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let realm = match tx.realm {
         Some(ref x) => x.0.to_string(),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let sname = match tx.sname {
         Some(ref x) => format!("{}", x),
-        None        => "<empty>".to_owned(),
+        None => "<empty>".to_owned(),
     };
     let encryption = match tx.etype {
         Some(ref x) => format!("{:?}", x),
-        None        => "<none>".to_owned(),
+        None => "<none>".to_owned(),
     };
     jsb.set_string("cname", &cname)?;
     jsb.set_string("realm", &realm)?;
     jsb.set_string("sname", &sname)?;
     jsb.set_string("encryption", &encryption)?;
-    jsb.set_bool("weak_encryption", tx.etype.map_or(false,test_weak_encryption))?;
+    jsb.set_bool(
+        "weak_encryption",
+        tx.etype.map_or(false, test_weak_encryption),
+    )?;
     if let Some(x) = tx.ticket_etype {
         let refs = format!("{:?}", x);
         jsb.set_string("ticket_encryption", &refs)?;
@@ -70,7 +74,6 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
 }
 
 #[no_mangle]
-pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
-{
+pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/krb/log.rs
+++ b/rust/src/krb/log.rs
@@ -70,7 +70,7 @@ fn krb5_log_response(jsb: &mut JsonBuilder, tx: &KRB5Transaction) -> Result<(), 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_krb5_log_json_response(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
+pub extern "C" fn SCKrb5LogJsonResponse(tx: &KRB5Transaction, jsb: &mut JsonBuilder) -> bool
 {
     krb5_log_response(jsb, tx).is_ok()
 }

--- a/rust/src/krb/mod.rs
+++ b/rust/src/krb/mod.rs
@@ -19,6 +19,6 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-pub mod krb5;
 pub mod detect;
+pub mod krb5;
 pub mod log;

--- a/rust/src/modbus/detect.rs
+++ b/rust/src/modbus/detect.rs
@@ -135,7 +135,7 @@ fn parse_range(min_str: &str, max_str: &str) -> Result<Range<u16>, ()> {
 
 /// Intermediary function between the C code and the parsing functions.
 #[no_mangle]
-pub unsafe extern "C" fn rs_modbus_parse(c_arg: *const c_char) -> *mut c_void {
+pub unsafe extern "C" fn SCModbusParse(c_arg: *const c_char) -> *mut c_void {
     if c_arg.is_null() {
         return std::ptr::null_mut();
     }
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn rs_modbus_parse(c_arg: *const c_char) -> *mut c_void {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_modbus_free(ptr: *mut c_void) {
+pub unsafe extern "C" fn SCModbusFree(ptr: *mut c_void) {
     if !ptr.is_null() {
         let _ = Box::from_raw(ptr as *mut DetectModbusRust);
     }
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn rs_modbus_free(ptr: *mut c_void) {
 /// Compares a transaction to a signature to determine whether the transaction
 /// matches the signature. If it does, 1 is returned; otherwise 0 is returned.
 #[no_mangle]
-pub extern "C" fn rs_modbus_inspect(tx: &ModbusTransaction, modbus: &DetectModbusRust) -> u8 {
+pub extern "C" fn SCModbusInspect(tx: &ModbusTransaction, modbus: &DetectModbusRust) -> u8 {
     // All necessary information can be found in the request (value inspection currently
     // only supports write functions, which hold the value in the request).
     // Only inspect the response in the case where there is no request.
@@ -633,7 +633,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 1);
         // function 23
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdWrMultRegs),
@@ -644,7 +644,7 @@ mod test {
         );
         // access write holding, address 15, value <4660
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -657,7 +657,7 @@ mod test {
         );
         // access write holding, address 15, value 4661
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -670,7 +670,7 @@ mod test {
         );
         // access write holding, address 16, value 20000<>22136
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -683,7 +683,7 @@ mod test {
         );
         // access write holding, address 16, value 22136<>30000
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -696,7 +696,7 @@ mod test {
         );
         // access write holding, address 15, value >4660
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -709,7 +709,7 @@ mod test {
         );
         // access write holding, address 16, value <22137
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -722,7 +722,7 @@ mod test {
         );
         // access write holding, address 16, value <22137
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -735,7 +735,7 @@ mod test {
         );
         // access write holding, address 17, value 39612
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -748,7 +748,7 @@ mod test {
         );
         // access write holding, address 17, value 30000<>39613
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -761,7 +761,7 @@ mod test {
         );
         // access write holding, address 15, value 4659<>5000
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -774,7 +774,7 @@ mod test {
         );
         // access write holding, address 17, value >39611
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     access_type: Some(AccessType::WRITE | AccessType::HOLDING),
@@ -787,7 +787,7 @@ mod test {
         );
         // unit 12
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(12..12),
@@ -798,7 +798,7 @@ mod test {
         );
         // unit 5<>9
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(5..9),
@@ -809,7 +809,7 @@ mod test {
         );
         // unit 11<>15
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(11..15),
@@ -820,7 +820,7 @@ mod test {
         );
         // unit >11
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(11..u16::MAX),
@@ -831,7 +831,7 @@ mod test {
         );
         // unit <9
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(u16::MIN..9),
@@ -842,7 +842,7 @@ mod test {
         );
         // unit 10
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(10..10),
@@ -853,7 +853,7 @@ mod test {
         );
         // unit 5<>15
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(5..15),
@@ -864,7 +864,7 @@ mod test {
         );
         // unit >9
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(9..u16::MAX),
@@ -875,7 +875,7 @@ mod test {
         );
         // unit <11
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     unit_id: Some(u16::MIN..11),
@@ -886,7 +886,7 @@ mod test {
         );
         // unit 10, function 20
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdFileRec),
@@ -898,7 +898,7 @@ mod test {
         );
         // unit 11, function 20
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdFileRec),
@@ -910,7 +910,7 @@ mod test {
         );
         // unit 11, function 23
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdWrMultRegs),
@@ -922,7 +922,7 @@ mod test {
         );
         // unit 11, function public
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     category: Some(CodeCategory::PUBLIC_ASSIGNED | CodeCategory::PUBLIC_UNASSIGNED),
@@ -934,7 +934,7 @@ mod test {
         );
         // unit 10, function user
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     category: Some(Flags::from(CodeCategory::USER_DEFINED)),
@@ -946,7 +946,7 @@ mod test {
         );
         // unit 10, function 23
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdWrMultRegs),
@@ -958,7 +958,7 @@ mod test {
         );
         // unit 10, function public
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     category: Some(CodeCategory::PUBLIC_ASSIGNED | CodeCategory::PUBLIC_UNASSIGNED),
@@ -970,7 +970,7 @@ mod test {
         );
         // unit 10, function !user
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[0],
                 &DetectModbusRust {
                     category: Some(!CodeCategory::USER_DEFINED),
@@ -1000,7 +1000,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 2);
         // function 8, subfunction 4
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[1],
                 &DetectModbusRust {
                     function: Some(FunctionCode::Diagnostic),
@@ -1030,7 +1030,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 3);
         // function reserved
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[2],
                 &DetectModbusRust {
                     category: Some(Flags::from(CodeCategory::RESERVED)),
@@ -1057,7 +1057,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 4);
         // function !assigned
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[3],
                 &DetectModbusRust {
                     category: Some(!CodeCategory::PUBLIC_ASSIGNED),
@@ -1086,7 +1086,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 5);
         // access read
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1097,7 +1097,7 @@ mod test {
         );
         // access read, address 30870
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1109,7 +1109,7 @@ mod test {
         );
         // unit 10, access read, address 30863
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1122,7 +1122,7 @@ mod test {
         );
         // unit 11, access read, address 30870
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1135,7 +1135,7 @@ mod test {
         );
         // unit 11, access read, address 30863
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1148,7 +1148,7 @@ mod test {
         );
         // unit 10, access write
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::WRITE)),
@@ -1160,7 +1160,7 @@ mod test {
         );
         // unit 10, access read, address 30870
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[4],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1191,7 +1191,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 6);
         // access read input
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1202,7 +1202,7 @@ mod test {
         );
         // access read input, address <9
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1214,7 +1214,7 @@ mod test {
         );
         // access read input, address 5<>9
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1226,7 +1226,7 @@ mod test {
         );
         // access read input, address >104
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1238,7 +1238,7 @@ mod test {
         );
         // access read input, address 104<>110
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1250,7 +1250,7 @@ mod test {
         );
         // access read input, address 9
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1262,7 +1262,7 @@ mod test {
         );
         // access read input, address <10
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1274,7 +1274,7 @@ mod test {
         );
         // access read input, address 5<>10
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1286,7 +1286,7 @@ mod test {
         );
         // access read input, address >103
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1298,7 +1298,7 @@ mod test {
         );
         // access read input, address 103<>110
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1310,7 +1310,7 @@ mod test {
         );
         // access read input, address 104
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[5],
                 &DetectModbusRust {
                     access_type: Some(AccessType::READ | AccessType::INPUT),
@@ -1341,7 +1341,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 7);
         // function 1
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[6],
                 &DetectModbusRust {
                     function: Some(FunctionCode::RdCoils),
@@ -1354,7 +1354,7 @@ mod test {
         // Fails because there was no request, and the address is not retrievable
         // from the response.
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[6],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),
@@ -1385,7 +1385,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 8);
         // function 6
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[7],
                 &DetectModbusRust {
                     function: Some(FunctionCode::WrSingleReg),
@@ -1396,7 +1396,7 @@ mod test {
         );
         // access write, address 10
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[7],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::WRITE)),
@@ -1427,7 +1427,7 @@ mod test {
         assert_eq!(modbus.transactions.len(), 9);
         // function 8
         assert_eq!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[8],
                 &DetectModbusRust {
                     function: Some(FunctionCode::Diagnostic),
@@ -1438,7 +1438,7 @@ mod test {
         );
         // access read
         assert_ne!(
-            rs_modbus_inspect(
+            SCModbusInspect(
                 &modbus.transactions[8],
                 &DetectModbusRust {
                     access_type: Some(Flags::from(AccessType::READ)),

--- a/rust/src/quic/detect.rs
+++ b/rust/src/quic/detect.rs
@@ -21,7 +21,7 @@ use std::os::raw::c_void;
 use std::ptr;
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_ua(
+pub unsafe extern "C" fn SCQuicTxGetUa(
     tx: &QuicTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(ua) = &tx.ua {
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_ua(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_sni(
+pub unsafe extern "C" fn SCQuicTxGetSni(
     tx: &QuicTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(sni) = &tx.sni {
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_sni(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_ja3(
+pub unsafe extern "C" fn SCQuicTxGetJa3(
     tx: &QuicTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(ja3) = &tx.ja3 {
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_ja3(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_ja4(
+pub unsafe extern "C" fn SCQuicTxGetJa4(
     tx: &QuicTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(ja4) = &tx.ja4 {
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_ja4(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_version(
+pub unsafe extern "C" fn SCQuicTxGetVersion(
     tx: &QuicTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if tx.header.flags.is_long {
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_version(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
+pub unsafe extern "C" fn SCQuicTxGetCyuHash(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn rs_quic_tx_get_cyu_hash(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_tx_get_cyu_string(
+pub unsafe extern "C" fn SCQuicTxGetCyuString(
     _de: *mut DetectEngineThreadCtx, tx: *const c_void, _flags: u8, i: u32, buffer: *mut *const u8,
     buffer_len: *mut u32,
 ) -> bool {

--- a/rust/src/quic/logger.rs
+++ b/rust/src/quic/logger.rs
@@ -154,7 +154,7 @@ fn log_quic(tx: &QuicTransaction, js: &mut JsonBuilder) -> Result<(), JsonError>
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_quic_to_json(
+pub unsafe extern "C" fn SCQuicLogJson(
     tx: *mut std::os::raw::c_void, js: &mut JsonBuilder,
 ) -> bool {
     let tx = cast_pointer!(tx, QuicTransaction);

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -41,7 +41,7 @@ static mut G_SIP_CONTENT_TYPE_HDR_BUFFER_ID: c_int = 0;
 static mut G_SIP_CONTENT_LENGTH_HDR_BUFFER_ID: c_int = 0;
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_sip_tx_get_method(
+pub unsafe extern "C" fn SCSipTxGetMethod(
     tx: &SIPTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(ref r) = tx.request {
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn rs_sip_tx_get_method(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_sip_tx_get_uri(
+pub unsafe extern "C" fn SCSipTxGetUri(
     tx: &SIPTransaction, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> u8 {
     if let Some(ref r) = tx.request {

--- a/rust/src/sip/log.rs
+++ b/rust/src/sip/log.rs
@@ -57,6 +57,6 @@ fn log(tx: &SIPTransaction, js: &mut JsonBuilder) -> Result<(), JsonError> {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_sip_log_json(tx: &SIPTransaction, js: &mut JsonBuilder) -> bool {
+pub extern "C" fn SCSipLogJson(tx: &SIPTransaction, js: &mut JsonBuilder) -> bool {
     log(tx, js).is_ok()
 }

--- a/rust/src/sip/parser.rs
+++ b/rust/src/sip/parser.rs
@@ -113,7 +113,7 @@ fn expand_header_name(h: &str) -> &str {
     }
 }
 
-pub fn sip_parse_request(oi: &[u8]) -> IResult<&[u8], Request> {
+pub fn parse_request(oi: &[u8]) -> IResult<&[u8], Request> {
     let (i, method) = parse_method(oi)?;
     let (i, _) = char(' ')(i)?;
     let (i, path) = parse_request_uri(i)?;
@@ -143,7 +143,7 @@ pub fn sip_parse_request(oi: &[u8]) -> IResult<&[u8], Request> {
     ))
 }
 
-pub fn sip_parse_response(oi: &[u8]) -> IResult<&[u8], Response> {
+pub fn parse_response(oi: &[u8]) -> IResult<&[u8], Response> {
     let (i, version) = parse_version(oi)?;
     let (i, _) = char(' ')(i)?;
     let (i, code) = parse_code(i)?;
@@ -308,7 +308,7 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        let (_, req) = sip_parse_request(buf).unwrap();
+        let (_, req) = parse_request(buf).unwrap();
         assert_eq!(req.method, "REGISTER");
         assert_eq!(req.path, "sip:sip.cybercity.dk");
         assert_eq!(req.version, "SIP/2.0");
@@ -324,7 +324,7 @@ mod tests {
                           \r\nABCD"
             .as_bytes();
 
-        let (body, req) = sip_parse_request(buf).expect("parsing failed");
+        let (body, req) = parse_request(buf).expect("parsing failed");
         assert_eq!(req.method, "REGISTER");
         assert_eq!(req.path, "sip:sip.cybercity.dk");
         assert_eq!(req.version, "SIP/2.0");
@@ -338,7 +338,7 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        let (_, resp) = sip_parse_response(buf).unwrap();
+        let (_, resp) = parse_response(buf).unwrap();
         assert_eq!(resp.version, "SIP/2.0");
         assert_eq!(resp.code, "401");
         assert_eq!(resp.reason, "Unauthorized");
@@ -370,7 +370,7 @@ mod tests {
                           \r\n"
             .as_bytes();
 
-        let (_, req) = sip_parse_request(buf).unwrap();
+        let (_, req) = parse_request(buf).unwrap();
         assert_eq!(req.method, "REGISTER");
         assert_eq!(req.path, "sip:sip.cybercity.dk");
         assert_eq!(req.version, "SIP/2.0");

--- a/rust/src/telnet/telnet.rs
+++ b/rust/src/telnet/telnet.rs
@@ -378,8 +378,7 @@ fn probe(input: &[u8]) -> IResult<&[u8], ()> {
 // C exports.
 
 /// C entry point for a probing parser.
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_probing_parser(
+unsafe extern "C" fn telnet_probing_parser(
     _flow: *const Flow,
     _direction: u8,
     input: *const u8,
@@ -397,20 +396,17 @@ pub unsafe extern "C" fn rs_telnet_probing_parser(
     return ALPROTO_UNKNOWN;
 }
 
-#[no_mangle]
-pub extern "C" fn rs_telnet_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
+extern "C" fn telnet_state_new(_orig_state: *mut std::os::raw::c_void, _orig_proto: AppProto) -> *mut std::os::raw::c_void {
     let state = TelnetState::new();
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut std::os::raw::c_void;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_free(state: *mut std::os::raw::c_void) {
+unsafe extern "C" fn telnet_state_free(state: *mut std::os::raw::c_void) {
     std::mem::drop(Box::from_raw(state as *mut TelnetState));
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_tx_free(
+unsafe extern "C" fn telnet_state_tx_free(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) {
@@ -418,8 +414,7 @@ pub unsafe extern "C" fn rs_telnet_state_tx_free(
     state.free_tx(tx_id);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_parse_request(
+unsafe extern "C" fn telnet_parse_request(
     flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -446,8 +441,7 @@ pub unsafe extern "C" fn rs_telnet_parse_request(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_parse_response(
+unsafe extern "C" fn telnet_parse_response(
     flow: *const Flow,
     state: *mut std::os::raw::c_void,
     pstate: *mut std::os::raw::c_void,
@@ -468,8 +462,7 @@ pub unsafe extern "C" fn rs_telnet_parse_response(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_get_tx(
+unsafe extern "C" fn telnet_state_get_tx(
     state: *mut std::os::raw::c_void,
     tx_id: u64,
 ) -> *mut std::os::raw::c_void {
@@ -484,16 +477,14 @@ pub unsafe extern "C" fn rs_telnet_state_get_tx(
     }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_state_get_tx_count(
+unsafe extern "C" fn telnet_state_get_tx_count(
     state: *mut std::os::raw::c_void,
 ) -> u64 {
     let state = cast_pointer!(state, TelnetState);
     return state.tx_id;
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_telnet_tx_get_alstate_progress(
+unsafe extern "C" fn telnet_tx_get_alstate_progress(
     tx: *mut std::os::raw::c_void,
     _direction: u8,
 ) -> std::os::raw::c_int {
@@ -509,26 +500,26 @@ export_state_data_get!(telnet_get_state_data, TelnetState);
 const PARSER_NAME: &[u8] = b"telnet\0";
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_telnet_register_parser() {
+pub unsafe extern "C" fn SCRegisterTelnetParser() {
     let default_port = CString::new("[23]").unwrap();
     let parser = RustParser {
         name: PARSER_NAME.as_ptr() as *const std::os::raw::c_char,
         default_port: default_port.as_ptr(),
         ipproto: IPPROTO_TCP,
-        probe_ts: Some(rs_telnet_probing_parser),
-        probe_tc: Some(rs_telnet_probing_parser),
+        probe_ts: Some(telnet_probing_parser),
+        probe_tc: Some(telnet_probing_parser),
         min_depth: 0,
         max_depth: 16,
-        state_new: rs_telnet_state_new,
-        state_free: rs_telnet_state_free,
-        tx_free: rs_telnet_state_tx_free,
-        parse_ts: rs_telnet_parse_request,
-        parse_tc: rs_telnet_parse_response,
-        get_tx_count: rs_telnet_state_get_tx_count,
-        get_tx: rs_telnet_state_get_tx,
+        state_new: telnet_state_new,
+        state_free: telnet_state_free,
+        tx_free: telnet_state_tx_free,
+        parse_ts: telnet_parse_request,
+        parse_tc: telnet_parse_response,
+        get_tx_count: telnet_state_get_tx_count,
+        get_tx: telnet_state_get_tx,
         tx_comp_st_ts: 1,
         tx_comp_st_tc: 1,
-        tx_get_progress: rs_telnet_tx_get_alstate_progress,
+        tx_get_progress: telnet_tx_get_alstate_progress,
         get_eventinfo: Some(TelnetEvent::get_event_info),
         get_eventinfo_byid : Some(TelnetEvent::get_event_info_by_id),
         localstorage_new: None,

--- a/rust/src/tftp/log.rs
+++ b/rust/src/tftp/log.rs
@@ -34,6 +34,6 @@ fn tftp_log_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> Result<(), Js
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_log_json_request(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> bool {
+pub extern "C" fn SCTftpLogJsonRequest(tx: &TFTPTransaction, jb: &mut JsonBuilder) -> bool {
     tftp_log_request(tx, jb).is_ok()
 }

--- a/rust/src/tftp/tftp.rs
+++ b/rust/src/tftp/tftp.rs
@@ -87,25 +87,25 @@ impl TFTPTransaction {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_alloc() -> *mut std::os::raw::c_void {
+pub extern "C" fn SCTftpStateAlloc() -> *mut std::os::raw::c_void {
     let state = TFTPState { state_data: AppLayerStateData::new(), transactions : Vec::new(), tx_id: 0, };
     let boxed = Box::new(state);
     return Box::into_raw(boxed) as *mut _;
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_free(state: *mut std::os::raw::c_void) {
+pub extern "C" fn SCTftpStateFree(state: *mut std::os::raw::c_void) {
     std::mem::drop(unsafe { Box::from_raw(state as *mut TFTPState) });
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_state_tx_free(state: &mut TFTPState,
+pub extern "C" fn SCTftpStateTxFree(state: &mut TFTPState,
                                         tx_id: u64) {
     state.free_tx(tx_id);
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_get_tx(state: &mut TFTPState,
+pub extern "C" fn SCTftpGetTx(state: &mut TFTPState,
                                     tx_id: u64) -> *mut std::os::raw::c_void {
     match state.get_tx_by_id(tx_id) {
         Some(tx) => tx as *const _ as *mut _,
@@ -114,7 +114,7 @@ pub extern "C" fn rs_tftp_get_tx(state: &mut TFTPState,
 }
 
 #[no_mangle]
-pub extern "C" fn rs_tftp_get_tx_cnt(state: &mut TFTPState) -> u64 {
+pub extern "C" fn SCTftpGetTxCnt(state: &mut TFTPState) -> u64 {
     return state.tx_id;
 }
 
@@ -155,7 +155,7 @@ fn parse_tftp_request(input: &[u8]) -> Option<TFTPTransaction> {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_request(state: &mut TFTPState,
+pub unsafe extern "C" fn SCTftpParseRequest(state: &mut TFTPState,
                                   input: *const u8,
                                   len: u32) -> i64 {
     let buf = std::slice::from_raw_parts(input, len as usize);
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn rs_tftp_request(state: &mut TFTPState,
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_get_tx_data(
+pub unsafe extern "C" fn SCTftpGetTxData(
     tx: *mut std::os::raw::c_void)
     -> *mut AppLayerTxData
 {
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn rs_tftp_get_tx_data(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_tftp_get_state_data(
+pub unsafe extern "C" fn SCTftpGetStateData(
     state: *mut std::os::raw::c_void)
     -> *mut AppLayerStateData
 {

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -96,7 +96,7 @@ int HTPFileOpen(HtpState *s, HtpTxUserData *tx, const uint8_t *filename, uint16_
 int HTPParseContentRange(const bstr *rawvalue, HTTPContentRange *range)
 {
     uint32_t len = (uint32_t)bstr_len(rawvalue);
-    return rs_http_parse_content_range(range, bstr_ptr(rawvalue), len);
+    return SCHttpParseContentRange(range, bstr_ptr(rawvalue), len);
 }
 
 /**

--- a/src/app-layer-http2.c
+++ b/src/app-layer-http2.c
@@ -62,8 +62,8 @@ void RegisterHTTP2Parsers(void)
         if (HTTP2RegisterPatternsForProtocolDetection() < 0)
             return;
 
-        rs_http2_init(&sfc);
-        rs_http2_register_parser();
+        SCHttp2Init(&sfc);
+        SCRegisterHttp2Parser();
     }
 
 #ifdef UNITTESTS
@@ -82,18 +82,18 @@ void HTTP2MimicHttp1Request(void *alstate_orig, void *h2s)
         return;
     }
     // else
-    rs_http2_tx_set_method(h2s, bstr_ptr(htp_tx_request_method(h1tx)),
+    SCHttp2TxSetMethod(h2s, bstr_ptr(htp_tx_request_method(h1tx)),
             (uint32_t)bstr_len(htp_tx_request_method(h1tx)));
     if (htp_tx_request_uri(h1tx) != NULL) {
         // A request line without spaces gets interpreted as a request_method
         // and has request_uri=NULL
-        rs_http2_tx_set_uri(h2s, bstr_ptr(htp_tx_request_uri(h1tx)),
+        SCHttp2TxSetUri(h2s, bstr_ptr(htp_tx_request_uri(h1tx)),
                 (uint32_t)bstr_len(htp_tx_request_uri(h1tx)));
     }
     size_t nbheaders = htp_tx_request_headers_size(h1tx);
     for (size_t i = 0; i < nbheaders; i++) {
         const htp_header_t *h = htp_tx_request_header_index(h1tx, i);
-        rs_http2_tx_add_header(h2s, htp_header_name_ptr(h), (uint32_t)htp_header_name_len(h),
+        SCHttp2TxAddHeader(h2s, htp_header_name_ptr(h), (uint32_t)htp_header_name_len(h),
                 htp_header_value_ptr(h), (uint32_t)htp_header_value_len(h));
     }
 }

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -48,7 +48,7 @@ void ModbusParserRegisterTests(void);
  */
 void RegisterModbusParsers(void)
 {
-    rs_modbus_register_parser();
+    SCRegisterModbusParser();
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_MODBUS, ModbusParserRegisterTests);
 #endif
@@ -292,18 +292,18 @@ static int ModbusParserTest01(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 1);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_address(&request) == 0x7890);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_quantity(&request) == 19);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 1);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestAddress(&request) == 0x7890);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestQuantity(&request) == 19);
 
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
                             STREAM_TOCLIENT, readCoilsRsp,
                             sizeof(readCoilsRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -337,14 +337,14 @@ static int ModbusParserTest02(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 16);
-    FAIL_IF_NOT(rs_modbus_message_get_write_multreq_address(&request) == 0x01);
-    FAIL_IF_NOT(rs_modbus_message_get_write_multreq_quantity(&request) == 2);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 16);
+    FAIL_IF_NOT(SCModbusMessageGetWriteMultreqAddress(&request) == 0x01);
+    FAIL_IF_NOT(SCModbusMessageGetWriteMultreqQuantity(&request) == 2);
 
     size_t data_len;
-    const uint8_t *data = rs_modbus_message_get_write_multreq_data(&request, &data_len);
+    const uint8_t *data = SCModbusMessageGetWriteMultreqData(&request, &data_len);
     FAIL_IF_NOT(data_len == 4);
     FAIL_IF_NOT(data[0] == 0x00);
     FAIL_IF_NOT(data[1] == 0x0A);
@@ -356,7 +356,7 @@ static int ModbusParserTest02(void) {
                             sizeof(writeMultipleRegistersRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -418,17 +418,17 @@ static int ModbusParserTest03(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 23);
-    FAIL_IF_NOT(rs_modbus_message_get_rw_multreq_read_address(&request) == 0x03);
-    FAIL_IF_NOT(rs_modbus_message_get_rw_multreq_read_quantity(&request) == 6);
-    FAIL_IF_NOT(rs_modbus_message_get_rw_multreq_write_address(&request) == 0x0E);
-    FAIL_IF_NOT(rs_modbus_message_get_rw_multreq_write_quantity(&request) == 3);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 23);
+    FAIL_IF_NOT(SCModbusMessageGetRwMultreqReadAddress(&request) == 0x03);
+    FAIL_IF_NOT(SCModbusMessageGetRwMultreqReadQuantity(&request) == 6);
+    FAIL_IF_NOT(SCModbusMessageGetRwMultreqWriteAddress(&request) == 0x0E);
+    FAIL_IF_NOT(SCModbusMessageGetRwMultreqWriteQuantity(&request) == 3);
 
     size_t data_len;
-    uint8_t const *data = rs_modbus_message_get_rw_multreq_write_data(&request, &data_len);
+    uint8_t const *data = SCModbusMessageGetRwMultreqWriteData(&request, &data_len);
     FAIL_IF_NOT(data_len == 6);
     FAIL_IF_NOT(data[0] == 0x12);
     FAIL_IF_NOT(data[1] == 0x34);
@@ -442,7 +442,7 @@ static int ModbusParserTest03(void) {
                             sizeof(readWriteMultipleRegistersRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p);
@@ -488,11 +488,11 @@ static int ModbusParserTest04(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 8);
-    FAIL_IF_NOT(rs_modbus_message_get_subfunction(&request) == 4);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 8);
+    FAIL_IF_NOT(SCModbusMessageGetSubfunction(&request) == 4);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -767,19 +767,19 @@ static int ModbusParserTest08(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 1);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_address(&request) == 0x7890);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_quantity(&request) == 19);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 1);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestAddress(&request) == 0x7890);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestQuantity(&request) == 19);
 
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
                             STREAM_TOCLIENT, readCoilsErrorRsp,
                             sizeof(readCoilsErrorRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p);
@@ -831,12 +831,12 @@ static int ModbusParserTest09(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 1);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_address(&request) == 0x7890);
-    FAIL_IF_NOT(rs_modbus_message_get_read_request_quantity(&request) == 19);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 1);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestAddress(&request) == 0x7890);
+    FAIL_IF_NOT(SCModbusMessageGetReadRequestQuantity(&request) == 19);
 
     input_len = sizeof(readCoilsRsp);
     part2_len = 10;
@@ -850,7 +850,7 @@ static int ModbusParserTest09(void) {
                             STREAM_TOCLIENT, input, input_len);
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -892,17 +892,17 @@ static int ModbusParserTest10(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 2);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 2);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 1);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 1);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 16);
-    FAIL_IF_NOT(rs_modbus_message_get_write_multreq_address(&request) == 0x01);
-    FAIL_IF_NOT(rs_modbus_message_get_write_multreq_quantity(&request) == 2);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 16);
+    FAIL_IF_NOT(SCModbusMessageGetWriteMultreqAddress(&request) == 0x01);
+    FAIL_IF_NOT(SCModbusMessageGetWriteMultreqQuantity(&request) == 2);
 
     size_t data_len;
-    uint8_t const *data = rs_modbus_message_get_write_multreq_data(&request, &data_len);
+    uint8_t const *data = SCModbusMessageGetWriteMultreqData(&request, &data_len);
     FAIL_IF_NOT(data_len == 4);
     FAIL_IF_NOT(data[0] == 0x00);
     FAIL_IF_NOT(data[1] == 0x0A);
@@ -1104,19 +1104,19 @@ static int ModbusParserTest13(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 22);
-    FAIL_IF_NOT(rs_modbus_message_get_and_mask(&request) == 0x00F2);
-    FAIL_IF_NOT(rs_modbus_message_get_or_mask(&request) == 0x0025);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 22);
+    FAIL_IF_NOT(SCModbusMessageGetAndMask(&request) == 0x00F2);
+    FAIL_IF_NOT(SCModbusMessageGetOrMask(&request) == 0x0025);
 
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
                             STREAM_TOCLIENT, maskWriteRegisterRsp,
                             sizeof(maskWriteRegisterRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -1150,19 +1150,19 @@ static int ModbusParserTest14(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 6);
-    FAIL_IF_NOT(rs_modbus_message_get_write_address(&request) == 0x0001);
-    FAIL_IF_NOT(rs_modbus_message_get_write_data(&request) == 0x0003);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 6);
+    FAIL_IF_NOT(SCModbusMessageGetWriteAddress(&request) == 0x0001);
+    FAIL_IF_NOT(SCModbusMessageGetWriteData(&request) == 0x0003);
 
     r = AppLayerParserParse(NULL, alp_tctx, &f, ALPROTO_MODBUS,
                             STREAM_TOCLIENT, writeSingleRegisterRsp,
                             sizeof(writeSingleRegisterRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
 
     AppLayerParserThreadCtxFree(alp_tctx);
     StreamTcpFreeConfig(true);
@@ -1223,10 +1223,10 @@ static int ModbusParserTest15(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 22);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 22);
 
     /* do detect */
     SigMatchSignatures(&tv, de_ctx, det_ctx, p);
@@ -1238,11 +1238,11 @@ static int ModbusParserTest15(void) {
                             sizeof(maskWriteRegisterRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
-    ModbusMessage response = rs_modbus_state_get_tx_response(modbus_state, 0);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
+    ModbusMessage response = SCModbusStateGetTxResponse(modbus_state, 0);
     FAIL_IF_NULL(response._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&response) == 22);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&response) == 22);
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -1311,12 +1311,12 @@ static int ModbusParserTest16(void) {
     ModbusState *modbus_state = f.alstate;
     FAIL_IF_NULL(modbus_state);
 
-    ModbusMessage request = rs_modbus_state_get_tx_request(modbus_state, 0);
+    ModbusMessage request = SCModbusStateGetTxRequest(modbus_state, 0);
     FAIL_IF_NULL(request._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&request) == 6);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&request) == 6);
     size_t data_len;
-    const uint8_t *data = rs_modbus_message_get_bytevec_data(&request, &data_len);
+    const uint8_t *data = SCModbusMessageGetBytevecData(&request, &data_len);
     FAIL_IF_NOT(data_len == 2);
     FAIL_IF_NOT(data[0] == 0x00);
     FAIL_IF_NOT(data[1] == 0x01);
@@ -1331,12 +1331,12 @@ static int ModbusParserTest16(void) {
                             sizeof(writeSingleRegisterRsp));
     FAIL_IF_NOT(r == 0);
 
-    FAIL_IF_NOT(rs_modbus_state_get_tx_count(modbus_state) == 1);
-    ModbusMessage response = rs_modbus_state_get_tx_response(modbus_state, 0);
+    FAIL_IF_NOT(SCModbusStateGetTxCount(modbus_state) == 1);
+    ModbusMessage response = SCModbusStateGetTxResponse(modbus_state, 0);
     FAIL_IF_NULL(response._0);
 
-    FAIL_IF_NOT(rs_modbus_message_get_function(&response) == 6);
-    FAIL_IF_NOT(rs_modbus_message_get_write_address(&response) == 0x0001);
+    FAIL_IF_NOT(SCModbusMessageGetFunction(&response) == 6);
+    FAIL_IF_NOT(SCModbusMessageGetWriteAddress(&response) == 0x0001);
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1790,7 +1790,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     rs_register_ntp_parser();
     RegisterTFTPParsers();
     RegisterIKEParsers();
-    rs_register_krb5_parser();
+    SCRegisterKrb5Parser();
     SCRegisterDhcpParser();
     SCRegisterSnmpParser();
     rs_sip_register_parser();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1793,7 +1793,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     SCRegisterKrb5Parser();
     SCRegisterDhcpParser();
     SCRegisterSnmpParser();
-    rs_sip_register_parser();
+    SCRegisterSipParser();
     rs_quic_register_parser();
     rs_websocket_register_parser();
     SCRegisterLdapTcpParser();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1794,7 +1794,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     SCRegisterDhcpParser();
     SCRegisterSnmpParser();
     SCRegisterSipParser();
-    rs_quic_register_parser();
+    SCRegisterQuicParser();
     rs_websocket_register_parser();
     SCRegisterLdapTcpParser();
     SCRegisterLdapUdpParser();

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1805,7 +1805,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     SCRegisterPop3Parser();
     SCRegisterRdpParser();
     RegisterHTTP2Parsers();
-    rs_telnet_register_parser();
+    SCRegisterTelnetParser();
     RegisterIMAPParsers();
 
     for (size_t i = 0; i < preregistered_callbacks_nb; i++) {

--- a/src/app-layer-tftp.c
+++ b/src/app-layer-tftp.c
@@ -43,12 +43,12 @@
 
 static void *TFTPStateAlloc(void *orig_state, AppProto proto_orig)
 {
-    return rs_tftp_state_alloc();
+    return SCTftpStateAlloc();
 }
 
 static void TFTPStateFree(void *state)
 {
-    rs_tftp_state_free(state);
+    SCTftpStateFree(state);
 }
 
 /**
@@ -59,7 +59,7 @@ static void TFTPStateFree(void *state)
  */
 static void TFTPStateTxFree(void *state, uint64_t tx_id)
 {
-    rs_tftp_state_tx_free(state, tx_id);
+    SCTftpStateTxFree(state, tx_id);
 }
 
 static int TFTPStateGetEventInfo(
@@ -108,7 +108,7 @@ static AppLayerResult TFTPParseRequest(Flow *f, void *state, AppLayerParserState
         SCReturnStruct(APP_LAYER_OK);
     }
 
-    int64_t res = rs_tftp_request(state, input, input_len);
+    int64_t res = SCTftpParseRequest(state, input, input_len);
     if (res < 0) {
         SCReturnStruct(APP_LAYER_ERROR);
     }
@@ -126,12 +126,12 @@ static AppLayerResult TFTPParseResponse(Flow *f, void *state, AppLayerParserStat
 
 static uint64_t TFTPGetTxCnt(void *state)
 {
-    return rs_tftp_get_tx_cnt(state);
+    return SCTftpGetTxCnt(state);
 }
 
 static void *TFTPGetTx(void *state, uint64_t tx_id)
 {
-    return rs_tftp_get_tx(state, tx_id);
+    return SCTftpGetTx(state, tx_id);
 }
 
 /**
@@ -228,9 +228,8 @@ void RegisterTFTPParsers(void)
         AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_TFTP,
                                            TFTPStateGetEventInfo);
 
-        AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_TFTP,
-                                         rs_tftp_get_tx_data);
-        AppLayerParserRegisterStateDataFunc(IPPROTO_UDP, ALPROTO_TFTP, rs_tftp_get_state_data);
+        AppLayerParserRegisterTxDataFunc(IPPROTO_UDP, ALPROTO_TFTP, SCTftpGetTxData);
+        AppLayerParserRegisterStateDataFunc(IPPROTO_UDP, ALPROTO_TFTP, SCTftpGetStateData);
     }
     else {
         SCLogDebug("TFTP protocol parsing disabled.");

--- a/src/detect-asn1.c
+++ b/src/detect-asn1.c
@@ -59,9 +59,9 @@ bool DetectAsn1Match(const SigMatchData *smd, const uint8_t *buffer, const uint3
         const uint32_t offset)
 {
     const DetectAsn1Data *ad = (const DetectAsn1Data *)smd->ctx;
-    Asn1 *asn1 = rs_asn1_decode(buffer, buffer_len, offset, ad);
-    uint8_t ret = rs_asn1_checks(asn1, ad);
-    rs_asn1_free(asn1);
+    Asn1 *asn1 = SCAsn1Decode(buffer, buffer_len, offset, ad);
+    uint8_t ret = SCAsn1Checks(asn1, ad);
+    SCAsn1Free(asn1);
     return ret == 1;
 }
 
@@ -75,7 +75,7 @@ bool DetectAsn1Match(const SigMatchData *smd, const uint8_t *buffer, const uint3
  */
 static DetectAsn1Data *DetectAsn1Parse(const char *asn1str)
 {
-    DetectAsn1Data *ad = rs_detect_asn1_parse(asn1str);
+    DetectAsn1Data *ad = SCAsn1DetectParse(asn1str);
 
     if (ad == NULL) {
         SCLogError("Malformed asn1 argument: %s", asn1str);
@@ -120,7 +120,7 @@ static int DetectAsn1Setup(DetectEngineCtx *de_ctx, Signature *s, const char *as
 static void DetectAsn1Free(DetectEngineCtx *de_ctx, void *ptr)
 {
     DetectAsn1Data *ad = (DetectAsn1Data *)ptr;
-    rs_detect_asn1_free(ad);
+    SCAsn1DetectFree(ad);
 }
 
 #ifdef UNITTESTS

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -234,7 +234,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_cookie(txv, STREAM_TOSERVER, &b, &b_len) != 1)
+        if (SCHttp2TxGetCookie(txv, STREAM_TOSERVER, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -254,7 +254,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_cookie(txv, STREAM_TOCLIENT, &b, &b_len) != 1)
+        if (SCHttp2TxGetCookie(txv, STREAM_TOCLIENT, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-header-names.c
+++ b/src/detect-http-header-names.c
@@ -170,7 +170,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_header_names(txv, flow_flags, &b, &b_len) != 1)
+        if (SCHttp2TxGetHeaderNames(txv, flow_flags, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -152,7 +152,7 @@ static InspectionBuffer *GetBuffer2ForTX(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_headers(txv, flow_flags, &b, &b_len) != 1)
+        if (SCHttp2TxGetHeaders(txv, flow_flags, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -592,7 +592,7 @@ void DetectHttpRequestHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, rs_http2_tx_get_header, 2);
+            HTTP2StateOpen, SCHttp2TxGetHeader, 2);
     DetectAppLayerMultiRegister("http_request_header", ALPROTO_HTTP1, SIG_FLAG_TOSERVER,
             HTP_REQUEST_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 
@@ -625,7 +625,7 @@ void DetectHttpResponseHeaderRegister(void)
             SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, rs_http2_tx_get_header, 2);
+            HTTP2StateOpen, SCHttp2TxGetHeader, 2);
     DetectAppLayerMultiRegister("http_response_header", ALPROTO_HTTP1, SIG_FLAG_TOCLIENT,
             HTP_RESPONSE_PROGRESS_HEADERS, GetHttp1HeaderData, 2);
 

--- a/src/detect-http-headers-stub.h
+++ b/src/detect-http-headers-stub.h
@@ -85,7 +85,7 @@ static InspectionBuffer *GetRequestData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_header_value(txv, STREAM_TOSERVER, HEADER_NAME, &b, &b_len) != 1)
+        if (SCHttp2TxGetHeaderValue(txv, STREAM_TOSERVER, HEADER_NAME, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -139,7 +139,7 @@ static InspectionBuffer *GetResponseData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_header_value(txv, STREAM_TOCLIENT, HEADER_NAME, &b, &b_len) != 1)
+        if (SCHttp2TxGetHeaderValue(txv, STREAM_TOCLIENT, HEADER_NAME, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-host.c
+++ b/src/detect-http-host.c
@@ -270,7 +270,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_host_norm(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetHostNorm(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -290,7 +290,7 @@ static InspectionBuffer *GetRawData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_host(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetHost(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -229,7 +229,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_method(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetMethod(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -217,7 +217,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_headers_raw(txv, flow_flags, &b, &b_len) != 1)
+        if (SCHttp2TxGetHeadersRaw(txv, flow_flags, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-request-line.c
+++ b/src/detect-http-request-line.c
@@ -82,7 +82,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_request_line(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetRequestLine(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-response-line.c
+++ b/src/detect-http-response-line.c
@@ -82,7 +82,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_response_line(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetResponseLine(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -188,7 +188,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_status(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetStatus(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -193,7 +193,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_useragent(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetUserAgent(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -242,7 +242,7 @@ static InspectionBuffer *GetData2(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_http2_tx_get_uri(txv, &b, &b_len) != 1)
+        if (SCHttp2TxGetUri(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-http2.c
+++ b/src/detect-http2.c
@@ -175,9 +175,9 @@ void DetectHttp2Register(void)
     sigmatch_table[DETECT_HTTP2_HEADERNAME].flags |= SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOCLIENT,
-            HTTP2StateOpen, rs_http2_tx_get_header_name, 2);
+            HTTP2StateOpen, SCHttp2TxGetHeaderName, 2);
     DetectAppLayerMultiRegister("http2_header_name", ALPROTO_HTTP2, SIG_FLAG_TOSERVER,
-            HTTP2StateOpen, rs_http2_tx_get_header_name, 2);
+            HTTP2StateOpen, SCHttp2TxGetHeaderName, 2);
 
     DetectBufferTypeSupportsMultiInstance("http2_header_name");
     DetectBufferTypeSetDescriptionByName("http2_header_name",
@@ -205,7 +205,7 @@ static int DetectHTTP2frametypeMatch(DetectEngineThreadCtx *det_ctx,
 {
     uint8_t *detect = (uint8_t *)ctx;
 
-    return rs_http2_tx_has_frametype(txv, flags, *detect);
+    return SCHttp2TxHasFrametype(txv, flags, *detect);
 }
 
 static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
@@ -216,7 +216,7 @@ static int DetectHTTP2FuncParseFrameType(const char *str, uint8_t *ft)
     }
 
     // it it failed so far, parse string value from enumeration
-    int r = rs_http2_parse_frametype(str);
+    int r = SCHttp2ParseFrametype(str);
     if (r >= 0 && r <= UINT8_MAX) {
         *ft = (uint8_t)r;
         return 1;
@@ -284,7 +284,7 @@ static int DetectHTTP2errorcodeMatch(DetectEngineThreadCtx *det_ctx,
 {
     uint32_t *detect = (uint32_t *)ctx;
 
-    return rs_http2_tx_has_errorcode(txv, flags, *detect);
+    return SCHttp2TxHasErrorCode(txv, flags, *detect);
     //TODOask handle negation rules
 }
 
@@ -296,7 +296,7 @@ static int DetectHTTP2FuncParseErrorCode(const char *str, uint32_t *ec)
     }
 
     // it it failed so far, parse string value from enumeration
-    int r = rs_http2_parse_errorcode(str);
+    int r = SCHttp2ParseErrorCode(str);
     if (r >= 0) {
         *ec = r;
         return 1;
@@ -363,14 +363,14 @@ static int DetectHTTP2priorityMatch(DetectEngineThreadCtx *det_ctx,
 
 {
     uint32_t nb = 0;
-    int value = rs_http2_tx_get_next_priority(txv, flags, nb);
+    int value = SCHttp2TxGetNextPriority(txv, flags, nb);
     const DetectU8Data *du8 = (const DetectU8Data *)ctx;
     while (value >= 0) {
         if (DetectU8Match((uint8_t)value, du8)) {
             return 1;
         }
         nb++;
-        value = rs_http2_tx_get_next_priority(txv, flags, nb);
+        value = SCHttp2TxGetNextPriority(txv, flags, nb);
     }
     return 0;
 }
@@ -425,14 +425,14 @@ static int DetectHTTP2windowMatch(DetectEngineThreadCtx *det_ctx,
 
 {
     uint32_t nb = 0;
-    int value = rs_http2_tx_get_next_window(txv, flags, nb);
+    int value = SCHttp2TxGetNextWindow(txv, flags, nb);
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
     while (value >= 0) {
         if (DetectU32Match(value, du32)) {
             return 1;
         }
         nb++;
-        value = rs_http2_tx_get_next_window(txv, flags, nb);
+        value = SCHttp2TxGetNextWindow(txv, flags, nb);
     }
     return 0;
 }
@@ -486,7 +486,7 @@ static int DetectHTTP2sizeUpdateMatch(DetectEngineThreadCtx *det_ctx,
                                const SigMatchCtx *ctx)
 
 {
-    return rs_http2_detect_sizeupdatectx_match(ctx, txv, flags);
+    return SCHttp2DetectSizeUpdateCtxMatch(ctx, txv, flags);
 }
 
 /**
@@ -538,7 +538,7 @@ static int DetectHTTP2settingsMatch(DetectEngineThreadCtx *det_ctx,
                                const SigMatchCtx *ctx)
 
 {
-    return rs_http2_detect_settingsctx_match(ctx, txv, flags);
+    return SCHttp2DetectSettingsCtxMatch(ctx, txv, flags);
 }
 
 /**
@@ -556,7 +556,7 @@ static int DetectHTTP2settingsSetup (DetectEngineCtx *de_ctx, Signature *s, cons
     if (DetectSignatureSetAppProto(s, ALPROTO_HTTP2) != 0)
         return -1;
 
-    void *http2set = rs_http2_detect_settingsctx_parse(str);
+    void *http2set = SCHttp2DetectSettingsCtxParse(str);
     if (http2set == NULL)
         return -1;
 
@@ -576,7 +576,7 @@ static int DetectHTTP2settingsSetup (DetectEngineCtx *de_ctx, Signature *s, cons
  */
 void DetectHTTP2settingsFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    rs_http2_detect_settingsctx_free(ptr);
+    SCHttp2DetectSettingsCtxFree(ptr);
 }
 
 static int DetectHTTP2headerNameSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)

--- a/src/detect-ike-chosen-sa.c
+++ b/src/detect-ike-chosen-sa.c
@@ -105,7 +105,7 @@ static int DetectIkeChosenSaMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8
     const DetectIkeChosenSaData *dd = (const DetectIkeChosenSaData *)ctx;
 
     uint32_t value;
-    if (!rs_ike_state_get_sa_attribute(txv, dd->sa_type, &value))
+    if (!SCIkeStateGetSaAttribute(txv, dd->sa_type, &value))
         SCReturnInt(0);
     if (value == dd->sa_value)
         SCReturnInt(1);

--- a/src/detect-ike-exch-type.c
+++ b/src/detect-ike-exch-type.c
@@ -87,7 +87,7 @@ static int DetectIkeExchTypeMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8
     SCEnter();
 
     uint8_t exch_type;
-    if (!rs_ike_state_get_exch_type(txv, &exch_type))
+    if (!SCIkeStateGetExchType(txv, &exch_type))
         SCReturnInt(0);
 
     const DetectU8Data *du8 = (const DetectU8Data *)ctx;

--- a/src/detect-ike-key-exchange-payload-length.c
+++ b/src/detect-ike-key-exchange-payload-length.c
@@ -91,7 +91,7 @@ static int DetectIkeKeyExchangePayloadLengthMatch(DetectEngineThreadCtx *det_ctx
     SCEnter();
 
     uint32_t length;
-    if (!rs_ike_state_get_key_exchange_payload_length(txv, &length))
+    if (!SCIkeStateGetKeyExchangePayloadLength(txv, &length))
         SCReturnInt(0);
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
     return DetectU32Match(length, du32);

--- a/src/detect-ike-key-exchange-payload.c
+++ b/src/detect-ike-key-exchange-payload.c
@@ -78,7 +78,7 @@ static InspectionBuffer *GetKeyExchangeData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_ike_state_get_key_exchange(txv, &b, &b_len) != 1)
+        if (SCIkeStateGetKeyExchange(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-ike-nonce-payload-length.c
+++ b/src/detect-ike-nonce-payload-length.c
@@ -87,7 +87,7 @@ static int DetectIkeNoncePayloadLengthMatch(DetectEngineThreadCtx *det_ctx, Flow
     SCEnter();
 
     uint32_t length;
-    if (!rs_ike_state_get_nonce_payload_length(txv, &length))
+    if (!SCIkeStateGetNoncePayloadLength(txv, &length))
         SCReturnInt(0);
     const DetectU32Data *du32 = (const DetectU32Data *)ctx;
     return DetectU32Match(length, du32);

--- a/src/detect-ike-nonce-payload.c
+++ b/src/detect-ike-nonce-payload.c
@@ -78,7 +78,7 @@ static InspectionBuffer *GetNonceData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_ike_state_get_nonce(txv, &b, &b_len) != 1)
+        if (SCIkeStateGetNonce(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-ike-spi.c
+++ b/src/detect-ike-spi.c
@@ -95,7 +95,7 @@ static InspectionBuffer *GetInitiatorData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_ike_state_get_spi_initiator(txv, &b, &b_len) != 1)
+        if (SCIkeStateGetSpiInitiator(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -115,7 +115,7 @@ static InspectionBuffer *GetResponderData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_ike_state_get_spi_responder(txv, &b, &b_len) != 1)
+        if (SCIkeStateGetSpiResponder(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-ike-vendor.c
+++ b/src/detect-ike-vendor.c
@@ -53,7 +53,7 @@ void DetectIkeVendorRegister(void)
     sigmatch_table[DETECT_IKE_VENDOR].flags |= SIGMATCH_INFO_STICKY_BUFFER;
 
     DetectAppLayerMultiRegister(
-            "ike.vendor", ALPROTO_IKE, SIG_FLAG_TOSERVER, 1, rs_ike_tx_get_vendor, 1);
+            "ike.vendor", ALPROTO_IKE, SIG_FLAG_TOSERVER, 1, SCIkeTxGetVendor, 1);
 
     g_ike_vendor_buffer_id = DetectBufferTypeGetByName("ike.vendor");
 

--- a/src/detect-ja4-hash.c
+++ b/src/detect-ja4-hash.c
@@ -170,7 +170,7 @@ static InspectionBuffer *Ja4DetectGetHash(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_ja4(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetJa4(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-krb5-cname.c
+++ b/src/detect-krb5-cname.c
@@ -60,7 +60,7 @@ void DetectKrb5CNameRegister(void)
     sigmatch_table[DETECT_KRB5_CNAME].desc = "sticky buffer to match on Kerberos 5 client name";
 
     DetectAppLayerMultiRegister(
-            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_cname, 2);
+            "krb5_cname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, SCKrb5TxGetCname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_cname",
             "Kerberos 5 ticket client name");

--- a/src/detect-krb5-errcode.c
+++ b/src/detect-krb5-errcode.c
@@ -103,7 +103,7 @@ static int DetectKrb5ErrCodeMatch (DetectEngineThreadCtx *det_ctx,
 
     SCEnter();
 
-    ret = rs_krb5_tx_get_errcode(txv, &err_code);
+    ret = SCKrb5TxGetErrorCode(txv, &err_code);
     if (ret != 0)
         SCReturnInt(0);
 

--- a/src/detect-krb5-msgtype.c
+++ b/src/detect-krb5-msgtype.c
@@ -102,7 +102,7 @@ static int DetectKrb5MsgTypeMatch (DetectEngineThreadCtx *det_ctx,
 
     SCEnter();
 
-    rs_krb5_tx_get_msgtype(txv, &msg_type);
+    SCKrb5TxGetMsgType(txv, &msg_type);
 
     if (dd->msg_type == msg_type)
         SCReturnInt(1);

--- a/src/detect-krb5-sname.c
+++ b/src/detect-krb5-sname.c
@@ -60,7 +60,7 @@ void DetectKrb5SNameRegister(void)
     sigmatch_table[DETECT_KRB5_SNAME].desc = "sticky buffer to match on Kerberos 5 server name";
 
     DetectAppLayerMultiRegister(
-            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, rs_krb5_tx_get_sname, 2);
+            "krb5_sname", ALPROTO_KRB5, SIG_FLAG_TOCLIENT, 1, SCKrb5TxGetSname, 2);
 
     DetectBufferTypeSetDescriptionByName("krb5_sname",
             "Kerberos 5 ticket server name");

--- a/src/detect-krb5-ticket-encryption.c
+++ b/src/detect-krb5-ticket-encryption.c
@@ -27,7 +27,7 @@ static int g_krb5_ticket_encryption_list_id = 0;
 
 static void DetectKrb5TicketEncryptionFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    rs_krb5_detect_encryption_free(ptr);
+    SCKrb5DetectEncryptionFree(ptr);
 }
 
 static int DetectKrb5TicketEncryptionMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags,
@@ -37,7 +37,7 @@ static int DetectKrb5TicketEncryptionMatch(DetectEngineThreadCtx *det_ctx, Flow 
 
     SCEnter();
 
-    SCReturnInt(rs_krb5_detect_encryption_match(txv, dd));
+    SCReturnInt(SCKrb5DetectEncryptionMatch(txv, dd));
 }
 
 static int DetectKrb5TicketEncryptionSetup(
@@ -48,7 +48,7 @@ static int DetectKrb5TicketEncryptionSetup(
     if (DetectSignatureSetAppProto(s, ALPROTO_KRB5) != 0)
         return -1;
 
-    krb5d = rs_krb5_detect_encryption_parse(krb5str);
+    krb5d = SCKrb5DetectEncryptionParse(krb5str);
     if (krb5d == NULL)
         goto error;
 

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -66,7 +66,7 @@ static int g_modbus_buffer_id = 0;
 static void DetectModbusFree(DetectEngineCtx *de_ctx, void *ptr) {
     SCEnter();
     if (ptr != NULL) {
-        rs_modbus_free(ptr);
+        SCModbusFree(ptr);
     }
     SCReturn;
 }
@@ -89,7 +89,7 @@ static int DetectModbusSetup(DetectEngineCtx *de_ctx, Signature *s, const char *
     if (DetectSignatureSetAppProto(s, ALPROTO_MODBUS) != 0)
         return -1;
 
-    if ((modbus = rs_modbus_parse(str)) == NULL) {
+    if ((modbus = SCModbusParse(str)) == NULL) {
         SCLogError("invalid modbus option");
         goto error;
     }
@@ -111,7 +111,7 @@ error:
 static int DetectModbusMatch(DetectEngineThreadCtx *det_ctx, Flow *f, uint8_t flags, void *state,
         void *txv, const Signature *s, const SigMatchCtx *ctx)
 {
-    return rs_modbus_inspect(txv, (void *)ctx);
+    return SCModbusInspect(txv, (void *)ctx);
 }
 
 /**

--- a/src/detect-quic-cyu-hash.c
+++ b/src/detect-quic-cyu-hash.c
@@ -69,7 +69,7 @@ void DetectQuicCyuHashRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, rs_quic_tx_get_cyu_hash, 2);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, SCQuicTxGetCyuHash, 2);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-cyu-string.c
+++ b/src/detect-quic-cyu-string.c
@@ -67,7 +67,7 @@ void DetectQuicCyuStringRegister(void)
 #endif
 
     DetectAppLayerMultiRegister(
-            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, rs_quic_tx_get_cyu_string, 2);
+            BUFFER_NAME, ALPROTO_QUIC, SIG_FLAG_TOSERVER, 1, SCQuicTxGetCyuString, 2);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-quic-sni.c
+++ b/src/detect-quic-sni.c
@@ -55,7 +55,7 @@ static InspectionBuffer *GetSniData(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_sni(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetSni(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-quic-ua.c
+++ b/src/detect-quic-ua.c
@@ -55,7 +55,7 @@ static InspectionBuffer *GetUaData(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_ua(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetUa(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-quic-version.c
+++ b/src/detect-quic-version.c
@@ -55,7 +55,7 @@ static InspectionBuffer *GetVersionData(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_version(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetVersion(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-sip-method.c
+++ b/src/detect-sip-method.c
@@ -114,7 +114,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_sip_tx_get_method(txv, &b, &b_len) != 1)
+        if (SCSipTxGetMethod(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-sip-uri.c
+++ b/src/detect-sip-uri.c
@@ -87,7 +87,7 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
         const uint8_t *b = NULL;
         uint32_t b_len = 0;
 
-        if (rs_sip_tx_get_uri(txv, &b, &b_len) != 1)
+        if (SCSipTxGetUri(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -142,7 +142,7 @@ static int DetectStreamSizeMatch(
  */
 static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const char *streamstr)
 {
-    DetectStreamSizeData *sd = rs_detect_stream_size_parse(streamstr);
+    DetectStreamSizeData *sd = SCDetectStreamSizeParse(streamstr);
     if (sd == NULL)
         return -1;
 
@@ -161,7 +161,7 @@ static int DetectStreamSizeSetup (DetectEngineCtx *de_ctx, Signature *s, const c
  */
 void DetectStreamSizeFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    rs_detect_stream_size_free(ptr);
+    SCDetectStreamSizeFree(ptr);
 }
 
 /* prefilter code */
@@ -238,7 +238,7 @@ static int DetectStreamSizeParseTest01 (void)
 {
     int result = 0;
     DetectStreamSizeData *sd = NULL;
-    sd = rs_detect_stream_size_parse("server,<,6");
+    sd = SCDetectStreamSizeParse("server,<,6");
     if (sd != NULL) {
         if (sd->flags & StreamSizeServer && sd->du32.mode == DETECT_UINT_LT && sd->du32.arg1 == 6)
             result = 1;
@@ -257,7 +257,7 @@ static int DetectStreamSizeParseTest02 (void)
 {
     int result = 1;
     DetectStreamSizeData *sd = NULL;
-    sd = rs_detect_stream_size_parse("invalidoption,<,6");
+    sd = SCDetectStreamSizeParse("invalidoption,<,6");
     if (sd != NULL) {
         printf("expected: NULL got 0x%02X %" PRIu32 ": ", sd->flags, sd->du32.arg1);
         result = 0;
@@ -298,7 +298,7 @@ static int DetectStreamSizeParseTest03 (void)
     memset(&f, 0, sizeof(Flow));
     memset(&tcph, 0, sizeof(TCPHdr));
 
-    sd = rs_detect_stream_size_parse("client,>,8");
+    sd = SCDetectStreamSizeParse("client,>,8");
     if (sd != NULL) {
         if (!(sd->flags & StreamSizeClient)) {
             printf("sd->flags not STREAM_SIZE_CLIENT: ");
@@ -374,7 +374,7 @@ static int DetectStreamSizeParseTest04 (void)
     memset(&f, 0, sizeof(Flow));
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
-    sd = rs_detect_stream_size_parse(" client , > , 8 ");
+    sd = SCDetectStreamSizeParse(" client , > , 8 ");
     if (sd != NULL) {
         if (!(sd->flags & StreamSizeClient) && sd->du32.mode != DETECT_UINT_GT &&
                 sd->du32.arg1 != 8) {

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -85,7 +85,7 @@ void DetectUrilenRegister(void)
 
 static DetectUrilenData *DetectUrilenParse (const char *urilenstr)
 {
-    return rs_detect_urilen_parse(urilenstr);
+    return SCDetectUrilenParse(urilenstr);
 }
 
 /**
@@ -140,7 +140,7 @@ static void DetectUrilenFree(DetectEngineCtx *de_ctx, void *ptr)
         return;
 
     DetectUrilenData *urilend = (DetectUrilenData *)ptr;
-    rs_detect_urilen_free(urilend);
+    SCDetectUrilenFree(urilend);
 }
 
 /** \brief set prefilter dsize pair

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -260,7 +260,7 @@ bool AlertJsonDoh2(void *txptr, SCJsonBuilder *js)
 
     SCJbGetMark(js, &mark);
     // first log HTTP2 part
-    bool r = rs_http2_log_json(txptr, js);
+    bool r = SCHttp2LogJson(txptr, js);
     if (!r) {
         SCJbRestoreMark(js, &mark);
     }
@@ -296,7 +296,7 @@ static int JsonDoh2Logger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
 
     SCJbGetMark(jb, &mark);
     // first log HTTP2 part
-    bool r = rs_http2_log_json(txptr, jb);
+    bool r = SCHttp2LogJson(txptr, jb);
     if (!r) {
         SCJbRestoreMark(jb, &mark);
     }

--- a/src/output-json-ike.c
+++ b/src/output-json-ike.c
@@ -68,7 +68,7 @@ bool EveIKEAddMetadata(const Flow *f, uint64_t tx_id, SCJsonBuilder *js)
     if (state) {
         IKETransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_IKE, state, tx_id);
         if (tx) {
-            return rs_ike_logger_log(state, tx, LOG_IKE_EXTENDED, js);
+            return SCIkeLoggerLog(state, tx, LOG_IKE_EXTENDED, js);
         }
     }
 
@@ -86,7 +86,7 @@ static int JsonIKELogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
     }
 
     LogIKEFileCtx *ike_ctx = thread->ikelog_ctx;
-    if (!rs_ike_logger_log(state, tx, ike_ctx->flags, jb)) {
+    if (!SCIkeLoggerLog(state, tx, ike_ctx->flags, jb)) {
         goto error;
     }
 

--- a/src/output.c
+++ b/src/output.c
@@ -916,7 +916,7 @@ void OutputRegisterRootLoggers(void)
             ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, (EveJsonSimpleTxLogFunc)rs_quic_to_json, NULL);
     // ALPROTO_DHCP TODO missing
-    RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)SCSipLogJson, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RFB, (EveJsonSimpleTxLogFunc)rs_rfb_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_POP3, (EveJsonSimpleTxLogFunc)SCPop3LoggerLog, NULL);
     RegisterSimpleJsonApplayerLogger(

--- a/src/output.c
+++ b/src/output.c
@@ -910,7 +910,7 @@ void OutputRegisterRootLoggers(void)
     RegisterSimpleJsonApplayerLogger(
             ALPROTO_FTPDATA, (EveJsonSimpleTxLogFunc)EveFTPDataAddMetadata, "ftp_data");
     RegisterSimpleJsonApplayerLogger(
-            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
+            ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)SCTftpLogJsonRequest, NULL);
     // ALPROTO_IKE special: uses state
     RegisterSimpleJsonApplayerLogger(
             ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);

--- a/src/output.c
+++ b/src/output.c
@@ -932,8 +932,7 @@ void OutputRegisterRootLoggers(void)
             ALPROTO_TEMPLATE, (EveJsonSimpleTxLogFunc)rs_template_logger_log, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RDP, (EveJsonSimpleTxLogFunc)SCRdpToJson, NULL);
     // special case : http2 is logged in http object
-    RegisterSimpleJsonApplayerLogger(
-            ALPROTO_HTTP2, (EveJsonSimpleTxLogFunc)rs_http2_log_json, "http");
+    RegisterSimpleJsonApplayerLogger(ALPROTO_HTTP2, (EveJsonSimpleTxLogFunc)SCHttp2LogJson, "http");
     // underscore instead of dash for bittorrent_dht
     RegisterSimpleJsonApplayerLogger(ALPROTO_BITTORRENT_DHT,
             (EveJsonSimpleTxLogFunc)SCBittorrentDhtLogger, "bittorrent_dht");

--- a/src/output.c
+++ b/src/output.c
@@ -914,7 +914,7 @@ void OutputRegisterRootLoggers(void)
     // ALPROTO_IKE special: uses state
     RegisterSimpleJsonApplayerLogger(
             ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);
-    RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, (EveJsonSimpleTxLogFunc)rs_quic_to_json, NULL);
+    RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, (EveJsonSimpleTxLogFunc)SCQuicLogJson, NULL);
     // ALPROTO_DHCP TODO missing
     RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)SCSipLogJson, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_RFB, (EveJsonSimpleTxLogFunc)rs_rfb_logger_log, NULL);

--- a/src/output.c
+++ b/src/output.c
@@ -913,7 +913,7 @@ void OutputRegisterRootLoggers(void)
             ALPROTO_TFTP, (EveJsonSimpleTxLogFunc)rs_tftp_log_json_request, NULL);
     // ALPROTO_IKE special: uses state
     RegisterSimpleJsonApplayerLogger(
-            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)rs_krb5_log_json_response, NULL);
+            ALPROTO_KRB5, (EveJsonSimpleTxLogFunc)SCKrb5LogJsonResponse, NULL);
     RegisterSimpleJsonApplayerLogger(ALPROTO_QUIC, (EveJsonSimpleTxLogFunc)rs_quic_to_json, NULL);
     // ALPROTO_DHCP TODO missing
     RegisterSimpleJsonApplayerLogger(ALPROTO_SIP, (EveJsonSimpleTxLogFunc)rs_sip_log_json, NULL);

--- a/src/util-ja3.c
+++ b/src/util-ja3.c
@@ -267,7 +267,7 @@ InspectionBuffer *Ja3DetectGetHash(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetJa3(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;
@@ -292,7 +292,7 @@ InspectionBuffer *Ja3DetectGetString(DetectEngineThreadCtx *det_ctx,
         uint32_t b_len = 0;
         const uint8_t *b = NULL;
 
-        if (rs_quic_tx_get_ja3(txv, &b, &b_len) != 1)
+        if (SCQuicTxGetJa3(txv, &b, &b_len) != 1)
             return NULL;
         if (b == NULL || b_len == 0)
             return NULL;


### PR DESCRIPTION
- **rust/dns: rs_ prefix name cleanup**
  

- **rust/krb: remove rs_ prefix; visibility fixes**
  - remove pub/no_mangle where not needed
  - replace rs_ naming with SC naming
  

- **rust/krb: rust format**
  

- **rust/asn1: replace rs_ naming with SC naming**
  

- **rust/detect: replace rs_ naming with SC**
  

- **rust/telnet: replace rs_ naming with SC**
  

- **rust/tftp: replace rs_ naming with SC**
  

- **rust/sip: replace rs_ naming with SC**
  

- **rust/modbus: replace rs_ naming with SC**
  

- **rust/http2: replace rs_ naming with SC**
  

- **rust/ike: replace rs_ naming with SC**
  

- **rust/quic: replace rs_ naming with SC**
  