### PR TITLE
detect/ftp: Use helper functions with ftp.command

### DIFF
--- a/src/detect-ftp-command.c
+++ b/src/detect-ftp-command.c
@@ -29,13 +29,9 @@
 #include "detect-parse.h"
 #include "detect-engine.h"
 #include "detect-engine-buffer.h"
-#include "detect-engine-mpm.h"
-#include "detect-engine-prefilter.h"
-#include "detect-content.h"
+#include "detect-engine-helper.h"
 
 #include "flow.h"
-
-#include "util-debug.h"
 
 #include "app-layer.h"
 #include "app-layer-ftp.h"
@@ -60,8 +56,8 @@ static int DetectFtpCommandSetup(DetectEngineCtx *de_ctx, Signature *s, const ch
     return 0;
 }
 
-static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
+static InspectionBuffer *DetectFTPCommandGetData(DetectEngineThreadCtx *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
         const int list_id)
 {
     InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
@@ -73,13 +69,13 @@ static InspectionBuffer *GetData(DetectEngineThreadCtx *det_ctx,
 
         const char *b = NULL;
         uint8_t b_len = 0;
-
         if (SCGetFtpCommandInfo(tx->command_descriptor.command_index, &b, NULL, &b_len)) {
             InspectionBufferSetupAndApplyTransforms(
                     det_ctx, list_id, buffer, (const uint8_t *)b, b_len, transforms);
+        } else {
+            return NULL;
         }
     }
-
     return buffer;
 }
 
@@ -92,15 +88,8 @@ void DetectFtpCommandRegister(void)
     sigmatch_table[DETECT_FTP_COMMAND].Setup = DetectFtpCommandSetup;
     sigmatch_table[DETECT_FTP_COMMAND].flags |= SIGMATCH_NOOPT;
 
-    DetectAppLayerInspectEngineRegister(BUFFER_NAME, ALPROTO_FTP, SIG_FLAG_TOSERVER, 0,
-            DetectEngineInspectBufferGeneric, GetData);
-
-    DetectAppLayerMpmRegister(BUFFER_NAME, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
-            GetData, ALPROTO_FTP, 1);
-
-    DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
-
-    g_ftp_cmd_buffer_id = DetectBufferTypeGetByName(BUFFER_NAME);
+    g_ftp_cmd_buffer_id = DetectHelperBufferMpmRegister(
+            BUFFER_NAME, BUFFER_NAME, ALPROTO_FTP, STREAM_TOSERVER, DetectFTPCommandGetData);
 
     SCLogDebug("registering " BUFFER_NAME " rule option");
 }


### PR DESCRIPTION
Continuation of #12866 

Refactor ftp.command handling to use helper functions from detect-engine-helper.[ch] for reduced code duplication.

Describe changes:
- Refactor the ftp.command keyword handling to use the helper functions for code reduction.
-
Updates:
- Rebase and use updated helper functions

### Provide values to any of the below to override the defaults.

- To use an LibHTP, Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
LIBHTP_REPO=
LIBHTP_BRANCH=
