### PR TITLE
pgsql: don't log empty request - v3

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2528,6 +2528,8 @@ flow. Some of the possible request messages are:
 * "startup_message": message sent to start a new PostgreSQL connection
 * "password_message": if password output for PGSQL is enabled in suricata.yaml,
   carries the password sent during Authentication phase
+* "password_redacted": set to true in case there is a password message, but its
+  logging is disabled
 * "simple_query": issued SQL command during simple query subprotocol. PostgreSQL
   identifies specific sets of commands that change the set of expected messages
   to be exchanged as subprotocols.

--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2526,7 +2526,7 @@ Requests are sent by the frontend (client), which would be the source of a pgsql
 flow. Some of the possible request messages are:
 
 * "startup_message": message sent to start a new PostgreSQL connection
-* "password_message": if password output for PGSQL is enabled in suricata.yaml,
+* "password": if password output for PGSQL is enabled in suricata.yaml,
   carries the password sent during Authentication phase
 * "password_redacted": set to true in case there is a password message, but its
   logging is disabled

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3612,9 +3612,6 @@
                         "password": {
                             "type": "string"
                         },
-                        "password_message": {
-                            "type": "string"
-                        },
                         "password_redacted": {
                             "type": "boolean",
                             "description": "indicates if a password message was received but not logged due to Suricata settings"

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3615,6 +3615,10 @@
                         "password_message": {
                             "type": "string"
                         },
+                        "password_redacted": {
+                            "type": "boolean",
+                            "description": "indicates if a password message was received but not logged due to Suricata settings"
+                        },
                         "process_id": {
                             "type": "integer"
                         },

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -80,7 +80,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
             payload,
         }) => {
             if flags & PGSQL_LOG_PASSWORDS != 0 {
-                js.set_string_from_bytes("password", payload)?;
+                js.set_string_from_bytes(req.to_str(), payload)?;
             } else {
                 js.set_bool("password_redacted", true)?;
             }

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -81,6 +81,8 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
         }) => {
             if flags & PGSQL_LOG_PASSWORDS != 0 {
                 js.set_string_from_bytes("password", payload)?;
+            } else {
+                js.set_bool("password_redacted", true)?;
             }
         }
         PgsqlFEMessage::SASLResponse(RegularPacket {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -393,7 +393,7 @@ impl PgsqlFEMessage {
         match self {
             PgsqlFEMessage::StartupMessage(_) => "startup_message",
             PgsqlFEMessage::SSLRequest(_) => "ssl_request",
-            PgsqlFEMessage::PasswordMessage(_) => "password_message",
+            PgsqlFEMessage::PasswordMessage(_) => "password",
             PgsqlFEMessage::SASLInitialResponse(_) => "sasl_initial_response",
             PgsqlFEMessage::SASLResponse(_) => "sasl_response",
             PgsqlFEMessage::SimpleQuery(_) => "simple_query",

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -360,6 +360,8 @@ outputs:
         - pgsql:
             enabled: no
             # passwords: yes           # enable output of passwords. Disabled by default
+                                       # If a password message is seen but this setting
+                                       # is disabled, "password_redacted": true is logged
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats


### PR DESCRIPTION
## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7647

Sharing as a draft as I feel there may be more changes to come, based on other discussions about `pgsql` logs.

Previous PR: #13124 

Describe changes:
- update JSON schema with description for the new field (will do a follow-up PR to document other fields)
- bring commit for cleaning-up `password_message`
- rebase

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2489
