### PR TITLE
userguide: [minor] updates and fixes - v1

### DIFF
--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -325,6 +325,13 @@ The available command-line options are:
 - ``simulate-alert-queue-realloc-failure``: prevent the engine from dynamically
   growing the temporary alert queue, during alerts processing.
 
+Glossary
+========
+
+- **inspection**: traffic is inspected for events, anomalies and logging;
+- **detection**: evaluate traffic against loaded rules to generate alerts and/ or
+  block or approve traffic.
+
 Common abbreviations
 --------------------
 

--- a/doc/userguide/configuration/exception-policies.rst
+++ b/doc/userguide/configuration/exception-policies.rst
@@ -1,7 +1,7 @@
 .. _exception policies:
 
 Exception Policies
-==================
+##################
 
 Suricata has a set of configuration variables to indicate what should the engine
 do when certain exception conditions, such as hitting a memcap, are reached.
@@ -16,13 +16,10 @@ For developers or for researching purposes, there are also simulation options
 exposed in debug mode and passed via command-line. These exist to force or
 simulate failures or errors and understand Suricata behavior under such conditions.
 
-Exception Policies
-------------------
-
 .. _master-switch:
 
 Master Switch
-~~~~~~~~~~~~~
+*************
 
 It is possible to set all configuration policies via what we call "master
 switch". This offers a quick way to define what the engine should do in case of
@@ -46,7 +43,7 @@ This value will be overwritten by specific exception policies whose settings are
 also defined in the yaml file.
 
 Auto
-''''
+====
 
 **In IPS mode**, the default behavior for most of the exception policies is to
 fail close. This means dropping the flow, or the packet, when the flow action is
@@ -66,7 +63,7 @@ It is possible to disable this default, by setting the exception policies'
 .. _eps_settings:
 
 Specific settings
-~~~~~~~~~~~~~~~~~
+*****************
 
 Exception policies are implemented for:
 
@@ -132,7 +129,7 @@ The *drop*, *pass* and *reject* are similar to the rule actions described in :re
 actions<suricata-yaml-action-order>`.
 
 Exception Policies and Midstream Pick-up Sessions
--------------------------------------------------
+*************************************************
 
 Suricata behavior can be difficult to track in case of midstream session
 pick-ups. Consider this matrix illustrating the different interactions for
@@ -214,17 +211,18 @@ whole flow.
 Notes:
 
    * Not valid means that Suricata will error out and won't start.
-   * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender of the matching packet.
+   * ``REJECT`` will make Suricata send a Reset-packet unreach error to the sender
+     of the matching packet.
 
 .. _eps_output:
 
 Log Output
-----------
+**********
 
 .. _eps_flow_event:
 
 Flow Event
-~~~~~~~~~~
+==========
 
 When an Exception Policy is triggered, this will be indicated in the flow log
 event for the associated flow, also indicating which target triggered that, and
@@ -266,7 +264,7 @@ exception policy, but that is set up to ``ignore``::
 .. _eps_stats:
 
 Available Stats
-~~~~~~~~~~~~~~~
+===============
 
 There are stats counters for each supported exception policy scenario that will
 be logged when exception policies are enabled:
@@ -303,7 +301,7 @@ temporarily (for more, read :ref:`stats configuration<suricata_yaml_outputs>`).
 
 
 Command-line Options for Simulating Exceptions
-----------------------------------------------
+==============================================
 
 It is also possible to force specific exception scenarios, to check engine
 behavior under failure or error conditions.

--- a/doc/userguide/rules/index.rst
+++ b/doc/userguide/rules/index.rst
@@ -53,5 +53,6 @@ Suricata Rules
    tag
    vlan-keywords
    ldap-keywords
-   rule-types
    email-keywords
+   rule-types
+.. please leave 'rule-types' as last item when adding keyword items

--- a/doc/userguide/rules/rule-types.rst
+++ b/doc/userguide/rules/rule-types.rst
@@ -290,7 +290,7 @@ for one or more of rule(s) shown.
 Decoder Events Only
 ^^^^^^^^^^^^^^^^^^^
 
-Signatures the inspect broken or invalid packets. They expose Suricata decoding
+Signatures that inspect broken or invalid packets. They expose Suricata decoding
 events.
 
 For more examples check https://github.com/OISF/suricata/blob/master/rules/decoder-events.rules.


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
none

Describe changes:
- add a small `glossary` section explaining the terms `inspection` and `detection` in the Exception Policies chapter. This was triggered by a convo with @jlucovsky 
- change heading markdowns for Exception Policies page, and a few minor similar edits
- fix typo and index order for Rule Types chapter