### PR TITLE
useguide/lua: note detection order impact - v1

### DIFF
--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -1052,6 +1052,22 @@ You can use it to set string
          SCFlowvarSet(0, a, #a)
      end 
 
+
+.. note::
+
+   During detection, the following steps happen, in that ordem:
+    - pattern matching
+    - lua script execution
+    - setting flow variables as part of post match
+
+   Due to that, depending on the use case, two rules may be necessary:
+    - one that does pattern matching and flow var setting,
+    - a second rule that has the Lua script.
+
+   For more details, see RedMine ticket
+   https://redmine.openinfosecfoundation.org/issues/2094 and Suricata-verify test
+   https://github.com/OISF/suricata-verify/tree/master/tests/pre8/lua-scflowvarget.
+
 Misc
 ----
 


### PR DESCRIPTION
This situation was indicated in a suricata-verify test, but not in our docs.

Related to
Bug #2094

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Add explanation present in test https://github.com/OISF/suricata-verify/pull/2467#discussion_r2060879328 to the Lua function docs
As Jason indicated this was a test for Suri 7, my understanding is that isn't an issue present in Suri 8 -- but maybe I'm wrong in that assumption.
