### PR TITLE
datasets: fix set with ip sets

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1191,12 +1191,12 @@ static int DatasetAddIPv6(Dataset *set, const uint8_t *data, const uint32_t data
         return -1;
     }
 
-    if (data_len != 16) {
+    if (data_len != 16 && data_len != 4) {
         return -2;
     }
 
     IPv6Type lookup = { .rep.value = 0 };
-    memcpy(lookup.ipv6, data, 16);
+    memcpy(lookup.ipv6, data, data_len);
     struct THashDataGetResult res = THashGetFromHash(set->hash, &lookup);
     if (res.data) {
         DatasetUnlockData(res.data);


### PR DESCRIPTION
It can get an IPv6 or an IPv4 so we need to handle both length.

Ticket: #7689

Make sure these boxes are checked accordingly before submitting your Pull Request -- thank you.

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7689

Describe changes:
- fix setting IPv4 in IP dataset

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2492