### PR TITLE
Detect singlebuf v3

### DIFF
--- a/examples/plugins/altemplate/src/detect.rs
+++ b/examples/plugins/altemplate/src/detect.rs
@@ -24,7 +24,7 @@ use super::template::{TemplateTransaction, ALPROTO_TEMPLATE};
 use std::os::raw::{c_int, c_void};
 use suricata::cast_pointer;
 use suricata::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use suricata::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
@@ -46,7 +46,7 @@ unsafe extern "C" fn template_buffer_setup(
 }
 
 /// Get the request/response buffer for a transaction from C.
-unsafe extern "C" fn template_buffer_get_data(
+unsafe extern "C" fn template_buffer_get(
     tx: *const c_void, flags: u8, buf: *mut *const u8, len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, TemplateTransaction);
@@ -62,21 +62,6 @@ unsafe extern "C" fn template_buffer_get_data(
         return true;
     }
     return false;
-}
-
-unsafe extern "C" fn template_buffer_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        template_buffer_get_data,
-    );
 }
 
 pub(super) unsafe extern "C" fn detect_template_register() {

--- a/rust/src/applayertemplate/detect.rs
+++ b/rust/src/applayertemplate/detect.rs
@@ -21,7 +21,7 @@ use crate::conf::conf_get_node;
 /* TEMPLATE_END_REMOVE */
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
@@ -43,7 +43,7 @@ unsafe extern "C" fn template_buffer_setup(
 }
 
 /// Get the request/response buffer for a transaction from C.
-unsafe extern "C" fn template_buffer_get_data(
+unsafe extern "C" fn template_buffer_get(
     tx: *const c_void, flags: u8, buf: *mut *const u8, len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, TemplateTransaction);
@@ -59,21 +59,6 @@ unsafe extern "C" fn template_buffer_get_data(
         return true;
     }
     return false;
-}
-
-unsafe extern "C" fn template_buffer_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        template_buffer_get_data,
-    );
 }
 
 #[no_mangle]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -153,21 +153,14 @@ pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
 /// cbindgen:ignore
 extern "C" {
     pub fn DetectHelperKeywordSetCleanCString(id: c_int);
-    pub fn DetectHelperGetData(
-        de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-        tx: *const c_void, list_id: c_int,
-        get_buf: unsafe extern "C" fn(*const c_void, u8, *mut *const u8, *mut u32) -> bool,
-    ) -> *mut c_void;
     pub fn DetectHelperBufferMpmRegister(
         name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
         get_data: unsafe extern "C" fn(
-            *mut c_void,
-            *const c_void,
             *const c_void,
             u8,
-            *const c_void,
-            i32,
-        ) -> *mut c_void,
+            *mut *const u8,
+            *mut u32,
+        ) -> bool,
     ) -> c_int;
     pub fn DetectHelperKeywordRegister(kw: *const SCSigTableAppLiteElmt) -> c_int;
     pub fn DetectHelperKeywordAliasRegister(kwid: c_int, alias: *const c_char);

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -37,9 +37,8 @@ use crate::detect::uint::{
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
 
@@ -1251,7 +1250,7 @@ pub unsafe extern "C" fn product_name_setup(
     return 0;
 }
 
-unsafe extern "C" fn product_name_get(
+unsafe extern "C" fn product_name_get_data(
     tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, EnipTransaction);
@@ -1271,21 +1270,6 @@ unsafe extern "C" fn product_name_get(
     return false;
 }
 
-unsafe extern "C" fn product_name_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        product_name_get,
-    );
-}
-
 pub unsafe extern "C" fn service_name_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
 ) -> c_int {
@@ -1298,7 +1282,7 @@ pub unsafe extern "C" fn service_name_setup(
     return 0;
 }
 
-unsafe extern "C" fn service_name_get(
+unsafe extern "C" fn service_name_get_data(
     tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, EnipTransaction);
@@ -1318,20 +1302,6 @@ unsafe extern "C" fn service_name_get(
     return false;
 }
 
-unsafe extern "C" fn service_name_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        service_name_get,
-    );
-}
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectEnipRegister() {
     let kw = SCSigTableAppLiteElmt {

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -23,9 +23,9 @@ use crate::detect::uint::{
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
@@ -317,21 +317,6 @@ unsafe extern "C" fn ldap_detect_request_dn_setup(
 }
 
 unsafe extern "C" fn ldap_detect_request_dn_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        ldap_tx_get_request_dn,
-    );
-}
-
-unsafe extern "C" fn ldap_tx_get_request_dn(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, LdapTransaction);

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -24,9 +24,9 @@ use crate::detect::uint::{
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectHelperMultiBufferMpmRegister,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
 
@@ -53,7 +53,7 @@ fn mqtt_tx_has_type(tx: &MQTTTransaction, mtype: &DetectUintData<u8>) -> c_int {
     return 0;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_clientid(
+unsafe extern "C" fn mqtt_conn_clientid_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -73,7 +73,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_clientid(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_username(
+unsafe extern "C" fn mqtt_conn_username_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -94,7 +94,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_username(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_password(
+unsafe extern "C" fn mqtt_conn_password_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -115,7 +115,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_password(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_willtopic(
+unsafe extern "C" fn mqtt_conn_willtopic_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -136,7 +136,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_willtopic(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_willmessage(
+unsafe extern "C" fn mqtt_conn_willmsg_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -157,7 +157,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_willmessage(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_connect_protocol_string(
+unsafe extern "C" fn mqtt_conn_protocolstring_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -177,7 +177,7 @@ unsafe extern "C" fn mqtt_tx_get_connect_protocol_string(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_publish_topic(
+unsafe extern "C" fn mqtt_pub_topic_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -197,7 +197,7 @@ unsafe extern "C" fn mqtt_tx_get_publish_topic(
     return false;
 }
 
-unsafe extern "C" fn mqtt_tx_get_publish_message(
+unsafe extern "C" fn mqtt_pub_msg_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, MQTTTransaction);
@@ -596,21 +596,6 @@ unsafe extern "C" fn mqtt_pub_topic_setup(
     return 0;
 }
 
-unsafe extern "C" fn mqtt_pub_topic_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_publish_topic,
-    );
-}
-
 unsafe extern "C" fn mqtt_pub_msg_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
 ) -> c_int {
@@ -621,21 +606,6 @@ unsafe extern "C" fn mqtt_pub_msg_setup(
         return -1;
     }
     return 0;
-}
-
-unsafe extern "C" fn mqtt_pub_msg_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_publish_message,
-    );
 }
 
 unsafe extern "C" fn mqtt_protocol_version_setup(
@@ -920,21 +890,6 @@ unsafe extern "C" fn mqtt_conn_willtopic_setup(
     return 0;
 }
 
-unsafe extern "C" fn mqtt_conn_willtopic_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_willtopic,
-    );
-}
-
 unsafe extern "C" fn mqtt_conn_willmsg_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
 ) -> c_int {
@@ -945,21 +900,6 @@ unsafe extern "C" fn mqtt_conn_willmsg_setup(
         return -1;
     }
     return 0;
-}
-
-unsafe extern "C" fn mqtt_conn_willmsg_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_willmessage,
-    );
 }
 
 unsafe extern "C" fn mqtt_conn_username_setup(
@@ -974,21 +914,6 @@ unsafe extern "C" fn mqtt_conn_username_setup(
     return 0;
 }
 
-unsafe extern "C" fn mqtt_conn_username_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_username,
-    );
-}
-
 unsafe extern "C" fn mqtt_conn_protocolstring_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
 ) -> c_int {
@@ -999,21 +924,6 @@ unsafe extern "C" fn mqtt_conn_protocolstring_setup(
         return -1;
     }
     return 0;
-}
-
-unsafe extern "C" fn mqtt_conn_protocolstring_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_protocol_string,
-    );
 }
 
 unsafe extern "C" fn mqtt_conn_password_setup(
@@ -1028,21 +938,6 @@ unsafe extern "C" fn mqtt_conn_password_setup(
     return 0;
 }
 
-unsafe extern "C" fn mqtt_conn_password_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_password,
-    );
-}
-
 unsafe extern "C" fn mqtt_conn_clientid_setup(
     de: *mut DetectEngineCtx, s: *mut Signature, _raw: *const std::os::raw::c_char,
 ) -> c_int {
@@ -1053,21 +948,6 @@ unsafe extern "C" fn mqtt_conn_clientid_setup(
         return -1;
     }
     return 0;
-}
-
-unsafe extern "C" fn mqtt_conn_clientid_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        mqtt_tx_get_connect_clientid,
-    );
 }
 
 #[no_mangle]

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -25,16 +25,15 @@ use crate::detect::uint::{
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
 
-unsafe extern "C" fn rfb_name_get_data(
+unsafe extern "C" fn rfb_name_get(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, RFBTransaction);
@@ -50,21 +49,6 @@ unsafe extern "C" fn rfb_name_get_data(
     *buffer = ptr::null();
     *buffer_len = 0;
     return false;
-}
-
-unsafe extern "C" fn rfb_name_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        rfb_name_get_data,
-    );
 }
 
 static mut G_RFB_NAME_BUFFER_ID: c_int = 0;

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -19,7 +19,7 @@
 
 use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
@@ -59,21 +59,6 @@ unsafe extern "C" fn sdp_session_name_setup(
 }
 
 unsafe extern "C" fn sdp_session_name_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_session_name_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_session_name_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -107,21 +92,6 @@ unsafe extern "C" fn sdp_session_info_setup(
 }
 
 unsafe extern "C" fn sdp_session_info_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_session_info_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_session_info_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -154,21 +124,6 @@ unsafe extern "C" fn sdp_origin_setup(
 }
 
 unsafe extern "C" fn sdp_origin_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_origin_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_origin_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -202,21 +157,6 @@ unsafe extern "C" fn sdp_uri_setup(
 }
 
 unsafe extern "C" fn sdp_uri_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_uri_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_uri_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -249,21 +189,6 @@ unsafe extern "C" fn sdp_email_setup(
 }
 
 unsafe extern "C" fn sdp_email_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_email_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_email_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -296,21 +221,6 @@ unsafe extern "C" fn sdp_phone_number_setup(
 }
 
 unsafe extern "C" fn sdp_phone_number_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_phone_number_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_phone_number_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -343,21 +253,6 @@ unsafe extern "C" fn sdp_conn_data_setup(
 }
 
 unsafe extern "C" fn sdp_conn_data_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_conn_data_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_conn_data_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -499,21 +394,6 @@ unsafe extern "C" fn sdp_timezone_setup(
 }
 
 unsafe extern "C" fn sdp_timezone_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_timezone_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_timezone_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -546,21 +426,6 @@ unsafe extern "C" fn sdp_encryption_key_setup(
 }
 
 unsafe extern "C" fn sdp_encryption_key_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sdp_encryption_key_get_data,
-    );
-}
-
-unsafe extern "C" fn sdp_encryption_key_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -19,7 +19,7 @@
 
 use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
@@ -91,21 +91,6 @@ unsafe extern "C" fn sip_protocol_setup(
 }
 
 unsafe extern "C" fn sip_protocol_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sip_protocol_get_data,
-    );
-}
-
-unsafe extern "C" fn sip_protocol_get_data(
     tx: *const c_void, direction: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -149,21 +134,6 @@ unsafe extern "C" fn sip_stat_code_setup(
 }
 
 unsafe extern "C" fn sip_stat_code_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sip_stat_code_get_data,
-    );
-}
-
-unsafe extern "C" fn sip_stat_code_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -193,20 +163,6 @@ unsafe extern "C" fn sip_stat_msg_setup(
 }
 
 unsafe extern "C" fn sip_stat_msg_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sip_stat_msg_get_data,
-    );
-}
-unsafe extern "C" fn sip_stat_msg_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -236,21 +192,6 @@ unsafe extern "C" fn sip_request_line_setup(
 }
 
 unsafe extern "C" fn sip_request_line_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sip_request_line_get_data,
-    );
-}
-
-unsafe extern "C" fn sip_request_line_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);
@@ -279,21 +220,6 @@ unsafe extern "C" fn sip_response_line_setup(
 }
 
 unsafe extern "C" fn sip_response_line_get(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        sip_response_line_get_data,
-    );
-}
-
-unsafe extern "C" fn sip_response_line_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SIPTransaction);

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -22,9 +22,8 @@ use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
@@ -118,7 +117,7 @@ unsafe extern "C" fn snmp_detect_usm_setup(
     return 0;
 }
 
-unsafe extern "C" fn snmp_detect_usm_get(
+unsafe extern "C" fn snmp_detect_usm_get_data(
     tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SNMPTransaction);
@@ -128,21 +127,6 @@ unsafe extern "C" fn snmp_detect_usm_get(
         return true;
     }
     return false;
-}
-
-unsafe extern "C" fn snmp_detect_usm_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        snmp_detect_usm_get,
-    );
 }
 
 unsafe extern "C" fn snmp_detect_community_setup(
@@ -157,7 +141,7 @@ unsafe extern "C" fn snmp_detect_community_setup(
     return 0;
 }
 
-unsafe extern "C" fn snmp_detect_community_get(
+unsafe extern "C" fn snmp_detect_community_get_data(
     tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, SNMPTransaction);
@@ -167,21 +151,6 @@ unsafe extern "C" fn snmp_detect_community_get(
         return true;
     }
     return false;
-}
-
-unsafe extern "C" fn snmp_detect_community_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        snmp_detect_community_get,
-    );
 }
 
 pub(super) unsafe extern "C" fn detect_snmp_register() {

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -23,9 +23,8 @@ use crate::detect::uint::{
 };
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::websocket::parser::WebSocketOpcode;
 use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
@@ -255,28 +254,13 @@ pub unsafe extern "C" fn websocket_detect_payload_setup(
     return 0;
 }
 
-pub unsafe extern "C" fn websocket_detect_payload_get(
+pub unsafe extern "C" fn websocket_detect_payload_get_data(
     tx: *const c_void, _flow_flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
 ) -> bool {
     let tx = cast_pointer!(tx, WebSocketTransaction);
     *buffer = tx.pdu.payload.as_ptr();
     *buffer_len = tx.pdu.payload.len() as u32;
     return true;
-}
-
-pub unsafe extern "C" fn websocket_detect_payload_get_data(
-    de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
-    tx: *const c_void, list_id: c_int,
-) -> *mut c_void {
-    return DetectHelperGetData(
-        de,
-        transforms,
-        flow,
-        flow_flags,
-        tx,
-        list_id,
-        websocket_detect_payload_get,
-    );
 }
 
 #[no_mangle]

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -45,27 +45,13 @@ static int DetectMimeEmailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailFromData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailFromData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_from = NULL;
-        uint32_t b_email_from_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_from, &b_email_from_len, "from") != 1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_from, b_email_from_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "from") != 1);
 }
 
 static int DetectMimeEmailSubjectSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -79,28 +65,13 @@ static int DetectMimeEmailSubjectSetup(DetectEngineCtx *de_ctx, Signature *s, co
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailSubjectData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailSubjectData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_sub = NULL;
-        uint32_t b_email_sub_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_sub, &b_email_sub_len, "subject") !=
-                1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_sub, b_email_sub_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "subject") != 1);
 }
 
 static int DetectMimeEmailToSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -114,29 +85,13 @@ static int DetectMimeEmailToSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailToData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailToData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_to = NULL;
-        uint32_t b_email_to_len = 0;
-
-        if ((tx->mime_state != NULL)) {
-            if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_to, &b_email_to_len, "to") != 1)
-                return NULL;
-        }
-
-        if (b_email_to == NULL || b_email_to_len == 0)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_to, b_email_to_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "to") != 1);
 }
 
 static int DetectMimeEmailCcSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -150,27 +105,13 @@ static int DetectMimeEmailCcSetup(DetectEngineCtx *de_ctx, Signature *s, const c
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailCcData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailCcData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_cc = NULL;
-        uint32_t b_email_cc_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_cc, &b_email_cc_len, "cc") != 1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_cc, b_email_cc_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "cc") != 1);
 }
 
 static int DetectMimeEmailDateSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -184,27 +125,13 @@ static int DetectMimeEmailDateSetup(DetectEngineCtx *de_ctx, Signature *s, const
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailDateData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailDateData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_date = NULL;
-        uint32_t b_email_date_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(tx->mime_state, &b_email_date, &b_email_date_len, "date") != 1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_date, b_email_date_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "date") != 1);
 }
 
 static int DetectMimeEmailMessageIdSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -218,28 +145,13 @@ static int DetectMimeEmailMessageIdSetup(DetectEngineCtx *de_ctx, Signature *s, 
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailMessageIdData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailMessageIdData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_msg_id = NULL;
-        uint32_t b_email_msg_id_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(
-                    tx->mime_state, &b_email_msg_id, &b_email_msg_id_len, "message-id") != 1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_msg_id, b_email_msg_id_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "message-id") != 1);
 }
 
 static int DetectMimeEmailXMailerSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -253,28 +165,13 @@ static int DetectMimeEmailXMailerSetup(DetectEngineCtx *de_ctx, Signature *s, co
     return 0;
 }
 
-static InspectionBuffer *GetMimeEmailXMailerData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetMimeEmailXMailerData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-
-        const uint8_t *b_email_x_mailer = NULL;
-        uint32_t b_email_x_mailer_len = 0;
-
-        if (tx->mime_state == NULL)
-            return NULL;
-
-        if (SCDetectMimeEmailGetData(
-                    tx->mime_state, &b_email_x_mailer, &b_email_x_mailer_len, "x-mailer") != 1)
-            return NULL;
-
-        InspectionBufferSetup(det_ctx, list_id, buffer, b_email_x_mailer, b_email_x_mailer_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mime_state == NULL)
+        return false;
+    return (SCDetectMimeEmailGetData(tx->mime_state, data, data_len, "x-mailer") != 1);
 }
 
 static int DetectMimeEmailUrlSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -43,38 +43,20 @@ int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direc
     return DetectBufferTypeRegister(name);
 }
 
-InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id,
-        bool (*GetBuf)(void *txv, const uint8_t flow_flags, const uint8_t **buf, uint32_t *buf_len))
-{
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        const uint8_t *b = NULL;
-        uint32_t b_len = 0;
-
-        if (!GetBuf(txv, flow_flags, &b, &b_len))
-            return NULL;
-
-        InspectionBufferSetupAndApplyTransforms(det_ctx, list_id, buffer, b, b_len, transforms);
-    }
-    return buffer;
-}
-
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionBufferGetDataPtr GetData)
+        uint8_t direction, DetectTxGetBufferPtr GetData)
 {
     if (direction & STREAM_TOSERVER) {
-        DetectAppLayerInspectEngineRegister(
+        DetectAppLayerInspectEngineRegisterSimple(
                 name, alproto, SIG_FLAG_TOSERVER, 0, DetectEngineInspectBufferGeneric, GetData);
-        DetectAppLayerMpmRegister(
-                name, SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister, GetData, alproto, 0);
+        DetectAppLayerMpmRegisterSimple(
+                name, SIG_FLAG_TOSERVER, 2, PrefilterSimpleMpmRegister, GetData, alproto, 0);
     }
     if (direction & STREAM_TOCLIENT) {
-        DetectAppLayerInspectEngineRegister(
+        DetectAppLayerInspectEngineRegisterSimple(
                 name, alproto, SIG_FLAG_TOCLIENT, 0, DetectEngineInspectBufferGeneric, GetData);
-        DetectAppLayerMpmRegister(
-                name, SIG_FLAG_TOCLIENT, 2, PrefilterGenericMpmRegister, GetData, alproto, 0);
+        DetectAppLayerMpmRegisterSimple(
+                name, SIG_FLAG_TOCLIENT, 2, PrefilterSimpleMpmRegister, GetData, alproto, 0);
     }
     DetectBufferTypeSetDescriptionByName(name, desc);
     return DetectBufferTypeGetByName(name);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -34,13 +34,8 @@ int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
 int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
 
-typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
-
-InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
-        const int list_id, SimpleGetTxBuffer GetBuf);
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionBufferGetDataPtr GetData);
+        uint8_t direction, DetectTxGetBufferPtr GetData);
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
 int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -87,6 +87,9 @@ typedef int (*PrefilterRegisterFunc)(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
 void DetectAppLayerMpmRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionBufferGetDataPtr GetData,
         AppProto alproto, int tx_min_progress);
+void DetectAppLayerMpmRegisterSimple(const char *name, int direction, int priority,
+        PrefilterRegisterFunc PrefilterRegister, DetectTxGetBufferPtr GetData, AppProto alproto,
+        int tx_min_progress);
 void DetectAppLayerMpmMultiRegister(const char *name, int direction, int priority,
         PrefilterRegisterFunc PrefilterRegister, InspectionMultiBufferGetDataPtr GetData,
         AppProto alproto, int tx_min_progress);

--- a/src/detect-engine-prefilter.c
+++ b/src/detect-engine-prefilter.c
@@ -1499,10 +1499,48 @@ const char *PrefilterStoreGetName(const uint32_t id)
 
 typedef struct PrefilterMpmCtx {
     int list_id;
-    InspectionBufferGetDataPtr GetData;
+    union {
+        InspectionBufferGetDataPtr GetData;
+        DetectTxGetBufferPtr GetDataSimple;
+    };
     const MpmCtx *mpm_ctx;
     const DetectEngineTransforms *transforms;
 } PrefilterMpmCtx;
+
+/** \brief Generic Mpm prefilter callback for simple DetectTxGetBufferPtr
+ *
+ *  \param det_ctx detection engine thread ctx
+ *  \param p packet to inspect
+ *  \param f flow to inspect
+ *  \param txv tx to inspect
+ *  \param pectx inspection context
+ */
+static void PrefilterMpmTxSimple(DetectEngineThreadCtx *det_ctx, const void *pectx, Packet *p,
+        Flow *f, void *txv, const uint64_t idx, const AppLayerTxData *_txd, const uint8_t flags)
+{
+    SCEnter();
+
+    const PrefilterMpmCtx *ctx = (const PrefilterMpmCtx *)pectx;
+    const MpmCtx *mpm_ctx = ctx->mpm_ctx;
+    SCLogDebug("running on list %d", ctx->list_id);
+
+    InspectionBuffer *buffer = DetectGetSingleData(
+            det_ctx, ctx->transforms, f, flags, txv, ctx->list_id, ctx->GetDataSimple);
+    if (buffer == NULL)
+        return;
+
+    const uint32_t data_len = buffer->inspect_len;
+    const uint8_t *data = buffer->inspect;
+
+    SCLogDebug("mpm'ing buffer:");
+    // PrintRawDataFp(stdout, data, data_len);
+
+    if (data != NULL && data_len >= mpm_ctx->minlen) {
+        (void)mpm_table[mpm_ctx->mpm_type].Search(
+                mpm_ctx, &det_ctx->mtc, &det_ctx->pmq, data, data_len);
+        PREFILTER_PROFILING_ADD_BYTES(det_ctx, data_len);
+    }
+}
 
 /** \brief Generic Mpm prefilter callback
  *
@@ -1521,8 +1559,7 @@ static void PrefilterMpm(DetectEngineThreadCtx *det_ctx, const void *pectx, Pack
     const MpmCtx *mpm_ctx = ctx->mpm_ctx;
     SCLogDebug("running on list %d", ctx->list_id);
 
-    InspectionBuffer *buffer = ctx->GetData(det_ctx, ctx->transforms,
-            f, flags, txv, ctx->list_id);
+    InspectionBuffer *buffer = ctx->GetData(det_ctx, ctx->transforms, f, flags, txv, ctx->list_id);
     if (buffer == NULL)
         return;
 
@@ -1559,6 +1596,26 @@ int PrefilterGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmC
     int r = PrefilterAppendTxEngine(de_ctx, sgh, PrefilterMpm,
         mpm_reg->app_v2.alproto, mpm_reg->app_v2.tx_min_progress,
         pectx, PrefilterGenericMpmFree, mpm_reg->pname);
+    if (r != 0) {
+        SCFree(pectx);
+    }
+    return r;
+}
+
+int PrefilterSimpleMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
+        const DetectBufferMpmRegistry *mpm_reg, int list_id)
+{
+    SCEnter();
+    PrefilterMpmCtx *pectx = SCCalloc(1, sizeof(*pectx));
+    if (pectx == NULL)
+        return -1;
+    pectx->list_id = list_id;
+    pectx->GetDataSimple = mpm_reg->app_v2.GetDataSimple;
+    pectx->mpm_ctx = mpm_ctx;
+    pectx->transforms = &mpm_reg->transforms;
+
+    int r = PrefilterAppendTxEngine(de_ctx, sgh, PrefilterMpmTxSimple, mpm_reg->app_v2.alproto,
+            mpm_reg->app_v2.tx_min_progress, pectx, PrefilterGenericMpmFree, mpm_reg->pname);
     if (r != 0) {
         SCFree(pectx);
     }

--- a/src/detect-engine-prefilter.h
+++ b/src/detect-engine-prefilter.h
@@ -97,6 +97,9 @@ void PrefilterDeinit(DetectEngineCtx *de_ctx);
 int PrefilterGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistry *mpm_reg, int list_id);
 
+int PrefilterSimpleMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
+        const DetectBufferMpmRegistry *mpm_reg, int list_id);
+
 int PrefilterMultiGenericMpmRegister(DetectEngineCtx *de_ctx, SigGroupHead *sgh, MpmCtx *mpm_ctx,
         const DetectBufferMpmRegistry *mpm_reg, int list_id);
 

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -151,6 +151,13 @@ uint8_t DetectEngineInspectBufferGeneric(DetectEngineCtx *de_ctx, DetectEngineTh
         const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
         void *alstate, void *txv, uint64_t tx_id);
 
+uint8_t DetectEngineInspectBufferSimple(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
+        const DetectEngineAppInspectionEngine *engine, const Signature *s, Flow *f, uint8_t flags,
+        void *alstate, void *txv, uint64_t tx_id);
+
+InspectionBuffer *DetectGetSingleData(struct DetectEngineThreadCtx_ *det_ctx,
+        const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
+        const int list_id, DetectTxGetBufferPtr GetBuf);
 InspectionBuffer *DetectGetMultiData(struct DetectEngineThreadCtx_ *det_ctx,
         const DetectEngineTransforms *transforms, Flow *f, const uint8_t flow_flags, void *txv,
         const int list_id, uint32_t index, InspectionMultiBufferGetDataPtr GetBuf);
@@ -175,6 +182,9 @@ int DetectEngineInspectPktBufferGeneric(
  */
 void DetectAppLayerInspectEngineRegister(const char *name, AppProto alproto, uint32_t dir,
         int progress, InspectEngineFuncPtr Callback2, InspectionBufferGetDataPtr GetData);
+
+void DetectAppLayerInspectEngineRegisterSimple(const char *name, AppProto alproto, uint32_t dir,
+        int progress, InspectEngineFuncPtr Callback2, DetectTxGetBufferPtr GetData);
 
 void DetectAppLayerMultiRegister(const char *name, AppProto alproto, uint32_t dir, int progress,
         InspectionMultiBufferGetDataPtr GetData, int priority);

--- a/src/detect-ftp-command-data.c
+++ b/src/detect-ftp-command-data.c
@@ -62,7 +62,7 @@ static int DetectFtpCommandDataSetup(DetectEngineCtx *de_ctx, Signature *s, cons
 }
 
 static bool DetectFTPCommandDataGetData(
-        void *txv, const uint8_t _flow_flags, const uint8_t **buffer, uint32_t *buffer_len)
+        const void *txv, const uint8_t _flow_flags, const uint8_t **buffer, uint32_t *buffer_len)
 {
     FTPTransaction *tx = (FTPTransaction *)txv;
 
@@ -86,14 +86,6 @@ static bool DetectFTPCommandDataGetData(
     return false;
 }
 
-static InspectionBuffer *GetDataWrapper(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *_f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
-{
-    return DetectHelperGetData(
-            det_ctx, transforms, _f, _flow_flags, txv, list_id, DetectFTPCommandDataGetData);
-}
-
 void DetectFtpCommandDataRegister(void)
 {
     /* ftp.command sticky buffer */
@@ -105,7 +97,7 @@ void DetectFtpCommandDataRegister(void)
     sigmatch_table[DETECT_FTP_COMMAND_DATA].flags |= SIGMATCH_NOOPT;
 
     DetectHelperBufferMpmRegister(
-            BUFFER_NAME, BUFFER_NAME, ALPROTO_FTP, STREAM_TOSERVER, GetDataWrapper);
+            BUFFER_NAME, BUFFER_DESC, ALPROTO_FTP, STREAM_TOSERVER, DetectFTPCommandDataGetData);
 
     DetectBufferTypeSetDescriptionByName(BUFFER_NAME, BUFFER_DESC);
 

--- a/src/detect-ftp-dynamic-port.c
+++ b/src/detect-ftp-dynamic-port.c
@@ -45,7 +45,6 @@
 #define KEYWORD_NAME "ftp.dynamic_port"
 #define KEYWORD_DOC  "ftp-keywords.html#ftp-dynamic_port"
 #define BUFFER_NAME  "ftp.dynamic_port"
-#define BUFFER_DESC  "ftp dynamic_port"
 
 static int g_ftp_dynport_buffer_id = 0;
 

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -28,6 +28,7 @@
 #include "detect-engine-buffer.h"
 #include "detect-engine-content-inspection.h"
 #include "detect-engine-helper.h"
+#include "detect-engine-prefilter.h"
 #include "detect-parse.h"
 #include "app-layer-smtp.h"
 #include "rust.h"
@@ -75,19 +76,15 @@ static int DetectSmtpMailFromSetup(DetectEngineCtx *de_ctx, Signature *s, const 
     return 0;
 }
 
-static InspectionBuffer *GetSmtpMailFromData(DetectEngineThreadCtx *det_ctx,
-        const DetectEngineTransforms *transforms, Flow *f, const uint8_t _flow_flags, void *txv,
-        const int list_id)
+static bool GetSmtpMailFromData(
+        const void *txv, const uint8_t _flow_flags, const uint8_t **data, uint32_t *data_len)
 {
-    InspectionBuffer *buffer = InspectionBufferGet(det_ctx, list_id);
-    if (buffer->inspect == NULL) {
-        SMTPTransaction *tx = (SMTPTransaction *)txv;
-        if (tx->mail_from == NULL || tx->mail_from_len == 0)
-            return NULL;
-        InspectionBufferSetup(det_ctx, list_id, buffer, tx->mail_from, tx->mail_from_len);
-        InspectionBufferApplyTransforms(det_ctx, buffer, transforms);
-    }
-    return buffer;
+    SMTPTransaction *tx = (SMTPTransaction *)txv;
+    if (tx->mail_from == NULL)
+        return false;
+    *data = tx->mail_from;
+    *data_len = tx->mail_from_len;
+    return true;
 }
 
 static int DetectSmtpRcptToSetup(DetectEngineCtx *de_ctx, Signature *s, const char *arg)
@@ -137,8 +134,12 @@ void SCDetectSMTPRegister(void)
     kw.Setup = DetectSmtpHeloSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_smtp_helo_buffer_id = DetectHelperBufferMpmRegister(
-            "smtp.helo", "SMTP helo", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpHeloData);
+    DetectAppLayerInspectEngineRegister("smtp.helo", ALPROTO_SMTP, SIG_FLAG_TOSERVER, 0,
+            DetectEngineInspectBufferGeneric, GetSmtpHeloData);
+    DetectAppLayerMpmRegister("smtp.helo", SIG_FLAG_TOSERVER, 2, PrefilterGenericMpmRegister,
+            GetSmtpHeloData, ALPROTO_SMTP, 0);
+    DetectBufferTypeSetDescriptionByName("smtp.helo", "SMTP helo");
+    g_smtp_helo_buffer_id = DetectBufferTypeGetByName("smtp.helo");
 
     kw.name = "smtp.mail_from";
     kw.desc = "SMTP mail from buffer";

--- a/src/detect.h
+++ b/src/detect.h
@@ -424,6 +424,9 @@ typedef InspectionBuffer *(*InspectionBufferGetDataPtr)(
         Flow *f, const uint8_t flow_flags,
         void *txv, const int list_id);
 
+typedef bool (*DetectTxGetBufferPtr)(
+        const void *txv, const uint8_t flow_flags, const uint8_t **buf, uint32_t *buf_len);
+
 typedef bool (*InspectionMultiBufferGetDataPtr)(struct DetectEngineThreadCtx_ *det_ctx,
         const void *txv, const uint8_t flow_flags, uint32_t local_id, const uint8_t **buf,
         uint32_t *buf_len);
@@ -449,6 +452,7 @@ typedef struct DetectEngineAppInspectionEngine_ {
     struct {
         union {
             InspectionBufferGetDataPtr GetData;
+            DetectTxGetBufferPtr GetDataSimple;
             InspectionMultiBufferGetDataPtr GetMultiData;
         };
         InspectEngineFuncPtr Callback;
@@ -781,6 +785,7 @@ typedef struct DetectBufferMpmRegistry_ {
         struct {
             union {
                 InspectionBufferGetDataPtr GetData;
+                DetectTxGetBufferPtr GetDataSimple;
                 InspectionMultiBufferGetDataPtr GetMultiData;
             };
             AppProto alproto;


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket, this is a cleanup

Describe changes:
- detect/singlebuf : introduce a new simpler callback prototype `DetectTxGetBufferPtr` whose goal is to replace `InspectionBufferGetDataPtr` for most cases
- `DetectHelperBufferMpmRegister` uses that new callback prototype. It will be used by new function `DetectGetSingleData` which checks if inspection buffer is already cached, and applies the transforms
- remove `DetectHelperGetData` and one layer of callbacks for all rust keywords and the C ones that used it

The core change is 
`const InspectionBuffer *buffer = DetectGetSingleData(det_ctx, transforms, f, flags, txv, list_id, engine->v2.GetDataSimple);` 
instead of 
`const InspectionBuffer *buffer = engine->v2.GetData(det_ctx, transforms, f, flags, txv, list_id);`

Continuation of https://github.com/OISF/suricata/pull/13104 and #13083 

Still to do afterwards : convert more keywords to rust and `DetectHelperBufferMpmRegister`