### PR TITLE
detect: fix SCTime_t -Wshorten-64-to-32 warnings

### DIFF
--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -82,7 +82,7 @@ void ThresholdDestroy(void)
 typedef struct ThresholdEntry_ {
     uint32_t key[5];
 
-    uint32_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
+    uint64_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
                                  its not "seconds", that define the time interval */
     uint32_t seconds;       /**< Event seconds */
     uint32_t current_count; /**< Var for count control */

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -79,8 +79,8 @@ typedef struct DetectTagDataEntry_ {
         uint32_t packets;               /**< number of packets (metric packets) */
         uint32_t bytes;                 /**< number of bytes (metric bytes) */
     };
-    uint32_t first_ts;                  /**< First time seen (for metric = seconds) */
-    uint32_t last_ts;                   /**< Last time seen (to prune old sessions) */
+    uint64_t first_ts; /**< First time seen (for metric = seconds) */
+    uint64_t last_ts;  /**< Last time seen (to prune old sessions) */
 #if __WORDSIZE == 64
     uint32_t pad1;
 #endif

--- a/src/host-bit.c
+++ b/src/host-bit.c
@@ -91,7 +91,7 @@ static XBit *HostBitGet(Host *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void HostBitAdd(Host *h, uint32_t idx, uint32_t expire)
+static void HostBitAdd(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void HostBitRemove(Host *h, uint32_t idx)
     }
 }
 
-void HostBitSet(Host *h, uint32_t idx, uint32_t expire)
+void HostBitSet(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void HostBitUnset(Host *h, uint32_t idx)
     }
 }
 
-void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
+void HostBitToggle(Host *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
@@ -154,7 +154,7 @@ void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsset(Host *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
@@ -167,7 +167,7 @@ int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int HostBitIsnotset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsnotset(Host *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {

--- a/src/host-bit.h
+++ b/src/host-bit.h
@@ -33,11 +33,11 @@ void HostBitRegisterTests(void);
 int HostHasHostBits(Host *host);
 int HostBitsTimedoutCheck(Host *h, SCTime_t ts);
 
-void HostBitSet(Host *, uint32_t, uint32_t);
+void HostBitSet(Host *, uint32_t, uint64_t);
 void HostBitUnset(Host *, uint32_t);
-void HostBitToggle(Host *, uint32_t, uint32_t);
-int HostBitIsset(Host *, uint32_t, uint32_t);
-int HostBitIsnotset(Host *, uint32_t, uint32_t);
+void HostBitToggle(Host *, uint32_t, uint64_t);
+int HostBitIsset(Host *, uint32_t, uint64_t);
+int HostBitIsnotset(Host *, uint32_t, uint64_t);
 int HostBitList(Host *, XBit **);
 
 #endif /* SURICATA_HOST_BIT_H */

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -91,7 +91,7 @@ static XBit *IPPairBitGet(IPPair *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void IPPairBitAdd(IPPair *h, uint32_t idx, uint32_t expire)
+static void IPPairBitAdd(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void IPPairBitRemove(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitSet(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitSet(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void IPPairBitUnset(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitToggle(IPPair *h, uint32_t idx, uint64_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
@@ -154,7 +154,7 @@ void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsset(IPPair *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
@@ -168,7 +168,7 @@ int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int IPPairBitIsnotset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsnotset(IPPair *h, uint32_t idx, uint64_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {

--- a/src/ippair-bit.h
+++ b/src/ippair-bit.h
@@ -32,10 +32,10 @@ void IPPairBitRegisterTests(void);
 int IPPairHasBits(IPPair *host);
 int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts);
 
-void IPPairBitSet(IPPair *, uint32_t, uint32_t);
+void IPPairBitSet(IPPair *, uint32_t, uint64_t);
 void IPPairBitUnset(IPPair *, uint32_t);
-void IPPairBitToggle(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsset(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsnotset(IPPair *, uint32_t, uint32_t);
+void IPPairBitToggle(IPPair *, uint32_t, uint64_t);
+int IPPairBitIsset(IPPair *, uint32_t, uint64_t);
+int IPPairBitIsnotset(IPPair *, uint32_t, uint64_t);
 
 #endif /* SURICATA_IPPAIR_BIT_H */

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -1428,7 +1428,7 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data_unused)
 
     struct Bit {
         uint32_t id;
-        uint32_t expire;
+        uint64_t expire;
     } bits[256];
     memset(&bits, 0, sizeof(bits));
     int i = 0, use = 0;
@@ -1463,7 +1463,7 @@ TmEcode UnixSocketHostbitList(json_t *cmd, json_t* answer, void *data_unused)
         json_t *bitobject = json_object();
         if (bitobject == NULL)
             continue;
-        uint32_t expire = 0;
+        uint64_t expire = 0;
         if ((uint32_t)SCTIME_SECS(ts) < bits[i].expire)
             expire = bits[i].expire - (uint32_t)SCTIME_SECS(ts);
 

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -60,7 +60,7 @@ typedef struct XBit_ {
     uint8_t pad[2];
     uint32_t idx;       /* name idx */
     GenericVar *next;
-    uint32_t expire;
+    uint64_t expire;
 } XBit;
 
 void XBitFree(XBit *);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix SCTime_t `-Wshorten-64-to-32` warnings for remaining files : detect

@jlucovsky how does that look to you ? (as you did 31793aface5 )

#13159 next iteration with new warnings getting fixed

Still to do afterwards :
- fix other detect warnings
- CI check
