### PR TITLE
eve: add ip version field - v1

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -54,6 +54,10 @@
         "in_iface": {
             "type": "string"
         },
+        "ip_v": {
+            "type": "integer",
+            "description": "IP version of the packet or flow"
+        },
         "log_level": {
             "type": "string"
         },

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -143,6 +143,13 @@ static SCJsonBuilder *CreateEveHeaderFromFlow(const Flow *f)
             break;
     }
 
+    /* ip version */
+    if (FLOW_IS_IPV4(f)) {
+        SCJbSetUint(jb, "ip_v", 4);
+    } else if (FLOW_IS_IPV6(f)) {
+        SCJbSetUint(jb, "ip_v", 6);
+    }
+
     if (SCProtoNameValid(f->proto)) {
         SCJbSetString(jb, "proto", known_proto[f->proto]);
     } else {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -902,6 +902,13 @@ SCJsonBuilder *CreateEveHeader(const Packet *p, enum SCOutputJsonLogDirection di
         SCJbSetString(js, "proto", addr->proto);
     }
 
+    /* ip version */
+    if (PacketIsIPv4(p)) {
+        SCJbSetUint(js, "ip_v", 4);
+    } else if (PacketIsIPv6(p)) {
+        SCJbSetUint(js, "ip_v", 6);
+    }
+
     /* icmp */
     switch (p->proto) {
         case IPPROTO_ICMP:


### PR DESCRIPTION
Adds the field `ip_v` (integer) to the common fields of EVE. To facilitate searches based on IP version, for instance.

Task #7047

## Changes (if applicable):
- [ ] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7047

Describe changes:
- add field `ip_v` (integer) to common fields / header of EVE

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2498