### PR TITLE
github-ci: use current directory for unit test logging

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2829,7 +2829,7 @@ jobs:
       - name: Run
         run: |
           ./src/suricata --build-info
-          ./src/suricata -u -l /tmp/
+          ./src/suricata -u -l .
           # need cwd in path due to npcap dlls (see above)
           PATH="$PATH:$(pwd)" python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
@@ -2877,7 +2877,7 @@ jobs:
       - name: Run
         run: |
           ./src/suricata --build-info
-          ./src/suricata -u -l /tmp/
+          ./src/suricata -u -l .
           python3 ./suricata-verify/run.py -q --debug-failed
       - run: make install
       - run: suricata-update -V


### PR DESCRIPTION
/tmp appears to exist when you make it, but doesn't appear to actually
exist after msys translation, so just use "."
