### PR TITLE
pgsql: add initial support to CopyIn mode/ subprotocol - v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -2538,6 +2538,10 @@ flow. Some of the possible request messages are:
   transaction where the query was sent.
 * "message": requests which do not have meaningful payloads are logged like this,
   where the field value is the message type
+* "copy_data_in": object. Part of the CopyIn subprotocol, consolidated data
+  resulting from a ``Copy From Stdin`` query
+* "copy_done": string. Similar to ``command_completed`` but sent after the
+  frontend finishes sending a batch of ``CopyData`` messages
 
 There are several different authentication messages possible, based on selected
 authentication method. (e.g. the SASL authentication will have a set of
@@ -2564,6 +2568,8 @@ pgsql flow. Some of the possible request messages are:
 * "data_size": in bytes. When one or many ``DataRow`` messages are parsed, the
   total size in bytes of the data returned
 * "command_completed": string. Informs the command just completed by the backend
+* "copy_in_response": object. Indicates the beginning of a CopyIn mode, shows
+  how many columns will be copied from STDIN (``copy_column_cnt`` field)
 * "copy_out_response": object. Indicates the beginning of a CopyTo mode, shows
   how many columns will be copied to STDOUT (``copy_column_cnt`` field)
 * "copy_data_out": object. Consolidated data on the CopyData sent by the backend

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3741,12 +3741,15 @@
                         },
                         "copy_data_out": {
                             "type": "object",
+                            "description": "CopyData message from CopyOut mode",
                             "properties": {
                                 "row_count": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of rows sent in CopyData messages"
                                 },
                                 "data_size": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "accumulated data size of all CopyData messages sent"
                                 }
                             }
                         },
@@ -3831,9 +3834,11 @@
                         },
                         "copy_out_response": {
                             "type": "object",
+                            "description": "backend/server response accepting CopyOut mode",
                             "properties": {
                                 "copy_column_count": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of columns that will be copied in the CopyData message"
                                 }
                             }
                         },

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -3654,6 +3654,20 @@
                 "request": {
                     "type": "object",
                     "properties": {
+                        "copy_data_in": {
+                            "type": "object",
+                            "description": "CopyData message from CopyIn mode",
+                            "properties": {
+                                "msg_count": {
+                                    "type": "integer",
+                                    "description": "how many CopyData messages were sent (does not necessarily match number of rows from the query)"
+                                },
+                                "data_size": {
+                                    "type": "integer",
+                                    "description": "accumulated data size of all CopyData messages sent"
+                                }
+                            }
+                        },
                         "message": {
                             "type": "string"
                         },
@@ -3831,6 +3845,16 @@
                         },
                         "severity_non_localizable": {
                             "type": "string"
+                        },
+                        "copy_in_response": {
+                            "type": "object",
+                            "description": "backend/server response accepting CopyIn mode",
+                            "properties": {
+                                "copy_column_count": {
+                                    "type": "integer",
+                                    "description": "number of columns that will be copied in the CopyData message"
+                                }
+                            }
                         },
                         "copy_out_response": {
                             "type": "object",

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -209,7 +209,7 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
         }) => {
             // We take care of these elsewhere
         }
-        PgsqlBEMessage::CopyOutResponse(CopyOutResponse {
+        PgsqlBEMessage::CopyOutResponse(CopyResponse {
             identifier: _,
             length: _,
             column_cnt,

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -100,6 +100,11 @@ fn log_request(req: &PgsqlFEMessage, flags: u32, js: &mut JsonBuilder) -> Result
             identifier: _,
             length: _,
             payload,
+        })
+        | PgsqlFEMessage::CopyFail(RegularPacket {
+            identifier: _,
+            length: _,
+            payload,
         }) => {
             js.set_string_from_bytes(req.to_str(), payload)?;
         }
@@ -108,10 +113,18 @@ fn log_request(req: &PgsqlFEMessage, flags: u32, js: &mut JsonBuilder) -> Result
             js.set_uint("process_id", *pid)?;
             js.set_uint("secret_key", *backend_key)?;
         }
-        PgsqlFEMessage::Terminate(NoPayloadMessage {
+        PgsqlFEMessage::ConsolidatedCopyDataIn(ConsolidatedDataRowPacket {
             identifier: _,
-            length: _,
+            row_cnt,
+            data_size,
         }) => {
+            js.open_object(req.to_str())?;
+            js.set_uint("msg_count", *row_cnt)?;
+            js.set_uint("data_size", *data_size)?;
+            js.close()?;
+        }
+        PgsqlFEMessage::CopyDone(_)
+        | PgsqlFEMessage::Terminate(_) => {
             js.set_string("message", req.to_str())?;
         }
         PgsqlFEMessage::UnknownMessageType(RegularPacket {
@@ -215,6 +228,11 @@ fn log_response(res: &PgsqlBEMessage, jb: &mut JsonBuilder) -> Result<(), JsonEr
             // We take care of these elsewhere
         }
         PgsqlBEMessage::CopyOutResponse(CopyResponse {
+            identifier: _,
+            length: _,
+            column_cnt,
+        })
+        | PgsqlBEMessage::CopyInResponse(CopyResponse {
             identifier: _,
             length: _,
             column_cnt,

--- a/rust/src/pgsql/logger.rs
+++ b/rust/src/pgsql/logger.rs
@@ -29,8 +29,15 @@ pub const PGSQL_LOG_PASSWORDS: u32 = BIT_U32!(0);
 fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
     js.open_object("pgsql")?;
     js.set_uint("tx_id", tx.tx_id)?;
-    if let Some(request) = &tx.request {
-        js.set_object("request", &log_request(request, flags)?)?;
+    if !tx.requests.is_empty() {
+        // For now, even if 'requests' is an array, we don't need to log it as such, as
+        // there are no duplicated messages
+        js.open_object("request")?;
+        for request in &tx.requests {
+            SCLogNotice!("Suricata requests length: {}", tx.requests.len());
+            log_request(request, flags, js)?;
+        }
+        js.close()?;
     } else if tx.responses.is_empty() {
         SCLogDebug!("Suricata created an empty PGSQL transaction");
         // TODO Log anomaly event?
@@ -48,8 +55,7 @@ fn log_pgsql(tx: &PgsqlTransaction, flags: u32, js: &mut JsonBuilder) -> Result<
     Ok(())
 }
 
-fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonError> {
-    let mut js = JsonBuilder::try_new_object()?;
+fn log_request(req: &PgsqlFEMessage, flags: u32, js: &mut JsonBuilder) -> Result<(), JsonError> {
     match req {
         PgsqlFEMessage::StartupMessage(StartupPacket {
             length: _,
@@ -116,8 +122,7 @@ fn log_request(req: &PgsqlFEMessage, flags: u32) -> Result<JsonBuilder, JsonErro
             // We don't want to log these, for now. Cf redmine: #6576
         }
     }
-    js.close()?;
-    Ok(js)
+    Ok(())
 }
 
 fn log_response_object(tx: &PgsqlTransaction) -> Result<JsonBuilder, JsonError> {

--- a/rust/src/pgsql/parser.rs
+++ b/rust/src/pgsql/parser.rs
@@ -269,7 +269,7 @@ pub struct NotificationResponse {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct CopyOutResponse {
+pub struct CopyResponse {
     pub identifier: u8,
     pub length: u32,
     pub column_cnt: u16,
@@ -298,7 +298,7 @@ pub enum PgsqlBEMessage {
     ParameterStatus(ParameterStatusMessage),
     BackendKeyData(BackendKeyDataMessage),
     CommandComplete(RegularPacket),
-    CopyOutResponse(CopyOutResponse),
+    CopyOutResponse(CopyResponse),
     ConsolidatedCopyDataOut(ConsolidatedDataRowPacket),
     CopyDone(NoPayloadMessage),
     ReadyForQuery(ReadyForQueryMessage),
@@ -1041,7 +1041,7 @@ pub fn parse_copy_out_response(i: &[u8]) -> IResult<&[u8], PgsqlBEMessage, Pgsql
     let (i, _formats) = many_m_n(0, columns.to_usize(), be_u16)(i)?;
     Ok((
         i,
-        PgsqlBEMessage::CopyOutResponse(CopyOutResponse {
+        PgsqlBEMessage::CopyOutResponse(CopyResponse {
             identifier,
             length,
             column_cnt: columns,

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -635,14 +635,14 @@ impl PgsqlState {
                                 && tx.get_row_cnt() > 0
                             {
                                 // let's summarize the info from the data_rows in one response
-                                let dummy_resp = PgsqlBEMessage::ConsolidatedDataRow(
+                                let consolidated_data_row = PgsqlBEMessage::ConsolidatedDataRow(
                                     ConsolidatedDataRowPacket {
                                         identifier: b'D',
                                         row_cnt: tx.get_row_cnt(),
                                         data_size: tx.data_size, // total byte count of all data_row messages combined
                                     },
                                 );
-                                tx.responses.push(dummy_resp);
+                                tx.responses.push(consolidated_data_row);
                                 tx.responses.push(response);
                                 // reset values
                                 tx.data_row_cnt = 0;
@@ -651,14 +651,14 @@ impl PgsqlState {
                                 tx.incr_row_cnt();
                             } else if state == PgsqlStateProgress::CopyDoneReceived && tx.get_row_cnt() > 0 {
                                 // let's summarize the info from the data_rows in one response
-                                let dummy_resp = PgsqlBEMessage::ConsolidatedCopyDataOut(
+                                let consolidated_copy_data = PgsqlBEMessage::ConsolidatedCopyDataOut(
                                     ConsolidatedDataRowPacket {
                                         identifier: b'd',
                                         row_cnt: tx.get_row_cnt(),
                                         data_size: tx.data_size, // total byte count of all data_row messages combined
                                     },
                                 );
-                                tx.responses.push(dummy_resp);
+                                tx.responses.push(consolidated_copy_data);
                                 tx.responses.push(response);
                                 // reset values
                                 tx.data_row_cnt = 0;

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -60,7 +60,7 @@ pub struct PgsqlTransaction {
     pub tx_id: u64,
     pub tx_req_state: PgsqlTxProgress,
     pub tx_res_state: PgsqlTxProgress,
-    pub request: Option<PgsqlFEMessage>,
+    pub requests: Vec<PgsqlFEMessage>,
     pub responses: Vec<PgsqlBEMessage>,
 
     pub data_row_cnt: u64,
@@ -87,7 +87,7 @@ impl PgsqlTransaction {
             tx_id: 0,
             tx_req_state: PgsqlTxProgress::TxInit,
             tx_res_state: PgsqlTxProgress::TxInit,
-            request: None,
+            requests: Vec::<PgsqlFEMessage>::new(),
             responses: Vec::<PgsqlBEMessage>::new(),
             data_row_cnt: 0,
             data_size: 0,
@@ -380,7 +380,7 @@ impl PgsqlState {
                     // https://samadhiweb.com/blog/2013.04.28.graphviz.postgresv3.html
                     if let Some(tx) = self.find_or_create_tx() {
                         tx.tx_data.updated_ts = true;
-                        tx.request = Some(request);
+                        tx.requests.push(request);
                         if let Some(state) = new_state {
                             if Self::request_is_complete(state) {
                                 // The request is always complete at this point

--- a/rust/src/pgsql/pgsql.rs
+++ b/rust/src/pgsql/pgsql.rs
@@ -123,7 +123,11 @@ pub enum PgsqlStateProgress {
     // Related to Backend-received messages //
     CopyOutResponseReceived,
     CopyDataOutReceived,
+    CopyInResponseReceived,
+    FirstCopyDataInReceived,
+    ConsolidatingCopyDataIn,
     CopyDoneReceived,
+    CopyFailReceived,
     SSLRejectedReceived,
     // SSPIAuthenticationReceived, // TODO implement
     SASLAuthenticationReceived,
@@ -257,6 +261,7 @@ impl PgsqlState {
             || self.state_progress == PgsqlStateProgress::SSLRequestReceived
             || self.state_progress == PgsqlStateProgress::ConnectionTerminated
             || self.state_progress == PgsqlStateProgress::CancelRequestReceived
+            || self.state_progress == PgsqlStateProgress::FirstCopyDataInReceived
         {
             let tx = self.new_tx();
             self.transactions.push_back(tx);
@@ -266,13 +271,17 @@ impl PgsqlState {
         return self.transactions.back_mut();
     }
 
+    fn get_curr_state(&mut self) -> PgsqlStateProgress {
+        self.state_progress
+    }
+
     /// Define PgsqlState progression, based on the request received
     ///
     /// As PostgreSQL transactions can have multiple messages, State progression
     /// is what helps us keep track of the PgsqlTransactions - when one finished
     /// when the other starts.
     /// State isn't directly updated to avoid reference borrowing conflicts.
-    fn request_next_state(request: &PgsqlFEMessage) -> Option<PgsqlStateProgress> {
+    fn request_next_state(&mut self, request: &PgsqlFEMessage) -> Option<PgsqlStateProgress> {
         match request {
             PgsqlFEMessage::SSLRequest(_) => Some(PgsqlStateProgress::SSLRequestReceived),
             PgsqlFEMessage::StartupMessage(_) => Some(PgsqlStateProgress::StartupMessageReceived),
@@ -288,6 +297,22 @@ impl PgsqlState {
 
                 // Important to keep in mind that: "In simple Query mode, the format of retrieved values is always text, except when the given command is a FETCH from a cursor declared with the BINARY option. In that case, the retrieved values are in binary format. The format codes given in the RowDescription message tell which format is being used." (from pgsql official documentation)
             }
+            PgsqlFEMessage::ConsolidatedCopyDataIn(_) => {
+                match self.get_curr_state() {
+                    PgsqlStateProgress::FirstCopyDataInReceived
+                    | PgsqlStateProgress::ConsolidatingCopyDataIn => {
+                        return Some(PgsqlStateProgress::ConsolidatingCopyDataIn);
+                    }
+                    PgsqlStateProgress::CopyInResponseReceived => {
+                        return Some(PgsqlStateProgress::FirstCopyDataInReceived);
+                    }
+                    _ => {
+                        return Some(PgsqlStateProgress::ConsolidatingCopyDataIn);
+                    }
+                }
+            }
+            PgsqlFEMessage::CopyDone(_) => Some(PgsqlStateProgress::CopyDoneReceived),
+            PgsqlFEMessage::CopyFail(_) => Some(PgsqlStateProgress::CopyFailReceived),
             PgsqlFEMessage::CancelRequest(_) => Some(PgsqlStateProgress::CancelRequestReceived),
             PgsqlFEMessage::Terminate(_) => {
                 SCLogDebug!("Match: Terminate message");
@@ -330,6 +355,8 @@ impl PgsqlState {
             | PgsqlStateProgress::SASLInitialResponseReceived
             | PgsqlStateProgress::SASLResponseReceived
             | PgsqlStateProgress::CancelRequestReceived
+            | PgsqlStateProgress::CopyDoneReceived
+            | PgsqlStateProgress::CopyFailReceived
             | PgsqlStateProgress::ConnectionTerminated => true,
             _ => false,
         }
@@ -364,7 +391,7 @@ impl PgsqlState {
             match PgsqlState::state_based_req_parsing(self.state_progress, start) {
                 Ok((rem, request)) => {
                     start = rem;
-                    let new_state = PgsqlState::request_next_state(&request);
+                    let new_state = self.request_next_state(&request);
 
                     if let Some(state) = new_state {
                         self.state_progress = state;
@@ -380,10 +407,31 @@ impl PgsqlState {
                     // https://samadhiweb.com/blog/2013.04.28.graphviz.postgresv3.html
                     if let Some(tx) = self.find_or_create_tx() {
                         tx.tx_data.updated_ts = true;
-                        tx.requests.push(request);
                         if let Some(state) = new_state {
-                            if Self::request_is_complete(state) {
-                                // The request is always complete at this point
+                            if state == PgsqlStateProgress::FirstCopyDataInReceived
+                            || state == PgsqlStateProgress::ConsolidatingCopyDataIn {
+                                // here we're actually only counting how many messages were received.
+                                // frontends are not forced to send one row per message
+                                if let PgsqlFEMessage::ConsolidatedCopyDataIn(msg) = request {
+                                    tx.sum_data_size(msg.data_size);
+                                    tx.incr_row_cnt();
+                                }
+                            } else if state == PgsqlStateProgress::CopyDoneReceived && tx.get_row_cnt() > 0 {
+                                let consolidated_copy_data = PgsqlFEMessage::ConsolidatedCopyDataIn(
+                                    ConsolidatedDataRowPacket {
+                                        identifier: b'd',
+                                        row_cnt: tx.get_row_cnt(),
+                                        data_size: tx.data_size, // total byte count of all copy_data messages combined
+                                    },
+                                );
+                                tx.requests.push(consolidated_copy_data);
+                                tx.requests.push(request);
+                                // reset values
+                                tx.data_row_cnt = 0;
+                                tx.data_size = 0;
+                            } else if Self::request_is_complete(state) {
+                                tx.requests.push(request);
+                                // The request is complete at this point
                                 tx.tx_req_state = PgsqlTxProgress::TxDone;
                                 if state == PgsqlStateProgress::ConnectionTerminated
                                     || state == PgsqlStateProgress::CancelRequestReceived
@@ -491,6 +539,7 @@ impl PgsqlState {
             }
             PgsqlBEMessage::RowDescription(_) => Some(PgsqlStateProgress::RowDescriptionReceived),
             PgsqlBEMessage::CopyOutResponse(_) => Some(PgsqlStateProgress::CopyOutResponseReceived),
+            PgsqlBEMessage::CopyInResponse(_) => Some(PgsqlStateProgress::CopyInResponseReceived),
             PgsqlBEMessage::ConsolidatedDataRow(msg) => {
                 // Increment tx.data_size here, since we know msg type, so that we can later on log that info
                 self.transactions.back_mut()?.sum_data_size(msg.data_size);
@@ -541,6 +590,7 @@ impl PgsqlState {
             | PgsqlStateProgress::SASLAuthenticationReceived
             | PgsqlStateProgress::SASLAuthenticationContinueReceived
             | PgsqlStateProgress::SASLAuthenticationFinalReceived
+            | PgsqlStateProgress::CopyInResponseReceived
             | PgsqlStateProgress::Finished => true,
             _ => false,
         }


### PR DESCRIPTION
## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [x] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes (including schema descriptions)

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7645

Previous PR: https://github.com/OISF/suricata/pull/13134

Describe changes: Took feedback into consideration, to some extent:
- remove commit related to `password_message` clean-up
- rename `dummy_*` variables, use something more descriptive
- remove TODO comments -- moved this to a ticket
- add comment to indicate why we don't need `requests` to be logged as an array, yet (also because this should come with log v2, so trying to keep efforts separated, as much as possible)
- rebase

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2504