### PR TITLE
detect: fix SCTime_t -Wshorten-64-to-32 warnings

### DIFF
--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -150,7 +150,7 @@ int TagFlowAdd(Packet *p, DetectTagDataEntry *tde)
         if (new_tde != NULL) {
             new_tde->next = FlowGetStorageById(p->flow, flow_tag_id);
             FlowSetStorageById(p->flow, flow_tag_id, new_tde);
-            SCLogDebug("adding tag with first_ts %u", new_tde->first_ts);
+            SCLogDebug("adding tag with first_ts %" PRIu64, (uint64_t)new_tde->first_ts.secs);
             (void) SC_ATOMIC_ADD(num_tags, 1);
         }
     } else if (tag_cnt == DETECT_TAG_MAX_TAGS) {
@@ -254,7 +254,7 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
 
     while (iter != NULL) {
         /* update counters */
-        iter->last_ts = SCTIME_SECS(p->ts);
+        iter->last_ts = p->ts;
         switch (iter->metric) {
             case DETECT_TAG_METRIC_PACKET:
                 iter->packets++;
@@ -329,10 +329,11 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
                 case DETECT_TAG_METRIC_SECONDS:
                     /* last_ts handles this metric, but also a generic time based
                      * expiration to prevent dead sessions/hosts */
-                    if (iter->last_ts - iter->first_ts > iter->count) {
-                        SCLogDebug("flow tag expired: %u - %u = %u > %u",
-                            iter->last_ts, iter->first_ts,
-                            (iter->last_ts - iter->first_ts), iter->count);
+                    if (iter->last_ts.secs - iter->first_ts.secs > iter->count) {
+                        // cast needed as gcc and clang behave differently
+                        SCLogDebug("flow tag expired: %" PRIu64 " - %" PRIu64 " = %" PRIu64 " > %u",
+                                (uint64_t)iter->last_ts.secs, (uint64_t)iter->first_ts.secs,
+                                (uint64_t)(iter->last_ts.secs - iter->first_ts.secs), iter->count);
                         /* tag expired */
                         if (prev != NULL) {
                             tde = iter;
@@ -376,7 +377,7 @@ static void TagHandlePacketHost(Host *host, Packet *p)
     prev = NULL;
     while (iter != NULL) {
         /* update counters */
-        iter->last_ts = SCTIME_SECS(p->ts);
+        iter->last_ts = p->ts;
         switch (iter->metric) {
             case DETECT_TAG_METRIC_PACKET:
                 iter->packets++;
@@ -448,10 +449,10 @@ static void TagHandlePacketHost(Host *host, Packet *p)
                 case DETECT_TAG_METRIC_SECONDS:
                     /* last_ts handles this metric, but also a generic time based
                      * expiration to prevent dead sessions/hosts */
-                    if (iter->last_ts - iter->first_ts > iter->count) {
-                        SCLogDebug("host tag expired: %u - %u = %u > %u",
-                            iter->last_ts, iter->first_ts,
-                            (iter->last_ts - iter->first_ts), iter->count);
+                    if (iter->last_ts.secs - iter->first_ts.secs > iter->count) {
+                        SCLogDebug("host tag expired: %" PRIu64 " - %" PRIu64 " = %" PRIu64 " > %u",
+                                (uint64_t)iter->last_ts.secs, (uint64_t)iter->first_ts.secs,
+                                (uint64_t)(iter->last_ts.secs - iter->first_ts.secs), iter->count);
                         /* tag expired */
                         if (prev != NULL) {
                             tde = iter;
@@ -568,7 +569,7 @@ int TagTimeoutCheck(Host *host, SCTime_t ts)
 
     prev = NULL;
     while (tmp != NULL) {
-        SCTime_t timeout_at = SCTIME_FROM_SECS(tmp->last_ts + TAG_MAX_LAST_TIME_SEEN);
+        SCTime_t timeout_at = SCTIME_ADD_SECS(tmp->last_ts, TAG_MAX_LAST_TIME_SEEN);
         if (SCTIME_CMP_GTE(timeout_at, ts)) {
             prev = tmp;
             tmp = tmp->next;

--- a/src/detect-engine-threshold.c
+++ b/src/detect-engine-threshold.c
@@ -82,7 +82,7 @@ void ThresholdDestroy(void)
 typedef struct ThresholdEntry_ {
     uint32_t key[5];
 
-    uint32_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
+    uint64_t tv_timeout;    /**< Timeout for new_action (for rate_filter)
                                  its not "seconds", that define the time interval */
     uint32_t seconds;       /**< Event seconds */
     uint32_t current_count; /**< Var for count control */

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -107,7 +107,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_src);
 
-            HostBitToggle(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitToggle(p->host_src, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -119,7 +119,7 @@ static int DetectHostbitMatchToggle (Packet *p, const DetectXbitsData *fd)
             else
                 HostLock(p->host_dst);
 
-            HostBitToggle(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitToggle(p->host_dst, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
             HostUnlock(p->host_dst);
             break;
     }
@@ -167,7 +167,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            HostBitSet(p->host_src, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitSet(p->host_src, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
             HostUnlock(p->host_src);
             break;
         case DETECT_XBITS_TRACK_IPDST:
@@ -178,7 +178,7 @@ static int DetectHostbitMatchSet (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            HostBitSet(p->host_dst, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+            HostBitSet(p->host_dst, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
             HostUnlock(p->host_dst);
             break;
     }
@@ -197,7 +197,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsset(p->host_src, fd->idx, p->ts);
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -208,7 +208,7 @@ static int DetectHostbitMatchIsset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsset(p->host_dst, fd->idx, p->ts);
             HostUnlock(p->host_dst);
             return r;
     }
@@ -227,7 +227,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_src);
 
-            r = HostBitIsnotset(p->host_src, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsnotset(p->host_src, fd->idx, p->ts);
             HostUnlock(p->host_src);
             return r;
         case DETECT_XBITS_TRACK_IPDST:
@@ -238,7 +238,7 @@ static int DetectHostbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
             } else
                 HostLock(p->host_dst);
 
-            r = HostBitIsnotset(p->host_dst, fd->idx, SCTIME_SECS(p->ts));
+            r = HostBitIsnotset(p->host_dst, fd->idx, p->ts);
             HostUnlock(p->host_dst);
             return r;
     }

--- a/src/detect-tag.c
+++ b/src/detect-tag.c
@@ -106,7 +106,7 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
 
             tde.sid = s->id;
             tde.gid = s->gid;
-            tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
+            tde.last_ts = tde.first_ts = p->ts;
             tde.metric = td->metric;
             tde.count = td->count;
             if (td->direction == DETECT_TAG_DIR_SRC)
@@ -123,12 +123,12 @@ static int DetectTagMatch(DetectEngineThreadCtx *det_ctx, Packet *p,
                 /* If it already exists it will be updated */
                 tde.sid = s->id;
                 tde.gid = s->gid;
-                tde.last_ts = tde.first_ts = SCTIME_SECS(p->ts);
+                tde.last_ts = tde.first_ts = p->ts;
                 tde.metric = td->metric;
                 tde.count = td->count;
 
-                SCLogDebug("Adding to or updating flow; first_ts %u count %u",
-                    tde.first_ts, tde.count);
+                SCLogDebug("Adding to or updating flow; first_ts %" PRIu64 " count %u",
+                        tde.first_ts.secs, tde.count);
                 TagFlowAdd(p, &tde);
             } else {
                 SCLogDebug("No flow to append the session tag");

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -79,8 +79,8 @@ typedef struct DetectTagDataEntry_ {
         uint32_t packets;               /**< number of packets (metric packets) */
         uint32_t bytes;                 /**< number of bytes (metric bytes) */
     };
-    uint32_t first_ts;                  /**< First time seen (for metric = seconds) */
-    uint32_t last_ts;                   /**< Last time seen (to prune old sessions) */
+    SCTime_t first_ts; /**< First time seen (for metric = seconds) */
+    SCTime_t last_ts;  /**< Last time seen (to prune old sessions) */
 #if __WORDSIZE == 64
     uint32_t pad1;
 #endif

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -94,7 +94,7 @@ static int DetectIPPairbitMatchToggle (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitToggle(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+    IPPairBitToggle(pair, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
     IPPairRelease(pair);
     return 1;
 }
@@ -117,7 +117,7 @@ static int DetectIPPairbitMatchSet (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    IPPairBitSet(pair, fd->idx, SCTIME_SECS(p->ts) + fd->expire);
+    IPPairBitSet(pair, fd->idx, SCTIME_ADD_SECS(p->ts, fd->expire));
     IPPairRelease(pair);
     return 1;
 }
@@ -129,7 +129,7 @@ static int DetectIPPairbitMatchIsset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 0;
 
-    r = IPPairBitIsset(pair, fd->idx, SCTIME_SECS(p->ts));
+    r = IPPairBitIsset(pair, fd->idx, p->ts);
     IPPairRelease(pair);
     return r;
 }
@@ -141,7 +141,7 @@ static int DetectIPPairbitMatchIsnotset (Packet *p, const DetectXbitsData *fd)
     if (pair == NULL)
         return 1;
 
-    r = IPPairBitIsnotset(pair, fd->idx, SCTIME_SECS(p->ts));
+    r = IPPairBitIsnotset(pair, fd->idx, p->ts);
     IPPairRelease(pair);
     return r;
 }

--- a/src/host-bit.c
+++ b/src/host-bit.c
@@ -70,7 +70,7 @@ int HostBitsTimedoutCheck(Host *h, SCTime_t ts)
     for ( ; gv != NULL; gv = gv->next) {
         if (gv->type == DETECT_XBITS) {
             XBit *xb = (XBit *)gv;
-            if (xb->expire > (uint32_t)SCTIME_SECS(ts))
+            if (SCTIME_CMP_GT(xb->expire, ts))
                 return 0;
         }
     }
@@ -91,7 +91,7 @@ static XBit *HostBitGet(Host *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void HostBitAdd(Host *h, uint32_t idx, uint32_t expire)
+static void HostBitAdd(Host *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void HostBitRemove(Host *h, uint32_t idx)
     }
 }
 
-void HostBitSet(Host *h, uint32_t idx, uint32_t expire)
+void HostBitSet(Host *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void HostBitUnset(Host *h, uint32_t idx)
     }
 }
 
-void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
+void HostBitToggle(Host *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
@@ -154,11 +154,11 @@ void HostBitToggle(Host *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsset(Host *h, uint32_t idx, SCTime_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb != NULL) {
-        if (fb->expire < ts) {
+        if (SCTIME_CMP_LT(fb->expire, ts)) {
             HostBitRemove(h,idx);
             return 0;
         }
@@ -167,14 +167,14 @@ int HostBitIsset(Host *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int HostBitIsnotset(Host *h, uint32_t idx, uint32_t ts)
+int HostBitIsnotset(Host *h, uint32_t idx, SCTime_t ts)
 {
     XBit *fb = HostBitGet(h, idx);
     if (fb == NULL) {
         return 1;
     }
 
-    if (fb->expire < ts) {
+    if (SCTIME_CMP_LT(fb->expire, ts)) {
         HostBitRemove(h,idx);
         return 1;
     }
@@ -211,7 +211,7 @@ static int HostBitTest01 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 0);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(0));
 
     XBit *fb = HostBitGet(h,0);
     if (fb != NULL)
@@ -251,7 +251,7 @@ static int HostBitTest03 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 30);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(30));
 
     XBit *fb = HostBitGet(h,0);
     if (fb == NULL) {
@@ -284,10 +284,10 @@ static int HostBitTest04 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 30);
-    HostBitAdd(h, 1, 30);
-    HostBitAdd(h, 2, 30);
-    HostBitAdd(h, 3, 30);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(30));
 
     XBit *fb = HostBitGet(h,0);
     if (fb != NULL)
@@ -308,10 +308,10 @@ static int HostBitTest05 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 30);
-    HostBitAdd(h, 1, 30);
-    HostBitAdd(h, 2, 30);
-    HostBitAdd(h, 3, 30);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(30));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(30));
 
     XBit *fb = HostBitGet(h,1);
     if (fb != NULL)
@@ -332,10 +332,10 @@ static int HostBitTest06 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,2);
     if (fb != NULL)
@@ -356,10 +356,10 @@ static int HostBitTest07 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,3);
     if (fb != NULL)
@@ -380,10 +380,10 @@ static int HostBitTest08 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,0);
     if (fb == NULL)
@@ -413,10 +413,10 @@ static int HostBitTest09 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,1);
     if (fb == NULL)
@@ -446,10 +446,10 @@ static int HostBitTest10 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,2);
     if (fb == NULL)
@@ -479,10 +479,10 @@ static int HostBitTest11 (void)
     if (h == NULL)
         goto end;
 
-    HostBitAdd(h, 0, 90);
-    HostBitAdd(h, 1, 90);
-    HostBitAdd(h, 2, 90);
-    HostBitAdd(h, 3, 90);
+    HostBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    HostBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = HostBitGet(h,3);
     if (fb == NULL)

--- a/src/host-bit.h
+++ b/src/host-bit.h
@@ -33,11 +33,11 @@ void HostBitRegisterTests(void);
 int HostHasHostBits(Host *host);
 int HostBitsTimedoutCheck(Host *h, SCTime_t ts);
 
-void HostBitSet(Host *, uint32_t, uint32_t);
+void HostBitSet(Host *, uint32_t, SCTime_t);
 void HostBitUnset(Host *, uint32_t);
-void HostBitToggle(Host *, uint32_t, uint32_t);
-int HostBitIsset(Host *, uint32_t, uint32_t);
-int HostBitIsnotset(Host *, uint32_t, uint32_t);
+void HostBitToggle(Host *, uint32_t, SCTime_t);
+int HostBitIsset(Host *, uint32_t, SCTime_t);
+int HostBitIsnotset(Host *, uint32_t, SCTime_t);
 int HostBitList(Host *, XBit **);
 
 #endif /* SURICATA_HOST_BIT_H */

--- a/src/ippair-bit.c
+++ b/src/ippair-bit.c
@@ -70,7 +70,7 @@ int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts)
     for ( ; gv != NULL; gv = gv->next) {
         if (gv->type == DETECT_XBITS) {
             XBit *xb = (XBit *)gv;
-            if (xb->expire > (uint32_t)SCTIME_SECS(ts))
+            if (SCTIME_CMP_GT(xb->expire, ts))
                 return 0;
         }
     }
@@ -91,7 +91,7 @@ static XBit *IPPairBitGet(IPPair *h, uint32_t idx)
 }
 
 /* add a flowbit to the flow */
-static void IPPairBitAdd(IPPair *h, uint32_t idx, uint32_t expire)
+static void IPPairBitAdd(IPPair *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -128,7 +128,7 @@ static void IPPairBitRemove(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitSet(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitSet(IPPair *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
@@ -144,7 +144,7 @@ void IPPairBitUnset(IPPair *h, uint32_t idx)
     }
 }
 
-void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
+void IPPairBitToggle(IPPair *h, uint32_t idx, SCTime_t expire)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
@@ -154,11 +154,11 @@ void IPPairBitToggle(IPPair *h, uint32_t idx, uint32_t expire)
     }
 }
 
-int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsset(IPPair *h, uint32_t idx, SCTime_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb != NULL) {
-        if (fb->expire < ts) {
+        if (SCTIME_CMP_LT(fb->expire, ts)) {
             IPPairBitRemove(h, idx);
             return 0;
         }
@@ -168,14 +168,14 @@ int IPPairBitIsset(IPPair *h, uint32_t idx, uint32_t ts)
     return 0;
 }
 
-int IPPairBitIsnotset(IPPair *h, uint32_t idx, uint32_t ts)
+int IPPairBitIsnotset(IPPair *h, uint32_t idx, SCTime_t ts)
 {
     XBit *fb = IPPairBitGet(h, idx);
     if (fb == NULL) {
         return 1;
     }
 
-    if (fb->expire < ts) {
+    if (SCTIME_CMP_LT(fb->expire, ts)) {
         IPPairBitRemove(h, idx);
         return 1;
     }
@@ -195,7 +195,7 @@ static int IPPairBitTest01 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0, 0);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(0));
 
     XBit *fb = IPPairBitGet(h,0);
     if (fb != NULL)
@@ -235,7 +235,7 @@ static int IPPairBitTest03 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0, 30);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(30));
 
     XBit *fb = IPPairBitGet(h,0);
     if (fb == NULL) {
@@ -268,10 +268,10 @@ static int IPPairBitTest04 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,30);
-    IPPairBitAdd(h, 1,30);
-    IPPairBitAdd(h, 2,30);
-    IPPairBitAdd(h, 3,30);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(30));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(30));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(30));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(30));
 
     XBit *fb = IPPairBitGet(h,0);
     if (fb != NULL)
@@ -292,10 +292,10 @@ static int IPPairBitTest05 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,1);
     if (fb != NULL)
@@ -316,10 +316,10 @@ static int IPPairBitTest06 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,2);
     if (fb != NULL)
@@ -340,10 +340,10 @@ static int IPPairBitTest07 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,3);
     if (fb != NULL)
@@ -364,10 +364,10 @@ static int IPPairBitTest08 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,0);
     if (fb == NULL)
@@ -397,10 +397,10 @@ static int IPPairBitTest09 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,1);
     if (fb == NULL)
@@ -430,10 +430,10 @@ static int IPPairBitTest10 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,2);
     if (fb == NULL)
@@ -463,10 +463,10 @@ static int IPPairBitTest11 (void)
     if (h == NULL)
         goto end;
 
-    IPPairBitAdd(h, 0,90);
-    IPPairBitAdd(h, 1,90);
-    IPPairBitAdd(h, 2,90);
-    IPPairBitAdd(h, 3,90);
+    IPPairBitAdd(h, 0, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 1, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 2, SCTIME_FROM_SECS(90));
+    IPPairBitAdd(h, 3, SCTIME_FROM_SECS(90));
 
     XBit *fb = IPPairBitGet(h,3);
     if (fb == NULL)

--- a/src/ippair-bit.h
+++ b/src/ippair-bit.h
@@ -32,10 +32,10 @@ void IPPairBitRegisterTests(void);
 int IPPairHasBits(IPPair *host);
 int IPPairBitsTimedoutCheck(IPPair *h, SCTime_t ts);
 
-void IPPairBitSet(IPPair *, uint32_t, uint32_t);
+void IPPairBitSet(IPPair *, uint32_t, SCTime_t);
 void IPPairBitUnset(IPPair *, uint32_t);
-void IPPairBitToggle(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsset(IPPair *, uint32_t, uint32_t);
-int IPPairBitIsnotset(IPPair *, uint32_t, uint32_t);
+void IPPairBitToggle(IPPair *, uint32_t, SCTime_t);
+int IPPairBitIsset(IPPair *, uint32_t, SCTime_t);
+int IPPairBitIsnotset(IPPair *, uint32_t, SCTime_t);
 
 #endif /* SURICATA_IPPAIR_BIT_H */

--- a/src/tx-bit.c
+++ b/src/tx-bit.c
@@ -58,7 +58,7 @@ static int TxBitAdd(AppLayerTxData *txd, uint32_t idx)
         xb->type = DETECT_XBITS;
         xb->idx = idx;
         xb->next = NULL;
-        xb->expire = 0; // not used by tx bits
+        SCTIME_INIT(xb->expire); // not used by tx bits
 
         GenericVarAppend(&txd->txbits, (GenericVar *)xb);
         return 1;

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -60,7 +60,7 @@ typedef struct XBit_ {
     uint8_t pad[2];
     uint32_t idx;       /* name idx */
     GenericVar *next;
-    uint32_t expire;
+    SCTime_t expire;
 } XBit;
 
 void XBitFree(XBit *);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix SCTime_t `-Wshorten-64-to-32` warnings for remaining files : detect

@jlucovsky how does that look to you ? (as you did 31793aface5 )

#13203 next iteration with warnings getting fixed for gcc/clang discrepancy see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109516

Still to do afterwards :
- fix other detect warnings
- CI check
