### PR TITLE
detect/entropy: Correct slot for url initialization

### DIFF
--- a/src/detect-entropy.c
+++ b/src/detect-entropy.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2024 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -70,7 +70,7 @@ void DetectEntropyRegister(void)
 {
     sigmatch_table[DETECT_ENTROPY].name = "entropy";
     sigmatch_table[DETECT_ENTROPY].desc = "calculate entropy";
-    sigmatch_table[DETECT_BYTE_EXTRACT].url = "/rules/payload-keywords.html#entropy";
+    sigmatch_table[DETECT_ENTROPY].url = "/rules/payload-keywords.html#entropy";
     sigmatch_table[DETECT_ENTROPY].Free = DetectEntropyFree;
     sigmatch_table[DETECT_ENTROPY].Setup = DetectEntropySetup;
 }


### PR DESCRIPTION
Correct the sigmatch slot for url initialization.


Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Use the proper value for the `url` sigmatch slot initialization.


### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=
SU_REPO=
SU_BRANCH=
