### PR TITLE
Bindgen more 7667 v3.1

### DIFF
--- a/plugins/ndpi/ndpi.c
+++ b/plugins/ndpi/ndpi.c
@@ -467,7 +467,7 @@ static void EveCallback(ThreadVars *tv, const Packet *p, Flow *f, SCJsonBuilder 
 
 static void NdpInitRiskKeyword(void)
 {
-    /* SCSigTableAppLiteElmt and DetectHelperKeywordRegister don't yet
+    /* SCSigTableAppLiteElmt and SCDetectHelperKeywordRegister don't yet
      * support all the fields required to register the nDPI keywords,
      * missing the (packet) Match callback,
      * so we'll just register with an empty keyword specifier to get

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -28,7 +28,6 @@ use crate::flow::Flow;
 pub enum DetectEngineState {}
 pub enum AppLayerDecoderEvents {}
 pub enum GenericVar {}
-pub(crate) use suricata_sys::sys::DetectEngineThreadCtx;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -38,7 +38,10 @@ pub mod datasets;
 use std::os::raw::{c_int, c_void};
 use std::ffi::CString;
 
-use suricata_sys::sys::{AppProto, DetectEngineCtx, Signature, SCDetectHelperKeywordRegister, SCSigTableAppLiteElmt};
+use suricata_sys::sys::{
+    AppProto, DetectEngineCtx, SCDetectHelperKeywordRegister, SCDetectHelperKeywordSetCleanCString,
+    SCSigTableAppLiteElmt, Signature,
+};
 
 /// EnumString trait that will be implemented on enums that
 /// derive StringEnum.
@@ -87,7 +90,7 @@ pub fn helper_keyword_register_sticky_buffer(kw: &SigTableElmtStickyBuffer) -> c
     };
     unsafe {
         let r = SCDetectHelperKeywordRegister(&st);
-        DetectHelperKeywordSetCleanCString(r);
+        SCDetectHelperKeywordSetCleanCString(r);
         return r;
     }
 }
@@ -117,7 +120,6 @@ pub const SIGMATCH_INFO_STICKY_BUFFER: u16 = 0x200; // BIT_U16(9)
 
 /// cbindgen:ignore
 extern "C" {
-    pub fn DetectHelperKeywordSetCleanCString(id: c_int);
     pub fn DetectHelperGetData(
         de: *mut c_void, transforms: *const c_void, flow: *const c_void, flow_flags: u8,
         tx: *const c_void, list_id: c_int,

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -38,7 +38,6 @@ pub mod datasets;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ffi::CString;
 
-use crate::core::DetectEngineThreadCtx;
 use suricata_sys::sys::{AppProto, DetectEngineCtx, Signature};
 
 /// EnumString trait that will be implemented on enums that
@@ -178,18 +177,6 @@ extern "C" {
     pub fn SigMatchAppendSMToList(
         de: *mut DetectEngineCtx, s: *mut Signature, kwid: c_int, ctx: *const c_void, bufid: c_int,
     ) -> *mut c_void;
-    // in detect-engine-helper.h
-    pub fn DetectHelperMultiBufferMpmRegister(
-        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
-        get_multi_data: unsafe extern "C" fn(
-            *mut DetectEngineThreadCtx,
-            *const c_void,
-            u8,
-            u32,
-            *mut *const u8,
-            *mut u32,
-        ) -> bool,
-    ) -> c_int;
 }
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -190,18 +190,6 @@ extern "C" {
             *mut u32,
         ) -> bool,
     ) -> c_int;
-    pub fn DetectHelperMultiBufferProgressMpmRegister(
-        name: *const libc::c_char, desc: *const libc::c_char, alproto: AppProto, dir: u8,
-        get_multi_data: unsafe extern "C" fn(
-            *mut DetectEngineThreadCtx,
-            *const c_void,
-            u8,
-            u32,
-            *mut *const u8,
-            *mut u32,
-        ) -> bool,
-        progress: c_int,
-    ) -> c_int;
 }
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -170,9 +170,6 @@ extern "C" {
     ) -> c_int;
     pub fn DetectHelperKeywordRegister(kw: *const SCSigTableAppLiteElmt) -> c_int;
     pub fn DetectHelperKeywordAliasRegister(kwid: c_int, alias: *const c_char);
-    pub fn DetectHelperBufferRegister(
-        name: *const libc::c_char, alproto: AppProto, dir: u8,
-    ) -> c_int;
     pub fn DetectSignatureSetAppProto(s: *mut Signature, alproto: AppProto) -> c_int;
     pub fn SigMatchAppendSMToList(
         de: *mut DetectEngineCtx, s: *mut Signature, kwid: c_int, ctx: *const c_void, bufid: c_int,

--- a/rust/src/detect/mod.rs
+++ b/rust/src/detect/mod.rs
@@ -35,7 +35,7 @@ pub mod tojson;
 pub mod vlan;
 pub mod datasets;
 
-use std::os::raw::{c_char, c_int, c_void};
+use std::os::raw::{c_int, c_void};
 use std::ffi::CString;
 
 use suricata_sys::sys::{AppProto, DetectEngineCtx, Signature};
@@ -169,7 +169,6 @@ extern "C" {
         ) -> *mut c_void,
     ) -> c_int;
     pub fn DetectHelperKeywordRegister(kw: *const SCSigTableAppLiteElmt) -> c_int;
-    pub fn DetectHelperKeywordAliasRegister(kwid: c_int, alias: *const c_char);
     pub fn DetectSignatureSetAppProto(s: *mut Signature, alproto: AppProto) -> c_int;
     pub fn SigMatchAppendSMToList(
         de: *mut DetectEngineCtx, s: *mut Signature, kwid: c_int, ctx: *const c_void, bufid: c_int,

--- a/rust/src/dhcp/detect.rs
+++ b/rust/src/dhcp/detect.rs
@@ -23,11 +23,11 @@ use super::parser::DHCPOptionWrapper;
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{DetectUintData, SCDetectU64Free, SCDetectU64Match, SCDetectU64Parse};
 use crate::detect::{
-    DetectHelperBufferRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
-    SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList,
 };
-use suricata_sys::sys::{DetectEngineCtx, Signature};
 use std::os::raw::{c_int, c_void};
+use suricata_sys::sys::{DetectEngineCtx, SCDetectHelperBufferRegister, Signature};
 
 fn dhcp_tx_get_time(tx: &DHCPTransaction, code: u8) -> Option<u64> {
     for option in &tx.message.options {
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
         flags: 0,
     };
     G_DHCP_LEASE_TIME_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DHCP_LEASE_TIME_BUFFER_ID = DetectHelperBufferRegister(
+    G_DHCP_LEASE_TIME_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dhcp.leasetime\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
         flags: 0,
     };
     G_DHCP_REBINDING_TIME_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DHCP_REBINDING_TIME_BUFFER_ID = DetectHelperBufferRegister(
+    G_DHCP_REBINDING_TIME_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dhcp.rebinding-time\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn SCDetectDHCPRegister() {
         flags: 0,
     };
     G_DHCP_RENEWAL_TIME_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DHCP_RENEWAL_TIME_BUFFER_ID = DetectHelperBufferRegister(
+    G_DHCP_RENEWAL_TIME_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dhcp.renewal-time\0".as_ptr() as *const libc::c_char,
         ALPROTO_DHCP,
         STREAM_TOSERVER | STREAM_TOCLIENT,

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -22,16 +22,16 @@ use crate::detect::uint::{
     SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperKeywordAliasRegister,
-    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
+    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
-    SCDetectHelperBufferRegister, SCDetectHelperMultiBufferProgressMpmRegister, Signature,
+    SCDetectHelperBufferRegister, SCDetectHelperKeywordAliasRegister,
+    SCDetectHelperMultiBufferProgressMpmRegister, Signature,
 };
 
 /// Perform the DNS opcode match.
@@ -411,7 +411,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         setup: dns_detect_query_setup,
     };
     let g_dns_query_name_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    DetectHelperKeywordAliasRegister(
+    SCDetectHelperKeywordAliasRegister(
         g_dns_query_name_kw_id,
         b"dns_query\0".as_ptr() as *const libc::c_char,
     );

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::dns::{DNSRcode, DNSRecordType, DNSTransaction, ALPROTO_DNS};
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU16Free, SCDetectU8Free,
     SCDetectU8Parse,
@@ -30,8 +30,8 @@ use crate::direction::Direction;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
-    DetectEngineCtx, SCDetectBufferSetActiveList, SCDetectHelperMultiBufferProgressMpmRegister,
-    Signature,
+    DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
+    SCDetectHelperMultiBufferProgressMpmRegister, Signature,
 };
 
 /// Perform the DNS opcode match.

--- a/rust/src/dns/detect.rs
+++ b/rust/src/dns/detect.rs
@@ -22,16 +22,16 @@ use crate::detect::uint::{
     SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferRegister,
-    DetectHelperKeywordAliasRegister, DetectHelperKeywordRegister, DetectSignatureSetAppProto,
-    SCSigTableAppLiteElmt, SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperKeywordAliasRegister,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
-    SCDetectHelperMultiBufferProgressMpmRegister, Signature,
+    SCDetectHelperBufferRegister, SCDetectHelperMultiBufferProgressMpmRegister, Signature,
 };
 
 /// Perform the DNS opcode match.
@@ -352,7 +352,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         flags: 0,
     };
     G_DNS_OPCODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DNS_OPCODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_DNS_OPCODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dns.opcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         flags: 0,
     };
     G_DNS_RCODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DNS_RCODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_DNS_RCODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dns.rcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn SCDetectDNSRegister() {
         flags: 0,
     };
     G_DNS_RRTYPE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_DNS_RRTYPE_BUFFER_ID = DetectHelperBufferRegister(
+    G_DNS_RRTYPE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"dns.rrtype\0".as_ptr() as *const libc::c_char,
         ALPROTO_DNS,
         STREAM_TOSERVER | STREAM_TOCLIENT,

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -31,7 +31,7 @@ use crate::frames::Frame;
 
 use nom7::number::streaming::be_u16;
 use nom7::{Err, IResult};
-use suricata_sys::sys::AppProto;
+use suricata_sys::sys::{AppProto, DetectEngineThreadCtx};
 
 /// DNS record types.
 /// DNS error codes.

--- a/rust/src/enip/detect.rs
+++ b/rust/src/enip/detect.rs
@@ -36,12 +36,13 @@ use crate::detect::uint::{
     SCDetectU8Match, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, SCDetectBufferSetActiveList, SCDetectHelperBufferRegister, Signature,
+};
 
 use crate::direction::Direction;
 
@@ -1345,7 +1346,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIPSERVICE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIPSERVICE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIPSERVICE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"cip\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1360,7 +1361,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CAPABILITIES_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CAPABILITIES_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CAPABILITIES_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.capabilities\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1375,7 +1376,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIP_ATTRIBUTE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIP_ATTRIBUTE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIP_ATTRIBUTE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.cip_attribute\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1390,7 +1391,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIP_CLASS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIP_CLASS_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIP_CLASS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.cip_class\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1405,7 +1406,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_VENDOR_ID_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_VENDOR_ID_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_VENDOR_ID_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.vendor_id\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1420,7 +1421,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_STATUS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_STATUS_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_STATUS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1435,7 +1436,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_STATE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_STATE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_STATE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.state\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1450,7 +1451,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_SERIAL_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_SERIAL_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_SERIAL_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.serial\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1465,7 +1466,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_REVISION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_REVISION_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_REVISION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.revision\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1480,7 +1481,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_PROTOCOL_VERSION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_PROTOCOL_VERSION_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_PROTOCOL_VERSION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.protocol_version\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1495,7 +1496,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_PRODUCT_CODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_PRODUCT_CODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_PRODUCT_CODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.product_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1510,7 +1511,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_COMMAND_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_COMMAND_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_COMMAND_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.command\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1525,7 +1526,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_IDENTITY_STATUS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_IDENTITY_STATUS_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_IDENTITY_STATUS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.identity_status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1540,7 +1541,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_DEVICE_TYPE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_DEVICE_TYPE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_DEVICE_TYPE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.device_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1555,7 +1556,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIP_STATUS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIP_STATUS_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIP_STATUS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.cip_status\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1570,7 +1571,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIP_INSTANCE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIP_INSTANCE_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIP_INSTANCE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.cip_instance\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1586,7 +1587,7 @@ pub unsafe extern "C" fn SCDetectEnipRegister() {
         flags: 0,
     };
     G_ENIP_CIP_EXTENDEDSTATUS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_ENIP_CIP_EXTENDEDSTATUS_BUFFER_ID = DetectHelperBufferRegister(
+    G_ENIP_CIP_EXTENDEDSTATUS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"enip.cip_extendedstatus\0".as_ptr() as *const libc::c_char,
         ALPROTO_ENIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,

--- a/rust/src/http2/detect.rs
+++ b/rust/src/http2/detect.rs
@@ -19,7 +19,6 @@ use super::http2::{
     HTTP2Event, HTTP2Frame, HTTP2FrameTypeData, HTTP2State, HTTP2Transaction, HTTP2TransactionState,
 };
 use super::parser;
-use crate::core::DetectEngineThreadCtx;
 use crate::detect::uint::{detect_match_uint, DetectUintData};
 use crate::direction::Direction;
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -27,6 +26,7 @@ use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::rc::Rc;
 use std::str::FromStr;
+use suricata_sys::sys::DetectEngineThreadCtx;
 
 fn http2_tx_has_frametype(
     tx: &HTTP2Transaction, direction: Direction, value: u8,

--- a/rust/src/ike/detect.rs
+++ b/rust/src/ike/detect.rs
@@ -18,11 +18,11 @@
 // Author: Frank Honza <frank.honza@dcso.de>
 
 use super::ipsec_parser::IkeV2Transform;
-use crate::core::DetectEngineThreadCtx;
 use crate::ike::ike::*;
 use std::ffi::CStr;
 use std::os::raw::c_void;
 use std::ptr;
+use suricata_sys::sys::DetectEngineThreadCtx;
 
 #[no_mangle]
 pub extern "C" fn SCIkeStateGetExchType(tx: &IKETransaction, exch_type: *mut u8) -> u8 {

--- a/rust/src/krb/detect.rs
+++ b/rust/src/krb/detect.rs
@@ -17,8 +17,8 @@
 
 // written by Pierre Chifflier  <chifflier@wzdftpd.net>
 
-use crate::core::DetectEngineThreadCtx;
 use crate::krb::krb5::{test_weak_encryption, KRB5Transaction};
+use suricata_sys::sys::DetectEngineThreadCtx;
 
 use kerberos_parser::krb5::EncryptionType;
 

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -16,7 +16,7 @@
  */
 
 use super::ldap::{LdapTransaction, ALPROTO_LDAP};
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
     SCDetectU8Free,
@@ -24,11 +24,14 @@ use crate::detect::uint::{
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
+    SCDetectHelperMultiBufferMpmRegister, Signature,
+};
 
 use std::collections::VecDeque;
 use std::ffi::CStr;
@@ -700,12 +703,12 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         setup: ldap_detect_responses_dn_setup,
     };
     let _g_ldap_responses_dn_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_LDAP_RESPONSES_DN_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_LDAP_RESPONSES_DN_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"ldap.responses.dn\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,
-        ldap_tx_get_responses_dn,
+        Some(ldap_tx_get_responses_dn),
     );
     let kw = SCSigTableAppLiteElmt {
         name: b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
@@ -730,12 +733,12 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         setup: ldap_detect_responses_msg_setup,
     };
     let _g_ldap_responses_dn_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_LDAP_RESPONSES_MSG_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_LDAP_RESPONSES_MSG_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"ldap.responses.message\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES DISTINGUISHED_NAME\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,
-        ldap_tx_get_responses_msg,
+        Some(ldap_tx_get_responses_msg),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.request.attribute_type"),
@@ -744,12 +747,12 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         setup: ldap_detect_request_attibute_type_setup,
     };
     let _g_ldap_request_attribute_type_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_LDAP_REQUEST_ATTRIBUTE_TYPE_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"ldap.request.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP REQUEST ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOSERVER,
-        ldap_tx_get_req_attribute_type,
+        Some(ldap_tx_get_req_attribute_type),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("ldap.responses.attribute_type"),
@@ -758,11 +761,11 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         setup: ldap_detect_responses_attibute_type_setup,
     };
     let _g_ldap_responses_attribute_type_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_LDAP_RESPONSES_ATTRIBUTE_TYPE_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"ldap.responses.attribute_type\0".as_ptr() as *const libc::c_char,
         b"LDAP RESPONSES ATTRIBUTE TYPE\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,
-        ldap_tx_get_resp_attribute_type,
+        Some(ldap_tx_get_resp_attribute_type),
     );
 }

--- a/rust/src/ldap/detect.rs
+++ b/rust/src/ldap/detect.rs
@@ -22,15 +22,14 @@ use crate::detect::uint::{
     SCDetectU8Free,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::ldap::types::{LdapMessage, LdapResultCode, ProtocolOp, ProtocolOpCode};
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
-    SCDetectHelperMultiBufferMpmRegister, Signature,
+    SCDetectHelperBufferRegister, SCDetectHelperMultiBufferMpmRegister, Signature,
 };
 
 use std::collections::VecDeque;
@@ -646,7 +645,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: 0,
     };
     G_LDAP_REQUEST_OPERATION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_LDAP_REQUEST_OPERATION_BUFFER_ID = DetectHelperBufferRegister(
+    G_LDAP_REQUEST_OPERATION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"ldap.request.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOSERVER,
@@ -662,7 +661,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: 0,
     };
     G_LDAP_RESPONSES_OPERATION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_LDAP_RESPONSES_OPERATION_BUFFER_ID = DetectHelperBufferRegister(
+    G_LDAP_RESPONSES_OPERATION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"ldap.responses.operation\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,
@@ -677,7 +676,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: 0,
     };
     G_LDAP_RESPONSES_COUNT_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_LDAP_RESPONSES_COUNT_BUFFER_ID = DetectHelperBufferRegister(
+    G_LDAP_RESPONSES_COUNT_BUFFER_ID = SCDetectHelperBufferRegister(
         b"ldap.responses.count\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,
@@ -721,7 +720,7 @@ pub unsafe extern "C" fn SCDetectLdapRegister() {
         flags: 0,
     };
     G_LDAP_RESPONSES_RESULT_CODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_LDAP_RESPONSES_RESULT_CODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_LDAP_RESPONSES_RESULT_CODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"ldap.responses.result_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_LDAP,
         STREAM_TOCLIENT,

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -23,14 +23,13 @@ use crate::detect::uint::{
     SCDetectU8Free, SCDetectU8Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use suricata_sys::sys::{
     DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
-    SCDetectHelperMultiBufferMpmRegister, Signature,
+    SCDetectHelperBufferRegister, SCDetectHelperMultiBufferMpmRegister, Signature,
 };
 
 use nom7::branch::alt;
@@ -1108,7 +1107,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_TYPE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_TYPE_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_TYPE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.type\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1148,7 +1147,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_REASON_CODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_REASON_CODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_REASON_CODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.reason_code\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -1164,7 +1163,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_CONNACK_SESSIONPRESENT_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_CONNACK_SESSIONPRESENT_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_CONNACK_SESSIONPRESENT_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.connack.session_present\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOCLIENT,
@@ -1180,7 +1179,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_QOS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_QOS_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_QOS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.qos\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,
@@ -1223,7 +1222,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_PROTOCOL_VERSION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_PROTOCOL_VERSION_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_PROTOCOL_VERSION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.protocol_version\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,
@@ -1238,7 +1237,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_FLAGS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_FLAGS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,
@@ -1253,7 +1252,7 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         flags: 0,
     };
     G_MQTT_CONN_FLAGS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_MQTT_CONN_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
+    G_MQTT_CONN_FLAGS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"mqtt.connect.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,

--- a/rust/src/mqtt/detect.rs
+++ b/rust/src/mqtt/detect.rs
@@ -17,7 +17,7 @@
 
 // written by Sascha Steinbiss <sascha@steinbiss.name>
 
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{
     detect_match_uint, detect_parse_uint, detect_parse_uint_enum, DetectUintData, DetectUintMode,
     SCDetectU8Free, SCDetectU8Parse,
@@ -25,10 +25,13 @@ use crate::detect::uint::{
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
     DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
-    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
+    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
+    SigTableElmtStickyBuffer,
 };
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
+    SCDetectHelperMultiBufferMpmRegister, Signature,
+};
 
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag};
@@ -1087,12 +1090,12 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         }
     }
     let _g_mqtt_unsub_topic_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_MQTT_UNSUB_TOPIC_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_MQTT_UNSUB_TOPIC_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         keyword_name,
         b"unsubscribe topic query\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,
-        unsub_topic_get_data,
+        Some(unsub_topic_get_data),
     );
 
     let kw = SCSigTableAppLiteElmt {
@@ -1126,12 +1129,12 @@ pub unsafe extern "C" fn SCDetectMqttRegister() {
         }
     }
     let _g_mqtt_sub_topic_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_MQTT_SUB_TOPIC_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_MQTT_SUB_TOPIC_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         keyword_name,
         b"subscribe topic query\0".as_ptr() as *const libc::c_char,
         ALPROTO_MQTT,
         STREAM_TOSERVER,
-        sub_topic_get_data,
+        Some(sub_topic_get_data),
     );
 
     let kw = SCSigTableAppLiteElmt {

--- a/rust/src/quic/detect.rs
+++ b/rust/src/quic/detect.rs
@@ -15,10 +15,11 @@
  * 02110-1301, USA.
  */
 
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::quic::quic::QuicTransaction;
 use std::os::raw::c_void;
 use std::ptr;
+use suricata_sys::sys::DetectEngineThreadCtx;
 
 #[no_mangle]
 pub unsafe extern "C" fn SCQuicTxGetUa(

--- a/rust/src/rfb/detect.rs
+++ b/rust/src/rfb/detect.rs
@@ -24,15 +24,16 @@ use crate::detect::uint::{
     detect_match_uint, detect_parse_uint_enum, DetectUintData, SCDetectU32Free, SCDetectU32Parse,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, SCDetectBufferSetActiveList, SCDetectHelperBufferRegister, Signature,
+};
 
 unsafe extern "C" fn rfb_name_get_data(
     tx: *const c_void, _flags: u8, buffer: *mut *const u8, buffer_len: *mut u32,
@@ -214,7 +215,7 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
         flags: 0,
     };
     G_RFB_SEC_TYPE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_RFB_SEC_TYPE_BUFFER_ID = DetectHelperBufferRegister(
+    G_RFB_SEC_TYPE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"rfb.sectype\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,
         STREAM_TOSERVER,
@@ -229,7 +230,7 @@ pub unsafe extern "C" fn SCDetectRfbRegister() {
         flags: 0,
     };
     G_RFB_SEC_RESULT_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_RFB_SEC_RESULT_BUFFER_ID = DetectHelperBufferRegister(
+    G_RFB_SEC_RESULT_BUFFER_ID = SCDetectHelperBufferRegister(
         b"rfb.secresult\0".as_ptr() as *const libc::c_char,
         ALPROTO_RFB,
         STREAM_TOCLIENT,

--- a/rust/src/sdp/detect.rs
+++ b/rust/src/sdp/detect.rs
@@ -17,16 +17,19 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, DetectEngineThreadCtx, SCDetectBufferSetActiveList,
+    SCDetectHelperMultiBufferMpmRegister, Signature,
+};
 
 static mut G_SDP_ORIGIN_BUFFER_ID: c_int = 0;
 static mut G_SDP_SESSION_NAME_BUFFER_ID: c_int = 0;
@@ -875,12 +878,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_bandwidth_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_BANDWIDTH_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_BANDWIDTH_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         b"sdp.bandwidth\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_bandwidth_get_data,
+        Some(sip_bandwidth_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.time"),
@@ -889,12 +892,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_time_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_TIME_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_TIME_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         b"sdp.time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sdp_time_get_data,
+        Some(sdp_time_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.repeat_time"),
@@ -903,12 +906,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_repeat_time_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_REPEAT_TIME_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_REPEAT_TIME_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         b"sdp.repeat_time\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sdp_repeat_time_get_data,
+        Some(sdp_repeat_time_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.timezone"),
@@ -945,12 +948,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_attribute_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_ATTRIBUTE_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_ATTRIBUTE_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         b"sdp.attribute\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_attribute_get_data,
+        Some(sip_attribute_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media"),
@@ -961,12 +964,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_media_desc_media_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_MEDIA_DESC_MEDIA_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_media_desc_media_get_data,
+        Some(sip_media_desc_media_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.media_info"),
@@ -975,12 +978,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_media_desc_session_info_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_MEDIA_DESC_SESSION_INFO_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         b"sdp.media.media_info\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_media_desc_session_info_get_data,
+        Some(sip_media_desc_session_info_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.connection_data"),
@@ -989,12 +992,12 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_media_desc_connection_data_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_MEDIA_DESC_CONNECTION_DATA_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         b"sdp.media.connection_data\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_media_desc_connection_data_get_data,
+        Some(sip_media_desc_connection_data_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sdp.media.encryption_key"),
@@ -1003,11 +1006,11 @@ pub unsafe extern "C" fn SCDetectSdpRegister() {
         setup: sdp_media_desc_encryption_key_setup,
     };
     let _ = helper_keyword_register_sticky_buffer(&kw);
-    G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SDP_MEDIA_DESC_ENCRYPTION_KEY_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         b"sdp.media.encryption_key\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_media_desc_encryption_key_get_data,
+        Some(sip_media_desc_encryption_key_get_data),
     );
 }

--- a/rust/src/sip/detect.rs
+++ b/rust/src/sip/detect.rs
@@ -17,16 +17,16 @@
 
 // written by Giuseppe Longo <giuseppe@glongo.it>
 
-use crate::core::{DetectEngineThreadCtx, STREAM_TOCLIENT, STREAM_TOSERVER};
+use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::{
     helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
-    DetectHelperMultiBufferMpmRegister, DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
+    DetectSignatureSetAppProto, SigTableElmtStickyBuffer,
 };
 use crate::direction::Direction;
 use crate::sip::sip::{SIPTransaction, ALPROTO_SIP};
 use std::os::raw::{c_int, c_void};
 use std::ptr;
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature, SCDetectHelperMultiBufferMpmRegister, DetectEngineThreadCtx};
 
 static mut G_SIP_PROTOCOL_BUFFER_ID: c_int = 0;
 static mut G_SIP_STAT_CODE_BUFFER_ID: c_int = 0;
@@ -567,12 +567,12 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_from_hdr_setup,
     };
     let _g_sip_from_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_FROM_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_FROM_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.from\0".as_ptr() as *const libc::c_char,
         b"sip.from\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_from_hdr_get_data,
+        Some(sip_from_hdr_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.to"),
@@ -581,12 +581,12 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_to_hdr_setup,
     };
     let _g_sip_to_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_TO_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_TO_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.to\0".as_ptr() as *const libc::c_char,
         b"sip.to\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_to_hdr_get_data,
+        Some(sip_to_hdr_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.via"),
@@ -595,12 +595,12 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_via_hdr_setup,
     };
     let _g_sip_via_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_VIA_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_VIA_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.via\0".as_ptr() as *const libc::c_char,
         b"sip.via\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_via_hdr_get_data,
+        Some(sip_via_hdr_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.user_agent"),
@@ -609,12 +609,12 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_ua_hdr_setup,
     };
     let _g_sip_ua_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_UA_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_UA_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.ua\0".as_ptr() as *const libc::c_char,
         b"sip.ua\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_ua_hdr_get_data,
+        Some(sip_ua_hdr_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_type"),
@@ -623,12 +623,12 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_content_type_hdr_setup,
     };
     let _g_sip_content_type_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_CONTENT_TYPE_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_CONTENT_TYPE_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
         b"sip.content_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_content_type_hdr_get_data,
+        Some(sip_content_type_hdr_get_data),
     );
     let kw = SigTableElmtStickyBuffer {
         name: String::from("sip.content_length"),
@@ -637,11 +637,11 @@ pub unsafe extern "C" fn SCDetectSipRegister() {
         setup: sip_content_length_hdr_setup,
     };
     let _g_sip_content_length_hdr_kw_id = helper_keyword_register_sticky_buffer(&kw);
-    G_SIP_CONTENT_LENGTH_HDR_BUFFER_ID = DetectHelperMultiBufferMpmRegister(
+    G_SIP_CONTENT_LENGTH_HDR_BUFFER_ID = SCDetectHelperMultiBufferMpmRegister(
         b"sip.content_length\0".as_ptr() as *const libc::c_char,
         b"sip.content_length\0".as_ptr() as *const libc::c_char,
         ALPROTO_SIP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
-        sip_content_length_hdr_get_data,
+        Some(sip_content_length_hdr_get_data),
     );
 }

--- a/rust/src/snmp/detect.rs
+++ b/rust/src/snmp/detect.rs
@@ -21,13 +21,14 @@ use super::snmp::{SNMPTransaction, ALPROTO_SNMP};
 use crate::core::{STREAM_TOCLIENT, STREAM_TOSERVER};
 use crate::detect::uint::{DetectUintData, SCDetectU32Free, SCDetectU32Match, SCDetectU32Parse};
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use std::os::raw::{c_int, c_void};
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, SCDetectBufferSetActiveList, SCDetectHelperBufferRegister, Signature,
+};
 
 static mut G_SNMP_VERSION_KW_ID: c_int = 0;
 static mut G_SNMP_VERSION_BUFFER_ID: c_int = 0;
@@ -195,7 +196,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: 0,
     };
     G_SNMP_VERSION_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_SNMP_VERSION_BUFFER_ID = DetectHelperBufferRegister(
+    G_SNMP_VERSION_BUFFER_ID = SCDetectHelperBufferRegister(
         b"snmp.version\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -211,7 +212,7 @@ pub(super) unsafe extern "C" fn detect_snmp_register() {
         flags: 0,
     };
     G_SNMP_PDUTYPE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_SNMP_PDUTYPE_BUFFER_ID = DetectHelperBufferRegister(
+    G_SNMP_PDUTYPE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"snmp.pdu_type\0".as_ptr() as *const libc::c_char,
         ALPROTO_SNMP,
         STREAM_TOSERVER | STREAM_TOCLIENT,

--- a/rust/src/websocket/detect.rs
+++ b/rust/src/websocket/detect.rs
@@ -22,13 +22,14 @@ use crate::detect::uint::{
     SCDetectU32Match, SCDetectU32Parse, SCDetectU8Free, SCDetectU8Match,
 };
 use crate::detect::{
-    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister,
-    DetectHelperBufferRegister, DetectHelperGetData, DetectHelperKeywordRegister,
-    DetectSignatureSetAppProto, SCSigTableAppLiteElmt, SigMatchAppendSMToList,
-    SigTableElmtStickyBuffer,
+    helper_keyword_register_sticky_buffer, DetectHelperBufferMpmRegister, DetectHelperGetData,
+    DetectHelperKeywordRegister, DetectSignatureSetAppProto, SCSigTableAppLiteElmt,
+    SigMatchAppendSMToList, SigTableElmtStickyBuffer,
 };
 use crate::websocket::parser::WebSocketOpcode;
-use suricata_sys::sys::{DetectEngineCtx, SCDetectBufferSetActiveList, Signature};
+use suricata_sys::sys::{
+    DetectEngineCtx, SCDetectBufferSetActiveList, SCDetectHelperBufferRegister, Signature,
+};
 
 use nom7::branch::alt;
 use nom7::bytes::complete::{is_a, tag};
@@ -291,7 +292,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         flags: 0,
     };
     G_WEBSOCKET_OPCODE_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_WEBSOCKET_OPCODE_BUFFER_ID = DetectHelperBufferRegister(
+    G_WEBSOCKET_OPCODE_BUFFER_ID = SCDetectHelperBufferRegister(
         b"websocket.opcode\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -306,7 +307,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         flags: 0,
     };
     G_WEBSOCKET_MASK_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_WEBSOCKET_MASK_BUFFER_ID = DetectHelperBufferRegister(
+    G_WEBSOCKET_MASK_BUFFER_ID = SCDetectHelperBufferRegister(
         b"websocket.mask\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
         STREAM_TOSERVER | STREAM_TOCLIENT,
@@ -321,7 +322,7 @@ pub unsafe extern "C" fn SCDetectWebsocketRegister() {
         flags: 0,
     };
     G_WEBSOCKET_FLAGS_KW_ID = DetectHelperKeywordRegister(&kw);
-    G_WEBSOCKET_FLAGS_BUFFER_ID = DetectHelperBufferRegister(
+    G_WEBSOCKET_FLAGS_BUFFER_ID = SCDetectHelperBufferRegister(
         b"websocket.flags\0".as_ptr() as *const libc::c_char,
         ALPROTO_WEBSOCKET,
         STREAM_TOSERVER | STREAM_TOCLIENT,

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -327,6 +327,11 @@ extern "C" {
     pub fn SCDetectHelperNewKeywordId() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperKeywordAliasRegister(
+        kwid: ::std::os::raw::c_int, alias: *const ::std::os::raw::c_char,
+    );
+}
+extern "C" {
     pub fn SCDetectHelperBufferRegister(
         name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8,
     ) -> ::std::os::raw::c_int;

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -327,6 +327,10 @@ extern "C" {
     pub fn SCDetectHelperNewKeywordId() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperKeywordRegister(kw: *const SCSigTableAppLiteElmt)
+        -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperKeywordAliasRegister(
         kwid: ::std::os::raw::c_int, alias: *const ::std::os::raw::c_char,
     );

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -176,6 +176,9 @@ extern "C" {
         KeywordsRegister: ::std::option::Option<unsafe extern "C" fn()>,
     ) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    pub fn SCDetectHelperKeywordSetCleanCString(id: ::std::os::raw::c_int);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DetectEngineCtx_ {

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -327,6 +327,11 @@ extern "C" {
     pub fn SCDetectHelperNewKeywordId() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperBufferRegister(
+        name: *const ::std::os::raw::c_char, alproto: AppProto, direction: u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperMultiBufferMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -327,6 +327,12 @@ extern "C" {
     pub fn SCDetectHelperNewKeywordId() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn SCDetectHelperMultiBufferMpmRegister(
+        name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
+        alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
     pub fn SCDetectHelperMultiBufferProgressMpmRegister(
         name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
         alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,

--- a/rust/sys/src/sys.rs
+++ b/rust/sys/src/sys.rs
@@ -244,6 +244,16 @@ pub struct SigMatchCtx_ {
     _unused: [u8; 0],
 }
 pub type SigMatchCtx = SigMatchCtx_;
+pub type InspectionMultiBufferGetDataPtr = ::std::option::Option<
+    unsafe extern "C" fn(
+        det_ctx: *mut DetectEngineThreadCtx_,
+        txv: *const ::std::os::raw::c_void,
+        flow_flags: u8,
+        local_id: u32,
+        buf: *mut *const u8,
+        buf_len: *mut u32,
+    ) -> bool,
+>;
 #[doc = " App-layer light version of SigTableElmt"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -315,6 +325,13 @@ pub struct SCTransformTableElmt {
 }
 extern "C" {
     pub fn SCDetectHelperNewKeywordId() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn SCDetectHelperMultiBufferProgressMpmRegister(
+        name: *const ::std::os::raw::c_char, desc: *const ::std::os::raw::c_char,
+        alproto: AppProto, direction: u8, GetData: InspectionMultiBufferGetDataPtr,
+        progress: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SCDetectHelperTransformRegister(

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -337,7 +337,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.from";
     kw.Setup = DetectMimeEmailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_from_buffer_id = DetectHelperBufferMpmRegister(
             "email.from", "MIME EMAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailFromData);
 
@@ -346,7 +346,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.subject";
     kw.Setup = DetectMimeEmailSubjectSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_subject_buffer_id = DetectHelperBufferMpmRegister("email.subject",
             "MIME EMAIL SUBJECT", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailSubjectData);
 
@@ -355,7 +355,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.to";
     kw.Setup = DetectMimeEmailToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_to_buffer_id = DetectHelperBufferMpmRegister(
             "email.to", "MIME EMAIL TO", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailToData);
 
@@ -364,7 +364,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.cc";
     kw.Setup = DetectMimeEmailCcSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_cc_buffer_id = DetectHelperBufferMpmRegister(
             "email.cc", "MIME EMAIL CC", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailCcData);
 
@@ -373,7 +373,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.date";
     kw.Setup = DetectMimeEmailDateSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_date_buffer_id = DetectHelperBufferMpmRegister(
             "email.date", "MIME EMAIL DATE", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailDateData);
 
@@ -382,7 +382,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.message_id";
     kw.Setup = DetectMimeEmailMessageIdSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_message_id_buffer_id = DetectHelperBufferMpmRegister("email.message_id",
             "MIME EMAIL Message-Id", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailMessageIdData);
 
@@ -391,7 +391,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.x_mailer";
     kw.Setup = DetectMimeEmailXMailerSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_x_mailer_buffer_id = DetectHelperBufferMpmRegister("email.x_mailer",
             "MIME EMAIL X-Mailer", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailXMailerData);
 
@@ -400,7 +400,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.url";
     kw.Setup = DetectMimeEmailUrlSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_url_buffer_id = SCDetectHelperMultiBufferMpmRegister(
             "email.url", "MIME EMAIL URL", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData);
 
@@ -409,7 +409,7 @@ void DetectEmailRegister(void)
     kw.url = "/rules/email-keywords.html#email.received";
     kw.Setup = DetectMimeEmailReceivedSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_mime_email_received_buffer_id = SCDetectHelperMultiBufferMpmRegister("email.received",
             "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
 }

--- a/src/detect-email.c
+++ b/src/detect-email.c
@@ -401,7 +401,7 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailUrlSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_url_buffer_id = DetectHelperMultiBufferMpmRegister(
+    g_mime_email_url_buffer_id = SCDetectHelperMultiBufferMpmRegister(
             "email.url", "MIME EMAIL URL", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailUrlData);
 
     kw.name = "email.received";
@@ -410,6 +410,6 @@ void DetectEmailRegister(void)
     kw.Setup = DetectMimeEmailReceivedSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_mime_email_received_buffer_id = DetectHelperMultiBufferMpmRegister("email.received",
+    g_mime_email_received_buffer_id = SCDetectHelperMultiBufferMpmRegister("email.received",
             "MIME EMAIL RECEIVED", ALPROTO_SMTP, STREAM_TOSERVER, GetMimeEmailReceivedData);
 }

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -31,7 +31,7 @@
 #include "detect-engine-content-inspection.h"
 #include "rust.h"
 
-int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction)
+int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction)
 {
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerInspectEngineRegister(

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -81,7 +81,7 @@ int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto a
     return DetectBufferTypeGetByName(name);
 }
 
-int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
+int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress)
 {
     if (direction & STREAM_TOSERVER) {
@@ -98,7 +98,7 @@ int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *des
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData)
 {
-    return DetectHelperMultiBufferProgressMpmRegister(name, desc, alproto, direction, GetData, 0);
+    return SCDetectHelperMultiBufferProgressMpmRegister(name, desc, alproto, direction, GetData, 0);
 }
 
 int SCDetectHelperNewKeywordId(void)

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -81,8 +81,8 @@ int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto a
     return DetectBufferTypeGetByName(name);
 }
 
-int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress)
+int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,
+        AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress)
 {
     if (direction & STREAM_TOSERVER) {
         DetectAppLayerMultiRegister(name, alproto, SIG_FLAG_TOSERVER, progress, GetData, 2);
@@ -95,7 +95,7 @@ int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *d
     return DetectBufferTypeGetByName(name);
 }
 
-int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
+int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData)
 {
     return SCDetectHelperMultiBufferProgressMpmRegister(name, desc, alproto, direction, GetData, 0);

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -118,7 +118,7 @@ int SCDetectHelperNewKeywordId(void)
     return DETECT_TBLSIZE_IDX - 1;
 }
 
-int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw)
+int SCDetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw)
 {
     int keyword_id = SCDetectHelperNewKeywordId();
     if (keyword_id < 0) {

--- a/src/detect-engine-helper.c
+++ b/src/detect-engine-helper.c
@@ -139,7 +139,7 @@ int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw)
     return keyword_id;
 }
 
-void DetectHelperKeywordAliasRegister(int kwid, const char *alias)
+void SCDetectHelperKeywordAliasRegister(int kwid, const char *alias)
 {
     sigmatch_table[kwid].alias = alias;
 }

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -86,10 +86,10 @@ InspectionBuffer *DetectHelperGetData(struct DetectEngineThreadCtx_ *det_ctx,
         const int list_id, SimpleGetTxBuffer GetBuf);
 int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionBufferGetDataPtr GetData);
-int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
+int SCDetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
-int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
-        uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress);
+int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc,
+        AppProto alproto, uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress);
 
 int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw);
 

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -88,7 +88,7 @@ int DetectHelperBufferMpmRegister(const char *name, const char *desc, AppProto a
         uint8_t direction, InspectionBufferGetDataPtr GetData);
 int DetectHelperMultiBufferMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData);
-int DetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
+int SCDetectHelperMultiBufferProgressMpmRegister(const char *name, const char *desc, AppProto alproto,
         uint8_t direction, InspectionMultiBufferGetDataPtr GetData, int progress);
 
 int SCDetectHelperTransformRegister(const SCTransformTableElmt *kw);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -77,7 +77,7 @@ int SCDetectHelperNewKeywordId(void);
 
 int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
-int DetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
+int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);
 

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -76,7 +76,7 @@ typedef struct SCTransformTableElmt {
 int SCDetectHelperNewKeywordId(void);
 
 int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
-void DetectHelperKeywordAliasRegister(int kwid, const char *alias);
+void SCDetectHelperKeywordAliasRegister(int kwid, const char *alias);
 int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
 
 typedef bool (*SimpleGetTxBuffer)(void *, uint8_t, const uint8_t **, uint32_t *);

--- a/src/detect-engine-helper.h
+++ b/src/detect-engine-helper.h
@@ -75,7 +75,7 @@ typedef struct SCTransformTableElmt {
 
 int SCDetectHelperNewKeywordId(void);
 
-int DetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
+int SCDetectHelperKeywordRegister(const SCSigTableAppLiteElmt *kw);
 void SCDetectHelperKeywordAliasRegister(int kwid, const char *alias);
 int SCDetectHelperBufferRegister(const char *name, AppProto alproto, uint8_t direction);
 

--- a/src/detect-engine-register.c
+++ b/src/detect-engine-register.c
@@ -458,7 +458,7 @@ static void SigCleanCString(SigTableElmt *base)
     SCDetectSigMatchNamesFree(&kw);
 }
 
-void DetectHelperKeywordSetCleanCString(int id)
+void SCDetectHelperKeywordSetCleanCString(int id)
 {
     sigmatch_table[id].Cleanup = SigCleanCString;
 }

--- a/src/detect-engine-register.h
+++ b/src/detect-engine-register.h
@@ -350,6 +350,6 @@ void SigTableSetup(void);
 int SCSigTablePreRegister(void (*KeywordsRegister)(void));
 void SigTableRegisterTests(void);
 bool SigTableHasKeyword(const char *keyword);
-void DetectHelperKeywordSetCleanCString(int id);
+void SCDetectHelperKeywordSetCleanCString(int id);
 
 #endif /* SURICATA_DETECT_ENGINE_REGISTER_H */

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -136,7 +136,7 @@ void SCDetectSMTPRegister(void)
     kw.url = "/rules/smtp-keywords.html#smtp-helo";
     kw.Setup = DetectSmtpHeloSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_smtp_helo_buffer_id = DetectHelperBufferMpmRegister(
             "smtp.helo", "SMTP helo", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpHeloData);
 
@@ -145,7 +145,7 @@ void SCDetectSMTPRegister(void)
     kw.url = "/rules/smtp-keywords.html#smtp-mail-from";
     kw.Setup = DetectSmtpMailFromSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_smtp_mail_from_buffer_id = DetectHelperBufferMpmRegister(
             "smtp.mail_from", "SMTP MAIL FROM", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpMailFromData);
 
@@ -154,7 +154,7 @@ void SCDetectSMTPRegister(void)
     kw.url = "/rules/smtp-keywords.html#smtp-rcpt-to";
     kw.Setup = DetectSmtpRcptToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
-    DetectHelperKeywordRegister(&kw);
+    SCDetectHelperKeywordRegister(&kw);
     g_smtp_rcpt_to_buffer_id = SCDetectHelperMultiBufferMpmRegister(
             "smtp.rcpt_to", "SMTP RCPT TO", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpRcptToData);
 }

--- a/src/detect-smtp.c
+++ b/src/detect-smtp.c
@@ -155,6 +155,6 @@ void SCDetectSMTPRegister(void)
     kw.Setup = DetectSmtpRcptToSetup;
     kw.flags = SIGMATCH_NOOPT | SIGMATCH_INFO_STICKY_BUFFER;
     DetectHelperKeywordRegister(&kw);
-    g_smtp_rcpt_to_buffer_id = DetectHelperMultiBufferMpmRegister(
+    g_smtp_rcpt_to_buffer_id = SCDetectHelperMultiBufferMpmRegister(
             "smtp.rcpt_to", "SMTP RCPT TO", ALPROTO_SMTP, STREAM_TOSERVER, GetSmtpRcptToData);
 }


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7667

Describe changes:
- rust: bindgen more functions for detect, including removing SCSigTableAppLiteElmt definition from rust and use the suricata_sys one

https://github.com/OISF/suricata/pull/13166 next round

Still TODO afterwards in other PRs :
- Have https://github.com/OISF/suricata/pull/13215 take care of removing `DetectHelperGetData` and then we can bindgen new version of `DetectHelperBufferMpmRegister`
- bindgen functions from detect-parse.h redefined in rust/src/detect/mod.rs
- And to be more complete : remove extern definitions for other rust cases