### PR TITLE
detect: fix -Wshorten-64-to-32 warnings for content inspection

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -107,7 +107,7 @@ struct DetectEngineContentInspectionCtx {
 static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
         struct DetectEngineContentInspectionCtx *ctx, const Signature *s, const SigMatchData *smd,
         Packet *p, Flow *f, const uint8_t *buffer, const uint32_t buffer_len,
-        const uint32_t stream_start_offset, const uint8_t flags,
+        const uint64_t stream_start_offset, const uint8_t flags,
         const enum DetectContentInspectionType inspection_mode)
 {
     SCEnter();
@@ -732,7 +732,7 @@ final_match:
  */
 bool DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const Signature *s, const SigMatchData *smd, Packet *p, Flow *f, const uint8_t *buffer,
-        const uint32_t buffer_len, const uint32_t stream_start_offset, const uint8_t flags,
+        const uint32_t buffer_len, const uint64_t stream_start_offset, const uint8_t flags,
         const enum DetectContentInspectionType inspection_mode)
 {
     struct DetectEngineContentInspectionCtx ctx = { .recursion.count = 0,

--- a/src/detect-engine-content-inspection.h
+++ b/src/detect-engine-content-inspection.h
@@ -51,7 +51,7 @@ enum DetectContentInspectionType {
 /* implicit "public" just returns true match, false no match */
 bool DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx,
         const Signature *s, const SigMatchData *smd, Packet *p, Flow *f, const uint8_t *buffer,
-        const uint32_t buffer_len, const uint32_t stream_start_offset, const uint8_t flags,
+        const uint32_t buffer_len, const uint64_t stream_start_offset, const uint8_t flags,
         const enum DetectContentInspectionType inspection_mode);
 
 /** \brief content inspect entry for inspection buffers


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- detect fix `-Wshorten-64-to-32` warnings for detect engine content inspection : `stream_start_offset` is u64 as callers of `DetectEngineContentInspection` do

Same kind of fix as in #13220, they can be merged independently

Still to do afterwards :
- fix other detect warnings
- CI check
