### PR TITLE
detect: don't set conflicting packet/flow actions

### DIFF
--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -398,14 +398,22 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 }
             }
 
-            /* set actions on the flow */
-            FlowApplySignatureActions(p, pa, s, pa->flags);
+            bool skip_action_set = false;
+            if (p->action & ACTION_DROP) {
+                if (pa->action & ACTION_PASS) {
+                    skip_action_set = true;
+                }
+            }
+            if (!skip_action_set) {
+                /* set actions on the flow */
+                FlowApplySignatureActions(p, pa, s, pa->flags);
 
-            SCLogDebug("det_ctx->alert_queue[i].action %02x (DROP %s, PASS %s)", pa->action,
-                    BOOL2STR(pa->action & ACTION_DROP), BOOL2STR(pa->action & ACTION_PASS));
+                SCLogDebug("det_ctx->alert_queue[i].action %02x (DROP %s, PASS %s)", pa->action,
+                        BOOL2STR(pa->action & ACTION_DROP), BOOL2STR(pa->action & ACTION_PASS));
 
-            /* set actions on packet */
-            PacketApplySignatureActions(p, s, pa);
+                /* set actions on packet */
+                PacketApplySignatureActions(p, s, pa);
+            }
         }
 
         /* Thresholding removes this alert */


### PR DESCRIPTION
If for the same a packet a drop rule and a pass rule would match, the applying of actions could be contradictionary:

- the drop would be applied to the packet
- the pass rule would also be considered, not overriding the drop, but still setting the flow pass flag.

This would lead to the packet being dropped, but the rest of the flow getting passed, including retransmissions of the dropped packet.

This patch only sets drop/pass actions if no conflicting action has been set on the packet before. It respects the action-order.

Bug: #7653.

Fix based on:
57b17fb3b2fb ("detect: don't set conflicting packet/flow actions")

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2506