### PR TITLE
rust: clippy fixups - v2

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -283,7 +283,7 @@ jobs:
                 sudo \
                 which \
                 zlib-devel
-      - run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
+      - run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.85.0 -y
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - run: rustup component add rustfmt
       - run: rustup component add clippy

--- a/rust/derive/src/applayerstate.rs
+++ b/rust/derive/src/applayerstate.rs
@@ -24,14 +24,12 @@ fn get_attr_strip_prefix(attr: &syn::Attribute) -> String {
     let meta = attr.parse_meta().unwrap();
     if let syn::Meta::List(l) = meta {
         for n in l.nested {
-            if let syn::NestedMeta::Meta(m2) = n {
-                if let syn::Meta::NameValue(nv) = m2 {
-                    if nv.path.is_ident("alstate_strip_prefix") {
-                        if let syn::Lit::Str(s) = nv.lit {
-                            return s.value();
-                        }
-                        panic!("strip_prefix invalid syntax");
+            if let syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) = n {
+                if nv.path.is_ident("alstate_strip_prefix") {
+                    if let syn::Lit::Str(s) = nv.lit {
+                        return s.value();
                     }
+                    panic!("strip_prefix invalid syntax");
                 }
             }
         }

--- a/rust/htp/src/lib.rs
+++ b/rust/htp/src/lib.rs
@@ -6,9 +6,16 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
+
+// Allow unknown lints, our MSRV doesn't know them all, for
+// example static_mut_refs.
+#![allow(unknown_lints)]
+
+// Requires MSRV of 1.74 to fix.
+#![allow(clippy::io_other_error)]
+
 #[repr(C)]
 #[derive(PartialEq, Eq, Debug)]
-
 /// Status codes used by LibHTP internally.
 pub enum HtpStatus {
     /// The lowest value LibHTP will use internally.


### PR DESCRIPTION
- rust/applayer: collapse nested if let to remove clippy warning
- rust/htp: suppress io_other_error lint
- github-ci: use rust 1.85.0 for clippy check on templates
