### PR TITLE
etc/schema: sort properties in alphabetic order - v2


### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -66,7 +66,7 @@ jobs:
           path: .
 
   almalinux-9:
-    name: AlmaLinux 9
+    name: AlmaLinux 9 (schema)
     runs-on: ubuntu-latest
     container: almalinux:9
     needs: [prepare-deps, prepare-cbindgen]
@@ -229,6 +229,9 @@ jobs:
 
           # And build.
           PATH=/usr/local/bin:$PATH make clean all
+
+      - name: Check EVE schema ordering
+        run: ./scripts/schema-sort.py --check ./etc/schema.json
 
   almalinux-9-templates:
     name: AlmaLinux 9 Test Templates

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -6,202 +6,9 @@
         "timestamp"
     ],
     "properties": {
-        "app_proto": {
-            "type": "string"
-        },
-        "app_proto_expected": {
-            "type": "string"
-        },
-        "app_proto_orig": {
-            "type": "string"
-        },
-        "app_proto_tc": {
-            "type": "string"
-        },
-        "app_proto_ts": {
-            "type": "string"
-        },
-        "capture_file": {
-            "type": "string"
-        },
-        "community_id": {
-            "type": "string"
-        },
-        "dest_ip": {
-            "type": "string"
-        },
-        "dest_port": {
-            "type": "integer"
-        },
-        "event_type": {
-            "type": "string"
-        },
-        "flow_id": {
-            "type": "integer"
-        },
-        "host": {
-            "$comment":
-                    "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
-            "description": "the sensor-name, if configured",
-            "type": "string"
-        },
-        "icmp_code": {
-            "type": "integer"
-        },
-        "icmp_type": {
-            "type": "integer"
-        },
-        "in_iface": {
-            "type": "string"
-        },
-        "ip_v": {
-            "type": "integer",
-            "description": "IP version of the packet or flow"
-        },
-        "log_level": {
-            "type": "string"
-        },
-        "packet": {
-            "type": "string"
-        },
-        "parent_id": {
-            "type": "integer"
-        },
-        "payload": {
-            "type": "string"
-        },
-        "ts_progress": {
-            "type": "string"
-        },
-        "tc_progress": {
-            "type": "string"
-        },
-        "payload_length": {
-            "type": "integer"
-        },
-        "payload_printable": {
-            "type": "string"
-        },
-        "pcap_cnt": {
-            "type": "integer"
-        },
-        "pcap_filename": {
-            "type": "string"
-        },
-        "pkt_src": {
-            "type": "string"
-        },
-        "proto": {
-            "type": "string"
-        },
-        "response_icmp_code": {
-            "type": "integer"
-        },
-        "response_icmp_type": {
-            "type": "integer"
-        },
-        "spi": {
-            "type": "integer"
-        },
-        "src_ip": {
-            "type": "string"
-        },
-        "src_port": {
-            "type": "integer"
-        },
-        "suricata_version": {
-            "type": "string"
-        },
-        "stream": {
-            "type": "integer"
-        },
-        "timestamp": {
-            "type": "string",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+[+\\-]\\d+$"
-        },
-        "verdict": {
-            "$ref": "#/$defs/verdict_type"
-        },
-        "direction": {
-            "type": "string"
-        },
-        "tx_id": {
-            "type": "integer"
-        },
-        "tx_guessed": {
-            "description":
-                    "the signature that triggered this alert didn't tie to a transaction, so the transaction (and metadata) logged is a forced estimation and may not be the one you expect",
-            "type": "boolean"
-        },
-        "files": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "end": {
-                        "type": "integer"
-                    },
-                    "filename": {
-                        "type": "string"
-                    },
-                    "file_id": {
-                        "type": "integer"
-                    },
-                    "gaps": {
-                        "type": "boolean"
-                    },
-                    "magic": {
-                        "type": "string"
-                    },
-                    "md5": {
-                        "type": "string"
-                    },
-                    "sha1": {
-                        "type": "string"
-                    },
-                    "sha256": {
-                        "type": "string"
-                    },
-                    "size": {
-                        "type": "integer"
-                    },
-                    "start": {
-                        "type": "integer"
-                    },
-                    "state": {
-                        "type": "string"
-                    },
-                    "stored": {
-                        "type": "boolean"
-                    },
-                    "storing": {
-                        "description": "the file is set to be stored when completed",
-                        "type": "boolean"
-                    },
-                    "tx_id": {
-                        "type": "integer"
-                    },
-                    "sid": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "vlan": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "number"
-            }
-        },
         "alert": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "action": {
                     "type": "string"
@@ -211,24 +18,6 @@
                 },
                 "gid": {
                     "type": "integer"
-                },
-                "rev": {
-                    "type": "integer"
-                },
-                "rule": {
-                    "type": "string"
-                },
-                "severity": {
-                    "type": "integer"
-                },
-                "signature": {
-                    "type": "string"
-                },
-                "signature_id": {
-                    "type": "integer"
-                },
-                "xff": {
-                    "type": "string"
                 },
                 "metadata": {
                     "type": "object",
@@ -303,8 +92,7 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    "additionalProperties": true
+                    }
                 },
                 "references": {
                     "type": "array",
@@ -313,8 +101,24 @@
                         "type": "string"
                     }
                 },
+                "rev": {
+                    "type": "integer"
+                },
+                "rule": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "integer"
+                },
+                "signature": {
+                    "type": "string"
+                },
+                "signature_id": {
+                    "type": "integer"
+                },
                 "source": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "ip": {
                             "type": "string"
@@ -322,11 +126,11 @@
                         "port": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "target": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "ip": {
                             "type": "string"
@@ -334,21 +138,22 @@
                         "port": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "xff": {
+                    "type": "string"
                 }
-            },
-            "additionalProperties": false
-        },
-        "stream_tcp": {
-            "type": "object",
-            "additionalProperties": true
+            }
         },
         "anomaly": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "app_proto": {
                     "type": "string"
+                },
+                "code": {
+                    "type": "integer"
                 },
                 "event": {
                     "type": "string"
@@ -358,68 +163,83 @@
                 },
                 "type": {
                     "type": "string"
-                },
-                "code": {
-                    "type": "integer"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "app_proto": {
+            "type": "string"
+        },
+        "app_proto_expected": {
+            "type": "string"
+        },
+        "app_proto_orig": {
+            "type": "string"
+        },
+        "app_proto_tc": {
+            "type": "string"
+        },
+        "app_proto_ts": {
+            "type": "string"
         },
         "arp": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
-                "hw_type": {
+                "dest_ip": {
                     "type": "string",
-                    "description": "Network link protocol type"
-                },
-                "proto_type": {
-                    "type": "string",
-                    "description": "Internetwork protocol for which the ARP request is intended"
-                },
-                "opcode": {
-                    "type": "string",
-                    "description": "Specifies the operation that the sender is performing"
-                },
-                "src_mac": {
-                    "type": "string",
-                    "description": "Physical address of the sender"
-                },
-                "src_ip": {
-                    "type": "string",
-                    "description": "Logical address of the sender"
+                    "description": "Logical address of the intended receiver"
                 },
                 "dest_mac": {
                     "type": "string",
                     "description": "Physical address of the intended receiver"
                 },
-                "dest_ip": {
+                "hw_type": {
                     "type": "string",
-                    "description": "Logical address of the intended receiver"
+                    "description": "Network link protocol type"
+                },
+                "opcode": {
+                    "type": "string",
+                    "description": "Specifies the operation that the sender is performing"
+                },
+                "proto_type": {
+                    "type": "string",
+                    "description": "Internetwork protocol for which the ARP request is intended"
+                },
+                "src_ip": {
+                    "type": "string",
+                    "description": "Logical address of the sender"
+                },
+                "src_mac": {
+                    "type": "string",
+                    "description": "Physical address of the sender"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "bittorrent_dht": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "transaction_id": {
-                    "type": "string"
-                },
                 "client_version": {
                     "type": "string"
                 },
-                "request_type": {
-                    "type": "string"
+                "error": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "msg": {
+                            "type": "string"
+                        },
+                        "num": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "request": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "id": {
-                            "type": "string"
-                        },
-                        "target": {
                             "type": "string"
                         },
                         "implied_port": {
@@ -431,10 +251,16 @@
                         "port": {
                             "type": "integer"
                         },
+                        "target": {
+                            "type": "string"
+                        },
                         "token": {
                             "type": "string"
                         }
                     }
+                },
+                "request_type": {
+                    "type": "string"
                 },
                 "response": {
                     "type": "object",
@@ -506,23 +332,20 @@
                         }
                     }
                 },
-                "error": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "num": {
-                            "type": "integer"
-                        },
-                        "msg": {
-                            "type": "string"
-                        }
-                    }
+                "transaction_id": {
+                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "capture_file": {
+            "type": "string"
+        },
+        "community_id": {
+            "type": "string"
         },
         "dcerpc": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "activityuuid": {
                     "type": "string"
@@ -530,23 +353,12 @@
                 "call_id": {
                     "type": "integer"
                 },
-                "request": {
-                    "type": "string"
-                },
-                "response": {
-                    "type": "string"
-                },
-                "rpc_version": {
-                    "type": "string"
-                },
-                "seqnum": {
-                    "type": "integer"
-                },
                 "interfaces": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "ack_result": {
                                 "type": "integer"
@@ -567,12 +379,12 @@
                                     ]
                                 }
                             }
-                        },
-                        "additionalProperties": false
+                        }
                     }
                 },
                 "req": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "frag_cnt": {
                             "type": "integer"
@@ -588,11 +400,14 @@
                         "stub_data_size": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "request": {
+                    "type": "string"
                 },
                 "res": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "frag_cnt": {
                             "type": "integer"
@@ -600,14 +415,28 @@
                         "stub_data_size": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "response": {
+                    "type": "string"
+                },
+                "rpc_version": {
+                    "type": "string"
+                },
+                "seqnum": {
+                    "type": "integer"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "dest_ip": {
+            "type": "string"
+        },
+        "dest_port": {
+            "type": "integer"
         },
         "dhcp": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "assigned_ip": {
                     "type": "string"
@@ -624,6 +453,13 @@
                 "dhcp_type": {
                     "type": "string"
                 },
+                "dns_servers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "hostname": {
                     "type": "string"
                 },
@@ -635,6 +471,13 @@
                 },
                 "next_server_ip": {
                     "type": "string"
+                },
+                "params": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "rebinding_time": {
                     "type": "integer"
@@ -648,6 +491,13 @@
                 "requested_ip": {
                     "type": "string"
                 },
+                "routers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "subnet_mask": {
                     "type": "string"
                 },
@@ -656,48 +506,43 @@
                 },
                 "vendor_class_identifier": {
                     "type": "string"
-                },
-                "dns_servers": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "params": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "routers": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "direction": {
+            "type": "string"
         },
         "dnp3": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "dst": {
-                    "type": "integer"
-                },
-                "src": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                },
                 "application": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "complete": {
                             "type": "boolean"
+                        },
+                        "control": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "con": {
+                                    "type": "boolean"
+                                },
+                                "fin": {
+                                    "type": "boolean"
+                                },
+                                "fir": {
+                                    "type": "boolean"
+                                },
+                                "sequence": {
+                                    "type": "integer"
+                                },
+                                "uns": {
+                                    "type": "boolean"
+                                }
+                            }
                         },
                         "function_code": {
                             "type": "integer"
@@ -707,12 +552,20 @@
                             "minItems": 1,
                             "items": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "count": {
                                         "type": "integer"
                                     },
                                     "group": {
                                         "type": "integer"
+                                    },
+                                    "points": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {
+                                            "type": "object"
+                                        }
                                     },
                                     "prefix_code": {
                                         "type": "integer"
@@ -731,45 +584,15 @@
                                     },
                                     "variation": {
                                         "type": "integer"
-                                    },
-                                    "points": {
-                                        "type": "array",
-                                        "minItems": 1,
-                                        "items": {
-                                            "type": "object",
-                                            "additionalProperties": true
-                                        }
                                     }
-                                },
-                                "additionalProperties": false
-                            }
-                        },
-                        "control": {
-                            "type": "object",
-                            "properties": {
-                                "con": {
-                                    "type": "boolean"
-                                },
-                                "fin": {
-                                    "type": "boolean"
-                                },
-                                "fir": {
-                                    "type": "boolean"
-                                },
-                                "sequence": {
-                                    "type": "integer"
-                                },
-                                "uns": {
-                                    "type": "boolean"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "control": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dir": {
                             "type": "boolean"
@@ -786,11 +609,14 @@
                         "pri": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "dst": {
+                    "type": "integer"
                 },
                 "iin": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "indicators": {
                             "type": "array",
@@ -799,26 +625,39 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "dst": {
-                            "type": "integer"
-                        },
-                        "src": {
-                            "type": "integer"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
                         "application": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "complete": {
                                     "type": "boolean"
+                                },
+                                "control": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "con": {
+                                            "type": "boolean"
+                                        },
+                                        "fin": {
+                                            "type": "boolean"
+                                        },
+                                        "fir": {
+                                            "type": "boolean"
+                                        },
+                                        "sequence": {
+                                            "type": "integer"
+                                        },
+                                        "uns": {
+                                            "type": "boolean"
+                                        }
+                                    }
                                 },
                                 "function_code": {
                                     "type": "integer"
@@ -828,12 +667,20 @@
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "count": {
                                                 "type": "integer"
                                             },
                                             "group": {
                                                 "type": "integer"
+                                            },
+                                            "points": {
+                                                "type": "array",
+                                                "minItems": 1,
+                                                "items": {
+                                                    "type": "object"
+                                                }
                                             },
                                             "prefix_code": {
                                                 "type": "integer"
@@ -852,45 +699,15 @@
                                             },
                                             "variation": {
                                                 "type": "integer"
-                                            },
-                                            "points": {
-                                                "type": "array",
-                                                "minItems": 1,
-                                                "items": {
-                                                    "type": "object",
-                                                    "additionalProperties": true
-                                                }
                                             }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "control": {
-                                    "type": "object",
-                                    "properties": {
-                                        "con": {
-                                            "type": "boolean"
-                                        },
-                                        "fin": {
-                                            "type": "boolean"
-                                        },
-                                        "fir": {
-                                            "type": "boolean"
-                                        },
-                                        "sequence": {
-                                            "type": "integer"
-                                        },
-                                        "uns": {
-                                            "type": "boolean"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         },
                         "control": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "dir": {
                                     "type": "boolean"
@@ -907,29 +724,50 @@
                                 "pri": {
                                     "type": "boolean"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "dst": {
+                            "type": "integer"
+                        },
+                        "src": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "response": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "dst": {
-                            "type": "integer"
-                        },
-                        "src": {
-                            "type": "integer"
-                        },
-                        "type": {
-                            "type": "string"
-                        },
                         "application": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "complete": {
                                     "type": "boolean"
+                                },
+                                "control": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "con": {
+                                            "type": "boolean"
+                                        },
+                                        "fin": {
+                                            "type": "boolean"
+                                        },
+                                        "fir": {
+                                            "type": "boolean"
+                                        },
+                                        "sequence": {
+                                            "type": "integer"
+                                        },
+                                        "uns": {
+                                            "type": "boolean"
+                                        }
+                                    }
                                 },
                                 "function_code": {
                                     "type": "integer"
@@ -939,12 +777,20 @@
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "count": {
                                                 "type": "integer"
                                             },
                                             "group": {
                                                 "type": "integer"
+                                            },
+                                            "points": {
+                                                "type": "array",
+                                                "minItems": 1,
+                                                "items": {
+                                                    "type": "object"
+                                                }
                                             },
                                             "prefix_code": {
                                                 "type": "integer"
@@ -963,45 +809,15 @@
                                             },
                                             "variation": {
                                                 "type": "integer"
-                                            },
-                                            "points": {
-                                                "type": "array",
-                                                "minItems": 1,
-                                                "items": {
-                                                    "type": "object",
-                                                    "additionalProperties": true
-                                                }
                                             }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "control": {
-                                    "type": "object",
-                                    "properties": {
-                                        "con": {
-                                            "type": "boolean"
-                                        },
-                                        "fin": {
-                                            "type": "boolean"
-                                        },
-                                        "fir": {
-                                            "type": "boolean"
-                                        },
-                                        "sequence": {
-                                            "type": "integer"
-                                        },
-                                        "uns": {
-                                            "type": "boolean"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         },
                         "control": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "dir": {
                                     "type": "boolean"
@@ -1018,11 +834,14 @@
                                 "pri": {
                                     "type": "boolean"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "dst": {
+                            "type": "integer"
                         },
                         "iin": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "indicators": {
                                     "type": "array",
@@ -1031,17 +850,27 @@
                                         "type": "string"
                                     }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "src": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "src": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "dns": {
             "type": "object",
+            "additionalProperties": false,
             "required": [
                 "version"
             ],
@@ -1049,229 +878,28 @@
                 "aa": {
                     "type": "boolean"
                 },
-                "flags": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "qr": {
-                    "type": "boolean"
-                },
-                "ra": {
-                    "type": "boolean"
-                },
-                "rcode": {
-                    "type": "string",
-                    "suricata": {
-                        "keywords": [
-                            "dns.rcode"
-                        ]
-                    }
-                },
-                "rd": {
-                    "type": "boolean"
-                },
-                "rrname": {
-                    "type": "string"
-                },
-                "rrtype": {
-                    "type": "string"
-                },
-                "tx_id": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "version": {
-                    "description": "The version of this EVE DNS event",
-                    "type": "integer",
-                    "suricata": {
-                        "keywords": false
-                    }
-                },
-                "opcode": {
-                    "description": "DNS opcode as an integer",
-                    "type": "integer"
-                },
-                "tc": {
-                    "description": "DNS truncation flag",
-                    "type": "boolean"
-                },
-                "answers": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "rdata": {
-                                "type": "string",
-                                "suricata": {
-                                    "keywords": [
-                                        "dns.response.rrname"
-                                    ]
-                                }
-                            },
-                            "rrname": {
-                                "type": "string",
-                                "suricata": {
-                                    "keywords": [
-                                        "dns.answers.rrname",
-                                        "dns.response.rrname"
-                                    ]
-                                }
-                            },
-                            "rrtype": {
-                                "type": "string"
-                            },
-                            "ttl": {
-                                "type": "integer"
-                            },
-                            "soa": {
-                                "$ref": "#/$defs/dns.soa"
-                            },
-                            "srv": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "port": {
-                                        "type": "integer"
-                                    },
-                                    "priority": {
-                                        "type": "integer"
-                                    },
-                                    "weight": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "additionalProperties": false
-                            },
-                            "sshfp": {
-                                "description":
-                                        "A Secure Shell fingerprint, used to verify the system’s authenticity",
-                                "type": "object",
-                                "properties": {
-                                    "fingerprint": {
-                                        "type": "string"
-                                    },
-                                    "algo": {
-                                        "type": "integer"
-                                    },
-                                    "type": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "authorities": {
-                    "$ref": "#/$defs/dns.authorities"
-                },
                 "additionals": {
                     "$ref": "#/$defs/dns.additionals"
                 },
-                "query": {
-                    "$comment":
-                            "EVE DNS v2 style query logging; as of Suricata 8 only used in DNS records when v2 logging is enabled, not used for DNS records logged as part of an event.",
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "integer"
-                            },
-                            "rrname": {
-                                "type": "string"
-                            },
-                            "rrtype": {
-                                "type": "string"
-                            },
-                            "tx_id": {
-                                "type": "integer"
-                            },
-                            "type": {
-                                "type": "string"
-                            },
-                            "z": {
-                                "type": "boolean"
-                            },
-                            "opcode": {
-                                "description": "DNS opcode as an integer",
-                                "type": "integer"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "queries": {
-                    "$comment": "EVE DNS v3 style query logging.",
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "integer"
-                            },
-                            "rrname": {
-                                "type": "string",
-                                "suricata": {
-                                    "keywords": [
-                                        "dns.queries.rrname",
-                                        "dns.query"
-                                    ]
-                                }
-                            },
-                            "rrtype": {
-                                "type": "string",
-                                "suricata": {
-                                    "keywords": [
-                                        "dns.rrtype"
-                                    ]
-                                }
-                            },
-                            "tx_id": {
-                                "type": "integer"
-                            },
-                            "type": {
-                                "type": "string"
-                            },
-                            "z": {
-                                "type": "boolean"
-                            },
-                            "opcode": {
-                                "description": "DNS opcode as an integer",
-                                "type": "integer",
-                                "suricata": {
-                                    "keywords": [
-                                        "dns.opcode"
-                                    ]
-                                }
-                            },
-                            "rrname_truncated": {
-                                "description":
-                                        "Set to true if the rrname was too long and truncated by Suricata",
-                                "type": "boolean"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                },
                 "answer": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
+                        "additionals": {
+                            "$ref": "#/$defs/dns.additionals"
+                        },
+                        "authorities": {
+                            "$ref": "#/$defs/dns.authorities"
+                        },
                         "flags": {
                             "type": "string"
                         },
                         "id": {
                             "type": "integer"
+                        },
+                        "opcode": {
+                            "type": "integer",
+                            "description": "DNS opcode as an integer"
                         },
                         "qr": {
                             "type": "boolean"
@@ -1296,27 +924,88 @@
                         },
                         "version": {
                             "type": "integer"
-                        },
-                        "opcode": {
-                            "description": "DNS opcode as an integer",
-                            "type": "integer"
-                        },
-                        "authorities": {
-                            "$ref": "#/$defs/dns.authorities"
-                        },
-                        "additionals": {
-                            "$ref": "#/$defs/dns.additionals"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "answers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "rdata": {
+                                "type": "string",
+                                "suricata": {
+                                    "keywords": [
+                                        "dns.response.rrname"
+                                    ]
+                                }
+                            },
+                            "rrname": {
+                                "type": "string",
+                                "suricata": {
+                                    "keywords": [
+                                        "dns.answers.rrname",
+                                        "dns.response.rrname"
+                                    ]
+                                }
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "soa": {
+                                "$ref": "#/$defs/dns.soa"
+                            },
+                            "srv": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "type": "integer"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "type": "integer"
+                                    }
+                                }
+                            },
+                            "sshfp": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "algo": {
+                                        "type": "integer"
+                                    },
+                                    "fingerprint": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "description": "A Secure Shell fingerprint, used to verify the system\u2019s authenticity"
+                            },
+                            "ttl": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "authorities": {
+                    "$ref": "#/$defs/dns.authorities"
+                },
+                "flags": {
+                    "type": "string"
                 },
                 "grouped": {
-                    "desription":
-                            "DNS fields grouped by type: alternative format, no direct keywords",
                     "type": "object",
-                    "suricata": {
-                        "keywords": false
-                    },
+                    "additionalProperties": false,
                     "properties": {
                         "A": {
                             "type": "array",
@@ -1379,6 +1068,7 @@
                             "minItems": 1,
                             "items": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -1392,8 +1082,27 @@
                                     "weight": {
                                         "type": "integer"
                                     }
-                                },
-                                "additionalProperties": false
+                                }
+                            }
+                        },
+                        "SSHFP": {
+                            "type": "array",
+                            "description": "A Secure Shell fingerprint is used to verify the system\u2019s authenticity",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "algo": {
+                                        "type": "integer"
+                                    },
+                                    "fingerprint": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "integer"
+                                    }
+                                }
                             }
                         },
                         "TXT": {
@@ -1402,42 +1111,154 @@
                             "items": {
                                 "type": "string"
                             }
-                        },
-                        "SSHFP": {
-                            "description":
-                                    "A Secure Shell fingerprint is used to verify the system’s authenticity",
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "fingerprint": {
-                                        "type": "string"
-                                    },
-                                    "algo": {
-                                        "type": "integer"
-                                    },
-                                    "type": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
                         }
                     },
-                    "additionalProperties": false
+                    "desription": "DNS fields grouped by type: alternative format, no direct keywords",
+                    "suricata": {
+                        "keywords": false
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "opcode": {
+                    "type": "integer",
+                    "description": "DNS opcode as an integer"
+                },
+                "qr": {
+                    "type": "boolean"
+                },
+                "queries": {
+                    "type": "array",
+                    "$comment": "EVE DNS v3 style query logging.",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "opcode": {
+                                "type": "integer",
+                                "description": "DNS opcode as an integer",
+                                "suricata": {
+                                    "keywords": [
+                                        "dns.opcode"
+                                    ]
+                                }
+                            },
+                            "rrname": {
+                                "type": "string",
+                                "suricata": {
+                                    "keywords": [
+                                        "dns.queries.rrname",
+                                        "dns.query"
+                                    ]
+                                }
+                            },
+                            "rrname_truncated": {
+                                "type": "boolean",
+                                "description": "Set to true if the rrname was too long and truncated by Suricata"
+                            },
+                            "rrtype": {
+                                "type": "string",
+                                "suricata": {
+                                    "keywords": [
+                                        "dns.rrtype"
+                                    ]
+                                }
+                            },
+                            "tx_id": {
+                                "type": "integer"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "z": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "query": {
+                    "type": "array",
+                    "$comment": "EVE DNS v2 style query logging; as of Suricata 8 only used in DNS records when v2 logging is enabled, not used for DNS records logged as part of an event.",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "opcode": {
+                                "type": "integer",
+                                "description": "DNS opcode as an integer"
+                            },
+                            "rrname": {
+                                "type": "string"
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "tx_id": {
+                                "type": "integer"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "z": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "ra": {
+                    "type": "boolean"
+                },
+                "rcode": {
+                    "type": "string",
+                    "suricata": {
+                        "keywords": [
+                            "dns.rcode"
+                        ]
+                    }
+                },
+                "rd": {
+                    "type": "boolean"
+                },
+                "rrname": {
+                    "type": "string"
+                },
+                "rrtype": {
+                    "type": "string"
+                },
+                "tc": {
+                    "type": "boolean",
+                    "description": "DNS truncation flag"
+                },
+                "tx_id": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "integer",
+                    "description": "The version of this EVE DNS event",
+                    "suricata": {
+                        "keywords": false
+                    }
                 },
                 "z": {
                     "type": "boolean"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "drop": {
             "type": "object",
-            "suricata": {
-                "keywords": false
-            },
+            "additionalProperties": false,
             "properties": {
                 "ack": {
                     "type": "boolean"
@@ -1449,9 +1270,6 @@
                     "type": "integer"
                 },
                 "hoplimit": {
-                    "type": "integer"
-                },
-                "tc": {
                     "type": "integer"
                 },
                 "icmp_id": {
@@ -1469,11 +1287,17 @@
                 "psh": {
                     "type": "boolean"
                 },
+                "reason": {
+                    "type": "string"
+                },
                 "rst": {
                     "type": "boolean"
                 },
                 "syn": {
                     "type": "boolean"
+                },
+                "tc": {
+                    "type": "integer"
                 },
                 "tcpack": {
                     "type": "integer"
@@ -1502,18 +1326,25 @@
                 "urg": {
                     "type": "boolean"
                 },
-                "reason": {
-                    "type": "string"
-                },
                 "verdict": {
                     "$ref": "#/$defs/verdict_type"
                 }
             },
-            "additionalProperties": false
+            "suricata": {
+                "keywords": false
+            }
         },
         "email": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
+                "attachment": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "body_md5": {
                     "type": "string"
                 },
@@ -1538,6 +1369,9 @@
                 },
                 "has_ipv6_url": {
                     "type": "boolean"
+                },
+                "message_id": {
+                    "type": "string"
                 },
                 "received": {
                     "type": "array",
@@ -1571,22 +1405,12 @@
                 },
                 "x_mailer": {
                     "type": "string"
-                },
-                "attachment": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "message_id": {
-                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "engine": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "error": {
                     "type": "string"
@@ -1597,61 +1421,26 @@
                 "message": {
                     "type": "string"
                 },
-                "thread_name": {
-                    "type": "string"
-                },
                 "module": {
                     "type": "string"
+                },
+                "thread_name": {
+                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "enip": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "command": {
-                            "type": "string"
-                        },
-                        "status": {
-                            "type": "string"
-                        },
-                        "register_session": {
-                            "type": "object",
-                            "properties": {
-                                "protocol_version": {
-                                    "type": "integer"
-                                },
-                                "options": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "cip": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
-                                "service": {
-                                    "type": "string"
-                                },
-                                "path": {
-                                    "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "segment_type": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                },
                                 "class_name": {
                                     "type": "string"
                                 },
@@ -1660,8 +1449,9 @@
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
-                                            "service": {
+                                            "class_name": {
                                                 "type": "string"
                                             },
                                             "path": {
@@ -1669,6 +1459,7 @@
                                                 "minItems": 1,
                                                 "items": {
                                                     "type": "object",
+                                                    "additionalProperties": false,
                                                     "properties": {
                                                         "segment_type": {
                                                             "type": "string"
@@ -1676,112 +1467,70 @@
                                                         "value": {
                                                             "type": "integer"
                                                         }
-                                                    },
-                                                    "additionalProperties": false
+                                                    }
                                                 }
                                             },
-                                            "class_name": {
+                                            "service": {
                                                 "type": "string"
                                             }
-                                        },
-                                        "additionalProperties": false
+                                        }
                                     }
+                                },
+                                "path": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "segment_type": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                },
+                                "service": {
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "response": {
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "type": "string"
+                            }
                         },
-                        "status": {
+                        "command": {
                             "type": "string"
                         },
                         "register_session": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
-                                "protocol_version": {
-                                    "type": "integer"
-                                },
                                 "options": {
                                     "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "list_services": {
-                            "type": "object",
-                            "properties": {
+                                },
                                 "protocol_version": {
                                     "type": "integer"
-                                },
-                                "capabilities": {
-                                    "type": "integer"
-                                },
-                                "service_name": {
-                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         },
-                        "identity": {
-                            "type": "object",
-                            "properties": {
-                                "protocol_version": {
-                                    "type": "integer"
-                                },
-                                "revision": {
-                                    "type": "string"
-                                },
-                                "vendor_id": {
-                                    "type": "string"
-                                },
-                                "device_type": {
-                                    "type": "string"
-                                },
-                                "product_code": {
-                                    "type": "integer"
-                                },
-                                "status": {
-                                    "type": "integer"
-                                },
-                                "serial": {
-                                    "type": "integer"
-                                },
-                                "product_name": {
-                                    "type": "string"
-                                },
-                                "state": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "response": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
                         "cip": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
-                                "service": {
-                                    "type": "string"
-                                },
-                                "status": {
-                                    "type": "string"
-                                },
-                                "status_extended": {
-                                    "type": "string"
-                                },
-                                "status_extended_meaning": {
-                                    "type": "string"
-                                },
                                 "multiple": {
                                     "type": "array",
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "service": {
                                                 "type": "string"
@@ -1795,31 +1544,99 @@
                                             "status_extended_meaning": {
                                                 "type": "string"
                                             }
-                                        },
-                                        "additionalProperties": false
+                                        }
                                     }
+                                },
+                                "service": {
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "type": "string"
+                                },
+                                "status_extended": {
+                                    "type": "string"
+                                },
+                                "status_extended_meaning": {
+                                    "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "command": {
+                            "type": "string"
+                        },
+                        "identity": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "device_type": {
+                                    "type": "string"
+                                },
+                                "product_code": {
+                                    "type": "integer"
+                                },
+                                "product_name": {
+                                    "type": "string"
+                                },
+                                "protocol_version": {
+                                    "type": "integer"
+                                },
+                                "revision": {
+                                    "type": "string"
+                                },
+                                "serial": {
+                                    "type": "integer"
+                                },
+                                "state": {
+                                    "type": "integer"
+                                },
+                                "status": {
+                                    "type": "integer"
+                                },
+                                "vendor_id": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "list_services": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "capabilities": {
+                                    "type": "integer"
+                                },
+                                "protocol_version": {
+                                    "type": "integer"
+                                },
+                                "service_name": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "register_session": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "options": {
+                                    "type": "integer"
+                                },
+                                "protocol_version": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "status": {
+                            "type": "string"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "ether": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "dest_mac": {
                     "type": "string"
-                },
-                "src_mac": {
-                    "type": "string"
-                },
-                "ether_type": {
-                    "type": "integer",
-                    "description": "Ethernet type value "
                 },
                 "dest_macs": {
                     "type": "array",
@@ -1828,6 +1645,13 @@
                         "type": "string"
                     }
                 },
+                "ether_type": {
+                    "type": "integer",
+                    "description": "Ethernet type value "
+                },
+                "src_mac": {
+                    "type": "string"
+                },
                 "src_macs": {
                     "type": "array",
                     "minItems": 1,
@@ -1835,11 +1659,14 @@
                         "type": "string"
                     }
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "event_type": {
+            "type": "string"
         },
         "fileinfo": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "end": {
                     "type": "integer"
@@ -1865,6 +1692,13 @@
                 "sha256": {
                     "type": "string"
                 },
+                "sid": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "size": {
                     "type": "integer"
                 },
@@ -1878,24 +1712,77 @@
                     "type": "boolean"
                 },
                 "storing": {
-                    "description": "the file is set to be stored when completed",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "the file is set to be stored when completed"
                 },
                 "tx_id": {
                     "type": "integer"
-                },
-                "sid": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
+                }
+            }
+        },
+        "files": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "end": {
+                        "type": "integer"
+                    },
+                    "file_id": {
+                        "type": "integer"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "gaps": {
+                        "type": "boolean"
+                    },
+                    "magic": {
+                        "type": "string"
+                    },
+                    "md5": {
+                        "type": "string"
+                    },
+                    "sha1": {
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "type": "string"
+                    },
+                    "sid": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "size": {
+                        "type": "integer"
+                    },
+                    "start": {
+                        "type": "integer"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "stored": {
+                        "type": "boolean"
+                    },
+                    "storing": {
+                        "type": "boolean",
+                        "description": "the file is set to be stored when completed"
+                    },
+                    "tx_id": {
                         "type": "integer"
                     }
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "flow": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "action": {
                     "type": "string"
@@ -1903,7 +1790,7 @@
                 "age": {
                     "type": "integer",
                     "suricata": {
-                        "keywords" : [
+                        "keywords": [
                             "flow.age"
                         ]
                     }
@@ -1911,29 +1798,26 @@
                 "alerted": {
                     "type": "boolean"
                 },
-                "elephant": {
-                    "type": "boolean"
-                },
                 "bypass": {
                     "type": "string"
                 },
                 "bypassed": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "pkts_toserver": {
-                            "type": "integer"
-                        },
-                        "pkts_toclient": {
+                        "bytes_toclient": {
                             "type": "integer"
                         },
                         "bytes_toserver": {
                             "type": "integer"
                         },
-                        "bytes_toclient": {
+                        "pkts_toclient": {
+                            "type": "integer"
+                        },
+                        "pkts_toserver": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "bytes_toclient": {
                     "type": "integer",
@@ -1959,6 +1843,9 @@
                 "dest_port": {
                     "type": "integer"
                 },
+                "elephant": {
+                    "type": "boolean"
+                },
                 "emergency": {
                     "type": "boolean"
                 },
@@ -1966,19 +1853,18 @@
                     "type": "string"
                 },
                 "exception_policy": {
-                    "description":
-                            "The exception policy(ies) triggered by the flow. Not logged if none was triggered",
                     "type": "array",
                     "properties": {
-                        "target": {
-                            "description": "What triggered the exception",
-                            "type": "string"
-                        },
                         "policy": {
-                            "description": "Which exception policy was applied",
-                            "type": "string"
+                            "type": "string",
+                            "description": "Which exception policy was applied"
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": "What triggered the exception"
                         }
-                    }
+                    },
+                    "description": "The exception policy(ies) triggered by the flow. Not logged if none was triggered"
                 },
                 "pkts_toclient": {
                     "type": "integer",
@@ -2018,35 +1904,32 @@
                         ]
                     }
                 },
-                "wrong_thread": {
-                    "type": "boolean"
-                },
                 "tx_cnt": {
                     "type": "integer"
+                },
+                "wrong_thread": {
+                    "type": "boolean"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "flow_id": {
+            "type": "integer"
         },
         "frame": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "type": {
+                "complete": {
+                    "type": "boolean"
+                },
+                "direction": {
                     "type": "string"
                 },
                 "id": {
                     "type": "integer"
                 },
-                "direction": {
-                    "type": "string"
-                },
-                "stream_offset": {
-                    "type": "integer"
-                },
                 "length": {
                     "type": "integer"
-                },
-                "complete": {
-                    "type": "boolean"
                 },
                 "payload": {
                     "type": "string"
@@ -2054,14 +1937,20 @@
                 "payload_printable": {
                     "type": "string"
                 },
+                "stream_offset": {
+                    "type": "integer"
+                },
                 "tx_id": {
                     "type": "integer"
+                },
+                "type": {
+                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "ftp": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "command": {
                     "type": "string"
@@ -2072,18 +1961,6 @@
                 "command_truncated": {
                     "type": "boolean"
                 },
-                "dynamic_port": {
-                    "type": "integer"
-                },
-                "mode": {
-                    "type": "string"
-                },
-                "reply_received": {
-                    "type": "string"
-                },
-                "reply_truncated": {
-                    "type": "boolean"
-                },
                 "completion_code": {
                     "type": "array",
                     "minItems": 1,
@@ -2091,18 +1968,30 @@
                         "type": "string"
                     }
                 },
+                "dynamic_port": {
+                    "type": "integer"
+                },
+                "mode": {
+                    "type": "string"
+                },
                 "reply": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
                     }
+                },
+                "reply_received": {
+                    "type": "string"
+                },
+                "reply_truncated": {
+                    "type": "boolean"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "ftp_data": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "command": {
                     "type": "string"
@@ -2110,14 +1999,105 @@
                 "filename": {
                     "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "host": {
+            "type": "string",
+            "$comment": "May change to sensor_name in the future, or become user configurable: https://redmine.openinfosecfoundation.org/issues/4919",
+            "description": "the sensor-name, if configured"
         },
         "http": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
+                "content_range": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "end": {
+                            "type": "integer"
+                        },
+                        "raw": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "start": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "hostname": {
                     "type": "string"
+                },
+                "http2": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "request": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "error_code": {
+                                    "type": "string"
+                                },
+                                "has_multiple": {
+                                    "type": "string"
+                                },
+                                "priority": {
+                                    "type": "integer"
+                                },
+                                "settings": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "settings_id": {
+                                                "type": "string"
+                                            },
+                                            "settings_value": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "response": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "error_code": {
+                                    "type": "string"
+                                },
+                                "has_multiple": {
+                                    "type": "string"
+                                },
+                                "settings": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "settings_id": {
+                                                "type": "string"
+                                            },
+                                            "settings_value": {
+                                                "type": "integer"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "stream_id": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "http_content_type": {
                     "type": "string"
@@ -2152,12 +2132,50 @@
                 "redirect": {
                     "type": "string"
                 },
+                "request_headers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "response_headers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "status": {
                     "type": "integer"
                 },
                 "status_string": {
-                    "description": "status string when it is not a valid integer (like 2XX)",
-                    "type": "string"
+                    "type": "string",
+                    "description": "status string when it is not a valid integer (like 2XX)"
                 },
                 "true_client_ip": {
                     "type": "string"
@@ -2173,137 +2191,18 @@
                 },
                 "xff": {
                     "type": "string"
-                },
-                "request_headers": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "table_size_update": {
-                                "type": "integer"
-                            },
-                            "value": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "response_headers": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "table_size_update": {
-                                "type": "integer"
-                            },
-                            "value": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "content_range": {
-                    "type": "object",
-                    "properties": {
-                        "end": {
-                            "type": "integer"
-                        },
-                        "raw": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "integer"
-                        },
-                        "start": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "http2": {
-                    "type": "object",
-                    "properties": {
-                        "stream_id": {
-                            "type": "integer"
-                        },
-                        "request": {
-                            "type": "object",
-                            "properties": {
-                                "error_code": {
-                                    "type": "string"
-                                },
-                                "priority": {
-                                    "type": "integer"
-                                },
-                                "has_multiple": {
-                                    "type": "string"
-                                },
-                                "settings": {
-                                    "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "settings_id": {
-                                                "type": "string"
-                                            },
-                                            "settings_value": {
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "response": {
-                            "type": "object",
-                            "properties": {
-                                "error_code": {
-                                    "type": "string"
-                                },
-                                "has_multiple": {
-                                    "type": "string"
-                                },
-                                "settings": {
-                                    "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "settings_id": {
-                                                "type": "string"
-                                            },
-                                            "settings_value": {
-                                                "type": "integer"
-                                            }
-                                        },
-                                        "additionalProperties": false
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "icmp_code": {
+            "type": "integer"
+        },
+        "icmp_type": {
+            "type": "integer"
         },
         "ike": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "alg_auth": {
                     "type": "string"
@@ -2335,67 +2234,13 @@
                 "exchange_type_verbose": {
                     "type": "string"
                 },
-                "init_spi": {
-                    "type": "string"
-                },
-                "message_id": {
-                    "type": "integer"
-                },
-                "resp_spi": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "sa_key_length": {
-                    "type": "string"
-                },
-                "sa_key_length_raw": {
-                    "type": "integer"
-                },
-                "sa_life_duration": {
-                    "type": "string"
-                },
-                "sa_life_duration_raw": {
-                    "type": "integer"
-                },
-                "sa_life_type": {
-                    "type": "string"
-                },
-                "sa_life_type_raw": {
-                    "type": "integer"
-                },
-                "version_major": {
-                    "type": "integer"
-                },
-                "version_minor": {
-                    "type": "integer"
-                },
-                "payload": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "ikev1": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "doi": {
-                            "type": "integer"
-                        },
-                        "encrypted_payloads": {
-                            "type": "boolean"
-                        },
-                        "vendor_ids": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string"
-                            }
-                        },
                         "client": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "key_exchange_payload": {
                                     "type": "string"
@@ -2414,6 +2259,7 @@
                                     "minItems": 1,
                                     "items": {
                                         "type": "object",
+                                        "additionalProperties": false,
                                         "properties": {
                                             "alg_auth": {
                                                 "type": "string"
@@ -2457,15 +2303,20 @@
                                             "sa_life_type_raw": {
                                                 "type": "integer"
                                             }
-                                        },
-                                        "additionalProperties": false
+                                        }
                                     }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "doi": {
+                            "type": "integer"
+                        },
+                        "encrypted_payloads": {
+                            "type": "boolean"
                         },
                         "server": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "key_exchange_payload": {
                                     "type": "string"
@@ -2479,14 +2330,20 @@
                                 "nonce_payload_length": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "vendor_ids": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "ikev2": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "errors": {
                             "type": "integer"
@@ -2494,15 +2351,64 @@
                         "notify": {
                             "type": "array"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "init_spi": {
+                    "type": "string"
+                },
+                "message_id": {
+                    "type": "integer"
+                },
+                "payload": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resp_spi": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sa_key_length": {
+                    "type": "string"
+                },
+                "sa_key_length_raw": {
+                    "type": "integer"
+                },
+                "sa_life_duration": {
+                    "type": "string"
+                },
+                "sa_life_duration_raw": {
+                    "type": "integer"
+                },
+                "sa_life_type": {
+                    "type": "string"
+                },
+                "sa_life_type_raw": {
+                    "type": "integer"
+                },
+                "version_major": {
+                    "type": "integer"
+                },
+                "version_minor": {
+                    "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "in_iface": {
+            "type": "string"
+        },
+        "ip_v": {
+            "type": "integer",
+            "description": "IP version of the packet or flow"
         },
         "krb5": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "cname": {
                     "type": "string"
@@ -2535,120 +2441,27 @@
                     "type": "boolean"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "ldap": {
             "type": "object",
-            "optional": true,
             "properties": {
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "operation": {
-                            "type": "string"
-                        },
-                        "message_id": {
-                            "type": "integer"
-                        },
-                        "search_request": {
+                        "abandon_request": {
                             "type": "object",
-                            "optional": "true",
                             "properties": {
-                                "base_object": {
-                                    "type": "string"
-                                },
-                                "scope": {
+                                "message_id": {
                                     "type": "integer"
-                                },
-                                "deref_alias": {
-                                    "type": "integer"
-                                },
-                                "size_limit": {
-                                    "type": "integer"
-                                },
-                                "time_limit": {
-                                    "type": "integer"
-                                },
-                                "types_online": {
-                                    "type": "boolean"
-                                },
-                                "attributes": {
-                                    "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
-                            }
-                        },
-                        "bind_request": {
-                            "type": "object",
-                            "optional": "true",
-                            "properties": {
-                                "version": {
-                                    "type": "integer"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "sasl": {
-                                    "type": "object",
-                                    "optional": "true",
-                                    "properties": {
-                                        "mechanism": {
-                                            "type": "string"
-                                        },
-                                        "credentials": {
-                                            "type": "string",
-                                            "optional": "true"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "modify_request": {
-                            "type": "object",
-                            "optional": "true",
-                            "properties": {
-                                "object": {
-                                    "type": "string"
-                                },
-                                "changes": {
-                                    "type": "array",
-                                    "minItems": 1,
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "operation": {
-                                                "type": "string"
-                                            },
-                                            "modification": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "attribute_type": {
-                                                        "type": "string"
-                                                    },
-                                                    "attribute_values": {
-                                                        "type": "array",
-                                                        "minItems": 1,
-                                                        "items": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            },
+                            "optional": "true"
                         },
                         "add_request": {
                             "type": "object",
-                            "optional": "true",
                             "properties": {
-                                "entry": {
-                                    "type": "string"
-                                },
                                 "attributes": {
                                     "type": "array",
                                     "minItems": 1,
@@ -2667,44 +2480,41 @@
                                             }
                                         }
                                     }
-                                }
-                            }
-                        },
-                        "del_request": {
-                            "type": "object",
-                            "optional": "true",
-                            "properties": {
-                                "dn": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "mod_dn_request": {
-                            "type": "object",
-                            "optional": "true",
-                            "properties": {
+                                },
                                 "entry": {
                                     "type": "string"
-                                },
-                                "new_rdn": {
+                                }
+                            },
+                            "optional": "true"
+                        },
+                        "bind_request": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
                                     "type": "string"
                                 },
-                                "delete_old_rdn": {
-                                    "type": "boolean"
-                                },
-                                "new_superior": {
-                                    "type": "string",
+                                "sasl": {
+                                    "type": "object",
+                                    "properties": {
+                                        "credentials": {
+                                            "type": "string",
+                                            "optional": "true"
+                                        },
+                                        "mechanism": {
+                                            "type": "string"
+                                        }
+                                    },
                                     "optional": "true"
+                                },
+                                "version": {
+                                    "type": "integer"
                                 }
-                            }
+                            },
+                            "optional": "true"
                         },
                         "compare_request": {
                             "type": "object",
-                            "optional": "true",
                             "properties": {
-                                "entry": {
-                                    "type": "string"
-                                },
                                 "attribute_value_assertion": {
                                     "type": "object",
                                     "properties": {
@@ -2715,21 +2525,24 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "entry": {
+                                    "type": "string"
                                 }
-                            }
+                            },
+                            "optional": "true"
                         },
-                        "abandon_request": {
+                        "del_request": {
                             "type": "object",
-                            "optional": "true",
                             "properties": {
-                                "message_id": {
-                                    "type": "integer"
+                                "dn": {
+                                    "type": "string"
                                 }
-                            }
+                            },
+                            "optional": "true"
                         },
                         "extended_request": {
                             "type": "object",
-                            "optional": "true",
                             "properties": {
                                 "name": {
                                     "type": "string"
@@ -2738,10 +2551,102 @@
                                     "type": "string",
                                     "optional": "true"
                                 }
-                            }
+                            },
+                            "optional": "true"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "mod_dn_request": {
+                            "type": "object",
+                            "properties": {
+                                "delete_old_rdn": {
+                                    "type": "boolean"
+                                },
+                                "entry": {
+                                    "type": "string"
+                                },
+                                "new_rdn": {
+                                    "type": "string"
+                                },
+                                "new_superior": {
+                                    "type": "string",
+                                    "optional": "true"
+                                }
+                            },
+                            "optional": "true"
+                        },
+                        "modify_request": {
+                            "type": "object",
+                            "properties": {
+                                "changes": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "modification": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "attribute_type": {
+                                                        "type": "string"
+                                                    },
+                                                    "attribute_values": {
+                                                        "type": "array",
+                                                        "minItems": 1,
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "operation": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "object": {
+                                    "type": "string"
+                                }
+                            },
+                            "optional": "true"
+                        },
+                        "operation": {
+                            "type": "string"
+                        },
+                        "search_request": {
+                            "type": "object",
+                            "properties": {
+                                "attributes": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "base_object": {
+                                    "type": "string"
+                                },
+                                "deref_alias": {
+                                    "type": "integer"
+                                },
+                                "scope": {
+                                    "type": "integer"
+                                },
+                                "size_limit": {
+                                    "type": "integer"
+                                },
+                                "time_limit": {
+                                    "type": "integer"
+                                },
+                                "types_online": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "optional": "true"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "responses": {
                     "type": "array",
@@ -2750,122 +2655,73 @@
                     "items": {
                         "type": "object",
                         "properties": {
-                            "search_result_done": {
+                            "add_response": {
                                 "type": "object",
-                                "optional": "true",
                                 "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
                                     "matched_dn": {
                                         "type": "string"
                                     },
                                     "message": {
                                         "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
                                     }
-                                }
+                                },
+                                "optional": "true"
                             },
                             "bind_response": {
                                 "type": "object",
-                                "optional": "true",
                                 "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
                                     "matched_dn": {
                                         "type": "string"
                                     },
                                     "message": {
+                                        "type": "string"
+                                    },
+                                    "result_code": {
                                         "type": "string"
                                     },
                                     "server_sasl_creds": {
                                         "type": "string",
                                         "optional": "true"
                                     }
-                                }
-                            },
-                            "modify_response": {
-                                "type": "object",
-                                "optional": "true",
-                                "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
-                                    "matched_dn": {
-                                        "type": "string"
-                                    },
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "add_response": {
-                                "type": "object",
-                                "optional": "true",
-                                "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
-                                    "matched_dn": {
-                                        "type": "string"
-                                    },
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "del_response": {
-                                "type": "object",
-                                "optional": "true",
-                                "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
-                                    "matched_dn": {
-                                        "type": "string"
-                                    },
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "mod_dn_response": {
-                                "type": "object",
-                                "optional": "true",
-                                "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
-                                    "matched_dn": {
-                                        "type": "string"
-                                    },
-                                    "message": {
-                                        "type": "string"
-                                    }
-                                }
+                                },
+                                "optional": "true"
                             },
                             "compare_response": {
                                 "type": "object",
-                                "optional": "true",
                                 "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
                                     "matched_dn": {
                                         "type": "string"
                                     },
                                     "message": {
                                         "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
                                     }
-                                }
+                                },
+                                "optional": "true"
+                            },
+                            "del_response": {
+                                "type": "object",
+                                "properties": {
+                                    "matched_dn": {
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "optional": "true"
                             },
                             "extended_response": {
                                 "type": "object",
-                                "optional": "true",
                                 "properties": {
-                                    "result_code": {
-                                        "type": "string"
-                                    },
                                     "matched_dn": {
                                         "type": "string"
                                     },
@@ -2875,14 +2731,17 @@
                                     "name": {
                                         "type": "string"
                                     },
+                                    "result_code": {
+                                        "type": "string"
+                                    },
                                     "value": {
                                         "type": "string"
                                     }
-                                }
+                                },
+                                "optional": "true"
                             },
                             "intermediate_response": {
                                 "type": "object",
-                                "optional": "true",
                                 "properties": {
                                     "name": {
                                         "type": "string"
@@ -2890,16 +2749,66 @@
                                     "value": {
                                         "type": "string"
                                     }
-                                }
+                                },
+                                "optional": "true"
+                            },
+                            "mod_dn_response": {
+                                "type": "object",
+                                "properties": {
+                                    "matched_dn": {
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "optional": "true"
+                            },
+                            "modify_response": {
+                                "type": "object",
+                                "properties": {
+                                    "matched_dn": {
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "optional": "true"
+                            },
+                            "search_result_done": {
+                                "type": "object",
+                                "properties": {
+                                    "matched_dn": {
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "type": "string"
+                                    },
+                                    "result_code": {
+                                        "type": "string"
+                                    }
+                                },
+                                "optional": "true"
                             }
                         }
                     }
                 }
-            }
+            },
+            "optional": true
+        },
+        "log_level": {
+            "type": "string"
         },
         "metadata": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "flowbits": {
                     "type": "array",
@@ -2910,6 +2819,14 @@
                     "suricata": {
                         "keywords": [
                             "flowbits"
+                        ]
+                    }
+                },
+                "flowints": {
+                    "type": "object",
+                    "suricata": {
+                        "keywords": [
+                            "flowint"
                         ]
                     }
                 },
@@ -2928,8 +2845,7 @@
                             "value": {
                                 "type": "string"
                             }
-                        },
-                        "additionalProperties": true
+                        }
                     }
                 },
                 "pktvars": {
@@ -2937,6 +2853,7 @@
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "uid": {
                                 "type": "string"
@@ -2944,31 +2861,22 @@
                             "username": {
                                 "type": "string"
                             }
-                        },
-                        "additionalProperties": false
-                    }
-                },
-                "flowints": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "suricata": {
-                        "keywords": [
-                            "flowint"
-                        ]
+                        }
                     }
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "modbus": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "id": {
                     "type": "integer"
                 },
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "access_type": {
                             "type": "string"
@@ -2979,6 +2887,21 @@
                         "data": {
                             "type": "string"
                         },
+                        "diagnostic": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                },
+                                "raw": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
                         "error_flags": {
                             "type": "string"
                         },
@@ -2988,47 +2911,27 @@
                         "function_raw": {
                             "type": "integer"
                         },
+                        "mei": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                },
+                                "raw": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
                         "protocol_id": {
                             "type": "integer"
                         },
-                        "transaction_id": {
-                            "type": "integer"
-                        },
-                        "unit_id": {
-                            "type": "integer"
-                        },
-                        "diagnostic": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "data": {
-                                    "type": "string"
-                                },
-                                "raw": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "mei": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "data": {
-                                    "type": "string"
-                                },
-                                "raw": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "read": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "address": {
                                     "type": "integer"
@@ -3036,11 +2939,17 @@
                                 "quantity": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "transaction_id": {
+                            "type": "integer"
+                        },
+                        "unit_id": {
+                            "type": "integer"
                         },
                         "write": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "address": {
                                     "type": "integer"
@@ -3048,14 +2957,13 @@
                                 "data": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "response": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "access_type": {
                             "type": "string"
@@ -3066,8 +2974,35 @@
                         "data": {
                             "type": "string"
                         },
+                        "diagnostic": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                },
+                                "raw": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
                         "error_flags": {
                             "type": "string"
+                        },
+                        "exception": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "code": {
+                                    "type": "string"
+                                },
+                                "raw": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "function_code": {
                             "type": "string"
@@ -3078,50 +3013,24 @@
                         "protocol_id": {
                             "type": "integer"
                         },
+                        "read": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "data": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "transaction_id": {
                             "type": "integer"
                         },
                         "unit_id": {
                             "type": "integer"
                         },
-                        "diagnostic": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "data": {
-                                    "type": "string"
-                                },
-                                "raw": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "exception": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "raw": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "read": {
-                            "type": "object",
-                            "properties": {
-                                "data": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "write": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "address": {
                                     "type": "integer"
@@ -3129,24 +3038,26 @@
                                 "data": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "mqtt": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "connack": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
+                        },
+                        "properties": {
+                            "type": "object"
                         },
                         "qos": {
                             "type": "integer"
@@ -3159,16 +3070,12 @@
                         },
                         "session_present": {
                             "type": "boolean"
-                        },
-                        "properties": {
-                            "type": "object",
-                            "additionalProperties": true
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "connect": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "client_id": {
                             "type": "string"
@@ -3176,26 +3083,9 @@
                         "dup": {
                             "type": "boolean"
                         },
-                        "password": {
-                            "type": "string"
-                        },
-                        "protocol_string": {
-                            "type": "string"
-                        },
-                        "protocol_version": {
-                            "type": "integer"
-                        },
-                        "qos": {
-                            "type": "integer"
-                        },
-                        "retain": {
-                            "type": "boolean"
-                        },
-                        "username": {
-                            "type": "string"
-                        },
                         "flags": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "clean_session": {
                                     "type": "boolean"
@@ -3212,56 +3102,70 @@
                                 "will_retain": {
                                     "type": "boolean"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "password": {
+                            "type": "string"
                         },
                         "properties": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "type": "object"
+                        },
+                        "protocol_string": {
+                            "type": "string"
+                        },
+                        "protocol_version": {
+                            "type": "integer"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "username": {
+                            "type": "string"
                         },
                         "will": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "message": {
                                     "type": "string"
                                 },
+                                "properties": {
+                                    "type": "object"
+                                },
                                 "topic": {
                                     "type": "string"
-                                },
-                                "properties": {
-                                    "type": "object",
-                                    "additionalProperties": true
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "disconnect": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
-                            "type": "boolean"
-                        },
-                        "qos": {
-                            "type": "integer"
-                        },
-                        "reason_code": {
-                            "type": "integer"
-                        },
-                        "retain": {
                             "type": "boolean"
                         },
                         "properties": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "type": "object"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "reason_code": {
+                            "type": "integer"
+                        },
+                        "retain": {
+                            "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "pingreq": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3272,11 +3176,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "pingresp": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3287,11 +3191,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "puback": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3308,11 +3212,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "pubcomp": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3329,11 +3233,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "publish": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3343,6 +3247,9 @@
                         },
                         "message_id": {
                             "type": "integer"
+                        },
+                        "properties": {
+                            "type": "object"
                         },
                         "qos": {
                             "type": "integer"
@@ -3358,16 +3265,12 @@
                         },
                         "truncated": {
                             "type": "boolean"
-                        },
-                        "properties": {
-                            "type": "object",
-                            "additionalProperties": true
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "pubrec": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3384,11 +3287,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "pubrel": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3405,11 +3308,11 @@
                         "retain": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "suback": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3419,9 +3322,6 @@
                         },
                         "qos": {
                             "type": "integer"
-                        },
-                        "retain": {
-                            "type": "boolean"
                         },
                         "qos_granted": {
                             "type": "array",
@@ -3429,12 +3329,15 @@
                             "items": {
                                 "type": "integer"
                             }
+                        },
+                        "retain": {
+                            "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "subscribe": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3453,6 +3356,7 @@
                             "minItems": 1,
                             "items": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "qos": {
                                         "type": "integer"
@@ -3460,15 +3364,14 @@
                                     "topic": {
                                         "type": "string"
                                     }
-                                },
-                                "additionalProperties": false
+                                }
                             }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "unsuback": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3479,21 +3382,21 @@
                         "qos": {
                             "type": "integer"
                         },
-                        "retain": {
-                            "type": "boolean"
-                        },
                         "reason_codes": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
                                 "type": "integer"
                             }
+                        },
+                        "retain": {
+                            "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "unsubscribe": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "dup": {
                             "type": "boolean"
@@ -3514,15 +3417,18 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "ndpi": {
+            "type": "object",
+            "description": "nDPI plugin, contents provided by 3rd party library"
         },
         "netflow": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "age": {
                     "type": "integer"
@@ -3549,11 +3455,11 @@
                     "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "nfs": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "file_tx": {
                     "type": "boolean"
@@ -3570,6 +3476,38 @@
                 "procedure": {
                     "type": "string"
                 },
+                "read": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "chunks": {
+                            "type": "integer"
+                        },
+                        "first": {
+                            "type": "boolean"
+                        },
+                        "last": {
+                            "type": "boolean"
+                        },
+                        "last_xid": {
+                            "type": "integer"
+                        }
+                    },
+                    "optional": true
+                },
+                "rename": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "from": {
+                            "type": "string"
+                        },
+                        "to": {
+                            "type": "string"
+                        }
+                    },
+                    "optional": true
+                },
                 "status": {
                     "type": "string"
                 },
@@ -3579,41 +3517,9 @@
                 "version": {
                     "type": "integer"
                 },
-                "read": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "chunks": {
-                            "type": "integer"
-                        },
-                        "first": {
-                            "type": "boolean"
-                        },
-                        "last": {
-                            "type": "boolean"
-                        },
-                        "last_xid": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "rename": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "from": {
-                            "type": "string"
-                        },
-                        "to": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "write": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "chunks": {
                             "type": "integer"
@@ -3628,14 +3534,17 @@
                             "type": "integer"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "packet": {
+            "type": "string"
         },
         "packet_info": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "linktype": {
                     "type": "integer"
@@ -3645,14 +3554,33 @@
                     "description": "the descriptive name of the linktype"
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "parent_id": {
+            "type": "integer"
+        },
+        "payload": {
+            "type": "string"
+        },
+        "payload_length": {
+            "type": "integer"
+        },
+        "payload_printable": {
+            "type": "string"
+        },
+        "pcap_cnt": {
+            "type": "integer"
+        },
+        "pcap_filename": {
+            "type": "string"
         },
         "pgsql": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "message": {
                             "type": "string"
@@ -3687,6 +3615,7 @@
                         },
                         "startup_parameters": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "optional_parameters": {
                                     "type": "array",
@@ -3715,21 +3644,19 @@
                                             "replication": {
                                                 "type": "string"
                                             }
-                                        },
-                                        "additionalProperties": true
+                                        }
                                     }
                                 },
                                 "user": {
                                     "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "response": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "authentication_md5_password": {
                             "type": "string"
@@ -3740,19 +3667,27 @@
                         "code": {
                             "type": "string"
                         },
+                        "command_completed": {
+                            "type": "string"
+                        },
                         "copy_data_out": {
                             "type": "object",
                             "properties": {
-                                "row_count": {
+                                "data_size": {
                                     "type": "integer"
                                 },
-                                "data_size": {
+                                "row_count": {
                                     "type": "integer"
                                 }
                             }
                         },
-                        "command_completed": {
-                            "type": "string"
+                        "copy_out_response": {
+                            "type": "object",
+                            "properties": {
+                                "copy_column_count": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "data_rows": {
                             "type": "integer"
@@ -3811,8 +3746,7 @@
                                     "time_zone": {
                                         "type": "string"
                                     }
-                                },
-                                "additionalProperties": true
+                                }
                             }
                         },
                         "process_id": {
@@ -3830,191 +3764,178 @@
                         "severity_non_localizable": {
                             "type": "string"
                         },
-                        "copy_out_response": {
-                            "type": "object",
-                            "properties": {
-                                "copy_column_count": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
                         "ssl_accepted": {
                             "type": "boolean"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "tx_id": {
                     "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "pkt_src": {
+            "type": "string"
         },
         "pop3": {
             "type": "object",
-            "optional": true,
             "properties": {
                 "request": {
                     "type": "object",
-                    "optional": true,
                     "properties": {
-                        "command": {
-                            "description": "a pop3 command, for example `USER` or `STAT`",
-                            "type": "string"
-                        },
                         "args": {
-                            "description": "pop3 request arguments",
                             "type": "array",
+                            "description": "pop3 request arguments",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "a pop3 command, for example `USER` or `STAT`"
                         }
-                    }
+                    },
+                    "optional": true
                 },
                 "response": {
                     "type": "object",
-                    "optional": true,
                     "properties": {
-                        "success": {
-                            "description": "response indicated positive status ie +OK",
-                            "type": "boolean"
-                        },
-                        "status": {
-                            "type": "string"
-                        },
-                        "header": {
-                            "description": "first line of response",
-                            "type": "string"
-                        },
                         "data": {
                             "type": "array",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "header": {
+                            "type": "string",
+                            "description": "first line of response"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "success": {
+                            "type": "boolean",
+                            "description": "response indicated positive status ie +OK"
                         }
-                    }
+                    },
+                    "optional": true
                 }
-            }
+            },
+            "optional": true
+        },
+        "proto": {
+            "type": "string"
         },
         "quic": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "cyu": {
-                    "description":
-                            "ja3-like fingerprint for versions of QUIC before standardization",
                     "type": "array",
+                    "description": "ja3-like fingerprint for versions of QUIC before standardization",
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "hash": {
-                                "description": "cyu hash hex representation",
-                                "type": "string"
+                                "type": "string",
+                                "description": "cyu hash hex representation"
                             },
                             "string": {
-                                "description": "cyu hash string representation",
-                                "type": "string"
+                                "type": "string",
+                                "description": "cyu hash string representation"
                             }
-                        },
-                        "additionalProperties": false
+                        }
                     }
                 },
                 "extensions": {
-                    "description": "list of extensions in hello",
                     "type": "array",
+                    "description": "list of extensions in hello",
                     "minItems": 1,
                     "items": {
                         "type": "object",
+                        "additionalProperties": false,
                         "properties": {
                             "name": {
-                                "description": "human-friendly name of the extension",
-                                "type": "string"
+                                "type": "string",
+                                "description": "human-friendly name of the extension"
                             },
                             "type": {
-                                "description": "integer identifier of the extension",
-                                "type": "integer"
+                                "type": "integer",
+                                "description": "integer identifier of the extension"
                             },
                             "values": {
-                                "description": "extension values",
                                 "type": "array",
+                                "description": "extension values",
                                 "minItems": 1,
                                 "items": {
                                     "type": "string"
                                 }
                             }
-                        },
-                        "additionalProperties": false
+                        }
                     }
                 },
                 "ja3": {
-                    "description": "ja3 from client, as in TLS",
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "hash": {
-                            "description": "ja3 hex representation",
-                            "type": "string"
+                            "type": "string",
+                            "description": "ja3 hex representation"
                         },
                         "string": {
-                            "description": "ja3 string representation",
-                            "type": "string"
+                            "type": "string",
+                            "description": "ja3 string representation"
                         }
                     },
-                    "additionalProperties": false
+                    "description": "ja3 from client, as in TLS",
+                    "optional": true
                 },
                 "ja3s": {
-                    "description": "ja3 from server, as in TLS",
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "hash": {
-                            "description": "ja3s hex representation",
-                            "type": "string"
+                            "type": "string",
+                            "description": "ja3s hex representation"
                         },
                         "string": {
-                            "description": "ja3s string representation",
-                            "type": "string"
+                            "type": "string",
+                            "description": "ja3s string representation"
                         }
                     },
-                    "additionalProperties": false
+                    "description": "ja3 from server, as in TLS",
+                    "optional": true
                 },
                 "ja4": {
+                    "type": "string",
                     "suricata": {
                         "keywords": [
                             "ja4.hash"
                         ]
-                    },
-                    "type": "string"
+                    }
                 },
                 "sni": {
-                    "description": "Server Name Indication",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Server Name Indication"
                 },
                 "ua": {
-                    "description": "User Agent for versions of QUIC before standardization",
-                    "type": "string"
+                    "type": "string",
+                    "description": "User Agent for versions of QUIC before standardization"
                 },
                 "version": {
-                    "description": "Quic protocol version",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Quic protocol version"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "rdp": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
-                "cookie": {
-                    "type": "string"
-                },
-                "event_type": {
-                    "type": "string"
-                },
-                "tx_id": {
-                    "type": "integer"
-                },
                 "channels": {
                     "type": "array",
                     "minItems": 1,
@@ -4024,9 +3945,17 @@
                 },
                 "client": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "build": {
                             "type": "string"
+                        },
+                        "capabilities": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "client_name": {
                             "type": "string"
@@ -4057,29 +3986,34 @@
                         },
                         "version": {
                             "type": "string"
-                        },
-                        "capabilities": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string"
-                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "cookie": {
+                    "type": "string"
+                },
+                "event_type": {
+                    "type": "string"
+                },
+                "tx_id": {
+                    "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "response_icmp_code": {
+            "type": "integer"
+        },
+        "response_icmp_type": {
+            "type": "integer"
         },
         "rfb": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
-                "screen_shared": {
-                    "type": "boolean"
-                },
                 "authentication": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "security_result": {
                             "type": "string"
@@ -4089,6 +4023,7 @@
                         },
                         "vnc": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "challenge": {
                                     "type": "string"
@@ -4096,14 +4031,13 @@
                                 "response": {
                                     "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "client_protocol_version": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "major": {
                             "type": "string"
@@ -4111,11 +4045,11 @@
                         "minor": {
                             "type": "string"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "framebuffer": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "height": {
                             "type": "integer"
@@ -4123,11 +4057,9 @@
                         "name": {
                             "type": "string"
                         },
-                        "width": {
-                            "type": "integer"
-                        },
                         "pixel_format": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "big_endian": {
                                     "type": "boolean"
@@ -4159,14 +4091,19 @@
                                 "true_color": {
                                     "type": "boolean"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "width": {
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "screen_shared": {
+                    "type": "boolean"
                 },
                 "server_protocol_version": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "major": {
                             "type": "string"
@@ -4174,28 +4111,21 @@
                         "minor": {
                             "type": "string"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "rpc": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "auth_type": {
                     "type": "string"
                 },
-                "status": {
-                    "type": "string"
-                },
-                "xid": {
-                    "type": "integer"
-                },
                 "creds": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "gid": {
                             "type": "integer"
@@ -4207,14 +4137,20 @@
                             "type": "integer"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
+                },
+                "status": {
+                    "type": "string"
+                },
+                "xid": {
+                    "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "sip": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "code": {
                     "type": "string"
@@ -4231,99 +4167,10 @@
                 "response_line": {
                     "type": "string"
                 },
-                "uri": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                },
                 "sdp": {
                     "type": "object",
-                    "description": "SDP message body",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
-                        "version": {
-                            "type": "integer",
-                            "description": "SDP protocol version"
-                        },
-                        "origin": {
-                            "type": "string",
-                            "description": "Owner of the session"
-                        },
-                        "session_name": {
-                            "type": "string",
-                            "description": "Session name"
-                        },
-                        "session_info": {
-                            "type": "string",
-                            "optional": true,
-                            "description": "Textual information about the session"
-                        },
-                        "uri": {
-                            "type": "string",
-                            "optional": true,
-                            "description": "A pointer to additional information about the session"
-                        },
-                        "email": {
-                            "type": "string",
-                            "optional": true,
-                            "description":
-                                    "Email address for the person responsible for the conference"
-                        },
-                        "phone_number": {
-                            "type": "string",
-                            "optional": true,
-                            "description":
-                                    "Phone number for the person responsible for the conference"
-                        },
-                        "connection_data": {
-                            "type": "string",
-                            "optional": true,
-                            "description": "Connection data"
-                        },
-                        "bandwidths": {
-                            "type": "array",
-                            "optional": true,
-                            "description": "Proposed bandwidths to be used by the session or media",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "time_descriptions": {
-                            "type": "array",
-                            "description": "A list of time descriptions for a session",
-                            "minItems": 1,
-                            "items": {
-                                "type": "object",
-                                "optional": true,
-                                "properties": {
-                                    "time": {
-                                        "type": "string",
-                                        "optional": true,
-                                        "description": "Start and stop times for a session"
-                                    },
-                                    "repeat_time": {
-                                        "type": "string",
-                                        "optional": true,
-                                        "description": "Specify repeat times for a session"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
-                        },
-                        "timezone": {
-                            "type": "string",
-                            "optional": true,
-                            "description":
-                                    "Timezone to specify adjustments for times and offsets from the base time"
-                        },
-                        "encryption_key": {
-                            "type": "string",
-                            "optional": true,
-                            "description":
-                                    "Field used to convey encryption keys if SDP is used over a secure channel"
-                        },
                         "attributes": {
                             "type": "array",
                             "optional": true,
@@ -4334,23 +4181,47 @@
                                 "description": "Attribute's name and value"
                             }
                         },
+                        "bandwidths": {
+                            "type": "array",
+                            "optional": true,
+                            "description": "Proposed bandwidths to be used by the session or media",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "connection_data": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Connection data"
+                        },
+                        "email": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Email address for the person responsible for the conference"
+                        },
+                        "encryption_key": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Field used to convey encryption keys if SDP is used over a secure channel"
+                        },
                         "media_descriptions": {
                             "type": "array",
                             "description": "A list of media descriptions for a session",
                             "minItems": 1,
                             "items": {
                                 "type": "object",
-                                "optional": true,
+                                "additionalProperties": false,
                                 "properties": {
-                                    "media": {
-                                        "type": "string",
-                                        "description": "Media description"
-                                    },
-                                    "media_info": {
-                                        "type": "string",
+                                    "attributes": {
+                                        "type": "array",
+                                        "description": "A list of attributes specified for a media description",
                                         "optional": true,
-                                        "description":
-                                                "Media information primarily intended for labelling media streams"
+                                        "minItems": 1,
+                                        "items": {
+                                            "type": "string",
+                                            "description": "Attribute's name and value"
+                                        }
                                     },
                                     "bandwidths": {
                                         "type": "array",
@@ -4369,33 +4240,91 @@
                                     "encryption_key": {
                                         "type": "string",
                                         "optional": true,
-                                        "description":
-                                                "Field used to convey encryption keys if SDP is used over a secure channel"
+                                        "description": "Field used to convey encryption keys if SDP is used over a secure channel"
                                     },
-                                    "attributes": {
-                                        "type": "array",
-                                        "description":
-                                                "A list of attributes specified for a media description",
+                                    "media": {
+                                        "type": "string",
+                                        "description": "Media description"
+                                    },
+                                    "media_info": {
+                                        "type": "string",
                                         "optional": true,
-                                        "minItems": 1,
-                                        "items": {
-                                            "type": "string",
-                                            "description": "Attribute's name and value"
-                                        }
+                                        "description": "Media information primarily intended for labelling media streams"
                                     }
                                 },
-                                "additionalProperties": false
+                                "optional": true
                             }
+                        },
+                        "origin": {
+                            "type": "string",
+                            "description": "Owner of the session"
+                        },
+                        "phone_number": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Phone number for the person responsible for the conference"
+                        },
+                        "session_info": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Textual information about the session"
+                        },
+                        "session_name": {
+                            "type": "string",
+                            "description": "Session name"
+                        },
+                        "time_descriptions": {
+                            "type": "array",
+                            "description": "A list of time descriptions for a session",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "repeat_time": {
+                                        "type": "string",
+                                        "optional": true,
+                                        "description": "Specify repeat times for a session"
+                                    },
+                                    "time": {
+                                        "type": "string",
+                                        "optional": true,
+                                        "description": "Start and stop times for a session"
+                                    }
+                                },
+                                "optional": true
+                            }
+                        },
+                        "timezone": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "Timezone to specify adjustments for times and offsets from the base time"
+                        },
+                        "uri": {
+                            "type": "string",
+                            "optional": true,
+                            "description": "A pointer to additional information about the session"
+                        },
+                        "version": {
+                            "type": "integer",
+                            "description": "SDP protocol version"
                         }
                     },
-                    "additionalProperties": false
+                    "description": "SDP message body",
+                    "optional": true
+                },
+                "uri": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "smb": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "access": {
                     "type": "string"
@@ -4406,6 +4335,13 @@
                 "changed": {
                     "type": "integer"
                 },
+                "client_dialects": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "client_guid": {
                     "type": "string"
                 },
@@ -4414,6 +4350,74 @@
                 },
                 "created": {
                     "type": "integer"
+                },
+                "dcerpc": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "call_id": {
+                            "type": "integer"
+                        },
+                        "interfaces": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "ack_reason": {
+                                        "type": "integer"
+                                    },
+                                    "ack_result": {
+                                        "type": "integer"
+                                    },
+                                    "uuid": {
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "type": "string"
+                                    }
+                                },
+                                "optional": true
+                            }
+                        },
+                        "opnum": {
+                            "type": "integer"
+                        },
+                        "req": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "frag_cnt": {
+                                    "type": "integer"
+                                },
+                                "stub_data_size": {
+                                    "type": "integer"
+                                }
+                            },
+                            "optional": true
+                        },
+                        "request": {
+                            "type": "string"
+                        },
+                        "res": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "frag_cnt": {
+                                    "type": "integer"
+                                },
+                                "stub_data_size": {
+                                    "type": "integer"
+                                }
+                            },
+                            "optional": true
+                        },
+                        "response": {
+                            "type": "string"
+                        }
+                    },
+                    "optional": true
                 },
                 "dialect": {
                     "type": "string"
@@ -4436,6 +4440,23 @@
                 "id": {
                     "type": "integer"
                 },
+                "kerberos": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "realm": {
+                            "type": "string"
+                        },
+                        "snames": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "optional": true
+                },
                 "level_of_interest": {
                     "type": "string"
                 },
@@ -4451,160 +4472,9 @@
                 "named_pipe": {
                     "type": "string"
                 },
-                "rename": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "from": {
-                            "type": "string"
-                        },
-                        "to": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "request_done": {
-                    "type": "boolean"
-                },
-                "response_done": {
-                    "type": "boolean"
-                },
-                "server_guid": {
-                    "type": "string"
-                },
-                "session_id": {
-                    "type": "integer"
-                },
-                "set_info": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "class": {
-                            "type": "string"
-                        },
-                        "info_level": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "share": {
-                    "type": "string"
-                },
-                "share_type": {
-                    "type": "string"
-                },
-                "size": {
-                    "type": "integer"
-                },
-                "subcmd": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "status_code": {
-                    "type": "string"
-                },
-                "tree_id": {
-                    "type": "integer"
-                },
-                "client_dialects": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "dcerpc": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "call_id": {
-                            "type": "integer"
-                        },
-                        "opnum": {
-                            "type": "integer"
-                        },
-                        "request": {
-                            "type": "string"
-                        },
-                        "response": {
-                            "type": "string"
-                        },
-                        "interfaces": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "object",
-                                "optional": true,
-                                "properties": {
-                                    "ack_reason": {
-                                        "type": "integer"
-                                    },
-                                    "ack_result": {
-                                        "type": "integer"
-                                    },
-                                    "uuid": {
-                                        "type": "string"
-                                    },
-                                    "version": {
-                                        "type": "string"
-                                    }
-                                },
-                                "additionalProperties": false
-                            }
-                        },
-                        "req": {
-                            "type": "object",
-                            "optional": true,
-                            "properties": {
-                                "frag_cnt": {
-                                    "type": "integer"
-                                },
-                                "stub_data_size": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "res": {
-                            "type": "object",
-                            "optional": true,
-                            "properties": {
-                                "frag_cnt": {
-                                    "type": "integer"
-                                },
-                                "stub_data_size": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "kerberos": {
-                    "type": "object",
-                    "optional": true,
-                    "properties": {
-                        "realm": {
-                            "type": "string"
-                        },
-                        "snames": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "additionalProperties": false
-                },
                 "ntlmssp": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "domain": {
                             "type": "string"
@@ -4623,11 +4493,24 @@
                             "type": "boolean"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
+                },
+                "rename": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "from": {
+                            "type": "string"
+                        },
+                        "to": {
+                            "type": "string"
+                        }
+                    },
+                    "optional": true
                 },
                 "request": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "native_lm": {
                             "type": "string"
@@ -4636,11 +4519,14 @@
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
+                },
+                "request_done": {
+                    "type": "boolean"
                 },
                 "response": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "native_lm": {
                             "type": "string"
@@ -4649,11 +4535,17 @@
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
+                },
+                "response_done": {
+                    "type": "boolean"
+                },
+                "server_guid": {
+                    "type": "string"
                 },
                 "service": {
                     "type": "object",
-                    "optional": true,
+                    "additionalProperties": false,
                     "properties": {
                         "request": {
                             "type": "string"
@@ -4662,14 +4554,51 @@
                             "type": "string"
                         }
                     },
-                    "additionalProperties": false
+                    "optional": true
+                },
+                "session_id": {
+                    "type": "integer"
+                },
+                "set_info": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "class": {
+                            "type": "string"
+                        },
+                        "info_level": {
+                            "type": "string"
+                        }
+                    },
+                    "optional": true
+                },
+                "share": {
+                    "type": "string"
+                },
+                "share_type": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "string"
+                },
+                "subcmd": {
+                    "type": "string"
+                },
+                "tree_id": {
+                    "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "smtp": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "helo": {
                     "type": "string"
@@ -4685,11 +4614,11 @@
                     }
                 }
             },
-            "additionalProperties": false
+            "optional": true
         },
         "snmp": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "community": {
                     "type": "string"
@@ -4700,34 +4629,39 @@
                 "usm": {
                     "type": "string"
                 },
-                "version": {
-                    "type": "integer"
-                },
                 "vars": {
                     "type": "array",
                     "minItems": 1,
                     "items": {
                         "type": "string"
                     }
+                },
+                "version": {
+                    "type": "integer"
                 }
             },
-            "additionalProperties": false
+            "optional": true
+        },
+        "spi": {
+            "type": "integer"
+        },
+        "src_ip": {
+            "type": "string"
+        },
+        "src_port": {
+            "type": "integer"
         },
         "ssh": {
             "type": "object",
-            "optional": true,
+            "additionalProperties": false,
             "properties": {
                 "client": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "proto_version": {
-                            "type": "string"
-                        },
-                        "software_version": {
-                            "type": "string"
-                        },
                         "hassh": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "hash": {
                                     "type": "string"
@@ -4735,77 +4669,57 @@
                                 "string": {
                                     "type": "string"
                                 }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "server": {
-                    "type": "object",
-                    "properties": {
+                            }
+                        },
                         "proto_version": {
                             "type": "string"
                         },
                         "software_version": {
                             "type": "string"
-                        },
-                        "hassh": {
-                            "type": "object",
-                            "properties": {
-                                "hash": {
-                                    "type": "string"
-                                },
-                                "string": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            },
-            "additionalProperties": false
-        },
-        "stats": {
-            "type": "object",
-            "optional": true,
-            "suricata": {
-                "keywords": false
-            },
-            "properties": {
-                "uptime": {
-                    "description": "Suricata engine's uptime",
-                    "type": "integer"
-                },
-                "capture": {
-                    "type": "object",
-                    "properties": {
-                        "kernel_packets": {
-                            "type": "integer"
-                        },
-                        "kernel_drops": {
-                            "type": "integer"
-                        },
-                        "kernel_ifdrops": {
-                            "type": "integer"
                         }
                     }
                 },
+                "server": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "hassh": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "hash": {
+                                    "type": "string"
+                                },
+                                "string": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "proto_version": {
+                            "type": "string"
+                        },
+                        "software_version": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "optional": true
+        },
+        "stats": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
                 "app_layer": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "expectations": {
-                            "description": "Expectation (dynamic parallel flow) counter",
-                            "type": "integer"
-                        },
                         "error": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "bittorrent-dht": {
-                                    "description":
-                                            "Errors encountered parsing BitTorrent DHT protocol",
+                                    "description": "Errors encountered parsing BitTorrent DHT protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "dcerpc_tcp": {
@@ -4872,13 +4786,11 @@
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_tcp": {
-                                    "description":
-                                            "Errors encountered parsing Kerberos v5/TCP protocol",
+                                    "description": "Errors encountered parsing Kerberos v5/TCP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "krb5_udp": {
-                                    "description":
-                                            "Errors encountered parsing Kerberos v5/UDP protocol",
+                                    "description": "Errors encountered parsing Kerberos v5/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "ldap_tcp": {
@@ -4928,12 +4840,12 @@
                                     "description": "Errors encountered parsing RFB protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
-                                "sip_udp": {
-                                    "description": "Errors encountered parsing SIP/UDP protocol",
-                                    "$ref": "#/$defs/stats_applayer_error"
-                                },
                                 "sip_tcp": {
                                     "description": "Errors encountered parsing SIP/TCP protocol",
+                                    "$ref": "#/$defs/stats_applayer_error"
+                                },
+                                "sip_udp": {
+                                    "description": "Errors encountered parsing SIP/UDP protocol",
                                     "$ref": "#/$defs/stats_applayer_error"
                                 },
                                 "smb": {
@@ -4967,477 +4879,377 @@
                                 "websocket": {
                                     "$ref": "#/$defs/stats_applayer_error"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "expectations": {
+                            "type": "integer",
+                            "description": "Expectation (dynamic parallel flow) counter"
                         },
                         "flow": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "bittorrent-dht": {
-                                    "description": "Number of flows for BitTorrent DHT protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for BitTorrent DHT protocol"
                                 },
                                 "dcerpc_tcp": {
-                                    "description": "Number of flows for DCERPC/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DCERPC/TCP protocol"
                                 },
                                 "dcerpc_udp": {
-                                    "description": "Number of flows for DCERPC/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DCERPC/UDP protocol"
                                 },
                                 "dhcp": {
-                                    "description": "Number of flows for DHCP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DHCP"
                                 },
                                 "dnp3": {
-                                    "description": "Number of flows for DNP3",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DNP3"
                                 },
                                 "dns_tcp": {
-                                    "description": "Number of flows for DNS/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DNS/TCP protocol"
                                 },
                                 "dns_udp": {
-                                    "description": "Number of flows for DNS/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for DNS/UDP protocol"
                                 },
                                 "doh2": {
                                     "type": "integer"
                                 },
                                 "enip_tcp": {
-                                    "description": "Number of flows for ENIP/TCP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for ENIP/TCP"
                                 },
                                 "enip_udp": {
-                                    "description": "Number of flows for ENIP/UDP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for ENIP/UDP"
                                 },
                                 "failed_tcp": {
-                                    "description": "Number of failed flows for TCP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of failed flows for TCP"
                                 },
                                 "failed_udp": {
-                                    "description": "Number of failed flows for UDP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of failed flows for UDP"
                                 },
                                 "ftp": {
-                                    "description": "Number of flows for FTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for FTP"
                                 },
                                 "ftp-data": {
-                                    "description": "Number of flows for FTP data protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for FTP data protocol"
                                 },
                                 "http": {
-                                    "description": "Number of flows for HTTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for HTTP"
                                 },
                                 "http2": {
-                                    "description": "Number of flows for HTTP/2",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for HTTP/2"
                                 },
                                 "ike": {
-                                    "description": "Number of flows for IKE protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for IKE protocol"
                                 },
                                 "ikev2": {
-                                    "description": "Number of flows for IKE v2 protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for IKE v2 protocol"
                                 },
                                 "imap": {
-                                    "description": "Number of flows for IMAP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for IMAP"
                                 },
                                 "krb5_tcp": {
-                                    "description": "Number of flows for Kerberos v5/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for Kerberos v5/TCP protocol"
                                 },
                                 "krb5_udp": {
-                                    "description": "Number of flows for Kerberos v5/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for Kerberos v5/UDP protocol"
                                 },
                                 "ldap_tcp": {
-                                    "description": "Number of flows for LDAP/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for LDAP/TCP protocol"
                                 },
                                 "ldap_udp": {
-                                    "description": "Number of flows LDAP/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows LDAP/UDP protocol"
                                 },
                                 "modbus": {
-                                    "description": "Number of flows for Modbus protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for Modbus protocol"
                                 },
                                 "mqtt": {
-                                    "description": "Number of flows for MQTT protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for MQTT protocol"
                                 },
                                 "nfs_tcp": {
-                                    "description": "Number of flows for NFS/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for NFS/TCP protocol"
                                 },
                                 "nfs_udp": {
-                                    "description": "Number of flows for NFS/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for NFS/UDP protocol"
                                 },
                                 "ntp": {
-                                    "description": "Number of flows for NTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for NTP"
                                 },
                                 "pgsql": {
-                                    "description": "Number of flows for PostgreSQL protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for PostgreSQL protocol"
                                 },
                                 "pop3": {
                                     "type": "integer"
                                 },
                                 "quic": {
-                                    "description": "Number of flows for QUIC protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for QUIC protocol"
                                 },
                                 "rdp": {
-                                    "description": "Number of flows for RDP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for RDP"
                                 },
                                 "rfb": {
-                                    "description": "Number of flows for RFB protocol",
-                                    "type": "integer"
-                                },
-                                "sip_udp": {
-                                    "description": "Number of flows for SIP/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for RFB protocol"
                                 },
                                 "sip_tcp": {
-                                    "description": "Number of flows for SIP/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for SIP/TCP protocol"
+                                },
+                                "sip_udp": {
+                                    "type": "integer",
+                                    "description": "Number of flows for SIP/UDP protocol"
                                 },
                                 "smb": {
-                                    "description": "Number of flows for SMB protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for SMB protocol"
                                 },
                                 "smtp": {
-                                    "description": "Number of flows for SMTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for SMTP"
                                 },
                                 "snmp": {
-                                    "description": "Number of flows for SNMP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for SNMP"
                                 },
                                 "ssh": {
-                                    "description": "Number of flows for SSH protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for SSH protocol"
                                 },
                                 "telnet": {
-                                    "description": "Number of flows for Telnet protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for Telnet protocol"
                                 },
                                 "tftp": {
-                                    "description": "Number of flows for TFTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for TFTP"
                                 },
                                 "tls": {
-                                    "description": "Number of flows for TLS protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of flows for TLS protocol"
                                 },
                                 "websocket": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         },
                         "tx": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "bittorrent-dht": {
-                                    "description":
-                                            "Number of transactions for BitTorrent DHT protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for BitTorrent DHT protocol"
                                 },
                                 "dcerpc_tcp": {
-                                    "description": "Number of transactions for DCERPC/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DCERPC/TCP protocol"
                                 },
                                 "dcerpc_udp": {
-                                    "description": "Number of transactions for DCERPC/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DCERPC/UDP protocol"
                                 },
                                 "dhcp": {
-                                    "description": "Number of transactions for DHCP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DHCP"
                                 },
                                 "dnp3": {
-                                    "description": "Number of transactions for DNP3",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DNP3"
                                 },
                                 "dns_tcp": {
-                                    "description": "Number of transactions for DNS/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DNS/TCP protocol"
                                 },
                                 "dns_udp": {
-                                    "description": "Number of transactions for DNS/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for DNS/UDP protocol"
                                 },
                                 "doh2": {
                                     "type": "integer"
                                 },
                                 "enip_tcp": {
-                                    "description": "Number of transactions for ENIP/TCP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for ENIP/TCP"
                                 },
                                 "enip_udp": {
-                                    "description": "Number of transactions for ENIP/UDP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for ENIP/UDP"
                                 },
                                 "ftp": {
-                                    "description": "Number of transactions for FTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for FTP"
                                 },
                                 "ftp-data": {
-                                    "description": "Number of transactions for FTP data protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for FTP data protocol"
                                 },
                                 "http": {
-                                    "description": "Number of transactions for HTTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for HTTP"
                                 },
                                 "http2": {
-                                    "description": "Number of transactions for HTTP/2",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for HTTP/2"
                                 },
                                 "ike": {
-                                    "description": "Number of transactions for IKE protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for IKE protocol"
                                 },
                                 "ikev2": {
-                                    "description": "Number of transactions for IKE v2 protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for IKE v2 protocol"
                                 },
                                 "imap": {
-                                    "description": "Number of transactions for IMAP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for IMAP"
                                 },
                                 "krb5_tcp": {
-                                    "description":
-                                            "Number of transactions for Kerberos v5/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for Kerberos v5/TCP protocol"
                                 },
                                 "krb5_udp": {
-                                    "description":
-                                            "Number of transactions for Kerberos v5/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for Kerberos v5/UDP protocol"
                                 },
                                 "ldap_tcp": {
-                                    "description": "Number of transactions for LDAP/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for LDAP/TCP protocol"
                                 },
                                 "ldap_udp": {
-                                    "description": "Number of transactions for LDAP/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for LDAP/UDP protocol"
                                 },
                                 "modbus": {
-                                    "description": "Number of transactions for Modbus protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for Modbus protocol"
                                 },
                                 "mqtt": {
-                                    "description": "Number of transactions for MQTT protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for MQTT protocol"
                                 },
                                 "nfs_tcp": {
-                                    "description": "Number of transactions for NFS/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for NFS/TCP protocol"
                                 },
                                 "nfs_udp": {
-                                    "description": "Number of transactions for NFS/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for NFS/UDP protocol"
                                 },
                                 "ntp": {
-                                    "description": "Number of transactions for NTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for NTP"
                                 },
                                 "pgsql": {
-                                    "description": "Number of transactions for PostgreSQL protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for PostgreSQL protocol"
                                 },
                                 "pop3": {
                                     "type": "integer"
                                 },
                                 "quic": {
-                                    "description": "Number of transactions for QUIC protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for QUIC protocol"
                                 },
                                 "rdp": {
-                                    "description": "Number of transactions for RDP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for RDP"
                                 },
                                 "rfb": {
-                                    "description": "Number of transactions for RFB protocol",
-                                    "type": "integer"
-                                },
-                                "sip_udp": {
-                                    "description": "Number of transactions for SIP/UDP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for RFB protocol"
                                 },
                                 "sip_tcp": {
-                                    "description": "Number of transactions for SIP/TCP protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for SIP/TCP protocol"
+                                },
+                                "sip_udp": {
+                                    "type": "integer",
+                                    "description": "Number of transactions for SIP/UDP protocol"
                                 },
                                 "smb": {
-                                    "description": "Number of transactions for SMB protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for SMB protocol"
                                 },
                                 "smtp": {
-                                    "description": "Number of transactions for SMTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for SMTP"
                                 },
                                 "snmp": {
-                                    "description": "Number of transactions for SNMP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for SNMP"
                                 },
                                 "ssh": {
-                                    "description": "Number of transactions for SSH protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for SSH protocol"
                                 },
                                 "telnet": {
-                                    "description": "Number of transactions for Telnet protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for Telnet protocol"
                                 },
                                 "tftp": {
-                                    "description": "Number of transactions for TFTP",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for TFTP"
                                 },
                                 "tls": {
-                                    "description": "Number of transactions for TLS protocol",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "Number of transactions for TLS protocol"
                                 },
                                 "websocket": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
-                "ips": {
+                "capture": {
                     "type": "object",
                     "properties": {
-                        "accepted": {
-                            "description": "Number of accepted packets",
+                        "kernel_drops": {
                             "type": "integer"
                         },
-                        "blocked": {
-                            "description": "Number of blocked packets",
+                        "kernel_ifdrops": {
                             "type": "integer"
                         },
-                        "rejected": {
-                            "description": "Number of rejected packets",
+                        "kernel_packets": {
                             "type": "integer"
-                        },
-                        "replaced": {
-                            "description": "Number of replaced packets",
-                            "type": "integer"
-                        },
-                        "drop_reason": {
-                            "description": "Number of dropped packets, grouped by drop reason",
-                            "type": "object",
-                            "properties": {
-                                "decode_error": {
-                                    "description":
-                                            "Number of packets dropped due to decoding errors",
-                                    "type": "integer"
-                                },
-                                "defrag_error": {
-                                    "description":
-                                            "Number of packets dropped due to defragmentation errors",
-                                    "type": "integer"
-                                },
-                                "defrag_memcap": {
-                                    "description":
-                                            "Number of packets dropped due to defrag memcap exception policy",
-                                    "type": "integer"
-                                },
-                                "flow_memcap": {
-                                    "description":
-                                            "Number of packets dropped due to flow memcap exception policy",
-                                    "type": "integer"
-                                },
-                                "flow_drop": {
-                                    "description": "Number of packets dropped due to dropped flows",
-                                    "type": "integer"
-                                },
-                                "applayer_error": {
-                                    "description":
-                                            "Number of packets dropped due to app-layer error exception policy",
-                                    "type": "integer"
-                                },
-                                "applayer_memcap": {
-                                    "description":
-                                            "Number of packets dropped due to applayer memcap",
-                                    "type": "integer"
-                                },
-                                "rules": {
-                                    "description": "Number of packets dropped due to rule actions",
-                                    "type": "integer"
-                                },
-                                "threshold_detection_filter": {
-                                    "description":
-                                            "Number of packets dropped due to threshold detection filter",
-                                    "type": "integer"
-                                },
-                                "stream_error": {
-                                    "description":
-                                            "Number of packets dropped due to invalid TCP stream",
-                                    "type": "integer"
-                                },
-                                "stream_memcap": {
-                                    "description":
-                                            "Number of packets dropped due to stream memcap exception policy",
-                                    "type": "integer"
-                                },
-                                "stream_midstream": {
-                                    "description":
-                                            "Number of packets dropped due to stream midstream exception policy",
-                                    "type": "integer"
-                                },
-                                "stream_reassembly": {
-                                    "description":
-                                            "Number of packets dropped due to stream reassembly exception policy",
-                                    "type": "integer"
-                                },
-                                "stream_urgent": {
-                                    "description":
-                                            "Number of packets dropped due to TCP urgent flag",
-                                    "type": "integer"
-                                },
-                                "nfq_error": {
-                                    "description":
-                                            "Number of packets dropped due to no NFQ verdict",
-                                    "type": "integer"
-                                },
-                                "tunnel_packet_drop": {
-                                    "description":
-                                            "Number of packets dropped due to inner tunnel packet being dropped",
-                                    "type": "integer"
-                                },
-                                "default_packet_policy": {
-                                    "description":
-                                            "Number of packets dropped due to default packet policy",
-                                    "type": "integer"
-                                },
-                                "default_app_policy": {
-                                    "description":
-                                            "Number of packets dropped due to default app policy",
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "decoder": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
+                        "arp": {
+                            "type": "integer"
+                        },
                         "avg_pkt_size": {
                             "type": "integer"
                         },
@@ -5456,166 +5268,68 @@
                         "ethernet": {
                             "type": "integer"
                         },
-                        "arp": {
-                            "type": "integer"
-                        },
-                        "unknown_ethertype": {
-                            "type": "integer"
-                        },
-                        "geneve": {
-                            "type": "integer"
-                        },
-                        "gre": {
-                            "type": "integer"
-                        },
-                        "icmpv4": {
-                            "type": "integer"
-                        },
-                        "icmpv6": {
-                            "type": "integer"
-                        },
-                        "ieee8021ah": {
-                            "type": "integer"
-                        },
-                        "invalid": {
-                            "type": "integer"
-                        },
-                        "ipv4": {
-                            "type": "integer"
-                        },
-                        "ipv4_in_ipv6": {
-                            "type": "integer"
-                        },
-                        "ipv6": {
-                            "type": "integer"
-                        },
-                        "ipv6_in_ipv6": {
-                            "type": "integer"
-                        },
-                        "max_mac_addrs_dst": {
-                            "type": "integer"
-                        },
-                        "max_mac_addrs_src": {
-                            "type": "integer"
-                        },
-                        "max_pkt_size": {
-                            "type": "integer"
-                        },
-                        "mpls": {
-                            "type": "integer"
-                        },
-                        "nsh": {
-                            "type": "integer"
-                        },
-                        "null": {
-                            "type": "integer"
-                        },
-                        "pkts": {
-                            "type": "integer"
-                        },
-                        "ppp": {
-                            "type": "integer"
-                        },
-                        "pppoe": {
-                            "type": "integer"
-                        },
-                        "raw": {
-                            "type": "integer"
-                        },
-                        "sctp": {
-                            "type": "integer"
-                        },
-                        "sll": {
-                            "type": "integer"
-                        },
-                        "tcp": {
-                            "type": "integer"
-                        },
-                        "teredo": {
-                            "type": "integer"
-                        },
-                        "too_many_layers": {
-                            "type": "integer"
-                        },
-                        "udp": {
-                            "type": "integer"
-                        },
-                        "vlan": {
-                            "type": "integer"
-                        },
-                        "vlan_qinq": {
-                            "type": "integer"
-                        },
-                        "vlan_qinqinq": {
-                            "type": "integer"
-                        },
-                        "vntag": {
-                            "type": "integer"
-                        },
-                        "vxlan": {
-                            "type": "integer"
-                        },
                         "event": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "afpacket": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "trunc_pkt": {
-                                            "description":
-                                                    "Number of packets truncated by AF_PACKET",
-                                            "type": "integer"
+                                            "type": "integer",
+                                            "description": "Number of packets truncated by AF_PACKET"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "arp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
-                                        "pkt_too_small": {
-                                            "type": "integer"
-                                        },
-                                        "unsupported_hardware": {
-                                            "type": "integer"
-                                        },
-                                        "unsupported_protocol": {
-                                            "type": "integer"
-                                        },
-                                        "unsupported_pkt": {
-                                            "type": "integer"
-                                        },
                                         "invalid_hardware_size": {
                                             "type": "integer"
                                         },
                                         "invalid_protocol_size": {
                                             "type": "integer"
                                         },
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_hardware": {
+                                            "type": "integer"
+                                        },
                                         "unsupported_opcode": {
                                             "type": "integer"
+                                        },
+                                        "unsupported_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_protocol": {
+                                            "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "chdlc": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "dce": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "erspan": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer"
@@ -5626,20 +5340,20 @@
                                         "unsupported_version": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "esp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ethernet": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
@@ -5647,20 +5361,20 @@
                                         "unknown_ethertype": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "geneve": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "gre": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
@@ -5707,11 +5421,11 @@
                                         "wrong_version": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "icmpv4": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "ipv4_trunc_pkt": {
                                             "type": "integer"
@@ -5728,11 +5442,11 @@
                                         "unknown_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "icmpv6": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "experimentation_type": {
                                             "type": "integer"
@@ -5758,29 +5472,29 @@
                                         "unknown_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ieee8021ah": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ipraw": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "invalid_ip_version": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ipv4": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "frag_ignored": {
                                             "type": "integer"
@@ -5830,11 +5544,11 @@
                                         "wrong_ip_version": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ipv6": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "data_after_none_header": {
                                             "type": "integer"
@@ -5929,11 +5643,11 @@
                                         "zero_len_padn": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ltnull": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
@@ -5941,11 +5655,11 @@
                                         "unsupported_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "mpls": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "bad_label_implicit_null": {
                                             "type": "integer"
@@ -5965,11 +5679,11 @@
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "nsh": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "bad_header_length": {
                                             "type": "integer"
@@ -5989,11 +5703,11 @@
                                         "unsupported_version": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "ppp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "ip4_pkt_too_small": {
                                             "type": "integer"
@@ -6013,11 +5727,11 @@
                                         "wrong_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "pppoe": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "malformed_tags": {
                                             "type": "integer"
@@ -6028,29 +5742,29 @@
                                         "wrong_code": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "sctp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "sll": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "tcp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "hlen_too_small": {
                                             "type": "integer"
@@ -6067,11 +5781,11 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "udp": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "hlen_invalid": {
                                             "type": "integer"
@@ -6079,17 +5793,17 @@
                                         "hlen_too_small": {
                                             "type": "integer"
                                         },
-                                        "pkt_too_small": {
-                                            "type": "integer"
-                                        },
                                         "len_invalid": {
                                             "type": "integer"
+                                        },
+                                        "pkt_too_small": {
+                                            "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "vlan": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer"
@@ -6100,11 +5814,11 @@
                                         "unknown_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "vntag": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "header_too_small": {
                                             "type": "integer"
@@ -6112,104 +5826,194 @@
                                         "unknown_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 },
                                 "vxlan": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "geneve": {
+                            "type": "integer"
+                        },
+                        "gre": {
+                            "type": "integer"
+                        },
+                        "icmpv4": {
+                            "type": "integer"
+                        },
+                        "icmpv6": {
+                            "type": "integer"
+                        },
+                        "ieee8021ah": {
+                            "type": "integer"
+                        },
+                        "invalid": {
+                            "type": "integer"
+                        },
+                        "ipv4": {
+                            "type": "integer"
+                        },
+                        "ipv4_in_ipv6": {
+                            "type": "integer"
+                        },
+                        "ipv6": {
+                            "type": "integer"
+                        },
+                        "ipv6_in_ipv6": {
+                            "type": "integer"
+                        },
+                        "max_mac_addrs_dst": {
+                            "type": "integer"
+                        },
+                        "max_mac_addrs_src": {
+                            "type": "integer"
+                        },
+                        "max_pkt_size": {
+                            "type": "integer"
+                        },
+                        "mpls": {
+                            "type": "integer"
+                        },
+                        "nsh": {
+                            "type": "integer"
+                        },
+                        "null": {
+                            "type": "integer"
+                        },
+                        "pkts": {
+                            "type": "integer"
+                        },
+                        "ppp": {
+                            "type": "integer"
+                        },
+                        "pppoe": {
+                            "type": "integer"
+                        },
+                        "raw": {
+                            "type": "integer"
+                        },
+                        "sctp": {
+                            "type": "integer"
+                        },
+                        "sll": {
+                            "type": "integer"
+                        },
+                        "tcp": {
+                            "type": "integer"
+                        },
+                        "teredo": {
+                            "type": "integer"
+                        },
+                        "too_many_layers": {
+                            "type": "integer"
+                        },
+                        "udp": {
+                            "type": "integer"
+                        },
+                        "unknown_ethertype": {
+                            "type": "integer"
+                        },
+                        "vlan": {
+                            "type": "integer"
+                        },
+                        "vlan_qinq": {
+                            "type": "integer"
+                        },
+                        "vlan_qinqinq": {
+                            "type": "integer"
+                        },
+                        "vntag": {
+                            "type": "integer"
+                        },
+                        "vxlan": {
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "defrag": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "tracker_soft_reuse": {
-                            "type": "integer",
-                            "description":
-                                    "Finished tracker re-used from hash table before being moved to spare pool"
+                        "ipv4": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "fragments": {
+                                    "type": "integer"
+                                },
+                                "reassembled": {
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "type": "integer"
+                                }
+                            }
                         },
-                        "tracker_hard_reuse": {
-                            "type": "integer",
-                            "description":
-                                    "Active tracker force closed before completion and reused for new tracker"
-                        },
-                        "max_trackers_reached": {
-                            "type": "integer",
-                            "description":
-                                    "How many times a packet wasn't reassembled due to max-trackers limit being reached"
+                        "ipv6": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "fragments": {
+                                    "type": "integer"
+                                },
+                                "reassembled": {
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "type": "integer"
+                                }
+                            }
                         },
                         "max_frags_reached": {
                             "type": "integer",
-                            "description":
-                                    "How many times a fragment wasn't stored due to max-frags limit being reached"
+                            "description": "How many times a fragment wasn't stored due to max-frags limit being reached"
+                        },
+                        "max_trackers_reached": {
+                            "type": "integer",
+                            "description": "How many times a packet wasn't reassembled due to max-trackers limit being reached"
                         },
                         "memuse": {
                             "type": "integer",
                             "description": "Current memory use."
                         },
-                        "ipv4": {
-                            "type": "object",
-                            "properties": {
-                                "fragments": {
-                                    "type": "integer"
-                                },
-                                "reassembled": {
-                                    "type": "integer"
-                                },
-                                "timeouts": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "ipv6": {
-                            "type": "object",
-                            "properties": {
-                                "fragments": {
-                                    "type": "integer"
-                                },
-                                "reassembled": {
-                                    "type": "integer"
-                                },
-                                "timeouts": {
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
                         "mgr": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "tracker_timeout": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "tracker_hard_reuse": {
+                            "type": "integer",
+                            "description": "Active tracker force closed before completion and reused for new tracker"
+                        },
+                        "tracker_soft_reuse": {
+                            "type": "integer",
+                            "description": "Finished tracker re-used from hash table before being moved to spare pool"
                         },
                         "wrk": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "tracker_timeout": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "detect": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "alert": {
                             "type": "integer"
@@ -6220,47 +6024,12 @@
                         "alerts_suppressed": {
                             "type": "integer"
                         },
-                        "lua": {
-                            "type": "object",
-                            "properties": {
-                                "blocked_function_errors": {
-                                    "description":
-                                            "Counter for Lua scripts failing due to blocked functions being called",
-                                    "type": "integer"
-                                },
-                                "instruction_limit_errors": {
-                                    "description":
-                                            "Count of Lua rules exceeding the instruction limit",
-                                    "type": "integer"
-                                },
-                                "memory_limit_errors": {
-                                    "description": "Count of Lua rules exceeding the memory limit",
-                                    "type": "integer"
-                                },
-                                "errors": {
-                                    "description": "Errors encountered while running Lua scripts",
-                                    "type": "integer"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        "mpm_list": {
-                            "type": "integer"
-                        },
-                        "nonmpm_list": {
-                            "type": "integer"
-                        },
-                        "fnonmpm_list": {
-                            "type": "integer"
-                        },
-                        "match_list": {
-                            "type": "integer"
-                        },
                         "engines": {
                             "type": "array",
                             "minItems": 1,
                             "items": {
                                 "type": "object",
+                                "additionalProperties": false,
                                 "properties": {
                                     "id": {
                                         "type": "integer"
@@ -6268,21 +6037,53 @@
                                     "last_reload": {
                                         "type": "string"
                                     },
-                                    "rules_loaded": {
+                                    "rules_failed": {
                                         "type": "integer"
                                     },
-                                    "rules_failed": {
+                                    "rules_loaded": {
                                         "type": "integer"
                                     },
                                     "rules_skipped": {
                                         "type": "integer"
                                     }
-                                },
-                                "additionalProperties": false
+                                }
                             }
+                        },
+                        "fnonmpm_list": {
+                            "type": "integer"
+                        },
+                        "lua": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "blocked_function_errors": {
+                                    "type": "integer",
+                                    "description": "Counter for Lua scripts failing due to blocked functions being called"
+                                },
+                                "errors": {
+                                    "type": "integer",
+                                    "description": "Errors encountered while running Lua scripts"
+                                },
+                                "instruction_limit_errors": {
+                                    "type": "integer",
+                                    "description": "Count of Lua rules exceeding the instruction limit"
+                                },
+                                "memory_limit_errors": {
+                                    "type": "integer",
+                                    "description": "Count of Lua rules exceeding the memory limit"
+                                }
+                            }
+                        },
+                        "match_list": {
+                            "type": "integer"
+                        },
+                        "mpm_list": {
+                            "type": "integer"
+                        },
+                        "nonmpm_list": {
+                            "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "exception_policy": {
                     "type": "object",
@@ -6290,42 +6091,36 @@
                         "app_layer": {
                             "type": "object",
                             "error": {
-                                "description":
-                                        "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
+                                "description": "Consolidated stats on how many times app-layer error exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         },
                         "defrag": {
                             "type": "object",
                             "memcap": {
-                                "description":
-                                        "How many times defrag memcap exception policy was applied, and which one",
+                                "description": "How many times defrag memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         },
                         "flow": {
                             "type": "object",
                             "memcap": {
-                                "description":
-                                        "How many times flow memcap exception policy was applied, and which one",
+                                "description": "How many times flow memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         },
                         "tcp": {
                             "type": "object",
                             "midstream": {
-                                "description":
-                                        "How many times midstream exception policy was applied, and which one",
+                                "description": "How many times midstream exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             },
                             "ssn_memcap": {
-                                "description":
-                                        "How many times session memcap exception policy was applied, and which one",
+                                "description": "How many times session memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             },
                             "reassembly": {
-                                "description":
-                                        "How many times reassembly memcap exception policy was applied, and which one",
+                                "description": "How many times reassembly memcap exception policy was applied, and which one",
                                 "$ref": "#/$defs/exceptionPolicy"
                             }
                         }
@@ -6333,6 +6128,7 @@
                 },
                 "file_store": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "fs_errors": {
                             "type": "integer"
@@ -6343,124 +6139,67 @@
                         "open_files_max_hit": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "flow": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "active": {
-                            "description": "Number of currently active flows",
-                            "type": "integer"
-                        },
-                        "emerg_mode_entered": {
-                            "description": "Number of times emergency mode was entered",
-                            "type": "integer"
-                        },
-                        "emerg_mode_over": {
-                            "description": "Number of times recovery was made from emergency mode",
-                            "type": "integer"
-                        },
-                        "get_used": {
-                            "description":
-                                    "Number of reused flows from the hash table in case memcap was reached and spare pool was empty",
-                            "type": "integer"
-                        },
-                        "get_used_eval": {
-                            "description":
-                                    "Number of attempts at getting a flow directly from the hash",
-                            "type": "integer"
-                        },
-                        "get_used_eval_busy": {
-                            "description":
-                                    "Number of times a flow was found in the hash but the lock for hash bucket could not be obtained",
-                            "type": "integer"
-                        },
-                        "get_used_eval_reject": {
-                            "description":
-                                    "Number of flows that were evaluated but rejected from reuse as they were still alive/active",
-                            "type": "integer"
-                        },
-                        "get_used_failed": {
-                            "description":
-                                    "Number of times retrieval of flow from hash was attempted but was unsuccessful",
-                            "type": "integer"
-                        },
-                        "icmpv4": {
-                            "description": "Number of ICMPv4 flows",
-                            "type": "integer"
-                        },
-                        "icmpv6": {
-                            "description": "Number of ICMPv6 flows",
-                            "type": "integer"
-                        },
-                        "memcap": {
-                            "description": "Number of times memcap was reached for flows",
-                            "type": "integer"
-                        },
-                        "memuse": {
-                            "description": "Memory currently in use by the flows",
-                            "type": "integer"
-                        },
-                        "spare": {
-                            "description": "Number of flows in the spare pool",
-                            "type": "integer"
-                        },
-                        "tcp": {
-                            "description": "Number of TCP flows",
-                            "type": "integer"
-                        },
-                        "tcp_reuse": {
-                            "description":
-                                    "Number of TCP flows that were reused as they seemed to share the same flow tuple",
-                            "type": "integer"
-                        },
-                        "total": {
-                            "description": "Total number of flows",
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of currently active flows"
                         },
                         "elephant": {
-                            "description": "Total number of elephant flows",
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Total number of elephant flows"
                         },
-                        "udp": {
-                            "description": "Number of UDP flows",
-                            "type": "integer"
+                        "emerg_mode_entered": {
+                            "type": "integer",
+                            "description": "Number of times emergency mode was entered"
+                        },
+                        "emerg_mode_over": {
+                            "type": "integer",
+                            "description": "Number of times recovery was made from emergency mode"
                         },
                         "end": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "state": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
-                                        "new": {
-                                            "type": "integer"
-                                        },
-                                        "established": {
+                                        "capture_bypassed": {
                                             "type": "integer"
                                         },
                                         "closed": {
                                             "type": "integer"
                                         },
+                                        "established": {
+                                            "type": "integer"
+                                        },
                                         "local_bypassed": {
                                             "type": "integer"
                                         },
-                                        "capture_bypassed": {
+                                        "new": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
+                                    }
+                                },
+                                "tcp_liberal": {
+                                    "type": "integer"
                                 },
                                 "tcp_state": {
                                     "type": "object",
+                                    "additionalProperties": false,
                                     "properties": {
-                                        "none": {
+                                        "close_wait": {
                                             "type": "integer"
                                         },
-                                        "syn_sent": {
+                                        "closed": {
                                             "type": "integer"
                                         },
-                                        "syn_recv": {
+                                        "closing": {
                                             "type": "integer"
                                         },
                                         "established": {
@@ -6472,92 +6211,140 @@
                                         "fin_wait2": {
                                             "type": "integer"
                                         },
-                                        "time_wait": {
-                                            "type": "integer"
-                                        },
                                         "last_ack": {
                                             "type": "integer"
                                         },
-                                        "close_wait": {
+                                        "none": {
                                             "type": "integer"
                                         },
-                                        "closing": {
+                                        "syn_recv": {
                                             "type": "integer"
                                         },
-                                        "closed": {
+                                        "syn_sent": {
+                                            "type": "integer"
+                                        },
+                                        "time_wait": {
                                             "type": "integer"
                                         }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "tcp_liberal": {
-                                    "type": "integer"
+                                    }
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "get_used": {
+                            "type": "integer",
+                            "description": "Number of reused flows from the hash table in case memcap was reached and spare pool was empty"
+                        },
+                        "get_used_eval": {
+                            "type": "integer",
+                            "description": "Number of attempts at getting a flow directly from the hash"
+                        },
+                        "get_used_eval_busy": {
+                            "type": "integer",
+                            "description": "Number of times a flow was found in the hash but the lock for hash bucket could not be obtained"
+                        },
+                        "get_used_eval_reject": {
+                            "type": "integer",
+                            "description": "Number of flows that were evaluated but rejected from reuse as they were still alive/active"
+                        },
+                        "get_used_failed": {
+                            "type": "integer",
+                            "description": "Number of times retrieval of flow from hash was attempted but was unsuccessful"
+                        },
+                        "icmpv4": {
+                            "type": "integer",
+                            "description": "Number of ICMPv4 flows"
+                        },
+                        "icmpv6": {
+                            "type": "integer",
+                            "description": "Number of ICMPv6 flows"
+                        },
+                        "memcap": {
+                            "type": "integer",
+                            "description": "Number of times memcap was reached for flows"
+                        },
+                        "memuse": {
+                            "type": "integer",
+                            "description": "Memory currently in use by the flows"
                         },
                         "mgr": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "flows_checked": {
-                                    "description":
-                                            "number of flows checked for timeout in the last pass",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of flows checked for timeout in the last pass"
                                 },
                                 "flows_evicted": {
-                                    "description": "number of flows that were evicted",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of flows that were evicted"
                                 },
                                 "flows_evicted_needs_work": {
-                                    "description":
-                                            "number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of TCP flows that were returned to the workers in case reassembly, detection, logging still needs work"
                                 },
                                 "flows_notimeout": {
-                                    "description": "number of flows that did not time out",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of flows that did not time out"
                                 },
                                 "flows_timeout": {
-                                    "description": "number of flows that reached the time out",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of flows that reached the time out"
                                 },
                                 "full_hash_pass": {
-                                    "description":
-                                            "number of times a full pass of the hash table was done",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of times a full pass of the hash table was done"
                                 },
                                 "rows_maxlen": {
-                                    "description": "size of the biggest row in the hash table",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "size of the biggest row in the hash table"
                                 },
                                 "rows_per_sec": {
-                                    "description":
-                                            "number of rows to be scanned every second by a worker",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "number of rows to be scanned every second by a worker"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         },
                         "recycler": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
-                                "recycled": {
-                                    "description": "number of recycled flows",
-                                    "type": "integer"
-                                },
                                 "queue_avg": {
-                                    "description": "average number of recycled flows per queue",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "average number of recycled flows per queue"
                                 },
                                 "queue_max": {
-                                    "description": "maximum number of recycled flows per queue",
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "description": "maximum number of recycled flows per queue"
+                                },
+                                "recycled": {
+                                    "type": "integer",
+                                    "description": "number of recycled flows"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
+                        },
+                        "spare": {
+                            "type": "integer",
+                            "description": "Number of flows in the spare pool"
+                        },
+                        "tcp": {
+                            "type": "integer",
+                            "description": "Number of TCP flows"
+                        },
+                        "tcp_reuse": {
+                            "type": "integer",
+                            "description": "Number of TCP flows that were reused as they seemed to share the same flow tuple"
+                        },
+                        "total": {
+                            "type": "integer",
+                            "description": "Total number of flows"
+                        },
+                        "udp": {
+                            "type": "integer",
+                            "description": "Number of UDP flows"
                         },
                         "wrk": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "flows_evicted": {
                                     "type": "integer"
@@ -6586,14 +6373,13 @@
                                 "spare_sync_incomplete": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "flow_bypassed": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "bytes": {
                             "type": "integer"
@@ -6616,11 +6402,11 @@
                         "pkts": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "flow_mgr": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "bypassed_pruned": {
                             "type": "integer"
@@ -6661,26 +6447,11 @@
                         "rows_skipped": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
-                },
-                "memcap": {
-                    "type": "object",
-                    "properties": {
-                        "pressure": {
-                            "description":
-                                    "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http",
-                            "type": "integer"
-                        },
-                        "pressure_max": {
-                            "description": "Maximum pressure seen by the engine",
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "ftp": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "memcap": {
                             "type": "integer"
@@ -6688,20 +6459,27 @@
                         "memuse": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
-                "http": {
+                "host": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "memcap": {
                             "type": "integer"
                         },
                         "memuse": {
                             "type": "integer"
-                        },
+                        }
+                    }
+                },
+                "http": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
                         "byterange": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "memcap": {
                                     "type": "integer"
@@ -6709,26 +6487,19 @@
                                 "memuse": {
                                     "type": "integer"
                                 }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "host": {
-                    "type": "object",
-                    "properties": {
+                            }
+                        },
                         "memcap": {
                             "type": "integer"
                         },
                         "memuse": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "ippair": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "memcap": {
                             "type": "integer"
@@ -6736,25 +6507,140 @@
                         "memuse": {
                             "type": "integer"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "ips": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "accepted": {
+                            "type": "integer",
+                            "description": "Number of accepted packets"
+                        },
+                        "blocked": {
+                            "type": "integer",
+                            "description": "Number of blocked packets"
+                        },
+                        "drop_reason": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "applayer_error": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to app-layer error exception policy"
+                                },
+                                "applayer_memcap": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to applayer memcap"
+                                },
+                                "decode_error": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to decoding errors"
+                                },
+                                "default_app_policy": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to default app policy"
+                                },
+                                "default_packet_policy": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to default packet policy"
+                                },
+                                "defrag_error": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to defragmentation errors"
+                                },
+                                "defrag_memcap": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to defrag memcap exception policy"
+                                },
+                                "flow_drop": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to dropped flows"
+                                },
+                                "flow_memcap": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to flow memcap exception policy"
+                                },
+                                "nfq_error": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to no NFQ verdict"
+                                },
+                                "rules": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to rule actions"
+                                },
+                                "stream_error": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to invalid TCP stream"
+                                },
+                                "stream_memcap": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to stream memcap exception policy"
+                                },
+                                "stream_midstream": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to stream midstream exception policy"
+                                },
+                                "stream_reassembly": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to stream reassembly exception policy"
+                                },
+                                "stream_urgent": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to TCP urgent flag"
+                                },
+                                "threshold_detection_filter": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to threshold detection filter"
+                                },
+                                "tunnel_packet_drop": {
+                                    "type": "integer",
+                                    "description": "Number of packets dropped due to inner tunnel packet being dropped"
+                                }
+                            },
+                            "description": "Number of dropped packets, grouped by drop reason"
+                        },
+                        "rejected": {
+                            "type": "integer",
+                            "description": "Number of rejected packets"
+                        },
+                        "replaced": {
+                            "type": "integer",
+                            "description": "Number of replaced packets"
+                        }
+                    }
+                },
+                "memcap": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "pressure": {
+                            "type": "integer",
+                            "description": "Percentage of memcaps used by flow, stream, stream-reassembly and app-layer-http"
+                        },
+                        "pressure_max": {
+                            "type": "integer",
+                            "description": "Maximum pressure seen by the engine"
+                        }
+                    }
                 },
                 "pcap_log": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "written": {
-                            "description": "Number of packets written",
-                            "type": "integer"
-                        },
                         "filtered_bpf": {
-                            "description": "Number of packets filtered out by bpf (not written)",
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of packets filtered out by bpf (not written)"
+                        },
+                        "written": {
+                            "type": "integer",
+                            "description": "Number of packets written"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "tcp": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "ack_unseen_data": {
                             "type": "integer"
@@ -6804,13 +6690,13 @@
                         "rst": {
                             "type": "integer"
                         },
-                        "segment_memcap_drop": {
-                            "type": "integer"
-                        },
                         "segment_from_cache": {
                             "type": "integer"
                         },
                         "segment_from_pool": {
+                            "type": "integer"
+                        },
+                        "segment_memcap_drop": {
                             "type": "integer"
                         },
                         "sessions": {
@@ -6835,18 +6721,36 @@
                             "type": "integer"
                         },
                         "urg": {
-                            "description": "Number of TCP packets with the urgent flag set",
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of TCP packets with the urgent flag set"
                         },
                         "urgent_oob_data": {
-                            "description": "Number of OOB bytes tracked in TCP urgent handling",
-                            "type": "integer"
+                            "type": "integer",
+                            "description": "Number of OOB bytes tracked in TCP urgent handling"
                         }
-                    },
-                    "additionalProperties": false
+                    }
+                },
+                "uptime": {
+                    "type": "integer",
+                    "description": "Suricata engine's uptime"
                 }
             },
-            "additionalProperties": false
+            "optional": true,
+            "suricata": {
+                "keywords": false
+            }
+        },
+        "stream": {
+            "type": "integer"
+        },
+        "stream_tcp": {
+            "type": "object"
+        },
+        "suricata_version": {
+            "type": "string"
+        },
+        "tc_progress": {
+            "type": "string"
         },
         "tcp": {
             "type": "object",
@@ -6882,9 +6786,8 @@
                     "type": "integer"
                 },
                 "tc_urgent_oob_data": {
-                    "description":
-                            "Number of Out-of-Band bytes sent by server using TCP urgent packets",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Number of Out-of-Band bytes sent by server using TCP urgent packets"
                 },
                 "tcp_flags": {
                     "type": "string"
@@ -6902,18 +6805,17 @@
                     "type": "integer"
                 },
                 "ts_urgent_oob_data": {
-                    "description":
-                            "Number of Out-of-Band bytes sent by client using TCP urgent packets",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Number of Out-of-Band bytes sent by client using TCP urgent packets"
                 },
                 "urg": {
                     "type": "boolean"
                 }
-            },
-            "additionalProperties": true
+            }
         },
         "template": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "request": {
                     "type": "string"
@@ -6921,11 +6823,11 @@
                 "response": {
                     "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "tftp": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "file": {
                     "type": "string"
@@ -6936,11 +6838,15 @@
                 "packet": {
                     "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "timestamp": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+[+\\-]\\d+$"
         },
         "tls": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "certificate": {
                     "type": "string",
@@ -6965,6 +6871,7 @@
                 },
                 "client": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "certificate": {
                             "type": "string",
@@ -6997,24 +6904,12 @@
                             }
                         },
                         "issuerdn": {
+                            "type": "string",
                             "suricata": {
                                 "keywords": [
                                     "tls.cert_issuer",
                                     "tls.issuerdn"
                                 ]
-                            },
-                            "type": "string"
-                        },
-                        "subjectaltname": {
-                            "description": "TLS Subject Alternative Name field",
-                            "type": "array",
-                            "suricata": {
-                                "keywords": [
-                                    "tls.subjectaltname"
-                                ]
-                            },
-                            "items": {
-                                "type": "string"
                             }
                         },
                         "notafter": {
@@ -7053,13 +6948,24 @@
                                     "tls.subject"
                                 ]
                             }
+                        },
+                        "subjectaltname": {
+                            "type": "array",
+                            "description": "TLS Subject Alternative Name field",
+                            "suricata": {
+                                "keywords": [
+                                    "tls.subjectaltname"
+                                ]
+                            },
+                            "items": {
+                                "type": "string"
+                            }
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
                 "client_alpns": {
-                    "description": "TLS client ALPN field(s)",
                     "type": "array",
+                    "description": "TLS client ALPN field(s)",
                     "suricata": {
                         "keywords": [
                             "tls.alpn"
@@ -7072,10 +6978,6 @@
                 "client_handshake": {
                     "type": "object",
                     "properties": {
-                        "version": {
-                            "description": "TLS version in client hello",
-                            "type": "string"
-                        },
                         "ciphers": {
                             "description": "TLS client cipher(s)",
                             "type": "array",
@@ -7099,40 +7001,11 @@
                             "items": {
                                 "type": "integer"
                             }
-                        }
-                    }
-                },
-                "server_handshake": {
-                    "type": "object",
-                    "properties": {
+                        },
                         "version": {
-                            "description": "TLS version in server hello",
+                            "description": "TLS version in client hello",
                             "type": "string"
-                        },
-                        "cipher": {
-                            "description": "TLS server's chosen cipher",
-                            "type": "integer"
-                        },
-                        "exts": {
-                            "description": "TLS server extension(s)",
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "integer"
-                            }
                         }
-                    }
-                },
-                "server_alpns": {
-                    "description": "TLS server ALPN field(s)",
-                    "type": "array",
-                    "suricata": {
-                        "keywords": [
-                            "tls.alpn"
-                        ]
-                    },
-                    "items": {
-                        "type": "string"
                     }
                 },
                 "fingerprint": {
@@ -7148,24 +7021,64 @@
                     "type": "string"
                 },
                 "issuerdn": {
+                    "type": "string",
                     "suricata": {
                         "keywords": [
                             "tls.cert_issuer",
                             "tls.issuerdn"
                         ]
-                    },
-                    "type": "string"
+                    }
                 },
-                "subjectaltname": {
-                    "description": "TLS Subject Alternative Name field",
-                    "type": "array",
+                "ja3": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "hash": {
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "ja3.hash"
+                                ]
+                            }
+                        },
+                        "string": {
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "ja3s.string"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "ja3s": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "hash": {
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "ja3s.hash"
+                                ]
+                            }
+                        },
+                        "string": {
+                            "type": "string",
+                            "suricata": {
+                                "keywords": [
+                                    "ja3s.string"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "ja4": {
+                    "type": "string",
                     "suricata": {
                         "keywords": [
-                            "tls.subjectaltname"
+                            "ja4.hash"
                         ]
-                    },
-                    "items": {
-                        "type": "string"
                     }
                 },
                 "notafter": {
@@ -7196,6 +7109,39 @@
                         ]
                     }
                 },
+                "server_alpns": {
+                    "type": "array",
+                    "description": "TLS server ALPN field(s)",
+                    "suricata": {
+                        "keywords": [
+                            "tls.alpn"
+                        ]
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "server_handshake": {
+                    "type": "object",
+                    "properties": {
+                        "cipher": {
+                            "description": "TLS server's chosen cipher",
+                            "type": "integer"
+                        },
+                        "exts": {
+                            "description": "TLS server extension(s)",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "version": {
+                            "description": "TLS version in server hello",
+                            "type": "string"
+                        }
+                    }
+                },
                 "session_resumed": {
                     "type": "boolean"
                 },
@@ -7216,6 +7162,18 @@
                         ]
                     }
                 },
+                "subjectaltname": {
+                    "type": "array",
+                    "description": "TLS Subject Alternative Name field",
+                    "suricata": {
+                        "keywords": [
+                            "tls.subjectaltname"
+                        ]
+                    },
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "version": {
                     "type": "string",
                     "suricata": {
@@ -7223,64 +7181,12 @@
                             "tls.version"
                         ]
                     }
-                },
-                "ja3": {
-                    "type": "object",
-                    "properties": {
-                        "hash": {
-                            "suricata": {
-                                "keywords": [
-                                    "ja3.hash"
-                                ]
-                            },
-                            "type": "string"
-                        },
-                        "string": {
-                            "suricata": {
-                                "keywords": [
-                                    "ja3s.string"
-                                ]
-                            },
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "ja3s": {
-                    "type": "object",
-                    "properties": {
-                        "hash": {
-                            "suricata": {
-                                "keywords": [
-                                    "ja3s.hash"
-                                ]
-                            },
-                            "type": "string"
-                        },
-                        "string": {
-                            "suricata": {
-                                "keywords": [
-                                    "ja3s.string"
-                                ]
-                            },
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "ja4": {
-                    "suricata": {
-                        "keywords": [
-                            "ja4.hash"
-                        ]
-                    },
-                    "type": "string"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "traffic": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "id": {
                     "type": "array",
@@ -7296,11 +7202,14 @@
                         "type": "string"
                     }
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "ts_progress": {
+            "type": "string"
         },
         "tunnel": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "depth": {
                     "type": "integer"
@@ -7326,11 +7235,28 @@
                 "src_port": {
                     "type": "integer"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "tx_guessed": {
+            "type": "boolean",
+            "description": "the signature that triggered this alert didn't tie to a transaction, so the transaction (and metadata) logged is a forced estimation and may not be the one you expect"
+        },
+        "tx_id": {
+            "type": "integer"
+        },
+        "verdict": {
+            "$ref": "#/$defs/verdict_type"
+        },
+        "vlan": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "number"
+            }
         },
         "websocket": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "fin": {
                     "type": "boolean"
@@ -7347,17 +7273,13 @@
                 "payload_printable": {
                     "type": "string"
                 }
-            },
-            "additionalProperties": false
-        },
-        "ndpi": {
-            "description": "nDPI plugin, contents provided by 3rd party library",
-            "type": "object"
+            }
         }
     },
     "$defs": {
         "dns.soa": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "expire": {
                     "type": "integer"
@@ -7367,6 +7289,10 @@
                 },
                 "mname": {
                     "type": "string"
+                },
+                "mname_truncated": {
+                    "type": "boolean",
+                    "description": "Set to true if the mname was too long and truncated by Suricata"
                 },
                 "refresh": {
                     "type": "integer"
@@ -7379,20 +7305,15 @@
                 },
                 "serial": {
                     "type": "integer"
-                },
-                "mname_truncated": {
-                    "description":
-                            "Set to true if the mname was too long and truncated by Suricata",
-                    "type": "boolean"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "dns.authorities": {
             "type": "array",
             "minItems": 1,
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                     "rdata": {
                         "type": "string",
@@ -7401,6 +7322,10 @@
                                 "dns.response.rrname"
                             ]
                         }
+                    },
+                    "rdata_truncated": {
+                        "type": "boolean",
+                        "description": "Set to true if the rdata was too long and truncated by Suricata"
                     },
                     "rrname": {
                         "type": "string",
@@ -7411,27 +7336,20 @@
                             ]
                         }
                     },
+                    "rrname_truncated": {
+                        "type": "boolean",
+                        "description": "Set to true if the rrname was too long and truncated by Suricata"
+                    },
                     "rrtype": {
                         "type": "string"
-                    },
-                    "ttl": {
-                        "type": "integer"
                     },
                     "soa": {
                         "$ref": "#/$defs/dns.soa"
                     },
-                    "rdata_truncated": {
-                        "description":
-                                "Set to true if the rdata was too long and truncated by Suricata",
-                        "type": "boolean"
-                    },
-                    "rrname_truncated": {
-                        "description":
-                                "Set to true if the rrname was too long and truncated by Suricata",
-                        "type": "boolean"
+                    "ttl": {
+                        "type": "integer"
                     }
-                },
-                "additionalProperties": false
+                }
             }
         },
         "dns.additionals": {
@@ -7439,7 +7357,24 @@
             "minItems": 1,
             "items": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
+                    "opt": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "code": {
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "rdata": {
                         "type": "string",
                         "suricata": {
@@ -7462,57 +7397,39 @@
                     },
                     "ttl": {
                         "type": "integer"
-                    },
-                    "opt": {
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "integer"
-                                },
-                                "data": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
                     }
-                },
-                "additionalProperties": false
+                }
             }
         },
         "stats_applayer_error": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "gap": {
-                    "description": "Number of errors processing gaps",
-                    "type": "integer"
-                },
                 "alloc": {
-                    "description": "Number of errors allocating memory",
-                    "type": "integer"
-                },
-                "parser": {
-                    "description": "Number of errors reported by parser",
-                    "type": "integer"
-                },
-                "internal": {
-                    "description": "Number of internal parser errors",
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Number of errors allocating memory"
                 },
                 "exception_policy": {
-                    "description":
-                            "How many times app-layer error exception policy was applied, and which one",
+                    "description": "How many times app-layer error exception policy was applied, and which one",
                     "$ref": "#/$defs/exceptionPolicy"
+                },
+                "gap": {
+                    "type": "integer",
+                    "description": "Number of errors processing gaps"
+                },
+                "internal": {
+                    "type": "integer",
+                    "description": "Number of internal parser errors"
+                },
+                "parser": {
+                    "type": "integer",
+                    "description": "Number of errors reported by parser"
                 }
-            },
-            "additionalProperties": false
+            }
         },
         "tls_date": {
-            "$comment": "Definition for TLS date formats",
             "type": "string",
+            "$comment": "Definition for TLS date formats",
             "pattern": "^[1-2]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
         },
         "verdict_type": {
@@ -7552,6 +7469,10 @@
         "exceptionPolicy": {
             "type": "object",
             "properties": {
+                "bypass": {
+                    "type": "integer",
+                    "minimum": 0
+                },
                 "drop_flow": {
                     "type": "integer",
                     "minimum": 0
@@ -7565,10 +7486,6 @@
                     "minimum": 0
                 },
                 "pass_packet": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "bypass": {
                     "type": "integer",
                     "minimum": 0
                 },

--- a/scripts/schema-sort.py
+++ b/scripts/schema-sort.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Script to sort or just check that properties are in alphabetic order
+
+
+import json
+import sys
+import argparse
+from collections import OrderedDict
+
+
+def sort_properties(obj, path=""):
+    """Recursively sort 'properties' keys in a JSON schema object."""
+    if isinstance(obj, dict):
+        new_obj = OrderedDict()
+
+        for key, value in obj.items():
+            current_path = f"{path}.{key}" if path else key
+
+            if key == "properties" and isinstance(value, dict):
+                sorted_properties = OrderedDict(sorted(value.items()))
+                new_obj[key] = sorted_properties
+                for prop_key, prop_value in sorted_properties.items():
+                    new_obj[key][prop_key] = sort_properties(
+                        prop_value, f"{current_path}.{prop_key}"
+                    )
+            else:
+                new_obj[key] = sort_properties(value, current_path)
+
+        return new_obj
+
+    elif isinstance(obj, list):
+        return [sort_properties(item, f"{path}[{i}]") for i, item in enumerate(obj)]
+
+    else:
+        return obj
+
+
+def check_properties_sorted(obj, path=""):
+    """Check if all 'properties' keys have their contents sorted alphabetically."""
+    errors = []
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            current_path = f"{path}.{key}" if path else key
+            if key == "properties" and isinstance(value, dict):
+                keys_list = list(value.keys())
+                sorted_keys = sorted(keys_list)
+
+                if keys_list != sorted_keys:
+                    errors.append(f"Properties not sorted at path: {current_path}")
+                    errors.append(f"  Current order: {keys_list}")
+                    errors.append(f"  Should be: {sorted_keys}")
+
+                for prop_key, prop_value in value.items():
+                    errors.extend(
+                        check_properties_sorted(
+                            prop_value, f"{current_path}.{prop_key}"
+                        )
+                    )
+            else:
+                errors.extend(check_properties_sorted(value, current_path))
+
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            errors.extend(check_properties_sorted(item, f"{path}[{i}]"))
+
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sort JSON schema properties alphabetically"
+    )
+    parser.add_argument("schema_file", help="Path to the JSON schema file")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if properties are sorted (exit 1 if not)",
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Sort the file in place (only if not in check mode)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.schema_file, "r") as f:
+            schema = json.load(f, object_pairs_hook=OrderedDict)
+    except Exception as e:
+        print(f"Error reading schema file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.check:
+        errors = check_properties_sorted(schema)
+
+        if errors:
+            print("Schema properties are not sorted!", file=sys.stderr)
+            for error in errors:
+                print(error, file=sys.stderr)
+            sys.exit(1)
+        else:
+            print("Schema properties are properly sorted.")
+            sys.exit(0)
+    else:
+        sorted_schema = sort_properties(schema)
+
+        if args.in_place:
+            try:
+                with open(args.schema_file, "w") as f:
+                    json.dump(sorted_schema, f, indent=4)
+                    f.write("\n")
+                print(f"Sorted schema written to {args.schema_file}")
+            except Exception as e:
+                print(f"Error writing schema file: {e}", file=sys.stderr)
+                sys.exit(1)
+        else:
+            print(json.dumps(sorted_schema, indent=4))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Also:
- Place "additionalProperties" before "properties"
- Place "required" after "additionalProperties"
- Remove "additionalProperties" where true, as that is the default
- Add script to verify ordering

The order should help us spot duplicate keys, and make it easier to
add new keys in their proper place.
