### PR TITLE
transform: fix identity function for base64 xfrom

### DIFF
--- a/src/detect-transform-base64.c
+++ b/src/detect-transform-base64.c
@@ -46,11 +46,8 @@ static void DetectTransformFromBase64Id(const uint8_t **data, uint32_t *length, 
 {
     if (context) {
         SCDetectTransformFromBase64Data *b64d = (SCDetectTransformFromBase64Data *)context;
-        /* Since the context structure contains the unique values for the keyword usage,
-         * a pointer to the context structure is returned.
-         */
-        *data = (const uint8_t *)b64d;
-        *length = sizeof(*b64d);
+        *data = b64d->serialized;
+        *length = b64d->serialized_len;
     }
 }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
Follow-up on https://github.com/OISF/suricata/pull/13225 cc @jlucovsky 
Highlighted by oss-fuzz https://issues.oss-fuzz.com/u/1/issues/418327946

Describe changes:
- transform: fix identity function for base64 xfrom

Following https://github.com/OISF/suricata/pull/13157#discussion_r2094622070

2 different structures using the same variable for offest will have 2 different pointers `offset_str` and thus 2 different hashes even if we do not want it, right ?

Jeff, what do you think ?