### PR TITLE
Warnint 64to32 6186 v27.2

### DIFF
--- a/src/detect-engine-frame.c
+++ b/src/detect-engine-frame.c
@@ -258,12 +258,12 @@ static void BufferSetupUdp(DetectEngineThreadCtx *det_ctx, InspectionBuffer *buf
     uint8_t ci_flags = DETECT_CI_FLAGS_START;
     uint32_t frame_len;
     if (frame->len == -1) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = (uint32_t)(p->payload_len - frame->offset);
     } else {
         frame_len = (uint32_t)frame->len;
     }
     if (frame->offset + frame_len > p->payload_len) {
-        frame_len = p->payload_len - frame->offset;
+        frame_len = (uint32_t)(p->payload_len - frame->offset);
     } else {
         ci_flags |= DETECT_CI_FLAGS_END;
     }
@@ -341,7 +341,7 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
         SCLogDebug("have frame data start");
 
         if (frame->len >= 0) {
-            data_len = MIN(input_len, frame->len);
+            data_len = MIN(input_len, (uint32_t)frame->len);
             if (data_len == frame->len) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
@@ -368,20 +368,23 @@ static bool BufferSetup(struct FrameStreamData *fsd, InspectionBuffer *buffer, c
 
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            DEBUG_VALIDATE_BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
 
             uint32_t in_data_excess = 0;
             if (so_input_re >= so_frame_re) {
                 ci_flags |= DETECT_CI_FLAGS_END;
                 SCLogDebug("have frame data end");
-                in_data_excess = so_input_re - so_frame_re;
+                DEBUG_VALIDATE_BUG_ON(so_input_re - so_frame_re > UINT32_MAX);
+                in_data_excess = (uint32_t)(so_input_re - so_frame_re);
             }
             data_len = input_len - in_data_offset - in_data_excess;
         } else {
             /* in: relative to start of input data */
             BUG_ON(so_inspect_offset < input_offset);
-            const uint32_t in_data_offset = so_inspect_offset - input_offset;
+            DEBUG_VALIDATE_BUG_ON(so_inspect_offset - input_offset > UINT32_MAX);
+            const uint32_t in_data_offset = (uint32_t)(so_inspect_offset - input_offset);
             data += in_data_offset;
             data_len = input_len - in_data_offset;
         }

--- a/src/detect-ftp-completion-code.c
+++ b/src/detect-ftp-completion-code.c
@@ -72,7 +72,7 @@ static bool DetectFTPCompletionCodeGetData(DetectEngineThreadCtx *_det_ctx, cons
             DEBUG_VALIDATE_BUG_ON(wrapper->response == NULL);
             if (index == count) {
                 *buffer = (const uint8_t *)wrapper->response->code;
-                *buffer_len = wrapper->response->code_length;
+                *buffer_len = (uint32_t)wrapper->response->code_length;
                 return true;
             }
             count++;

--- a/src/detect-tls-alpn.c
+++ b/src/detect-tls-alpn.c
@@ -72,7 +72,7 @@ static bool TlsAlpnGetData(DetectEngineThreadCtx *det_ctx, const void *txv, cons
 
     if (SCTLSHandshakeGetALPN(connp->hs, idx, &d)) {
         *buf = d.data;
-        *buf_len = d.len;
+        *buf_len = (uint32_t)d.len;
         return true;
     } else {
         return false;

--- a/src/detect-transform-luaxform.c
+++ b/src/detect-transform-luaxform.c
@@ -148,7 +148,7 @@ static DetectLuaxformData *DetectLuaxformParse(DetectEngineCtx *de_ctx, const ch
         FatalError("unable to allocate memory for Lua transform: %s", optsstr);
     }
 
-    lua->id_data_len = strlen(lua->id_data);
+    lua->id_data_len = (uint32_t)strlen(lua->id_data);
 
     int count = 0;
     char *saveptr = NULL;
@@ -352,12 +352,12 @@ static void TransformLuaxform(
 
         if (lua_isstring(tlua->luastate, -2)) {
             const char *transformed_buffer = lua_tostring(tlua->luastate, -2);
-            int transformed_buffer_byte_count = lua_tointeger(tlua->luastate, -1);
+            lua_Integer transformed_buffer_byte_count = lua_tointeger(tlua->luastate, -1);
             if (transformed_buffer != NULL && transformed_buffer_byte_count > 0)
-                InspectionBufferCopy(
-                        buffer, (uint8_t *)transformed_buffer, transformed_buffer_byte_count);
-            SCLogDebug("transform returns [nbytes %d] \"%p\"", transformed_buffer_byte_count,
-                    transformed_buffer);
+                InspectionBufferCopy(buffer, (uint8_t *)transformed_buffer,
+                        (uint32_t)transformed_buffer_byte_count);
+            SCLogDebug("transform returns [nbytes %d] \"%p\"",
+                    (uint32_t)transformed_buffer_byte_count, transformed_buffer);
         }
     }
 

--- a/src/detect-transform-pcrexform.c
+++ b/src/detect-transform-pcrexform.c
@@ -146,7 +146,7 @@ static int DetectTransformPcrexformSetup (DetectEngineCtx *de_ctx, Signature *s,
         DetectTransformPcrexformFree(de_ctx, pxd);
         SCReturnInt(-1);
     }
-    pxd->id_data_len = strlen(regexstr);
+    pxd->id_data_len = (uint32_t)strlen(regexstr);
 
     int r = SCDetectSignatureAddTransform(s, DETECT_TRANSFORM_PCREXFORM, pxd);
     if (r != 0) {

--- a/src/output-json-ftp.c
+++ b/src/output-json-ftp.c
@@ -105,7 +105,7 @@ bool EveFTPLogCommand(void *vtx, SCJsonBuilder *jb)
                     is_cc_array_open = true;
                 }
                 SCJbAppendStringFromBytes(
-                        jb, (const uint8_t *)response->code, response->code_length);
+                        jb, (const uint8_t *)response->code, (uint32_t)response->code_length);
             }
             if (response->length) {
                 SCJbAppendStringFromBytes(js_resplist, (const uint8_t *)response->response,


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix some remaining `-Wshorten-64-to-32` warnings

The commit about detect-engine-content-inspection is the one that needs most review...
Let me know if I should do a PR with the first commits if they look ok.

https://github.com/OISF/suricata/pull/13266 without last commits and with debug print fixed

Still to do after : [detect/engine: fix -Wshorten-64-to-32 warnings](https://github.com/OISF/suricata/pull/13266/commits/b7ba0c869e4f32d19e84f1e97ea6c597b82ce736) and CI check
and add `-Wimplicit-int-conversion` to `--enable-warnings` default options