### PR TITLE
datasets: fix set with ip sets (backport7)

### DIFF
--- a/src/datasets.c
+++ b/src/datasets.c
@@ -1502,12 +1502,12 @@ static int DatasetAddIPv6(Dataset *set, const uint8_t *data, const uint32_t data
         return -1;
     }
 
-    if (data_len != 16) {
+    if (data_len != 16 && data_len != 4) {
         return -2;
     }
 
     IPv6Type lookup = { .rep.value = 0 };
-    memcpy(lookup.ipv6, data, 16);
+    memcpy(lookup.ipv6, data, data_len);
     struct THashDataGetResult res = THashGetFromHash(set->hash, &lookup);
     if (res.data) {
         DatasetUnlockData(res.data);


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7690

Describe changes:
- Backport of https://github.com/OISF/suricata/pull/13176 clean cherry-pick

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2517
