### PR TITLE
scripts: clang-format can use a different base than master

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -341,7 +341,8 @@ function HelpCommand {
 # on master. If our branch has not been rebased on the latest master, this
 # would result in including all new commits on master!
 function FirstCommitOfBranch {
-    local first_commit=$(git rev-list origin/master..HEAD | tail -n 1)
+    start="${SURICATA_BRANCH:-origin/master}"
+    local first_commit=$(git rev-list $start..HEAD | tail -n 1)
     echo $first_commit
 }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7292

Describe changes:
- scripts: clang-format can use a different base than master

Added the label typo/doc update because there is no suricata code change, even if this is not a doc update