### PR TITLE
rust: pass CC and CFLAGS to cargo - v2


### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1796,8 +1796,8 @@ jobs:
           CC: "clang-15"
           CXX: "clang++-15"
           RUSTFLAGS: "-C instrument-coverage"
-          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Wimplicit-int-conversion -Werror"
-          CXXFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion -Wimplicit-int-conversion"
+          CFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -fPIC -Wno-unused-parameter -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -Wimplicit-int-float-conversion -Werror"
+          CXXFLAGS: "-fprofile-instr-generate -fcoverage-mapping -O0 -g -fno-strict-aliasing -fsanitize=address -fno-omit-frame-pointer -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1 -stdlib=libc++ -Wimplicit-int-float-conversion"
           ac_cv_func_malloc_0_nonnull: "yes"
           ac_cv_func_realloc_0_nonnull: "yes"
       - run: make -j ${{ env.CPUS }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2780,9 +2780,9 @@ jobs:
           . ./testenv/bin/activate
           pip install pyyaml
       - run: ./autogen.sh
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure  --enable-warnings --enable-unittests --prefix="$HOME/.local/"
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make -j2
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make check
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --prefix="$HOME/.local/"
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" make -j2
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2809,6 +2809,11 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: cargo-registry
+      - name: Cache npcap
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: /npcap-bin
+          key: npcap-bin
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2826,8 +2831,11 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
-        run: curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
-      - run: 7z -y x -o/npcap-bin npcap-1.00.exe
+        run: |
+          if ! test -e /npcap-bin; then
+              curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
+              7z -y x -o/npcap-bin npcap-1.00.exe
+          fi
       - name: Place NPcap dll's in curent directory 
         run: cp /npcap-bin/*.dll .
       - name: Npcap SDK

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2826,11 +2826,10 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
-        run: |
-          curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
-          7z -y x -o/npcap-bin npcap-1.00.exe
-          # hack: place dlls in cwd
-          cp /npcap-bin/*.dll .
+        run: curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
+      - run: 7z -y x -o/npcap-bin npcap-1.00.exe
+      - name: Place NPcap dll's in curent directory 
+        run: cp /npcap-bin/*.dll .
       - name: Npcap SDK
         run: |
           curl -sL -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472f537d65345c98e88b8fb027241939404970bc85320da46468a9e424018ad0"
+checksum = "21fbf4d3c5a7bcb18d651a3de65f103f311322599479cbdd91a9ccf7429e789a"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -85,7 +85,7 @@ time = "~0.3.36"
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.6" }
+suricata-lua-sys = { version = "0.1.0-alpha.7" }
 
 htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -61,6 +61,7 @@ CARGO_ENV +=	LOCALSTATEDIR=$(e_localstatedir)
 all-local: Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
 	cd $(abs_top_srcdir)/rust && \
+		CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)"\
 		$(CARGO_ENV) \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -62,6 +62,7 @@ all-local: Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
 	cd $(abs_top_srcdir)/rust && \
 		CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)"\
+		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" \
 		$(CARGO_ENV) \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)


### PR DESCRIPTION
This will make sure that crates that require a C compiler use the same C
compiler used to build Suricata.

Without this, for example, the suricata-lua-sys would default to cc.

Update suricata-lua-sys to support passed in CFLAGS (it already handled CC).

Ticket: https://redmine.openinfosecfoundation.org/issues/7671

Also, to see why npcap is failing:
- github-ci: use multiple steps for downloading/installing npcap

Previous PR: https://github.com/OISF/suricata/pull/13273
