### PR TITLE
Snmp probe 7019 v1

### DIFF
--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -361,7 +361,7 @@ unsafe extern "C" fn snmp_probing_parser(_flow: *const Flow,
     }
     let slice = build_slice!(input,input_len as usize);
     let alproto = ALPROTO_SNMP;
-    if slice.len() < 4 { return ALPROTO_FAILED; }
+    if slice.len() < 4 { return ALPROTO_UNKNOWN; }
     match parse_pdu_envelope_version(slice) {
         Ok((_,_))               => alproto,
         Err(Err::Incomplete(_)) => ALPROTO_UNKNOWN,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7019

Describe changes:
- snmp: improve probing parser

Fix is quite simple.
Crafting a test is a bit more work : need to take a SNMP/TCP pcap and "split" a first packet in 2, with the first half having less than 4 bytes, and then test that SNMP is still recognized on both sides...