### PR TITLE
detect/files: increment local_file_id even if buffer is NULL

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -430,8 +430,10 @@ uint8_t DetectEngineInspectFiledata(DetectEngineCtx *de_ctx, DetectEngineThreadC
     for (; file != NULL; file = file->next) {
         InspectionBuffer *buffer = FiledataGetDataCallback(det_ctx, transforms, f, flags, file,
                 engine->sm_list, engine->sm_list_base, local_file_id, txv);
-        if (buffer == NULL)
+        if (buffer == NULL) {
+            local_file_id++;
             continue;
+        }
 
         bool eof = (file->state == FILE_STATE_CLOSED);
         uint8_t ciflags = eof ? DETECT_CI_FLAGS_END : 0;
@@ -479,8 +481,10 @@ static void PrefilterTxFiledata(DetectEngineThreadCtx *det_ctx, const void *pect
         for (File *file = ffc->head; file != NULL; file = file->next) {
             InspectionBuffer *buffer = FiledataGetDataCallback(det_ctx, ctx->transforms, f, flags,
                     file, list_id, ctx->base_list_id, local_file_id, txv);
-            if (buffer == NULL)
+            if (buffer == NULL) {
+                local_file_id++;
                 continue;
+            }
             SCLogDebug("[%" PRIu64 "] buffer size %u", p->pcap_cnt, buffer->inspect_len);
 
             if (buffer->inspect_len >= mpm_ctx->minlen) {

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -326,8 +326,10 @@ static uint8_t DetectEngineInspectFilemagic(DetectEngineCtx *de_ctx, DetectEngin
     for (File *file = ffc->head; file != NULL; file = file->next) {
         InspectionBuffer *buffer = FilemagicGetDataCallback(
                 det_ctx, transforms, f, flags, file, engine->sm_list, local_file_id);
-        if (buffer == NULL)
+        if (buffer == NULL) {
+            local_file_id++;
             continue;
+        }
 
         const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
                 buffer->inspect, buffer->inspect_len, buffer->inspect_offset,

--- a/src/detect-filename.c
+++ b/src/detect-filename.c
@@ -263,8 +263,10 @@ static uint8_t DetectEngineInspectFilename(DetectEngineCtx *de_ctx, DetectEngine
     for (File *file = ffc->head; file != NULL; file = file->next) {
         InspectionBuffer *buffer = FilenameGetDataCallback(
                 det_ctx, transforms, f, flags, file, engine->sm_list, local_file_id);
-        if (buffer == NULL)
+        if (buffer == NULL) {
+            local_file_id++;
             continue;
+        }
 
         const bool match = DetectEngineContentInspection(de_ctx, det_ctx, s, engine->smd, NULL, f,
                 buffer->inspect, buffer->inspect_len, buffer->inspect_offset,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7579

Describe changes:
- detect/files: increment local_file_id even if buffer is NULL

I am not sure if this bug can happen in practice today, but I think it is better to fix it now than make it happen tomorrow.

For the bug to really happen, we need to have 
- a tx with multiple files
- and the first one of these would return NULL for one of the keywords
- but not NULL for the next files