### PR TITLE
rust: pass CFLAGS to suricata-lua-sys - v3

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2780,9 +2780,9 @@ jobs:
           . ./testenv/bin/activate
           pip install pyyaml
       - run: ./autogen.sh
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure  --enable-warnings --enable-unittests --prefix="$HOME/.local/"
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make -j2
-      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" make check
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" CFLAGS="${DEFAULT_CFLAGS}" ./configure --enable-warnings --enable-unittests --prefix="$HOME/.local/"
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" make -j2
+      - run: CPATH="$HOMEBREW_PREFIX/include:$CPATH" LIBRARY_PATH="$HOMEBREW_PREFIX/lib:$LIBRARY_PATH" PATH="/opt/homebrew/opt/libtool/libexec/gnubin:$PATH" make check
       - run: tar xf prep/suricata-verify.tar.gz
       - name: Running suricata-verify
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2809,6 +2809,11 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: cargo-registry
+      - name: Cache npcap
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: /npcap-bin
+          key: npcap-bin
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -2826,8 +2831,11 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
-        run: curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
-      - run: 7z -y x -o/npcap-bin npcap-1.00.exe
+        run: |
+          if ! test -e /npcap-bin; then
+              curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
+              7z -y x -o/npcap-bin npcap-1.00.exe
+          fi
       - name: Place NPcap dll's in curent directory 
         run: cp /npcap-bin/*.dll .
       - name: Npcap SDK

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2826,11 +2826,10 @@ jobs:
           path: prep
       - run: tar xf prep/suricata-update.tar.gz
       - name: Npcap DLL
-        run: |
-          curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
-          7z -y x -o/npcap-bin npcap-1.00.exe
-          # hack: place dlls in cwd
-          cp /npcap-bin/*.dll .
+        run: curl -sL -O https://nmap.org/npcap/dist/npcap-1.00.exe
+      - run: 7z -y x -o/npcap-bin npcap-1.00.exe
+      - name: Place NPcap dll's in curent directory 
+        run: cp /npcap-bin/*.dll .
       - name: Npcap SDK
         run: |
           curl -sL -O https://nmap.org/npcap/dist/npcap-sdk-1.06.zip

--- a/rust/Cargo.lock.in
+++ b/rust/Cargo.lock.in
@@ -1599,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "suricata-lua-sys"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472f537d65345c98e88b8fb027241939404970bc85320da46468a9e424018ad0"
+checksum = "53577a4974f5aed1b59d26963f1e6abf17ea7cfc2206357759fb40487f85fbcf"
 dependencies = [
  "fs_extra",
 ]

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -85,7 +85,7 @@ time = "~0.3.36"
 suricata-derive = { path = "./derive", version = "@PACKAGE_VERSION@" }
 suricata-sys = { path = "./sys", version = "@PACKAGE_VERSION@" }
 
-suricata-lua-sys = { version = "0.1.0-alpha.6" }
+suricata-lua-sys = { version = "0.1.0-alpha.8" }
 
 htp = { package = "suricata-htp", path = "./htp", version = "2.0.0" }
 

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -61,6 +61,7 @@ CARGO_ENV +=	LOCALSTATEDIR=$(e_localstatedir)
 all-local: Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
 	cd $(abs_top_srcdir)/rust && \
+		CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)"\
 		$(CARGO_ENV) \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -62,6 +62,7 @@ all-local: Cargo.toml
 	mkdir -p $(abs_top_builddir)/rust/gen
 	cd $(abs_top_srcdir)/rust && \
 		CC="$(CC)" AR="$(AR)" RANLIB="$(RANLIB)"\
+		SURICATA_LUA_SYS_CFLAGS="$(CFLAGS)" \
 		$(CARGO_ENV) \
 		$(CARGO) build $(RELEASE) $(NIGHTLY_ARGS) \
 			--features "$(RUST_FEATURES)" $(RUST_TARGET)


### PR DESCRIPTION
This version doesn't pass CFLAGS to all Rust crates, but instead uses a
suricata-lua-sys specific variable, SURICATA_LUA_SYS_CFLAGS to just pass the
CFLAGS to suricata-lua-sys.
