### PR TITLE
scripts: clang-format can use a different base than master (backport7)

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -61,7 +61,7 @@ proper it provides additional functionality such as reformatting of all commits 
 
 Commands used in various situations:
 
-Formatting branch changes (compared to master):
+Formatting branch changes (compared to master or SURICATA_BRANCH env variable):
     branch          Format all changes in branch as additional commit
     rewrite-branch  Format every commit in branch and rewrite history
 
@@ -335,14 +335,15 @@ function HelpCommand {
     esac
 }
 
-# Return first commit of branch (off master).
+# Return first commit of branch (off master or SURICATA_BRANCH env variable).
 #
 # Use $first_commit^ if you need the commit on master we branched off.
 # Do not compare with master directly as it will diff with the latest commit
 # on master. If our branch has not been rebased on the latest master, this
 # would result in including all new commits on master!
 function FirstCommitOfBranch {
-    local first_commit=$(git rev-list origin/master..HEAD | tail -n 1)
+    start="${SURICATA_BRANCH:-origin/master}"
+    local first_commit=$(git rev-list $start..HEAD | tail -n 1)
     echo $first_commit
 }
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7293

Describe changes:
- Bakcport of #13284 clean cherry-pick
