### PR TITLE
snmp: probing parser returns unknown if not enough data (backport7)

### DIFF
--- a/rust/src/snmp/snmp.rs
+++ b/rust/src/snmp/snmp.rs
@@ -362,7 +362,7 @@ pub unsafe extern "C" fn rs_snmp_probing_parser(_flow: *const Flow,
     }
     let slice = build_slice!(input,input_len as usize);
     let alproto = ALPROTO_SNMP;
-    if slice.len() < 4 { return ALPROTO_FAILED; }
+    if slice.len() < 4 { return ALPROTO_UNKNOWN; }
     match parse_pdu_envelope_version(slice) {
         Ok((_,_))               => alproto,
         Err(Err::Incomplete(_)) => ALPROTO_UNKNOWN,


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7716

Describe changes:
- Backport of #13285 clean cherry-pick
