### PR TITLE
clang-format: don't reformat schema on rewrite-branch

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -544,7 +544,7 @@ function ReformatCommitsOnBranch {
         local first_commit=$(FirstCommitOfBranch)
         echo "First commit on branch: $first_commit"
         # Use --force in case it's run a second time on the same branch
-        git filter-branch --force --tree-filter "$GIT_CLANG_FORMAT $first_commit^" -- $first_commit..HEAD
+        git filter-branch --force --tree-filter "$GIT_CLANG_FORMAT --extensions c,h $first_commit^" -- $first_commit..HEAD
         if [ $? -ne 0 ]; then
             Die "Cannot rewrite branch. git filter-branch failed"
         fi


### PR DESCRIPTION
Add --extensions c,h flag to git clang-format when reformatting
commits on a branch. This prevents clang-format from modifying
non-C files like JSON schemas.

The extensions is used elsewhere in this script, so I suspect it was
just an oversight.

Also, ./scripts/schema-order.py --in-place will consistently format the
schema, while sorting the keys.
