### PR TITLE
types: address coverity warnings and harmonize types across codebase v2

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2440,12 +2440,10 @@ retry:
 
 bool DetectEngineMpmCachingEnabled(void)
 {
-    const char *strval = NULL;
-    if (SCConfGet("detect.sgh-mpm-caching", &strval) != 1)
-        return false;
-
     int sgh_mpm_caching = 0;
-    (void)SCConfGetBool("detect.sgh-mpm-caching", &sgh_mpm_caching);
+    if (SCConfGetBool("detect.sgh-mpm-caching", &sgh_mpm_caching) != 1) {
+        return false;
+    }
     return (bool)sgh_mpm_caching;
 }
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2457,9 +2457,7 @@ const char *DetectEngineMpmCachingGetPath(void)
 
     char yamlpath[] = "detect.sgh-mpm-caching-path";
     const char *strval = NULL;
-    (void)SCConfGet(yamlpath, &strval);
-
-    if (strval != NULL) {
+    if (SCConfGet(yamlpath, &strval) == 1 && strval != NULL) {
         return strval;
     }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -1030,7 +1030,7 @@ static inline bool FlowCompareKey(Flow *f, FlowKey *key)
  *  \param flow_id Flow ID of the flow to look for
  *  \retval f *LOCKED* flow or NULL
  */
-Flow *FlowGetExistingFlowFromFlowId(int64_t flow_id)
+Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id)
 {
     uint32_t hash = flow_id & 0x0000FFFF;
     FlowBucket *fb = &flow_hash[hash % flow_config.hash_size];

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -82,7 +82,7 @@ typedef struct FlowBucket_ {
 Flow *FlowGetFlowFromHash(ThreadVars *tv, FlowLookupStruct *tctx, Packet *, Flow **);
 
 Flow *FlowGetFromFlowKey(FlowKey *key, struct timespec *ttime, const uint32_t hash);
-Flow *FlowGetExistingFlowFromFlowId(int64_t flow_id);
+Flow *FlowGetExistingFlowFromFlowId(uint64_t flow_id);
 uint32_t FlowKeyGetHash(FlowKey *flow_key);
 uint32_t FlowGetIpPairProtoHash(const Packet *p);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -246,7 +246,7 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
         uint64_t bytes_todst = fc->todstbytecnt;
         bool update = fc->BypassUpdate(f, fc->bypass_data, SCTIME_SECS(ts));
         if (update) {
-            SCLogDebug("Updated flow: %"PRId64"", FlowGetId(f));
+            SCLogDebug("Updated flow: %" PRIu64 "", FlowGetId(f));
             pkts_tosrc = fc->tosrcpktcnt - pkts_tosrc;
             bytes_tosrc = fc->tosrcbytecnt - bytes_tosrc;
             pkts_todst = fc->todstpktcnt - pkts_todst;
@@ -259,7 +259,7 @@ static inline bool FlowBypassedTimeout(Flow *f, SCTime_t ts, FlowTimeoutCounters
             counters->bypassed_bytes += bytes_tosrc + bytes_todst;
             return false;
         }
-        SCLogDebug("No new packet, dead flow %" PRId64 "", FlowGetId(f));
+        SCLogDebug("No new packet, dead flow %" PRIu64 "", FlowGetId(f));
         if (f->livedev) {
             if (FLOW_IS_IPV4(f)) {
                 LiveDevSubBypassStats(f->livedev, 1, AF_INET);

--- a/src/flow.h
+++ b/src/flow.h
@@ -640,8 +640,8 @@ static inline void FlowDeReference(Flow **d)
  */
 static inline int64_t FlowGetId(const Flow *f)
 {
-    int64_t id = (uint64_t)(SCTIME_SECS(f->startts) & 0x0000FFFF) << 48 |
-                 (uint64_t)(SCTIME_USECS(f->startts) & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
+    int64_t id = (int64_t)(SCTIME_SECS(f->startts) & 0x0000FFFF) << 48 |
+                 (int64_t)(SCTIME_USECS(f->startts) & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
     /* reduce to 51 bits as JavaScript and even JSON often seem to
      * max out there. */
     id &= 0x7ffffffffffffLL;

--- a/src/flow.h
+++ b/src/flow.h
@@ -634,14 +634,12 @@ static inline void FlowDeReference(Flow **d)
 }
 
 /** \brief create a flow id that is as unique as possible
- *  \retval flow_id signed 64bit id
- *  \note signed because of the signedness of json_integer_t in
- *        the json output
+ *  \retval flow_id unsigned 64bit id
  */
-static inline int64_t FlowGetId(const Flow *f)
+static inline uint64_t FlowGetId(const Flow *f)
 {
-    int64_t id = (int64_t)(SCTIME_SECS(f->startts) & 0x0000FFFF) << 48 |
-                 (int64_t)(SCTIME_USECS(f->startts) & 0x0000FFFF) << 32 | (int64_t)f->flow_hash;
+    uint64_t id = (uint64_t)(SCTIME_SECS(f->startts) & 0xFFFF) << 48 |
+                  (uint64_t)(SCTIME_USECS(f->startts) & 0xFFFF) << 32 | (uint64_t)f->flow_hash;
     /* reduce to 51 bits as JavaScript and even JSON often seem to
      * max out there. */
     id &= 0x7ffffffffffffLL;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -702,7 +702,7 @@ void CreateEveFlowId(SCJsonBuilder *js, const Flow *f)
     if (f == NULL) {
         return;
     }
-    int64_t flow_id = FlowGetId(f);
+    uint64_t flow_id = FlowGetId(f);
     SCJbSetUint(js, "flow_id", flow_id);
     if (f->parent_id) {
         SCJbSetUint(js, "parent_id", f->parent_id);

--- a/src/runmode-dpdk.c
+++ b/src/runmode-dpdk.c
@@ -451,7 +451,7 @@ static int ConfigSetThreads(DPDKIfaceConfig *iconf, const char *entry_str)
         SCReturnInt(0);
     }
 
-    if (StringParseInt32(&iconf->threads, 10, 0, entry_str) < 0) {
+    if (StringParseUint16(&iconf->threads, 10, 0, entry_str) < 0) {
         SCLogError("Threads entry for interface %s contain non-numerical characters - \"%s\"",
                 iconf->iface, entry_str);
         SCReturnInt(-EINVAL);

--- a/src/source-dpdk.c
+++ b/src/source-dpdk.c
@@ -123,7 +123,7 @@ typedef struct DPDKThreadVars_ {
     uint16_t capture_dpdk_ierrors;
     uint16_t capture_dpdk_tx_errs;
     unsigned int flags;
-    int threads;
+    uint16_t threads;
     /* for IPS */
     DpdkCopyModeEnum copy_mode;
     uint16_t out_port_id;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -55,8 +55,7 @@ typedef struct DPDKIfaceConfig_ {
     char iface[RTE_ETH_NAME_MAX_LEN];
     uint16_t port_id;
     int32_t socket_id;
-    /* number of threads - zero means all available */
-    int threads;
+    uint16_t threads;
     /* IPS mode */
     DpdkCopyModeEnum copy_mode;
     const char *out_iface;

--- a/src/source-dpdk.h
+++ b/src/source-dpdk.h
@@ -76,7 +76,7 @@ typedef struct DPDKIfaceConfig_ {
     uint32_t mempool_cache_size;
     DPDKDeviceResources *pkt_mempools;
     uint16_t linkup_timeout; // in seconds how long to wait for link to come up
-    SC_ATOMIC_DECLARE(unsigned int, ref);
+    SC_ATOMIC_DECLARE(uint16_t, ref);
     /* threads bind queue id one by one */
     SC_ATOMIC_DECLARE(uint16_t, queue_id);
     SC_ATOMIC_DECLARE(uint16_t, inconsistent_numa_cnt);
@@ -96,7 +96,7 @@ typedef struct DPDKPacketVars_ {
     struct rte_mbuf *mbuf;
     uint16_t out_port_id;
     uint16_t out_queue_id;
-    uint8_t copy_mode;
+    DpdkCopyModeEnum copy_mode;
 } DPDKPacketVars;
 
 void TmModuleReceiveDPDKRegister(void);

--- a/src/util-dpdk-i40e.c
+++ b/src/util-dpdk-i40e.c
@@ -299,7 +299,7 @@ static int i40eDeviceSetRSSWithFlows(int port_id, const char *port_name, int nb_
 
 #endif /* RTE_VERSION < RTE_VERSION_NUM(20,0,0,0) */
 
-int i40eDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name)
+int i40eDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
     (void)nb_rx_queues; // avoid unused variable warnings
 

--- a/src/util-dpdk-i40e.h
+++ b/src/util-dpdk-i40e.h
@@ -30,7 +30,7 @@
 
 #include "util-dpdk.h"
 
-int i40eDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name);
+int i40eDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void i40eDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-ice.c
+++ b/src/util-dpdk-ice.c
@@ -90,7 +90,7 @@ static int iceDeviceSetRSSFlowIPv6(
     return DPDKCreateRSSFlow(port_id, port_name, rss_conf, RTE_ETH_RSS_IPV6, pattern);
 }
 
-int iceDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name)
+int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
     uint16_t queues[RTE_MAX_QUEUES_PER_PORT];
     struct rte_flow_error flush_error = { 0 };

--- a/src/util-dpdk-ice.h
+++ b/src/util-dpdk-ice.h
@@ -30,7 +30,7 @@
 
 #include "util-dpdk.h"
 
-int iceDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name);
+int iceDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void iceDeviceSetRSSConf(struct rte_eth_rss_conf *rss_conf);
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-ixgbe.c
+++ b/src/util-dpdk-ixgbe.c
@@ -45,7 +45,7 @@ void ixgbeDeviceSetRSSHashFunction(uint64_t *rss_hf)
     *rss_hf = RTE_ETH_RSS_IPV4 | RTE_ETH_RSS_IPV6 | RTE_ETH_RSS_IPV6_EX;
 }
 
-int ixgbeDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name)
+int ixgbeDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
     uint16_t queues[RTE_MAX_QUEUES_PER_PORT];
     struct rte_flow_error flush_error = { 0 };

--- a/src/util-dpdk-ixgbe.h
+++ b/src/util-dpdk-ixgbe.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_DPDK
 
-int ixgbeDeviceSetRSS(int port_id, int nb_rx_queues, char *port_name);
+int ixgbeDeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 void ixgbeDeviceSetRSSHashFunction(uint64_t *rss_conf);
 
 #endif /* HAVE_DPDK */

--- a/src/util-dpdk-mlx5.c
+++ b/src/util-dpdk-mlx5.c
@@ -40,7 +40,7 @@
 
 #define MLX5_RSS_HKEY_LEN 40
 
-int mlx5DeviceSetRSS(int port_id, int nb_rx_queues, char *port_name)
+int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name)
 {
     uint16_t queues[RTE_MAX_QUEUES_PER_PORT];
     struct rte_flow_error flush_error = { 0 };

--- a/src/util-dpdk-mlx5.h
+++ b/src/util-dpdk-mlx5.h
@@ -28,7 +28,7 @@
 
 #ifdef HAVE_DPDK
 
-int mlx5DeviceSetRSS(int port_id, int nb_rx_queues, char *port_name);
+int mlx5DeviceSetRSS(int port_id, uint16_t nb_rx_queues, char *port_name);
 
 #endif /* HAVE_DPDK */
 

--- a/src/util-ebpf.c
+++ b/src/util-ebpf.c
@@ -654,7 +654,7 @@ bool EBPFBypassUpdate(Flow *f, void *data, time_t tsec)
     bool activity = EBPFBypassCheckHalfFlow(f, fc, eb, eb->key[0], 0);
     activity |= EBPFBypassCheckHalfFlow(f, fc, eb, eb->key[1], 1);
     if (!activity) {
-        SCLogDebug("Delete entry: %u (%ld)", FLOW_IS_IPV6(f), FlowGetId(f));
+        SCLogDebug("Delete entry: %u (%" PRIu64 ")", FLOW_IS_IPV6(f), FlowGetId(f));
         /* delete the entries if no time update */
         EBPFDeleteKey(eb->mapfd, eb->key[0]);
         EBPFDeleteKey(eb->mapfd, eb->key[1]);

--- a/src/util-lua-flowlib.c
+++ b/src/util-lua-flowlib.c
@@ -67,7 +67,7 @@ static int LuaFlowId(lua_State *luastate)
 
     Flow *f = s->f;
 
-    int64_t id = FlowGetId(f);
+    int64_t id = (int64_t)FlowGetId(f);
     lua_pushinteger(luastate, id);
     return 1;
 }

--- a/src/util-memcmp.h
+++ b/src/util-memcmp.h
@@ -71,7 +71,7 @@ static inline int SCMemcmp(const void *s1, const void *s2, size_t n)
         /* do the actual compare: _mm_cmpestri() returns the number of matching bytes */
         r = _mm_cmpestri(b1, SCMEMCMP_BYTES, b2, SCMEMCMP_BYTES,
                 _SIDD_CMP_EQUAL_EACH | _SIDD_MASKED_NEGATIVE_POLARITY);
-        m += r;
+        m += (size_t)r;
         s1 += SCMEMCMP_BYTES;
         s2 += SCMEMCMP_BYTES;
     } while (r == SCMEMCMP_BYTES);
@@ -116,7 +116,7 @@ static inline int SCMemcmpLowercase(const void *s1, const void *s2, size_t n)
         /* search using our converted buffer, return number of matching bytes */
         r = _mm_cmpestri(b1, SCMEMCMP_BYTES, b2, SCMEMCMP_BYTES,
                 _SIDD_CMP_EQUAL_EACH | _SIDD_MASKED_NEGATIVE_POLARITY);
-        m += r;
+        m += (size_t)r;
         s1 += SCMEMCMP_BYTES;
         s2 += SCMEMCMP_BYTES;
     } while (r == SCMEMCMP_BYTES);

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -79,7 +79,7 @@ typedef struct {
 #define SCTIME_FROM_TIMEVAL(tv)                                                                    \
     (SCTime_t)                                                                                     \
     {                                                                                              \
-        .secs = (tv)->tv_sec, .usecs = (tv)->tv_usec                                               \
+        .secs = (uint64_t)(tv)->tv_sec, .usecs = (uint32_t)(tv)->tv_usec                           \
     }
 /** \brief variant to deal with potentially bad timestamps, like from pcap files */
 #define SCTIME_FROM_TIMEVAL_UNTRUSTED(tv)                                                          \


### PR DESCRIPTION
Follow-up of #13276 

Redmine tickets:
https://redmine.openinfosecfoundation.org/issues/6981
https://redmine.openinfosecfoundation.org/issues/7634

It started with DPDK warnings, but some extra types were adjusted in other files, too.

Changes:
v2:
change flow id to unit64_t - generally it makes more sense as it doesn't use signness. 

v1:
initial