### PR TITLE
decode/sll2: Support PCAPs encoded with Linux SLL ver 2

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -5762,6 +5762,15 @@
                                         }
                                     }
                                 },
+                                "sll2": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
                                 "tcp": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -5903,6 +5912,9 @@
                             "type": "integer"
                         },
                         "sll": {
+                            "type": "integer"
+                        },
+                        "sll2": {
                             "type": "integer"
                         },
                         "tcp": {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,6 +80,7 @@ noinst_HEADERS = \
 	decode-raw.h \
 	decode-sctp.h \
 	decode-sll.h \
+	decode-sll2.h \
 	decode-tcp.h \
 	decode-template.h \
 	decode-teredo.h \
@@ -673,6 +674,7 @@ libsuricata_c_a_SOURCES = \
 	decode-raw.c \
 	decode-sctp.c \
 	decode-sll.c \
+	decode-sll2.c \
 	decode-tcp.c \
 	decode-template.c \
 	decode-teredo.c \

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -286,6 +286,12 @@ const struct DecodeEvents_ DEvents[] = {
             SLL_PKT_TOO_SMALL,
     },
 
+    /* SLL2 EVENTS */
+    {
+            "decoder.sll2.pkt_too_small",
+            SLL2_PKT_TOO_SMALL,
+    },
+
     /* ETHERNET EVENTS */
     {
             "decoder.ethernet.pkt_too_small",

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -111,6 +111,9 @@ enum {
     /* SLL EVENTS */
     SLL_PKT_TOO_SMALL, /**< sll packet smaller than minimum size */
 
+    /* SLL2 EVENTS */
+    SLL2_PKT_TOO_SMALL, /**< sll2 packet smaller than minimum size */
+
     /* ETHERNET EVENTS */
     ETHERNET_PKT_TOO_SMALL,     /**< ethernet packet smaller than minimum size */
     ETHERNET_UNKNOWN_ETHERTYPE, /**< ethertype unknown/unhandled*/

--- a/src/decode-sll2.c
+++ b/src/decode-sll2.c
@@ -1,0 +1,65 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky <jeff.lucovsky@corelight.com>
+ *
+ * Decodes Sll2
+ */
+
+#include "suricata-common.h"
+#include "decode.h"
+#include "decode-sll2.h"
+#include "decode-events.h"
+
+#include "util-validate.h"
+#include "util-debug.h"
+
+int DecodeSll2(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, const uint8_t *pkt, uint32_t len)
+{
+    DEBUG_VALIDATE_BUG_ON(pkt == NULL);
+
+    StatsIncr(tv, dtv->counter_sll2);
+
+    if (unlikely(len < SLL2_HEADER_LEN)) {
+        ENGINE_SET_INVALID_EVENT(p, SLL2_PKT_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+    if (!PacketIncreaseCheckLayers(p)) {
+        return TM_ECODE_FAILED;
+    }
+
+    Sll2Hdr *sll2h = (Sll2Hdr *)pkt;
+
+    SCLogDebug("p %p pkt %p sll2_protocol %04x", p, pkt, SCNtohs(sll2h->sll_protocol));
+
+    DecodeNetworkLayer(
+            tv, dtv, SCNtohs(sll2h->sll_protocol), p, pkt + SLL2_HEADER_LEN, len - SLL2_HEADER_LEN);
+
+    return TM_ECODE_OK;
+}
+/**
+ * @}
+ */

--- a/src/decode-sll2.h
+++ b/src/decode-sll2.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Jeff Lucovsky (jeff.lucovsky@corelight.com)
+ */
+
+#ifndef SURICATA_DECODE_SLL2_H
+#define SURICATA_DECODE_SLL2_H
+
+#define SLL2_HEADER_LEN 20
+
+typedef struct Sll2Hdr_ {
+    uint16_t sll_protocol;     /* protocol */
+    uint16_t sll2_reservd;     /* reserved */
+    uint32_t sll_ifindex;      /* interface index*/
+    uint16_t sll2_arphdtotype; /* ARPHRD_ type*/
+    uint8_t sll2_pkttype;      /* packet type */
+    uint8_t sll2_addrlen;      /* link-layer addr len*/
+    uint8_t sll2_addr[8];      /* link-layer address */
+} __attribute__((__packed__)) Sll2Hdr;
+
+#endif /* SURICATA_DECODE_SLL2_H */

--- a/src/decode.c
+++ b/src/decode.c
@@ -614,6 +614,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_raw = StatsRegisterCounter("decoder.raw", tv);
     dtv->counter_null = StatsRegisterCounter("decoder.null", tv);
     dtv->counter_sll = StatsRegisterCounter("decoder.sll", tv);
+    dtv->counter_sll2 = StatsRegisterCounter("decoder.sll2", tv);
     dtv->counter_tcp = StatsRegisterCounter("decoder.tcp", tv);
 
     dtv->counter_tcp_syn = StatsRegisterCounter("tcp.syn", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -981,6 +981,7 @@ typedef struct DecodeThreadVars_
     uint16_t counter_ethertype_unknown;
 
     uint16_t counter_sll;
+    uint16_t counter_sll2;
     uint16_t counter_raw;
     uint16_t counter_null;
     uint16_t counter_sctp;
@@ -1129,6 +1130,7 @@ const char *PacketDropReasonToString(enum PacketDropReason r);
 /* decoder functions */
 int DecodeEthernet(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodeSll(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
+int DecodeSll2(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodePPP(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodePPPOESession(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
 int DecodePPPOEDiscovery(ThreadVars *, DecodeThreadVars *, Packet *, const uint8_t *, uint32_t);
@@ -1410,6 +1412,9 @@ static inline void DecodeLinkLayer(ThreadVars *tv, DecodeThreadVars *dtv,
             break;
         case LINKTYPE_LINUX_SLL:
             DecodeSll(tv, dtv, p, data, len);
+            break;
+        case LINKTYPE_LINUX_SLL2:
+            DecodeSll2(tv, dtv, p, data, len);
             break;
         case LINKTYPE_PPP:
             DecodePPP(tv, dtv, p, data, len);

--- a/src/source-pcap-file-helper.c
+++ b/src/source-pcap-file-helper.c
@@ -251,6 +251,9 @@ TmEcode InitPcapFile(PcapFileFileVars *pfv)
 TmEcode ValidateLinkType(int datalink, DecoderFunc *DecoderFn)
 {
     switch (datalink) {
+        case LINKTYPE_LINUX_SLL2:
+            *DecoderFn = DecodeSll2;
+            break;
         case LINKTYPE_LINUX_SLL:
             *DecoderFn = DecodeSll;
             break;

--- a/src/util-datalink.h
+++ b/src/util-datalink.h
@@ -47,6 +47,7 @@
 #define LINKTYPE_NULL      DLT_NULL
 #define LINKTYPE_ETHERNET  DLT_EN10MB
 #define LINKTYPE_LINUX_SLL 113
+#define LINKTYPE_LINUX_SLL2 276
 #define LINKTYPE_PPP       9
 #define LINKTYPE_RAW       DLT_RAW
 /* http://www.tcpdump.org/linktypes.html defines DLT_RAW as 101, yet others don't.


### PR DESCRIPTION
Support Linux Cooked mode v2 -- DLT 276

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- Add SLL2 linktype
- Recognize and decode SLL2 frames.

### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2523
SU_REPO=
SU_BRANCH=
