### PR TITLE
dns: parse multiple txt segments into an array - v1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -243,8 +243,8 @@ pub enum DNSRData {
     PTR(DNSName),
     MX(DNSName),
     NS(DNSName),
-    // RData is text
-    TXT(Vec<u8>),
+    // TXT records are an array of TXT entries
+    TXT(Vec<Vec<u8>>),
     NULL(Vec<u8>),
     // RData has several fields
     SOA(DNSRDataSOA),

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -162,8 +162,19 @@ pub extern "C" fn SCDnsLuaGetAnswerTable(clua: &mut CLuaState, tx: &mut DNSTrans
                         lua.settable(-3);
                     }
                 }
-                DNSRData::TXT(ref bytes)
-                | DNSRData::NULL(ref bytes)
+                DNSRData::TXT(ref txt) => {
+                    if !txt.is_empty() {
+                        lua.pushstring("addr");
+                        let combined = txt
+                            .iter()
+                            .map(|s| String::from_utf8_lossy(s))
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        lua.pushstring(&combined);
+                        lua.settable(-3);
+                    }
+                }
+                DNSRData::NULL(ref bytes)
                 | DNSRData::Unknown(ref bytes) => {
                     if !bytes.is_empty() {
                         lua.pushstring("addr");


### PR DESCRIPTION
A DNS TXT answer record can actually be made of up multiple TXT
entries in a single record. Suricata currently expands these into
multiple TXT records, however that is not very representative of the
actualy DNS message.

Instead, if a TXT record contains multiple labels, parse them into an
array.

We still expand multiple TXT segements into multiple TXT records at
logging time for compatibility, but this will allow something like
MDNS to log more accurately to the protocol.

The purpose of this PR is to make sure all tests pass. Even though we are now
parsing multiple TXT segments into an array, the logging format for DNS has not
change.
