### PR TITLE
detect/analyzer: use note instead of warning

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -744,12 +744,12 @@ static void DumpMatches(RuleAnalyzer *ctx, SCJsonBuilder *js, const SigMatchData
                                               "is interpreted as regular 'fast_pattern'");
                 }
                 if (LooksLikeHTTPMethod(cd->content, cd->content_len)) {
-                    AnalyzerWarning(ctx,
+                    AnalyzerNote(ctx,
                             (char *)"pattern looks like it inspects HTTP, use http.request_line or "
                                     "http.method and http.uri instead for improved performance");
                 }
                 if (LooksLikeHTTPUA(cd->content, cd->content_len)) {
-                    AnalyzerWarning(ctx,
+                    AnalyzerNote(ctx,
                             (char *)"pattern looks like it inspects HTTP, use http.user_agent "
                                     "or http.header for improved performance");
                 }


### PR DESCRIPTION
Another way is to add validation prior to `DumpMatches` call if we really do need to issue a warning. Seemed more like a friendly poke to me to tell the user to use certain keywords if they aren't already.
Thoughts?

Link to ticket: https://redmine.openinfosecfoundation.org/issues/5177

