### PR TITLE
detect/entropy: Add calculated entropy value to flowvars 

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2933,6 +2933,14 @@
                         ]
                     }
                 },
+                "flowfloats": {
+                    "type": "object",
+                    "suricata": {
+                        "keywords": [
+                            "flowfloats"
+                        ]
+                    }
+                },
                 "flowints": {
                     "type": "object",
                     "suricata": {

--- a/rust/src/detect/entropy.rs
+++ b/rust/src/detect/entropy.rs
@@ -27,13 +27,15 @@ use nom7::sequence::preceded;
 use nom7::{Err, IResult};
 
 use std::ffi::CStr;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::{c_double, c_char, c_void};
 use std::slice;
 
+#[repr(C)]
 #[derive(Debug)]
 pub struct DetectEntropyData {
     offset: i32,
     nbytes: i32,
+    fv_idx: i32,
     value: DetectFloatData<f64>,
 }
 
@@ -42,6 +44,7 @@ impl Default for DetectEntropyData {
         DetectEntropyData {
             offset: 0,
             nbytes: 0,
+            fv_idx: 0,
             value: DetectFloatData::<f64>::default(),
         }
     }
@@ -166,9 +169,10 @@ fn calculate_entropy(data: &[u8]) -> f64 {
 #[no_mangle]
 pub unsafe extern "C" fn SCDetectEntropyMatch(
     c_data: *const c_void, length: i32, ctx: &DetectEntropyData,
+    calculated_entropy: *mut c_double,
 ) -> bool {
     if c_data.is_null() {
-        return false;
+        return false
     }
 
     let buffer = std::slice::from_raw_parts(c_data as *const u8, length as usize);
@@ -200,7 +204,11 @@ pub unsafe extern "C" fn SCDetectEntropyMatch(
     let entropy = calculate_entropy(data_slice);
     SCLogDebug!("entropy is {}", entropy);
 
-    // Use a hypothetical `detect_entropy_match` function to check entropy
+    // Return entropy on request
+    if !calculated_entropy.is_null() {
+        *calculated_entropy = entropy;
+    }
+
     detect_match_float::<f64>(&ctx.value, entropy)
 }
 
@@ -248,8 +256,9 @@ mod tests {
             mode,
         };
         let ded = DetectEntropyData {
-            offset,
-            nbytes,
+            offset: offset,
+            nbytes: nbytes,
+            fv_idx: 0,
             value: ctx,
         };
 

--- a/src/detect-entropy.c
+++ b/src/detect-entropy.c
@@ -23,6 +23,8 @@
 #include "detect-engine-buffer.h"
 
 #include "detect-entropy.h"
+#include "util-var-name.h"
+#include "flow-var.h"
 
 #include "rust.h"
 
@@ -32,6 +34,8 @@ static int DetectEntropySetup(DetectEngineCtx *de_ctx, Signature *s, const char 
     if (ded == NULL) {
         goto error;
     }
+
+    ded->fv_idx = VarNameStoreRegister("entropy", VAR_TYPE_FLOW_FLOAT);
 
     int sm_list = DETECT_SM_LIST_PMATCH;
     if (s->init_data->list != DETECT_SM_LIST_NOTSET) {
@@ -57,13 +61,25 @@ error:
 
 static void DetectEntropyFree(DetectEngineCtx *de_ctx, void *ptr)
 {
-    SCDetectEntropyFree(ptr);
+    if (ptr) {
+        DetectEntropyData *ded = (DetectEntropyData *)ptr;
+        VarNameStoreUnregister(ded->fv_idx, VAR_TYPE_FLOW_FLOAT);
+        SCDetectEntropyFree(ptr);
+    }
 }
 
 bool DetectEntropyDoMatch(DetectEngineThreadCtx *det_ctx, const Signature *s,
         const SigMatchCtx *ctx, const uint8_t *buffer, const uint32_t buffer_len)
 {
-    return SCDetectEntropyMatch(buffer, buffer_len, (const DetectEntropyData *)ctx);
+    double entropy = -1.0;
+    bool rc = SCDetectEntropyMatch(buffer, buffer_len, (const DetectEntropyData *)ctx, &entropy);
+
+    if (entropy != -1.0) {
+        DetectEntropyData *ded = (DetectEntropyData *)ctx;
+        FlowVarAddFloat(det_ctx->p->flow, ded->fv_idx, entropy);
+    }
+
+    return rc;
 }
 
 void DetectEntropyRegister(void)

--- a/src/flow-var.c
+++ b/src/flow-var.c
@@ -47,6 +47,12 @@ static void FlowVarUpdateInt(FlowVar *fv, uint32_t value)
     fv->data.fv_int.value = value;
 }
 
+/* puts a new value into a flowvar */
+static void FlowVarUpdateFloat(FlowVar *fv, double value)
+{
+    fv->data.fv_float.value = value;
+}
+
 /** \brief get the flowvar with index 'idx' from the flow
  *  \note flow is not locked by this function, caller is
  *        responsible
@@ -132,6 +138,26 @@ void FlowVarAddIdValue(Flow *f, uint32_t idx, uint8_t *value, uint16_t size)
     }
 }
 
+/* add a flowvar to the flow, or update it */
+void FlowVarAddFloat(Flow *f, uint32_t idx, double value)
+{
+    FlowVar *fv = FlowVarGet(f, idx);
+    if (fv == NULL) {
+        fv = SCMalloc(sizeof(FlowVar));
+        if (unlikely(fv == NULL))
+            return;
+
+        fv->type = DETECT_FLOWVAR;
+        fv->datatype = FLOWVAR_TYPE_FLOAT;
+        fv->idx = idx;
+        fv->data.fv_float.value = value;
+        fv->next = NULL;
+
+        GenericVarAppend(&f->flowvar, (GenericVar *)fv);
+    } else {
+        FlowVarUpdateFloat(fv, value);
+    }
+}
 /* add a flowvar to the flow, or update it */
 void FlowVarAddIntNoLock(Flow *f, uint32_t idx, uint32_t value)
 {

--- a/src/flow-var.h
+++ b/src/flow-var.h
@@ -32,6 +32,7 @@
 
 #define FLOWVAR_TYPE_STR 1
 #define FLOWVAR_TYPE_INT 2
+#define FLOWVAR_TYPE_FLOAT 3
 
 typedef uint8_t FlowVarKeyLenType;
 /** Struct used to hold the string data type for flowvars */
@@ -45,6 +46,11 @@ typedef struct FlowVarTypeInt_ {
     uint32_t value;
 } FlowVarTypeInt;
 
+/** Struct used to hold the integer data type for flowvars */
+typedef struct FlowVarTypeFloat_ {
+    double value;
+} FlowVarTypeFloat;
+
 /** Generic Flowvar Structure */
 typedef struct FlowVar_ {
     uint16_t type; /* type, DETECT_FLOWVAR in this case */
@@ -57,6 +63,7 @@ typedef struct FlowVar_ {
     union {
         FlowVarTypeStr fv_str;
         FlowVarTypeInt fv_int;
+        FlowVarTypeFloat fv_float;
     } data;
     uint8_t *key;
 } FlowVar;
@@ -69,6 +76,7 @@ void FlowVarAddKeyValue(
 
 void FlowVarAddIntNoLock(Flow *, uint32_t, uint32_t);
 void FlowVarAddInt(Flow *, uint32_t, uint32_t);
+void FlowVarAddFloat(Flow *, uint32_t, double);
 FlowVar *FlowVarGet(Flow *, uint32_t);
 FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, FlowVarKeyLenType keylen);
 void FlowVarFree(FlowVar *);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -247,6 +247,7 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
     SCJsonBuilder *js_traffic_id = NULL;
     SCJsonBuilder *js_traffic_label = NULL;
     SCJsonBuilder *js_flowints = NULL;
+    SCJsonBuilder *js_flowfloats = NULL;
     SCJsonBuilder *js_flowbits = NULL;
     GenericVar *gv = f->flowvar;
     while (gv != NULL) {
@@ -292,6 +293,17 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
                 SCJbStartObject(js_flowvars);
                 SCJbSetString(js_flowvars, (const char *)keybuf, (char *)printable_buf);
                 SCJbClose(js_flowvars);
+            } else if (fv->datatype == FLOWVAR_TYPE_FLOAT) {
+                const char *varname = VarNameStoreLookupById(fv->idx, VAR_TYPE_FLOW_FLOAT);
+                if (varname) {
+                    if (js_flowfloats == NULL) {
+                        js_flowfloats = SCJbNewObject();
+                        if (js_flowfloats == NULL)
+                            break;
+                    }
+                    SCJbSetFloat(js_flowfloats, varname, fv->data.fv_float.value);
+                }
+
             } else if (fv->datatype == FLOWVAR_TYPE_INT) {
                 const char *varname = VarNameStoreLookupById(fv->idx,
                         VAR_TYPE_FLOW_INT);
@@ -303,7 +315,6 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
                     }
                     SCJbSetUint(js_flowints, varname, fv->data.fv_int.value);
                 }
-
             }
         } else if (gv->type == DETECT_FLOWBITS) {
             FlowBit *fb = (FlowBit *)gv;
@@ -347,6 +358,11 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
         SCJbClose(js_flowints);
         SCJbSetObject(js_root, "flowints", js_flowints);
         SCJbFree(js_flowints);
+    }
+    if (js_flowfloats) {
+        SCJbClose(js_flowfloats);
+        SCJbSetObject(js_root, "flowfloats", js_flowfloats);
+        SCJbFree(js_flowfloats);
     }
     if (js_flowvars) {
         SCJbClose(js_flowvars);

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -35,6 +35,7 @@ enum VarTypes {
 
     VAR_TYPE_FLOW_BIT,
     VAR_TYPE_FLOW_INT,
+    VAR_TYPE_FLOW_FLOAT,
     VAR_TYPE_FLOW_VAR,
 
     VAR_TYPE_HOST_BIT,


### PR DESCRIPTION
Continuation of #13341 

When the entropy keyword is used, record the calculated entropy value to a flow variable for logging use.

Describe changes:
- Modify the entropy match function to return the calculated entropy value and store it in a flow variable
- Modifications to flow variables to support variables of type float
- Extend the schema to include "flowfloats"

Updates:
- Added missing etc/schema.json file
- 
### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2534
SU_REPO=
SU_BRANCH=
