### PR TITLE
Warnint 64to32 6186 v28.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2296,6 +2296,27 @@ fi
                 AC_MSG_RESULT([yes]),
                 [AC_MSG_RESULT([no])
                 CFLAGS="$OCFLAGS"])
+        # Following warnings are not respected by unit tests
+        if test "$enable_unittests" != "yes"; then
+            # check if our compiler supports -Wimplicit-int-conversion
+            AC_MSG_CHECKING(for -Wimplicit-int-conversion support)
+            OCFLAGS=$CFLAGS
+            CFLAGS="$CFLAGS -Wimplicit-int-conversion"
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],
+                        [[]])],
+                    AC_MSG_RESULT([yes]),
+                    [AC_MSG_RESULT([no])
+                    CFLAGS="$OCFLAGS"])
+            # check if our compiler supports -Wshorten-64-to-32
+            AC_MSG_CHECKING(for -Wshorten-64-to-32 support)
+            OCFLAGS=$CFLAGS
+            CFLAGS="$CFLAGS -Wshorten-64-to-32"
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],
+                        [[]])],
+                    AC_MSG_RESULT([yes]),
+                    [AC_MSG_RESULT([no])
+                    CFLAGS="$OCFLAGS"])
+        fi
     ])
 
     AC_CHECK_LIB(fuzzpcap, FPC_IsFuzzPacketCapture, HAS_FUZZPCAP="yes")

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -597,12 +597,12 @@ static void *ParseAFPConfig(const char *iface)
     }
 
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "buffer-size", &value)) == 1) {
-        aconf->buffer_size = value;
+        aconf->buffer_size = (int)value;
     } else {
         aconf->buffer_size = 0;
     }
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "ring-size", &value)) == 1) {
-        aconf->ring_size = value;
+        aconf->ring_size = (int)value;
     }
 
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "block-size", &value)) == 1) {
@@ -610,12 +610,12 @@ static void *ParseAFPConfig(const char *iface)
             SCLogWarning("%s: block-size %" PRIuMAX " must be a multiple of pagesize (%u).", iface,
                     value, getpagesize());
         } else {
-            aconf->block_size = value;
+            aconf->block_size = (int)value;
         }
     }
 
     if ((SCConfGetChildValueIntWithDefault(if_root, if_default, "block-timeout", &value)) == 1) {
-        aconf->block_timeout = value;
+        aconf->block_timeout = (int)value;
     } else {
         aconf->block_timeout = 10;
     }
@@ -625,7 +625,7 @@ static void *ParseAFPConfig(const char *iface)
             SCLogWarning("%s: v2-block-size %" PRIuMAX " must be a multiple of pagesize (%u).",
                     iface, value, getpagesize());
         } else {
-            aconf->v2_block_size = value;
+            aconf->v2_block_size = (int)value;
         }
     }
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2744,7 +2744,7 @@ static void UpdateRawDataForVLANHdr(Packet *p)
 {
     if (p->afp_v.vlan_tci != 0) {
         uint8_t *pstart = GET_PKT_DATA(p) - VLAN_HEADER_LEN;
-        size_t plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
+        uint32_t plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
         /* move ethernet addresses */
         memmove(pstart, GET_PKT_DATA(p), 2 * ETH_ALEN);
         /* write vlan info */

--- a/src/tests/fuzz/fuzz_applayerparserparse.c
+++ b/src/tests/fuzz/fuzz_applayerparserparse.c
@@ -149,7 +149,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                 goto bail;
             }
             memcpy(isolatedBuffer, albuffer, alnext - albuffer);
-            (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alnext - albuffer);
+            (void)AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer,
+                    (uint32_t)(alnext - albuffer));
             free(isolatedBuffer);
             if (FlowChangeProto(f)) {
                 // exits if a protocol change is requested
@@ -192,7 +193,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
             goto bail;
         }
         memcpy(isolatedBuffer, albuffer, alsize);
-        (void) AppLayerParserParse(NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, alsize);
+        (void)AppLayerParserParse(
+                NULL, alp_tctx, f, f->alproto, flags, isolatedBuffer, (uint32_t)alsize);
         free(isolatedBuffer);
     }
 

--- a/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
+++ b/src/tests/fuzz/fuzz_applayerprotodetectgetproto.c
@@ -61,8 +61,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (data[0] & STREAM_TOSERVER) {
         flags = STREAM_TOSERVER;
     }
-    AppLayerProtoDetectGetProto(
-            alpd_tctx, f, data + HEADER_LEN, size - HEADER_LEN, f->proto, flags, &reverse);
+    AppLayerProtoDetectGetProto(alpd_tctx, f, data + HEADER_LEN, (uint32_t)(size - HEADER_LEN),
+            f->proto, flags, &reverse);
     FlowFree(f);
 
     return 0;

--- a/src/tests/fuzz/fuzz_decodebase64.c
+++ b/src/tests/fuzz/fuzz_decodebase64.c
@@ -16,7 +16,7 @@ static int initialized = 0;
 
 static void Base64FuzzTest(const uint8_t *src, size_t len)
 {
-    uint32_t decoded_len = SCBase64DecodeBufferSize(len);
+    uint32_t decoded_len = SCBase64DecodeBufferSize((uint32_t)len);
     uint8_t *decoded = SCCalloc(decoded_len, sizeof(uint8_t));
 
     for (uint8_t mode = SCBase64ModeRFC2045; mode <= SCBase64ModeStrict; mode++) {

--- a/src/tests/fuzz/fuzz_mimedecparseline.c
+++ b/src/tests/fuzz/fuzz_mimedecparseline.c
@@ -33,10 +33,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         uint8_t * next = memchr(buffer, '\n', size);
         if (next == NULL) {
             if (SCMimeSmtpGetState(state) >= MimeSmtpBody)
-                (void)SCSmtpMimeParseLine(buffer, size, 0, &events, state);
+                (void)SCSmtpMimeParseLine(buffer, (uint32_t)size, 0, &events, state);
             break;
         } else {
-            (void)SCSmtpMimeParseLine(buffer, next - buffer, 1, &events, state);
+            (void)SCSmtpMimeParseLine(buffer, (uint32_t)(next - buffer), 1, &events, state);
             if (buffer + size < next + 1) {
                 break;
             }

--- a/src/threads.h
+++ b/src/threads.h
@@ -252,12 +252,13 @@ enum {
 })
 
 #else
-#define SCGetThreadIdLong(...) ({ \
-   pid_t tmpthid; \
-   tmpthid = syscall(SYS_gettid); \
-   unsigned long _scgetthread_tid = (unsigned long)tmpthid; \
-   _scgetthread_tid; \
-})
+#define SCGetThreadIdLong(...)                                                                     \
+    ({                                                                                             \
+        pid_t tmpthid;                                                                             \
+        tmpthid = (pid_t)syscall(SYS_gettid);                                                      \
+        unsigned long _scgetthread_tid = (unsigned long)tmpthid;                                   \
+        _scgetthread_tid;                                                                          \
+    })
 #endif /* OS FREEBSD */
 
 extern thread_local char t_thread_name[THREAD_NAME_LEN + 1];

--- a/src/util-systemd.c
+++ b/src/util-systemd.c
@@ -74,7 +74,8 @@ static int Notify(const char *message)
     if (fd < 0)
         return -errno;
 
-    if (connect(fd, &socket_addr.sa, offsetof(struct sockaddr_un, sun_path) + path_length) != 0)
+    if (connect(fd, &socket_addr.sa,
+                offsetof(struct sockaddr_un, sun_path) + (uint32_t)path_length) != 0)
         return -errno;
 
     ssize_t written = write(fd, message, message_length);


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/6186

Describe changes:
- fix remaining `-Wshorten-64-to-32` warnings. Final PR !
- add it tot the set of flags for ./configure --enable-warnings

The commit about detect-engine-content-inspection needs review...

#13294 with needed rebase 

Afterwards, we can tackle `-Wsign-conversion` for 9 see https://redmine.openinfosecfoundation.org/issues/6632