### PR TITLE
Http1 brotli cursor blocking v2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,5 +108,5 @@ jobs:
               exit 1
           fi
       # does not work in other subdirectories for now
-      - run: cargo fmt
+      - run: cargo fmt --check
         working-directory: rust/htp

--- a/rust/htp/src/lib.rs
+++ b/rust/htp/src/lib.rs
@@ -6,11 +6,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
-
 // Allow unknown lints, our MSRV doesn't know them all, for
 // example static_mut_refs.
 #![allow(unknown_lints)]
-
 // Requires MSRV of 1.74 to fix.
 #![allow(clippy::io_other_error)]
 


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
No ticket but https://issues.oss-fuzz.com/u/1/issues/418282186
Should I create a ticket ?

Describe changes:
- http1: use a blocking cursor for decompression
- also check cargo fmt result in CI for rust/htp

Avoids an endless loop in brotli crate

Owning a fix instead of https://github.com/dropbox/rust-brotli-decompressor/pull/40