### PR TITLE
lua: config; bytevars - v3

### DIFF
--- a/doc/userguide/lua/libs/bytevar.rst
+++ b/doc/userguide/lua/libs/bytevar.rst
@@ -1,0 +1,76 @@
+Bytevar
+#######
+
+The ``suricata.bytevar`` module provides access to variables defined by 
+``byte_extract`` and ``byte_math`` keywords in Suricata rules. 
+
+It is only available in Suricata Lua rules, not output scripts.
+
+Setup
+*****
+
+::
+
+    local bytevars = require("suricata.bytevar")
+
+Module Functions
+****************
+
+.. function:: bytevars.ensure(sig, varname)
+
+   Ensures that the ``bytevar`` exists and sets it up for further use
+   in the script. Must be called during ``init()``.
+
+   :param sig: The signature object passed to ``init()``
+   :param string varname: Name of the variable as defined in the rule
+
+   :raises error: If the variable name is unknown
+   :raises error: If too many byte variables are registered
+
+   Example:
+
+   ::
+
+       function init(sig)
+           bytevars.ensure(sig, "var1")
+           bytevars.ensure(sig, "var2")
+           return {}
+       end
+
+.. function:: bytevars.get(index)
+
+   Returns a byte variable object for the given index. May be called
+   during ``thread_init()`` to save a handle to the bytevar.
+
+   :param number index: Zero-based index of the variable (in order of
+                        ``ensure()`` calls)
+   :returns: A byte variable object
+
+   Example:
+
+   ::
+
+       function thread_init()
+           bv_var1 = bytevars.get(0)
+           bv_var2 = bytevars.get(1)
+       end
+
+Byte Variable Object Methods
+****************************
+
+.. method:: bytevar:value()
+
+   Returns the current value of the byte variable.
+
+   :returns: The value of the byte variable.
+
+   Example:
+
+   ::
+
+       function match(args)
+           local var1 = bv_var1:value()
+           if var1 then
+               -- Use the value
+           end
+       end

--- a/doc/userguide/lua/libs/config.rst
+++ b/doc/userguide/lua/libs/config.rst
@@ -1,0 +1,25 @@
+Config Library
+##############
+
+The config library provides access to Suricata configuration settings.
+
+To use this library, you must require it::
+
+  local config = require("suricata.config")
+
+Functions
+*********
+
+``log_path()``
+==============
+
+Returns the configured log directory path.
+
+Example::
+
+  local config = require("suricata.config")
+
+  local log_path, err = config.log_path()
+  if log_path == nil then
+     print("failed to get log path " .. err)
+  end

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -25,3 +25,4 @@ environment without access to additional modules.
    ssh
    tls
    ja3
+   util

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -9,6 +9,7 @@ environment without access to additional modules.
 .. toctree::
 
    base64
+   config
    dns
    file
    flowlib

--- a/doc/userguide/lua/libs/index.rst
+++ b/doc/userguide/lua/libs/index.rst
@@ -9,6 +9,7 @@ environment without access to additional modules.
 .. toctree::
 
    base64
+   bytevar
    config
    dns
    file

--- a/doc/userguide/lua/libs/util.rst
+++ b/doc/userguide/lua/libs/util.rst
@@ -1,0 +1,34 @@
+Util
+####
+
+The ``suricata.util`` library provides utility functions for Lua
+scripts.
+
+Setup
+*****
+
+The library must be loaded prior to use::
+
+    local util = require("suricata.util")
+
+Functions
+=========
+
+.. function:: thread_info()
+
+   Get information about the current thread.
+
+   :returns: Table containing thread information with the following fields:
+
+      - ``id`` (number): Thread ID
+      - ``name`` (string): Thread name 
+      - ``group_name`` (string): Thread group name
+            
+   Example::
+
+       local util = require("suricata.util")
+       
+       local info = util.thread_info()
+       print("Thread ID: " .. info.id)
+       print("Thread Name: " .. info.name)
+       print("Thread Group: " .. info.group_name)

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -219,10 +219,7 @@ according to the host OS settings.
 ::
 
   function init (args)
-      local needs = {}
-      needs["type"] = "streaming"
-      needs["filter"] = "tcp"
-      return needs
+      return {streaming = "tcp"}
   end
 
 In case of HTTP body data, the bodies are unzipped and dechunked if applicable.
@@ -230,10 +227,7 @@ In case of HTTP body data, the bodies are unzipped and dechunked if applicable.
 ::
 
   function init (args)
-      local needs = {}
-      needs["type"] = "streaming"
-      needs["protocol"] = "http"
-      return needs
+      return {streaming = "http"}
   end
 
 The streaming data will be provided in the ``args`` to the log

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -313,28 +313,3 @@ SCThreadInfo
   tid, tname, tgroup = SCThreadInfo()
 
 It gives: tid (integer), tname (string), tgroup (string)
-
-
-
-SCByteVarGet
-~~~~~~~~~~~~
-
-Get the ByteVar at index given by the parameter. These variables are defined by
-`byte_extract` or `byte_math` in Suricata rules. Only callable from match scripts.
-
-::
-
- function init(args)
-     local needs = {}
-     needs["bytevar"] = {"var1", "var2"}
-     return needs
- end
-
-Here we define a register that we will be using variables `var1` and `var2`.
-The access to the Byte variables is done by index.
-
-::
-
- function match(args)
-     var1 = SCByteVarGet(0)
-     var2 = SCByteVarGet(1)

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -315,19 +315,6 @@ SCThreadInfo
 It gives: tid (integer), tname (string), tgroup (string)
 
 
-SCLogPath
-~~~~~~~~~
-
-Expose the log path.
-
-::
-
-
-  name = "fast_lua.log"
-  function setup (args)
-      filename = SCLogPath() .. "/" .. name
-      file = assert(io.open(filename, "a"))
-  end
 
 SCByteVarGet
 ~~~~~~~~~~~~

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -236,20 +236,24 @@ In case of HTTP body data, the bodies are unzipped and dechunked if applicable.
       return needs
   end
 
-SCStreamingBuffer
-~~~~~~~~~~~~~~~~~
-
-::
+The streaming data will be provided in the ``args`` to the log
+function within a ``stream`` subtable::
 
   function log(args)
-      -- sb_ts and sb_tc are bools indicating the direction of the data
-      data, sb_open, sb_close, sb_ts, sb_tc = SCStreamingBuffer()
-      if sb_ts then
-        print("->")
-      else
-        print("<-")
-      end
-      hex_dump(data)
+    -- The data (buffer)
+    local data = args["stream"]["data"]
+
+    -- Buffer open?
+    local open = args["stream"]["open"]
+
+    -- Buffer closed?
+    local close = args["stream"]["close"]
+
+    -- To server?
+    local ts = args["stream"]["toserver"]
+
+    -- To client?
+    local tc = args["stream"]["toclient"]
   end
 
 Flow variables

--- a/doc/userguide/lua/lua-functions.rst
+++ b/doc/userguide/lua/lua-functions.rst
@@ -299,15 +299,3 @@ SCFlowintDecr
 ~~~~~~~~~~~~~
 
 Decrement Flowint at index given by the first parameter.
-
-Misc
-----
-
-SCThreadInfo
-~~~~~~~~~~~~
-
-::
-
-  tid, tname, tgroup = SCThreadInfo()
-
-It gives: tid (integer), tname (string), tgroup (string)

--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -27,6 +27,7 @@ Example:
 
 ::
 
+  local config = require("suricata.config")
   local logger = require("suricata.log")
 
   function init (args)
@@ -36,7 +37,7 @@ Example:
   end
 
   function setup (args)
-      filename = SCLogPath() .. "/" .. name
+      filename = config.log_path() .. "/" .. name
       file = assert(io.open(filename, "a"))
       logger.info("HTTP Log Filename " .. filename)
       http = 0

--- a/lua/fast.lua
+++ b/lua/fast.lua
@@ -18,6 +18,7 @@
 
 local packet = require("suricata.packet")
 local rule = require("suricata.rule")
+local config = require("suricata.config")
 
 function init()
     local needs     = {}
@@ -27,7 +28,7 @@ function init()
 end
 
 function setup()
-    filename = SCLogPath() .. "/fast.log"
+    filename = config.log_path() .. "/fast.log"
     file = assert(io.open(filename, "a"))
     alert_count = 0
 end

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -536,6 +536,7 @@ noinst_HEADERS = \
 	util-lua-base64lib.h \
 	util-lua-builtins.h \
 	util-lua-common.h \
+	util-lua-config.h \
 	util-lua-dataset.h \
 	util-lua-dnp3-objects.h \
 	util-lua-dnp3.h \
@@ -1114,6 +1115,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-base64lib.c \
 	util-lua-builtins.c \
 	util-lua-common.c \
+	util-lua-config.c \
 	util-lua-dataset.c \
 	util-lua-dnp3-objects.c \
 	util-lua-dnp3.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -556,6 +556,7 @@ noinst_HEADERS = \
 	util-lua-smtp.h \
 	util-lua-ssh.h \
 	util-lua-tls.h \
+	util-lua-util.h \
 	util-lua.h \
 	util-macset.h \
 	util-magic.h \
@@ -1136,6 +1137,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-smtp.c \
 	util-lua-ssh.c \
 	util-lua-tls.c \
+	util-lua-util.c \
 	util-lua.c \
 	util-macset.c \
 	util-magic.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -545,6 +545,7 @@ noinst_HEADERS = \
 	util-lua-flowintlib.h \
 	util-lua-flowlib.h \
 	util-lua-flowvarlib.h \
+	util-lua-bytevarlib.h \
 	util-lua-hashlib.h \
 	util-lua-http.h \
 	util-lua-ja3.h \
@@ -1124,6 +1125,7 @@ libsuricata_c_a_SOURCES = \
 	util-lua-flowintlib.c \
 	util-lua-flowlib.c \
 	util-lua-flowvarlib.c \
+	util-lua-bytevarlib.c \
 	util-lua-hashlib.c \
 	util-lua-http.c \
 	util-lua-ja3.c \

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -66,12 +66,3 @@ void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *ld,
 
     LuaStateSetDirection(lua_state, (flags & STREAM_TOSERVER));
 }
-
-/**
- *  \brief Register Suricata Lua functions
- */
-int LuaRegisterExtensions(lua_State *lua_state)
-{
-    LuaRegisterFunctions(lua_state);
-    return 0;
-}

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -424,7 +424,6 @@ static void *DetectLuaThreadInit(void *data)
         SCLuaSbLoadLibs(t->luastate);
     }
 
-    LuaRegisterExtensions(t->luastate);
     LuaStateSetDetectLuaData(t->luastate, lua);
 
     /* hackish, needed to allow unittests to pass buffers as scripts instead of files */

--- a/src/detect-transform-luaxform.c
+++ b/src/detect-transform-luaxform.c
@@ -202,8 +202,6 @@ static void *DetectLuaxformThreadInit(void *data)
         SCLuaSbLoadLibs(t->luastate);
     }
 
-    LuaRegisterExtensions(t->luastate);
-
     int status = luaL_loadfile(t->luastate, lua->filename);
     if (status) {
         SCLogError("couldn't load file: %s", lua_tostring(t->luastate, -1));

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -505,7 +505,16 @@ static int LuaScriptInit(const char *filename, LogLuaScriptOptions *options, Log
 
         SCLogDebug("k='%s', v='%s'", k, v);
 
-        if (strcmp(k,"protocol") == 0 && strcmp(v, "http") == 0)
+        if (strcmp(k, "streaming") == 0) {
+            options->streaming = 1;
+            if (strcmp(v, "http") == 0) {
+                options->alproto = ALPROTO_HTTP1;
+            } else if (strcmp(v, "tcp") == 0) {
+                options->tcp_data = 1;
+            } else {
+                SCLogError("unsupported streaming argument: %s", v);
+            }
+        } else if (strcmp(k, "protocol") == 0 && strcmp(v, "http") == 0)
             options->alproto = ALPROTO_HTTP1;
         else if (strcmp(k,"protocol") == 0 && strcmp(v, "dns") == 0)
             options->alproto = ALPROTO_DNS;

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -607,9 +607,6 @@ static lua_State *LuaScriptSetup(const char *filename, LogLuaMasterCtx *ctx)
 
     lua_getglobal(luastate, "setup");
 
-    /* register functions common to all */
-    LuaRegisterFunctions(luastate);
-
     if (lua_pcall(luastate, 0, 0, 0) != 0) {
         SCLogError("couldn't run script 'setup' function: %s", lua_tostring(luastate, -1));
         goto error;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -228,7 +228,12 @@ void SCLogErr(int x, const char *file, const char *func, const int line, const c
 
 #define SCLogConfig(...)                                                                           \
     SCLog(SC_LOG_CONFIG, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogConfigRaw(file, func, line, ...)                                                      \
+    SCLog(SC_LOG_CONFIG, (file), (func), (line), _sc_module, __VA_ARGS__)
+
 #define SCLogPerf(...) SCLog(SC_LOG_PERF, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogPerfRaw(file, func, line, ...)                                                        \
+    SCLog(SC_LOG_PERF, (file), (func), (line), _sc_module, __VA_ARGS__)
 
 /**
  * \brief Macro used to log NOTICE messages.
@@ -303,6 +308,8 @@ void SCLogErr(int x, const char *file, const char *func, const int line, const c
  */
 #define SCLogDebug(...)                                                                            \
     SCLog(SC_LOG_DEBUG, __FILE__, __FUNCTION__, __LINE__, _sc_module, __VA_ARGS__)
+#define SCLogDebugRaw(file, func, line, ...)                                                       \
+    SCLog(SC_LOG_DEBUG, (file), (func), (line), _sc_module, __VA_ARGS__)
 
 /**
  * \brief Macro used to log debug messages on function entry.  Comes under the

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -36,6 +36,7 @@
 #include "util-lua-ja3.h"
 #include "util-lua-filelib.h"
 #include "util-lua-log.h"
+#include "util-lua-util.h"
 
 #include "lauxlib.h"
 
@@ -59,6 +60,7 @@ static const luaL_Reg builtins[] = {
     { "suricata.smtp", SCLuaLoadSmtpLib },
     { "suricata.ssh", SCLuaLoadSshLib },
     { "suricata.tls", SCLuaLoadTlsLib },
+    { "suricata.util", SCLuaLoadUtilLib },
     { NULL, NULL },
 };
 

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -18,6 +18,7 @@
 #include "suricata-common.h"
 #include "util-lua-builtins.h"
 #include "util-lua-base64lib.h"
+#include "util-lua-bytevarlib.h"
 #include "util-lua-config.h"
 #include "util-lua-dataset.h"
 #include "util-lua-dnp3.h"
@@ -40,6 +41,7 @@
 
 static const luaL_Reg builtins[] = {
     { "suricata.base64", SCLuaLoadBase64Lib },
+    { "suricata.bytevar", LuaLoadBytevarLib },
     { "suricata.config", SCLuaLoadConfigLib },
     { "suricata.dataset", LuaLoadDatasetLib },
     { "suricata.dnp3", SCLuaLoadDnp3Lib },

--- a/src/util-lua-builtins.c
+++ b/src/util-lua-builtins.c
@@ -18,6 +18,7 @@
 #include "suricata-common.h"
 #include "util-lua-builtins.h"
 #include "util-lua-base64lib.h"
+#include "util-lua-config.h"
 #include "util-lua-dataset.h"
 #include "util-lua-dnp3.h"
 #include "util-lua-flowintlib.h"
@@ -39,6 +40,7 @@
 
 static const luaL_Reg builtins[] = {
     { "suricata.base64", SCLuaLoadBase64Lib },
+    { "suricata.config", SCLuaLoadConfigLib },
     { "suricata.dataset", LuaLoadDatasetLib },
     { "suricata.dnp3", SCLuaLoadDnp3Lib },
     { "suricata.dns", SCLuaLoadDnsLib },

--- a/src/util-lua-bytevarlib.c
+++ b/src/util-lua-bytevarlib.c
@@ -1,0 +1,114 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "detect-byte.h"
+#include "util-lua-common.h"
+#include "util-lua-bytevarlib.h"
+#include "util-lua.h"
+#include "detect-lua.h"
+#include "detect-lua-extensions.h"
+
+#include "lauxlib.h"
+
+static const char suricata_bytevar_mt[] = "suricata:bytevar:mt";
+
+static DetectLuaData *GetLuaData(lua_State *luastate)
+{
+    DetectLuaData *ld;
+    lua_pushlightuserdata(luastate, (void *)&luaext_key_ld);
+    lua_gettable(luastate, LUA_REGISTRYINDEX);
+    ld = lua_touserdata(luastate, -1);
+    return ld;
+}
+
+static int LuaBytevarEnsure(lua_State *L)
+{
+    const Signature *s = lua_touserdata(L, -2);
+    const char *name = luaL_checkstring(L, -1);
+    DetectLuaData *ld = GetLuaData(L);
+    if (ld->bytevars == DETECT_LUA_MAX_BYTEVARS) {
+        luaL_error(L, "too many bytevars registered");
+    }
+
+    DetectByteIndexType idx;
+    if (!DetectByteRetrieveSMVar(name, s, &idx)) {
+        luaL_error(L, "unknown byte_extract or byte_math variable: %s", name);
+    }
+
+    ld->bytevar[ld->bytevars++] = idx;
+
+    return 1;
+}
+
+static int LuaBytevarGet(lua_State *L)
+{
+    int idx = luaL_checkinteger(L, 1);
+    DetectLuaData *ld = GetLuaData(L);
+    if (ld == NULL) {
+        return luaL_error(L, "internal error: no lua data");
+    }
+
+    if (idx < 0 || idx >= ld->bytevars) {
+        return luaL_error(L, "bytevar index out of range");
+    }
+
+    uint32_t *bytevar_id = lua_newuserdata(L, sizeof(*bytevar_id));
+    *bytevar_id = ld->bytevar[idx];
+
+    luaL_getmetatable(L, suricata_bytevar_mt);
+    lua_setmetatable(L, -2);
+
+    return 1;
+}
+
+static int LuaBytevarValue(lua_State *L)
+{
+    uint32_t *bytevar_id = luaL_checkudata(L, 1, suricata_bytevar_mt);
+    DetectEngineThreadCtx *det_ctx = LuaStateGetDetCtx(L);
+    if (det_ctx == NULL) {
+        return LuaCallbackError(L, "internal error: no det_ctx");
+    }
+    lua_pushinteger(L, det_ctx->byte_values[*bytevar_id]);
+    return 1;
+}
+
+static const luaL_Reg bytevarlib[] = {
+    // clang-format off
+    { "ensure", LuaBytevarEnsure, },
+    { "get", LuaBytevarGet, },
+    { NULL, NULL, },
+    // clang-format on
+};
+
+static const luaL_Reg bytevarmt[] = {
+    // clang-format off
+    { "value", LuaBytevarValue, },
+    { NULL, NULL, },
+    // clang-format on
+};
+
+int LuaLoadBytevarLib(lua_State *L)
+{
+    luaL_newmetatable(L, suricata_bytevar_mt);
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    luaL_setfuncs(L, bytevarmt, 0);
+
+    luaL_newlib(L, bytevarlib);
+    return 1;
+}

--- a/src/util-lua-bytevarlib.h
+++ b/src/util-lua-bytevarlib.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef SURICATA_UTIL_LUA_BYTEVARLIB_H
+#define SURICATA_UTIL_LUA_BYTEVARLIB_H
+
+#include "lua.h"
+
+int LuaLoadBytevarLib(lua_State *L);
+
+#endif /* SURICATA_UTIL_LUA_BYTEVARLIB_H */

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -99,43 +99,6 @@ void LuaPushTableKeyValueArray(
     lua_settable(luastate, -3);
 }
 
-/** \internal
- *  \brief fill lua stack with thread info
- *  \param luastate the lua state
- *  \param pa pointer to packet alert struct
- *  \retval cnt number of data items placed on the stack
- *
- *  Places: thread id (number), thread name (string, thread group name (string)
- */
-static int LuaCallbackThreadInfoPushToStackFromThreadVars(lua_State *luastate, const ThreadVars *tv)
-{
-    unsigned long tid = SCGetThreadIdLong();
-    lua_pushinteger (luastate, (lua_Integer)tid);
-    lua_pushstring (luastate, tv->name);
-    lua_pushstring (luastate, tv->thread_group_name);
-    return 3;
-}
-
-/** \internal
- *  \brief Wrapper for getting tuple info into a lua script
- *  \retval cnt number of items placed on the stack
- */
-static int LuaCallbackThreadInfo(lua_State *luastate)
-{
-    const ThreadVars *tv = LuaStateGetThreadVars(luastate);
-    if (tv == NULL)
-        return LuaCallbackError(luastate, "internal error: no tv");
-
-    return LuaCallbackThreadInfoPushToStackFromThreadVars(luastate, tv);
-}
-
-int LuaRegisterFunctions(lua_State *luastate)
-{
-    lua_pushcfunction(luastate, LuaCallbackThreadInfo);
-    lua_setglobal(luastate, "SCThreadInfo");
-    return 0;
-}
-
 int LuaStateNeedProto(lua_State *luastate, AppProto alproto)
 {
     AppProto flow_alproto = 0;

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -113,15 +113,6 @@ static int LuaCallbackStreamingBuffer(lua_State *luastate)
     return LuaCallbackStreamingBufferPushToStack(luastate, b);
 }
 
-static int LuaCallbackLogPath(lua_State *luastate)
-{
-    const char *ld = SCConfigGetLogDirectory();
-    if (ld == NULL)
-        return LuaCallbackError(luastate, "internal error: no log dir");
-
-    return LuaPushStringBuffer(luastate, (const uint8_t *)ld, strlen(ld));
-}
-
 /** \internal
  *  \brief fill lua stack with thread info
  *  \param luastate the lua state
@@ -157,9 +148,6 @@ int LuaRegisterFunctions(lua_State *luastate)
     /* registration of the callbacks */
     lua_pushcfunction(luastate, LuaCallbackStreamingBuffer);
     lua_setglobal(luastate, "SCStreamingBuffer");
-
-    lua_pushcfunction(luastate, LuaCallbackLogPath);
-    lua_setglobal(luastate, "SCLogPath");
 
     lua_pushcfunction(luastate, LuaCallbackThreadInfo);
     lua_setglobal(luastate, "SCThreadInfo");

--- a/src/util-lua-common.h
+++ b/src/util-lua-common.h
@@ -37,8 +37,6 @@ void LuaPushTableKeyValueLString(
         lua_State *luastate, const char *key, const char *value, size_t len);
 void LuaPushTableKeyValueArray(lua_State *luastate, const char *key, const uint8_t *value, size_t len);
 
-int LuaRegisterFunctions(lua_State *luastate);
-
 int LuaStateNeedProto(lua_State *luastate, AppProto alproto);
 
 /* hack to please scan-build. Even though LuaCallbackError *always*

--- a/src/util-lua-common.h
+++ b/src/util-lua-common.h
@@ -31,7 +31,10 @@ int LuaCallbackError(lua_State *luastate, const char *msg);
 const char *LuaGetStringArgument(lua_State *luastate, int argc);
 
 void LuaPushTableKeyValueInt(lua_State *luastate, const char *key, int value);
+void LuaPushTableKeyValueBoolean(lua_State *luastate, const char *key, bool value);
 void LuaPushTableKeyValueString(lua_State *luastate, const char *key, const char *value);
+void LuaPushTableKeyValueLString(
+        lua_State *luastate, const char *key, const char *value, size_t len);
 void LuaPushTableKeyValueArray(lua_State *luastate, const char *key, const uint8_t *value, size_t len);
 
 int LuaRegisterFunctions(lua_State *luastate);

--- a/src/util-lua-config.c
+++ b/src/util-lua-config.c
@@ -1,0 +1,56 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * Configuration API for Lua.
+ *
+ * local config = require("suricata.config")
+ */
+
+#include "suricata-common.h"
+#include "util-lua-config.h"
+#include "conf.h"
+#include "util-conf.h"
+#include "app-layer-protos.h"
+#include "util-lua-common.h"
+#include "util-lua.h"
+
+#include "lauxlib.h"
+
+static int LuaConfigLogPath(lua_State *L)
+{
+    const char *ld = SCConfigGetLogDirectory();
+    if (ld == NULL)
+        return LuaCallbackError(L, "internal error: no log dir");
+
+    return LuaPushStringBuffer(L, (const uint8_t *)ld, strlen(ld));
+}
+
+static const luaL_Reg configlib[] = {
+    // clang-format off
+    { "log_path", LuaConfigLogPath },
+    { NULL, NULL },
+    // clang-format on
+};
+
+int SCLuaLoadConfigLib(lua_State *L)
+{
+    luaL_newlib(L, configlib);
+    return 1;
+}

--- a/src/util-lua-config.h
+++ b/src/util-lua-config.h
@@ -1,0 +1,25 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef UTIL_LUA_CONFIG_H
+#define UTIL_LUA_CONFIG_H
+
+#include "lua.h"
+
+int SCLuaLoadConfigLib(lua_State *luastate);
+
+#endif /* UTIL_LUA_CONFIG_H */

--- a/src/util-lua-log.c
+++ b/src/util-lua-log.c
@@ -22,31 +22,64 @@
 
 #include "lauxlib.h"
 
+static bool LuaGetAr(lua_State *L, lua_Debug *ar)
+{
+    if (lua_getstack(L, 1, ar) && lua_getinfo(L, "nSl", ar)) {
+        return true;
+    }
+    return false;
+}
+
 static int LuaLogInfo(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogInfo("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogInfoRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogInfo("%s", msg);
+    }
     return 0;
 }
 
 static int LuaLogNotice(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogNotice("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogNoticeRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogNotice("%s", msg);
+    }
+
     return 0;
 }
 
 static int LuaLogWarning(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogWarning("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogWarningRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogWarning("%s", msg);
+    }
     return 0;
 }
 
 static int LuaLogError(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogError("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogErrorRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogError("%s", msg);
+    }
     return 0;
 }
 
@@ -54,7 +87,13 @@ static int LuaLogDebug(lua_State *L)
 {
 #ifdef DEBUG
     const char *msg = luaL_checkstring(L, 1);
-    SCLogDebug("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogDebugRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogDebug("%s", msg);
+    }
 #endif
     return 0;
 }
@@ -62,14 +101,26 @@ static int LuaLogDebug(lua_State *L)
 static int LuaLogConfig(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogConfig("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogConfigRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogConfig("%s", msg);
+    }
     return 0;
 }
 
 static int LuaLogPerf(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
-    SCLogPerf("%s", msg);
+    lua_Debug ar;
+    if (LuaGetAr(L, &ar)) {
+        const char *funcname = ar.name ? ar.name : ar.what;
+        SCLogPerfRaw(ar.short_src, funcname, ar.currentline, "%s", msg);
+    } else {
+        SCLogPerf("%s", msg);
+    }
     return 0;
 }
 

--- a/src/util-lua-sandbox.c
+++ b/src/util-lua-sandbox.c
@@ -101,13 +101,12 @@ static int LuaBlockedFunction(lua_State *L)
     SCLuaSbState *context = SCLuaSbGetContext(L);
     context->blocked_function_error = true;
     lua_Debug ar;
-    lua_getstack(L, 0, &ar);
-    lua_getinfo(L, "n", &ar);
-    if (ar.name) {
+    if (lua_getstack(L, 0, &ar) && lua_getinfo(L, "n", &ar) && ar.name) {
         luaL_error(L, "Blocked Lua function called: %s", ar.name);
     } else {
         luaL_error(L, "Blocked Lua function: name not available");
     }
+    /* never reached */
     return -1;
 }
 

--- a/src/util-lua-util.c
+++ b/src/util-lua-util.c
@@ -1,0 +1,67 @@
+/* Copyright (C) 2025 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "threads.h"
+#include "threadvars.h"
+
+#include "util-lua.h"
+#include "util-lua-common.h"
+#include "util-lua-util.h"
+
+#include "lua.h"
+#include "lauxlib.h"
+
+/**
+ * \brief Get thread information and return as a table
+ * \retval 1 table with thread info fields: id, name, thread_group_name
+ */
+static int LuaUtilThreadInfo(lua_State *luastate)
+{
+    const ThreadVars *tv = LuaStateGetThreadVars(luastate);
+    if (tv == NULL)
+        return LuaCallbackError(luastate, "internal error: no tv");
+
+    unsigned long tid = SCGetThreadIdLong();
+
+    lua_newtable(luastate);
+
+    lua_pushstring(luastate, "id");
+    lua_pushinteger(luastate, (lua_Integer)tid);
+    lua_settable(luastate, -3);
+
+    lua_pushstring(luastate, "name");
+    lua_pushstring(luastate, tv->name);
+    lua_settable(luastate, -3);
+
+    lua_pushstring(luastate, "group_name");
+    lua_pushstring(luastate, tv->thread_group_name);
+    lua_settable(luastate, -3);
+
+    return 1;
+}
+
+static const struct luaL_Reg utillib[] = {
+    { "thread_info", LuaUtilThreadInfo },
+    { NULL, NULL },
+};
+
+int SCLuaLoadUtilLib(lua_State *L)
+{
+    luaL_newlib(L, utillib);
+    return 1;
+}

--- a/src/util-lua-util.h
+++ b/src/util-lua-util.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2025 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,20 +15,11 @@
  * 02110-1301, USA.
  */
 
-/**
- * \file
- *
- * \author Victor Julien <victor@inliniac.net>
- */
+#ifndef SURICATA_UTIL_LUA_UTIL_H
+#define SURICATA_UTIL_LUA_UTIL_H
 
-#ifndef SURICATA_DETECT_LUA_EXT_H
-#define SURICATA_DETECT_LUA_EXT_H
+#include "lua.h"
 
-extern const char luaext_key_ld[];
+int SCLuaLoadUtilLib(lua_State *L);
 
-void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *, DetectEngineThreadCtx *det_ctx,
-        Flow *f, Packet *p, const Signature *s, uint8_t flags);
-
-void LuaLoadDatasetLib(lua_State *luastate);
-
-#endif
+#endif /* SURICATA_UTIL_LUA_UTIL_H */


### PR DESCRIPTION
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2532
Ticket: https://redmine.openinfosecfoundation.org/issues/7609

# lua/streaming

Instead of SCStreamingBuffer, just pass the data to the log function. The
caller explicitly opts in to streaming data, why not just pass the data to the log
function. Also simplify requesting streaming data.

# lua/bytevar: convert SCByteVar to Lua lib

Similar to flowvars and flowints, but a byte var cannot be registered
from a Lua script, but it still needs to be setup. Instead provide an
"ensure" function that sets it up, or errors out if the byte var is
unknown.

This also required passing the signature into the Lua init method, as
the state of the Signature object and the time of loading the Lua
keyword is required.

# lua/logging: re-add lua script and line numbers

Note that while we try to log the Lua function name, its never
logged. Instead "Lua" is logged as the function name.

# util/debug: expose more raw logging macros

Add raw logging macros for config, perf and debug.

# lua: fix coverity unchecked return

CID 1648351: (#1 of 1): Unchecked return value (CHECKED_RETURN)
1. check_return: Calling lua_getstack without checking return value (as is done elsewhere 9 out of 10 times).

# lua: create suricata.config lua lib

Currently only provides "log_path" as a replacement for SCLogPath.
