### PR TITLE
json/schema: Document email.attachment is equivalent to file.name

### DIFF
--- a/etc/schema.json
+++ b/etc/schema.json
@@ -1343,7 +1343,8 @@
                     "minItems": 1,
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "$comment": "The log fields email.attachment and file.name refer to the same value and are functionally equivalent"
                 },
                 "body_md5": {
                     "type": "string"


### PR DESCRIPTION
Ticket: [#7683](https://redmine.openinfosecfoundation.org/issues/7683)

## Contribution style:
- [x] I have read the contributing guide lines at
   https://docs.suricata.io/en/latest/devguide/contributing/contribution-process.html

## Our Contribution agreements:
- [x] I have signed the Open Information Security Foundation contribution agreement at
   https://suricata.io/about/contribution-agreement/ (note: this is only required once)

## Changes (if applicable):
- [x] I have updated the User Guide (in [doc/userguide/](https://github.com/OISF/suricata/tree/304271e63a9e388412f25f0f94a1a0da4bf619d9/doc/userguide)) to reflect the changes made
- [ ] I have updated the JSON schema (in [etc/schema.json](https://github.com/OISF/suricata/blob/304271e63a9e388412f25f0f94a1a0da4bf619d9/etc/schema.json)) to reflect all logging changes
      (including schema descriptions)
- [x] I have created a ticket at
      https://redmine.openinfosecfoundation.org/projects/suricata/issues/7683

Link to ticket: https://redmine.openinfosecfoundation.org/issues/7683

### Description:
- Document email.attachment is equivalent to file.name

I based this draft PR on this comment: https://github.com/OISF/suricata/pull/13126#discussion_r2078380943.
Let me know if it is what you meant @catenacyber .
