### PR TITLE
detect/entropy: Add calculated entropy value to metadata output

### DIFF
--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -733,6 +733,20 @@ a Shannon entropy value of 4 or higher::
 
 	alert http any any -> any any (msg:"entropy simple test"; file.data; entropy: value >= 4; sid:1;)
 
+Logging
+~~~~~~~
+
+When the ``entropy`` rule keyword is provide and the rule is evaluated, the calculated entropy
+value is logged within the ``metadata`` section of an output log. If the alert matched, it will
+be included there; here's an example that shows the calculated entropy value with the buffer
+on which the value was computed::
+
+     "metadata": {
+        "entropy": {
+          "file_data": 4.265743301617466
+        }
+      }
+
 rpc
 ---
 

--- a/etc/schema.json
+++ b/etc/schema.json
@@ -2933,6 +2933,14 @@
                         ]
                     }
                 },
+                "entropy": {
+                    "type": "object",
+                    "suricata": {
+                        "keywords": [
+                            "entropy"
+                        ]
+                    }
+                },
                 "flowints": {
                     "type": "object",
                     "suricata": {

--- a/src/flow-var.c
+++ b/src/flow-var.c
@@ -47,6 +47,12 @@ static void FlowVarUpdateInt(FlowVar *fv, uint32_t value)
     fv->data.fv_int.value = value;
 }
 
+/* puts a new value into a flowvar */
+static void FlowVarUpdateFloat(FlowVar *fv, double value)
+{
+    fv->data.fv_float.value = value;
+}
+
 /** \brief get the flowvar with index 'idx' from the flow
  *  \note flow is not locked by this function, caller is
  *        responsible
@@ -132,6 +138,26 @@ void FlowVarAddIdValue(Flow *f, uint32_t idx, uint8_t *value, uint16_t size)
     }
 }
 
+/* add a flowvar to the flow, or update it */
+void FlowVarAddFloat(Flow *f, uint32_t idx, double value)
+{
+    FlowVar *fv = FlowVarGet(f, idx);
+    if (fv == NULL) {
+        fv = SCMalloc(sizeof(FlowVar));
+        if (unlikely(fv == NULL))
+            return;
+
+        fv->type = DETECT_FLOWVAR;
+        fv->datatype = FLOWVAR_TYPE_FLOAT;
+        fv->idx = idx;
+        fv->data.fv_float.value = value;
+        fv->next = NULL;
+
+        GenericVarAppend(&f->flowvar, (GenericVar *)fv);
+    } else {
+        FlowVarUpdateFloat(fv, value);
+    }
+}
 /* add a flowvar to the flow, or update it */
 void FlowVarAddIntNoLock(Flow *f, uint32_t idx, uint32_t value)
 {

--- a/src/flow-var.h
+++ b/src/flow-var.h
@@ -32,6 +32,7 @@
 
 #define FLOWVAR_TYPE_STR 1
 #define FLOWVAR_TYPE_INT 2
+#define FLOWVAR_TYPE_FLOAT 3
 
 typedef uint8_t FlowVarKeyLenType;
 /** Struct used to hold the string data type for flowvars */
@@ -45,6 +46,11 @@ typedef struct FlowVarTypeInt_ {
     uint32_t value;
 } FlowVarTypeInt;
 
+/** Struct used to hold the integer data type for flowvars */
+typedef struct FlowVarTypeFloat_ {
+    double value;
+} FlowVarTypeFloat;
+
 /** Generic Flowvar Structure */
 typedef struct FlowVar_ {
     uint16_t type; /* type, DETECT_FLOWVAR in this case */
@@ -57,6 +63,7 @@ typedef struct FlowVar_ {
     union {
         FlowVarTypeStr fv_str;
         FlowVarTypeInt fv_int;
+        FlowVarTypeFloat fv_float;
     } data;
     uint8_t *key;
 } FlowVar;
@@ -69,6 +76,7 @@ void FlowVarAddKeyValue(
 
 void FlowVarAddIntNoLock(Flow *, uint32_t, uint32_t);
 void FlowVarAddInt(Flow *, uint32_t, uint32_t);
+void FlowVarAddFloat(Flow *, uint32_t, double);
 FlowVar *FlowVarGet(Flow *, uint32_t);
 FlowVar *FlowVarGetByKey(Flow *f, const uint8_t *key, FlowVarKeyLenType keylen);
 void FlowVarFree(FlowVar *);

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -247,6 +247,7 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
     SCJsonBuilder *js_traffic_id = NULL;
     SCJsonBuilder *js_traffic_label = NULL;
     SCJsonBuilder *js_flowints = NULL;
+    SCJsonBuilder *js_entropyvals = NULL;
     SCJsonBuilder *js_flowbits = NULL;
     GenericVar *gv = f->flowvar;
     while (gv != NULL) {
@@ -292,6 +293,17 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
                 SCJbStartObject(js_flowvars);
                 SCJbSetString(js_flowvars, (const char *)keybuf, (char *)printable_buf);
                 SCJbClose(js_flowvars);
+            } else if (fv->datatype == FLOWVAR_TYPE_FLOAT) {
+                const char *varname = VarNameStoreLookupById(fv->idx, VAR_TYPE_FLOW_FLOAT);
+                if (varname) {
+                    if (js_entropyvals == NULL) {
+                        js_entropyvals = SCJbNewObject();
+                        if (js_entropyvals == NULL)
+                            break;
+                    }
+                    SCJbSetFloat(js_entropyvals, varname, fv->data.fv_float.value);
+                }
+
             } else if (fv->datatype == FLOWVAR_TYPE_INT) {
                 const char *varname = VarNameStoreLookupById(fv->idx,
                         VAR_TYPE_FLOW_INT);
@@ -303,7 +315,6 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
                     }
                     SCJbSetUint(js_flowints, varname, fv->data.fv_int.value);
                 }
-
             }
         } else if (gv->type == DETECT_FLOWBITS) {
             FlowBit *fb = (FlowBit *)gv;
@@ -347,6 +358,11 @@ static void EveAddFlowVars(const Flow *f, SCJsonBuilder *js_root, SCJsonBuilder 
         SCJbClose(js_flowints);
         SCJbSetObject(js_root, "flowints", js_flowints);
         SCJbFree(js_flowints);
+    }
+    if (js_entropyvals) {
+        SCJbClose(js_entropyvals);
+        SCJbSetObject(js_root, "entropy", js_entropyvals);
+        SCJbFree(js_entropyvals);
     }
     if (js_flowvars) {
         SCJbClose(js_flowvars);

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -35,6 +35,7 @@ enum VarTypes {
 
     VAR_TYPE_FLOW_BIT,
     VAR_TYPE_FLOW_INT,
+    VAR_TYPE_FLOW_FLOAT,
     VAR_TYPE_FLOW_VAR,
 
     VAR_TYPE_HOST_BIT,


### PR DESCRIPTION
Continuation of #13342  

When the entropy keyword is used, record the calculated entropy value to a flow variable for logging use.

Describe changes:
- Modify the entropy match function to return the calculated entropy value and store it in a flow variable
- Modifications to flow variables to support variables of type float
- Extend the schema to include "entropy"

Here's an example of the output - snippet from an alert log showing the calculated entropy value and the origin of the data used in the calculation:

```
 "metadata": {
    "entropy": {
      "http_request_header": 3.4182958340544896
    }
  },
 ```
Updates:
- Added missing etc/schema.json file
- Briefly document output in the rule keyword section
- Updated logging to make it clear that entropy values are followed.
- Added buffer name in entropy output
- 
### Provide values to any of the below to override the defaults.

- To use a Suricata-Verify or Suricata-Update pull request,
  link to the pull request in the respective `_BRANCH` variable.
- Leave unused overrides blank or remove.

SV_REPO=
SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2534
SU_REPO=
SU_BRANCH=
