### PR TITLE
decode/ipv4: add missing ip-in-ip case handling - v3

### DIFF
--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -585,6 +585,16 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case IPPROTO_ESP:
             DecodeESP(tv, dtv, p, data, data_len);
             break;
+        case IPPROTO_IPIP: {
+            /* spawn off tunnel packet */
+            Packet *tp = PacketTunnelPktSetup(tv, dtv, p, data, data_len, DECODE_TUNNEL_IPV4);
+            if (tp != NULL) {
+                PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
+                PacketEnqueueNoLock(&tv->decode_pq, tp);
+            }
+            FlowSetupPacket(p);
+            break;
+        }
         case IPPROTO_IPV6:
             {
                 /* spawn off tunnel packet */


### PR DESCRIPTION
A flow with IPv4 IP in IP traffic won't handle this tunneling case properly.
This leads to potential malicious traffic not triggering alerts, as well as other inaccuracies in the logs.

Bug #7725

Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7725

Describe changes:
- handle `IP-in-IP` tunneling case for IPv4
- rebase

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2541