### PR TITLE
decode/ipv4: add missing ip-in-ip case handling - v4

### DIFF
--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -595,6 +595,16 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             FlowSetupPacket(p);
             break;
         }
+        case IPPROTO_IPIP: {
+            /* spawn off tunnel packet */
+            Packet *tp = PacketTunnelPktSetup(tv, dtv, p, data, data_len, DECODE_TUNNEL_IPV4);
+            if (tp != NULL) {
+                PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
+                PacketEnqueueNoLock(&tv->decode_pq, tp);
+            }
+            FlowSetupPacket(p);
+            break;
+        }
         case IPPROTO_IP:
             /* check PPP VJ uncompressed packets and decode tcp dummy */
             if (p->flags & PKT_PPP_VJ_UCOMP) {

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -585,17 +585,16 @@ int DecodeIPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         case IPPROTO_ESP:
             DecodeESP(tv, dtv, p, data, data_len);
             break;
-        case IPPROTO_IPV6:
-            {
-                /* spawn off tunnel packet */
-                Packet *tp = PacketTunnelPktSetup(tv, dtv, p, data, data_len, DECODE_TUNNEL_IPV6);
-                if (tp != NULL) {
-                    PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
-                    PacketEnqueueNoLock(&tv->decode_pq,tp);
-                }
-                FlowSetupPacket(p);
-                break;
+        case IPPROTO_IPV6: {
+            /* spawn off tunnel packet */
+            Packet *tp = PacketTunnelPktSetup(tv, dtv, p, data, data_len, DECODE_TUNNEL_IPV6);
+            if (tp != NULL) {
+                PKT_SET_SRC(tp, PKT_SRC_DECODER_IPV4);
+                PacketEnqueueNoLock(&tv->decode_pq, tp);
             }
+            FlowSetupPacket(p);
+            break;
+        }
         case IPPROTO_IP:
             /* check PPP VJ uncompressed packets and decode tcp dummy */
             if (p->flags & PKT_PPP_VJ_UCOMP) {


### PR DESCRIPTION
Previous PR: #13367 

Link to ticket: https://redmine.openinfosecfoundation.org/issues/

Describe changes:
- re-format `IPV6` case to make clang-format checks work

### Provide values to any of the below to override the defaults.

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2542