### PR TITLE
detect/content: account for distance variables

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -601,7 +601,8 @@ static void PropagateLimits(Signature *s, SigMatch *sm_head)
                             VALIDATE(depth + cd->within + dist >= 0 &&
                                      depth + cd->within + dist <= UINT16_MAX);
                             depth = cd->depth = (uint16_t)(depth + cd->within + dist);
-                        } else {
+                        } else if ((cd->flags & DETECT_CONTENT_DISTANCE_VAR) == 0) {
+                            // we cannot know the depth yet if it comes from a var
                             SCLogDebug("offset %u + cd->within %u", offset, cd->within);
                             VALIDATE(depth + cd->within >= 0 && depth + cd->within <= UINT16_MAX);
                             depth = cd->depth = (uint16_t)(offset + cd->within);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -247,8 +247,8 @@ static int DetectEngineContentInspectionInternal(DetectEngineThreadCtx *det_ctx,
             /* If the value came from a variable, make sure to adjust the depth so it's relative
              * to the offset value.
              */
-            if (cd->flags & (DETECT_CONTENT_DISTANCE_VAR|DETECT_CONTENT_OFFSET_VAR|DETECT_CONTENT_DEPTH_VAR)) {
-                 depth += offset;
+            if (cd->flags & (DETECT_CONTENT_OFFSET_VAR | DETECT_CONTENT_DEPTH_VAR)) {
+                depth += offset;
             }
 
             /* update offset with prev_offset if we're searching for


### PR DESCRIPTION
Link to ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7390

Describe changes:
- do not recompute depth if DETECT_CONTENT_DISTANCE_VAR
- do not have `PropagateLimits` pretend it knows depth if DETECT_CONTENT_DISTANCE_VAR

SV_BRANCH=https://github.com/OISF/suricata-verify/pull/2544

https://github.com/OISF/suricata/pull/13340 alternative (simpler ? better ?) fix